### PR TITLE
Add unit tests for sequence number

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -178,9 +178,7 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
 
     Iterable<ManifestFile> newManifestsWithMetadata = Iterables.transform(
         Iterables.concat(newManifests, addedManifests, rewrittenAddedManifests),
-        manifest -> GenericManifestFile.copyOf(manifest).withSnapshotId(snapshotId())
-            .withSequenceNumber(base.nextSequenceNumber())
-            .build());
+        manifest -> GenericManifestFile.copyOf(manifest).withSnapshotId(snapshotId()).build());
 
     // put new manifests at the beginning
     List<ManifestFile> apply = new ArrayList<>();

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -139,6 +139,8 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
     Preconditions.checkArgument(
         manifest.snapshotId() == null || manifest.snapshotId() == -1,
         "Snapshot id must be assigned during commit");
+    Preconditions.checkArgument(manifest.sequenceNumber() == -1,
+        "Sequence must be assigned during commit");
 
     if (snapshotIdInheritanceEnabled && manifest.snapshotId() == null) {
       addedManifests.add(manifest);
@@ -174,10 +176,11 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
 
     validateFilesCounts();
 
-    // TODO: add sequence numbers here
     Iterable<ManifestFile> newManifestsWithMetadata = Iterables.transform(
         Iterables.concat(newManifests, addedManifests, rewrittenAddedManifests),
-        manifest -> GenericManifestFile.copyOf(manifest).withSnapshotId(snapshotId()).build());
+        manifest -> GenericManifestFile.copyOf(manifest).withSnapshotId(snapshotId())
+            .withSequenceNumber(base.nextSequenceNumber())
+            .build());
 
     // put new manifests at the beginning
     List<ManifestFile> apply = new ArrayList<>();

--- a/core/src/main/java/org/apache/iceberg/FastAppend.java
+++ b/core/src/main/java/org/apache/iceberg/FastAppend.java
@@ -97,6 +97,8 @@ class FastAppend extends SnapshotProducer<AppendFiles> implements AppendFiles {
     Preconditions.checkArgument(
         manifest.snapshotId() == null || manifest.snapshotId() == -1,
         "Snapshot id must be assigned during commit");
+    Preconditions.checkArgument(manifest.sequenceNumber() == -1,
+        "Sequence number must be assigned during commit");
 
     if (snapshotIdInheritanceEnabled && manifest.snapshotId() == null) {
       summaryBuilder.addedManifest(manifest);
@@ -131,10 +133,13 @@ class FastAppend extends SnapshotProducer<AppendFiles> implements AppendFiles {
       throw new RuntimeIOException(e, "Failed to write manifest");
     }
 
-    // TODO: add sequence numbers here
     Iterable<ManifestFile> appendManifestsWithMetadata = Iterables.transform(
         Iterables.concat(appendManifests, rewrittenAppendManifests),
-        manifest -> GenericManifestFile.copyOf(manifest).withSnapshotId(snapshotId()).build());
+        manifest -> GenericManifestFile.copyOf(manifest)
+            .withSnapshotId(snapshotId())
+            .withSequenceNumber(base.nextSequenceNumber())
+            .build());
+
     Iterables.addAll(newManifests, appendManifestsWithMetadata);
 
     if (base.currentSnapshot() != null) {

--- a/core/src/main/java/org/apache/iceberg/FastAppend.java
+++ b/core/src/main/java/org/apache/iceberg/FastAppend.java
@@ -135,11 +135,7 @@ class FastAppend extends SnapshotProducer<AppendFiles> implements AppendFiles {
 
     Iterable<ManifestFile> appendManifestsWithMetadata = Iterables.transform(
         Iterables.concat(appendManifests, rewrittenAppendManifests),
-        manifest -> GenericManifestFile.copyOf(manifest)
-            .withSnapshotId(snapshotId())
-            .withSequenceNumber(base.nextSequenceNumber())
-            .build());
-
+        manifest -> GenericManifestFile.copyOf(manifest).withSnapshotId(snapshotId()).build());
     Iterables.addAll(newManifests, appendManifestsWithMetadata);
 
     if (base.currentSnapshot() != null) {

--- a/core/src/main/java/org/apache/iceberg/GenericManifestFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericManifestFile.java
@@ -419,6 +419,11 @@ public class GenericManifestFile
       return this;
     }
 
+    public CopyBuilder withSequenceNumber(Long newSequenceNumber) {
+      manifestFile.sequenceNumber = newSequenceNumber;
+      return this;
+    }
+
     public ManifestFile build() {
       return manifestFile;
     }

--- a/core/src/main/java/org/apache/iceberg/GenericManifestFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericManifestFile.java
@@ -419,11 +419,6 @@ public class GenericManifestFile
       return this;
     }
 
-    public CopyBuilder withSequenceNumber(Long newSequenceNumber) {
-      manifestFile.sequenceNumber = newSequenceNumber;
-      return this;
-    }
-
     public ManifestFile build() {
       return manifestFile;
     }

--- a/core/src/main/java/org/apache/iceberg/MergeAppend.java
+++ b/core/src/main/java/org/apache/iceberg/MergeAppend.java
@@ -55,6 +55,8 @@ class MergeAppend extends MergingSnapshotProducer<AppendFiles> implements Append
     Preconditions.checkArgument(
         manifest.snapshotId() == null || manifest.snapshotId() == -1,
         "Snapshot id must be assigned during commit");
+    Preconditions.checkArgument(manifest.sequenceNumber() == -1,
+        "Sequence must be assigned during commit");
     add(manifest);
     return this;
   }

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -277,9 +277,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
 
       Iterable<ManifestFile> newManifestsWithMetadata = Iterables.transform(
           newManifests,
-          manifest -> GenericManifestFile.copyOf(manifest).withSnapshotId(snapshotId())
-              .withSequenceNumber(base.nextSequenceNumber())
-              .build());
+          manifest -> GenericManifestFile.copyOf(manifest).withSnapshotId(snapshotId()).build());
 
       // filter any existing manifests
       List<ManifestFile> filtered;

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -525,7 +525,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
     Evaluator inclusive = extractInclusiveDeleteExpression(reader);
     Evaluator strict = extractStrictDeleteExpression(reader);
     boolean hasDeletedFiles = false;
