### PR TITLE
[python] Adding parquet package which contains classes necessary for …

### DIFF
--- a/python/iceberg/parquet/__init__.py
+++ b/python/iceberg/parquet/__init__.py
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+__all__ = ["convert_parquet_to_iceberg",
+           "prune_columns",
+           "ParquetReader",
+           "ParquetRowgroupEvaluator",
+           "USE_RG_FILTERING_PROP"]
+
+from .parquet_reader import ParquetReader, USE_RG_FILTERING_PROP
+from .parquet_rowgroup_evaluator import ParquetRowgroupEvaluator
+from .parquet_schema_utils import prune_columns
+from .parquet_to_iceberg import convert_parquet_to_iceberg

--- a/python/iceberg/parquet/arrow_table_utils.py
+++ b/python/iceberg/parquet/arrow_table_utils.py
@@ -1,0 +1,211 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+
+from iceberg.api.expressions import Operation, Predicate
+import numpy as np
+import pandas as pd
+import pyarrow as pa
+
+
+_logger = logging.getLogger(__name__)
+
+
+def apply_iceberg_filter(table, expected_to_file_map, expr):
+    """
+    Builds an indicator array to apply to a pandas dataframe and then returns the resulting
+    pyarrow.Table
+
+    Parameters
+    ----------
+    table: pyarrow.Table
+        The table to apply the filter on
+    expected_to_file_map: map
+        A mapping of the current schema field names to the file field names
+    expr: iceberg.api.expressions.Expression
+        A predicate expression to use as a filter
+
+    Returns
+    -------
+    pyarrow.Table
+        A pyarrow Table with the rows that don't match the predicate filtered out
+
+    """
+    if expr is None:
+        return table
+
+    indicator_array = get_indicator(table, expected_to_file_map, expr)
+    # TODO: Re-implement with pyarrow api when it becomes available
+    #   See https://issues.apache.org/jira/browse/ARROW-6996
+    return pa.Table.from_pandas(table.to_pandas()[indicator_array], schema=table.schema, preserve_index=False)
+
+
+def get_indicator(table, field_map, expr):
+    """
+    Builds an indicator array for the given expression by traversing the expression tree.
+
+    Parameters
+    ----------
+    table: pyarrow.Table
+        The table to apply the filter on
+    field_map: map
+        A mapping of the current schema field names to the file field names
+    expr: iceberg.api.expressions.Expression
+        An expression to use as a filter
+
+    Returns
+    -------
+    pandas.core.series.Series
+        A pandas series with a boolean indicator for whether the row qualifies for the filter
+
+    """
+    if isinstance(expr, Predicate):
+        return predicate(table, field_map, expr)
+
+    if expr.op() == Operation.TRUE:
+        return np.full(table.num_rows, fill_value=True, dtype=np.bool)
+    elif expr.op() == Operation.FALSE:
+        return np.full(table.num_rows, fill_value=False, dtype=np.bool)
+    elif expr.op() == Operation.NOT:
+        return not_(get_indicator(table, field_map, expr.child))
+    elif expr.op() == Operation.AND:
+        return and_(get_indicator(table, field_map, expr.left),
+                    get_indicator(table, field_map, expr.right))
+    elif expr.op() == Operation.OR:
+        return or_(get_indicator(table, field_map, expr.left),
+                   get_indicator(table, field_map, expr.right))
+    else:
+        raise RuntimeError("Unknown operation: {}".format(expr.op()))
+
+
+def predicate(table, field_map, pred):  # noqa: ignore=C901
+    """
+    Given a table and a predicate this function builds the indicator array
+    by projecting the necessary field into a pandas dataframe and applying the
+    appropriate operation.
+
+    Parameters
+    ----------
+    table: pyarrow.Table
+        The table to apply the filter on
+    field_map: map
+        A mapping of the current schema field names to the file field names
+    pred: iceberg.api.expressions.Predicate
+        A predicate to use as a filter
+
+    Returns
+    -------
+    pandas.core.series.Series
+        A pandas series with a boolean indicator for whether the row qualifies for the predicate
+
+    """
+    idx = table.schema.get_field_index(field_map[pred.ref.name])
+
+    # if the field is missing, we can either say all rows do not match
+    # or if the op is `is null` then all rows must match
+    if idx < 0:
+        if pred.op == Operation.IS_NULL:
+            return np.full(table.num_rows, fill_value=True, dtype=np.bool)
+
+        return np.full(table.num_rows, fill_value=False, dtype=np.bool)
+
+    tbl_df = table[idx].data.to_pandas()
+    if pred.op == Operation.IS_NULL:
+        return pd.isnull(tbl_df)
+    elif pred.op == Operation.NOT_NULL:
+        return ~pd.isnull(tbl_df)
+    elif pred.op == Operation.LT:
+        final_df = tbl_df < pred.lit.value
+    elif pred.op == Operation.LT_EQ:
+        final_df = tbl_df <= pred.lit.value
+    elif pred.op == Operation.GT:
+        final_df = tbl_df > pred.lit.value
+    elif pred.op == Operation.GT_EQ:
+        final_df = tbl_df >= pred.lit.value
+    elif pred.op == Operation.EQ:
+        final_df = tbl_df == pred.lit.value
+    elif pred.op == Operation.NOT_EQ:
+        final_df = tbl_df != pred.lit.value
+    elif pred.op == Operation.IN:
+        raise NotImplementedError()
+    elif pred.op == Operation.NOT_IN:
+        raise NotImplementedError()
+    else:
+        raise NotImplementedError()
+
+    # we combine the value indicator array with a is not null comparison to maintain
+    # the semantics of SQL equality comparison wrt to null values
+    return final_df & ~pd.isnull(tbl_df)
+
+
+def and_(left, right):
+    """
+    And logical operator
+
+    Parameters
+    ----------
+    left: iceberg.api.Expression
+        The left side of the `and` expression
+    right: iceberg.api.Expression
+        The right side of the `and` expression
+
+    Returns
+    -------
+    pandas.core.series.Series
+        A pandas series with a boolean indicator for whether the row qualifies for the combined expression
+
+    """
+    return left & right
+
+
+def or_(left, right):
+    """
+    or logical operator
+
+    Parameters
+    ----------
+    left: iceberg.api.Expression
+        The left side of the `or` expression
+    right: iceberg.api.Expression
+        The right side of the `or` expression
+
+    Returns
+    -------
+    pandas.core.series.Series
+        A pandas series with a boolean indicator for whether the row qualifies for the combined expression
+
+    """
+    return left | right
+
+
+def not_(child):
+    """
+    Not logical operator
+
+    Parameters
+    ----------
+    child: iceberg.api.Expression
+        The expression to negate
+
+    Returns
+    -------
+    pandas.core.series.Series
+        A pandas series with a boolean indicator negated
+
+    """
+    return ~child

