### PR TITLE
[WIP] Extend metadata with SortOrder

### DIFF
--- a/api/src/main/java/org/apache/iceberg/SortField.java
+++ b/api/src/main/java/org/apache/iceberg/SortField.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+import org.apache.iceberg.SortTransforms.SortTransform;
+
+public class SortField implements Serializable {
+  public enum Direction {
+    ASC, DESC
+  }
+
+  public enum NullOrder {
+    NULLS_FIRST, NULLS_LAST
+  }
+
+  private final String name;
+  private final Direction direction;
+  private final NullOrder nullOrder;
+  private final SortTransform transform;
+  private final int[] sourceIds;
+
+  SortField(String name, Direction direction, NullOrder nullOrder, SortTransform transform, int[] sourceIds) {
+    this.name = name;
+    this.direction = direction;
+    this.nullOrder = nullOrder;
+    this.transform = transform;
+    this.sourceIds = sourceIds;
+  }
+
+  public String name() {
+    return name;
+  }
+
+  public Direction direction() {
+    return direction;
+  }
+
+  public NullOrder nullOrder() {
+    return nullOrder;
+  }
+
+  public SortTransform transform() {
+    return transform;
+  }
+
+  public int[] sourceIds() {
+    return sourceIds;
+  }
+
+  public boolean semanticEquals(SortField that) {
+    return direction == that.direction &&
+        nullOrder == that.nullOrder &&
+        Objects.equals(transform, that.transform) &&
+        Arrays.equals(sourceIds, that.sourceIds);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+
+    SortField that = (SortField) obj;
+    return Objects.equals(name, that.name) &&
+        direction == that.direction &&
+        nullOrder == that.nullOrder &&
+        Objects.equals(transform, that.transform) &&
+        Arrays.equals(sourceIds, that.sourceIds);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, direction, nullOrder, transform, Arrays.hashCode(sourceIds));
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/SortOrder.java
+++ b/api/src/main/java/org/apache/iceberg/SortOrder.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import org.apache.iceberg.SortField.Direction;
+import org.apache.iceberg.SortField.NullOrder;
+import org.apache.iceberg.SortTransforms.SortTransform;
+import org.apache.iceberg.types.Types;
+
+// TODO: toString()
+public class SortOrder implements Serializable {
+
+  private static final SortOrder UNSORTED_ORDER = new SortOrder(new Schema(), 0, ImmutableList.of());
+
+  private final Schema schema;
+  private final int orderId;
+  private final SortField[] fields;
+  private transient volatile List<SortField> fieldList;
+
+  public static SortOrder unsorted() {
+    return UNSORTED_ORDER;
+  }
+
+  private SortOrder(Schema schema, int orderId, List<SortField> fields) {
+    this.schema = schema;
+    this.orderId = orderId;
+    this.fields = new SortField[fields.size()];
+    for (int fieldIndex = 0; fieldIndex < this.fields.length; fieldIndex++) {
+      this.fields[fieldIndex] = fields.get(fieldIndex);
+    }
+  }
+
+  public Schema schema() {
+    return schema;
+  }
+
+  public int orderId() {
+    return orderId;
+  }
+
+  public List<SortField> fields() {
+    return lazyFieldList();
+  }
+
+  public boolean satisfies(SortOrder anotherSortOrder) {
+    if (anotherSortOrder.fields.length == 0) {
+      return true;
+    }
+
+    if (anotherSortOrder.fields.length > fields.length) {
+      return false;
+    }
+
+    for (int fieldIndex = 0; fieldIndex < anotherSortOrder.fields.length; fieldIndex++) {
+      SortField anotherField = anotherSortOrder.fields[fieldIndex];
+      SortField field = fields[fieldIndex];
+      if (!field.semanticEquals(anotherField)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+
+    SortOrder that = (SortOrder) obj;
+    return orderId == that.orderId && Arrays.equals(fields, that.fields);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(orderId, Arrays.hashCode(fields));
+  }
+
+  private List<SortField> lazyFieldList() {
+    if (fieldList == null) {
+      synchronized (this) {
+        if (fieldList == null) {
+          this.fieldList = ImmutableList.copyOf(fields);
+        }
+      }
+    }
+    return fieldList;
+  }
+
+  public static Builder builderFor(Schema schema) {
+    return new Builder(schema);
+  }
+
+  // TODO: add validation
+  public static class Builder {
+    private final Schema schema;
+    private final List<SortField> fields = Lists.newArrayList();
+    private int orderId = 0;
+
+    private Builder(Schema schema) {
+      this.schema = schema;
+    }
+
+    public Builder natural(String columnName) {
+      return natural(columnName, Direction.ASC, NullOrder.NULLS_FIRST);
+    }
+
+    public Builder natural(String columnName, Direction direction, NullOrder nullOrder) {
+      Types.NestedField column = findSourceColumn(columnName);
+      SortTransform transform = SortTransforms.IdentityTransform.get();
+      SortField field = new SortField(columnName, direction, nullOrder, transform, new int[]{column.fieldId()});
+      fields.add(field);
+      return this;
+    }
+
+    public Builder withOrderId(int newOrderId) {
+      this.orderId = newOrderId;
+      return this;
+    }
+
+    public SortOrder build() {
+      return new SortOrder(schema, orderId, fields);
+    }
+
+    Builder add(String name, Direction direction, NullOrder nullOrder, SortTransform transform, int[] sourceIds) {
+      SortField field = new SortField(name, direction, nullOrder, transform, sourceIds);
+      fields.add(field);
+      return this;
+    }
+
+    private Types.NestedField findSourceColumn(String sourceName) {
+      Types.NestedField sourceColumn = schema.findField(sourceName);
+      Preconditions.checkArgument(sourceColumn != null, "Cannot find source column: %s", sourceName);
+      return sourceColumn;
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/SortTransforms.java
+++ b/api/src/main/java/org/apache/iceberg/SortTransforms.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+public class SortTransforms {
+
+  private SortTransforms() {}
+
+  public static SortTransform fromString(String transform) {
+    if ("identity".equalsIgnoreCase(transform)) {
+      return IdentityTransform.get();
+    } else {
+      // TODO: consider UnknownSortTransform instead of throwing an exception
+      throw new IllegalArgumentException("Unknown sort transform: " + transform);
+    }
+  }
+
+  public interface SortTransform {}
+
+  public static class IdentityTransform implements SortTransform {
+    private static final IdentityTransform INSTANCE = new IdentityTransform();
+
+    public static IdentityTransform get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public String toString() {
+      return "identity";
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/Table.java
+++ b/api/src/main/java/org/apache/iceberg/Table.java
@@ -66,6 +66,20 @@ public interface Table {
   Map<Integer, PartitionSpec> specs();
 
   /**
+   * Return the {@link SortOrder sort order} for this table.
+   *
+   * @return this table's sort order
+   */
+  SortOrder sortOrder();
+
+  /**
+   * Return a map of {@link SortOrder sort orders} for this table.
+   *
+   * @return this table's sort orders map
+   */
+  Map<Integer, SortOrder> sortOrders();
+
+  /**
    * Return a map of string properties for this table.
    *
    * @return this table's properties map

--- a/api/src/main/java/org/apache/iceberg/Tables.java
+++ b/api/src/main/java/org/apache/iceberg/Tables.java
@@ -30,15 +30,24 @@ import java.util.Map;
  */
 public interface Tables {
   default Table create(Schema schema, String tableIdentifier) {
-    return create(schema, PartitionSpec.unpartitioned(), ImmutableMap.of(), tableIdentifier);
+    return create(schema, PartitionSpec.unpartitioned(), SortOrder.unsorted(), ImmutableMap.of(), tableIdentifier);
+  }
+
+  default Table create(Schema schema, PartitionSpec spec, SortOrder sortOrder, String tableIdentifier) {
+    return create(schema, spec, sortOrder, ImmutableMap.of(), tableIdentifier);
   }
 
   default Table create(Schema schema, PartitionSpec spec, String tableIdentifier) {
-    return create(schema, spec, ImmutableMap.of(), tableIdentifier);
+    return create(schema, spec, SortOrder.unsorted(), ImmutableMap.of(), tableIdentifier);
+  }
+
+  default Table create(Schema schema, PartitionSpec spec, Map<String, String> properties, String tableIdentifier) {
+    return create(schema, spec, SortOrder.unsorted(), properties, tableIdentifier);
   }
 
   Table create(Schema schema,
                PartitionSpec spec,
+               SortOrder sortOrder,
                Map<String, String> properties,
                String tableIdentifier);
 

--- a/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.catalog;
 import java.util.Map;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
@@ -38,6 +39,7 @@ public interface Catalog {
    * @param identifier a table identifier
    * @param schema a schema
    * @param spec a partition spec
+   * @param sortOrder a sort order
    * @param location a location for the table; leave null if unspecified
    * @param properties a string map of table properties
    * @return a Table instance
@@ -47,8 +49,49 @@ public interface Catalog {
       TableIdentifier identifier,
       Schema schema,
       PartitionSpec spec,
+      SortOrder sortOrder,
       String location,
       Map<String, String> properties);
+
+  /**
+   * Create a table.
+   *
+   * @param identifier a table identifier
+   * @param schema a schema
+   * @param spec a partition spec
+   * @param location a location for the table; leave null if unspecified
+   * @param properties a string map of table properties
+   * @return a Table instance
+   * @throws AlreadyExistsException if the table already exists
+   */
+  default Table createTable(
+      TableIdentifier identifier,
+      Schema schema,
+      PartitionSpec spec,
+      String location,
+      Map<String, String> properties) {
+    return createTable(identifier, schema, spec, SortOrder.unsorted(), location, properties);
+  }
+
+  /**
+   * Create a table.
+   *
+   * @param identifier a table identifier
+   * @param schema a schema
+   * @param spec a partition spec
+   * @param sortOrder a sort order
+   * @param properties a string map of table properties
+   * @return a Table instance
+   * @throws AlreadyExistsException if the table already exists
+   */
+  default Table createTable(
+      TableIdentifier identifier,
+      Schema schema,
+      PartitionSpec spec,
+      SortOrder sortOrder,
+      Map<String, String> properties) {
+    return createTable(identifier, schema, spec, sortOrder, null, properties);
+  }
 
   /**
    * Create a table.
@@ -65,7 +108,25 @@ public interface Catalog {
       Schema schema,
       PartitionSpec spec,
       Map<String, String> properties) {
-    return createTable(identifier, schema, spec, null, properties);
+    return createTable(identifier, schema, spec, SortOrder.unsorted(), null, properties);
+  }
+
+  /**
+   * Create a table.
+   *
+   * @param identifier a table identifier
+   * @param schema a schema
+   * @param spec a partition spec
+   * @param sortOrder a sort order
+   * @return a Table instance
+   * @throws AlreadyExistsException if the table already exists
+   */
+  default Table createTable(
+      TableIdentifier identifier,
+      Schema schema,
+      PartitionSpec spec,
+      SortOrder sortOrder) {
+    return createTable(identifier, schema, spec, sortOrder, null, null);
   }
 
   /**
@@ -81,7 +142,7 @@ public interface Catalog {
       TableIdentifier identifier,
       Schema schema,
       PartitionSpec spec) {
-    return createTable(identifier, schema, spec, null, null);
+    return createTable(identifier, schema, spec, SortOrder.unsorted(), null, null);
   }
 
   /**
@@ -95,8 +156,28 @@ public interface Catalog {
   default Table createTable(
       TableIdentifier identifier,
       Schema schema) {
-    return createTable(identifier, schema, PartitionSpec.unpartitioned(), null, null);
+    return createTable(identifier, schema, PartitionSpec.unpartitioned(), SortOrder.unsorted(), null, null);
   }
+
+  /**
+   * Start a transaction to create a table.
+   *
+   * @param identifier a table identifier
+   * @param schema a schema
+   * @param spec a partition spec
+   * @param sortOrder a sort order
+   * @param location a location for the table; leave null if unspecified
+   * @param properties a string map of table properties
+   * @return a {@link Transaction} to create the table
+   * @throws AlreadyExistsException if the table already exists
+   */
+  Transaction newCreateTableTransaction(
+      TableIdentifier identifier,
+      Schema schema,
+      PartitionSpec spec,
+      SortOrder sortOrder,
+      String location,
+      Map<String, String> properties);
 
   /**
    * Start a transaction to create a table.
@@ -109,12 +190,34 @@ public interface Catalog {
    * @return a {@link Transaction} to create the table
    * @throws AlreadyExistsException if the table already exists
    */
-  Transaction newCreateTableTransaction(
+  default Transaction newCreateTableTransaction(
       TableIdentifier identifier,
       Schema schema,
       PartitionSpec spec,
       String location,
-      Map<String, String> properties);
+      Map<String, String> properties) {
+    return newCreateTableTransaction(identifier, schema, spec, SortOrder.unsorted(), location, properties);
+  }
+
+  /**
+   * Start a transaction to create a table.
+   *
+   * @param identifier a table identifier
+   * @param schema a schema
+   * @param spec a partition spec
+   * @param sortOrder a sort order
+   * @param properties a string map of table properties
+   * @return a {@link Transaction} to create the table
+   * @throws AlreadyExistsException if the table already exists
+   */
+  default Transaction newCreateTableTransaction(
+      TableIdentifier identifier,
+      Schema schema,
+      PartitionSpec spec,
+      SortOrder sortOrder,
+      Map<String, String> properties) {
+    return newCreateTableTransaction(identifier, schema, spec, sortOrder, null, properties);
+  }
 
   /**
    * Start a transaction to create a table.
@@ -131,7 +234,25 @@ public interface Catalog {
       Schema schema,
       PartitionSpec spec,
       Map<String, String> properties) {
-    return newCreateTableTransaction(identifier, schema, spec, null, properties);
+    return newCreateTableTransaction(identifier, schema, spec, SortOrder.unsorted(), null, properties);
+  }
+
+  /**
+   * Start a transaction to create a table.
+   *
+   * @param identifier a table identifier
+   * @param schema a schema
+   * @param spec a partition spec
+   * @param sortOrder a sort order
+   * @return a {@link Transaction} to create the table
+   * @throws AlreadyExistsException if the table already exists
+   */
+  default Transaction newCreateTableTransaction(
+      TableIdentifier identifier,
+      Schema schema,
+      PartitionSpec spec,
+      SortOrder sortOrder) {
+    return newCreateTableTransaction(identifier, schema, spec, sortOrder, null, null);
   }
 
   /**
@@ -147,7 +268,7 @@ public interface Catalog {
       TableIdentifier identifier,
       Schema schema,
       PartitionSpec spec) {
-    return newCreateTableTransaction(identifier, schema, spec, null, null);
+    return newCreateTableTransaction(identifier, schema, spec, SortOrder.unsorted(), null, null);
   }
 
   /**
@@ -161,8 +282,32 @@ public interface Catalog {
   default Transaction newCreateTableTransaction(
       TableIdentifier identifier,
       Schema schema) {
-    return newCreateTableTransaction(identifier, schema, PartitionSpec.unpartitioned(), null, null);
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    SortOrder sortOrder = SortOrder.unsorted();
+    return newCreateTableTransaction(identifier, schema, spec, sortOrder, null, null);
   }
+
+  /**
+   * Start a transaction to replace a table.
+   *
+   * @param identifier a table identifier
+   * @param schema a schema
+   * @param spec a partition spec
+   * @param sortOrder a sort order
+   * @param location a location for the table; leave null if unspecified
+   * @param properties a string map of table properties
+   * @param orCreate whether to create the table if not exists
+   * @return a {@link Transaction} to replace the table
+   * @throws NoSuchTableException if the table doesn't exist and orCreate is false
+   */
+  Transaction newReplaceTableTransaction(
+      TableIdentifier identifier,
+      Schema schema,
+      PartitionSpec spec,
+      SortOrder sortOrder,
+      String location,
+      Map<String, String> properties,
+      boolean orCreate);
 
   /**
    * Start a transaction to replace a table.
@@ -176,13 +321,37 @@ public interface Catalog {
    * @return a {@link Transaction} to replace the table
    * @throws NoSuchTableException if the table doesn't exist and orCreate is false
    */
-  Transaction newReplaceTableTransaction(
+  default Transaction newReplaceTableTransaction(
       TableIdentifier identifier,
       Schema schema,
       PartitionSpec spec,
       String location,
       Map<String, String> properties,
-      boolean orCreate);
+      boolean orCreate) {
+    return newReplaceTableTransaction(identifier, schema, spec, SortOrder.unsorted(), location, properties, orCreate);
+  }
+
+  /**
+   * Start a transaction to replace a table.
+   *
+   * @param identifier a table identifier
+   * @param schema a schema
+   * @param spec a partition spec
+   * @param sortOrder a sort order
+   * @param properties a string map of table properties
+   * @param orCreate whether to create the table if not exists
+   * @return a {@link Transaction} to replace the table
+   * @throws NoSuchTableException if the table doesn't exist and orCreate is false
+   */
+  default Transaction newReplaceTableTransaction(
+      TableIdentifier identifier,
+      Schema schema,
+      PartitionSpec spec,
+      SortOrder sortOrder,
+      Map<String, String> properties,
+      boolean orCreate) {
+    return newReplaceTableTransaction(identifier, schema, spec, sortOrder, null, properties, orCreate);
+  }
 
   /**
    * Start a transaction to replace a table.
@@ -201,7 +370,27 @@ public interface Catalog {
       PartitionSpec spec,
       Map<String, String> properties,
       boolean orCreate) {
-    return newReplaceTableTransaction(identifier, schema, spec, null, properties, orCreate);
+    return newReplaceTableTransaction(identifier, schema, spec, SortOrder.unsorted(), null, properties, orCreate);
+  }
+
+  /**
+   * Start a transaction to replace a table.
+   *
+   * @param identifier a table identifier
+   * @param schema a schema
+   * @param spec a partition spec
+   * @param sortOrder a sort order
+   * @param orCreate whether to create the table if not exists
+   * @return a {@link Transaction} to replace the table
+   * @throws NoSuchTableException if the table doesn't exist and orCreate is false
+   */
+  default Transaction newReplaceTableTransaction(
+      TableIdentifier identifier,
+      Schema schema,
+      PartitionSpec spec,
+      SortOrder sortOrder,
+      boolean orCreate) {
+    return newReplaceTableTransaction(identifier, schema, spec, sortOrder, null, null, orCreate);
   }
 
   /**
@@ -219,7 +408,7 @@ public interface Catalog {
       Schema schema,
       PartitionSpec spec,
       boolean orCreate) {
-    return newReplaceTableTransaction(identifier, schema, spec, null, null, orCreate);
+    return newReplaceTableTransaction(identifier, schema, spec, SortOrder.unsorted(), null, null, orCreate);
   }
 
   /**
@@ -235,7 +424,9 @@ public interface Catalog {
       TableIdentifier identifier,
       Schema schema,
       boolean orCreate) {
-    return newReplaceTableTransaction(identifier, schema, PartitionSpec.unpartitioned(), null, null, orCreate);
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    SortOrder sortOrder = SortOrder.unsorted();
+    return newReplaceTableTransaction(identifier, schema, spec, sortOrder, null, null, orCreate);
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -28,6 +28,7 @@ import org.apache.iceberg.io.LocationProvider;
 
 abstract class BaseMetadataTable implements Table {
   private PartitionSpec spec = PartitionSpec.unpartitioned();
+  private SortOrder sortOrder = SortOrder.unsorted();
 
   abstract Table table();
   abstract String metadataTableName();
@@ -60,6 +61,16 @@ abstract class BaseMetadataTable implements Table {
   @Override
   public Map<Integer, PartitionSpec> specs() {
     return ImmutableMap.of(spec.specId(), spec);
+  }
+
+  @Override
+  public SortOrder sortOrder() {
+    return sortOrder;
+  }
+
+  @Override
+  public Map<Integer, SortOrder> sortOrders() {
+    return ImmutableMap.of(sortOrder.orderId(), sortOrder);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -20,9 +20,9 @@
 package org.apache.iceberg;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.MapMaker;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.Map;
@@ -47,6 +47,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
       TableIdentifier identifier,
       Schema schema,
       PartitionSpec spec,
+      SortOrder sortOrder,
       String location,
       Map<String, String> properties) {
     TableOperations ops = newTableOps(identifier);
@@ -61,8 +62,8 @@ public abstract class BaseMetastoreCatalog implements Catalog {
       baseLocation = defaultWarehouseLocation(identifier);
     }
 
-    TableMetadata metadata = TableMetadata.newTableMetadata(
-        ops, schema, spec, baseLocation, properties == null ? Maps.newHashMap() : properties);
+    Map<String, String> tableProps = properties != null ? properties : ImmutableMap.of();
+    TableMetadata metadata = TableMetadata.newTableMetadata(ops, schema, spec, sortOrder, baseLocation, tableProps);
 
     ops.commit(null, metadata);
 
@@ -78,6 +79,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
       TableIdentifier identifier,
       Schema schema,
       PartitionSpec spec,
+      SortOrder sortOrder,
       String location,
       Map<String, String> properties) {
 
@@ -87,8 +89,9 @@ public abstract class BaseMetastoreCatalog implements Catalog {
     }
 
     String baseLocation = location != null ? location : defaultWarehouseLocation(identifier);
-    Map<String, String> tableProperties = properties != null ? properties : Maps.newHashMap();
-    TableMetadata metadata = TableMetadata.newTableMetadata(ops, schema, spec, baseLocation, tableProperties);
+    Map<String, String> tableProps = properties != null ? properties : ImmutableMap.of();
+    TableMetadata metadata = TableMetadata.newTableMetadata(ops, schema, spec, sortOrder, baseLocation, tableProps);
+
     return Transactions.createTableTransaction(ops, metadata);
   }
 
@@ -97,6 +100,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
       TableIdentifier identifier,
       Schema schema,
       PartitionSpec spec,
+      SortOrder sortOrder,
       String location,
       Map<String, String> properties,
       boolean orCreate) {
@@ -107,8 +111,9 @@ public abstract class BaseMetastoreCatalog implements Catalog {
     }
 
     String baseLocation = location != null ? location : defaultWarehouseLocation(identifier);
-    Map<String, String> tableProperties = properties != null ? properties : Maps.newHashMap();
-    TableMetadata metadata = TableMetadata.newTableMetadata(ops, schema, spec, baseLocation, tableProperties);
+    Map<String, String> tableProps = properties != null ? properties : ImmutableMap.of();
+    TableMetadata metadata = TableMetadata.newTableMetadata(ops, schema, spec, sortOrder, baseLocation, tableProps);
+
     if (orCreate) {
       return Transactions.createOrReplaceTableTransaction(ops, metadata);
     } else {

--- a/core/src/main/java/org/apache/iceberg/BaseTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTable.java
@@ -70,6 +70,16 @@ public class BaseTable implements Table, HasTableOperations {
   }
 
   @Override
+  public SortOrder sortOrder() {
+    return ops.current().sortOrder();
+  }
+
+  @Override
+  public Map<Integer, SortOrder> sortOrders() {
+    return ops.current().sortOrdersById();
+  }
+
+  @Override
   public Map<String, String> properties() {
     return ops.current().properties();
   }

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -496,6 +496,16 @@ class BaseTransaction implements Transaction {
     }
 
     @Override
+    public SortOrder sortOrder() {
+      return current.sortOrder();
+    }
+
+    @Override
+    public Map<Integer, SortOrder> sortOrders() {
+      return current.sortOrdersById();
+    }
+
+    @Override
     public Map<String, String> properties() {
       return current.properties();
     }

--- a/core/src/main/java/org/apache/iceberg/SortOrderParser.java
+++ b/core/src/main/java/org/apache/iceberg/SortOrderParser.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Locale;
+import org.apache.iceberg.SortField.Direction;
+import org.apache.iceberg.SortField.NullOrder;
+import org.apache.iceberg.SortTransforms.SortTransform;
+import org.apache.iceberg.util.JsonUtil;
+
+public class SortOrderParser {
+
+  private static final String ORDER_ID = "order-id";
+  private static final String FIELDS = "fields";
+  private static final String NAME = "name";
+  private static final String DIRECTION = "direction";
+  private static final String NULL_ORDERING = "null-order";
+  private static final String TRANSFORM = "transform";
+  private static final String SOURCE_IDS = "source-ids";
+
+  private SortOrderParser() {}
+
+  public static void toJson(SortOrder sortOrder, JsonGenerator generator) throws IOException {
+    generator.writeStartObject();
+    generator.writeNumberField(ORDER_ID, sortOrder.orderId());
+    generator.writeFieldName(FIELDS);
+    toJsonFields(sortOrder, generator);
+    generator.writeEndObject();
+  }
+
+  private static void toJsonFields(SortOrder sortOrder, JsonGenerator generator) throws IOException {
+    generator.writeStartArray();
+    for (SortField field : sortOrder.fields()) {
+      generator.writeStartObject();
+      generator.writeStringField(NAME, field.name());
+      generator.writeStringField(DIRECTION, field.direction().toString().toLowerCase(Locale.ROOT));
+      generator.writeStringField(NULL_ORDERING, field.nullOrder().toString().toLowerCase(Locale.ROOT));
+      generator.writeStringField(TRANSFORM, field.transform().toString());
+      generator.writeFieldName(SOURCE_IDS);
+      generator.writeStartArray();
+      for (int sourceId : field.sourceIds()) {
+        generator.writeNumber(sourceId);
+      }
+      generator.writeEndArray();
+      generator.writeEndObject();
+    }
+    generator.writeEndArray();
+  }
+
+  public static SortOrder fromJson(Schema schema, JsonNode json) {
+    Preconditions.checkArgument(json.isObject(), "Cannot parse sort order from non-object: %s", json);
+    int orderId = JsonUtil.getInt(ORDER_ID, json);
+    SortOrder.Builder builder = SortOrder.builderFor(schema).withOrderId(orderId);
+    buildFromJsonFields(builder, json.get(FIELDS));
+    return builder.build();
+  }
+
+  private static void buildFromJsonFields(SortOrder.Builder builder, JsonNode json) {
+    Preconditions.checkArgument(json.isArray(), "Cannot parse partition order fields, not an array: %s", json);
+    Iterator<JsonNode> elements = json.elements();
+    while (elements.hasNext()) {
+      JsonNode element = elements.next();
+      Preconditions.checkArgument(element.isObject(), "Cannot parse sort field, not an object: %s", element);
+
+      String name = JsonUtil.getString(NAME, element);
+
+      String directionAsString = JsonUtil.getString(DIRECTION, element);
+      Direction direction = Direction.valueOf(directionAsString.toUpperCase(Locale.ROOT));
+
+      String nullOrderingAsString = JsonUtil.getString(NULL_ORDERING, element);
+      NullOrder nullOrder = NullOrder.valueOf(nullOrderingAsString.toUpperCase(Locale.ROOT));
+
+      String transformAsString = JsonUtil.getString(TRANSFORM, element);
+      SortTransform transform = SortTransforms.fromString(transformAsString);
+
+      JsonNode sourceIdNode = element.get(SOURCE_IDS);
+      int size = sourceIdNode.size();
+      int[] sourceIds = new int[size];
+      Iterator<JsonNode> sourceIdElements = sourceIdNode.elements();
+      for (int i = 0; i < size; i++) {
+        sourceIds[i] = sourceIdElements.next().asInt();
+      }
+
+      builder.add(name, direction, nullOrder, transform, sourceIds);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -89,6 +89,8 @@ public class TableMetadataParser {
   static final String PARTITION_SPEC = "partition-spec";
   static final String PARTITION_SPECS = "partition-specs";
   static final String DEFAULT_SPEC_ID = "default-spec-id";
+  static final String DEFAULT_SORT_ORDER_ID = "default-sort-order-id";
+  static final String SORT_ORDERS = "sort-orders";
   static final String PROPERTIES = "properties";
   static final String CURRENT_SNAPSHOT_ID = "current-snapshot-id";
   static final String SNAPSHOTS = "snapshots";
@@ -167,6 +169,13 @@ public class TableMetadataParser {
     }
     generator.writeEndArray();
 
+    generator.writeNumberField(DEFAULT_SORT_ORDER_ID, metadata.defaultSortOrderId());
+    generator.writeArrayFieldStart(SORT_ORDERS);
+    for (SortOrder sortOrder : metadata.sortOrders()) {
+      SortOrderParser.toJson(sortOrder, generator);
+    }
+    generator.writeEndArray();
+
     generator.writeObjectFieldStart(PROPERTIES);
     for (Map.Entry<String, String> keyValue : metadata.properties().entrySet()) {
       generator.writeStringField(keyValue.getKey(), keyValue.getValue());
@@ -241,6 +250,22 @@ public class TableMetadataParser {
           schema, TableMetadata.INITIAL_SPEC_ID, node.get(PARTITION_SPEC)));
     }
 
+    JsonNode sortOrderArray = node.get(SORT_ORDERS);
+    List<SortOrder> sortOrders;
+    int defaultSortOrderId;
+    if (sortOrderArray != null) {
+      defaultSortOrderId = JsonUtil.getInt(DEFAULT_SORT_ORDER_ID, node);
+      ImmutableList.Builder<SortOrder> sortOrdersBuilder = ImmutableList.builder();
+      for (JsonNode sortOrder : sortOrderArray) {
+        sortOrdersBuilder.add(SortOrderParser.fromJson(schema, sortOrder));
+      }
+      sortOrders = sortOrdersBuilder.build();
+    } else {
+      SortOrder defaultSortOrder = SortOrder.unsorted();
+      sortOrders = ImmutableList.of(defaultSortOrder);
+      defaultSortOrderId = defaultSortOrder.orderId();
+    }
+
     Map<String, String> properties = JsonUtil.getStringMap(PROPERTIES, node);
     long currentVersionId = JsonUtil.getLong(CURRENT_SNAPSHOT_ID, node);
     long lastUpdatedMillis = JsonUtil.getLong(LAST_UPDATED_MILLIS, node);
@@ -267,7 +292,7 @@ public class TableMetadataParser {
     }
 
     return new TableMetadata(ops, file, uuid, location,
-        lastUpdatedMillis, lastAssignedColumnId, schema, defaultSpecId, specs, properties,
-        currentVersionId, snapshots, ImmutableList.copyOf(entries.iterator()));
+        lastUpdatedMillis, lastAssignedColumnId, schema, defaultSpecId, specs, defaultSortOrderId,
+        sortOrders, properties, currentVersionId, snapshots, ImmutableList.copyOf(entries.iterator()));
   }
 }

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTables.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTables.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SnapshotsTable;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
@@ -117,12 +118,13 @@ public class HadoopTables implements Tables, Configurable {
    *
    * @param schema iceberg schema used to create the table
    * @param spec partitioning spec, if null the table will be unpartitioned
+   * @param order sort order, if null the table will be ununsorted
    * @param properties a string map of table properties, initialized to empty if null
    * @param location a path URI (e.g. hdfs:///warehouse/my_table)
    * @return newly created table implementation
    */
   @Override
-  public Table create(Schema schema, PartitionSpec spec, Map<String, String> properties,
+  public Table create(Schema schema, PartitionSpec spec, SortOrder order, Map<String, String> properties,
                       String location) {
     Preconditions.checkNotNull(schema, "A table schema is required");
 
@@ -133,7 +135,10 @@ public class HadoopTables implements Tables, Configurable {
 
     Map<String, String> tableProps = properties == null ? ImmutableMap.of() : properties;
     PartitionSpec partitionSpec = spec == null ? PartitionSpec.unpartitioned() : spec;
-    TableMetadata metadata = TableMetadata.newTableMetadata(ops, schema, partitionSpec, location, tableProps);
+    SortOrder sortOrder = order == null ? SortOrder.unsorted() : order;
+    TableMetadata metadata = TableMetadata.newTableMetadata(
+        ops, schema, partitionSpec, sortOrder, location, tableProps);
+
     ops.commit(null, metadata);
 
     return new BaseTable(ops, location);

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadataJson.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadataJson.java
@@ -67,6 +67,12 @@ public class TestTableMetadataJson {
 
     PartitionSpec spec = PartitionSpec.builderFor(schema).withSpecId(5).build();
 
+    SortOrder sortOrder = SortOrder.builderFor(schema)
+        .withOrderId(3)
+        .natural("y")
+        .natural("z")
+        .build();
+
     long previousSnapshotId = System.currentTimeMillis() - new Random(1234).nextInt(3600);
     Snapshot previousSnapshot = new BaseSnapshot(
         ops, previousSnapshotId, null, previousSnapshotId, null, null, ImmutableList.of(
@@ -83,8 +89,8 @@ public class TestTableMetadataJson {
 
     TableMetadata expected = new TableMetadata(ops, null, UUID.randomUUID().toString(), "s3://bucket/test/location",
         System.currentTimeMillis(), 3, schema, 5, ImmutableList.of(spec),
-        ImmutableMap.of("property", "value"), currentSnapshotId,
-        Arrays.asList(previousSnapshot, currentSnapshot), snapshotLog);
+        3, ImmutableList.of(sortOrder), ImmutableMap.of("property", "value"),
+        currentSnapshotId, Arrays.asList(previousSnapshot, currentSnapshot), snapshotLog);
 
     String asJson = TableMetadataParser.toJson(expected);
     TableMetadata metadata = TableMetadataParser.fromJson(ops, null,
@@ -131,6 +137,8 @@ public class TestTableMetadataJson {
 
     PartitionSpec spec = PartitionSpec.builderFor(schema).withSpecId(5).build();
 
+    SortOrder sortOrder = SortOrder.builderFor(schema).withOrderId(3).build();
+
     long previousSnapshotId = System.currentTimeMillis() - new Random(1234).nextInt(3600);
     Snapshot previousSnapshot = new BaseSnapshot(
         ops, previousSnapshotId, null, previousSnapshotId, null, null, ImmutableList.of(
@@ -144,8 +152,8 @@ public class TestTableMetadataJson {
 
     TableMetadata expected = new TableMetadata(ops, null, UUID.randomUUID().toString(), "s3://bucket/test/location",
         System.currentTimeMillis(), 3, schema, 5, ImmutableList.of(spec),
-        ImmutableMap.of("property", "value"), currentSnapshotId,
-        Arrays.asList(previousSnapshot, currentSnapshot), reversedSnapshotLog);
+        3, ImmutableList.of(sortOrder), ImmutableMap.of("property", "value"),
+        currentSnapshotId, Arrays.asList(previousSnapshot, currentSnapshot), reversedSnapshotLog);
 
     // add the entries after creating TableMetadata to avoid the sorted check
     reversedSnapshotLog.add(
@@ -176,6 +184,8 @@ public class TestTableMetadataJson {
 
     PartitionSpec spec = PartitionSpec.builderFor(schema).identity("x").withSpecId(6).build();
 
+    SortOrder sortOrder = SortOrder.builderFor(schema).withOrderId(2).natural("z").build();
+
     long previousSnapshotId = System.currentTimeMillis() - new Random(1234).nextInt(3600);
     Snapshot previousSnapshot = new BaseSnapshot(
         ops, previousSnapshotId, null, previousSnapshotId, null, null, ImmutableList.of(
@@ -187,8 +197,8 @@ public class TestTableMetadataJson {
 
     TableMetadata expected = new TableMetadata(ops, null, null, "s3://bucket/test/location",
         System.currentTimeMillis(), 3, schema, 6, ImmutableList.of(spec),
-        ImmutableMap.of("property", "value"), currentSnapshotId,
-        Arrays.asList(previousSnapshot, currentSnapshot), ImmutableList.of());
+        2, ImmutableList.of(sortOrder), ImmutableMap.of("property", "value"),
+        currentSnapshotId, Arrays.asList(previousSnapshot, currentSnapshot), ImmutableList.of());
 
     String asJson = toJsonWithoutSpecList(expected);
     TableMetadata metadata = TableMetadataParser

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.iceberg.BaseMetastoreCatalog;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -53,11 +54,11 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable {
   }
 
   @Override
-  public org.apache.iceberg.Table createTable(
-      TableIdentifier identifier, Schema schema, PartitionSpec spec, String location, Map<String, String> properties) {
+  public org.apache.iceberg.Table createTable(TableIdentifier identifier, Schema schema, PartitionSpec spec,
+                                              SortOrder sortOrder, String location, Map<String, String> properties) {
     Preconditions.checkArgument(identifier.namespace().levels().length == 1,
         "Missing database in table identifier: %s", identifier);
-    return super.createTable(identifier, schema, spec, location, properties);
+    return super.createTable(identifier, schema, spec, sortOrder, location, properties);
   }
 
   @Override


### PR DESCRIPTION
This PR contains **_a very early preview_** of how we can extend Iceberg metadata with `SortOrder`.

The API currently looks like this:

```
SortOrder.builderFor(schema)
    .natural("col1")
    .natural("col2", ASC, NULLS_FIRST)
    .build()
```

The extended metadata looks like this:

```
  "default-sort-order-id" : 0,
  "sort-orders" : [ {
    "order-id" : 0,
    "fields" : [ {
      "name" : "id",
      "direction" : "desc",
      "null-order" : "nulls_last",
      "transform" : "identity",
      "source-ids" : [ 1 ]
    }, {
      "name" : "data",
      "direction" : "asc",
      "null-order" : "nulls_first",
      "transform" : "identity",
      "source-ids" : [ 2 ]
    } ]
  } ],
```

Later, we can have something like this:

```
  "default-sort-order-id" : 3,
  "sort-orders" : [ {
    "order-id" : 3,
    "fields" : [ {
      "name" : "zvalue",
      "direction" : "asc",
      "null-order" : "nulls_first",
      "transform" : "zorder(8, 16)",
      "source-ids" : [ 1, 4 ]
    } ]
  } ],
```

**Open Questions:**
- Overall approach (any ideas are welcome).
- Whether we need to have the actual logic for sort transformations in Iceberg or in query engines. The current implementation assumes that query engines will simply report the ordering of incoming data. Another way is to have sort transformations in Iceberg and register them in query engines (e.g. function catalog), but it might be tricky for query engines to report that ordering back to Iceberg on writes. Moreover, all query engines have their internal memory format and we want to avoid the cost of serializing data to Java objects to simply perform the sorting step. Having sort transformations in Iceberg will be needed if we have to sort diff files for row-level updates in Iceberg rather than rely on the existing ordering.
- Whether to keep `Direction` and `NullOrder` as enums or convert them to booleans.
- Avoid major changes in the Catalog API. It is not a good idea to break the existing API but I am not sure generating that many methods is worth it. Maybe, we can simply reduce the number of overloaded methods that were added by this commit.

**TODOs:**
- Handle the sort order in all `TableMetadata` operations.
- Propagate the sort order to files and annotate each file with orderId.
- Remove `sortColumns` from `DataFile` and replace it with `sortOrderId`.
- API for updating the sort order in a table.
- It looks like query engines will have to report the ordering of data before writing. Then we will need to propagate this info to files.
- Document changes to the format.

This addresses #317.