### PR TITLE
Update schema for field additions, updates [e.g type widening] using an input schema

### DIFF
--- a/api/src/main/java/org/apache/iceberg/UpdateSchema.java
+++ b/api/src/main/java/org/apache/iceberg/UpdateSchema.java
@@ -325,4 +325,12 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
    */
   UpdateSchema deleteColumn(String name);
 
+  /**
+   * Applies all the additions and updates [type widening, field documentation]
+   * from the input schema
+   *
+   * @param newSchema - Input schema from which updates are applied
+   * @return this for method chaining
+   */
+  UpdateSchema updateSchema(Schema newSchema);
 }

--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -190,6 +190,7 @@ public class TypeUtil {
   }
 
   public static class SchemaVisitor<T> {
+    private final Deque<String> fieldNames = Lists.newLinkedList();
     private final Deque<Integer> fieldIds = Lists.newLinkedList();
 
     public T schema(Schema schema, T structResult) {
@@ -216,6 +217,10 @@ public class TypeUtil {
       return null;
     }
 
+    protected Deque<String> fieldNames() {
+      return fieldNames;
+    }
+
     protected Deque<Integer> fieldIds() {
       return fieldIds;
     }
@@ -232,11 +237,13 @@ public class TypeUtil {
         List<T> results = Lists.newArrayListWithExpectedSize(struct.fields().size());
         for (Types.NestedField field : struct.fields()) {
           visitor.fieldIds.push(field.fieldId());
+          visitor.fieldNames.push(field.name());
           T result;
           try {
             result = visit(field.type(), visitor);
           } finally {
             visitor.fieldIds.pop();
+            visitor.fieldNames.pop();
           }
           results.add(visitor.field(field, result));
         }

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -258,6 +259,64 @@ class SchemaUpdate implements UpdateSchema {
     }
 
     return this;
+  }
+
+  @Override
+  public UpdateSchema updateSchema(Schema newSchema) {
+    TypeUtil.visit(newSchema, new ApplyUpdates(schema, this));
+    return this;
+  }
+
+  private static final Joiner DOT = Joiner.on(".");
+
+  private static class ApplyUpdates extends TypeUtil.SchemaVisitor<Void> {
+    private final Schema schema;
+    private final UpdateSchema updateSchema;
+    private final Map<String, Integer> indexByName;
+
+    private ApplyUpdates(Schema schema, UpdateSchema updateSchema) {
+      this.schema = schema;
+      this.updateSchema = updateSchema;
+      this.indexByName = TypeUtil.indexByName(schema.asStruct());
+    }
+
+    @Override
+    public Void struct(Types.StructType struct, List<Void> fieldResults) {
+      for (Types.NestedField newField : struct.fields()) {
+        Types.NestedField field = schema.findField(newField.fieldId());
+        String parents = DOT.join(fieldNames());
+        if (field == null) {
+          // found new field
+          if (parents.isEmpty()) {
+            // top level field
+            updateSchema.addColumn(null, newField.name(), newField.type());
+          } else if (indexByName.containsKey(parents)) {
+            // parent struct present
+            updateSchema.addColumn(parents, newField.name(), newField.type());
+          }
+          // else parent struct not present, so we will
+          // backtrack until we find a parent or reach top level
+        } else {
+          // updates
+          String name = join(parents, field.name());
+          if (field.type().isPrimitiveType() && !field.type().equals(newField.type())) {
+            Preconditions.checkState(newField.type().isPrimitiveType(), "%s is not a primitive type", field);
+            updateSchema.updateColumn(name, newField.type().asPrimitiveType());
+          }
+          if (newField.doc() != null && !newField.doc().equals(field.doc())) {
+            updateSchema.updateColumnDoc(name, newField.doc());
+          }
+        }
+      }
+      return null;
+    }
+  }
+
+  private static String join(String parent, String name) {
+    if (parent.isEmpty()) {
+      return name;
+    }
+    return DOT.join(parent, name);
   }
 
   /**

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -27,6 +27,8 @@ import java.util.Set;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.types.Types.NestedField;
+import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.util.Pair;
 import org.junit.Assert;
 import org.junit.Test;
@@ -658,5 +660,121 @@ public class TestSchemaUpdate {
               .apply();
         }
     );
+  }
+
+  @Test
+  public void testUpdatesUsingInputSchema() {
+    Schema schema = new Schema(
+        NestedField.required(1, "id", Types.IntegerType.get()),
+        NestedField.optional(2, "partition", Types.DoubleType.get()));
+
+    Schema newSchema = new Schema(
+        // type promotion with documentation
+        NestedField.required(1, "id", Types.LongType.get(), "type promoted"),
+        NestedField.optional(2, "partition", Types.DoubleType.get()),
+        // struct is added, as an optional field
+        NestedField.optional(3, "location", StructType.of(
+            NestedField.required(4, "lat", Types.FloatType.get()))),
+        // top level field added as optional
+        NestedField.optional(5, "tz", Types.TimestampType.withoutZone()));
+
+    Schema applied = new SchemaUpdate(schema, 2).updateSchema(newSchema).apply();
+    Assert.assertEquals(newSchema.asStruct(), applied.asStruct());
+
+    // nested adds
+    newSchema = new Schema(
+        NestedField.required(1, "id", Types.IntegerType.get()),
+        NestedField.optional(2, "partition", Types.DoubleType.get()),
+        // struct is added, as an optional field
+        NestedField.optional(3, "a", StructType.of(
+            NestedField.required(4, "a_b", StructType.of(
+                NestedField.required(5, "a_b_c", StructType.of(
+                    NestedField.required(6, "a_b_c_d", Types.IntegerType.get()))))))));
+
+    applied = new SchemaUpdate(schema, 2).updateSchema(newSchema).apply();
+    Assert.assertEquals(newSchema.asStruct(), applied.asStruct());
+  }
+
+  @Test
+  public void testMapUpdatesUsingInputSchema() {
+    Schema schema = new Schema(
+        NestedField.required(1, "id", Types.LongType.get()));
+
+    Schema newSchema = new Schema(
+        // map addition
+        NestedField.required(1, "id", Types.LongType.get()),
+        NestedField.optional(2, "location", Types.MapType.ofRequired(
+            3, 4, Types.LongType.get(), StructType.of(
+                NestedField.required(5, "lat", Types.FloatType.get())))));
+
+    Schema applied = new SchemaUpdate(schema, 1).updateSchema(newSchema).apply();
+
+    Assert.assertEquals(newSchema.asStruct(), applied.asStruct());
+
+    // complex maps
+    schema = new Schema(
+        NestedField.required(1, "locations", Types.MapType.ofOptional(2, 3,
+            StructType.of(
+                NestedField.required(4, "k1", Types.IntegerType.get())
+            ),
+            StructType.of(
+                NestedField.required(5, "lat", Types.FloatType.get()),
+                NestedField.required(6, "long", Types.FloatType.get())
+            )
+        )));
+
+    newSchema = new Schema(
+        NestedField.required(1, "locations", Types.MapType.ofOptional(2, 3,
+            StructType.of(
+                NestedField.required(4, "k1", Types.IntegerType.get())
+            ),
+            StructType.of(
+                NestedField.required(5, "lat", Types.FloatType.get()),
+                // nested field in map's value column is type widened
+                NestedField.required(6, "long", Types.DoubleType.get())
+            )
+        )));
+
+    applied = new SchemaUpdate(schema, 6).updateSchema(newSchema).apply();
+    Assert.assertEquals(newSchema.asStruct(), applied.asStruct());
+  }
+
+  @Test
+  public void testListUpdatesUsingInputSchema() {
+    Schema schema = new Schema(
+        NestedField.required(1, "id", Types.LongType.get()));
+
+    Schema newSchema = new Schema(
+        // optional list field added
+        NestedField.required(1, "id", Types.LongType.get()),
+        NestedField.optional(2, "list", Types.ListType.ofRequired(
+            3,
+            StructType.of(
+                NestedField.required(4, "lat", Types.FloatType.get()),
+                NestedField.required(5, "long", Types.FloatType.get())))));
+
+    Schema applied = new SchemaUpdate(schema, 1).updateSchema(newSchema).apply();
+    Assert.assertEquals(newSchema.asStruct(), applied.asStruct());
+
+
+    schema = new Schema(
+        NestedField.required(1, "id", Types.LongType.get()),
+        NestedField.optional(2, "list", Types.ListType.ofRequired(
+            3,
+            StructType.of(
+                NestedField.required(4, "lat", Types.FloatType.get()),
+                NestedField.required(5, "long", Types.FloatType.get())))));
+
+    newSchema = new Schema(
+        NestedField.required(1, "id", Types.LongType.get()),
+        NestedField.optional(2, "list", Types.ListType.ofRequired(
+            3,
+            StructType.of(
+                NestedField.required(4, "lat", Types.DoubleType.get()),
+                // field in a nested struct under list is type widened
+                NestedField.required(5, "long", Types.DoubleType.get())))));
+
+    applied = new SchemaUpdate(schema, 5).updateSchema(newSchema).apply();
+    Assert.assertEquals(newSchema.asStruct(), applied.asStruct());
   }
 }


### PR DESCRIPTION
First step to support #540

Currently only additions and updates are supported. No renames and deletes. Unclear if there's a good way to support renames and deletes

Also relates to #244
@fbocse fyi