### PR TITLE
Fix NPE when counting entries

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Schema.java
+++ b/api/src/main/java/org/apache/iceberg/Schema.java
@@ -124,9 +124,21 @@ public class Schema implements Serializable {
     return struct.fields();
   }
 
+  /**
+   * Returns the {@link Type} of a sub-field identified by the field name.
+   *
+   * @param name a field name
+   * @return a Type for the sub-field or null if it is not found
+   */
   public Type findType(String name) {
     Preconditions.checkArgument(!name.isEmpty(), "Invalid column name: (empty)");
-    return findType(lazyNameToId().get(name));
+    Integer id = lazyNameToId().get(name);
+    if (id != null) {  // name is found
+      return findType(id);
+    }
+
+    // name could not be found
+    return null;
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
@@ -28,6 +28,7 @@ import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.ParallelIterable;
 import org.apache.iceberg.util.ThreadPools;
@@ -100,7 +101,8 @@ public class AllEntriesTable extends BaseMetadataTable {
         TableOperations ops, Snapshot snapshot, Expression rowFilter,
         boolean ignoreResiduals, boolean caseSensitive, boolean colStats) {
       CloseableIterable<ManifestFile> manifests = allManifestFiles(ops.current().snapshots());
-      Schema fileSchema = new Schema(schema().findType("data_file").asStructType().fields());
+      Type fileProjection = schema().findType("data_file");
+      Schema fileSchema = fileProjection != null ? new Schema(fileProjection.asStructType().fields()) : null;
       String schemaString = SchemaParser.toJson(schema());
       String specString = PartitionSpecParser.toJson(PartitionSpec.unpartitioned());
       Expression filter = ignoreResiduals ? Expressions.alwaysTrue() : rowFilter;

--- a/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
@@ -102,7 +102,7 @@ public class AllEntriesTable extends BaseMetadataTable {
         boolean ignoreResiduals, boolean caseSensitive, boolean colStats) {
       CloseableIterable<ManifestFile> manifests = allManifestFiles(ops.current().snapshots());
       Type fileProjection = schema().findType("data_file");
-      Schema fileSchema = fileProjection != null ? new Schema(fileProjection.asStructType().fields()) : null;
+      Schema fileSchema = fileProjection != null ? new Schema(fileProjection.asStructType().fields()) : new Schema();
       String schemaString = SchemaParser.toJson(schema());
       String specString = PartitionSpecParser.toJson(PartitionSpec.unpartitioned());
       Expression filter = ignoreResiduals ? Expressions.alwaysTrue() : rowFilter;

--- a/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 
 /**
@@ -97,7 +98,8 @@ public class ManifestEntriesTable extends BaseMetadataTable {
         boolean ignoreResiduals, boolean caseSensitive, boolean colStats) {
       // return entries from both data and delete manifests
       CloseableIterable<ManifestFile> manifests = CloseableIterable.withNoopClose(snapshot.allManifests());
-      Schema fileSchema = new Schema(schema().findType("data_file").asStructType().fields());
+      Type fileProjection = schema().findType("data_file");
+      Schema fileSchema = fileProjection != null ? new Schema(fileProjection.asStructType().fields()) : null;
       String schemaString = SchemaParser.toJson(schema());
       String specString = PartitionSpecParser.toJson(PartitionSpec.unpartitioned());
       Expression filter = ignoreResiduals ? Expressions.alwaysTrue() : rowFilter;

--- a/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
@@ -99,7 +99,7 @@ public class ManifestEntriesTable extends BaseMetadataTable {
       // return entries from both data and delete manifests
       CloseableIterable<ManifestFile> manifests = CloseableIterable.withNoopClose(snapshot.allManifests());
       Type fileProjection = schema().findType("data_file");
-      Schema fileSchema = fileProjection != null ? new Schema(fileProjection.asStructType().fields()) : null;
+      Schema fileSchema = fileProjection != null ? new Schema(fileProjection.asStructType().fields()) : new Schema();
       String schemaString = SchemaParser.toJson(schema());
       String specString = PartitionSpecParser.toJson(PartitionSpec.unpartitioned());
       Expression filter = ignoreResiduals ? Expressions.alwaysTrue() : rowFilter;

--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
@@ -163,7 +163,7 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
 
   private Schema lazySchema() {
     if (schema == null) {
-      if (requestedSchema != null && requestedSchema.size() != 0) {
+      if (requestedSchema != null) {
         // the projection should include all columns that will be returned, including those only used in filters
         this.schema = SparkSchemaUtil.prune(table.schema(), requestedSchema, filterExpression(), caseSensitive);
       } else {

--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
@@ -163,7 +163,7 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
 
   private Schema lazySchema() {
     if (schema == null) {
-      if (requestedSchema != null) {
+      if (requestedSchema != null && requestedSchema.size() != 0) {
         // the projection should include all columns that will be returned, including those only used in filters
         this.schema = SparkSchemaUtil.prune(table.schema(), requestedSchema, filterExpression(), caseSensitive);
       } else {

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -112,10 +112,10 @@ public abstract class TestIcebergSourceTablesBase {
 
     table.refresh();
 
-    Dataset<Row> actual = spark.read()
+    List<Row> actual = spark.read()
         .format("iceberg")
-        .load(loadLocation(tableIdentifier, "entries"));
-    long actualCount = actual.count();
+        .load(loadLocation(tableIdentifier, "entries"))
+        .collectAsList();
 
     Snapshot snapshot = table.currentSnapshot();
 
@@ -134,8 +134,8 @@ public abstract class TestIcebergSourceTablesBase {
     }
 
     Assert.assertEquals("Entries table should have one row", 1, expected.size());
-    Assert.assertEquals("Actual results should have one row", 1, actualCount);
-    TestHelpers.assertEqualsSafe(entriesTable.schema().asStruct(), expected.get(0), actual.collectAsList().get(0));
+    Assert.assertEquals("Actual results should have one row", 1, actual.size());
+    TestHelpers.assertEqualsSafe(entriesTable.schema().asStruct(), expected.get(0), actual.get(0));
   }
 
   @Test

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -112,10 +112,10 @@ public abstract class TestIcebergSourceTablesBase {
 
     table.refresh();
 
-    List<Row> actual = spark.read()
+    Dataset<Row> actual = spark.read()
         .format("iceberg")
-        .load(loadLocation(tableIdentifier, "entries"))
-        .collectAsList();
+        .load(loadLocation(tableIdentifier, "entries"));
+    long actualCount = actual.count();
 
     Snapshot snapshot = table.currentSnapshot();
 
@@ -134,8 +134,8 @@ public abstract class TestIcebergSourceTablesBase {
     }
 
     Assert.assertEquals("Entries table should have one row", 1, expected.size());
-    Assert.assertEquals("Actual results should have one row", 1, actual.size());
-    TestHelpers.assertEqualsSafe(entriesTable.schema().asStruct(), expected.get(0), actual.get(0));
+    Assert.assertEquals("Actual results should have one row", 1, actualCount);
+    TestHelpers.assertEqualsSafe(entriesTable.schema().asStruct(), expected.get(0), actual.collectAsList().get(0));
   }
 
   @Test

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -194,6 +194,30 @@ public abstract class TestIcebergSourceTablesBase {
   }
 
   @Test
+  public void testCountEntriesTable() {
+    TableIdentifier tableIdentifier = TableIdentifier.of("db", "count_entries_test");
+    createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
+
+    // init load
+    List<SimpleRecord> records = Lists.newArrayList(new SimpleRecord(1, "1"));
+    Dataset<Row> inputDf = spark.createDataFrame(records, SimpleRecord.class);
+    inputDf.select("id", "data").write()
+        .format("iceberg")
+        .mode("append")
+        .save(loadLocation(tableIdentifier));
+
+    final int expectedEntryCount = 1;
+
+    // count entries
+    Assert.assertEquals("Count should return " + expectedEntryCount,
+        expectedEntryCount, spark.read().format("iceberg").load(loadLocation(tableIdentifier, "entries")).count());
+
+    // count all_entries
+    Assert.assertEquals("Count should return " + expectedEntryCount,
+        expectedEntryCount, spark.read().format("iceberg").load(loadLocation(tableIdentifier, "all_entries")).count());
+  }
+
+  @Test
   public void testFilesTable() throws Exception {
     TableIdentifier tableIdentifier = TableIdentifier.of("db", "files_test");
     Table table = createTable(tableIdentifier, SCHEMA, PartitionSpec.builderFor(SCHEMA).identity("id").build());


### PR DESCRIPTION
This PR is to address a NPE when counting on table's entries (found by @jerryshao), which could be triggered by
```
spark.read.format("iceberg").load("db.table.entries").count()
```
The stacktrace is as follow:
```
java.lang.NullPointerException
  at org.apache.iceberg.Schema.findType(Schema.java:129)
  at org.apache.iceberg.ManifestEntriesTable$EntriesTableScan.planFiles(ManifestEntriesTable.java:105)
  at org.apache.iceberg.BaseTableScan.planFiles(BaseTableScan.java:215)
  at org.apache.iceberg.BaseTableScan.splitFiles(BaseTableScan.java:284)
  at org.apache.iceberg.BaseTableScan.planTasks(BaseTableScan.java:248)
  at org.apache.iceberg.spark.source.Reader.tasks(Reader.java:300)
  at org.apache.iceberg.spark.source.Reader.planInputPartitions(Reader.java:187)
  at org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanExec.partitions$lzycompute(DataSourceV2ScanExec.scala:76)
  at org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanExec.partitions(DataSourceV2ScanExec.scala:75)
  at org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanExec.outputPartitioning(DataSourceV2ScanExec.scala:65)
```