-    for (ManifestEntry<DataFile> entry : reader.entries()) {
+    for (ManifestEntry entry : reader.entries()) {
       DataFile file = entry.file();
       boolean fileDelete = deletePaths.contains(pathWrapper.set(file.path())) ||
           dropPartitions.contains(partitionWrapper.set(file.partition()));
@@ -675,11 +675,11 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
               // suppress deletes from previous snapshots. only files deleted by this snapshot
               // should be added to the new manifest
               if (entry.snapshotId() == snapshotId()) {
-                writer.addEntry(entry);
+                writer.delete(entry);
               }
             } else if (entry.status() == Status.ADDED && entry.snapshotId() == snapshotId()) {
               // adds from this snapshot are still adds, otherwise they should be existing
-              writer.addEntry(entry);
+              writer.add(entry);
             } else {
               // add all files from the old manifest as existing files
               writer.existing(entry);

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -275,10 +275,11 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
         newManifests = Iterables.concat(appendManifests, rewrittenAppendManifests);
       }
 
-      // TODO: add sequence numbers here
       Iterable<ManifestFile> newManifestsWithMetadata = Iterables.transform(
           newManifests,
-          manifest -> GenericManifestFile.copyOf(manifest).withSnapshotId(snapshotId()).build());
+          manifest -> GenericManifestFile.copyOf(manifest).withSnapshotId(snapshotId())
+              .withSequenceNumber(base.nextSequenceNumber())
+              .build());
 
       // filter any existing manifests
       List<ManifestFile> filtered;

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -525,7 +525,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
     Evaluator inclusive = extractInclusiveDeleteExpression(reader);
     Evaluator strict = extractStrictDeleteExpression(reader);
     boolean hasDeletedFiles = false;