--- a/python/iceberg/parquet/gandiva_utils.py
+++ b/python/iceberg/parquet/gandiva_utils.py
@@ -1,0 +1,141 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from iceberg.api.expressions import Operation, Predicate
+import numpy as np
+import pyarrow as pa
+import pyarrow.gandiva as gandiva
+
+
+builder = gandiva.TreeExprBuilder()
+LIT_TYPE_MAP = {bytes: pa.binary(),
+                bool: pa.bool_(),
+                int: pa.int32(),
+                # decimal.Decimal: pa.decimal128(field.type.precision, field.type.scale),
+                float: pa.float64(),
+                str: pa.string()}
+
+
+def apply_iceberg_filter(table, expected_to_file_map, expr):
+    """
+         (Experimental) Not currently used anywhere.  This will build a selection vector
+         for the given filter using pyarrow.gandiva
+
+         Parameters
+         ----------
+         table: pyarrow.Table
+             The table to apply the filter on
+         expected_to_file_map: map
+             A mapping of the current schema field names to the file field names
+         expr: iceberg.api.expressions.Expression
+             A predicate expression to use as a filter
+
+         Returns
+         -------
+         pyarrow.Table
+             A pyarrow Table with the rows that don't match the predicate filtered out
+
+    """
+    if expr is None:
+        return table
+    final_condition = builder.make_condition(get_gandiva_filter(table, expected_to_file_map, expr))
+    final_filter = gandiva.make_filter(table.schema, final_condition)
+    curr_idx = 0
+    selection_vector = np.empty(0, dtype=np.uint32)
+    for batch in table.to_batches():
+        tmp_selection_vector = final_filter.evaluate(batch, pa.default_memory_pool()).to_array().to_numpy()
+        selection_vector = np.append(selection_vector, [tmp_selection_vector + curr_idx])
+        curr_idx += len(batch)
+
+    indicator = np.zeros(len(table), np.bool_)
+    indicator[selection_vector] = True
+    filt_table = pa.Table.from_pandas(table.to_pandas()[indicator], schema=table.schema)
+    return filt_table.remove_column(filt_table.num_columns - 1)
+
+
+def get_gandiva_filter(table, field_map, expr):
+
+    if isinstance(expr, Predicate):
+        return predicate(table, field_map, expr)
+
+    if expr.op() == Operation.TRUE:
+        return True
+    elif expr.op() == Operation.FALSE:
+        return False
+    elif expr.op() == Operation.NOT:
+        return not_(get_gandiva_filter(table, field_map, expr.child))
+    elif expr.op() == Operation.AND:
+        return and_(get_gandiva_filter(table, field_map, expr.left),
+                    get_gandiva_filter(table, field_map, expr.right))
+    elif expr.op() == Operation.OR:
+        return or_(get_gandiva_filter(table, field_map, expr.left),
+                   get_gandiva_filter(table, field_map, expr.right))
+    else:
+        raise RuntimeError("Unknown operation: {}".format(expr.op()))
+
+
+def predicate(table, field_map, pred):  # noqa: ignore=C901
+    col_name = field_map.get(pred.ref.name)
+    if col_name is None:
+        if pred.op == Operation.IS_NULL:
+            return np.full(table.num_rows, fill_value=True, dtype=np.bool)
+
+        return np.full(table.num_rows, fill_value=False, dtype=np.bool)
+
+    if pred.op == Operation.IS_NULL:
+        raise NotImplementedError()
+    elif pred.op == Operation.NOT_NULL:
+        raise NotImplementedError()
+
+    pred_node = builder.make_field(table.schema.field_by_name(col_name))
+    lit_arrow_type = LIT_TYPE_MAP.get(type(pred.lit.value))
+    if lit_arrow_type == pa.int32() and pred.lit.value > 2**31:
+        lit_arrow_type = pa.int64()
+
+    gandiva_lit = builder.make_literal(pred.lit.value, lit_arrow_type)
+
+    if pred.op == Operation.EQ:
+        return builder.make_function("equal", [pred_node, gandiva_lit], pa.bool_())
+    elif pred.op == Operation.LT:
+        return builder.make_function("less_than", [pred_node, gandiva_lit], pa.bool_())
+    elif pred.op == Operation.LT_EQ:
+        return builder.make_or([builder.make_function("less_than", [pred_node, gandiva_lit], pa.bool_()),
+                               builder.make_function("equal", [pred_node, gandiva_lit], pa.bool_())])
+
+    elif pred.op == Operation.GT:
+        return builder.make_function("greater_than", [pred_node, gandiva_lit], pa.bool_())
+    elif pred.op == Operation.GT_EQ:
+        return builder.make_or([builder.make_function("greater_than", [pred_node, gandiva_lit], pa.bool_()),
+                               builder.make_function("equal", [pred_node, gandiva_lit], pa.bool_())])
+    elif pred.op == Operation.NOT_EQ:
+        return builder.make_function("not_equal", [pred_node, gandiva_lit], pa.bool_())
+    elif pred.op == Operation.IN:
+        raise NotImplementedError()
+    elif pred.op == Operation.NOT_IN:
+        raise NotImplementedError()
+
+
+def and_(left, right):
+    return builder.make_and([left, right])
+
+
+def or_(left, right):
+    return builder.make_or([left, right])
+
+
+def not_(child):
+    raise NotImplementedError()

