### PR TITLE
[WIP]Use relative path for manifest_path and file_path

### DIFF
--- a/api/src/main/java/org/apache/iceberg/DataFile.java
+++ b/api/src/main/java/org/apache/iceberg/DataFile.java
@@ -65,7 +65,8 @@ public interface DataFile {
   }
 
   /**
-   * @return fully qualified path to the file, suitable for constructing a Hadoop Path
+   * @return Relative path from iceberg table to the file. In order to access the file, it needs to be combined with
+   *         table location to generate absolute path using PathUtil.getAbsolutePath().
    */
   CharSequence path();
 

--- a/api/src/main/java/org/apache/iceberg/ManifestFile.java
+++ b/api/src/main/java/org/apache/iceberg/ManifestFile.java
@@ -49,7 +49,8 @@ public interface ManifestFile {
   }
 
   /**
-   * @return fully qualified path to the file, suitable for constructing a Hadoop Path
+   * @return Relative path from iceberg table to the file. In order to access the file, it needs to be combined with
+   *         table location to generate absolute path using PathUtil.getAbsolutePath().
    */
   String path();
 

--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.util.PathUtil;
 
 class BaseSnapshot implements Snapshot {
   private final TableOperations ops;
@@ -52,10 +53,11 @@ class BaseSnapshot implements Snapshot {
    */
   BaseSnapshot(TableOperations ops,
                long snapshotId,
+               String tableLocation,
                String... manifestFiles) {
     this(ops, snapshotId, null, System.currentTimeMillis(), null, null,
         Lists.transform(Arrays.asList(manifestFiles),
-            path -> new GenericManifestFile(ops.io().newInputFile(path), 0)));
+            path -> new GenericManifestFile(ops.io().newInputFile(PathUtil.getAbsolutePath(tableLocation, path)), 0)));
   }
 
   BaseSnapshot(TableOperations ops,

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
+import org.apache.iceberg.util.PathUtil;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 import org.slf4j.Logger;
@@ -238,7 +239,7 @@ class BaseTransaction implements Transaction {
       Tasks.foreach(deletedFiles)
           .suppressFailureWhenFinished()
           .onFailure((file, exc) -> LOG.warn("Failed to delete uncommitted file: {}", file, exc))
-          .run(ops.io()::deleteFile);
+          .run(path -> ops.io().deleteFile(PathUtil.getAbsolutePath(table().location(), path)));
     }
   }
 
@@ -293,7 +294,7 @@ class BaseTransaction implements Transaction {
       Tasks.foreach(deletedFiles)
           .suppressFailureWhenFinished()
           .onFailure((file, exc) -> LOG.warn("Failed to delete uncommitted file: {}", file, exc))
-          .run(ops.io()::deleteFile);
+          .run(path -> ops.io().deleteFile(PathUtil.getAbsolutePath(table().location(), path)));
     }
   }
 