-    for (ManifestEntry entry : reader.entries()) {
+    for (ManifestEntry<DataFile> entry : reader.entries()) {
       DataFile file = entry.file();
       boolean fileDelete = deletePaths.contains(pathWrapper.set(file.path())) ||
           dropPartitions.contains(partitionWrapper.set(file.partition()));

--- a/core/src/test/java/org/apache/iceberg/TestSequenceNumberForV2Table.java
+++ b/core/src/test/java/org/apache/iceberg/TestSequenceNumberForV2Table.java
@@ -251,8 +251,6 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
         .stageOnly()
         .commit();
 
-    Snapshot snapshot = table.currentSnapshot();
-
     Assert.assertEquals("Snapshot sequence number should be 1", 1,
         table.currentSnapshot().sequenceNumber());
 
@@ -315,9 +313,10 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
 
     for (ManifestFile manifest : table.currentSnapshot().manifests()) {
       for (ManifestEntry entry : ManifestFiles.read(manifest, FILE_IO).entries()) {
-        if (expectedSeqs != null) {
+        String path = entry.file().path().toString();
+        if (fileToSeqMap.containsKey(path)) {
           Assert.assertEquals("Sequence number should match expected",
-              fileToSeqMap.get(entry.file().path().toString()), entry.sequenceNumber());
+              fileToSeqMap.get(path), entry.sequenceNumber());
         }
       }
     }
@@ -334,9 +333,10 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
         expectedSequenceNumber, manifestFile.sequenceNumber());
 
     for (ManifestEntry entry : ManifestFiles.read(manifestFile, FILE_IO).entries()) {
-      if (expectedSeqs != null) {
+      String path = entry.file().path().toString();
+      if (fileToSeqMap.containsKey(path)) {
         Assert.assertEquals("Sequence number should match expected",
-            fileToSeqMap.get(entry.file().path().toString()), entry.sequenceNumber());
+            fileToSeqMap.get(path), entry.sequenceNumber());
       }
     }
   }

--- a/core/src/test/java/org/apache/iceberg/TestSequenceNumberForV2Table.java
+++ b/core/src/test/java/org/apache/iceberg/TestSequenceNumberForV2Table.java
@@ -37,24 +37,6 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
   }
 
   @Test
-  public void testFastAppend() throws IOException {
-    table.newFastAppend().appendFile(FILE_A).commit();
-    ManifestFile manifestFile = table.currentSnapshot().manifests().get(0);
-    validateManifestEntries(manifestFile, 1, files(FILE_A), seqs(1));
-
-    table.newFastAppend().appendFile(FILE_B).commit();
-    Assert.assertEquals(2, table.currentSnapshot().sequenceNumber());
-    manifestFile = table.currentSnapshot().manifests().stream()
-        .filter(manifest -> manifest.snapshotId() == table.currentSnapshot().snapshotId())
-        .collect(Collectors.toList()).get(0);
-    validateManifestEntries(manifestFile, 2, files(FILE_B), seqs(2));
-
-    manifestFile = writeManifest(FILE_C, FILE_D);
-    table.newFastAppend().appendManifest(manifestFile).commit();
-    validateDataFiles(files(FILE_A, FILE_B, FILE_C, FILE_D), seqs(1, 2, 3, 3));
-  }
-
-  @Test
   public void testMergeAppend() throws IOException {
     table.newAppend().appendFile(FILE_A).commit();
     ManifestFile manifestFile = table.currentSnapshot().manifests().get(0);
@@ -273,6 +255,8 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
 
     Assert.assertEquals("Snapshot sequence number should be 4",
         4, table.currentSnapshot().sequenceNumber());
+
+
     validateDataFiles(files(FILE_A, FILE_B, FILE_C), seqs(1, 4, 3));
   }
 
@@ -298,7 +282,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
 
     // cherry-pick snapshot, this will fast forward
     table.manageSnapshots().cherrypick(stagedSnapshot.snapshotId()).commit();
