### PR TITLE
Make table metadata serializable

### DIFF
--- a/api/src/main/java/org/apache/iceberg/HistoryEntry.java
+++ b/api/src/main/java/org/apache/iceberg/HistoryEntry.java
@@ -19,13 +19,15 @@
 
 package org.apache.iceberg;
 
+import java.io.Serializable;
+
 /**
  * Table history entry.
  * <p>
  * An entry contains a change to the table state. At the given timestamp, the current snapshot was
  * set to the given snapshot ID.
  */
-public interface HistoryEntry {
+public interface HistoryEntry extends Serializable {
   /**
    * @return the timestamp in milliseconds of the change
    */

--- a/api/src/main/java/org/apache/iceberg/Snapshot.java
+++ b/api/src/main/java/org/apache/iceberg/Snapshot.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
@@ -30,7 +31,7 @@ import java.util.Map;
  * <p>
  * Snapshots are created by table operations, like {@link AppendFiles} and {@link RewriteFiles}.
  */
-public interface Snapshot {
+public interface Snapshot extends Serializable {
   /**
    * Return this snapshot's sequence number.
    * <p>

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -135,7 +135,7 @@ public class AllManifestsTable extends BaseMetadataTable {
               schemaString, specString, ResidualEvaluator.unpartitioned(rowFilter)));
         } else {
           return StaticDataTask.of(
-              ops.io().newInputFile(ops.current().file().location()),
+              ops.io().newInputFile(ops.current().metadataFileLocation()),
               snap.allManifests(),
               manifest -> ManifestsTable.manifestFileToRow(table().spec(), manifest));
         }

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -244,7 +244,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
         .onFailure((list, exc) -> LOG.warn("Delete failed for manifest list: {}", list, exc))
         .run(io::deleteFile);
 
-    Tasks.foreach(metadata.file().location())
+    Tasks.foreach(metadata.metadataFileLocation())
         .noRetry().suppressFailureWhenFinished()
         .onFailure((list, exc) -> LOG.warn("Delete failed for metadata file: {}", list, exc))
         .run(io::deleteFile);

--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -218,7 +218,7 @@ class BaseSnapshot implements Snapshot {
         .add("timestamp_ms", timestampMillis)
         .add("operation", operation)
         .add("summary", summary)
-        .add("manifest-list", manifestList.location())
+        .add("manifest-list", manifestListLocation)
         .toString();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
-import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -41,16 +40,16 @@ class BaseSnapshot implements Snapshot {
   private final Long parentId;
   private final long sequenceNumber;
   private final long timestampMillis;
-  private final InputFile manifestList;
+  private final String manifestListLocation;
   private final String operation;
   private final Map<String, String> summary;
 
   // lazily initialized
-  private List<ManifestFile> allManifests = null;
-  private List<ManifestFile> dataManifests = null;
-  private List<ManifestFile> deleteManifests = null;
-  private List<DataFile> cachedAdds = null;
-  private List<DataFile> cachedDeletes = null;
+  private transient List<ManifestFile> allManifests = null;
+  private transient List<ManifestFile> dataManifests = null;
+  private transient List<ManifestFile> deleteManifests = null;
+  private transient List<DataFile> cachedAdds = null;
+  private transient List<DataFile> cachedDeletes = null;
 
   /**
    * For testing only.
@@ -70,7 +69,7 @@ class BaseSnapshot implements Snapshot {
                long timestampMillis,
                String operation,
                Map<String, String> summary,
-               InputFile manifestList) {
+               String manifestList) {
     this.io = io;
     this.sequenceNumber = sequenceNumber;
     this.snapshotId = snapshotId;
@@ -78,7 +77,7 @@ class BaseSnapshot implements Snapshot {
     this.timestampMillis = timestampMillis;
     this.operation = operation;
     this.summary = summary;
-    this.manifestList = manifestList;
+    this.manifestListLocation = manifestList;
   }
 
   BaseSnapshot(FileIO io,
@@ -88,7 +87,7 @@ class BaseSnapshot implements Snapshot {
                String operation,
                Map<String, String> summary,
                List<ManifestFile> dataManifests) {
-    this(io, INITIAL_SEQUENCE_NUMBER, snapshotId, parentId, timestampMillis, operation, summary, (InputFile) null);
+    this(io, INITIAL_SEQUENCE_NUMBER, snapshotId, parentId, timestampMillis, operation, summary, null);
     this.allManifests = dataManifests;
   }
 
@@ -125,7 +124,7 @@ class BaseSnapshot implements Snapshot {
   private void cacheManifests() {
     if (allManifests == null) {
       // if manifests isn't set, then the snapshotFile is set and should be read to get the list
-      this.allManifests = ManifestLists.read(manifestList);
+      this.allManifests = ManifestLists.read(io.newInputFile(manifestListLocation));
     }
 
     if (dataManifests == null) {
@@ -178,7 +177,7 @@ class BaseSnapshot implements Snapshot {
 
   @Override
   public String manifestListLocation() {
-    return manifestList != null ? manifestList.location() : null;
+    return manifestListLocation;
   }
 
   private void cacheChanges() {

--- a/core/src/main/java/org/apache/iceberg/HistoryTable.java
+++ b/core/src/main/java/org/apache/iceberg/HistoryTable.java
@@ -70,7 +70,10 @@ public class HistoryTable extends BaseMetadataTable {
   }
 
   private DataTask task(TableScan scan) {
-    return StaticDataTask.of(ops.current().file(), ops.current().snapshotLog(), convertHistoryEntryFunc(table));
+    return StaticDataTask.of(
+        ops.io().newInputFile(ops.current().metadataFileLocation()),
+        ops.current().snapshotLog(),
+        convertHistoryEntryFunc(table));
   }
 
   private class HistoryScan extends StaticTableScan {

--- a/core/src/main/java/org/apache/iceberg/ManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestsTable.java
@@ -74,9 +74,9 @@ public class ManifestsTable extends BaseMetadataTable {
   }
 
   protected DataTask task(TableScan scan) {
-    String manifestListLocation = scan.snapshot().manifestListLocation();
+    String location = scan.snapshot().manifestListLocation();
     return StaticDataTask.of(
-        ops.io().newInputFile(manifestListLocation != null ? manifestListLocation : ops.current().file().location()),
+        ops.io().newInputFile(location != null ? location : ops.current().metadataFileLocation()),
         scan.snapshot().allManifests(),
         manifest -> ManifestsTable.manifestFileToRow(spec, manifest));
   }

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -65,7 +65,7 @@ public class PartitionsTable extends BaseMetadataTable {
 
   private DataTask task(TableScan scan) {
     return StaticDataTask.of(
-        ops.current().file(),
+        ops.io().newInputFile(ops.current().metadataFileLocation()),
         partitions(table, scan.snapshot().snapshotId()),
         PartitionsTable::convertPartition);
   }

--- a/core/src/main/java/org/apache/iceberg/SnapshotParser.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotParser.java
@@ -141,9 +141,7 @@ public class SnapshotParser {
     if (node.has(MANIFEST_LIST)) {
       // the manifest list is stored in a manifest list file
       String manifestList = JsonUtil.getString(MANIFEST_LIST, node);
-      return new BaseSnapshot(
-          io, sequenceNumber, snapshotId, parentId, timestamp, operation, summary,
-          io.newInputFile(manifestList));
+      return new BaseSnapshot(io, sequenceNumber, snapshotId, parentId, timestamp, operation, summary, manifestList);
 
     } else {
       // fall back to an embedded manifest list. pass in the manifest's InputFile so length can be

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -173,7 +173,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
 
       return new BaseSnapshot(ops.io(),
           sequenceNumber, snapshotId(), parentSnapshotId, System.currentTimeMillis(), operation(), summary(base),
-          ops.io().newInputFile(manifestList.location()));
+          manifestList.location());
 
     } else {
       return new BaseSnapshot(ops.io(),

--- a/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
@@ -67,7 +67,10 @@ public class SnapshotsTable extends BaseMetadataTable {
   }
 
   private DataTask task(BaseTableScan scan) {
-    return StaticDataTask.of(ops.current().file(), ops.current().snapshots(), SnapshotsTable::snapshotToRow);
+    return StaticDataTask.of(
+        ops.io().newInputFile(ops.current().metadataFileLocation()),
+        ops.current().snapshots(),
+        SnapshotsTable::snapshotToRow);
   }
 
   private class SnapshotsTableScan extends StaticTableScan {

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -185,7 +185,7 @@ public class TableMetadata implements Serializable {
     }
   }
 
-  private transient final InputFile file;
+  private final transient InputFile file;
 
   // stored metadata
   private final String metadataFileLocation;

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -188,6 +188,7 @@ public class TableMetadata implements Serializable {
   private transient final InputFile file;
 
   // stored metadata
+  private final String metadataFileLocation;
   private final int formatVersion;
   private final String uuid;
   private final String location;
@@ -230,6 +231,7 @@ public class TableMetadata implements Serializable {
 
     this.formatVersion = formatVersion;
     this.file = file;
+    this.metadataFileLocation = file != null ? file.location() : null;
     this.uuid = uuid;
     this.location = location;
     this.lastSequenceNumber = lastSequenceNumber;
@@ -276,8 +278,8 @@ public class TableMetadata implements Serializable {
     return formatVersion;
   }
 
-  public InputFile file() {
-    return file;
+  public String metadataFileLocation() {
+    return metadataFileLocation;
   }
 
   public String uuid() {

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -42,7 +43,7 @@ import org.apache.iceberg.util.PropertyUtil;
 /**
  * Metadata for a table.
  */
-public class TableMetadata {
+public class TableMetadata implements Serializable {
   static final long INITIAL_SEQUENCE_NUMBER = 0;
   static final int DEFAULT_TABLE_FORMAT_VERSION = 1;
   static final int SUPPORTED_TABLE_FORMAT_VERSION = 2;
@@ -184,7 +185,7 @@ public class TableMetadata {
     }
   }
 
-  private final InputFile file;
+  private transient final InputFile file;
 
   // stored metadata
   private final int formatVersion;

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
@@ -102,7 +102,7 @@ public class TestSnapshotJson {
     }
 
     Snapshot expected = new BaseSnapshot(
-        ops.io(), id, 34, parentId, System.currentTimeMillis(), null, null, localInput(manifestList));
+        ops.io(), id, 34, parentId, System.currentTimeMillis(), null, null, localInput(manifestList).location());
     Snapshot inMemory = new BaseSnapshot(
         ops.io(), id, parentId, expected.timestampMillis(), null, null, manifests);
 

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadataSerialization.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadataSerialization.java
@@ -19,11 +19,11 @@
 
 package org.apache.iceberg;
 
-import com.google.common.collect.Lists;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadataSerialization.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadataSerialization.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import com.google.common.collect.Lists;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestTableMetadataSerialization extends TableTestBase {
+  @Parameterized.Parameters
+  public static Object[][] parameters() {
+    return new Object[][] {
+        new Object[] { 1 },
+        new Object[] { 2 },
+    };
+  }
+
+  public TestTableMetadataSerialization(int formatVersion) {
+    super(formatVersion);
+  }
+
+  @Test
+  public void testSerialization() throws Exception {
+    // add a commit to the metadata so there is at least one snapshot, and history
+    table.newAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    TableMetadata meta = table.ops().current();
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (ObjectOutputStream writer = new ObjectOutputStream(out)) {
+      writer.writeObject(meta);
+    }
+
+    TableMetadata result;
+    ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+    try (ObjectInputStream reader = new ObjectInputStream(in)) {
+      result = (TableMetadata) reader.readObject();
+    }
+
+    Assert.assertNull("File should not be serializable", result.file());
+    Assert.assertEquals("UUID should match", meta.uuid(), result.uuid());
+    Assert.assertEquals("Location should match", meta.location(), result.location());
+    Assert.assertEquals("Last updated should match", meta.lastUpdatedMillis(), result.lastUpdatedMillis());
+    Assert.assertEquals("Last column id", meta.lastColumnId(), result.lastColumnId());
+    Assert.assertEquals("Schema should match", meta.schema().asStruct(), result.schema().asStruct());
+    Assert.assertEquals("Spec should match", meta.defaultSpecId(), result.defaultSpecId());
+    Assert.assertEquals("Spec list should match", meta.specs(), result.specs());
+    Assert.assertEquals("Properties should match", meta.properties(), result.properties());
+    Assert.assertEquals("Current snapshot ID should match",
+        meta.currentSnapshot().snapshotId(), result.currentSnapshot().snapshotId());
+    Assert.assertEquals("Snapshots should match",
+        Lists.transform(meta.snapshots(), Snapshot::snapshotId),
+        Lists.transform(result.snapshots(), Snapshot::snapshotId));
+    Assert.assertEquals("History should match", meta.snapshotLog(), result.snapshotLog());
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadataSerialization.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadataSerialization.java
@@ -64,7 +64,8 @@ public class TestTableMetadataSerialization extends TableTestBase {
       result = (TableMetadata) reader.readObject();
     }
 
-    Assert.assertNull("File should not be serializable", result.file());
+    Assert.assertEquals("Metadata file location should match",
+        meta.metadataFileLocation(), result.metadataFileLocation());
     Assert.assertEquals("UUID should match", meta.uuid(), result.uuid());
     Assert.assertEquals("Location should match", meta.location(), result.location());
     Assert.assertEquals("Last updated should match", meta.lastUpdatedMillis(), result.lastUpdatedMillis());

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -169,7 +169,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
 
       tbl.setSd(storageDescriptor(metadata)); // set to pickup any schema changes
       String metadataLocation = tbl.getParameters().get(METADATA_LOCATION_PROP);
-      String baseMetadataLocation = base != null ? base.file().location() : null;
+      String baseMetadataLocation = base != null ? base.metadataFileLocation() : null;
       if (!Objects.equals(baseMetadataLocation, metadataLocation)) {
         throw new CommitFailedException(
             "Base metadata location '%s' is not same as the current table metadata location '%s' for %s.%s",

--- a/hive/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
+++ b/hive/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
@@ -214,7 +214,8 @@ public class HiveTableTest extends HiveTableBaseTest {
           new File(manifest.path().replace("file:", "")).exists());
     }
     Assert.assertFalse("Table metadata file should not exist",
-        new File(((HasTableOperations) table).operations().current().file().location().replace("file:", "")).exists());
+        new File(((HasTableOperations) table).operations().current()
+            .metadataFileLocation().replace("file:", "")).exists());
   }
 
   @Test

--- a/spark/src/main/java/org/apache/iceberg/actions/RemoveOrphanFilesAction.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/RemoveOrphanFilesAction.java
@@ -195,7 +195,7 @@ public class RemoveOrphanFilesAction extends BaseAction<List<String>> {
     otherMetadataFiles.add(ops.metadataFileLocation("version-hint.text"));
 
     TableMetadata metadata = ops.current();
-    otherMetadataFiles.add(metadata.file().location());
+    otherMetadataFiles.add(metadata.metadataFileLocation());
     for (TableMetadata.MetadataLogEntry previousMetadataFile : metadata.previousFiles()) {
       otherMetadataFiles.add(previousMetadataFile.file());
     }


### PR DESCRIPTION
The motivation for this is to enable caches that use Java serialization to track `TableMetadata` by the metadata file location.

This cleans up a few areas:
* `TableMetadata.file` is now replaced by `TableMetadata.metadataFileLocation`, so the API exposes a `String` instead of an `InputFile`
* Locations that previously called `file` get an `InputFile` from `FileIO` or just use the location string
* `Snapshot` keeps track of the manifest list path using a `String` instead of an `InputFile`