--- a/python/iceberg/parquet/parquet_reader.py
+++ b/python/iceberg/parquet/parquet_reader.py
@@ -1,0 +1,341 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from collections import OrderedDict
+from datetime import datetime
+import decimal
+import logging
+
+import fastparquet
+from iceberg.api.expressions import Expressions
+from iceberg.api.types import TypeID
+from iceberg.core.util import SCAN_THREAD_POOL_ENABLED
+import numpy as np
+import pyarrow as pa
+import pyarrow.lib as lib
+import pyarrow.parquet as pq
+
+from .arrow_table_utils import apply_iceberg_filter
+from .parquet_rowgroup_evaluator import ParquetRowgroupEvaluator
+from .parquet_schema_utils import prune_columns
+from .parquet_to_iceberg import convert_parquet_to_iceberg
+
+_logger = logging.getLogger(__name__)
+
+
+USE_RG_FILTERING_PROP = "use-row-group-filtering"
+
+DTYPE_MAP = {TypeID.BINARY: lambda field: pa.binary(),
+             TypeID.BOOLEAN: lambda field: (pa.bool_(), False),
+             TypeID.DATE: lambda field: (pa.date32(), datetime.now()),
+             TypeID.DECIMAL: lambda field: (pa.decimal128(field.type.precision, field.type.scale),
+                                            decimal.Decimal()),
+             TypeID.DOUBLE: lambda field: (pa.float64(), np.nan),
+             TypeID.FIXED: lambda field: pa.binary(field.length()),
+             TypeID.FLOAT: lambda field: (pa.float32(), np.nan),
+             TypeID.INTEGER: lambda field: (pa.int32(), np.nan),
+             TypeID.LIST: lambda field: (pa.list_(pa.field("element",
+                                                           DTYPE_MAP.get(field.type.element_type.type_id)(field.type)[0])),
+                                         None),
+             TypeID.LONG: lambda field: (pa.int64(), np.nan),
+             # pyarrow doesn't currently support reading parquet map types
+             # TypeID.MAP: lambda field: (,),
+             TypeID.STRING: lambda field: (pa.string(), ""),
+             TypeID.STRUCT: lambda field: (pa.struct([(nested_field.name,
+                                                       DTYPE_MAP.get(nested_field.type.type_id)(nested_field.type)[0])
+                                                     for nested_field in field.type.fields]), {}),
+             TypeID.TIMESTAMP: lambda field: (pa.timestamp("us"), datetime.now()),
+             # Not implemented yet, since Spark doesn't support time type
+             # TypeID.TIME: pa.time64(None)
+             }
+
+
+class ParquetReader(object):
+    """
+    Handles Reading a parquet file for a given start to end range.  Also, enforces
+    the projected iceberg schema on the read data.  This may involve selectively reading
+    columns, remapping column names, re-arranging the projection ordering, and possibly
+    adding null columns
+
+    Parameters
+    ----------
+    input : iceberg.api.io.InputFile
+        An iceberg InputFile that is pointing to the parquet file that is to be read.
+    expected_schema : iceberg.api.Schema
+        An iceberg schema with the schema to project in the output
+    options : dict
+        A dict of options to pass to the reader
+    filter : iceberg.api.expressions.Expression
+        A row-level filtering expression to apply to the parquet row groups
+        and to the final output table
+    start : int, default None
+        The start byte range for this reader.This is passed to the ParquetRowGroupEvaluator
+    end : int, default None
+        The end byte range for this reader. This is passed to the ParquetRowGroupEvaluator
+    """
+    def __init__(self, input, expected_schema, options, filter,
+                 case_sensitive, start=None, end=None):
+        self._input = input
+        self._input_fo = input.new_fo()
+
+        # TODO: Remove usage of fastparquet
+        self._pq_file = fastparquet.ParquetFile(self._input_fo)
+        self._arrow_file = pq.ParquetFile(self._input_fo)
+        self._file_schema = convert_parquet_to_iceberg(self._pq_file.schema)
+        self._expected_schema = expected_schema
+        self._file_to_expected_name_map = ParquetReader.get_field_map(self._file_schema,
+                                                                      self._expected_schema)
+
+        self._options = options
+        self.use_threads = self._options.get(SCAN_THREAD_POOL_ENABLED, False)
+
+        _logger.debug("Starting Parquet Reader with %s" %
+                      "threaded scan enabled" if self.use_threads else "threaded scan disabled")
+        _logger.debug("Reading %s" % self._input.path)
+
+        self._filter = filter if filter != Expressions.always_true() else None
+        self._case_sensitive = case_sensitive
+        self.start = start
+        self.end = end
+
+        self.materialized_table = False
+        self.curr_iterator = None
+        self._table = None
+
+    def to_pandas(self):
+        """
+        Return a pandas dataframe for the given file and filter
+
+        Returns
+        -------
+        pandas.core.frame.DataFrame
+            A pandas dataframe with the data from the file, projected to the specified schema and
+            with the filter expression applied
+
+        """
+        if not self.materialized_table:
+            self._read_data()
+
+        return self._table.to_pandas(use_threads=self.use_threads)
+
+    def to_arrow_table(self):
+        """
+        Return a pyarrow Table given file and filter
+
+        Returns
+        -------
+        pyarrow.Table
+            A pyarrow Table with the data from the file, projected to the specified schema and
+            with the filter expression applied
+        """
+        if not self.materialized_table:
+            self._read_data()
+
+        return self._table
+
+    def _read_data(self):
+        """
+        Private function to perform the read and schema evolution
+
+        """
+        # only scan the columns projected and in our file
+        cols_to_read = prune_columns(self._file_schema, self._expected_schema)
+
+        if not self._options.get(USE_RG_FILTERING_PROP, True):
+            _logger.debug("Reading Full file")
+            arrow_tbls = [pq.ParquetFile(self._input.new_fo()).read(columns=cols_to_read,
+                                                                    use_threads=self.use_threads)]
+        else:
+            _logger.debug("Using row group filtering")
+            # filter out row groups that cannot contain our filter expressions
+            rg_evaluator = ParquetRowgroupEvaluator(self._file_schema, self._filter,
+                                                    self.start, self.end)
+
+            read_row_groups = [i for i, row_group in enumerate(self._pq_file.row_groups)
+                               if rg_evaluator.eval(row_group)]
+
+            if len(read_row_groups) == 0:
+                self._table = None
+                self.materialized_table = True
+                return
+
+            arrow_tbls = [self.read_rgs(i, cols_to_read) for i in read_row_groups]
+
+        _logger.debug("data fetch done")
+        processed_tbl = ParquetReader.migrate_schema(self._file_to_expected_name_map,
+                                                     lib.concat_tables(arrow_tbls))
+        for i, field in self.get_missing_fields():
+            dtype_func = DTYPE_MAP.get(field.type.type_id)
+            if dtype_func is None:
+                raise RuntimeError("Unable to create null column for type %s" % field.type.type_id)
+
+            processed_tbl = (processed_tbl
+                             .add_column(i, ParquetReader.create_null_column(processed_tbl[0],
+                                                                             field.name,
+                                                                             dtype_func(field))))
+        else:
+            processed_tbl = lib.concat_tables(arrow_tbls)
+
+        self._table = processed_tbl
+        self.materialized_table = True
+
+    def read_rgs(self, i, cols_to_read):
+        """
+        Handles Reading a single row group and performing the row-level filtering.
+
+        Parameters
+        ----------
+        i : int
+            The row group number to read
+        cols_to_read : list
+            A list of columns to read, must be using the names from the parquet schema
+
+        Returns
+        -------
+        pyarrow.Table
+            A pyarrow Table with the data from the row group with the filter expression applied
+        """
+        with self._input.new_fo() as thread_file:
+            arrow_tbl = (pq.ParquetFile(thread_file)
+                         .read_row_group(i, columns=cols_to_read))
+        filtered_table = apply_iceberg_filter(arrow_tbl,
+                                              ParquetReader.get_reverse_field_map(self._file_schema,
+                                                                                  self._expected_schema),
+                                              self._filter)
+
+        return filtered_table
+
+    def close(self):
+        """
+        Function to close out the file-like object that was opened at object creation
+
+        """
+        self._input_fo.close()
+
+    def get_missing_fields(self):
+        """
+        Get a list of the fields in the expected schema that don't exist in the file schema
+
+        Returns
+        -------
+        pyarrow.Table
+            A pyarrow Table with the data from the row group with the filter expression applied
+        """
+        return [(i, field) for i, field in enumerate(self._expected_schema.as_struct().fields)
+                if self._file_schema.find_field(field.id) is None]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    @staticmethod
+    def get_field_map(file_schema, expected_schema):
+        """
+        Get a map that maps the field name from the file schema to the expected schema field name
+        based on their id's
+
+        Parameters
+        ----------
+        file_schema : iceberg.api.Schema
+            The iceberg schema of the parquet file
+        expected_schema : iceberg.api.Schema
+            The iceberg schema of the expected output
+
+        Returns
+        -------
+        collections.OrderedDict
+            map that maps the file field name to the expected field name
+
+        """
+        return OrderedDict({file_schema.find_field(field.id).name: field.name
+                            for field in expected_schema.as_struct().fields
+                            if file_schema.find_field(field.id) is not None})
+
+    @staticmethod
+    def get_reverse_field_map(file_schema, expected_schema):
+        """
+        Get a map that maps the field name from the expected schema to the file schema field name
+        based on their id's
+
+        Parameters
+        ----------
+        file_schema : iceberg.api.Schema
+            The iceberg schema of the parquet file
+        expected_schema : iceberg.api.Schema
+            The iceberg schema of the expected output
+
+        Returns
+        -------
+        map
+            map that maps the expected field name to the file field name
+        """
+        return {expected_schema.find_field(field.id).name: field.name
+                for field in file_schema.as_struct().fields
+                if expected_schema.find_field(field.id) is not None}
+
+    @staticmethod
+    def migrate_schema(mapping, table):
+        """
+        Re-order the columns in the pyarrow.Table to the expected schema output ordering
+
+        Parameters
+        ----------
+        mapping : collections.OrderedDict
+            An OrderedDict that has the desired ordering and mapping of columns
+        table : pyarrow.Table
+            The pyarrow.Table to be rearranged
+
+        Returns
+        -------
+        pyarrow.Table
+            A pyarrow.Table rearranged to match the naming and ordering is specified by mapping
+
+        """
+        new_columns = []
+        for key, value in mapping.items():
+            column_idx = table.schema.get_field_index(key)
+            column = table[column_idx]
+            new_columns.append(pa.Column.from_array(value, column.data))
+
+        return pa.Table.from_arrays(new_columns)
+
+    @staticmethod
+    def create_null_column(reference_column, name, dtype_tuple):
+        """
+        Create a filled column of Null values
+
+        Parameters
+        ----------
+        reference_column : pyarrow.Column
+            A column to use as the reference for the chunked arrays
+        name : str
+            The column_name
+        dtype_tuple : tuple
+            A tuple that contains the pyarrow datatype and the init value to use for the array
+        Returns
+        -------
+        pyarrow.Table
+            A pyarrow.Table rearranged to match the naming and ordering is specified by mapping
+
+        """
+        dtype, init_val = dtype_tuple
+        chunk = pa.chunked_array([pa.array(np.full(len(c), init_val), type=dtype, mask=[True] * len(c))
+                                  for c in reference_column.data.chunks], type=dtype)
+
+        return pa.Column.from_array(name, chunk)

