### PR TITLE
Add DeleteFile and manifest reader and writer for deletes

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ContentFile.java
+++ b/api/src/main/java/org/apache/iceberg/ContentFile.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Superinterface of {@link DataFile} and {@link DeleteFile} that exposes common methods.
+ *
+ * @param <F> the concrete Java class of a ContentFile instance.
+ */
+public interface ContentFile<F> {
+  /**
+   * @return type of content stored in the file; one of DATA, POSITION_DELETES, or EQUALITY_DELETES
+   */
+  FileContent content();
+
+  /**
+   * @return fully qualified path to the file, suitable for constructing a Hadoop Path
+   */
+  CharSequence path();
+
+  /**
+   * @return format of the file
+   */
+  FileFormat format();
+
+  /**
+   * @return partition for this file as a {@link StructLike}
+   */
+  StructLike partition();
+
+  /**
+   * @return the number of top-level records in the file
+   */
+  long recordCount();
+
+  /**
+   * @return the file size in bytes
+   */
+  long fileSizeInBytes();
+
+  /**
+   * @return if collected, map from column ID to the size of the column in bytes, null otherwise
+   */
+  Map<Integer, Long> columnSizes();
+
+  /**
+   * @return if collected, map from column ID to the count of its non-null values, null otherwise
+   */
+  Map<Integer, Long> valueCounts();
+
+  /**
+   * @return if collected, map from column ID to its null value count, null otherwise
+   */
+  Map<Integer, Long> nullValueCounts();
+
+  /**
+   * @return if collected, map from column ID to value lower bounds, null otherwise
+   */
+  Map<Integer, ByteBuffer> lowerBounds();
+
+  /**
+   * @return if collected, map from column ID to value upper bounds, null otherwise
+   */
+  Map<Integer, ByteBuffer> upperBounds();
+
+  /**
+   * @return metadata about how this file is encrypted, or null if the file is stored in plain
+   *         text.
+   */
+  ByteBuffer keyMetadata();
+
+  /**
+   * @return List of recommended split locations, if applicable, null otherwise.
+   * When available, this information is used for planning scan tasks whose boundaries
+   * are determined by these offsets. The returned list must be sorted in ascending order.
+   */
+  List<Long> splitOffsets();
+
+
+  /**
+   * Copies this file. Manifest readers can reuse file instances; use
+   * this method to copy data when collecting files from tasks.
+   *
+   * @return a copy of this data file
+   */
+  F copy();
+
+  /**
+   * Copies this file without file stats. Manifest readers can reuse file instances; use
+   * this method to copy data without stats when collecting files.
+   *
+   * @return a copy of this data file, without lower bounds, upper bounds, value counts, or null value counts
+   */
+  F copyWithoutStats();
+}

--- a/api/src/main/java/org/apache/iceberg/DataFile.java
+++ b/api/src/main/java/org/apache/iceberg/DataFile.java
@@ -19,9 +19,6 @@
 
 package org.apache.iceberg;
 
-import java.nio.ByteBuffer;
-import java.util.List;
-import java.util.Map;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.BinaryType;
 import org.apache.iceberg.types.Types.IntegerType;
@@ -35,9 +32,9 @@ import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 /**
- * Interface for files listed in a table manifest.
+ * Interface for data files listed in a table manifest.
  */