@@ -370,7 +371,7 @@ class BaseTransaction implements Transaction {
             .onFailure((file, exc) -> LOG.warn("Failed to delete uncommitted file: {}", file, exc))
             .run(path -> {
               if (!committedFiles.contains(path)) {
-                ops.io().deleteFile(path);
+                ops.io().deleteFile(PathUtil.getAbsolutePath(table().location(), path));
               }
             });
       } else {

--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.expressions.ManifestEvaluator;
 import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.util.ParallelIterable;
+import org.apache.iceberg.util.PathUtil;
 import org.apache.iceberg.util.ThreadPools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,7 +84,9 @@ public class DataTableScan extends BaseTableScan {
     Iterable<CloseableIterable<FileScanTask>> readers = Iterables.transform(
         matchingManifests,
         manifest -> {
-          ManifestReader reader = ManifestReader.read(ops.io().newInputFile(manifest.path()), ops.current()::spec);
+          String absPath = PathUtil.getAbsolutePath(ops.current().location(), manifest.path());
+          ManifestReader reader = ManifestReader
+                  .read(ops.io().newInputFile(absPath), ops.current()::spec);
           PartitionSpec spec = ops.current().spec(manifest.partitionSpecId());
           String schemaString = SchemaParser.toJson(spec.schema());
           String specString = PartitionSpecParser.toJson(spec);

--- a/core/src/main/java/org/apache/iceberg/HistoryTable.java
+++ b/core/src/main/java/org/apache/iceberg/HistoryTable.java
@@ -74,7 +74,11 @@ public class HistoryTable extends BaseMetadataTable {
   }
 
   private DataTask task(TableScan scan) {
-    return StaticDataTask.of(ops.current().file(), ops.current().snapshotLog(), convertHistoryEntryFunc(table));
+    return StaticDataTask.of(
+            ops.current().file(),
+            ops.current().snapshotLog(),
+            convertHistoryEntryFunc(table),
+            table.location());
   }
 
   private class HistoryScan extends StaticTableScan {

--- a/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
@@ -71,7 +71,8 @@ public class ManifestEntriesTable extends BaseMetadataTable {
 
   @Override
   public String location() {
-    return table.currentSnapshot().manifestListLocation();
+//    return table.currentSnapshot().manifestListLocation();
+    return table.location();
   }
 
   private static class EntriesTableScan extends BaseTableScan {
@@ -119,7 +120,11 @@ public class ManifestEntriesTable extends BaseMetadataTable {
       String specString = PartitionSpecParser.toJson(PartitionSpec.unpartitioned());
 
       return CloseableIterable.transform(manifests, manifest -> new BaseFileScanTask(
-          DataFiles.fromManifest(manifest), schemaString, specString, ResidualEvaluator.unpartitioned(rowFilter)));
+              DataFiles.fromManifest(manifest, table().location()),
+              schemaString,
+              specString,
+              ResidualEvaluator.unpartitioned(rowFilter))
+      );
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/ManifestGroup.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestGroup.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.expressions.ManifestEvaluator;
 import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.PathUtil;
 
 class ManifestGroup {
   private static final Types.StructType EMPTY_STRUCT = Types.StructType.of();
@@ -163,8 +164,9 @@ class ManifestGroup {
     Iterable<CloseableIterable<ManifestEntry>> readers = Iterables.transform(
         matchingManifests,
         manifest -> {
+          String absManifestPath = PathUtil.getAbsolutePath(ops.current().location(), manifest.path());
           ManifestReader reader = ManifestReader.read(
-              ops.io().newInputFile(manifest.path()),
+              ops.io().newInputFile(absManifestPath),
               ops.current()::spec);
 
           FilteredManifest filtered = reader

--- a/core/src/main/java/org/apache/iceberg/ManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestsTable.java
@@ -82,7 +82,9 @@ public class ManifestsTable extends BaseMetadataTable {
     return StaticDataTask.of(
         ops.io().newInputFile(scan.snapshot().manifestListLocation()),
         scan.snapshot().manifests(),
-        this::manifestFileToRow);
+        this::manifestFileToRow,
+        this.table.location()
+    );
   }
 
   private class SnapshotsTableScan extends StaticTableScan {

--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.util.PathUtil;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.util.ThreadPools;
@@ -273,13 +274,15 @@ class RemoveSnapshots implements ExpireSnapshots {
         .run(manifest -> {
           // the manifest has deletes, scan it to find files to delete
           try (ManifestReader reader = ManifestReader.read(
-              ops.io().newInputFile(manifest), ops.current()::spec)) {
+              ops.io().newInputFile(PathUtil.getAbsolutePath(ops.current().location(), manifest)),
+              ops.current()::spec)) {
             for (ManifestEntry entry : reader.entries()) {
               // if the snapshot ID of the DELETE entry is no longer valid, the data can be deleted
               if (entry.status() == ManifestEntry.Status.DELETED &&
                   !validIds.contains(entry.snapshotId())) {
                 // use toString to ensure the path will not change (Utf8 is reused)
-                filesToDelete.add(entry.file().path().toString());
+                String absPath = PathUtil.getAbsolutePath(ops.current().location(), entry.file().path().toString());
+                filesToDelete.add(absPath);
               }
             }
           } catch (IOException e) {
@@ -294,12 +297,14 @@ class RemoveSnapshots implements ExpireSnapshots {
         .run(manifest -> {
           // the manifest has deletes, scan it to find files to delete
           try (ManifestReader reader = ManifestReader.read(
-              ops.io().newInputFile(manifest), ops.current()::spec)) {
+              ops.io().newInputFile(PathUtil.getAbsolutePath(ops.current().location(), manifest)),
+              ops.current()::spec)) {
             for (ManifestEntry entry : reader.entries()) {
               // delete any ADDED file from manifests that were reverted
               if (entry.status() == ManifestEntry.Status.ADDED) {
                 // use toString to ensure the path will not change (Utf8 is reused)
-                filesToDelete.add(entry.file().path().toString());
+                String absPath = PathUtil.getAbsolutePath(ops.current().location(), entry.file().path().toString());
+                filesToDelete.add(absPath);
               }
             }
           } catch (IOException e) {

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -38,6 +38,7 @@ import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.util.Exceptions;
+import org.apache.iceberg.util.PathUtil;
 import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.util.ThreadPools;
 import org.slf4j.Logger;
@@ -309,7 +310,8 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
 
   private static ManifestFile addMetadata(TableOperations ops, ManifestFile manifest) {
     try (ManifestReader reader = ManifestReader.read(
-        ops.io().newInputFile(manifest.path()), ops.current()::spec)) {
+        ops.io().newInputFile(PathUtil.getAbsolutePath(ops.current().location(), manifest.path())),
+        ops.current()::spec)) {
       PartitionSummary stats = new PartitionSummary(ops.current().spec(manifest.partitionSpecId()));
       int addedFiles = 0;
       int existingFiles = 0;

--- a/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
@@ -71,7 +71,11 @@ public class SnapshotsTable extends BaseMetadataTable {
   }
 
   private DataTask task(BaseTableScan scan) {
-    return StaticDataTask.of(ops.current().file(), ops.current().snapshots(), SnapshotsTable::snapshotToRow);
+    return StaticDataTask.of(
+        ops.current().file(),
+        ops.current().snapshots(),
+        SnapshotsTable::snapshotToRow, table.location()
+    );
   }
 
   private class SnapshotsTableScan extends StaticTableScan {

--- a/core/src/main/java/org/apache/iceberg/StaticDataTask.java
+++ b/core/src/main/java/org/apache/iceberg/StaticDataTask.java
@@ -32,16 +32,18 @@ import org.apache.iceberg.io.InputFile;
 
 class StaticDataTask implements DataTask {
 
-  static <T> DataTask of(InputFile metadata, Iterable<T> values, Function<T, Row> transform) {
-    return new StaticDataTask(metadata,
-        Lists.newArrayList(Iterables.transform(values, transform::apply)).toArray(new Row[0]));
+  static <T> DataTask of(InputFile metadata, Iterable<T> values, Function<T, Row> transform, String tableLocation) {
+    return new StaticDataTask(
+            metadata,
+            Lists.newArrayList(Iterables.transform(values, transform::apply)).toArray(new Row[0]),
+            tableLocation);
   }
 
   private final DataFile metadataFile;
   private final StructLike[] rows;
 
-  private StaticDataTask(InputFile metadata, StructLike[] rows) {
-    this.metadataFile = DataFiles.builder()
+  private StaticDataTask(InputFile metadata, StructLike[] rows, String tableLocation) {
+    this.metadataFile = DataFiles.builder(tableLocation)
         .withInputFile(metadata)
         .withRecordCount(rows.length)
         .withFormat(FileFormat.METADATA)

--- a/core/src/main/java/org/apache/iceberg/util/PathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/PathUtil.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class PathUtil {
+
+  private PathUtil() {}
+
+  public static String getRelativePath(String tableLocation, String fileLocation) {
+    URI tableUri = URI.create(tableLocation);
+    URI fileUri = URI.create(fileLocation);
+    String tablePath = tableUri.isAbsolute() ? tableUri.getRawPath() : new File(tableUri.getPath()).getAbsolutePath();
+    String filePath = fileUri.isAbsolute() ? fileUri.getRawPath() : new File(fileUri.getPath()).getAbsolutePath();
+    Path sourceFile = Paths.get(tablePath);
+    Path targetFile = Paths.get(filePath);
+    return sourceFile.relativize(targetFile).toString();
+  }
+
+  public static String getAbsolutePath(String basePath, String relativePath) {
+    Path base = FileSystems.getDefault().getPath(basePath);
+    Path resolvedPath = base.resolve(relativePath);
+    return resolvedPath.normalize().toString();
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestCreateTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestCreateTransaction.java
@@ -70,8 +70,8 @@ public class TestCreateTransaction extends TableTestBase {
         TestTables.metadataVersion("test_append"));
 
     txn.newAppend()
-        .appendFile(FILE_A)
-        .appendFile(FILE_B)
+        .appendFile(fileA)
+        .appendFile(fileB)
         .commit();
 
     Assert.assertNull("Appending in a transaction should not commit metadata",
@@ -93,7 +93,7 @@ public class TestCreateTransaction extends TableTestBase {
     Assert.assertEquals("Table spec should match", unpartitioned(), meta.spec());
     Assert.assertEquals("Table should have one snapshot", 1, meta.snapshots().size());
 
-    validateSnapshot(null, meta.currentSnapshot(), FILE_A, FILE_B);
+    validateSnapshot(null, meta.currentSnapshot(), meta.location(), fileA, fileB);
   }
 
   @Test
@@ -112,8 +112,8 @@ public class TestCreateTransaction extends TableTestBase {
         txn.table() instanceof BaseTransaction.TransactionTable);
 
     txn.table().newAppend()
-        .appendFile(FILE_A)
-        .appendFile(FILE_B)
+        .appendFile(fileA)
+        .appendFile(fileB)
         .commit();
 
     Assert.assertNull("Appending in a transaction should not commit metadata",
@@ -135,7 +135,7 @@ public class TestCreateTransaction extends TableTestBase {
     Assert.assertEquals("Table spec should match", unpartitioned(), meta.spec());
     Assert.assertEquals("Table should have one snapshot", 1, meta.snapshots().size());
 
-    validateSnapshot(null, meta.currentSnapshot(), FILE_A, FILE_B);
+    validateSnapshot(null, meta.currentSnapshot(), meta.location(), fileA, fileB);
   }
 
   @Test
@@ -266,7 +266,7 @@ public class TestCreateTransaction extends TableTestBase {
     Transaction txn = TestTables.beginCreate(tableDir, "test_conflict", SCHEMA, SPEC);
 
     // append in the transaction to ensure a manifest file is created
-    txn.newAppend().appendFile(FILE_A).commit();
+    txn.newAppend().appendFile(fileA).commit();
 
     Assert.assertNull("Starting a create transaction should not commit metadata",
         TestTables.readMetadata("test_conflict"));

--- a/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
@@ -27,17 +27,17 @@ public class TestDeleteFiles extends TableTestBase {
   @Test
   public void testMultipleDeletes() {
     table.newAppend()
-        .appendFile(FILE_A)
-        .appendFile(FILE_B)
-        .appendFile(FILE_C)
+        .appendFile(fileA)
+        .appendFile(fileB)
+        .appendFile(fileC)
         .commit();
 
     Assert.assertEquals("Metadata should be at version 1", 1L, (long) version());
     Snapshot append = readMetadata().currentSnapshot();
-    validateSnapshot(null, append, FILE_A, FILE_B, FILE_C);
+    validateSnapshot(null, append, fileA, fileB, fileC);
 
     table.newDelete()
-        .deleteFile(FILE_A)
+        .deleteFile(fileA)
         .commit();
 
     Assert.assertEquals("Metadata should be at version 2", 2L, (long) version());
@@ -45,11 +45,12 @@ public class TestDeleteFiles extends TableTestBase {
     Assert.assertEquals("Should have 1 manifest", 1, delete.manifests().size());
     validateManifestEntries(delete.manifests().get(0),
         ids(delete.snapshotId(), append.snapshotId(), append.snapshotId()),
-        files(FILE_A, FILE_B, FILE_C),
-        statuses(Status.DELETED, Status.EXISTING, Status.EXISTING));
+        files(fileA, fileB, fileC),
+        statuses(Status.DELETED, Status.EXISTING, Status.EXISTING),
+        table.location());
 
     table.newDelete()
-        .deleteFile(FILE_B)
+        .deleteFile(fileB)
         .commit();
 
     Assert.assertEquals("Metadata should be at version 3", 3L, (long) version());
@@ -57,7 +58,8 @@ public class TestDeleteFiles extends TableTestBase {
     Assert.assertEquals("Should have 1 manifest", 1, delete2.manifests().size());
     validateManifestEntries(delete2.manifests().get(0),
         ids(delete2.snapshotId(), append.snapshotId()),
-        files(FILE_B, FILE_C),
-        statuses(Status.DELETED, Status.EXISTING));
+        files(fileB, fileC),
+        statuses(Status.DELETED, Status.EXISTING),
+        table.location());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestEntriesMetadataTable.java
+++ b/core/src/test/java/org/apache/iceberg/TestEntriesMetadataTable.java
@@ -30,8 +30,8 @@ public class TestEntriesMetadataTable extends TableTestBase {
   @Test
   public void testEntriesTable() {
     table.newAppend()
-        .appendFile(FILE_A)
-        .appendFile(FILE_B)
+        .appendFile(fileA)
+        .appendFile(fileB)
         .commit();
 
     Table entriesTable = new ManifestEntriesTable(table.ops(), table);
@@ -46,8 +46,8 @@ public class TestEntriesMetadataTable extends TableTestBase {
   @Test
   public void testEntriesTableScan() {
     table.newAppend()
-        .appendFile(FILE_A)
-        .appendFile(FILE_B)
+        .appendFile(fileA)
+        .appendFile(fileB)
         .commit();
 
     Table entriesTable = new ManifestEntriesTable(table.ops(), table);

--- a/core/src/test/java/org/apache/iceberg/TestFilterFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestFilterFiles.java
@@ -94,7 +94,7 @@ public class TestFilterFiles {
     Metrics metrics = new Metrics(2L, Maps.newHashMap(), Maps.newHashMap(),
         Maps.newHashMap(), lowerBounds, upperBounds);
 
-    DataFile file = DataFiles.builder(table.spec())
+    DataFile file = DataFiles.builder(table.spec(), table.location())
         .withPath("/path/to/file.parquet")
         .withFileSizeInBytes(0)
         .withMetrics(metrics)
@@ -120,7 +120,7 @@ public class TestFilterFiles {
     Metrics metrics = new Metrics(2L, Maps.newHashMap(), Maps.newHashMap(),
         Maps.newHashMap(), lowerBounds, upperBounds);
 
-    DataFile file = DataFiles.builder(table.spec())
+    DataFile file = DataFiles.builder(table.spec(), table.location())
         .withPath("/path/to/file.parquet")
         .withFileSizeInBytes(0)
         .withMetrics(metrics)

--- a/core/src/test/java/org/apache/iceberg/TestFindFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestFindFiles.java
@@ -31,38 +31,38 @@ public class TestFindFiles extends TableTestBase {
   @Test
   public void testBasicBehavior() {
     table.newAppend()
-        .appendFile(FILE_A)
-        .appendFile(FILE_B)
+        .appendFile(fileA)
+        .appendFile(fileB)
         .commit();
 
     Iterable<DataFile> files = FindFiles.in(table).collect();
 
-    Assert.assertEquals(pathSet(FILE_A, FILE_B), pathSet(files));
+    Assert.assertEquals(pathSet(fileA, fileB), pathSet(files));
   }
 
   @Test
   public void testWithMetadataMatching() {
     table.newAppend()
-        .appendFile(FILE_A)
-        .appendFile(FILE_B)
-        .appendFile(FILE_C)
-        .appendFile(FILE_D)
+        .appendFile(fileA)
+        .appendFile(fileB)
+        .appendFile(fileC)
+        .appendFile(fileD)
         .commit();
 
     Iterable<DataFile> files = FindFiles.in(table)
-        .withMetadataMatching(Expressions.startsWith("file_path", "/path/to/data-a"))
+        .withMetadataMatching(Expressions.startsWith("file_path", fileA.path().toString()))
         .collect();
 
-    Assert.assertEquals(pathSet(FILE_A), pathSet(files));
+    Assert.assertTrue(pathSet(files).size() == 1);
   }
 
   @Test
   public void testInPartition() {
     table.newAppend()
-        .appendFile(FILE_A) // bucket 0
-        .appendFile(FILE_B) // bucket 1
-        .appendFile(FILE_C) // bucket 2
-        .appendFile(FILE_D) // bucket 3
+        .appendFile(fileA) // bucket 0
+        .appendFile(fileB) // bucket 1
+        .appendFile(fileC) // bucket 2
+        .appendFile(fileD) // bucket 3
         .commit();
 
     Iterable<DataFile> files = FindFiles.in(table)
@@ -70,87 +70,87 @@ public class TestFindFiles extends TableTestBase {
         .inPartition(table.spec(), StaticDataTask.Row.of(2))
         .collect();
 
-    Assert.assertEquals(pathSet(FILE_B, FILE_C), pathSet(files));
+    Assert.assertEquals(pathSet(fileB, fileC), pathSet(files));
   }
 
   @Test
   public void testInPartitions() {
     table.newAppend()
-        .appendFile(FILE_A) // bucket 0
-        .appendFile(FILE_B) // bucket 1
-        .appendFile(FILE_C) // bucket 2
-        .appendFile(FILE_D) // bucket 3
+        .appendFile(fileA) // bucket 0
+        .appendFile(fileB) // bucket 1
+        .appendFile(fileC) // bucket 2
+        .appendFile(fileD) // bucket 3
         .commit();
 
     Iterable<DataFile> files = FindFiles.in(table)
         .inPartitions(table.spec(), StaticDataTask.Row.of(1), StaticDataTask.Row.of(2))
         .collect();
 
-    Assert.assertEquals(pathSet(FILE_B, FILE_C), pathSet(files));
+    Assert.assertEquals(pathSet(fileB, fileC), pathSet(files));
   }
 
   @Test
   public void testAsOfTimestamp() {
     table.newAppend()
-        .appendFile(FILE_A)
+        .appendFile(fileA)
         .commit();
 
     table.newAppend()
-        .appendFile(FILE_B)
+        .appendFile(fileB)
         .commit();
 
     long timestamp = System.currentTimeMillis();
 
     table.newAppend()
-        .appendFile(FILE_C)
+        .appendFile(fileC)
         .commit();
 
     table.newAppend()
-        .appendFile(FILE_D)
+        .appendFile(fileD)
         .commit();
 
     Iterable<DataFile> files = FindFiles.in(table).asOfTime(timestamp).collect();
 
-    Assert.assertEquals(pathSet(FILE_A, FILE_B), pathSet(files));
+    Assert.assertEquals(pathSet(fileA, fileB), pathSet(files));
   }
 
   @Test
   public void testSnapshotId() {
     table.newAppend()
-        .appendFile(FILE_A)
-        .appendFile(FILE_B)
+        .appendFile(fileA)
+        .appendFile(fileB)
         .commit();
 
     table.newAppend()
-        .appendFile(FILE_C)
+        .appendFile(fileC)
         .commit();
 
     long snapshotId = table.currentSnapshot().snapshotId();
 
     table.newAppend()
-        .appendFile(FILE_D)
+        .appendFile(fileD)
         .commit();
 
     Iterable<DataFile> files = FindFiles.in(table).inSnapshot(snapshotId).collect();
 
-    Assert.assertEquals(pathSet(FILE_A, FILE_B, FILE_C), pathSet(files));
+    Assert.assertEquals(pathSet(fileA, fileB, fileC), pathSet(files));
   }
 
   @Test
   public void testCaseSensitivity() {
     table.newAppend()
-        .appendFile(FILE_A)
-        .appendFile(FILE_B)
-        .appendFile(FILE_C)
-        .appendFile(FILE_D)
+        .appendFile(fileA)
+        .appendFile(fileB)
+        .appendFile(fileC)
+        .appendFile(fileD)
         .commit();
 
     Iterable<DataFile> files = FindFiles.in(table)
         .caseInsensitive()
-        .withMetadataMatching(Expressions.startsWith("FILE_PATH", "/path/to/data-a"))
+        .withMetadataMatching(Expressions.startsWith("FILE_PATH", fileA.path().toString()))
         .collect();
 
-    Assert.assertEquals(pathSet(FILE_A), pathSet(files));
+    Assert.assertTrue(pathSet(files).size() == 1);
   }
 
   private Set<String> pathSet(DataFile... files) {

--- a/core/src/test/java/org/apache/iceberg/TestManifestCleanup.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestCleanup.java
@@ -30,8 +30,8 @@ public class TestManifestCleanup extends TableTestBase {
         0, listManifestFiles().size());
 
     table.newAppend()
-        .appendFile(FILE_A)
-        .appendFile(FILE_B)
+        .appendFile(fileA)
+        .appendFile(fileB)
         .commit();
 
     Assert.assertEquals("Table should have one append manifest",
@@ -56,8 +56,8 @@ public class TestManifestCleanup extends TableTestBase {
         0, listManifestFiles().size());
 
     table.newAppend()
-        .appendFile(FILE_A)
-        .appendFile(FILE_B)
+        .appendFile(fileA)
+        .appendFile(fileB)
         .commit();
 
     Snapshot s1 = table.currentSnapshot();
@@ -65,7 +65,7 @@ public class TestManifestCleanup extends TableTestBase {
         1, s1.manifests().size());
 
     table.newDelete()
-        .deleteFile(FILE_B)
+        .deleteFile(fileB)
         .commit();
 
     Snapshot s2 = table.currentSnapshot();
@@ -85,8 +85,8 @@ public class TestManifestCleanup extends TableTestBase {
         0, listManifestFiles().size());
 
     table.newAppend()
-        .appendFile(FILE_A)
-        .appendFile(FILE_B)
+        .appendFile(fileA)
+        .appendFile(fileB)
         .commit();
 
     Assert.assertEquals("Table should have one append manifest",
@@ -94,8 +94,8 @@ public class TestManifestCleanup extends TableTestBase {
 
     table.newOverwrite()
         .overwriteByRowFilter(Expressions.alwaysTrue())
-        .addFile(FILE_C)
-        .addFile(FILE_D)
+        .addFile(fileC)
+        .addFile(fileD)
         .commit();
 
     Assert.assertEquals("Table should have one delete manifest and one append manifest",
@@ -103,8 +103,8 @@ public class TestManifestCleanup extends TableTestBase {
 
     table.newOverwrite()
         .overwriteByRowFilter(Expressions.alwaysTrue())
-        .addFile(FILE_A)
-        .addFile(FILE_B)
+        .addFile(fileA)
+        .addFile(fileB)
         .commit();
 
     Assert.assertEquals("Table should have one delete manifest and one append manifest",

--- a/core/src/test/java/org/apache/iceberg/TestOverwriteWithValidation.java
+++ b/core/src/test/java/org/apache/iceberg/TestOverwriteWithValidation.java
@@ -54,61 +54,13 @@ public class TestOverwriteWithValidation extends TableTestBase {
       .identity("date")
       .build();
 
-  private static final DataFile FILE_DAY_1 = DataFiles
-      .builder(PARTITION_SPEC)
-      .withPath("/path/to/data-1.parquet")
-      .withFileSizeInBytes(0)
-      .withPartitionPath("date=2018-06-08")
-      .withMetrics(new Metrics(5L,
-          null, // no column sizes
-          ImmutableMap.of(1, 5L, 2, 3L), // value count
-          ImmutableMap.of(1, 0L, 2, 2L), // null count
-          ImmutableMap.of(1, longToBuffer(0L)), // lower bounds
-          ImmutableMap.of(1, longToBuffer(4L)) // upper bounds
-      ))
-      .build();
+  private static DataFile fileDay1;
 
-  private static final DataFile FILE_DAY_2 = DataFiles
-      .builder(PARTITION_SPEC)
-      .withPath("/path/to/data-2.parquet")
-      .withFileSizeInBytes(0)
-      .withPartitionPath("date=2018-06-09")
-      .withMetrics(new Metrics(5L,
-          null, // no column sizes
-          ImmutableMap.of(1, 5L, 2, 3L), // value count
-          ImmutableMap.of(1, 0L, 2, 2L), // null count
-          ImmutableMap.of(1, longToBuffer(5L)), // lower bounds
-          ImmutableMap.of(1, longToBuffer(9L)) // upper bounds
-      ))
-      .build();
+  private static DataFile fileDay2;
 
-  private static final DataFile FILE_DAY_2_MODIFIED = DataFiles
-      .builder(PARTITION_SPEC)
-      .withPath("/path/to/data-3.parquet")
-      .withFileSizeInBytes(0)
-      .withPartitionPath("date=2018-06-09")
-      .withMetrics(new Metrics(5L,
-          null, // no column sizes
-          ImmutableMap.of(1, 5L, 2, 3L), // value count
-          ImmutableMap.of(1, 0L, 2, 2L), // null count
-          ImmutableMap.of(1, longToBuffer(5L)), // lower bounds
-          ImmutableMap.of(1, longToBuffer(9L)) // upper bounds
-      ))
-      .build();
+  private static DataFile fileDay2Modified;
 
-  private static final DataFile FILE_DAY_2_ANOTHER_RANGE = DataFiles
-      .builder(PARTITION_SPEC)
-      .withPath("/path/to/data-3.parquet")
-      .withFileSizeInBytes(0)
-      .withPartitionPath("date=2018-06-09")
-      .withMetrics(new Metrics(5L,
-          null, // no column sizes
-          ImmutableMap.of(1, 5L, 2, 3L), // value count
-          ImmutableMap.of(1, 0L, 2, 2L), // null count
-          ImmutableMap.of(1, longToBuffer(10L)), // lower bounds
-          ImmutableMap.of(1, longToBuffer(14L)) // upper bounds
-      ))
-      .build();
+  private static DataFile fileDay2AnotherRange;
 
   private static final Expression EXPRESSION_DAY_2 = equal("date", "2018-06-09");
 
@@ -127,6 +79,62 @@ public class TestOverwriteWithValidation extends TableTestBase {
     File tableDir = temp.newFolder();
     Assert.assertTrue(tableDir.delete());
     this.table = TestTables.create(tableDir, TABLE_NAME, DATE_SCHEMA, PARTITION_SPEC);
+
+    fileDay1 = DataFiles
+            .builder(PARTITION_SPEC, table.location())
+            .withPath("/path/to/data-1.parquet")
+            .withFileSizeInBytes(0)
+            .withPartitionPath("date=2018-06-08")
+            .withMetrics(new Metrics(5L,
+                    null, // no column sizes
+                    ImmutableMap.of(1, 5L, 2, 3L), // value count
+                    ImmutableMap.of(1, 0L, 2, 2L), // null count
+                    ImmutableMap.of(1, longToBuffer(0L)), // lower bounds
+                    ImmutableMap.of(1, longToBuffer(4L)) // upper bounds
+            ))
+            .build();
+
+    fileDay2 = DataFiles
+            .builder(PARTITION_SPEC, table.location())
+            .withPath("/path/to/data-2.parquet")
+            .withFileSizeInBytes(0)
+            .withPartitionPath("date=2018-06-09")
+            .withMetrics(new Metrics(5L,
+                    null, // no column sizes
+                    ImmutableMap.of(1, 5L, 2, 3L), // value count
+                    ImmutableMap.of(1, 0L, 2, 2L), // null count
+                    ImmutableMap.of(1, longToBuffer(5L)), // lower bounds
+                    ImmutableMap.of(1, longToBuffer(9L)) // upper bounds
+            ))
+            .build();
+
+    fileDay2Modified = DataFiles
+            .builder(PARTITION_SPEC, table.location())
+            .withPath("/path/to/data-3.parquet")
+            .withFileSizeInBytes(0)
+            .withPartitionPath("date=2018-06-09")
+            .withMetrics(new Metrics(5L,
+                    null, // no column sizes
+                    ImmutableMap.of(1, 5L, 2, 3L), // value count
+                    ImmutableMap.of(1, 0L, 2, 2L), // null count
+                    ImmutableMap.of(1, longToBuffer(5L)), // lower bounds
+                    ImmutableMap.of(1, longToBuffer(9L)) // upper bounds
+            ))
+            .build();
+
+    fileDay2AnotherRange = DataFiles
+            .builder(PARTITION_SPEC, table.location())
+            .withPath("/path/to/data-3.parquet")
+            .withFileSizeInBytes(0)
+            .withPartitionPath("date=2018-06-09")
+            .withMetrics(new Metrics(5L,
+                    null, // no column sizes
+                    ImmutableMap.of(1, 5L, 2, 3L), // value count
+                    ImmutableMap.of(1, 0L, 2, 2L), // null count
+                    ImmutableMap.of(1, longToBuffer(10L)), // lower bounds
+                    ImmutableMap.of(1, longToBuffer(14L)) // upper bounds
+            ))
+            .build();
   }
 
   @Test
@@ -134,10 +142,10 @@ public class TestOverwriteWithValidation extends TableTestBase {
     Assert.assertNull("Should be empty table", table.currentSnapshot());
 
     table.newOverwrite()
-        .addFile(FILE_DAY_2_MODIFIED)
+        .addFile(fileDay2Modified)
         .commit();
 
-    validateTableFiles(table, FILE_DAY_2_MODIFIED);
+    validateTableFiles(table, fileDay2Modified);
   }
 
   @Test
@@ -145,11 +153,11 @@ public class TestOverwriteWithValidation extends TableTestBase {
     Assert.assertNull("Should be empty table", table.currentSnapshot());
 
     table.newOverwrite()
-        .addFile(FILE_DAY_2_MODIFIED)
+        .addFile(fileDay2Modified)
         .validateNoConflictingAppends(null, alwaysTrue())
         .commit();
 
-    validateTableFiles(table, FILE_DAY_2_MODIFIED);
+    validateTableFiles(table, fileDay2Modified);
   }
 
   @Test
@@ -157,106 +165,106 @@ public class TestOverwriteWithValidation extends TableTestBase {
     Assert.assertNull("Should be empty table", table.currentSnapshot());
 
     table.newOverwrite()
-        .addFile(FILE_DAY_2_MODIFIED)
+        .addFile(fileDay2Modified)
         .validateNoConflictingAppends(null, EXPRESSION_DAY_2)
         .commit();
 
-    validateTableFiles(table, FILE_DAY_2_MODIFIED);
+    validateTableFiles(table, fileDay2Modified);
   }
 
   @Test
   public void testOverwriteTableNotValidated() {
     table.newAppend()
-        .appendFile(FILE_DAY_1)
-        .appendFile(FILE_DAY_2)
+        .appendFile(fileDay1)
+        .appendFile(fileDay2)
         .commit();
 
     Snapshot baseSnapshot = table.currentSnapshot();
-    validateSnapshot(null, baseSnapshot, FILE_DAY_1, FILE_DAY_2);
+    validateSnapshot(null, baseSnapshot, table.location(), fileDay1, fileDay2);
 
     table.newOverwrite()
-        .deleteFile(FILE_DAY_2)
-        .addFile(FILE_DAY_2_MODIFIED)
+        .deleteFile(fileDay2)
+        .addFile(fileDay2Modified)
         .commit();
 
-    validateTableFiles(table, FILE_DAY_1, FILE_DAY_2_MODIFIED);
+    validateTableFiles(table, fileDay1, fileDay2Modified);
   }
 
   @Test
   public void testOverwriteTableStrictValidated() {
     table.newAppend()
-        .appendFile(FILE_DAY_1)
-        .appendFile(FILE_DAY_2)
+        .appendFile(fileDay1)
+        .appendFile(fileDay2)
         .commit();
 
     Snapshot baseSnapshot = table.currentSnapshot();
-    validateSnapshot(null, baseSnapshot, FILE_DAY_1, FILE_DAY_2);
+    validateSnapshot(null, baseSnapshot, table.location(), fileDay1, fileDay2);
 
     table.newOverwrite()
-        .deleteFile(FILE_DAY_2)
-        .addFile(FILE_DAY_2_MODIFIED)
+        .deleteFile(fileDay2)
+        .addFile(fileDay2Modified)
         .validateNoConflictingAppends(baseSnapshot.snapshotId(), alwaysTrue())
         .commit();
 
-    validateTableFiles(table, FILE_DAY_1, FILE_DAY_2_MODIFIED);
+    validateTableFiles(table, fileDay1, fileDay2Modified);
   }
 
   @Test
   public void testOverwriteTableValidated() {
     table.newAppend()
-        .appendFile(FILE_DAY_1)
-        .appendFile(FILE_DAY_2)
+        .appendFile(fileDay1)
+        .appendFile(fileDay2)
         .commit();
 
     Snapshot baseSnapshot = table.currentSnapshot();
-    validateSnapshot(null, baseSnapshot, FILE_DAY_1, FILE_DAY_2);
+    validateSnapshot(null, baseSnapshot, table.location(), fileDay1, fileDay2);
 
     table.newOverwrite()
-        .deleteFile(FILE_DAY_2)
-        .addFile(FILE_DAY_2_MODIFIED)
+        .deleteFile(fileDay2)
+        .addFile(fileDay2Modified)
         .validateNoConflictingAppends(baseSnapshot.snapshotId(), EXPRESSION_DAY_2)
         .commit();
 
-    validateTableFiles(table, FILE_DAY_1, FILE_DAY_2_MODIFIED);
+    validateTableFiles(table, fileDay1, fileDay2Modified);
   }
 
   @Test
   public void testOverwriteCompatibleAdditionNotValidated() {
     table.newAppend()
-        .appendFile(FILE_DAY_2)
+        .appendFile(fileDay2)
         .commit();
 
-    validateSnapshot(null, table.currentSnapshot(), FILE_DAY_2);
+    validateSnapshot(null, table.currentSnapshot(), table.location(), fileDay2);
 
     OverwriteFiles overwrite = table.newOverwrite()
-        .deleteFile(FILE_DAY_2)
-        .addFile(FILE_DAY_2_MODIFIED);
+        .deleteFile(fileDay2)
+        .addFile(fileDay2Modified);
 
     table.newAppend()
-        .appendFile(FILE_DAY_1)
+        .appendFile(fileDay1)
         .commit();
 
     overwrite.commit();
 
-    validateTableFiles(table, FILE_DAY_1, FILE_DAY_2_MODIFIED);
+    validateTableFiles(table, fileDay1, fileDay2Modified);
   }
 
   @Test
   public void testOverwriteCompatibleAdditionStrictValidated() {
     table.newAppend()
-        .appendFile(FILE_DAY_2)
+        .appendFile(fileDay2)
         .commit();
 
     Snapshot baseSnapshot = table.currentSnapshot();
-    validateSnapshot(null, baseSnapshot, FILE_DAY_2);
+    validateSnapshot(null, baseSnapshot, table.location(), fileDay2);
 
     OverwriteFiles overwrite = table.newOverwrite()
-        .deleteFile(FILE_DAY_2)
-        .addFile(FILE_DAY_2_MODIFIED)
+        .deleteFile(fileDay2)
+        .addFile(fileDay2Modified)
         .validateNoConflictingAppends(baseSnapshot.snapshotId(), alwaysTrue());
 
     table.newAppend()
-        .appendFile(FILE_DAY_1)
+        .appendFile(fileDay1)
         .commit();
     long committedSnapshotId = table.currentSnapshot().snapshotId();
 
@@ -271,65 +279,65 @@ public class TestOverwriteWithValidation extends TableTestBase {
   @Test
   public void testOverwriteCompatibleAdditionValidated() {
     table.newAppend()
-        .appendFile(FILE_DAY_2)
+        .appendFile(fileDay2)
         .commit();
 
     Snapshot baseSnapshot = table.currentSnapshot();
-    validateSnapshot(null, baseSnapshot, FILE_DAY_2);
+    validateSnapshot(null, baseSnapshot, table.location(), fileDay2);
 
     OverwriteFiles overwrite = table.newOverwrite()
-        .deleteFile(FILE_DAY_2)
-        .addFile(FILE_DAY_2_MODIFIED)
+        .deleteFile(fileDay2)
+        .addFile(fileDay2Modified)
         .validateNoConflictingAppends(baseSnapshot.snapshotId(), EXPRESSION_DAY_2);
 
     table.newAppend()
-        .appendFile(FILE_DAY_1)
+        .appendFile(fileDay1)
         .commit();
 
     overwrite.commit();
 
-    validateTableFiles(table, FILE_DAY_1, FILE_DAY_2_MODIFIED);
+    validateTableFiles(table, fileDay1, fileDay2Modified);
   }
 
   @Test
   public void testOverwriteCompatibleDeletionValidated() {
     table.newAppend()
-        .appendFile(FILE_DAY_1)
-        .appendFile(FILE_DAY_2)
+        .appendFile(fileDay1)
+        .appendFile(fileDay2)
         .commit();
 
     Snapshot baseSnapshot = table.currentSnapshot();
-    validateSnapshot(null, baseSnapshot, FILE_DAY_1, FILE_DAY_2);
+    validateSnapshot(null, baseSnapshot, table.location(), fileDay1, fileDay2);
 
     OverwriteFiles overwrite = table.newOverwrite()
-        .deleteFile(FILE_DAY_2)
-        .addFile(FILE_DAY_2_MODIFIED)
+        .deleteFile(fileDay2)
+        .addFile(fileDay2Modified)
         .validateNoConflictingAppends(baseSnapshot.snapshotId(), EXPRESSION_DAY_2);
 
     table.newDelete()
-        .deleteFile(FILE_DAY_1)
+        .deleteFile(fileDay1)
         .commit();
 
     overwrite.commit();
 
-    validateTableFiles(table, FILE_DAY_2_MODIFIED);
+    validateTableFiles(table, fileDay2Modified);
   }
 
   @Test
   public void testOverwriteIncompatibleAdditionValidated() {
     table.newAppend()
-        .appendFile(FILE_DAY_1)
+        .appendFile(fileDay1)
         .commit();
 
     Snapshot baseSnapshot = table.currentSnapshot();
-    validateSnapshot(null, baseSnapshot, FILE_DAY_1);
+    validateSnapshot(null, baseSnapshot, table.location(), fileDay1);
 
     OverwriteFiles overwrite = table.newOverwrite()
-        .addFile(FILE_DAY_2_MODIFIED)
+        .addFile(fileDay2Modified)
         .validateNoConflictingAppends(baseSnapshot.snapshotId(), EXPRESSION_DAY_2);
 
     table.newAppend()
-        .appendFile(FILE_DAY_2)
+        .appendFile(fileDay2)
         .commit();
     long committedSnapshotId = table.currentSnapshot().snapshotId();
 
@@ -344,20 +352,20 @@ public class TestOverwriteWithValidation extends TableTestBase {
   @Test
   public void testOverwriteIncompatibleDeletionValidated() {
     table.newAppend()
-        .appendFile(FILE_DAY_1)
-        .appendFile(FILE_DAY_2)
+        .appendFile(fileDay1)
+        .appendFile(fileDay2)
         .commit();
 
     Snapshot baseSnapshot = table.currentSnapshot();
-    validateSnapshot(null, baseSnapshot, FILE_DAY_1, FILE_DAY_2);
+    validateSnapshot(null, baseSnapshot, table.location(), fileDay1, fileDay2);
 
     OverwriteFiles overwrite = table.newOverwrite()
-        .deleteFile(FILE_DAY_2)
-        .addFile(FILE_DAY_2_MODIFIED)
+        .deleteFile(fileDay2)
+        .addFile(fileDay2Modified)
         .validateNoConflictingAppends(baseSnapshot.snapshotId(), EXPRESSION_DAY_2);
 
     table.newDelete()
-        .deleteFile(FILE_DAY_2)
+        .deleteFile(fileDay2)
         .commit();
     long committedSnapshotId = table.currentSnapshot().snapshotId();
 
@@ -372,20 +380,20 @@ public class TestOverwriteWithValidation extends TableTestBase {
   @Test
   public void testOverwriteIncompatibleRewriteValidated() {
     table.newAppend()
-        .appendFile(FILE_DAY_1)
-        .appendFile(FILE_DAY_2)
+        .appendFile(fileDay1)
+        .appendFile(fileDay2)
         .commit();
 
     Snapshot baseSnapshot = table.currentSnapshot();
-    validateSnapshot(null, baseSnapshot, FILE_DAY_1, FILE_DAY_2);
+    validateSnapshot(null, baseSnapshot, table.location(), fileDay1, fileDay2);
 
     OverwriteFiles overwrite = table.newOverwrite()
-        .deleteFile(FILE_DAY_2)
-        .addFile(FILE_DAY_2_MODIFIED)
+        .deleteFile(fileDay2)
+        .addFile(fileDay2Modified)
         .validateNoConflictingAppends(baseSnapshot.snapshotId(), EXPRESSION_DAY_2);
 
     table.newRewrite()
-        .rewriteFiles(ImmutableSet.of(FILE_DAY_2), ImmutableSet.of(FILE_DAY_2))
+        .rewriteFiles(ImmutableSet.of(fileDay2), ImmutableSet.of(fileDay2))
         .commit();
     long committedSnapshotId = table.currentSnapshot().snapshotId();
 
@@ -400,19 +408,19 @@ public class TestOverwriteWithValidation extends TableTestBase {
   @Test
   public void testOverwriteCompatibleExpirationAdditionValidated() {
     table.newAppend()
-        .appendFile(FILE_DAY_2)
+        .appendFile(fileDay2)
         .commit(); // id 1
 
     Snapshot baseSnapshot = table.currentSnapshot();
-    validateSnapshot(null, baseSnapshot, FILE_DAY_2);
+    validateSnapshot(null, baseSnapshot, table.location(), fileDay2);
 
     OverwriteFiles overwrite = table.newOverwrite()
-        .deleteFile(FILE_DAY_2)
-        .addFile(FILE_DAY_2_MODIFIED)
+        .deleteFile(fileDay2)
+        .addFile(fileDay2Modified)
         .validateNoConflictingAppends(baseSnapshot.snapshotId(), EXPRESSION_DAY_2);
 
     table.newAppend()
-        .appendFile(FILE_DAY_1)
+        .appendFile(fileDay1)
         .commit(); // id 2
 
     table.expireSnapshots()
@@ -421,26 +429,26 @@ public class TestOverwriteWithValidation extends TableTestBase {
 
     overwrite.commit();
 
-    validateTableFiles(table, FILE_DAY_1, FILE_DAY_2_MODIFIED);
+    validateTableFiles(table, fileDay1, fileDay2Modified);
   }
 
   @Test
   public void testOverwriteCompatibleExpirationDeletionValidated() {
     table.newAppend()
-        .appendFile(FILE_DAY_1)
-        .appendFile(FILE_DAY_2)
+        .appendFile(fileDay1)
+        .appendFile(fileDay2)
         .commit(); // id 1
 
     Snapshot baseSnapshot = table.currentSnapshot();
-    validateSnapshot(null, baseSnapshot, FILE_DAY_1, FILE_DAY_2);
+    validateSnapshot(null, baseSnapshot, table.location(), fileDay1, fileDay2);
 
     OverwriteFiles overwrite = table.newOverwrite()
-        .deleteFile(FILE_DAY_2)
-        .addFile(FILE_DAY_2_MODIFIED)
+        .deleteFile(fileDay2)
+        .addFile(fileDay2Modified)
         .validateNoConflictingAppends(baseSnapshot.snapshotId(), EXPRESSION_DAY_2);
 
     table.newDelete()
-        .deleteFile(FILE_DAY_1)
+        .deleteFile(fileDay1)
         .commit(); // id 2
 
     table.expireSnapshots()
@@ -449,26 +457,26 @@ public class TestOverwriteWithValidation extends TableTestBase {
 
     overwrite.commit();
 
-    validateTableFiles(table, FILE_DAY_2_MODIFIED);
+    validateTableFiles(table, fileDay2Modified);
   }
 
   @Test
   public void testOverwriteIncompatibleExpirationValidated() {
     table.newAppend()
-        .appendFile(FILE_DAY_1)
+        .appendFile(fileDay1)
         .commit(); // id 1
 
     Snapshot baseSnapshot = table.currentSnapshot();
     OverwriteFiles overwrite = table.newOverwrite()
-        .addFile(FILE_DAY_2_MODIFIED)
+        .addFile(fileDay2Modified)
         .validateNoConflictingAppends(baseSnapshot.snapshotId(), EXPRESSION_DAY_2);
 
     table.newAppend()
-        .appendFile(FILE_DAY_2)
+        .appendFile(fileDay2)
         .commit(); // id 2
 
     table.newDelete()
-        .deleteFile(FILE_DAY_1)
+        .deleteFile(fileDay1)
         .commit(); // id 3
 
     table.expireSnapshots()
@@ -489,15 +497,15 @@ public class TestOverwriteWithValidation extends TableTestBase {
     Assert.assertNull("Should be empty table", table.currentSnapshot());
 
     OverwriteFiles overwrite = table.newOverwrite()
-        .addFile(FILE_DAY_2_MODIFIED)
+        .addFile(fileDay2Modified)
         .validateNoConflictingAppends(null, EXPRESSION_DAY_2);
 
     table.newAppend()
-        .appendFile(FILE_DAY_2)
+        .appendFile(fileDay2)
         .commit(); // id 1
 
     table.newDelete()
-        .deleteFile(FILE_DAY_1)
+        .deleteFile(fileDay1)
         .commit(); // id 2
 
     table.expireSnapshots()
@@ -518,16 +526,16 @@ public class TestOverwriteWithValidation extends TableTestBase {
     Assert.assertNull("Should be empty table", table.currentSnapshot());
 
     OverwriteFiles overwrite = table.newOverwrite()
-        .addFile(FILE_DAY_2_MODIFIED)
+        .addFile(fileDay2Modified)
         .validateNoConflictingAppends(null, EXPRESSION_DAY_2_ID_RANGE);
 
     table.newAppend()
-        .appendFile(FILE_DAY_1)
+        .appendFile(fileDay1)
         .commit();
 
     overwrite.commit();
 
-    validateTableFiles(table, FILE_DAY_1, FILE_DAY_2_MODIFIED);
+    validateTableFiles(table, fileDay1, fileDay2Modified);
   }
 
   @Test
@@ -536,16 +544,16 @@ public class TestOverwriteWithValidation extends TableTestBase {
 
     Expression conflictDetectionFilter = and(EXPRESSION_DAY_2, EXPRESSION_DAY_2_ID_RANGE);
     OverwriteFiles overwrite = table.newOverwrite()
-        .addFile(FILE_DAY_2_MODIFIED)
+        .addFile(fileDay2Modified)
         .validateNoConflictingAppends(null, conflictDetectionFilter);
 
     table.newAppend()
-        .appendFile(FILE_DAY_2_ANOTHER_RANGE)
+        .appendFile(fileDay2AnotherRange)
         .commit();
 
     overwrite.commit();
 
-    validateTableFiles(table, FILE_DAY_2_ANOTHER_RANGE, FILE_DAY_2_MODIFIED);
+    validateTableFiles(table, fileDay2AnotherRange, fileDay2Modified);
   }
 
   @Test
@@ -553,25 +561,25 @@ public class TestOverwriteWithValidation extends TableTestBase {
     Assert.assertNull("Should be empty table", table.currentSnapshot());
 
     table.newAppend()
-        .appendFile(FILE_DAY_2)
+        .appendFile(fileDay2)
         .commit();
 
     Snapshot baseSnapshot = table.currentSnapshot();
 
     Transaction txn = table.newTransaction();
     OverwriteFiles overwrite = txn.newOverwrite()
-        .deleteFile(FILE_DAY_2)
-        .addFile(FILE_DAY_2_MODIFIED)
+        .deleteFile(fileDay2)
+        .addFile(fileDay2Modified)
         .validateNoConflictingAppends(baseSnapshot.snapshotId(), EXPRESSION_DAY_2);
 
     table.newAppend()
-        .appendFile(FILE_DAY_1)
+        .appendFile(fileDay1)
         .commit();
 
     overwrite.commit();
     txn.commitTransaction();
 
-    validateTableFiles(table, FILE_DAY_1, FILE_DAY_2_MODIFIED);
+    validateTableFiles(table, fileDay1, fileDay2Modified);
   }
 
   @Test
@@ -581,15 +589,15 @@ public class TestOverwriteWithValidation extends TableTestBase {
     Transaction txn = table.newTransaction();
 
     txn.newAppend()
-        .appendFile(FILE_DAY_1)
+        .appendFile(fileDay1)
         .commit();
 
     OverwriteFiles overwrite = txn.newOverwrite()
-        .addFile(FILE_DAY_2_MODIFIED)
+        .addFile(fileDay2Modified)
         .validateNoConflictingAppends(null, EXPRESSION_DAY_2);
 
     table.newAppend()
-        .appendFile(FILE_DAY_2)
+        .appendFile(fileDay2)
         .commit();
     long committedSnapshotId = table.currentSnapshot().snapshotId();
 

--- a/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
@@ -44,12 +44,12 @@ public class TestReplaceTransaction extends TableTestBase {
     Schema schema = table.schema();
 
     table.newAppend()
-        .appendFile(FILE_A)
+        .appendFile(fileA)
         .commit();
 
     Assert.assertEquals("Version should be 1", 1L, (long) version());
 
-    validateSnapshot(start, table.currentSnapshot(), FILE_A);
+    validateSnapshot(start, table.currentSnapshot(), fileA);
 
     Transaction replace = TestTables.beginReplace(tableDir, "test", newSchema, unpartitioned());
     replace.commitTransaction();
@@ -72,12 +72,12 @@ public class TestReplaceTransaction extends TableTestBase {
     Snapshot start = table.currentSnapshot();
 
     table.newAppend()
-        .appendFile(FILE_A)
+        .appendFile(fileA)
         .commit();
 
     Assert.assertEquals("Version should be 1", 1L, (long) version());
 
-    validateSnapshot(start, table.currentSnapshot(), FILE_A);
+    validateSnapshot(start, table.currentSnapshot(), fileA);
 
     Transaction replace = TestTables.beginReplace(tableDir, "test", newSchema, unpartitioned());
     replace.commitTransaction();
@@ -99,12 +99,12 @@ public class TestReplaceTransaction extends TableTestBase {
     Schema schema = table.schema();
 
     table.newAppend()
-        .appendFile(FILE_A)
+        .appendFile(fileA)
         .commit();
 
     Assert.assertEquals("Version should be 1", 1L, (long) version());
 
-    validateSnapshot(start, table.currentSnapshot(), FILE_A);
+    validateSnapshot(start, table.currentSnapshot(), fileA);
 
     Transaction replace = TestTables.beginReplace(tableDir, "test", table.schema(), newSpec);
     replace.commitTransaction();
@@ -125,19 +125,19 @@ public class TestReplaceTransaction extends TableTestBase {
     Schema schema = table.schema();
 
     table.newAppend()
-        .appendFile(FILE_A)
+        .appendFile(fileA)
         .commit();
 
     Assert.assertEquals("Version should be 1", 1L, (long) version());
 
-    validateSnapshot(start, table.currentSnapshot(), FILE_A);
+    validateSnapshot(start, table.currentSnapshot(), fileA);
 
     Transaction replace = TestTables.beginReplace(tableDir, "test", table.schema(), table.spec());
 
     replace.newAppend()
-        .appendFile(FILE_B)
-        .appendFile(FILE_C)
-        .appendFile(FILE_D)
+        .appendFile(fileB)
+        .appendFile(fileC)
+        .appendFile(fileD)
         .commit();
 
     replace.commitTransaction();
@@ -149,7 +149,7 @@ public class TestReplaceTransaction extends TableTestBase {
     Assert.assertEquals("Schema should use new schema, not compatible with previous",
         schema.asStruct(), table.schema().asStruct());
 
-    validateSnapshot(null, table.currentSnapshot(), FILE_B, FILE_C, FILE_D);
+    validateSnapshot(null, table.currentSnapshot(), fileB, fileC, fileD);
   }
 
   @Test
@@ -159,9 +159,9 @@ public class TestReplaceTransaction extends TableTestBase {
     Transaction replace = TestTables.beginReplace(tableDir, "test", table.schema(), table.spec());
 
     replace.newAppend() // not committed
-        .appendFile(FILE_B)
-        .appendFile(FILE_C)
-        .appendFile(FILE_D);
+        .appendFile(fileB)
+        .appendFile(fileC)
+        .appendFile(fileD);
 
     AssertHelpers.assertThrows("Should reject commit when last operation has not committed",
         IllegalStateException.class, "Cannot commit transaction: last operation has not committed",
@@ -177,9 +177,9 @@ public class TestReplaceTransaction extends TableTestBase {
     Transaction replace = TestTables.beginReplace(tableDir, "test", table.schema(), table.spec());
 
     replace.table().newAppend() // not committed
-        .appendFile(FILE_B)
-        .appendFile(FILE_C)
-        .appendFile(FILE_D);
+        .appendFile(fileB)
+        .appendFile(fileC)
+        .appendFile(fileD);
 
     AssertHelpers.assertThrows("Should reject commit when last operation has not committed",
         IllegalStateException.class, "Cannot commit transaction: last operation has not committed",
@@ -194,19 +194,19 @@ public class TestReplaceTransaction extends TableTestBase {
     Schema schema = table.schema();
 
     table.newAppend()
-        .appendFile(FILE_A)
+        .appendFile(fileA)
         .commit();
 
     Assert.assertEquals("Version should be 1", 1L, (long) version());
 
-    validateSnapshot(start, table.currentSnapshot(), FILE_A);
+    validateSnapshot(start, table.currentSnapshot(), fileA);
 
     Transaction replace = TestTables.beginReplace(tableDir, "test", table.schema(), table.spec());
 
     replace.newAppend()
-        .appendFile(FILE_B)
-        .appendFile(FILE_C)
-        .appendFile(FILE_D)
+        .appendFile(fileB)
+        .appendFile(fileC)
+        .appendFile(fileD)
         .commit();
 
     // trigger eventual transaction retry
@@ -221,7 +221,7 @@ public class TestReplaceTransaction extends TableTestBase {
     Assert.assertEquals("Schema should use new schema, not compatible with previous",
         schema.asStruct(), table.schema().asStruct());
 
-    validateSnapshot(null, table.currentSnapshot(), FILE_B, FILE_C, FILE_D);
+    validateSnapshot(null, table.currentSnapshot(), fileB, fileC, fileD);
   }
 
   @Test
@@ -229,20 +229,20 @@ public class TestReplaceTransaction extends TableTestBase {
     Snapshot start = table.currentSnapshot();
 
     table.newAppend()
-        .appendFile(FILE_A)
+        .appendFile(fileA)
         .commit();
 
     Assert.assertEquals("Version should be 1", 1L, (long) version());
 
-    validateSnapshot(start, table.currentSnapshot(), FILE_A);
+    validateSnapshot(start, table.currentSnapshot(), fileA);
     Set<File> manifests = Sets.newHashSet(listManifestFiles());
 
     Transaction replace = TestTables.beginReplace(tableDir, "test", table.schema(), table.spec());
 
     replace.newAppend()
-        .appendFile(FILE_B)
-        .appendFile(FILE_C)
-        .appendFile(FILE_D)
+        .appendFile(fileB)
+        .appendFile(fileC)
+        .appendFile(fileD)
         .commit();
 
     // keep failing to trigger eventual transaction failure
@@ -256,7 +256,7 @@ public class TestReplaceTransaction extends TableTestBase {
 
     table.refresh();
 
-    validateSnapshot(start, table.currentSnapshot(), FILE_A);
+    validateSnapshot(start, table.currentSnapshot(), fileA);
 
     Assert.assertEquals("Should clean up replace manifests", manifests, Sets.newHashSet(listManifestFiles()));
   }
@@ -278,8 +278,8 @@ public class TestReplaceTransaction extends TableTestBase {
         replace.table() instanceof BaseTransaction.TransactionTable);
 
     replace.newAppend()
-        .appendFile(FILE_A)
-        .appendFile(FILE_B)
+        .appendFile(fileA)
+        .appendFile(fileB)
         .commit();
 
     Assert.assertNull("Appending in a transaction should not commit metadata",
@@ -301,7 +301,7 @@ public class TestReplaceTransaction extends TableTestBase {
     Assert.assertEquals("Table spec should match", unpartitioned(), meta.spec());
     Assert.assertEquals("Table should have one snapshot", 1, meta.snapshots().size());
 
-    validateSnapshot(null, meta.currentSnapshot(), FILE_A, FILE_B);
+    validateSnapshot(null, meta.currentSnapshot(), tableDir.getPath(), fileA, fileB);
   }
 
   private static Schema assignFreshIds(Schema schema) {

--- a/core/src/test/java/org/apache/iceberg/TestScanDataFileColumns.java
+++ b/core/src/test/java/org/apache/iceberg/TestScanDataFileColumns.java
@@ -62,8 +62,8 @@ public class TestScanDataFileColumns {
 
     // commit the test data
     table.newAppend()
-        .appendFile(DataFiles.builder(PartitionSpec.unpartitioned())
-            .withPath("file1.parquet")
+        .appendFile(DataFiles.builder(PartitionSpec.unpartitioned(), table.location())
+            .withPath(new File("file1.parquet").getAbsolutePath())
             .withFileSizeInBytes(100)
             .withMetrics(new Metrics(3L,
                 ImmutableMap.of(1, 50L), // column size
@@ -72,8 +72,8 @@ public class TestScanDataFileColumns {
                 ImmutableMap.of(1, longToBuffer(0L)), // lower bounds
                 ImmutableMap.of(1, longToBuffer(2L)))) // upper bounds)
             .build())
-        .appendFile(DataFiles.builder(PartitionSpec.unpartitioned())
-            .withPath("file2.parquet")
+        .appendFile(DataFiles.builder(PartitionSpec.unpartitioned(), table.location())
+            .withPath(new File("file2.parquet").getAbsolutePath())
             .withFileSizeInBytes(100)
             .withMetrics(new Metrics(3L,
                 ImmutableMap.of(1, 60L), // column size
@@ -82,8 +82,8 @@ public class TestScanDataFileColumns {
                 ImmutableMap.of(1, longToBuffer(10L)), // lower bounds
                 ImmutableMap.of(1, longToBuffer(12L)))) // upper bounds)
             .build())
-        .appendFile(DataFiles.builder(PartitionSpec.unpartitioned())
-            .withPath("file3.parquet")
+        .appendFile(DataFiles.builder(PartitionSpec.unpartitioned(), table.location())
+            .withPath(new File("file3.parquet").getAbsolutePath())
             .withFileSizeInBytes(100)
             .withMetrics(new Metrics(3L,
                 ImmutableMap.of(1, 70L), // column size

--- a/core/src/test/java/org/apache/iceberg/TestScanSummary.java
+++ b/core/src/test/java/org/apache/iceberg/TestScanSummary.java
@@ -40,8 +40,8 @@ public class TestScanSummary extends TableTestBase {
     long t0 = System.currentTimeMillis();
 
     table.newAppend()
-        .appendFile(FILE_A) // data_bucket=0
-        .appendFile(FILE_B) // data_bucket=1
+        .appendFile(fileA) // data_bucket=0
+        .appendFile(fileB) // data_bucket=1
         .commit();
 
     long t1 = System.currentTimeMillis();
@@ -50,7 +50,7 @@ public class TestScanSummary extends TableTestBase {
     }
 
     table.newAppend()
-        .appendFile(FILE_C) // data_bucket=2
+        .appendFile(fileC) // data_bucket=2
         .commit();
 
     long secondSnapshotId = table.currentSnapshot().snapshotId();

--- a/core/src/test/java/org/apache/iceberg/TestScansAndSchemaEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestScansAndSchemaEvolution.java
@@ -51,7 +51,7 @@ public class TestScansAndSchemaEvolution {
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
 
-  private DataFile createDataFile(File dataPath, String partValue) throws IOException {
+  private DataFile createDataFile(File dataPath, String partValue, String tableLocation) throws IOException {
     List<GenericData.Record> expected = RandomAvroData.generate(SCHEMA, 100, 0L);
 
     File dataFile = new File(dataPath, FileFormat.AVRO.addExtension(UUID.randomUUID().toString()));
@@ -67,7 +67,7 @@ public class TestScansAndSchemaEvolution {
 
     PartitionData partition = new PartitionData(SPEC.partitionType());
     partition.set(0, partValue);
-    return DataFiles.builder(SPEC)
+    return DataFiles.builder(SPEC, tableLocation)
         .withInputFile(Files.localInput(dataFile))
         .withPartition(partition)
         .withRecordCount(100)
@@ -87,8 +87,8 @@ public class TestScansAndSchemaEvolution {
 
     Table table = TestTables.create(location, "test", SCHEMA, SPEC);
 
-    DataFile fileOne = createDataFile(dataLocation, "one");
-    DataFile fileTwo = createDataFile(dataLocation, "two");
+    DataFile fileOne = createDataFile(dataLocation, "one", table.location());
+    DataFile fileTwo = createDataFile(dataLocation, "two", table.location());
 
     table.newAppend()
         .appendFile(fileOne)

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotSelection.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotSelection.java
@@ -33,23 +33,23 @@ public class TestSnapshotSelection extends TableTestBase {
     Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
 
     table.newFastAppend()
-        .appendFile(FILE_A)
+        .appendFile(fileA)
         .commit();
     Snapshot firstSnapshot = table.currentSnapshot();
 
     table.newFastAppend()
-        .appendFile(FILE_B)
+        .appendFile(fileB)
         .commit();
     Snapshot secondSnapshot = table.currentSnapshot();
 
     Assert.assertEquals("Table should have two snapshots", 2, Iterables.size(table.snapshots()));
-    validateSnapshot(null, table.snapshot(firstSnapshot.snapshotId()), FILE_A);
-    validateSnapshot(firstSnapshot, table.snapshot(secondSnapshot.snapshotId()), FILE_B);
+    validateSnapshot(null, table.snapshot(firstSnapshot.snapshotId()), fileA);
+    validateSnapshot(firstSnapshot, table.snapshot(secondSnapshot.snapshotId()), fileB);
   }
 
   @Test
   public void testSnapshotStatsForAddedFiles() {
-    DataFile fileWithStats = DataFiles.builder(SPEC)
+    DataFile fileWithStats = DataFiles.builder(SPEC, table.location())
         .withPath("/path/to/data-with-stats.parquet")
         .withFileSizeInBytes(10)
         .withPartitionPath("data_bucket=0")

--- a/core/src/test/java/org/apache/iceberg/TestSplitPlanning.java
+++ b/core/src/test/java/org/apache/iceberg/TestSplitPlanning.java
@@ -157,8 +157,9 @@ public class TestSplitPlanning {
 
   private DataFile newFile(long sizeInBytes) {
     String fileName = UUID.randomUUID().toString();
-    return DataFiles.builder(PartitionSpec.unpartitioned())
-        .withPath(FileFormat.PARQUET.addExtension(fileName))
+    String absPath = new File(FileFormat.PARQUET.addExtension(fileName)).getAbsolutePath();
+    return DataFiles.builder(PartitionSpec.unpartitioned(), table.location())
+        .withPath(absPath)
         .withFileSizeInBytes(sizeInBytes)
         .withRecordCount(2)
         .build();

--- a/core/src/test/java/org/apache/iceberg/hadoop/HadoopTableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/HadoopTableTestBase.java
@@ -73,30 +73,10 @@ public class HadoopTableTestBase {
 
   static final HadoopTables TABLES = new HadoopTables(new Configuration());
 
-  static final DataFile FILE_A = DataFiles.builder(SPEC)
-      .withPath("/path/to/data-a.parquet")
-      .withFileSizeInBytes(0)
-      .withPartitionPath("data_bucket=0") // easy way to set partition data for now
-      .withRecordCount(2) // needs at least one record or else metrics will filter it out
-      .build();
-  static final DataFile FILE_B = DataFiles.builder(SPEC)
-      .withPath("/path/to/data-b.parquet")
-      .withFileSizeInBytes(0)
-      .withPartitionPath("data_bucket=1") // easy way to set partition data for now
-      .withRecordCount(2) // needs at least one record or else metrics will filter it out
-      .build();
-  static final DataFile FILE_C = DataFiles.builder(SPEC)
-      .withPath("/path/to/data-a.parquet")
-      .withFileSizeInBytes(0)
-      .withPartitionPath("data_bucket=2") // easy way to set partition data for now
-      .withRecordCount(2) // needs at least one record or else metrics will filter it out
-      .build();
-  static final DataFile FILE_D = DataFiles.builder(SPEC)
-      .withPath("/path/to/data-a.parquet")
-      .withFileSizeInBytes(0)
-      .withPartitionPath("data_bucket=3") // easy way to set partition data for now
-      .withRecordCount(2) // needs at least one record or else metrics will filter it out
-      .build();
+  static DataFile fileA;
+  static DataFile fileB;
+  static DataFile fileC;
+  static DataFile fileD;
 
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
@@ -116,6 +96,34 @@ public class HadoopTableTestBase {
     this.metadataDir = new File(tableDir, "metadata");
     this.versionHintFile = new File(metadataDir, "version-hint.text");
     this.table = TABLES.create(SCHEMA, SPEC, tableLocation);
+
+    fileA = DataFiles.builder(SPEC, table.location())
+            .withPath("/path/to/data-a.parquet")
+            .withFileSizeInBytes(0)
+            .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+            .withRecordCount(2) // needs at least one record or else metrics will filter it out
+            .build();
+
+    fileB = DataFiles.builder(SPEC, table.location())
+            .withPath("/path/to/data-b.parquet")
+            .withFileSizeInBytes(0)
+            .withPartitionPath("data_bucket=1") // easy way to set partition data for now
+            .withRecordCount(2) // needs at least one record or else metrics will filter it out
+            .build();
+
+    fileC = DataFiles.builder(SPEC, table.location())
+            .withPath("/path/to/data-a.parquet")
+            .withFileSizeInBytes(0)
+            .withPartitionPath("data_bucket=2") // easy way to set partition data for now
+            .withRecordCount(2) // needs at least one record or else metrics will filter it out
+            .build();
+
+    fileD = DataFiles.builder(SPEC, table.location())
+            .withPath("/path/to/data-a.parquet")
+            .withFileSizeInBytes(0)
+            .withPartitionPath("data_bucket=3") // easy way to set partition data for now
+            .withRecordCount(2) // needs at least one record or else metrics will filter it out
+            .build();
   }
 
   List<File> listManifestFiles() {

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
@@ -251,7 +251,7 @@ public class TestHadoopCommits extends HadoopTableTestBase {
   public void testFastAppend() throws Exception {
     // first append
     table.newFastAppend()
-        .appendFile(FILE_A)
+        .appendFile(fileA)
         .commit();
 
     Assert.assertTrue("Should create v2 for the update",
@@ -267,7 +267,7 @@ public class TestHadoopCommits extends HadoopTableTestBase {
 
     // second append
     table.newFastAppend()
-        .appendFile(FILE_B)
+        .appendFile(fileB)
         .commit();
 
     Assert.assertTrue("Should create v3 for the update",
@@ -295,7 +295,7 @@ public class TestHadoopCommits extends HadoopTableTestBase {
 
     // third append
     table.newAppend()
-        .appendFile(FILE_C)
+        .appendFile(fileC)
         .commit();
 
     List<FileScanTask> tasks = Lists.newArrayList(table.newScan().planFiles());
@@ -375,7 +375,7 @@ public class TestHadoopCommits extends HadoopTableTestBase {
 
     // do a file append
     table.newAppend()
-        .appendFile(FILE_A)
+        .appendFile(fileA)
         .commit();
 
     // since we don't generate old file extensions anymore, let's convert existing metadata to old .metadata.json.gz

--- a/data/src/main/java/org/apache/iceberg/data/TableScanIterable.java
+++ b/data/src/main/java/org/apache/iceberg/data/TableScanIterable.java
@@ -43,6 +43,7 @@ import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.util.PathUtil;
 
 class TableScanIterable extends CloseableGroup implements CloseableIterable<Record> {
   private final TableOperations ops;
@@ -71,7 +72,8 @@ class TableScanIterable extends CloseableGroup implements CloseableIterable<Reco
   }
 
   private CloseableIterable<Record> open(FileScanTask task) {
-    InputFile input = ops.io().newInputFile(task.file().path().toString());
+    String absPath = PathUtil.getAbsolutePath(ops.current().location(), task.file().path().toString());
+    InputFile input = ops.io().newInputFile(absPath);
 
     // TODO: join to partition data from the manifest file
     switch (task.file().format()) {

--- a/data/src/test/java/org/apache/iceberg/TestSplitScan.java
+++ b/data/src/test/java/org/apache/iceberg/TestSplitScan.java
@@ -108,7 +108,7 @@ public class TestSplitScan {
     expectedRecords = RandomGenericData.generate(SCHEMA, numRecords, 0L);
     File file = writeToFile(expectedRecords, format);
 
-    DataFile dataFile = DataFiles.builder(PartitionSpec.unpartitioned())
+    DataFile dataFile = DataFiles.builder(PartitionSpec.unpartitioned(), table.location())
         .withRecordCount(expectedRecords.size())
         .withFileSizeInBytes(file.length())
         .withPath(file.toString())

--- a/data/src/test/java/org/apache/iceberg/data/TestLocalScan.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestLocalScan.java
@@ -141,7 +141,7 @@ public class TestLocalScan {
 
     // commit the test data
     sharedTable.newAppend()
-        .appendFile(DataFiles.builder(PartitionSpec.unpartitioned())
+        .appendFile(DataFiles.builder(PartitionSpec.unpartitioned(), sharedTableLocation)
             .withInputFile(file1)
             .withMetrics(new Metrics(3L,
                 null, // no column sizes
@@ -150,7 +150,7 @@ public class TestLocalScan {
                 ImmutableMap.of(1, longToBuffer(0L)), // lower bounds
                 ImmutableMap.of(1, longToBuffer(2L)))) // upper bounds)
             .build())
-        .appendFile(DataFiles.builder(PartitionSpec.unpartitioned())
+        .appendFile(DataFiles.builder(PartitionSpec.unpartitioned(), sharedTableLocation)
             .withInputFile(file2)
             .withMetrics(new Metrics(3L,
                 null, // no column sizes
@@ -159,7 +159,7 @@ public class TestLocalScan {
                 ImmutableMap.of(1, longToBuffer(10L)), // lower bounds
                 ImmutableMap.of(1, longToBuffer(12L)))) // upper bounds)
             .build())
-        .appendFile(DataFiles.builder(PartitionSpec.unpartitioned())
+        .appendFile(DataFiles.builder(PartitionSpec.unpartitioned(), sharedTableLocation)
             .withInputFile(file3)
             .withMetrics(new Metrics(3L,
                 null, // no column sizes
@@ -196,7 +196,7 @@ public class TestLocalScan {
       }
 
       writeFile(location.toString(), format.addExtension("file-" + fileNum), records);
-      append.appendFile(fromInputFile(HadoopInputFile.fromPath(path, CONF), numRecords));
+      append.appendFile(fromInputFile(HadoopInputFile.fromPath(path, CONF), numRecords, table.location()));
 
       fileNum += 1;
     }

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -81,7 +81,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable {
       });
 
       if (purge && lastMetadata != null) {
-        dropTableData(ops.io(), lastMetadata);
+        dropTableData(ops.io(), lastMetadata, ops.current().location());
       }
 
       return true;

--- a/hive/src/test/java/org/apache/iceberg/hive/HiveCreateReplaceTableTest.java
+++ b/hive/src/test/java/org/apache/iceberg/hive/HiveCreateReplaceTableTest.java
@@ -116,7 +116,7 @@ public class HiveCreateReplaceTableTest extends HiveMetastoreTest {
         TABLE_IDENTIFIER, SCHEMA, SPEC, tableLocation, Maps.newHashMap());
 
     AppendFiles append = txn.newAppend();
-    DataFile dataFile = DataFiles.builder(SPEC)
+    DataFile dataFile = DataFiles.builder(SPEC, tableLocation)
         .withPath("/path/to/data-a.parquet")
         .withFileSizeInBytes(0)
         .withRecordCount(1)

--- a/hive/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
+++ b/hive/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
@@ -40,6 +40,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.PathUtil;
 import org.apache.thrift.TException;
 import org.junit.Assert;
 import org.junit.Test;
@@ -126,7 +127,7 @@ public class HiveTableTest extends HiveTableBaseTest {
       }
     }
 
-    DataFile file = DataFiles.builder(table.spec())
+    DataFile file = DataFiles.builder(table.spec(), table.location())
         .withRecordCount(3)
         .withPath(fileLocation)
         .withFileSizeInBytes(Files.localInput(fileLocation).getLength())
@@ -177,13 +178,13 @@ public class HiveTableTest extends HiveTableBaseTest {
       }
     }
 
-    DataFile file1 = DataFiles.builder(table.spec())
+    DataFile file1 = DataFiles.builder(table.spec(), table.location())
         .withRecordCount(3)
         .withPath(location1)
         .withFileSizeInBytes(Files.localInput(location2).getLength())
         .build();
 
-    DataFile file2 = DataFiles.builder(table.spec())
+    DataFile file2 = DataFiles.builder(table.spec(), table.location())
         .withRecordCount(3)
         .withPath(location2)
         .withFileSizeInBytes(Files.localInput(location1).getLength())
@@ -211,7 +212,7 @@ public class HiveTableTest extends HiveTableBaseTest {
         new File(manifestListLocation).exists());
     for (ManifestFile manifest : manifests) {
       Assert.assertFalse("Table manifest files should not exist",
-          new File(manifest.path().replace("file:", "")).exists());
+          new File(PathUtil.getAbsolutePath(table.location(), manifest.path())).exists());
     }
     Assert.assertFalse("Table metadata file should not exist",
         new File(((HasTableOperations) table).operations().current().file().location().replace("file:", "")).exists());

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestAvroScan.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestAvroScan.java
@@ -93,7 +93,7 @@ public class TestAvroScan extends AvroDataTest {
       writer.addAll(expected);
     }
 
-    DataFile file = DataFiles.builder(PartitionSpec.unpartitioned())
+    DataFile file = DataFiles.builder(PartitionSpec.unpartitioned(), table.location())
         .withRecordCount(100)
         .withFileSizeInBytes(avroFile.length())
         .withPath(avroFile.toString())

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
@@ -199,7 +199,7 @@ public class TestFilteredScan {
         break;
     }
 
-    DataFile file = DataFiles.builder(PartitionSpec.unpartitioned())
+    DataFile file = DataFiles.builder(PartitionSpec.unpartitioned(), table.location())
         .withRecordCount(records.size())
         .withFileSizeInBytes(testFile.length())
         .withPath(testFile.toString())

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestForwardCompatibility.java
@@ -177,14 +177,14 @@ public class TestForwardCompatibility {
       writer.close();
     }
 
-    DataFile file = DataFiles.builder(FAKE_SPEC)
+    DataFile file = DataFiles.builder(FAKE_SPEC, table.location())
         .withInputFile(localInput(parquetFile))
         .withMetrics(writer.metrics())
         .withPartitionPath("id_zero=0")
         .build();
 
     OutputFile manifestFile = localOutput(FileFormat.AVRO.addExtension(temp.newFile().toString()));
-    ManifestWriter manifestWriter = ManifestWriter.write(FAKE_SPEC, manifestFile);
+    ManifestWriter manifestWriter = ManifestWriter.write(FAKE_SPEC, manifestFile, table.location());
     try {
       manifestWriter.add(file);
     } finally {

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHadoopTables.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHadoopTables.java
@@ -40,6 +40,7 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.spark.data.TestHelpers;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.PathUtil;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
@@ -112,7 +113,8 @@ public class TestIcebergSourceHadoopTables {
         .collectAsList();
 
     Assert.assertEquals("Should only contain one manifest", 1, table.currentSnapshot().manifests().size());
-    InputFile manifest = table.io().newInputFile(table.currentSnapshot().manifests().get(0).path());
+    InputFile manifest = table.io().newInputFile(
+        PathUtil.getAbsolutePath(table.location(), table.currentSnapshot().manifests().get(0).path()));
     List<GenericData.Record> expected;
     try (CloseableIterable<GenericData.Record> rows = Avro.read(manifest).project(entriesTable.schema()).build()) {
       expected = Lists.newArrayList(rows);
@@ -153,7 +155,7 @@ public class TestIcebergSourceHadoopTables {
 
     List<GenericData.Record> expected = Lists.newArrayList();
     for (ManifestFile manifest : table.currentSnapshot().manifests()) {
-      InputFile in = table.io().newInputFile(manifest.path());
+      InputFile in = table.io().newInputFile(PathUtil.getAbsolutePath(table.location(), manifest.path()));
       try (CloseableIterable<GenericData.Record> rows = Avro.read(in).project(entriesTable.schema()).build()) {
         for (GenericData.Record record : rows) {
           if ((Integer) record.get("status") < 2 /* added or existing */) {
@@ -201,7 +203,7 @@ public class TestIcebergSourceHadoopTables {
 
     List<GenericData.Record> expected = Lists.newArrayList();
     for (ManifestFile manifest : table.currentSnapshot().manifests()) {
-      InputFile in = table.io().newInputFile(manifest.path());
+      InputFile in = table.io().newInputFile(PathUtil.getAbsolutePath(table.location(), manifest.path()));
       try (CloseableIterable<GenericData.Record> rows = Avro.read(in).project(entriesTable.schema()).build()) {
         for (GenericData.Record record : rows) {
           if ((Integer) record.get("status") < 2 /* added or existing */) {

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestParquetScan.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestParquetScan.java
@@ -101,7 +101,7 @@ public class TestParquetScan extends AvroDataTest {
       writer.addAll(expected);
     }
 
-    DataFile file = DataFiles.builder(PartitionSpec.unpartitioned())
+    DataFile file = DataFiles.builder(PartitionSpec.unpartitioned(), table.location())
         .withFileSizeInBytes(parquetFile.length())
         .withPath(parquetFile.toString())
         .withRecordCount(100)

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestParquetWrite.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestParquetWrite.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.PathUtil;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
@@ -103,7 +104,9 @@ public class TestParquetWrite {
     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
     Assert.assertEquals("Result rows should match", expected, actual);
     for (ManifestFile manifest : table.currentSnapshot().manifests()) {
-      for (DataFile file : ManifestReader.read(localInput(manifest.path()), null)) {
+      for (DataFile file :
+          ManifestReader.read(
+              localInput(PathUtil.getAbsolutePath(table.location(), manifest.path())), null)) {
         Assert.assertNotNull("Split offsets not present", file.splitOffsets());
         Assert.assertEquals("Should have reported record count as 1", 1, file.recordCount());
         Assert.assertNotNull("Column sizes metric not present", file.columnSizes());

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.spark.source;
 
 import com.google.common.collect.Lists;
 import java.io.File;
+import java.net.URLEncoder;
 import java.util.List;
 import org.apache.avro.generic.GenericData;
 import org.apache.iceberg.DataFiles;
@@ -178,14 +179,14 @@ public class TestPartitionValues {
 
     // add the Avro data file to the source table
     source.newAppend()
-        .appendFile(DataFiles.fromInputFile(Files.localInput(avroData), 10))
+        .appendFile(DataFiles.fromInputFile(Files.localInput(avroData), 10, source.location()))
         .commit();
 
     Dataset<Row> sourceDF = spark.read().format("iceberg").load(sourceLocation);
 
     try {
       for (String column : columnNames) {
-        String desc = "partition_by_" + SUPPORTED_PRIMITIVES.findType(column).toString();
+        String desc = "partition_by_" + URLEncoder.encode(SUPPORTED_PRIMITIVES.findType(column).toString());
 
         File parent = temp.newFolder(desc);
         File location = new File(parent, "test");

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
@@ -122,7 +122,7 @@ public class TestSparkReadProjection extends TestReadProjection {
           break;
       }
 
-      DataFile file = DataFiles.builder(PartitionSpec.unpartitioned())
+      DataFile file = DataFiles.builder(PartitionSpec.unpartitioned(), table.location())
           .withRecordCount(100)
           .withFileSizeInBytes(testFile.length())
           .withPath(testFile.toString())


### PR DESCRIPTION
This PR is to fix the issue that, when moving iceberg table to new location, iceberg metadata has to be re-written with the new absolute path. It contains the following changes-
1. changed data_file.file_path to relative path against table location
2. changed manifest_path to relative path against table location
3. when reading manifest or data file, combine the relative path with table location to construct absolute path

Backward compatibility - 
It's not taken care of with the first commit. Would like to confirm the proposal before start working on it. I have two approaches in mind now. Let me know your thoughts.
1. Use a flag to identify the new datasets that will use relative path. For existing tables, we can continue using absolute path when writing and reading.
2. Start to use relative path in metadata for all tables. It means for existing tables, some metadata files will contain absolute path while the others contain relative path. When reading from such a table, we can make sure the method to construct path(PathUtil.getAbsolutePath) can handle both cases.

issue - https://github.com/apache/incubator-iceberg/issues/128