--- a/python/iceberg/parquet/parquet_rowgroup_evaluator.py
+++ b/python/iceberg/parquet/parquet_rowgroup_evaluator.py
@@ -1,0 +1,239 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from iceberg.api.expressions import Binder, Expressions, ExpressionVisitors
+from iceberg.api.types import Conversions
+
+
+class ParquetRowgroupEvaluator():
+    """
+    Handles Reading a parquet file for a given start to end range.  Also, enforces
+    the projected iceberg schema on the read data.  This may involve selectively reading
+    columns, remapping column names, re-arranging the projection ordering, and possibly
+    adding null columns
+
+    Parameters
+    ----------
+    schema : iceberg.api.Schema
+        An iceberg schema to use for binding the predicate
+    unbound : iceberg.api.expressions.UnboundPredicate
+        The unbound predicate to evaluate
+    start : int
+        The start index of the assigned reader
+    end : int
+        The end-index of the assigned reader
+    """
+    def __init__(self, schema, unbound, start, end):
+        self.schema = schema
+        self.struct = schema.as_struct()
+
+        self.expr = None if unbound is None else Binder.bind(self.struct, Expressions.rewrite_not(unbound))
+        self.start = start
+        self.end = end
+        self._visitors = None
+
+    def _visitor(self):
+        if self._visitors is None:
+            self._visitors = ParquetRowgroupEvalVisitor(self.expr, self.schema, self.struct,
+                                                        self.start, self.end)
+
+        return self._visitors
+
+    def eval(self, row_group):
+        return self._visitor().eval(row_group)
+
+
+class ParquetRowgroupEvalVisitor(ExpressionVisitors.BoundExpressionVisitor):
+    ROWS_MIGHT_MATCH = True
+    ROWS_CANNOT_MATCH = False
+
+    def __init__(self, expr, schema, struct, start, end):
+        self.expr = expr
+        self.schema = schema
+        self.struct = struct
+        self.start = start
+        self.end = end
+        self.lower_bounds = None
+        self.upper_bounds = None
+        self.midpoint = None
+
+    def eval(self, row_group):
+        """
+        Returns a boolean that determines if the given row-group may contain rows
+        for the assigned predicate and read-range[start, end]
+
+        Parameters
+        ----------
+        row_group : fastparquet.parquet_thrift.parquet.ttypes.RowGroup
+            The fastparquet thirft metadata for the row-group being evaluated
+        Returns
+        -------
+        boolean
+            True if rows for the current evaluator might exist in the row group, false otherwise
+        """
+        if row_group.num_rows <= 0:
+            return ParquetRowgroupEvalVisitor.ROWS_CANNOT_MATCH
+        self.get_stats(row_group)
+
+        # if the mid-point of the row-group is not contained by the
+        # start-end range we don't read it
+        if self.start is not None and self.end is not None \
+                and not (self.start <= self.midpoint <= self.end):
+            return ParquetRowgroupEvalVisitor.ROWS_CANNOT_MATCH
+
+        if self.expr is None:
+            return ParquetRowgroupEvalVisitor.ROWS_MIGHT_MATCH
+
+        return ExpressionVisitors.visit(self.expr, self)
+
+    def always_true(self):
+        return ParquetRowgroupEvalVisitor.ROWS_MIGHT_MATCH
+
+    def always_false(self):
+        return ParquetRowgroupEvalVisitor.ROWS_CANNOT_MATCH
+
+    def not_(self, result):
+        return not result
+
+    def and_(self, left_result, right_result):
+        return left_result and right_result
+
+    def or_(self, left_result, right_result):
+        return left_result or right_result
+
+    def is_null(self, ref):
+        return ParquetRowgroupEvalVisitor.ROWS_MIGHT_MATCH
+
+    def not_null(self, ref):
+        return ParquetRowgroupEvalVisitor.ROWS_MIGHT_MATCH
+
+    def lt(self, ref, lit):
+        id = ref.field_id
+        field = self.struct.field(id=id)
+
+        if field is None:
+            raise RuntimeError("Cannot filter by nested column: %s" % self.schema.find_field(id))
+
+        if self.lower_bounds is not None and id in self.lower_bounds:
+            lower = Conversions.from_byte_buffer(field.type, self.lower_bounds.get(id))
+            if lower >= lit.value:
+                return ParquetRowgroupEvalVisitor.ROWS_CANNOT_MATCH
+
+        return ParquetRowgroupEvalVisitor.ROWS_MIGHT_MATCH
+
+    def lt_eq(self, ref, lit):
+        id = ref.field_id
+        field = self.struct.field(id=id)
+
+        if field is None:
+            raise RuntimeError("Cannot filter by nested column: %s" % self.schema.find_field(id))
+
+        if self.lower_bounds is not None and id in self.lower_bounds:
+            lower = Conversions.from_byte_buffer(field.type, self.lower_bounds.get(id))
+            if lower > lit.value:
+                return ParquetRowgroupEvalVisitor.ROWS_CANNOT_MATCH
+
+        return ParquetRowgroupEvalVisitor.ROWS_MIGHT_MATCH
+
+    def gt(self, ref, lit):
+        id = ref.field_id
+        field = self.struct.field(id=id)
+
+        if field is None:
+            raise RuntimeError("Cannot filter by nested column: %s" % self.schema.find_field(id))
+
+        if self.upper_bounds is not None and id in self.upper_bounds:
+            upper = Conversions.from_byte_buffer(field.type, self.upper_bounds.get(id))
+            if upper <= lit.value:
+                return ParquetRowgroupEvalVisitor.ROWS_CANNOT_MATCH
+
+        return ParquetRowgroupEvalVisitor.ROWS_MIGHT_MATCH
+
+    def gt_eq(self, ref, lit):
+        id = ref.field_id
+        field = self.struct.field(id=id)
+
+        if field is None:
+            raise RuntimeError("Cannot filter by nested column: %s" % self.schema.find_field(id))
+
+        if self.upper_bounds is not None and id in self.upper_bounds:
+            upper = Conversions.from_byte_buffer(field.type, self.upper_bounds.get(id))
+            if upper < lit.value:
+                return ParquetRowgroupEvalVisitor.ROWS_CANNOT_MATCH
+
+        return ParquetRowgroupEvalVisitor.ROWS_MIGHT_MATCH
+
+    def eq(self, ref, lit):
+        id = ref.field_id
+        field = self.struct.field(id=id)
+
+        if field is None:
+            raise RuntimeError("Cannot filter by nested column: %s" % self.schema.find_field(id))
+
+        if self.lower_bounds is not None and id in self.lower_bounds:
+            lower = Conversions.from_byte_buffer(field.type, self.lower_bounds[id])
+            if lower > lit.value:
+                return ParquetRowgroupEvalVisitor.ROWS_CANNOT_MATCH
+
+        if self.upper_bounds is not None and id in self.upper_bounds:
+            upper = Conversions.from_byte_buffer(field.type, self.upper_bounds[id])
+            if upper < lit.value:
+                return ParquetRowgroupEvalVisitor.ROWS_CANNOT_MATCH
+
+        return ParquetRowgroupEvalVisitor.ROWS_MIGHT_MATCH
+
+    def not_eq(self, ref, lit):
+        return ParquetRowgroupEvalVisitor.ROWS_MIGHT_MATCH
+
+    def in_(self, ref, lit):
+        return ParquetRowgroupEvalVisitor.ROWS_MIGHT_MATCH
+
+    def not_in(self, ref, lit):
+        return ParquetRowgroupEvalVisitor.ROWS_MIGHT_MATCH
+
+    def get_stats(self, row_group):
+        """
+        Summarizes the row group statistics for upper and lower bounds.  Also calculates
+        the mid-point of the row-group for determining start <= midpoint <= end
+
+        Parameters
+        ----------
+        row_group : fastparquet.parquet_thrift.parquet.ttypes.RowGroup
+            The fastparquet thrift metadata for the row-group being evaluated
+        """
+        # TODO: Convert stats to use pyarrow stats
+        #   For an example predicate pushdown implementation see:
+        #      https://github.com/JDASoftwareGroup/kartothek/blob/master/kartothek/serialization/_parquet.py
+
+        self.lower_bounds = {}
+        self.upper_bounds = {}
+        start = -1
+        size = 0
+
+        for column in row_group.columns:
+            if start < 0:
+                start = column.file_offset
+            metadata = column.meta_data
+            size += metadata.total_compressed_size
+            id = self.schema.lazy_name_to_id().get(".".join(metadata.path_in_schema))
+            if id is not None:
+                if metadata.statistics.min is not None:
+                    self.lower_bounds[id] = metadata.statistics.min
+                if metadata.statistics.min is not None:
+                    self.upper_bounds[id] = metadata.statistics.max
+
+        self.midpoint = int(size / 2 + start)