-public interface DataFile {
+public interface DataFile extends ContentFile<DataFile> {
   // fields for adding delete data files
   Types.NestedField CONTENT = optional(134, "content", IntegerType.get(),
       "Contents of the file: 0=data, 1=position deletes, 2=equality deletes");
@@ -86,84 +83,8 @@ public interface DataFile {
   /**
    * @return the content stored in the file; one of DATA, POSITION_DELETES, or EQUALITY_DELETES
    */
-  FileContent content();
-
-  /**
-   * @return fully qualified path to the file, suitable for constructing a Hadoop Path
-   */
-  CharSequence path();
-
-  /**
-   * @return format of the data file
-   */
-  FileFormat format();
-
-  /**
-   * @return partition data for this file as a {@link StructLike}
-   */
-  StructLike partition();
-
-  /**
-   * @return the number of top-level records in the data file
-   */
-  long recordCount();
-
-  /**
-   * @return the data file size in bytes
-   */
-  long fileSizeInBytes();
-
-  /**
-   * @return if collected, map from column ID to the size of the column in bytes, null otherwise
-   */
-  Map<Integer, Long> columnSizes();
-
-  /**
-   * @return if collected, map from column ID to the count of its non-null values, null otherwise
-   */
-  Map<Integer, Long> valueCounts();
-
-  /**
-   * @return if collected, map from column ID to its null value count, null otherwise
-   */
-  Map<Integer, Long> nullValueCounts();
-
-  /**
-   * @return if collected, map from column ID to value lower bounds, null otherwise
-   */
-  Map<Integer, ByteBuffer> lowerBounds();
-
-  /**
-   * @return if collected, map from column ID to value upper bounds, null otherwise
-   */
-  Map<Integer, ByteBuffer> upperBounds();
-
-  /**
-   * @return metadata about how this file is encrypted, or null if the file is stored in plain
-   *         text.
-   */
-  ByteBuffer keyMetadata();
-
-  /**
-   * @return List of recommended split locations, if applicable, null otherwise.
-   * When available, this information is used for planning scan tasks whose boundaries
-   * are determined by these offsets. The returned list must be sorted in ascending order.
-   */
-  List<Long> splitOffsets();
-
-  /**
-   * Copies this {@link DataFile data file}. Manifest readers can reuse data file instances; use
-   * this method to copy data when collecting files from tasks.
-   *
-   * @return a copy of this data file
-   */
-  DataFile copy();
-
-  /**
-   * Copies this {@link DataFile data file} without file stats. Manifest readers can reuse data file instances; use
-   * this method to copy data without stats when collecting files.
-   *
-   * @return a copy of this data file, without lower bounds, upper bounds, value counts, or null value counts
-   */
-  DataFile copyWithoutStats();
+  @Override
+  default FileContent content() {
+    return FileContent.DATA;
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/DataFile.java
+++ b/api/src/main/java/org/apache/iceberg/DataFile.java
@@ -86,9 +86,7 @@ public interface DataFile {
   /**
    * @return the content stored in the file; one of DATA, POSITION_DELETES, or EQUALITY_DELETES
    */
-  default FileContent content() {
-    return FileContent.DATA;
-  }
+  FileContent content();
 
   /**
    * @return fully qualified path to the file, suitable for constructing a Hadoop Path

--- a/api/src/main/java/org/apache/iceberg/DeleteFile.java
+++ b/api/src/main/java/org/apache/iceberg/DeleteFile.java
@@ -21,29 +21,17 @@ package org.apache.iceberg;
 
 import java.util.List;
 
-public interface DeleteFile extends DataFile {
+/**
+ * Interface for delete files listed in a table delete manifest.
+ */
+public interface DeleteFile extends ContentFile<DeleteFile> {
   /**
    * @return List of recommended split locations, if applicable, null otherwise.
    * When available, this information is used for planning scan tasks whose boundaries
    * are determined by these offsets. The returned list must be sorted in ascending order.
    */
+  @Override
   default List<Long> splitOffsets() {
     return null;
   }
-
-  /**
-   * Copies this {@link DataFile data file}. Manifest readers can reuse data file instances; use
-   * this method to copy data when collecting files from tasks.
-   *
-   * @return a copy of this data file
-   */
-  DeleteFile copy();
-
-  /**
-   * Copies this {@link DataFile data file} without file stats. Manifest readers can reuse data file instances; use
-   * this method to copy data without stats when collecting files.
-   *
-   * @return a copy of this data file, without lower bounds, upper bounds, value counts, or null value counts
-   */
-  DeleteFile copyWithoutStats();
 }

--- a/api/src/main/java/org/apache/iceberg/DeleteFile.java
+++ b/api/src/main/java/org/apache/iceberg/DeleteFile.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.List;
+
+public interface DeleteFile extends DataFile {
+  /**
+   * @return List of recommended split locations, if applicable, null otherwise.
+   * When available, this information is used for planning scan tasks whose boundaries
+   * are determined by these offsets. The returned list must be sorted in ascending order.
+   */
+  default List<Long> splitOffsets() {
+    return null;
+  }
+
+  /**
+   * Copies this {@link DataFile data file}. Manifest readers can reuse data file instances; use
+   * this method to copy data when collecting files from tasks.
+   *
+   * @return a copy of this data file
+   */
+  DeleteFile copy();
+
+  /**
+   * Copies this {@link DataFile data file} without file stats. Manifest readers can reuse data file instances; use
+   * this method to copy data without stats when collecting files.
+   *
+   * @return a copy of this data file, without lower bounds, upper bounds, value counts, or null value counts
+   */
+  DeleteFile copyWithoutStats();
+}

--- a/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
@@ -25,6 +25,7 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.ExpressionVisitors.BoundExpressionVisitor;
@@ -40,7 +41,7 @@ import static org.apache.iceberg.expressions.Expressions.rewriteNot;
  * <p>
  * This evaluation is inclusive: it returns true if a file may match and false if it cannot match.
  * <p>
- * Files are passed to {@link #eval(DataFile)}, which returns true if the file may contain matching
+ * Files are passed to {@link #eval(ContentFile)}, which returns true if the file may contain matching
  * rows and false if the file cannot contain matching rows. Files may be skipped if and only if the
  * return value of {@code eval} is false.
  */
@@ -70,7 +71,7 @@ public class InclusiveMetricsEvaluator {
    * @param file a data file
    * @return false if the file cannot contain rows that match the expression, true otherwise.
    */
-  public boolean eval(DataFile file) {
+  public boolean eval(ContentFile<?> file) {
     // TODO: detect the case where a column is missing from the file using file's max field id.
     return visitor().eval(file);
   }
@@ -84,7 +85,7 @@ public class InclusiveMetricsEvaluator {
     private Map<Integer, ByteBuffer> lowerBounds = null;
     private Map<Integer, ByteBuffer> upperBounds = null;
 
-    private boolean eval(DataFile file) {
+    private boolean eval(ContentFile<?> file) {
       if (file.recordCount() == 0) {
         return ROWS_CANNOT_MATCH;
       }

--- a/api/src/test/java/org/apache/iceberg/TestHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/TestHelpers.java
@@ -312,6 +312,11 @@ public class TestHelpers {
     }
 
     @Override
+    public FileContent content() {
+      return FileContent.DATA;
+    }
+
+    @Override
     public CharSequence path() {
       return path;
     }

--- a/api/src/test/java/org/apache/iceberg/TestHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/TestHelpers.java
@@ -312,11 +312,6 @@ public class TestHelpers {
     }
 
     @Override
-    public FileContent content() {
-      return FileContent.DATA;
-    }
-
-    @Override
     public CharSequence path() {
       return path;
     }

--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -1,0 +1,392 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import java.io.Serializable;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.specific.SpecificData;
+import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ByteBuffers;
+
+/**
+ * Base class for both {@link DataFile} and {@link DeleteFile}.
+ */
+abstract class BaseFile<ThisT> implements IndexedRecord, StructLike, SpecificData.SchemaConstructable, Serializable {
+  static final Types.StructType EMPTY_STRUCT_TYPE = Types.StructType.of();
+  static final PartitionData EMPTY_PARTITION_DATA = new PartitionData(EMPTY_STRUCT_TYPE) {
+    @Override
+    public PartitionData copy() {
+      return this; // this does not change
+    }
+  };
+
+  private int[] fromProjectionPos;
+  private Types.StructType partitionType;
+
+  private FileContent content = FileContent.DATA;
+  private String filePath = null;
+  private FileFormat format = null;
+  private PartitionData partitionData = null;
+  private Long recordCount = null;
+  private long fileSizeInBytes = -1L;
+
+  // optional fields
+  private Map<Integer, Long> columnSizes = null;
+  private Map<Integer, Long> valueCounts = null;
+  private Map<Integer, Long> nullValueCounts = null;
+  private Map<Integer, ByteBuffer> lowerBounds = null;
+  private Map<Integer, ByteBuffer> upperBounds = null;
+  private List<Long> splitOffsets = null;
+  private byte[] keyMetadata = null;
+
+  // cached schema
+  private transient org.apache.avro.Schema avroSchema = null;
+
+  /**
+   * Used by Avro reflection to instantiate this class when reading manifest files.
+   */
+  BaseFile(org.apache.avro.Schema avroSchema) {
+    this.avroSchema = avroSchema;
+
+    Types.StructType schema = AvroSchemaUtil.convert(avroSchema).asNestedType().asStructType();
+
+    // partition type may be null if the field was not projected
+    Type partType = schema.fieldType("partition");
+    if (partType != null) {
+      this.partitionType = partType.asNestedType().asStructType();
+    } else {
+      this.partitionType = EMPTY_STRUCT_TYPE;
+    }
+
+    List<Types.NestedField> fields = schema.fields();
+    List<Types.NestedField> allFields = DataFile.getType(partitionType).fields();
+    this.fromProjectionPos = new int[fields.size()];
+    for (int i = 0; i < fromProjectionPos.length; i += 1) {
+      boolean found = false;
+      for (int j = 0; j < allFields.size(); j += 1) {
+        if (fields.get(i).fieldId() == allFields.get(j).fieldId()) {
+          found = true;
+          fromProjectionPos[i] = j;
+        }
+      }
+
+      if (!found) {
+        throw new IllegalArgumentException("Cannot find projected field: " + fields.get(i));
+      }
+    }
+
+    this.partitionData = new PartitionData(partitionType);
+  }
+
+  BaseFile(FileContent content, String filePath, FileFormat format,
+           PartitionData partition, long fileSizeInBytes, long recordCount,
+           Map<Integer, Long> columnSizes, Map<Integer, Long> valueCounts, Map<Integer, Long> nullValueCounts,
+           Map<Integer, ByteBuffer> lowerBounds, Map<Integer, ByteBuffer> upperBounds, List<Long> splitOffsets,
+           ByteBuffer keyMetadata) {
+    this.content = content;
+    this.filePath = filePath;
+    this.format = format;
+
+    // this constructor is used by DataFiles.Builder, which passes null for unpartitioned data
+    if (partition == null) {
+      this.partitionData = EMPTY_PARTITION_DATA;
+      this.partitionType = EMPTY_PARTITION_DATA.getPartitionType();
+    } else {
+      this.partitionData = partition;
+      this.partitionType = partition.getPartitionType();
+    }
+
+    // this will throw NPE if metrics.recordCount is null
+    this.recordCount = recordCount;
+    this.fileSizeInBytes = fileSizeInBytes;
+    this.columnSizes = columnSizes;
+    this.valueCounts = valueCounts;
+    this.nullValueCounts = nullValueCounts;
+    this.lowerBounds = SerializableByteBufferMap.wrap(lowerBounds);
+    this.upperBounds = SerializableByteBufferMap.wrap(upperBounds);
+    this.splitOffsets = copy(splitOffsets);
+    this.keyMetadata = ByteBuffers.toByteArray(keyMetadata);
+  }
+
+  /**
+   * Copy constructor.
+   *
+   * @param toCopy a generic data file to copy.
+   * @param fullCopy whether to copy all fields or to drop column-level stats
+   */
+  BaseFile(BaseFile<ThisT> toCopy, boolean fullCopy) {
+    this.content = toCopy.content;
+    this.filePath = toCopy.filePath;
+    this.format = toCopy.format;
+    this.partitionData = toCopy.partitionData.copy();
+    this.partitionType = toCopy.partitionType;
+    this.recordCount = toCopy.recordCount;
+    this.fileSizeInBytes = toCopy.fileSizeInBytes;
+    if (fullCopy) {
+      // TODO: support lazy conversion to/from map
+      this.columnSizes = copy(toCopy.columnSizes);
+      this.valueCounts = copy(toCopy.valueCounts);
+      this.nullValueCounts = copy(toCopy.nullValueCounts);
+      this.lowerBounds = SerializableByteBufferMap.wrap(copy(toCopy.lowerBounds));
+      this.upperBounds = SerializableByteBufferMap.wrap(copy(toCopy.upperBounds));
+    } else {
+      this.columnSizes = null;
+      this.valueCounts = null;
+      this.nullValueCounts = null;
+      this.lowerBounds = null;
+      this.upperBounds = null;
+    }
+    this.fromProjectionPos = toCopy.fromProjectionPos;
+    this.keyMetadata = toCopy.keyMetadata == null ? null : Arrays.copyOf(toCopy.keyMetadata, toCopy.keyMetadata.length);
+    this.splitOffsets = copy(toCopy.splitOffsets);
+  }
+
+  /**
+   * Constructor for Java serialization.
+   */
+  BaseFile() {
+  }
+
+  @Override
+  public org.apache.avro.Schema getSchema() {
+    if (avroSchema == null) {
+      this.avroSchema = getAvroSchema(partitionType);
+    }
+    return avroSchema;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void put(int i, Object value) {
+    int pos = i;
+    // if the schema was projected, map the incoming ordinal to the expected one
+    if (fromProjectionPos != null) {
+      pos = fromProjectionPos[i];
+    }
+    switch (pos) {
+      case 0:
+        this.content = value != null ? FileContent.values()[(Integer) value] : FileContent.DATA;
+        return;
+      case 1:
+        // always coerce to String for Serializable
+        this.filePath = value.toString();
+        return;
+      case 2:
+        this.format = FileFormat.valueOf(value.toString());
+        return;
+      case 3:
+        this.partitionData = (PartitionData) value;
+        return;
+      case 4:
+        this.recordCount = (Long) value;
+        return;
+      case 5:
+        this.fileSizeInBytes = (Long) value;
+        return;
+      case 6:
+        this.columnSizes = (Map<Integer, Long>) value;
+        return;
+      case 7:
+        this.valueCounts = (Map<Integer, Long>) value;
+        return;
+      case 8:
+        this.nullValueCounts = (Map<Integer, Long>) value;
+        return;
+      case 9:
+        this.lowerBounds = SerializableByteBufferMap.wrap((Map<Integer, ByteBuffer>) value);
+        return;
+      case 10:
+        this.upperBounds = SerializableByteBufferMap.wrap((Map<Integer, ByteBuffer>) value);
+        return;
+      case 11:
+        this.keyMetadata = ByteBuffers.toByteArray((ByteBuffer) value);
+        return;
+      case 12:
+        this.splitOffsets = (List<Long>) value;
+        return;
+      default:
+        // ignore the object, it must be from a newer version of the format
+    }
+  }
+
+  @Override
+  public <T> void set(int pos, T value) {
+    put(pos, value);
+  }
+
+  @Override
+  public Object get(int i) {
+    int pos = i;
+    // if the schema was projected, map the incoming ordinal to the expected one
+    if (fromProjectionPos != null) {
+      pos = fromProjectionPos[i];
+    }
+    switch (pos) {
+      case 0:
+        return FileContent.DATA.id();
+      case 1:
+        return filePath;
+      case 2:
+        return format != null ? format.toString() : null;
+      case 3:
+        return partitionData;
+      case 4:
+        return recordCount;
+      case 5:
+        return fileSizeInBytes;
+      case 6:
+        return columnSizes;
+      case 7:
+        return valueCounts;
+      case 8:
+        return nullValueCounts;
+      case 9:
+        return lowerBounds;
+      case 10:
+        return upperBounds;
+      case 11:
+        return keyMetadata != null ? ByteBuffer.wrap(keyMetadata) : null;
+      case 12:
+        return splitOffsets;
+      default:
+        throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+    }
+  }
+
+  @Override
+  public <T> T get(int pos, Class<T> javaClass) {
+    return javaClass.cast(get(pos));
+  }
+
+  @Override
+  public int size() {
+    return DataFile.getType(EMPTY_STRUCT_TYPE).fields().size();
+  }
+
+  public FileContent content() {
+    return content;
+  }
+
+  public CharSequence path() {
+    return filePath;
+  }
+
+  public FileFormat format() {
+    return format;
+  }
+
+  public StructLike partition() {
+    return partitionData;
+  }
+
+  public long recordCount() {
+    return recordCount;
+  }
+
+  public long fileSizeInBytes() {
+    return fileSizeInBytes;
+  }
+
+  public Map<Integer, Long> columnSizes() {
+    return columnSizes;
+  }
+
+  public Map<Integer, Long> valueCounts() {
+    return valueCounts;
+  }
+
+  public Map<Integer, Long> nullValueCounts() {
+    return nullValueCounts;
+  }
+
+  public Map<Integer, ByteBuffer> lowerBounds() {
+    return lowerBounds;
+  }
+
+  public Map<Integer, ByteBuffer> upperBounds() {
+    return upperBounds;
+  }
+
+  public ByteBuffer keyMetadata() {
+    return keyMetadata != null ? ByteBuffer.wrap(keyMetadata) : null;
+  }
+
+  public List<Long> splitOffsets() {
+    return splitOffsets;
+  }
+
+  public abstract ThisT copyWithoutStats();
+
+  public abstract ThisT copy();
+
+  private static <K, V> Map<K, V> copy(Map<K, V> map) {
+    if (map != null) {
+      Map<K, V> copy = Maps.newHashMapWithExpectedSize(map.size());
+      copy.putAll(map);
+      return Collections.unmodifiableMap(copy);
+    }
+    return null;
+  }
+
+  private static <E> List<E> copy(List<E> list) {
+    if (list != null) {
+      List<E> copy = Lists.newArrayListWithExpectedSize(list.size());
+      copy.addAll(list);
+      return Collections.unmodifiableList(copy);
+    }
+    return null;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("file_path", filePath)
+        .add("file_format", format)
+        .add("partition", partitionData)
+        .add("record_count", recordCount)
+        .add("file_size_in_bytes", fileSizeInBytes)
+        .add("column_sizes", columnSizes)
+        .add("value_counts", valueCounts)
+        .add("null_value_counts", nullValueCounts)
+        .add("lower_bounds", lowerBounds)
+        .add("upper_bounds", upperBounds)
+        .add("key_metadata", keyMetadata == null ? "null" : "(redacted)")
+        .add("split_offsets", splitOffsets == null ? "null" : splitOffsets)
+        .toString();
+  }
+
+  private static org.apache.avro.Schema getAvroSchema(Types.StructType partitionType) {
+    Types.StructType type = DataFile.getType(partitionType);
+    return AvroSchemaUtil.convert(type, ImmutableMap.of(
+        type, GenericDataFile.class.getName(),
+        partitionType, PartitionData.class.getName()));
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -39,7 +39,8 @@ import org.apache.iceberg.util.ByteBuffers;
 /**
  * Base class for both {@link DataFile} and {@link DeleteFile}.
  */
-abstract class BaseFile<ThisT> implements IndexedRecord, StructLike, SpecificData.SchemaConstructable, Serializable {
+abstract class BaseFile<F>
+    implements ContentFile<F>, IndexedRecord, StructLike, SpecificData.SchemaConstructable, Serializable {
   static final Types.StructType EMPTY_STRUCT_TYPE = Types.StructType.of();
   static final PartitionData EMPTY_PARTITION_DATA = new PartitionData(EMPTY_STRUCT_TYPE) {
     @Override
@@ -142,7 +143,7 @@ abstract class BaseFile<ThisT> implements IndexedRecord, StructLike, SpecificDat
    * @param toCopy a generic data file to copy.
    * @param fullCopy whether to copy all fields or to drop column-level stats
    */
-  BaseFile(BaseFile<ThisT> toCopy, boolean fullCopy) {
+  BaseFile(BaseFile<F> toCopy, boolean fullCopy) {
     this.content = toCopy.content;
     this.filePath = toCopy.filePath;
     this.format = toCopy.format;
@@ -342,10 +343,6 @@ abstract class BaseFile<ThisT> implements IndexedRecord, StructLike, SpecificDat
   public List<Long> splitOffsets() {
     return splitOffsets;
   }
-
-  public abstract ThisT copyWithoutStats();
-
-  public abstract ThisT copy();
 
   private static <K, V> Map<K, V> copy(Map<K, V> map) {
     if (map != null) {

--- a/core/src/main/java/org/apache/iceberg/BaseManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/BaseManifestReader.java
@@ -57,7 +57,7 @@ abstract class BaseManifestReader<T, ThisT> extends CloseableGroup implements Cl
 
   protected enum FileType {
     DATA_FILES(GenericDataFile.class.getName()),
-    DELETE_FILES("...");
+    DELETE_FILES(GenericDeleteFile.class.getName());
 
     private final String fileClass;
 

--- a/core/src/main/java/org/apache/iceberg/BaseManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/BaseManifestReader.java
@@ -221,8 +221,7 @@ abstract class BaseManifestReader<F extends ContentFile<F>, ThisT>
   @Override
   public CloseableIterator<F> iterator() {
     if (dropStats(rowFilter, columns)) {
-      return CloseableIterable.transform(liveEntries(), e -> e.file().copyWithoutStats())
-          .iterator();
+      return CloseableIterable.transform(liveEntries(), e -> e.file().copyWithoutStats()).iterator();
     } else {
       return CloseableIterable.transform(liveEntries(), e -> e.file().copy()).iterator();
     }

--- a/core/src/main/java/org/apache/iceberg/BaseManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/BaseManifestReader.java
@@ -50,7 +50,7 @@ import static org.apache.iceberg.expressions.Expressions.alwaysTrue;
  * @param <T> The Java class of files returned by this reader.
  * @param <ThisT> The Java class of this reader, returned by configuration methods.
  */
-abstract class BaseManifestReader<T, ThisT> extends CloseableGroup implements CloseableIterable<T> {
+abstract class BaseManifestReader<T extends DataFile, ThisT> extends CloseableGroup implements CloseableIterable<T> {
   static final ImmutableList<String> ALL_COLUMNS = ImmutableList.of("*");
   private static final Set<String> STATS_COLUMNS = Sets.newHashSet(
       "value_counts", "null_value_counts", "lower_bounds", "upper_bounds");

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -262,7 +262,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
         .onFailure((item, exc) -> LOG.warn("Failed to get deleted files: this may cause orphaned data files", exc))
         .run(manifest -> {
           try (ManifestReader reader = ManifestFiles.read(manifest, io)) {
-            for (ManifestEntry entry : reader.entries()) {
+            for (ManifestEntry<?> entry : reader.entries()) {
               // intern the file path because the weak key map uses identity (==) instead of equals
               String path = entry.file().path().toString().intern();
               Boolean alreadyDeleted = deletedFiles.putIfAbsent(path, true);

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -287,7 +287,7 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
     return activeFilesCount;
   }
 
-  private void appendEntry(ManifestEntry entry, Object key, int partitionSpecId) {
+  private void appendEntry(ManifestEntry<DataFile> entry, Object key, int partitionSpecId) {
     Preconditions.checkNotNull(entry, "Manifest entry cannot be null");
     Preconditions.checkNotNull(key, "Key cannot be null");
 
@@ -323,13 +323,13 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
 
   class WriterWrapper {
     private final PartitionSpec spec;
-    private ManifestWriter writer;
+    private ManifestWriter<DataFile> writer;
 
     WriterWrapper(PartitionSpec spec) {
       this.spec = spec;
     }
 
-    synchronized void addEntry(ManifestEntry entry) {
+    synchronized void addEntry(ManifestEntry<DataFile> entry) {
       if (writer == null) {
         writer = newManifestWriter(spec);
       } else if (writer.length() >= getManifestTargetSizeBytes()) {

--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -158,10 +158,10 @@ class BaseSnapshot implements Snapshot {
     // read only manifests that were created by this snapshot
     Iterable<ManifestFile> changedManifests = Iterables.filter(manifests(),
         manifest -> Objects.equal(manifest.snapshotId(), snapshotId));
-    try (CloseableIterable<ManifestEntry> entries = new ManifestGroup(io, changedManifests)
+    try (CloseableIterable<ManifestEntry<DataFile>> entries = new ManifestGroup(io, changedManifests)
         .ignoreExisting()
         .entries()) {
-      for (ManifestEntry entry : entries) {
+      for (ManifestEntry<DataFile> entry : entries) {
         switch (entry.status()) {
           case ADDED:
             adds.add(entry.file().copy());

--- a/core/src/main/java/org/apache/iceberg/DeleteManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteManifestReader.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.Map;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+
+/**
+ * Reader for manifest files.
+ * <p>
+ * Create readers using {@link ManifestFiles#readDeleteManifest(ManifestFile, FileIO, Map)}.
+ */
+public class DeleteManifestReader extends BaseManifestReader<DeleteFile, DeleteManifestReader> {
+  protected DeleteManifestReader(InputFile file, Map<Integer, PartitionSpec> specsById, InheritableMetadata metadata) {
+    super(file, specsById, metadata, FileType.DELETE_FILES);
+  }
+
+  @Override
+  protected DeleteManifestReader self() {
+    return this;
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/FileHistory.java
+++ b/core/src/main/java/org/apache/iceberg/FileHistory.java
@@ -80,7 +80,7 @@ public class FileHistory {
     }
 
     @SuppressWarnings("unchecked")
-    public Iterable<ManifestEntry> build() {
+    public Iterable<ManifestEntry<?>> build() {
       Iterable<Snapshot> snapshots = table.snapshots();
 
       if (startTime != null) {
@@ -100,11 +100,11 @@ public class FileHistory {
       // a manifest group will only read each manifest once
       ManifestGroup group = new ManifestGroup(((HasTableOperations) table).operations().io(), manifests);
 
-      List<ManifestEntry> results = Lists.newArrayList();
-      try (CloseableIterable<ManifestEntry> entries = group.select(HISTORY_COLUMNS).entries()) {
+      List<ManifestEntry<?>> results = Lists.newArrayList();
+      try (CloseableIterable<ManifestEntry<DataFile>> entries = group.select(HISTORY_COLUMNS).entries()) {
         // TODO: replace this with an IN predicate
         CharSequenceWrapper locationWrapper = CharSequenceWrapper.wrap(null);
-        for (ManifestEntry entry : entries) {
+        for (ManifestEntry<?> entry : entries) {
           if (entry != null && locations.contains(locationWrapper.set(entry.file().path()))) {
             results.add(entry.copy());
           }

--- a/core/src/main/java/org/apache/iceberg/FindFiles.java
+++ b/core/src/main/java/org/apache/iceberg/FindFiles.java
@@ -197,7 +197,7 @@ public class FindFiles {
       }
 
       // when snapshot is not null
-      CloseableIterable<ManifestEntry> entries = new ManifestGroup(ops.io(), snapshot.manifests())
+      CloseableIterable<ManifestEntry<DataFile>> entries = new ManifestGroup(ops.io(), snapshot.manifests())
           .specsById(ops.current().specsById())
           .filterData(rowFilter)
           .filterFiles(fileFilter)

--- a/core/src/main/java/org/apache/iceberg/GenericDataFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDataFile.java
@@ -19,142 +19,39 @@
 
 package org.apache.iceberg;
 
-import java.io.Serializable;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import org.apache.avro.generic.IndexedRecord;
-import org.apache.avro.specific.SpecificData;
-import org.apache.iceberg.avro.AvroSchemaUtil;
-import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.apache.iceberg.types.Type;
-import org.apache.iceberg.types.Types;
-import org.apache.iceberg.util.ByteBuffers;
 
-class GenericDataFile
-    implements DataFile, IndexedRecord, StructLike, SpecificData.SchemaConstructable, Serializable {
-  private static final Types.StructType EMPTY_STRUCT_TYPE = Types.StructType.of();
-  private static final PartitionData EMPTY_PARTITION_DATA = new PartitionData(EMPTY_STRUCT_TYPE) {
-    @Override
-    public PartitionData copy() {
-      return this; // this does not change
-    }
-  };
-
-  private int[] fromProjectionPos;
-  private Types.StructType partitionType;
-
-  private String filePath = null;
-  private FileFormat format = null;
-  private PartitionData partitionData = null;
-  private Long recordCount = null;
-  private long fileSizeInBytes = -1L;
-
-  // optional fields
-  private Map<Integer, Long> columnSizes = null;
-  private Map<Integer, Long> valueCounts = null;
-  private Map<Integer, Long> nullValueCounts = null;
-  private Map<Integer, ByteBuffer> lowerBounds = null;
-  private Map<Integer, ByteBuffer> upperBounds = null;
-  private List<Long> splitOffsets = null;
-  private byte[] keyMetadata = null;
-
-  // cached schema
-  private transient org.apache.avro.Schema avroSchema = null;
-
+class GenericDataFile extends BaseFile<DataFile> implements DataFile {
   /**
    * Used by Avro reflection to instantiate this class when reading manifest files.
    */
-  @SuppressWarnings("checkstyle:RedundantModifier") // Must be public
-  public GenericDataFile(org.apache.avro.Schema avroSchema) {
-    this.avroSchema = avroSchema;
-
-    Types.StructType schema = AvroSchemaUtil.convert(avroSchema).asNestedType().asStructType();
-
-    // partition type may be null if the field was not projected
-    Type partType = schema.fieldType("partition");
-    if (partType != null) {
-      this.partitionType = partType.asNestedType().asStructType();
-    } else {
-      this.partitionType = EMPTY_STRUCT_TYPE;
-    }
-
-    List<Types.NestedField> fields = schema.fields();
-    List<Types.NestedField> allFields = DataFile.getType(partitionType).fields();
-    this.fromProjectionPos = new int[fields.size()];
-    for (int i = 0; i < fromProjectionPos.length; i += 1) {
-      boolean found = false;
-      for (int j = 0; j < allFields.size(); j += 1) {
-        if (fields.get(i).fieldId() == allFields.get(j).fieldId()) {
-          found = true;
-          fromProjectionPos[i] = j;
-        }
-      }
-
-      if (!found) {
-        throw new IllegalArgumentException("Cannot find projected field: " + fields.get(i));
-      }
-    }
-
-    this.partitionData = new PartitionData(partitionType);
+  GenericDataFile(org.apache.avro.Schema avroSchema) {
+    super(avroSchema);
   }
 
   GenericDataFile(String filePath, FileFormat format, long recordCount,
                   long fileSizeInBytes) {
-    this.filePath = filePath;
-    this.format = format;
-    this.partitionData = EMPTY_PARTITION_DATA;
-    this.partitionType = EMPTY_PARTITION_DATA.getPartitionType();
-    this.recordCount = recordCount;
-    this.fileSizeInBytes = fileSizeInBytes;
+    this(filePath, format, null, recordCount, fileSizeInBytes);
   }
 
   GenericDataFile(String filePath, FileFormat format, PartitionData partition,
                   long recordCount, long fileSizeInBytes) {
-    this.filePath = filePath;
-    this.format = format;
-    this.partitionData = partition;
-    this.partitionType = partition.getPartitionType();
-    this.recordCount = recordCount;
-    this.fileSizeInBytes = fileSizeInBytes;
+    super(FileContent.DATA, filePath, format, partition, fileSizeInBytes, recordCount,
+        null, null, null, null, null, null, null);
   }
 
   GenericDataFile(String filePath, FileFormat format, PartitionData partition,
                   long fileSizeInBytes, Metrics metrics, List<Long> splitOffsets) {
-    this.filePath = filePath;
-    this.format = format;
-
-    // this constructor is used by DataFiles.Builder, which passes null for unpartitioned data
-    if (partition == null) {
-      this.partitionData = EMPTY_PARTITION_DATA;
-      this.partitionType = EMPTY_PARTITION_DATA.getPartitionType();
-    } else {
-      this.partitionData = partition;
-      this.partitionType = partition.getPartitionType();
-    }
-
-    // this will throw NPE if metrics.recordCount is null
-    this.recordCount = metrics.recordCount();
-    this.fileSizeInBytes = fileSizeInBytes;
-    this.columnSizes = metrics.columnSizes();
-    this.valueCounts = metrics.valueCounts();
-    this.nullValueCounts = metrics.nullValueCounts();
-    this.lowerBounds = SerializableByteBufferMap.wrap(metrics.lowerBounds());
-    this.upperBounds = SerializableByteBufferMap.wrap(metrics.upperBounds());
-    this.splitOffsets = copy(splitOffsets);
+    this(filePath, format, partition, fileSizeInBytes, metrics, null, splitOffsets);
   }
 
   GenericDataFile(String filePath, FileFormat format, PartitionData partition,
                   long fileSizeInBytes, Metrics metrics,
                   ByteBuffer keyMetadata, List<Long> splitOffsets) {
-    this(filePath, format, partition, fileSizeInBytes, metrics, splitOffsets);
-    this.keyMetadata = ByteBuffers.toByteArray(keyMetadata);
+    super(FileContent.DATA, filePath, format, partition, fileSizeInBytes, metrics.recordCount(),
+        metrics.columnSizes(), metrics.valueCounts(), metrics.nullValueCounts(),
+        metrics.lowerBounds(), metrics.upperBounds(), splitOffsets, keyMetadata);
   }
 
   /**
@@ -164,242 +61,13 @@ class GenericDataFile
    * @param fullCopy whether to copy all fields or to drop column-level stats
    */
   private GenericDataFile(GenericDataFile toCopy, boolean fullCopy) {
-    this.filePath = toCopy.filePath;
-    this.format = toCopy.format;
-    this.partitionData = toCopy.partitionData.copy();
-    this.partitionType = toCopy.partitionType;
-    this.recordCount = toCopy.recordCount;
-    this.fileSizeInBytes = toCopy.fileSizeInBytes;
-    if (fullCopy) {
-      // TODO: support lazy conversion to/from map
-      this.columnSizes = copy(toCopy.columnSizes);
-      this.valueCounts = copy(toCopy.valueCounts);
-      this.nullValueCounts = copy(toCopy.nullValueCounts);
-      this.lowerBounds = SerializableByteBufferMap.wrap(copy(toCopy.lowerBounds));
-      this.upperBounds = SerializableByteBufferMap.wrap(copy(toCopy.upperBounds));
-    } else {
-      this.columnSizes = null;
-      this.valueCounts = null;
-      this.nullValueCounts = null;
-      this.lowerBounds = null;
-      this.upperBounds = null;
-    }
-    this.fromProjectionPos = toCopy.fromProjectionPos;
-    this.keyMetadata = toCopy.keyMetadata == null ? null : Arrays.copyOf(toCopy.keyMetadata, toCopy.keyMetadata.length);
-    this.splitOffsets = copy(toCopy.splitOffsets);
+    super(toCopy, fullCopy);
   }
 
   /**
    * Constructor for Java serialization.
    */
   GenericDataFile() {
-  }
-
-  @Override
-  public FileContent content() {
-    return FileContent.DATA;
-  }
-
-  @Override
-  public CharSequence path() {
-    return filePath;
-  }
-
-  @Override
-  public FileFormat format() {
-    return format;
-  }
-
-  @Override
-  public StructLike partition() {
-    return partitionData;
-  }
-
-  @Override
-  public long recordCount() {
-    return recordCount;
-  }
-
-  @Override
-  public long fileSizeInBytes() {
-    return fileSizeInBytes;
-  }
-
-  @Override
-  public Map<Integer, Long> columnSizes() {
-    return columnSizes;
-  }
-
-  @Override
-  public Map<Integer, Long> valueCounts() {
-    return valueCounts;
-  }
-
-  @Override
-  public Map<Integer, Long> nullValueCounts() {
-    return nullValueCounts;
-  }
-
-  @Override
-  public Map<Integer, ByteBuffer> lowerBounds() {
-    return lowerBounds;
-  }
-
-  @Override
-  public Map<Integer, ByteBuffer> upperBounds() {
-    return upperBounds;
-  }
-
-  @Override
-  public ByteBuffer keyMetadata() {
-    return keyMetadata != null ? ByteBuffer.wrap(keyMetadata) : null;
-  }
-
-  @Override
-  public List<Long> splitOffsets() {
-    return splitOffsets;
-  }
-
-  @Override
-  public org.apache.avro.Schema getSchema() {
-    if (avroSchema == null) {
-      this.avroSchema = getAvroSchema(partitionType);
-    }
-    return avroSchema;
-  }
-
-  @Override
-  @SuppressWarnings("unchecked")
-  public void put(int i, Object v) {
-    int pos = i;
-    // if the schema was projected, map the incoming ordinal to the expected one
-    if (fromProjectionPos != null) {
-      pos = fromProjectionPos[i];
-    }
-    switch (pos) {
-      case 0:
-        Preconditions.checkState(v == null || (Integer) v == FileContent.DATA.id(),
-            "Invalid content for a DataFile: %s", v);
-        return;
-      case 1:
-        // always coerce to String for Serializable
-        this.filePath = v.toString();
-        return;
-      case 2:
-        this.format = FileFormat.valueOf(v.toString());
-        return;
-      case 3:
-        this.partitionData = (PartitionData) v;
-        return;
-      case 4:
-        this.recordCount = (Long) v;
-        return;
-      case 5:
-        this.fileSizeInBytes = (Long) v;
-        return;
-      case 6:
-        this.columnSizes = (Map<Integer, Long>) v;
-        return;
-      case 7:
-        this.valueCounts = (Map<Integer, Long>) v;
-        return;
-      case 8:
-        this.nullValueCounts = (Map<Integer, Long>) v;
-        return;
-      case 9:
-        this.lowerBounds = SerializableByteBufferMap.wrap((Map<Integer, ByteBuffer>) v);
-        return;
-      case 10:
-        this.upperBounds = SerializableByteBufferMap.wrap((Map<Integer, ByteBuffer>) v);
-        return;
-      case 11:
-        this.keyMetadata = ByteBuffers.toByteArray((ByteBuffer) v);
-        return;
-      case 12:
-        this.splitOffsets = (List<Long>) v;
-        return;
-      default:
-        // ignore the object, it must be from a newer version of the format
-    }
-  }
-
-  @Override
-  public <T> void set(int pos, T value) {
-    put(pos, value);
-  }
-
-  @Override
-  public Object get(int i) {
-    int pos = i;
-    // if the schema was projected, map the incoming ordinal to the expected one
-    if (fromProjectionPos != null) {
-      pos = fromProjectionPos[i];
-    }
-    switch (pos) {
-      case 0:
-        return FileContent.DATA.id();
-      case 1:
-        return filePath;
-      case 2:
-        return format != null ? format.toString() : null;
-      case 3:
-        return partitionData;
-      case 4:
-        return recordCount;
-      case 5:
-        return fileSizeInBytes;
-      case 6:
-        return columnSizes;
-      case 7:
-        return valueCounts;
-      case 8:
-        return nullValueCounts;
-      case 9:
-        return lowerBounds;
-      case 10:
-        return upperBounds;
-      case 11:
-        return keyMetadata();
-      case 12:
-        return splitOffsets;
-      default:
-        throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
-    }
-  }
-
-  @Override
-  public <T> T get(int pos, Class<T> javaClass) {
-    return javaClass.cast(get(pos));
-  }
-
-  private static org.apache.avro.Schema getAvroSchema(Types.StructType partitionType) {
-    Types.StructType type = DataFile.getType(partitionType);
-    return AvroSchemaUtil.convert(type, ImmutableMap.of(
-        type, GenericDataFile.class.getName(),
-        partitionType, PartitionData.class.getName()));
-  }
-
-  @Override
-  public int size() {
-    return DataFile.getType(EMPTY_STRUCT_TYPE).fields().size();
-  }
-
-  @Override
-  public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("file_path", filePath)
-        .add("file_format", format)
-        .add("partition", partitionData)
-        .add("record_count", recordCount)
-        .add("file_size_in_bytes", fileSizeInBytes)
-        .add("column_sizes", columnSizes)
-        .add("value_counts", valueCounts)
-        .add("null_value_counts", nullValueCounts)
-        .add("lower_bounds", lowerBounds)
-        .add("upper_bounds", upperBounds)
-        .add("key_metadata", keyMetadata == null ? "null" : "(redacted)")
-        .add("split_offsets", splitOffsets == null ? "null" : splitOffsets)
-        .toString();
   }
 
   @Override
@@ -410,23 +78,5 @@ class GenericDataFile
   @Override
   public DataFile copy() {
     return new GenericDataFile(this, true /* full copy */);
-  }
-
-  private static <K, V> Map<K, V> copy(Map<K, V> map) {
-    if (map != null) {
-      Map<K, V> copy = Maps.newHashMapWithExpectedSize(map.size());
-      copy.putAll(map);
-      return Collections.unmodifiableMap(copy);
-    }
-    return null;
-  }
-
-  private static <E> List<E> copy(List<E> list) {
-    if (list != null) {
-      List<E> copy = Lists.newArrayListWithExpectedSize(list.size());
-      copy.addAll(list);
-      return Collections.unmodifiableList(copy);
-    }
-    return null;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/GenericDataFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDataFile.java
@@ -19,8 +19,12 @@
 
 package org.apache.iceberg;
 
+import com.google.common.collect.ImmutableMap;
 import java.nio.ByteBuffer;
 import java.util.List;
+import org.apache.avro.Schema;
+import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.types.Types;
 
 class GenericDataFile extends BaseFile<DataFile> implements DataFile {
   /**
@@ -78,5 +82,12 @@ class GenericDataFile extends BaseFile<DataFile> implements DataFile {
   @Override
   public DataFile copy() {
     return new GenericDataFile(this, true /* full copy */);
+  }
+
+  protected Schema getAvroSchema(Types.StructType partitionStruct) {
+    Types.StructType type = DataFile.getType(partitionStruct);
+    return AvroSchemaUtil.convert(type, ImmutableMap.of(
+        type, GenericDataFile.class.getName(),
+        partitionStruct, PartitionData.class.getName()));
   }
 }

--- a/core/src/main/java/org/apache/iceberg/GenericDeleteFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDeleteFile.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+
+import java.nio.ByteBuffer;
+
+class GenericDeleteFile extends BaseFile<DeleteFile> implements DeleteFile {
+  /**
+   * Used by Avro reflection to instantiate this class when reading manifest files.
+   */
+  GenericDeleteFile(org.apache.avro.Schema avroSchema) {
+    super(avroSchema);
+  }
+
+  GenericDeleteFile(FileContent content, String filePath, FileFormat format, PartitionData partition,
+                    long fileSizeInBytes, Metrics metrics, ByteBuffer keyMetadata) {
+    super(content, filePath, format, partition, fileSizeInBytes, metrics.recordCount(),
+        metrics.columnSizes(), metrics.valueCounts(), metrics.nullValueCounts(),
+        metrics.lowerBounds(), metrics.upperBounds(), null, keyMetadata);
+  }
+
+  /**
+   * Copy constructor.
+   *
+   * @param toCopy a generic data file to copy.
+   * @param fullCopy whether to copy all fields or to drop column-level stats
+   */
+  private GenericDeleteFile(GenericDeleteFile toCopy, boolean fullCopy) {
+    super(toCopy, fullCopy);
+  }
+
+  /**
+   * Constructor for Java serialization.
+   */
+  GenericDeleteFile() {
+  }
+
+  @Override
+  public DeleteFile copyWithoutStats() {
+    return new GenericDeleteFile(this, false /* drop stats */);
+  }
+
+  @Override
+  public DeleteFile copy() {
+    return new GenericDeleteFile(this, true /* full copy */);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/GenericDeleteFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDeleteFile.java
@@ -20,13 +20,17 @@
 package org.apache.iceberg;
 
 
+import com.google.common.collect.ImmutableMap;
 import java.nio.ByteBuffer;
+import org.apache.avro.Schema;
+import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.types.Types;
 
 class GenericDeleteFile extends BaseFile<DeleteFile> implements DeleteFile {
   /**
    * Used by Avro reflection to instantiate this class when reading manifest files.
    */
-  GenericDeleteFile(org.apache.avro.Schema avroSchema) {
+  GenericDeleteFile(Schema avroSchema) {
     super(avroSchema);
   }
 
@@ -61,5 +65,12 @@ class GenericDeleteFile extends BaseFile<DeleteFile> implements DeleteFile {
   @Override
   public DeleteFile copy() {
     return new GenericDeleteFile(this, true /* full copy */);
+  }
+
+  protected Schema getAvroSchema(Types.StructType partitionStruct) {
+    Types.StructType type = DataFile.getType(partitionStruct);
+    return AvroSchemaUtil.convert(type, ImmutableMap.of(
+        type, GenericDeleteFile.class.getName(),
+        partitionStruct, PartitionData.class.getName()));
   }
 }

--- a/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
+++ b/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
@@ -25,7 +25,8 @@ import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.types.Types;
 
-class GenericManifestEntry<F extends ContentFile<F>> implements ManifestEntry<F>, IndexedRecord, SpecificData.SchemaConstructable, StructLike {
+class GenericManifestEntry<F extends ContentFile<F>>
+    implements ManifestEntry<F>, IndexedRecord, SpecificData.SchemaConstructable, StructLike {
   private final org.apache.avro.Schema schema;
   private Status status = Status.EXISTING;
   private Long snapshotId = null;

--- a/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
+++ b/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
@@ -27,7 +27,6 @@ import org.apache.iceberg.types.Types;
 
 class GenericManifestEntry implements ManifestEntry, IndexedRecord, SpecificData.SchemaConstructable, StructLike {
   private final org.apache.avro.Schema schema;
-  private final V1Metadata.IndexedDataFile fileWrapper;
   private Status status = Status.EXISTING;
   private Long snapshotId = null;
   private Long sequenceNumber = null;
@@ -35,17 +34,14 @@ class GenericManifestEntry implements ManifestEntry, IndexedRecord, SpecificData
 
   GenericManifestEntry(org.apache.avro.Schema schema) {
     this.schema = schema;
-    this.fileWrapper = null; // do not use the file wrapper to read
   }
 
   GenericManifestEntry(Types.StructType partitionType) {
     this.schema = AvroSchemaUtil.convert(V1Metadata.entrySchema(partitionType), "manifest_entry");
-    this.fileWrapper = new V1Metadata.IndexedDataFile(schema.getField("data_file").schema());
   }
 
   private GenericManifestEntry(GenericManifestEntry toCopy, boolean fullCopy) {
     this.schema = toCopy.schema;
-    this.fileWrapper = new V1Metadata.IndexedDataFile(schema.getField("data_file").schema());
     this.status = toCopy.status;
     this.snapshotId = toCopy.snapshotId;
     if (fullCopy) {
@@ -163,11 +159,7 @@ class GenericManifestEntry implements ManifestEntry, IndexedRecord, SpecificData
       case 2:
         return sequenceNumber;
       case 3:
-        if (fileWrapper == null || file instanceof GenericDataFile) {
-          return file;
-        } else {
-          return fileWrapper.wrap(file);
-        }
+        return file;
       default:
         throw new UnsupportedOperationException("Unknown field ordinal: " + i);
     }

--- a/core/src/main/java/org/apache/iceberg/InheritableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/InheritableMetadata.java
@@ -22,5 +22,5 @@ package org.apache.iceberg;
 import java.io.Serializable;
 
 interface InheritableMetadata extends Serializable {
-  ManifestEntry apply(ManifestEntry manifestEntry);
+  <F extends ContentFile<F>> ManifestEntry<F> apply(ManifestEntry<F> manifestEntry);
 }

--- a/core/src/main/java/org/apache/iceberg/InheritableMetadataFactory.java
+++ b/core/src/main/java/org/apache/iceberg/InheritableMetadataFactory.java
@@ -51,7 +51,7 @@ class InheritableMetadataFactory {
     }
 
     @Override
-    public ManifestEntry apply(ManifestEntry manifestEntry) {
+    public <F extends ContentFile<F>> ManifestEntry<F> apply(ManifestEntry<F> manifestEntry) {
       if (manifestEntry.snapshotId() == null) {
         manifestEntry.setSnapshotId(snapshotId);
       }
@@ -70,7 +70,7 @@ class InheritableMetadataFactory {
     }
 
     @Override
-    public ManifestEntry apply(ManifestEntry manifestEntry) {
+    public <F extends ContentFile<F>> ManifestEntry<F> apply(ManifestEntry<F> manifestEntry) {
       manifestEntry.setSnapshotId(snapshotId);
       return manifestEntry;
     }
@@ -81,7 +81,7 @@ class InheritableMetadataFactory {
     private EmptyInheritableMetadata() {}
 
     @Override
-    public ManifestEntry apply(ManifestEntry manifestEntry) {
+    public <F extends ContentFile<F>> ManifestEntry<F> apply(ManifestEntry<F> manifestEntry) {
       if (manifestEntry.snapshotId() == null) {
         throw new IllegalArgumentException("Entries must have explicit snapshot ids if inherited metadata is empty");
       }

--- a/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
@@ -129,7 +129,7 @@ public class ManifestEntriesTable extends BaseMetadataTable {
     public CloseableIterable<StructLike> rows() {
       return CloseableIterable.transform(
           ManifestFiles.read(manifest, io).project(fileSchema).entries(),
-          file -> (GenericManifestEntry) file);
+          file -> (GenericManifestEntry<?>) file);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/ManifestEntry.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntry.java
@@ -25,7 +25,7 @@ import org.apache.iceberg.types.Types.StructType;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
-interface ManifestEntry {
+interface ManifestEntry<F extends ContentFile<F>> {
   enum Status {
     EXISTING(0),
     ADDED(1),
@@ -89,9 +89,9 @@ interface ManifestEntry {
   /**
    * @return a file
    */
-  DataFile file();
+  F file();
 
-  ManifestEntry copy();
+  ManifestEntry<F> copy();
 
-  ManifestEntry copyWithoutStats();
+  ManifestEntry<F> copyWithoutStats();
 }

--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -164,10 +164,10 @@ public class ManifestFiles {
   private static ManifestFile copyManifestInternal(int formatVersion, ManifestReader reader, OutputFile outputFile,
                                                    long snapshotId, SnapshotSummary.Builder summaryBuilder,
                                                    ManifestEntry.Status allowedEntryStatus) {
-    ManifestWriter writer = write(formatVersion, reader.spec(), outputFile, snapshotId);
+    ManifestWriter<DataFile> writer = write(formatVersion, reader.spec(), outputFile, snapshotId);
     boolean threw = true;
     try {
-      for (ManifestEntry entry : reader.entries()) {
+      for (ManifestEntry<DataFile> entry : reader.entries()) {
         Preconditions.checkArgument(
             allowedEntryStatus == entry.status(),
             "Invalid manifest entry status: %s (allowed status: %s)",

--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -113,6 +113,26 @@ public class ManifestFiles {
     return new DeleteManifestReader(file, specsById, inheritableMetadata);
   }
 
+  /**
+   * Create a new {@link ManifestWriter} for the given format version.
+   *
+   * @param formatVersion a target format version
+   * @param spec a {@link PartitionSpec}
+   * @param outputFile an {@link OutputFile} where the manifest will be written
+   * @param snapshotId a snapshot ID for the manifest entries, or null for an inherited ID
+   * @return a manifest writer
+   */
+  public static ManifestWriter<DeleteFile> writeDeleteManifest(int formatVersion, PartitionSpec spec,
+                                                               OutputFile outputFile, Long snapshotId) {
+    switch (formatVersion) {
+      case 1:
+        throw new IllegalArgumentException("Cannot write delete files in a v1 table");
+      case 2:
+        return new ManifestWriter.V2DeleteWriter(spec, outputFile, snapshotId);
+    }
+    throw new UnsupportedOperationException("Cannot write manifest for table version: " + formatVersion);
+  }
+
   static ManifestFile copyAppendManifest(int formatVersion,
                                          InputFile toCopy, Map<Integer, PartitionSpec> specsById,
                                          OutputFile outputFile, long snapshotId,

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -526,7 +526,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
     Evaluator inclusive = extractInclusiveDeleteExpression(reader);
     Evaluator strict = extractStrictDeleteExpression(reader);
     boolean hasDeletedFiles = false;
-    for (ManifestEntry entry : reader.entries()) {
+    for (ManifestEntry<DataFile> entry : reader.entries()) {
       DataFile file = entry.file();
       boolean fileDelete = deletePaths.contains(pathWrapper.set(file.path())) ||
           dropPartitions.contains(partitionWrapper.set(file.partition()));
@@ -555,7 +555,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
     // manifest. produce a copy of the manifest with all deleted files removed.
     List<DataFile> deletedFiles = Lists.newArrayList();
     Set<CharSequenceWrapper> deletedPaths = Sets.newHashSet();
-    ManifestWriter writer = newManifestWriter(reader.spec());
+    ManifestWriter<DataFile> writer = newManifestWriter(reader.spec());
     try {
       reader.entries().forEach(entry -> {
         DataFile file = entry.file();
@@ -667,11 +667,11 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
       return mergeManifests.get(bin);
     }
 
-    ManifestWriter writer = newManifestWriter(ops.current().spec());
+    ManifestWriter<DataFile> writer = newManifestWriter(ops.current().spec());
     try {
       for (ManifestFile manifest : bin) {
         try (ManifestReader reader = ManifestFiles.read(manifest, ops.io(), ops.current().specsById())) {
-          for (ManifestEntry entry : reader.entries()) {
+          for (ManifestEntry<DataFile> entry : reader.entries()) {
             if (entry.status() == Status.DELETED) {
               // suppress deletes from previous snapshots. only files deleted by this snapshot
               // should be added to the new manifest

--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -350,7 +350,7 @@ class RemoveSnapshots implements ExpireSnapshots {
         .run(manifest -> {
           // the manifest has deletes, scan it to find files to delete
           try (ManifestReader reader = ManifestFiles.read(manifest, ops.io(), ops.current().specsById())) {
-            for (ManifestEntry entry : reader.entries()) {
+            for (ManifestEntry<?> entry : reader.entries()) {
               // if the snapshot ID of the DELETE entry is no longer valid, the data can be deleted
               if (entry.status() == ManifestEntry.Status.DELETED &&
                   !validIds.contains(entry.snapshotId())) {
@@ -370,7 +370,7 @@ class RemoveSnapshots implements ExpireSnapshots {
         .run(manifest -> {
           // the manifest has deletes, scan it to find files to delete
           try (ManifestReader reader = ManifestFiles.read(manifest, ops.io(), ops.current().specsById())) {
-            for (ManifestEntry entry : reader.entries()) {
+            for (ManifestEntry<?> entry : reader.entries()) {
               // delete any ADDED file from manifests that were reverted
               if (entry.status() == ManifestEntry.Status.ADDED) {
                 // use toString to ensure the path will not change (Utf8 is reused)

--- a/core/src/main/java/org/apache/iceberg/ScanSummary.java
+++ b/core/src/main/java/org/apache/iceberg/ScanSummary.java
@@ -218,7 +218,7 @@ public class ScanSummary {
       TopN<String, PartitionMetrics> topN = new TopN<>(
           limit, throwIfLimited, Comparators.charSequences());
 
-      try (CloseableIterable<ManifestEntry> entries = new ManifestGroup(ops.io(), manifests)
+      try (CloseableIterable<ManifestEntry<DataFile>> entries = new ManifestGroup(ops.io(), manifests)
           .specsById(ops.current().specsById())
           .filterData(rowFilter)
           .ignoreDeleted()
@@ -226,7 +226,7 @@ public class ScanSummary {
           .entries()) {
 
         PartitionSpec spec = table.spec();
-        for (ManifestEntry entry : entries) {
+        for (ManifestEntry<?> entry : entries) {
           Long timestamp = snapshotTimestamps.get(entry.snapshotId());
 
           // if filtering, skip timestamps that are outside the range
@@ -280,7 +280,7 @@ public class ScanSummary {
       return this;
     }
 
-    private PartitionMetrics updateFromFile(DataFile file, Long timestampMillis) {
+    private PartitionMetrics updateFromFile(ContentFile<?> file, Long timestampMillis) {
       this.fileCount += 1;
       this.recordCount += file.recordCount();
       this.totalSize += file.fileSizeInBytes();

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -331,7 +331,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
         ops.metadataFileLocation(FileFormat.AVRO.addExtension(commitUUID + "-m" + manifestCount.getAndIncrement())));
   }
 
-  protected ManifestWriter newManifestWriter(PartitionSpec spec) {
+  protected ManifestWriter<DataFile> newManifestWriter(PartitionSpec spec) {
     return ManifestFiles.write(ops.current().formatVersion(), spec, newManifestOutput(), snapshotId());
   }
 
@@ -358,7 +358,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
 
       Long snapshotId = null;
       long maxSnapshotId = Long.MIN_VALUE;
-      for (ManifestEntry entry : reader.entries()) {
+      for (ManifestEntry<DataFile> entry : reader.entries()) {
         if (entry.snapshotId() > maxSnapshotId) {
           maxSnapshotId = entry.snapshotId();
         }

--- a/core/src/main/java/org/apache/iceberg/V1Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V1Metadata.java
@@ -221,17 +221,17 @@ class V1Metadata {
   /**
    * Wrapper used to write a ManifestEntry to v1 metadata.
    */
-  static class IndexedManifestEntry implements ManifestEntry, IndexedRecord {
+  static class IndexedManifestEntry implements ManifestEntry<DataFile>, IndexedRecord {
     private final org.apache.avro.Schema avroSchema;
     private final IndexedDataFile fileWrapper;
-    private ManifestEntry wrapped = null;
+    private ManifestEntry<DataFile> wrapped = null;
 
     IndexedManifestEntry(Types.StructType partitionType) {
       this.avroSchema = AvroSchemaUtil.convert(entrySchema(partitionType), "manifest_entry");
       this.fileWrapper = new IndexedDataFile(avroSchema.getField("data_file").schema());
     }
 
-    public IndexedManifestEntry wrap(ManifestEntry entry) {
+    public IndexedManifestEntry wrap(ManifestEntry<DataFile> entry) {
       this.wrapped = entry;
       return this;
     }
@@ -295,12 +295,12 @@ class V1Metadata {
     }
 
     @Override
-    public ManifestEntry copy() {
+    public ManifestEntry<DataFile> copy() {
       return wrapped.copy();
     }
 
     @Override
-    public ManifestEntry copyWithoutStats() {
+    public ManifestEntry<DataFile> copyWithoutStats() {
       return wrapped.copyWithoutStats();
     }
   }
@@ -318,7 +318,6 @@ class V1Metadata {
     }
 
     IndexedDataFile wrap(DataFile file) {
-      Preconditions.checkArgument(!(file instanceof DeleteFile), "Cannot write delete file to v1 table: %s", file);
       this.wrapped = file;
       return this;
     }

--- a/core/src/main/java/org/apache/iceberg/V1Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V1Metadata.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg;
 
+import com.google.common.base.Preconditions;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
@@ -317,6 +318,7 @@ class V1Metadata {
     }
 
     IndexedDataFile wrap(DataFile file) {
+      Preconditions.checkArgument(!(file instanceof DeleteFile), "Cannot write delete file to v1 table: %s", file);
       this.wrapped = file;
       return this;
     }
@@ -362,6 +364,11 @@ class V1Metadata {
     @Override
     public org.apache.avro.Schema getSchema() {
       return avroSchema;
+    }
+
+    @Override
+    public FileContent content() {
+      return wrapped.content();
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/V1Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V1Metadata.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg;
 
-import com.google.common.base.Preconditions;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;

--- a/core/src/main/java/org/apache/iceberg/V2Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V2Metadata.java
@@ -351,9 +351,9 @@ class V2Metadata {
   }
 
   /**
-   * Wrapper used to write a DataFile to v2 metadata.
+   * Wrapper used to write DataFile or DeleteFile to v2 metadata.
    */
-  static class IndexedDataFile implements DataFile, IndexedRecord {
+  static class IndexedDataFile implements DataFile, DeleteFile, IndexedRecord {
     private final org.apache.avro.Schema avroSchema;
     private final IndexedStructLike partitionWrapper;
     private DataFile wrapped = null;
@@ -377,7 +377,7 @@ class V2Metadata {
     public Object get(int pos) {
       switch (pos) {
         case 0:
-          return FileContent.DATA.id();
+          return wrapped.content().id();
         case 1:
           return wrapped.path().toString();
         case 2:
@@ -409,6 +409,11 @@ class V2Metadata {
     @Override
     public void put(int i, Object v) {
       throw new UnsupportedOperationException("Cannot read into IndexedDataFile");
+    }
+
+    @Override
+    public FileContent content() {
+      return wrapped.content();
     }
 
     @Override
@@ -472,13 +477,13 @@ class V2Metadata {
     }
 
     @Override
-    public DataFile copy() {
-      return wrapped.copy();
+    public IndexedDataFile copy() {
+      throw new UnsupportedOperationException("Cannot copy IndexedDataFile wrapper");
     }
 
     @Override
-    public DataFile copyWithoutStats() {
-      return wrapped.copyWithoutStats();
+    public IndexedDataFile copyWithoutStats() {
+      throw new UnsupportedOperationException("Cannot copy IndexedDataFile wrapper");
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TableTestBase.java
@@ -147,7 +147,7 @@ public class TableTestBase {
     Assert.assertTrue(manifestFile.delete());
     OutputFile outputFile = table.ops().io().newOutputFile(manifestFile.getCanonicalPath());
 
-    ManifestWriter writer = ManifestFiles.write(formatVersion, table.spec(), outputFile, snapshotId);
+    ManifestWriter<DataFile> writer = ManifestFiles.write(formatVersion, table.spec(), outputFile, snapshotId);
     try {
       for (DataFile file : files) {
         writer.add(file);
@@ -159,22 +159,22 @@ public class TableTestBase {
     return writer.toManifestFile();
   }
 
-  ManifestFile writeManifest(String fileName, ManifestEntry... entries) throws IOException {
+  ManifestFile writeManifest(String fileName, ManifestEntry<DataFile>... entries) throws IOException {
     return writeManifest(null, fileName, entries);
   }
 
-  ManifestFile writeManifest(Long snapshotId, ManifestEntry... entries) throws IOException {
+  ManifestFile writeManifest(Long snapshotId, ManifestEntry<DataFile>... entries) throws IOException {
     return writeManifest(snapshotId, "input.m0.avro", entries);
   }
 
-  ManifestFile writeManifest(Long snapshotId, String fileName, ManifestEntry... entries) throws IOException {
+  ManifestFile writeManifest(Long snapshotId, String fileName, ManifestEntry<DataFile>... entries) throws IOException {
     File manifestFile = temp.newFile(fileName);
     Assert.assertTrue(manifestFile.delete());
     OutputFile outputFile = table.ops().io().newOutputFile(manifestFile.getCanonicalPath());
 
-    ManifestWriter writer = ManifestFiles.write(formatVersion, table.spec(), outputFile, snapshotId);
+    ManifestWriter<DataFile> writer = ManifestFiles.write(formatVersion, table.spec(), outputFile, snapshotId);
     try {
-      for (ManifestEntry entry : entries) {
+      for (ManifestEntry<DataFile> entry : entries) {
         writer.addEntry(entry);
       }
     } finally {
@@ -189,7 +189,7 @@ public class TableTestBase {
     Assert.assertTrue(manifestFile.delete());
     OutputFile outputFile = table.ops().io().newOutputFile(manifestFile.getCanonicalPath());
 
-    ManifestWriter writer = ManifestFiles.write(formatVersion, table.spec(), outputFile, null);
+    ManifestWriter<DataFile> writer = ManifestFiles.write(formatVersion, table.spec(), outputFile, null);
     try {
       for (DataFile file : files) {
         writer.add(file);
@@ -201,8 +201,8 @@ public class TableTestBase {
     return writer.toManifestFile();
   }
 
-  ManifestEntry manifestEntry(ManifestEntry.Status status, Long snapshotId, DataFile file) {
-    GenericManifestEntry entry = new GenericManifestEntry(table.spec().partitionType());
+  ManifestEntry<DataFile> manifestEntry(ManifestEntry.Status status, Long snapshotId, DataFile file) {
+    GenericManifestEntry<DataFile> entry = new GenericManifestEntry<>(table.spec().partitionType());
     switch (status) {
       case ADDED:
         return entry.wrapAppend(snapshotId, file);
@@ -240,7 +240,7 @@ public class TableTestBase {
     long id = snap.snapshotId();
     Iterator<String> newPaths = paths(newFiles).iterator();
 
-    for (ManifestEntry entry : ManifestFiles.read(manifest, FILE_IO).entries()) {
+    for (ManifestEntry<DataFile> entry : ManifestFiles.read(manifest, FILE_IO).entries()) {
       DataFile file = entry.file();
       if (sequenceNumber != null) {
         V1Assert.assertEquals("Sequence number should default to 0", 0, entry.sequenceNumber().longValue());
@@ -283,7 +283,7 @@ public class TableTestBase {
                         Iterator<Long> seqs,
                         Iterator<Long> ids,
                         Iterator<DataFile> expectedFiles) {
-    for (ManifestEntry entry : ManifestFiles.read(manifest, FILE_IO).entries()) {
+    for (ManifestEntry<DataFile> entry : ManifestFiles.read(manifest, FILE_IO).entries()) {
       DataFile file = entry.file();
       DataFile expected = expectedFiles.next();
       if (seqs != null) {
@@ -303,7 +303,7 @@ public class TableTestBase {
                                       Iterator<Long> ids,
                                       Iterator<DataFile> expectedFiles,
                                       Iterator<ManifestEntry.Status> expectedStatuses) {
-    for (ManifestEntry entry : ManifestFiles.read(manifest, FILE_IO).entries()) {
+    for (ManifestEntry<DataFile> entry : ManifestFiles.read(manifest, FILE_IO).entries()) {
       DataFile file = entry.file();
       DataFile expected = expectedFiles.next();
       final ManifestEntry.Status expectedStatus = expectedStatuses.next();

--- a/core/src/test/java/org/apache/iceberg/TestManifestReader.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReader.java
@@ -47,7 +47,7 @@ public class TestManifestReader extends TableTestBase {
   public void testManifestReaderWithEmptyInheritableMetadata() throws IOException {
     ManifestFile manifest = writeManifest(1000L, manifestEntry(Status.EXISTING, 1000L, FILE_A));
     try (ManifestReader reader = ManifestFiles.read(manifest, FILE_IO)) {
-      ManifestEntry entry = Iterables.getOnlyElement(reader.entries());
+      ManifestEntry<DataFile> entry = Iterables.getOnlyElement(reader.entries());
       Assert.assertEquals(Status.EXISTING, entry.status());
       Assert.assertEquals(FILE_A.path(), entry.file().path());
       Assert.assertEquals(1000L, (long) entry.snapshotId());
@@ -67,7 +67,7 @@ public class TestManifestReader extends TableTestBase {
   public void testManifestReaderWithPartitionMetadata() throws IOException {
     ManifestFile manifest = writeManifest(1000L, manifestEntry(Status.EXISTING, 123L, FILE_A));
     try (ManifestReader reader = ManifestFiles.read(manifest, FILE_IO)) {
-      ManifestEntry entry = Iterables.getOnlyElement(reader.entries());
+      ManifestEntry<DataFile> entry = Iterables.getOnlyElement(reader.entries());
       Assert.assertEquals(123L, (long) entry.snapshotId());
 
       List<Types.NestedField> fields = ((PartitionData) entry.file().partition()).getPartitionType().fields();
@@ -88,7 +88,7 @@ public class TestManifestReader extends TableTestBase {
 
     ManifestFile manifest = writeManifest(1000L, manifestEntry(Status.EXISTING, 123L, FILE_A));
     try (ManifestReader reader = ManifestFiles.read(manifest, FILE_IO)) {
-      ManifestEntry entry = Iterables.getOnlyElement(reader.entries());
+      ManifestEntry<DataFile> entry = Iterables.getOnlyElement(reader.entries());
       Assert.assertEquals(123L, (long) entry.snapshotId());
 
       List<Types.NestedField> fields = ((PartitionData) entry.file().partition()).getPartitionType().fields();

--- a/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
@@ -745,7 +745,7 @@ public class TestMergeAppend extends TableTestBase {
         initialManifest, pending.manifests().get(1));
 
     // field ids of manifest entries in two manifests with different specs of the same source field should be different
-    ManifestEntry entry = ManifestFiles.read(pending.manifests().get(0), FILE_IO).entries().iterator().next();
+    ManifestEntry<DataFile> entry = ManifestFiles.read(pending.manifests().get(0), FILE_IO).entries().iterator().next();
     Types.NestedField field = ((PartitionData) entry.file().partition()).getPartitionType().fields().get(0);
     Assert.assertEquals(1000, field.fieldId());
     Assert.assertEquals("id_bucket", field.name());

--- a/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
@@ -955,7 +955,7 @@ public class TestRewriteManifests extends TableTestBase {
 
     Assert.assertEquals(3, Iterables.size(table.snapshots()));
 
-    ManifestEntry entry = manifestEntry(ManifestEntry.Status.EXISTING, firstSnapshot.snapshotId(), FILE_A);
+    ManifestEntry<DataFile> entry = manifestEntry(ManifestEntry.Status.EXISTING, firstSnapshot.snapshotId(), FILE_A);
     // update the entry's sequence number or else it will be rejected by the writer
     entry.setSequenceNumber(firstSnapshot.sequenceNumber());
     ManifestFile newManifest = writeManifest("manifest-file-1.avro", entry);
@@ -1005,7 +1005,7 @@ public class TestRewriteManifests extends TableTestBase {
     Assert.assertEquals(1, manifests.size());
     ManifestFile manifest = manifests.get(0);
 
-    ManifestEntry appendEntry = manifestEntry(ManifestEntry.Status.ADDED, snapshot.snapshotId(), FILE_A);
+    ManifestEntry<DataFile> appendEntry = manifestEntry(ManifestEntry.Status.ADDED, snapshot.snapshotId(), FILE_A);
     // update the entry's sequence number or else it will be rejected by the writer
     appendEntry.setSequenceNumber(snapshot.sequenceNumber());
 
@@ -1018,7 +1018,7 @@ public class TestRewriteManifests extends TableTestBase {
             .addManifest(invalidAddedFileManifest)
             .commit());
 
-    ManifestEntry deleteEntry = manifestEntry(ManifestEntry.Status.DELETED, snapshot.snapshotId(), FILE_A);
+    ManifestEntry<DataFile> deleteEntry = manifestEntry(ManifestEntry.Status.DELETED, snapshot.snapshotId(), FILE_A);
     // update the entry's sequence number or else it will be rejected by the writer
     deleteEntry.setSequenceNumber(snapshot.sequenceNumber());
 


### PR DESCRIPTION
This adds a new interface, DeleteFile, and implementations of ManfiestReader and ManifestWriter for deletes.

DeleteFile and DataFile now inherit from a common interface, ContentFile, with all of the metadata. The purpose of separate interfaces is to keep data and delete files separate in the APIs. DataFile can't be written to a delete manifest, for example. This also uses a common implementation, BaseFile for both GenericDataFile and GenericDeleteFile.

Because ManifestEntry stores a DataFile or a DeleteFile, this adds a type parameter to it. Adding this type parameter is why so many files changed, but most of the changes are in the last commit and are just parameter additions.

Some classes that may be used to return DeleteFiles (or ManifestEntry<DeleteFile>) currently return only DataFile, like ManifestGroup. This is currently safe because there is no code to read a DeleteManifest in those classes. We can update the implementations as we add support for delete manifests.