### PR TITLE
Exclude Guava from the compile classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,9 @@ subprojects {
     testCompile.extendsFrom compileOnly
 
     compileClasspath {
-      if (project.name != 'iceberg-bundled-guava') {
+      // do not exclude Guava so the bundle project can reference classes.
+      // the Spark module is also excluded because this breaks the Scala compiler
+      if (project.name != 'iceberg-bundled-guava' && project.name != 'iceberg-spark') {
         exclude group: 'com.google.guava', module: 'guava'
       }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,13 @@ subprojects {
 
   configurations {
     testCompile.extendsFrom compileOnly
+
+    compileClasspath {
+      if (project.name != 'iceberg-bundled-guava') {
+        exclude group: 'com.google.guava', module: 'guava'
+      }
+    }
+
     all {
       exclude group: 'org.slf4j', module: 'slf4j-log4j12'
       exclude group: 'org.mortbay.jetty'

--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -19,9 +19,6 @@
 
 package org.apache.iceberg;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -33,6 +30,9 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.specific.SpecificData;
 import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ByteBuffers;

--- a/core/src/main/java/org/apache/iceberg/GenericDataFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDataFile.java
@@ -19,11 +19,11 @@
 
 package org.apache.iceberg;
 
-import com.google.common.collect.ImmutableMap;
 import java.nio.ByteBuffer;
 import java.util.List;
 import org.apache.avro.Schema;
 import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
 
 class GenericDataFile extends BaseFile<DataFile> implements DataFile {

--- a/core/src/main/java/org/apache/iceberg/GenericDeleteFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDeleteFile.java
@@ -20,10 +20,10 @@
 package org.apache.iceberg;
 
 
-import com.google.common.collect.ImmutableMap;
 import java.nio.ByteBuffer;
 import org.apache.avro.Schema;
 import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
 
 class GenericDeleteFile extends BaseFile<DeleteFile> implements DeleteFile {


### PR DESCRIPTION
This excludes Guava from `compileClasspath` so that Iceberg cannot use the classes directly, but tests will still pass because the `testRuntime` classpath does have transitive Guava classes.