--- a/python/iceberg/parquet/parquet_schema_utils.py
+++ b/python/iceberg/parquet/parquet_schema_utils.py
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from iceberg.api.types import get_projected_ids
+
+
+def prune_columns(file_schema, expected_schema):
+    """
+    Given two Iceberg schema's returns a list of column_names for all id's in the
+    file schema that are projected in the expected schema
+
+    Parameters
+    ----------
+    file_schema : iceberg.api.Schema
+        An Iceberg schema of the file being read
+    expected_schema : iceberg.api.Schema
+        An Iceberg schema of the final projection
+    Returns
+    -------
+    list
+        The column names in the file that matched ids in the expected schema
+    """
+    return [column.name for column in file_schema.as_struct().fields
+            if column.id in get_projected_ids(expected_schema)]

--- a/python/iceberg/parquet/parquet_to_iceberg.py
+++ b/python/iceberg/parquet/parquet_to_iceberg.py
@@ -1,0 +1,154 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import fastparquet
+from iceberg.api import Schema
+from iceberg.api.types import (BinaryType,
+                               BooleanType,
+                               DateType,
+                               DecimalType,
+                               DoubleType,
+                               FixedType,
+                               FloatType,
+                               IntegerType,
+                               ListType,
+                               LongType,
+                               MapType,
+                               NestedField,
+                               StringType,
+                               StructType,
+                               TimestampType,
+                               TimeType)
+
+
+parquet_type_name_map = {0: lambda x=None: BooleanType.get(),
+                         1: lambda x=None: IntegerType.get(),
+                         2: lambda x=None: LongType.get(),
+                         3: lambda x=None: LongType.get(),
+                         4: lambda x=None: FloatType.get(),
+                         5: lambda x=None: DoubleType.get(),
+                         6: lambda x: FixedType.of_length(x),
+                         7: lambda x=None: BinaryType.get()}
+parquet_ctype_name_map = {0: lambda x=None, y=None: StringType.get(),
+                          4: lambda x=None, y=None: StringType.get(),
+                          5: lambda x, y: DecimalType.of(x, y),
+                          6: lambda x=None, y=None: DateType.get(),
+                          7: lambda x=None, y=None: TimeType.get(),
+                          8: lambda x=None, y=None: TimeType.get(),
+                          9: lambda x=None, y=None: TimestampType.with_timezone(),
+                          10: lambda x=None, y=None: TimestampType.with_timezone(),
+                          11: lambda x=None, y=None: IntegerType.get(),
+                          12: lambda x=None, y=None: IntegerType.get(),
+                          15: lambda x=None, y=None: IntegerType.get(),
+                          16: lambda x=None, y=None: IntegerType.get(),
+                          17: lambda x=None, y=None: IntegerType.get(),
+                          18: lambda x=None, y=None: LongType.get(),
+                          19: lambda x=None, y=None: StringType.get(),
+                          20: lambda x=None, y=None: StringType.get()}
+
+
+def convert_parquet_to_iceberg(schema):
+    """
+    Entry point to convert a fastparquet schema into an iceberg schema
+
+    Parameters
+    ----------
+    schema : fastparquet.schema.SchemaHelper
+        An fastparquet schema of the file being read
+
+    Returns
+    -------
+    iceberg.api.Schema
+        The equivalent iceberg schema for the given fastparquet schema
+    """
+    return convert_field(schema.root)
+
+
+def convert_field(root):  # noqa: ignore=C901
+    """
+    Given two Iceberg schema's returns a list of column_names for all id's in the
+    file schema that are projected in the expected schema
+
+    Parameters
+    ----------
+    root : fastparquet.parquet_thrift.parquet.ttypes.SchemaElement
+        The current element to convert
+
+    Returns
+    -------
+    Union[NestedField, StructType]
+        Returns the NestedField tht matches the given schema element or the collection of
+        NestFields wrapped in a StructType at the terminal processing iteration
+    """
+
+    # TODO: Convert conversion to use pyarrow schema
+
+    try:
+        iceberg_type = parquet_ctype_name_map[root.converted_type](root.precision, root.scale)
+    except KeyError:
+        try:
+            iceberg_type = parquet_type_name_map[root.type]()
+        except KeyError:
+            if root.converted_type == fastparquet.parquet_thrift.ConvertedType.MAP:
+                repeated_key_value = root.children["map"]
+
+                if len(repeated_key_value.children) == 2:
+                    key_result = convert_field(repeated_key_value.children["key"])
+                    value_result = convert_field(repeated_key_value.children["value"])
+
+                if value_result.is_optional:
+                    map_type = MapType.of_optional(key_result.field_id, value_result.field_id,
+                                                   key_result.type, value_result.type)
+                else:
+                    map_type = MapType.of_required(key_result.field_id, value_result.field_id,
+                                                   key_result.type, value_result.type)
+
+                return get_nested_field(root.field_id, root.name, map_type, root.repetition_type == 0)
+
+            elif root.converted_type == fastparquet.parquet_thrift.ConvertedType.LIST:
+                repeated = root.children["list"]
+                element = repeated.children["element"]
+                element_type = convert_field(element)
+                if element.repetition_type == 0:
+                    list_type = ListType.of_required(element.field_id, element_type.type)
+                else:
+                    list_type = ListType.of_required(element.field_id, element_type.type)
+
+                return get_nested_field(root.field_id, root.name, list_type, root.repetition_type == 0)
+
+            else:
+                fields = []
+                if len(root.children) > 0:
+                    for child in root.children.values():
+                        fields.append(convert_field(child))
+                else:
+                    raise RuntimeError("Unable to convert type to iceberg %s" % root)
+
+                if root.name == "table":
+                    return Schema(fields)
+                else:
+                    struct_type = StructType.of(fields)
+                    return get_nested_field(root.field_id, root.name, struct_type, root.repetition_type == 0)
+
+    return get_nested_field(root.field_id, root.name, iceberg_type, root.repetition_type == 0)
+
+
+def get_nested_field(field_id, field_name, field_type, is_required):
+    if is_required:
+        return NestedField.required(field_id, field_name, field_type)
+    else:
+        return NestedField.optional(field_id, field_name, field_type)