-    Assert.assertEquals("Snapshot sequence number should be 4",
+    Assert.assertEquals("Snapshot sequence number should be 2",
         2, table.currentSnapshot().sequenceNumber());
 
     validateDataFiles(files(FILE_A, FILE_B), seqs(1, 2));

--- a/core/src/test/java/org/apache/iceberg/TestSequenceNumberForV2Table.java
+++ b/core/src/test/java/org/apache/iceberg/TestSequenceNumberForV2Table.java
@@ -1,0 +1,299 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestSequenceNumberForV2Table extends TableTestBase {
+
+  public TestSequenceNumberForV2Table() {
+    super(2);
+  }
+
+  @Test
+  public void testSequenceNumberForFastAppend() throws IOException {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Assert.assertEquals(1, table.currentSnapshot().sequenceNumber());
+    ManifestFile manifestFile = table.currentSnapshot().manifests().get(0);
+    Assert.assertEquals(1, manifestFile.sequenceNumber());
+
+    table.newFastAppend().appendFile(FILE_B).commit();
+    Assert.assertEquals(2, table.currentSnapshot().sequenceNumber());
+    manifestFile = table.currentSnapshot().manifests().stream()
+        .filter(manifest -> manifest.snapshotId() == table.currentSnapshot().snapshotId())
+        .collect(Collectors.toList()).get(0);
+    Assert.assertEquals(2, manifestFile.sequenceNumber());
+
+    manifestFile = writeManifest(FILE_C, FILE_D);
+    table.newFastAppend().appendManifest(manifestFile).commit();
+    Assert.assertEquals(3, table.currentSnapshot().sequenceNumber());
+
+    manifestFile = table.currentSnapshot().manifests().stream()
+        .filter(manifest -> manifest.snapshotId() == table.currentSnapshot().snapshotId())
+        .collect(Collectors.toList()).get(0);
+    Assert.assertEquals(3, manifestFile.sequenceNumber());
+
+    for (ManifestEntry entry : ManifestFiles.read(manifestFile,
+        table.io(), table.ops().current().specsById()).entries()) {
+      if (entry.file().path().equals(FILE_C.path()) || entry.file().path().equals(FILE_D.path())) {
+        Assert.assertEquals(3, entry.sequenceNumber().longValue());
+      }
+    }
+  }
+
+  @Test
+  public void testSequenceNumberForMergeAppend() throws IOException {
+    table.updateProperties()
+        .set(TableProperties.MANIFEST_MIN_MERGE_COUNT, "1")
+        .commit();
+    table.newAppend().appendFile(FILE_A).commit();
+    Assert.assertEquals(1, table.currentSnapshot().sequenceNumber());
+
+    table.newAppend().appendFile(FILE_B).commit();
+    Assert.assertEquals(2, table.currentSnapshot().sequenceNumber());
+
+    ManifestFile manifestFile = writeManifest(FILE_C, FILE_D);
+    table.newAppend().appendManifest(manifestFile).commit();
+    Assert.assertEquals(3, table.currentSnapshot().sequenceNumber());
+
+    manifestFile = table.currentSnapshot().manifests().get(0);
+
+    Assert.assertEquals("the sequence number of manifest should be 3", 3, manifestFile.sequenceNumber());
+
+    for (ManifestEntry entry : ManifestFiles.read(manifestFile,
+        table.io(), table.ops().current().specsById()).entries()) {
+      if (entry.file().path().equals(FILE_A.path())) {
+        Assert.assertEquals("the sequence number of data file should be 1", 1, entry.sequenceNumber().longValue());
+      }
+
+      if (entry.file().path().equals(FILE_B.path())) {
+        Assert.assertEquals("the sequence number of data file should be 2", 2, entry.sequenceNumber().longValue());
+      }
+
+      if (entry.file().path().equals(FILE_C.path()) || entry.file().path().equals(FILE_D.path())) {
+        Assert.assertEquals("the sequence number of data file should be 3", 3, entry.sequenceNumber().longValue());
+      }
+    }
+  }
+
+  @Test
+  public void testSequenceNumberForRewrite() {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    table.newFastAppend().appendFile(FILE_B).commit();
+    Assert.assertEquals(2, table.currentSnapshot().sequenceNumber());
+
+    table.rewriteManifests().clusterBy(file -> "").commit();
+    Assert.assertEquals("the sequence number of snapshot should be 3",
+        3, table.currentSnapshot().sequenceNumber());
+
+    ManifestFile newManifest = table.currentSnapshot().manifests().get(0);
+    Assert.assertEquals("the sequence number of manifest should be 3",
+        3, newManifest.sequenceNumber());
+
+    for (ManifestEntry entry : ManifestFiles.read(newManifest,
+        table.io(), table.ops().current().specsById()).entries()) {
+      if (entry.file().path().equals(FILE_A.path())) {
+        Assert.assertEquals("the sequence number of data file should be 1", 1, entry.sequenceNumber().longValue());
+      }
+
+      if (entry.file().path().equals(FILE_B.path())) {
+        Assert.assertEquals("the sequence number of data file should be 1", 2, entry.sequenceNumber().longValue());
+      }
+    }
+  }
+
+  @Test
+  public void testCommitConflict() {
+    Transaction txn = table.newTransaction();
+
+    txn.newFastAppend().appendFile(FILE_A).apply();
+    table.newFastAppend().appendFile(FILE_B).commit();
+
+    AssertHelpers.assertThrows("Should failed due to conflict",
+        IllegalStateException.class, "last operation has not committed", txn::commitTransaction);
+
+    Assert.assertEquals(1, TestTables.load(tableDir, "test").currentSnapshot().sequenceNumber());
+
+    AppendFiles appendFiles = table.newFastAppend().appendFile(FILE_C);
+    appendFiles.apply();
+    table.newFastAppend().appendFile(FILE_D).commit();
+    appendFiles.commit();
+
+    ManifestFile manifestFile = table.currentSnapshot().manifests().stream()
+        .filter(manifest -> manifest.snapshotId() == table.currentSnapshot().snapshotId())
+        .collect(Collectors.toList()).get(0);
+
+    for (ManifestEntry entry : ManifestFiles.read(manifestFile, table.io(),
+        table.ops().current().specsById()).entries()) {
+      if (entry.file().path().equals(FILE_C.path())) {
+        Assert.assertEquals(table.currentSnapshot().sequenceNumber(), entry.sequenceNumber().longValue());
+      }
+    }
+  }
+
+  @Test
+  public void testConcurrentCommit() throws InterruptedException {
+    ExecutorService threadPool = Executors.newFixedThreadPool(4);
+    List<Callable<Void>> tasks = new ArrayList<>();
+
+    Callable<Void> write1 = () -> {
+      Transaction txn = table.newTransaction();
+      txn.newFastAppend().appendFile(FILE_A).commit();
+      txn.commitTransaction();
+      return null;
+    };
+
+    Callable<Void> write2 = () -> {
+      Transaction txn = table.newTransaction();
+      txn.newAppend().appendFile(FILE_B).commit();
+      txn.commitTransaction();
+      return null;
+    };
+
+    Callable<Void> write3 = () -> {
+      Transaction txn = table.newTransaction();
+      txn.newDelete().deleteFile(FILE_A).commit();
+      txn.commitTransaction();
+      return null;
+    };
+
+    Callable<Void> write4 = () -> {
+      Transaction txn = table.newTransaction();
+      txn.newOverwrite().addFile(FILE_D).commit();
+      txn.commitTransaction();
+      return null;
+    };
+
+    tasks.add(write1);
+    tasks.add(write2);
+    tasks.add(write3);
+    tasks.add(write4);
+    threadPool.invokeAll(tasks);
+    threadPool.shutdown();
+
+    Assert.assertEquals(4, TestTables.load(tableDir, "test").currentSnapshot().sequenceNumber());
+  }
+
+  @Test
+  public void testRollBack() {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    long snapshotId = table.currentSnapshot().snapshotId();
+    table.newFastAppend().appendFile(FILE_B).commit();
+
+    Assert.assertEquals(2, TestTables.load(tableDir, "test").currentSnapshot().sequenceNumber());
+
+    table.manageSnapshots().rollbackTo(snapshotId).commit();
+
+    Assert.assertEquals(1, TestTables.load(tableDir, "test").currentSnapshot().sequenceNumber());
+  }
+
+  @Test
+  public void testMultipleTxnOperations() {
+    Snapshot snapshot;
+    Transaction txn = table.newTransaction();
+    txn.newOverwrite().addFile(FILE_A).commit();
+    txn.commitTransaction();
+    Assert.assertEquals(1, TestTables.load(tableDir, "test").currentSnapshot().sequenceNumber());
+
+    txn = table.newTransaction();
+    Set<DataFile> toAddFiles = new HashSet<>();
+    Set<DataFile> toDeleteFiles = new HashSet<>();
+    toAddFiles.add(FILE_B);
+    toDeleteFiles.add(FILE_A);
+    txn.newRewrite().rewriteFiles(toDeleteFiles, toAddFiles).commit();
+    txn.commitTransaction();
+    Assert.assertEquals(2, TestTables.load(tableDir, "test").currentSnapshot().sequenceNumber());
+
+    txn = table.newTransaction();
+    txn.newReplacePartitions().addFile(FILE_C).commit();
+    txn.commitTransaction();
+    Assert.assertEquals(3, TestTables.load(tableDir, "test").currentSnapshot().sequenceNumber());
+
+    txn = table.newTransaction();
+    txn.newDelete().deleteFile(FILE_C).commit();
+    txn.commitTransaction();
+
+    Assert.assertEquals(4, TestTables.load(tableDir, "test").currentSnapshot().sequenceNumber());
+
+    txn = table.newTransaction();
+    txn.newAppend().appendFile(FILE_C).commit();
+    txn.commitTransaction();
+    Assert.assertEquals(5, TestTables.load(tableDir, "test").currentSnapshot().sequenceNumber());
+
+    snapshot = table.currentSnapshot();
+    txn = table.newTransaction();
+    txn.newOverwrite().addFile(FILE_D).deleteFile(FILE_C).commit();
+    txn.commitTransaction();
+    Assert.assertEquals(6, TestTables.load(tableDir, "test").currentSnapshot().sequenceNumber());
+
+    txn = table.newTransaction();
+    txn.expireSnapshots().expireOlderThan(snapshot.timestampMillis()).commit();
+    txn.commitTransaction();
+    Assert.assertEquals(6, TestTables.load(tableDir, "test").currentSnapshot().sequenceNumber());
+  }
+
+  @Test
+  public void testSequenceNumberForCherryPicking() {
+    table.newAppend()
+        .appendFile(FILE_A)
+        .commit();
+
+    // WAP commit
+    table.newAppend()
+        .appendFile(FILE_B)
+        .set("wap.id", "123456789")
+        .stageOnly()
+        .commit();
+
+    Assert.assertEquals("the snapshot sequence number should be 1", 1,
+        table.currentSnapshot().sequenceNumber());
+
+    // pick the snapshot that's staged but not committed
+    Snapshot wapSnapshot = readMetadata().snapshots().get(1);
+
+    Assert.assertEquals("the snapshot sequence number should be 2", 2,
+        wapSnapshot.sequenceNumber());
+
+    // table has new commit
+    table.newAppend()
+        .appendFile(FILE_C)
+        .commit();
+
+    Assert.assertEquals("the snapshot sequence number should be 3",
+        3, table.currentSnapshot().sequenceNumber());
+
+    // cherry-pick snapshot
+    table.manageSnapshots().cherrypick(wapSnapshot.snapshotId()).commit();
+
+    Assert.assertEquals("the snapshot sequence number should be 4",
+        4, table.currentSnapshot().sequenceNumber());
+
+  }
+}


### PR DESCRIPTION
When running unit tests from the previous sequence number PR, the unit test `testSequenceNumberForMergeAppend` failed due to the manifest entry sequence number is not correct. That is because we rewrite the manifest with unassigned sequence number. To fix that, we could always assign sequence number to the adding manifest from `add(ManifestFile)` API. 

This also includes some tests for sequence number from the previous PR.