### PR TITLE
Replace references for incubator-iceberg with iceberg repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ![](site/docs/img/Iceberg-logo.png)
 
-[![](https://travis-ci.org/apache/incubator-iceberg.svg?branch=master)](https://travis-ci.org/apache/incubator-iceberg)
+[![](https://travis-ci.org/apache/iceberg.svg?branch=master)](https://travis-ci.org/apache/iceberg)
 [![](https://badges.gitter.im/iceberg-tables/Lobby.svg)](https://gitter.im/iceberg-tables/Lobby)
 
 Apache Iceberg is a new table format for storing large, slow-moving tabular data. It is designed to improve on the de-facto standard table layout built into Hive, Presto, and Spark.

--- a/deploy.gradle
+++ b/deploy.gradle
@@ -90,7 +90,7 @@ subprojects {
           }
           issueManagement {
             system = 'GitHub'
-            url = 'https://github.com/apache/incubator-iceberg/issues'
+            url = 'https://github.com/apache/iceberg/issues'
           }
         }
       }

--- a/dev/source-release.sh
+++ b/dev/source-release.sh
@@ -71,7 +71,7 @@ gpg --armor --output ${tarball}.asc --detach-sig $tarball
 sha512sum $tarball > ${tarball}.sha512
 
 # check out the Iceberg RC folder
-svn co --depth=empty https://dist.apache.org/repos/dist/dev/incubator/iceberg tmp
+svn co --depth=empty https://dist.apache.org/repos/dist/dev/iceberg tmp
 
 # add the release candidate for the tag
 mkdir -p tmp/$tagrc
@@ -83,7 +83,7 @@ svn ci -m "Apache Iceberg $version RC${rc}" tmp/$tagrc
 rm -rf tmp
 
 echo "Success! The release candidate is available here:"
-echo "  https://dist.apache.org/repos/dist/dev/incubator/iceberg/$tagrc"
+echo "  https://dist.apache.org/repos/dist/dev/iceberg/$tagrc"
 echo ""
 echo "Commit SHA1: $release_hash"
 

--- a/python/README.md
+++ b/python/README.md
@@ -24,8 +24,8 @@ Iceberg is a python library for programatic access to iceberg table metadata as 
 Iceberg python is currently in development, for development and testing purposes the best way to install the library is to perform the following steps:
 
 ```
-git clone https://github.com/apache/incubator-iceberg.git
-cd incubator-iceberg/python
+git clone https://github.com/apache/iceberg.git
+cd iceberg/python
 pip install -e .
 ```
 
@@ -44,5 +44,5 @@ tox
     * [dev@iceberg.apache.org](mailto:dev@iceberg.apache.org)
 
 - Issues
-    * [File a github incident](https://github.com/apache/incubator-iceberg/issues)
+    * [File a github incident](https://github.com/apache/iceberg/issues)
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -20,11 +20,11 @@ from setuptools import setup
 
 setup(
     name='iceberg',
-    maintainer='Apache Incubator Iceberg Devs',
+    maintainer='Apache Iceberg Devs',
     author_email='dev@iceberg.apache.org',
     description='Iceberg is a new table format for storing large, slow-moving tabular data',
     keywords='iceberg',
-    url='https://github.com/apache/incubator-iceberg/blob/master/README.md',
+    url='https://github.com/apache/iceberg/blob/master/README.md',
     python_requires='>=3.6',
     install_requires=['botocore',
                       'boto3',

--- a/site/docs/community.md
+++ b/site/docs/community.md
@@ -26,14 +26,14 @@ Community discussions happen primarily on the dev mailing list or on specific is
 
 ## Contributing
 
-Iceberg uses Apache's GitHub integration. The code is available at <https://github.com/apache/incubator-iceberg>
+Iceberg uses Apache's GitHub integration. The code is available at <https://github.com/apache/iceberg>
 
 The Iceberg community prefers to receive contributions as [Github pull requests][github-pr-docs].
 
 * [View open pull requests][iceberg-prs]
 * [Learn about pull requests][github-pr-docs]
 
-[iceberg-prs]: https://github.com/apache/incubator-iceberg/pulls
+[iceberg-prs]: https://github.com/apache/iceberg/pulls
 [github-pr-docs]: https://help.github.com/articles/about-pull-requests/
 
 
@@ -44,8 +44,8 @@ Issues are tracked in GitHub:
 * [View open issues][open-issues]
 * [Open a new issue][new-issue]
 
-[open-issues]: https://github.com/apache/incubator-iceberg/issues
-[new-issue]: https://github.com/apache/incubator-iceberg/issues/new
+[open-issues]: https://github.com/apache/iceberg/issues
+[new-issue]: https://github.com/apache/iceberg/issues/new
 
 
 ## Mailing Lists

--- a/site/docs/how-to-release.md
+++ b/site/docs/how-to-release.md
@@ -4,7 +4,7 @@
 To create a release candidate, you will need:
 
 * Apache LDAP credentals for Nexus and SVN
-* A [GPG key for signing](https://www.apache.org/dev/release-signing#generate), published in [KEYS](https://dist.apache.org/repos/dist/dev/incubator/iceberg/KEYS)
+* A [GPG key for signing](https://www.apache.org/dev/release-signing#generate), published in [KEYS](https://dist.apache.org/repos/dist/dev/iceberg/KEYS)
 
 ### Nexus access
 
@@ -42,7 +42,7 @@ dev/source-release.sh 0.8.1 0
 Preparing source for apache-iceberg-0.8.1-rc0
 ...
 Success! The release candidate is available here:
-  https://dist.apache.org/repos/dist/dev/incubator/iceberg/apache-iceberg-0.8.1-rc0/
+  https://dist.apache.org/repos/dist/dev/iceberg/apache-iceberg-0.8.1-rc0/
 
 Commit SHA1: 4b4716c76559b3cdf3487e6b60ab52950241989b
 ```
@@ -92,14 +92,14 @@ I propose the following RC to be released as official Apache Iceberg <VERSION> r
 
 The commit id is <SHA1>
 * This corresponds to the tag: apache-iceberg-<VERSION>-rc<NUM>
-* https://github.com/apache/incubator-iceberg/commits/apache-iceberg-<VERSION>-rc<NUM>
-* https://github.com/apache/incubator-iceberg/tree/<SHA1>
+* https://github.com/apache/iceberg/commits/apache-iceberg-<VERSION>-rc<NUM>
+* https://github.com/apache/iceberg/tree/<SHA1>
 
 The release tarball, signature, and checksums are here:
-* https://dist.apache.org/repos/dist/dev/incubator/iceberg/apache-iceberg-<VERSION>-rc<NUM>/
+* https://dist.apache.org/repos/dist/dev/iceberg/apache-iceberg-<VERSION>-rc<NUM>/
 
 You can find the KEYS file here:
-* https://dist.apache.org/repos/dist/dev/incubator/iceberg/KEYS
+* https://dist.apache.org/repos/dist/dev/iceberg/KEYS
 
 Convenience binary artifacts are staged in Nexus. The Maven repository URL is:
 * https://repository.apache.org/content/repositories/orgapacheiceberg-<ID>/
@@ -124,8 +124,8 @@ First, copy the source release directory to releases:
 ```bash
 mkdir iceberg
 cd iceberg
-svn co https://dist.apache.org/repos/dist/dev/incubator/iceberg candidates
-svn co https://dist.apache.org/repos/dist/release/incubator/iceberg releases
+svn co https://dist.apache.org/repos/dist/dev/iceberg candidates
+svn co https://dist.apache.org/repos/dist/release/iceberg releases
 cp -r candidates/apache-iceberg-<VERSION>-rcN/ releases/apache-iceberg-<VERSION>
 cd releases
 svn add apache-iceberg-<VERSION>
@@ -153,7 +153,7 @@ delivers high query performance for tables with tens of petabytes of data,
 along with atomic commits, concurrent writes, and SQL-compatible table
 evolution.
 
-This release can be downloaded from: https://www.apache.org/dyn/closer.cgi/incubator/iceberg/<TARBALL NAME WITHOUT .tar.gz>/<TARBALL NAME>
+This release can be downloaded from: https://www.apache.org/dyn/closer.cgi/iceberg/<TARBALL NAME WITHOUT .tar.gz>/<TARBALL NAME>
 
 Java artifacts are available from Maven Central.
 

--- a/site/docs/python-quickstart.md
+++ b/site/docs/python-quickstart.md
@@ -22,8 +22,8 @@
 
 Iceberg python is currently in development, for development and testing purposes the best way to install the library is to perform the following steps:
 ```
-git clone https://github.com/apache/incubator-iceberg.git
-cd incubator-iceberg/python
+git clone https://github.com/apache/iceberg.git
+cd iceberg/python
 pip install -e .
 ```
 

--- a/site/docs/releases.md
+++ b/site/docs/releases.md
@@ -1,7 +1,7 @@
 
 ## Downloads
 
-The latest version of Iceberg is [0.8.0-incubating](https://github.com/apache/incubator-iceberg/releases/tag/apache-iceberg-0.8.0-incubating).
+The latest version of Iceberg is [0.8.0-incubating](https://github.com/apache/iceberg/releases/tag/apache-iceberg-0.8.0-incubating).
 
 * [0.8.0-incubating source tar.gz](https://www.apache.org/dyn/closer.cgi/incubator/iceberg/apache-iceberg-0.8.0-incubating/apache-iceberg-0.8.0-incubating.tar.gz) -- [signature](https://downloads.apache.org/incubator/iceberg/apache-iceberg-0.8.0-incubating/apache-iceberg-0.8.0-incubating.tar.gz.asc) -- [sha512](https://downloads.apache.org/incubator/iceberg/apache-iceberg-0.8.0-incubating/apache-iceberg-0.8.0-incubating.tar.gz.sha512)
 * [0.8.0-incubating Spark 2.4 runtime Jar](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime/0.8.0-incubating/iceberg-spark-runtime-0.8.0-incubating.jar)
@@ -40,7 +40,7 @@ To add a dependency on Iceberg in Maven, add the following to your `pom.xml`:
 
 ### 0.7.0
 
-* Git tag: [apache-iceberg-0.7.0-incubating](https://github.com/apache/incubator-iceberg/releases/tag/apache-iceberg-0.7.0-incubating)
+* Git tag: [apache-iceberg-0.7.0-incubating](https://github.com/apache/iceberg/releases/tag/apache-iceberg-0.7.0-incubating)
 * [0.7.0-incubating source tar.gz](https://www.apache.org/dyn/closer.cgi/incubator/iceberg/apache-iceberg-0.7.0-incubating/apache-iceberg-0.7.0-incubating.tar.gz) -- [signature](https://dist.apache.org/repos/dist/release/incubator/iceberg/apache-iceberg-0.7.0-incubating/apache-iceberg-0.7.0-incubating.tar.gz.asc) -- [sha512](https://dist.apache.org/repos/dist/release/incubator/iceberg/apache-iceberg-0.7.0-incubating/apache-iceberg-0.7.0-incubating.tar.gz.sha512)
 * [0.7.0-incubating Spark 2.4 runtime Jar](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime/0.7.0-incubating/iceberg-spark-runtime-0.7.0-incubating.jar)
 

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -59,20 +59,20 @@ nav:
     - Spark: spark.md
     - Presto: presto.md
   - Java:
-    - Git Repo: https://github.com/apache/incubator-iceberg
+    - Git Repo: https://github.com/apache/iceberg
     - Quickstart: java-api-quickstart.md
     - API intro: api.md
     - Javadoc: /javadoc/
     - Custom Catalog: custom-catalog.md
   - Python:
-    - Git Repo: https://github.com/apache/incubator-iceberg/tree/master/python
+    - Git Repo: https://github.com/apache/iceberg/tree/master/python
     - Quickstart: python-quickstart.md
     - API Intro: python-api-intro.md
     - Feature Support: python-feature-support.md
   - Format:
     - Definitions: terms.md
     - Spec: spec.md
-  - Iceberg on GitHub: https://github.com/apache/incubator-iceberg
+  - Iceberg on GitHub: https://github.com/apache/iceberg
   - ASF:
     - License: https://www.apache.org/licenses/
     - Security: https://www.apache.org/security/

--- a/spark/src/test/java/org/apache/iceberg/examples/README.md
+++ b/spark/src/test/java/org/apache/iceberg/examples/README.md
@@ -31,7 +31,7 @@ You'll also need `spark-sql`:
 To add a dependency on Iceberg in Gradle, add the following to `build.gradle`:
 ```
 dependencies {
-  compile 'org.apache.iceberg:iceberg-core:0.7.0-incubating'
+  compile 'org.apache.iceberg:iceberg-core:0.8.0-incubating'
 }
 ```
 
@@ -39,7 +39,7 @@ dependencies {
 The following section will break down the different areas of Iceberg explored in the examples, with links to the code and extra information that could be useful for new users. 
 
 ### Writing data to tables
-There are multiple ways of creating tables with Iceberg, including using the Hive Metastore to keep track of tables ([HiveCatalog](https://iceberg.apache.org/api-quickstart/#using-a-hive-catalog)), or using HDFS / your local file system ([HadoopTables](https://iceberg.incubator.apache.org/api-quickstart/#using-hadoop-tables)) to store the tables. However, it should be noted that directory tables (such as those using `HadoopTables`)  don’t support all catalog operations, like rename and therefore use the `Tables` interface instead of the `Catalog` interface.
+There are multiple ways of creating tables with Iceberg, including using the Hive Metastore to keep track of tables ([HiveCatalog](https://iceberg.apache.org/api-quickstart/#using-a-hive-catalog)), or using HDFS / your local file system ([HadoopTables](https://iceberg.apache.org/api-quickstart/#using-hadoop-tables)) to store the tables. However, it should be noted that directory tables (such as those using `HadoopTables`)  don’t support all catalog operations, like rename and therefore use the `Tables` interface instead of the `Catalog` interface.
 It should be noted that `HadoopTables` _shouldn’t_ be used with file systems that do not support atomic rename as Iceberg depends on this to synchronize concurrent commits. 
 To limit complexity, these examples create tables on your local file system using the `HadoopTables` class.
 
@@ -86,7 +86,7 @@ This section looks a little bit closer at the metadata produced by Iceberg table
     └── version-hint.text
 ```
 
-The metadata for your table is kept in json files and each commit to a table will produce a new metadata file. For tables using a metastore for the metadata, the file used is whichever file the metastore points at. For `HadoopTables`, the file used will be the latest version available. Look [here](https://iceberg.incubator.apache.org/spec/#table-metadata) for more information on metadata.
+The metadata for your table is kept in json files and each commit to a table will produce a new metadata file. For tables using a metastore for the metadata, the file used is whichever file the metastore points at. For `HadoopTables`, the file used will be the latest version available. Look [here](https://iceberg.apache.org/spec/#table-metadata) for more information on metadata.
 
 The metadata file will contain things like the table location, the schema and the partition spec:
 
@@ -183,7 +183,7 @@ However, this means you need to occasionally deal with concurrent writer conflic
 
 Iceberg deals with this by attempting retries of the write based on the new metadata. This can happen if the files the first write changed aren't touched by the second write, then it's deemed safe to commit the second update. 
 
-[This test](ConcurrencyTest.java) looks to experiment with how optimistic concurrency works. For more information on conflict resolution, look [here](https://iceberg.incubator.apache.org/spec/#table-metadata) and for information on write concurrency, look [here](https://iceberg.incubator.apache.org/reliability/#concurrent-write-operations).
+[This test](ConcurrencyTest.java) looks to experiment with how optimistic concurrency works. For more information on conflict resolution, look [here](https://iceberg.apache.org/spec/#table-metadata) and for information on write concurrency, look [here](https://iceberg.apache.org/reliability/#concurrent-write-operations).
 
 By default, Iceberg has set the `commit.retry.num-retries` property to **4**. You can edit this default by creating an `UpdateProperties` object and assigning a new number to that property:
 
@@ -191,4 +191,4 @@ By default, Iceberg has set the `commit.retry.num-retries` property to **4**. Yo
   table.updateProperties().set("commit.retry.num-retries", "1").commit();
 ```
 
-You can find more information on other table properties you can configure [here](https://iceberg.incubator.apache.org/configuration/#table-properties).
+You can find more information on other table properties you can configure [here](https://iceberg.apache.org/configuration/#table-properties).


### PR DESCRIPTION
This PR replaces references to the current incubator-iceberg repository with references to the new name. This should be committed and deployed to the site after the rename is completed.