--- a/python/setup.py
+++ b/python/setup.py
@@ -38,7 +38,7 @@ setup(
                       'requests',
                       'retrying',
                       'pandas',
-                      'pyarrow'
+                      'pyarrow==0.14.1'
                       ],
     setup_requires=['setupmeta']
 )

--- a/python/tests/api/expressions/test_str_to_expr.py
+++ b/python/tests/api/expressions/test_str_to_expr.py
@@ -49,7 +49,7 @@ def test_lt():
 def test_lte():
     expected_expr = Expressions.less_than_or_equal("col_a", 1)
     conv_expr = Expressions.convert_string_to_expr("col_a <= 1")
-    assert expected_expr == conv_expr\
+    assert expected_expr == conv_expr
 
 
 def test_and():

--- a/python/tests/core/utils/__init__.py
+++ b/python/tests/core/utils/__init__.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/python/tests/parquet/__init__.py
+++ b/python/tests/parquet/__init__.py
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# TODO: remove once ready for arrow 0.15.1
+#   until then necessary to prevent crash from numba/pyarrow incompat
+#   see: https://github.com/numba/numba/issues/4256#issuecomment-546860012
+import fastparquet  # noqa: ignore=F401

--- a/python/tests/parquet/conftest.py
+++ b/python/tests/parquet/conftest.py
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pyarrow as pa
+import pytest
+
+
+@pytest.fixture(scope="session")
+def pyarrow_array():
+    return [pa.array([1, 2, 3, None, 5], type=pa.int32()),
+            pa.array(['us', 'can', 'us', 'us', 'can'], type=pa.string()),
+            pa.array([[0], [1, 2], [1], [1, 2, 3], None], type=pa.list_(pa.int64())),
+            pa.array([True, None, False, True, True], pa.bool_())]
+
+
+@pytest.fixture(scope="session")
+def pytable_colnames():
+    return ['int_col', 'str_col', 'list_col', 'bool_col']

--- a/python/tests/parquet/test_gandiva_row_filtering.py
+++ b/python/tests/parquet/test_gandiva_row_filtering.py
@@ -1,0 +1,153 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from collections import OrderedDict
+
+from iceberg.api.expressions import Expressions
+from iceberg.parquet.gandiva_utils import apply_iceberg_filter
+import pyarrow as pa
+import pytest
+
+
+@pytest.mark.parametrize("filter_value, col_name, op, ref_dict",
+                         [(1, "int_col", Expressions.equal, OrderedDict([('int_col', [1]),
+                                                                         ('str_col', ['us']),
+                                                                         ('list_col', [[0]]),
+                                                                         ('bool_col', [True])])),
+                          (3, "int_col", Expressions.less_than_or_equal, OrderedDict([('int_col', [1, 2, 3]),
+                                                                                      ('str_col', ['us', 'can', 'us']),
+                                                                                      ('list_col', [[0], [1, 2], [1]]),
+                                                                                      ('bool_col', [True, None, False])])),
+                          (3, "int_col", Expressions.less_than, OrderedDict([('int_col', [1, 2]),
+                                                                             ('str_col', ['us', 'can']),
+                                                                             ('list_col', [[0], [1, 2]]),
+                                                                             ('bool_col', [True, None])])),
+                          (5, "int_col", Expressions.greater_than_or_equal, OrderedDict([('int_col', [5]),
+                                                                                         ('str_col', ['can']),
+                                                                                         ('list_col', [None]),
+                                                                                         ('bool_col', [True])])),
+                          (2, "int_col", Expressions.greater_than, OrderedDict([('int_col', [3, 5]),
+                                                                                ('str_col', ['us', 'can']),
+                                                                                ('list_col', [[1], None]),
+                                                                                ('bool_col', [False, True])]))
+                          ])
+def test_int_comparison_expressions(pytable_colnames, pyarrow_array, filter_value, col_name, op, ref_dict):
+    batches = [pa.RecordBatch.from_arrays(pyarrow_array, pytable_colnames)]
+    tbl = pa.Table.from_batches(batches)
+
+    filt_table = apply_iceberg_filter(tbl, {col: col for col in pytable_colnames}, op(col_name, filter_value))
+
+    assert filt_table.to_batches()[0].to_pydict() == ref_dict
+
+
+@pytest.mark.parametrize("filter_value, col_name, op, ref_dict",
+                         [("us", "str_col", Expressions.equal, OrderedDict([('int_col', [1, 3, None]),
+                                                                            ('str_col', ['us', 'us', 'us']),
+                                                                            ('list_col', [[0], [1], [1, 2, 3]]),
+                                                                            ('bool_col', [True, False, True])])),
+                          ("can", "str_col", Expressions.less_than_or_equal, OrderedDict([('int_col', [2, 5]),
+                                                                                          ('str_col', ['can', 'can']),
+                                                                                          ('list_col', [[1, 2], None]),
+                                                                                          ('bool_col', [None, True])])),
+                          ("cb", "str_col", Expressions.less_than, OrderedDict([('int_col', [2, 5]),
+                                                                                ('str_col', ['can', 'can']),
+                                                                                ('list_col', [[1, 2], None]),
+                                                                                ('bool_col', [None, True])])),
+                          ("us", "str_col", Expressions.greater_than_or_equal, OrderedDict([('int_col', [1, 3, None]),
+                                                                                            ('str_col', ['us', 'us', 'us']),
+                                                                                            ('list_col', [[0], [1], [1, 2, 3]]),
+                                                                                            ('bool_col', [True, False, True])])),
+                          ("ua", "str_col", Expressions.greater_than, OrderedDict([('int_col', [1, 3, None]),
+                                                                                   ('str_col', ['us', 'us', 'us']),
+                                                                                   ('list_col', [[0], [1], [1, 2, 3]]),
+                                                                                   ('bool_col', [True, False, True])]))
+                          ])
+def test_str_comparison_expressions(pytable_colnames, pyarrow_array, filter_value, col_name, op, ref_dict):
+    batches = [pa.RecordBatch.from_arrays(pyarrow_array, pytable_colnames)]
+    tbl = pa.Table.from_batches(batches)
+
+    filt_table = apply_iceberg_filter(tbl, {col: col for col in pytable_colnames}, op(col_name, filter_value))
+
+    assert filt_table.to_batches()[0].to_pydict() == ref_dict
+
+
+@pytest.mark.parametrize("filter_value, col_name, op, ref_dict",
+                         [(True, "bool_col", Expressions.equal, OrderedDict([('int_col', [1, None, 5]),
+                                                                             ('str_col', ['us', 'us', 'can']),
+                                                                             ('list_col', [[0], [1, 2, 3], None]),
+                                                                             ('bool_col', [True, True, True])])),
+                          (True, "bool_col", Expressions.not_equal, OrderedDict([('int_col', [3]),
+                                                                                 ('str_col', ['us']),
+                                                                                 ('list_col', [[1]]),
+                                                                                 ('bool_col', [False])])),
+                          (False, "bool_col", Expressions.equal, OrderedDict([('int_col', [3]),
+                                                                              ('str_col', ['us']),
+                                                                              ('list_col', [[1]]),
+                                                                              ('bool_col', [False])])),
+                          (False, "bool_col", Expressions.not_equal, OrderedDict([('int_col', [1, None, 5]),
+                                                                                  ('str_col', ['us', 'us', 'can']),
+                                                                                  ('list_col', [[0], [1, 2, 3], None]),
+                                                                                  ('bool_col', [True, True, True])]))
+                          ])
+def test_bool_comparison_expressions(pytable_colnames, pyarrow_array, filter_value, col_name, op, ref_dict):
+
+    batches = [pa.RecordBatch.from_arrays(pyarrow_array, pytable_colnames)]
+    tbl = pa.Table.from_batches(batches)
+
+    filt_table = apply_iceberg_filter(tbl, {col: col for col in pytable_colnames}, op(col_name, filter_value))
+
+    assert filt_table.to_batches()[0].to_pydict() == ref_dict
+
+
+@pytest.mark.parametrize("col_name, op, ref_dict",
+                         [("int_col", Expressions.is_null, OrderedDict([('int_col', [None]),
+                                                                        ('str_col', ['us']),
+                                                                        ('list_col', [[1, 2, 3]]),
+                                                                        ('bool_col', [True])])),
+                          ("list_col", Expressions.is_null, OrderedDict([('int_col', [5]),
+                                                                         ('str_col', ['can']),
+                                                                         ('list_col', [None]),
+                                                                         ('bool_col', [True])])),
+                          ("bool_col", Expressions.is_null, OrderedDict([('int_col', [2]),
+                                                                         ('str_col', ['can']),
+                                                                         ('list_col', [[1, 2]]),
+                                                                         ('bool_col', [None])])),
+                          ("int_col", Expressions.not_null, OrderedDict([('int_col', [1, 2, 3, 5]),
+                                                                         ('str_col', ['us', 'can', 'us', 'can']),
+                                                                         ('list_col', [[0], [1, 2], [1], None]),
+                                                                         ('bool_col', [True, None, False, True])])),
+                          ("str_col", Expressions.not_null, OrderedDict([('int_col', [1, 2, 3, None, 5]),
+                                                                         ('str_col', ['us', 'can', 'us', 'us', 'can']),
+                                                                         ('list_col', [[0], [1, 2], [1], [1, 2, 3], None]),
+                                                                         ('bool_col', [True, None, False, True, True])])),
+                          ("list_col", Expressions.not_null, OrderedDict([('int_col', [1, 2, 3, None]),
+                                                                          ('str_col', ['us', 'can', 'us', 'us']),
+                                                                          ('list_col', [[0], [1, 2], [1], [1, 2, 3]]),
+                                                                          ('bool_col', [True, None, False, True])])),
+                          ("bool_col", Expressions.not_null, OrderedDict([('int_col', [1, 3, None, 5]),
+                                                                          ('str_col', ['us', 'us', 'us', 'can']),
+                                                                          ('list_col', [[0], [1], [1, 2, 3], None]),
+                                                                          ('bool_col', [True, False, True, True])])),
+
+                          ])
+def test_nullable_expressions(pytable_colnames, pyarrow_array, col_name, op, ref_dict):
+
+    batches = [pa.RecordBatch.from_arrays(pyarrow_array, pytable_colnames)]
+    tbl = pa.Table.from_batches(batches)
+
+    with pytest.raises(NotImplementedError):
+        apply_iceberg_filter(tbl, {col: col for col in pytable_colnames}, op(col_name))

--- a/python/tests/parquet/test_row_level_filtering.py
+++ b/python/tests/parquet/test_row_level_filtering.py
@@ -1,0 +1,154 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from collections import OrderedDict
+
+from iceberg.api.expressions import Expressions
+from iceberg.parquet.arrow_table_utils import apply_iceberg_filter
+import pyarrow as pa
+import pytest
+
+
+@pytest.mark.parametrize("filter_value, col_name, op, ref_dict",
+                         [(1, "int_col", Expressions.equal, OrderedDict([('int_col', [1]),
+                                                                         ('str_col', ['us']),
+                                                                         ('list_col', [[0]]),
+                                                                         ('bool_col', [True])])),
+                          (3, "int_col", Expressions.less_than_or_equal, OrderedDict([('int_col', [1, 2, 3]),
+                                                                                      ('str_col', ['us', 'can', 'us']),
+                                                                                      ('list_col', [[0], [1, 2], [1]]),
+                                                                                      ('bool_col', [True, None, False])])),
+                          (3, "int_col", Expressions.less_than, OrderedDict([('int_col', [1, 2]),
+                                                                             ('str_col', ['us', 'can']),
+                                                                             ('list_col', [[0], [1, 2]]),
+                                                                             ('bool_col', [True, None])])),
+                          (5, "int_col", Expressions.greater_than_or_equal, OrderedDict([('int_col', [5]),
+                                                                                         ('str_col', ['can']),
+                                                                                         ('list_col', [None]),
+                                                                                         ('bool_col', [True])])),
+                          (2, "int_col", Expressions.greater_than, OrderedDict([('int_col', [3, 5]),
+                                                                                ('str_col', ['us', 'can']),
+                                                                                ('list_col', [[1], None]),
+                                                                                ('bool_col', [False, True])]))
+                          ])
+def test_int_comparison_expressions(pytable_colnames, pyarrow_array, filter_value, col_name, op, ref_dict):
+    batches = [pa.RecordBatch.from_arrays(pyarrow_array, pytable_colnames)]
+    tbl = pa.Table.from_batches(batches)
+
+    filt_table = apply_iceberg_filter(tbl, {col: col for col in pytable_colnames}, op(col_name, filter_value))
+
+    assert filt_table.to_batches()[0].to_pydict() == ref_dict
+
+
+@pytest.mark.parametrize("filter_value, col_name, op, ref_dict",
+                         [("us", "str_col", Expressions.equal, OrderedDict([('int_col', [1, 3, None]),
+                                                                            ('str_col', ['us', 'us', 'us']),
+                                                                            ('list_col', [[0], [1], [1, 2, 3]]),
+                                                                            ('bool_col', [True, False, True])])),
+                          ("can", "str_col", Expressions.less_than_or_equal, OrderedDict([('int_col', [2, 5]),
+                                                                                          ('str_col', ['can', 'can']),
+                                                                                          ('list_col', [[1, 2], None]),
+                                                                                          ('bool_col', [None, True])])),
+                          ("cb", "str_col", Expressions.less_than, OrderedDict([('int_col', [2, 5]),
+                                                                                ('str_col', ['can', 'can']),
+                                                                                ('list_col', [[1, 2], None]),
+                                                                                ('bool_col', [None, True])])),
+                          ("us", "str_col", Expressions.greater_than_or_equal, OrderedDict([('int_col', [1, 3, None]),
+                                                                                            ('str_col', ['us', 'us', 'us']),
+                                                                                            ('list_col', [[0], [1], [1, 2, 3]]),
+                                                                                            ('bool_col', [True, False, True])])),
+                          ("ua", "str_col", Expressions.greater_than, OrderedDict([('int_col', [1, 3, None]),
+                                                                                   ('str_col', ['us', 'us', 'us']),
+                                                                                   ('list_col', [[0], [1], [1, 2, 3]]),
+                                                                                   ('bool_col', [True, False, True])]))
+                          ])
+def test_str_comparison_expressions(pytable_colnames, pyarrow_array, filter_value, col_name, op, ref_dict):
+    batches = [pa.RecordBatch.from_arrays(pyarrow_array, pytable_colnames)]
+    tbl = pa.Table.from_batches(batches)
+
+    filt_table = apply_iceberg_filter(tbl, {col: col for col in pytable_colnames}, op(col_name, filter_value))
+
+    assert filt_table.to_batches()[0].to_pydict() == ref_dict
+
+
+@pytest.mark.parametrize("filter_value, col_name, op, ref_dict",
+                         [(True, "bool_col", Expressions.equal, OrderedDict([('int_col', [1, None, 5]),
+                                                                             ('str_col', ['us', 'us', 'can']),
+                                                                             ('list_col', [[0], [1, 2, 3], None]),
+                                                                             ('bool_col', [True, True, True])])),
+                          (True, "bool_col", Expressions.not_equal, OrderedDict([('int_col', [3]),
+                                                                                 ('str_col', ['us']),
+                                                                                 ('list_col', [[1]]),
+                                                                                 ('bool_col', [False])])),
+                          (False, "bool_col", Expressions.equal, OrderedDict([('int_col', [3]),
+                                                                              ('str_col', ['us']),
+                                                                              ('list_col', [[1]]),
+                                                                              ('bool_col', [False])])),
+                          (False, "bool_col", Expressions.not_equal, OrderedDict([('int_col', [1, None, 5]),
+                                                                                  ('str_col', ['us', 'us', 'can']),
+                                                                                  ('list_col', [[0], [1, 2, 3], None]),
+                                                                                  ('bool_col', [True, True, True])]))
+                          ])
+def test_bool_comparison_expressions(pytable_colnames, pyarrow_array, filter_value, col_name, op, ref_dict):
+
+    batches = [pa.RecordBatch.from_arrays(pyarrow_array, pytable_colnames)]
+    tbl = pa.Table.from_batches(batches)
+
+    filt_table = apply_iceberg_filter(tbl, {col: col for col in pytable_colnames}, op(col_name, filter_value))
+
+    assert filt_table.to_batches()[0].to_pydict() == ref_dict
+
+
+@pytest.mark.parametrize("col_name, op, ref_dict",
+                         [("int_col", Expressions.is_null, OrderedDict([('int_col', [None]),
+                                                                        ('str_col', ['us']),
+                                                                        ('list_col', [[1, 2, 3]]),
+                                                                        ('bool_col', [True])])),
+                          ("list_col", Expressions.is_null, OrderedDict([('int_col', [5]),
+                                                                         ('str_col', ['can']),
+                                                                         ('list_col', [None]),
+                                                                         ('bool_col', [True])])),
+                          ("bool_col", Expressions.is_null, OrderedDict([('int_col', [2]),
+                                                                         ('str_col', ['can']),
+                                                                         ('list_col', [[1, 2]]),
+                                                                         ('bool_col', [None])])),
+                          ("int_col", Expressions.not_null, OrderedDict([('int_col', [1, 2, 3, 5]),
+                                                                         ('str_col', ['us', 'can', 'us', 'can']),
+                                                                         ('list_col', [[0], [1, 2], [1], None]),
+                                                                         ('bool_col', [True, None, False, True])])),
+                          ("str_col", Expressions.not_null, OrderedDict([('int_col', [1, 2, 3, None, 5]),
+                                                                         ('str_col', ['us', 'can', 'us', 'us', 'can']),
+                                                                         ('list_col', [[0], [1, 2], [1], [1, 2, 3], None]),
+                                                                         ('bool_col', [True, None, False, True, True])])),
+                          ("list_col", Expressions.not_null, OrderedDict([('int_col', [1, 2, 3, None]),
+                                                                          ('str_col', ['us', 'can', 'us', 'us']),
+                                                                          ('list_col', [[0], [1, 2], [1], [1, 2, 3]]),
+                                                                          ('bool_col', [True, None, False, True])])),
+                          ("bool_col", Expressions.not_null, OrderedDict([('int_col', [1, 3, None, 5]),
+                                                                          ('str_col', ['us', 'us', 'us', 'can']),
+                                                                          ('list_col', [[0], [1], [1, 2, 3], None]),
+                                                                          ('bool_col', [True, False, True, True])])),
+
+                          ])
+def test_nullable_expressions(pytable_colnames, pyarrow_array, col_name, op, ref_dict):
+
+    batches = [pa.RecordBatch.from_arrays(pyarrow_array, pytable_colnames)]
+    tbl = pa.Table.from_batches(batches)
+
+    filt_table = apply_iceberg_filter(tbl, {col: col for col in pytable_colnames}, op(col_name))
+
+    assert filt_table.to_batches()[0].to_pydict() == ref_dict


### PR DESCRIPTION
@danielcweeks This adds the parquet package for reading parquet files.  This package is independent from the remaining PR needed for core to finish off table scanning.  I included an Gandiva module that is currently not being used, but has been tested to be functional.