### PR TITLE
Update dependency locks

### DIFF
--- a/api/dependencies.lock
+++ b/api/dependencies.lock
@@ -1,4 +1,365 @@
 {
+    "allProcessors": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "annotationProcessor": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "checkstyle": {
+        "antlr:antlr": {
+            "locked": "2.7.7",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "26.0-jre",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.puppycrawl.tools:checkstyle": {
+            "locked": "8.13"
+        },
+        "commons-beanutils:commons-beanutils": {
+            "locked": "1.9.3",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "commons-cli:commons-cli": {
+            "locked": "1.4",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "commons-collections:commons-collections": {
+            "locked": "3.2.2",
+            "transitive": [
+                "commons-beanutils:commons-beanutils"
+            ]
+        },
+        "net.sf.saxon:Saxon-HE": {
+            "locked": "9.8.0-14",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "org.antlr:antlr4-runtime": {
+            "locked": "4.7.1",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.14",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        }
+    },
     "compile": {
         "com.github.stephenc.findbugs:findbugs-annotations": {
             "locked": "1.3.9-1"
@@ -32,6 +393,154 @@
             "locked": "1.7.25"
         }
     },
+    "errorprone": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "errorproneJavac": {
+        "com.google.errorprone:javac": {
+            "locked": "9+181-r4173-1",
+            "requested": "9+181-r4173-1"
+        }
+    },
     "runtime": {
         "com.github.stephenc.findbugs:findbugs-annotations": {
             "locked": "1.3.9-1"
@@ -52,6 +561,148 @@
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25"
+        }
+    },
+    "testAnnotationProcessor": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
         }
     },
     "testCompile": {

--- a/arrow/dependencies.lock
+++ b/arrow/dependencies.lock
@@ -1,4 +1,365 @@
 {
+    "allProcessors": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "annotationProcessor": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "checkstyle": {
+        "antlr:antlr": {
+            "locked": "2.7.7",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "26.0-jre",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.puppycrawl.tools:checkstyle": {
+            "locked": "8.13"
+        },
+        "commons-beanutils:commons-beanutils": {
+            "locked": "1.9.3",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "commons-cli:commons-cli": {
+            "locked": "1.4",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "commons-collections:commons-collections": {
+            "locked": "3.2.2",
+            "transitive": [
+                "commons-beanutils:commons-beanutils"
+            ]
+        },
+        "net.sf.saxon:Saxon-HE": {
+            "locked": "9.8.0-14",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "org.antlr:antlr4-runtime": {
+            "locked": "4.7.1",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.14",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        }
+    },
     "compile": {
         "com.carrotsearch:hppc": {
             "locked": "0.7.2",
@@ -653,6 +1014,154 @@
             ]
         }
     },
+    "errorprone": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "errorproneJavac": {
+        "com.google.errorprone:javac": {
+            "locked": "9+181-r4173-1",
+            "requested": "9+181-r4173-1"
+        }
+    },
     "runtime": {
         "com.carrotsearch:hppc": {
             "locked": "0.7.2",
@@ -1086,6 +1595,148 @@
             "locked": "1.1.7.3",
             "transitive": [
                 "org.apache.parquet:parquet-hadoop"
+            ]
+        }
+    },
+    "testAnnotationProcessor": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
             ]
         }
     },

--- a/common/dependencies.lock
+++ b/common/dependencies.lock
@@ -1,4 +1,365 @@
 {
+    "allProcessors": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "annotationProcessor": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "checkstyle": {
+        "antlr:antlr": {
+            "locked": "2.7.7",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "26.0-jre",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.puppycrawl.tools:checkstyle": {
+            "locked": "8.13"
+        },
+        "commons-beanutils:commons-beanutils": {
+            "locked": "1.9.3",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "commons-cli:commons-cli": {
+            "locked": "1.4",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "commons-collections:commons-collections": {
+            "locked": "3.2.2",
+            "transitive": [
+                "commons-beanutils:commons-beanutils"
+            ]
+        },
+        "net.sf.saxon:Saxon-HE": {
+            "locked": "9.8.0-14",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "org.antlr:antlr4-runtime": {
+            "locked": "4.7.1",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.14",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        }
+    },
     "compile": {
         "com.github.stephenc.findbugs:findbugs-annotations": {
             "locked": "1.3.9-1"
@@ -32,6 +393,154 @@
             "locked": "1.7.25"
         }
     },
+    "errorprone": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "errorproneJavac": {
+        "com.google.errorprone:javac": {
+            "locked": "9+181-r4173-1",
+            "requested": "9+181-r4173-1"
+        }
+    },
     "runtime": {
         "com.github.stephenc.findbugs:findbugs-annotations": {
             "locked": "1.3.9-1"
@@ -52,6 +561,148 @@
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25"
+        }
+    },
+    "testAnnotationProcessor": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
         }
     },
     "testCompile": {

--- a/core/dependencies.lock
+++ b/core/dependencies.lock
@@ -1,4 +1,365 @@
 {
+    "allProcessors": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "annotationProcessor": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "checkstyle": {
+        "antlr:antlr": {
+            "locked": "2.7.7",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "26.0-jre",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.puppycrawl.tools:checkstyle": {
+            "locked": "8.13"
+        },
+        "commons-beanutils:commons-beanutils": {
+            "locked": "1.9.3",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "commons-cli:commons-cli": {
+            "locked": "1.4",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "commons-collections:commons-collections": {
+            "locked": "3.2.2",
+            "transitive": [
+                "commons-beanutils:commons-beanutils"
+            ]
+        },
+        "net.sf.saxon:Saxon-HE": {
+            "locked": "9.8.0-14",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "org.antlr:antlr4-runtime": {
+            "locked": "4.7.1",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.14",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        }
+    },
     "compile": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.10.2",
@@ -131,21 +492,6 @@
             "locked": "2.3.3",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "16.0.1",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.apache.hadoop:hadoop-common",
-                "org.apache.hadoop:hadoop-hdfs",
-                "org.apache.hadoop:hadoop-yarn-api",
-                "org.apache.hadoop:hadoop-yarn-client",
-                "org.apache.hadoop:hadoop-yarn-common",
-                "org.apache.hadoop:hadoop-yarn-server-common",
-                "org.apache.hadoop:hadoop-yarn-server-nodemanager"
             ]
         },
         "com.google.inject:guice": {
@@ -1343,6 +1689,154 @@
             ]
         }
     },
+    "errorprone": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "errorproneJavac": {
+        "com.google.errorprone:javac": {
+            "locked": "9+181-r4173-1",
+            "requested": "9+181-r4173-1"
+        }
+    },
     "runtime": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.10.2",
@@ -1486,6 +1980,148 @@
                 "org.apache.avro:avro",
                 "org.apache.iceberg:iceberg-api",
                 "org.apache.iceberg:iceberg-common"
+            ]
+        }
+    },
+    "testAnnotationProcessor": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
             ]
         }
     },

--- a/data/dependencies.lock
+++ b/data/dependencies.lock
@@ -1,4 +1,365 @@
 {
+    "allProcessors": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "annotationProcessor": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "checkstyle": {
+        "antlr:antlr": {
+            "locked": "2.7.7",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "26.0-jre",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.puppycrawl.tools:checkstyle": {
+            "locked": "8.13"
+        },
+        "commons-beanutils:commons-beanutils": {
+            "locked": "1.9.3",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "commons-cli:commons-cli": {
+            "locked": "1.4",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "commons-collections:commons-collections": {
+            "locked": "3.2.2",
+            "transitive": [
+                "commons-beanutils:commons-beanutils"
+            ]
+        },
+        "net.sf.saxon:Saxon-HE": {
+            "locked": "9.8.0-14",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "org.antlr:antlr4-runtime": {
+            "locked": "4.7.1",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.14",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        }
+    },
     "compile": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.10.2",
@@ -151,15 +512,6 @@
             "locked": "2.3.3",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "16.0.1",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.apache.hadoop:hadoop-common"
             ]
         },
         "com.google.protobuf:protobuf-java": {
@@ -1268,6 +1620,154 @@
             ]
         }
     },
+    "errorprone": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "errorproneJavac": {
+        "com.google.errorprone:javac": {
+            "locked": "9+181-r4173-1",
+            "requested": "9+181-r4173-1"
+        }
+    },
     "runtime": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.10.2",
@@ -1449,6 +1949,148 @@
                 "org.apache.iceberg:iceberg-api",
                 "org.apache.iceberg:iceberg-common",
                 "org.apache.iceberg:iceberg-core"
+            ]
+        }
+    },
+    "testAnnotationProcessor": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
             ]
         }
     },

--- a/hive/dependencies.lock
+++ b/hive/dependencies.lock
@@ -1,4 +1,365 @@
 {
+    "allProcessors": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "annotationProcessor": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "checkstyle": {
+        "antlr:antlr": {
+            "locked": "2.7.7",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "26.0-jre",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.puppycrawl.tools:checkstyle": {
+            "locked": "8.13"
+        },
+        "commons-beanutils:commons-beanutils": {
+            "locked": "1.9.3",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "commons-cli:commons-cli": {
+            "locked": "1.4",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "commons-collections:commons-collections": {
+            "locked": "3.2.2",
+            "transitive": [
+                "commons-beanutils:commons-beanutils"
+            ]
+        },
+        "net.sf.saxon:Saxon-HE": {
+            "locked": "9.8.0-14",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "org.antlr:antlr4-runtime": {
+            "locked": "4.7.1",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.14",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        }
+    },
     "compile": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.10.2",
@@ -170,24 +531,6 @@
             "locked": "2.3.3",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "16.0.1",
-            "transitive": [
-                "com.jolbox:bonecp",
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.apache.hadoop:hadoop-common",
-                "org.apache.hadoop:hadoop-hdfs",
-                "org.apache.hadoop:hadoop-yarn-api",
-                "org.apache.hadoop:hadoop-yarn-client",
-                "org.apache.hadoop:hadoop-yarn-common",
-                "org.apache.hadoop:hadoop-yarn-server-common",
-                "org.apache.hadoop:hadoop-yarn-server-nodemanager",
-                "org.apache.hive.shims:hive-shims-common",
-                "org.apache.hive:hive-metastore"
             ]
         },
         "com.google.inject:guice": {
@@ -758,34 +1101,34 @@
             ]
         },
         "org.apache.hive.shims:hive-shims-common": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-shims"
             ]
         },
         "org.apache.hive:hive-common": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-serde"
             ]
         },
         "org.apache.hive:hive-metastore": {
-            "locked": "2.3.6"
+            "locked": "2.3.7"
         },
         "org.apache.hive:hive-serde": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-metastore"
             ]
         },
         "org.apache.hive:hive-service-rpc": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-serde"
             ]
         },
         "org.apache.hive:hive-shims": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-common",
                 "org.apache.hive:hive-metastore",
@@ -1759,13 +2102,13 @@
             ]
         },
         "org.apache.hive.shims:hive-shims-0.23": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-shims"
             ]
         },
         "org.apache.hive.shims:hive-shims-common": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive.shims:hive-shims-0.23",
                 "org.apache.hive.shims:hive-shims-scheduler",
@@ -1773,34 +2116,34 @@
             ]
         },
         "org.apache.hive.shims:hive-shims-scheduler": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-shims"
             ]
         },
         "org.apache.hive:hive-common": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-serde"
             ]
         },
         "org.apache.hive:hive-metastore": {
-            "locked": "2.3.6"
+            "locked": "2.3.7"
         },
         "org.apache.hive:hive-serde": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-metastore"
             ]
         },
         "org.apache.hive:hive-service-rpc": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-serde"
             ]
         },
         "org.apache.hive:hive-shims": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-common",
                 "org.apache.hive:hive-metastore",
@@ -2127,6 +2470,154 @@
             ]
         }
     },
+    "errorprone": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "errorproneJavac": {
+        "com.google.errorprone:javac": {
+            "locked": "9+181-r4173-1",
+            "requested": "9+181-r4173-1"
+        }
+    },
     "runtime": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.10.2",
@@ -2308,6 +2799,148 @@
                 "org.apache.iceberg:iceberg-api",
                 "org.apache.iceberg:iceberg-common",
                 "org.apache.iceberg:iceberg-core"
+            ]
+        }
+    },
+    "testAnnotationProcessor": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
             ]
         }
     },
@@ -3081,13 +3714,13 @@
             ]
         },
         "org.apache.hive.shims:hive-shims-0.23": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-shims"
             ]
         },
         "org.apache.hive.shims:hive-shims-common": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive.shims:hive-shims-0.23",
                 "org.apache.hive.shims:hive-shims-scheduler",
@@ -3095,37 +3728,37 @@
             ]
         },
         "org.apache.hive.shims:hive-shims-scheduler": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-shims"
             ]
         },
         "org.apache.hive:hive-common": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-serde"
             ]
         },
         "org.apache.hive:hive-exec": {
-            "locked": "2.3.6"
+            "locked": "2.3.7"
         },
         "org.apache.hive:hive-metastore": {
-            "locked": "2.3.6"
+            "locked": "2.3.7"
         },
         "org.apache.hive:hive-serde": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-metastore"
             ]
         },
         "org.apache.hive:hive-service-rpc": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-serde"
             ]
         },
         "org.apache.hive:hive-shims": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-common",
                 "org.apache.hive:hive-exec",
@@ -3140,7 +3773,7 @@
             ]
         },
         "org.apache.hive:hive-vector-code-gen": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-exec"
             ]
@@ -4149,37 +4782,37 @@
             ]
         },
         "org.apache.hive.shims:hive-shims-common": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-shims"
             ]
         },
         "org.apache.hive:hive-common": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-serde"
             ]
         },
         "org.apache.hive:hive-exec": {
-            "locked": "2.3.6"
+            "locked": "2.3.7"
         },
         "org.apache.hive:hive-metastore": {
-            "locked": "2.3.6"
+            "locked": "2.3.7"
         },
         "org.apache.hive:hive-serde": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-metastore"
             ]
         },
         "org.apache.hive:hive-service-rpc": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-serde"
             ]
         },
         "org.apache.hive:hive-shims": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-common",
                 "org.apache.hive:hive-exec",
@@ -4194,7 +4827,7 @@
             ]
         },
         "org.apache.hive:hive-vector-code-gen": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-exec"
             ]
@@ -5262,13 +5895,13 @@
             ]
         },
         "org.apache.hive.shims:hive-shims-0.23": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-shims"
             ]
         },
         "org.apache.hive.shims:hive-shims-common": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive.shims:hive-shims-0.23",
                 "org.apache.hive.shims:hive-shims-scheduler",
@@ -5276,37 +5909,37 @@
             ]
         },
         "org.apache.hive.shims:hive-shims-scheduler": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-shims"
             ]
         },
         "org.apache.hive:hive-common": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-serde"
             ]
         },
         "org.apache.hive:hive-exec": {
-            "locked": "2.3.6"
+            "locked": "2.3.7"
         },
         "org.apache.hive:hive-metastore": {
-            "locked": "2.3.6"
+            "locked": "2.3.7"
         },
         "org.apache.hive:hive-serde": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-metastore"
             ]
         },
         "org.apache.hive:hive-service-rpc": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-serde"
             ]
         },
         "org.apache.hive:hive-shims": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-common",
                 "org.apache.hive:hive-exec",
@@ -5321,7 +5954,7 @@
             ]
         },
         "org.apache.hive:hive-vector-code-gen": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-exec"
             ]
@@ -6404,13 +7037,13 @@
             ]
         },
         "org.apache.hive.shims:hive-shims-0.23": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-shims"
             ]
         },
         "org.apache.hive.shims:hive-shims-common": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive.shims:hive-shims-0.23",
                 "org.apache.hive.shims:hive-shims-scheduler",
@@ -6418,37 +7051,37 @@
             ]
         },
         "org.apache.hive.shims:hive-shims-scheduler": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-shims"
             ]
         },
         "org.apache.hive:hive-common": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-serde"
             ]
         },
         "org.apache.hive:hive-exec": {
-            "locked": "2.3.6"
+            "locked": "2.3.7"
         },
         "org.apache.hive:hive-metastore": {
-            "locked": "2.3.6"
+            "locked": "2.3.7"
         },
         "org.apache.hive:hive-serde": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-metastore"
             ]
         },
         "org.apache.hive:hive-service-rpc": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-serde"
             ]
         },
         "org.apache.hive:hive-shims": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-common",
                 "org.apache.hive:hive-exec",
@@ -6463,7 +7096,7 @@
             ]
         },
         "org.apache.hive:hive-vector-code-gen": {
-            "locked": "2.3.6",
+            "locked": "2.3.7",
             "transitive": [
                 "org.apache.hive:hive-exec"
             ]

--- a/mr/dependencies.lock
+++ b/mr/dependencies.lock
@@ -1,4 +1,365 @@
 {
+    "allProcessors": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "annotationProcessor": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "checkstyle": {
+        "antlr:antlr": {
+            "locked": "2.7.7",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "26.0-jre",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.puppycrawl.tools:checkstyle": {
+            "locked": "8.13"
+        },
+        "commons-beanutils:commons-beanutils": {
+            "locked": "1.9.3",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "commons-cli:commons-cli": {
+            "locked": "1.4",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "commons-collections:commons-collections": {
+            "locked": "3.2.2",
+            "transitive": [
+                "commons-beanutils:commons-beanutils"
+            ]
+        },
+        "net.sf.saxon:Saxon-HE": {
+            "locked": "9.8.0-14",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "org.antlr:antlr4-runtime": {
+            "locked": "4.7.1",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.14",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        }
+    },
     "compile": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.10.2",
@@ -292,21 +653,6 @@
             "locked": "2.3.3",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "16.0.1",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.apache.hadoop:hadoop-common",
-                "org.apache.hadoop:hadoop-hdfs",
-                "org.apache.hadoop:hadoop-yarn-api",
-                "org.apache.hadoop:hadoop-yarn-client",
-                "org.apache.hadoop:hadoop-yarn-common",
-                "org.apache.hadoop:hadoop-yarn-server-common",
-                "org.apache.hadoop:hadoop-yarn-server-nodemanager"
             ]
         },
         "com.google.inject:guice": {
@@ -1782,6 +2128,154 @@
             ]
         }
     },
+    "errorprone": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "errorproneJavac": {
+        "com.google.errorprone:javac": {
+            "locked": "9+181-r4173-1",
+            "requested": "9+181-r4173-1"
+        }
+    },
     "runtime": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.10.2",
@@ -2229,6 +2723,148 @@
             "locked": "1.1.7.3",
             "transitive": [
                 "org.apache.parquet:parquet-hadoop"
+            ]
+        }
+    },
+    "testAnnotationProcessor": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
             ]
         }
     },

--- a/orc/dependencies.lock
+++ b/orc/dependencies.lock
@@ -1,4 +1,365 @@
 {
+    "allProcessors": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "annotationProcessor": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "checkstyle": {
+        "antlr:antlr": {
+            "locked": "2.7.7",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "26.0-jre",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.puppycrawl.tools:checkstyle": {
+            "locked": "8.13"
+        },
+        "commons-beanutils:commons-beanutils": {
+            "locked": "1.9.3",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "commons-cli:commons-cli": {
+            "locked": "1.4",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "commons-collections:commons-collections": {
+            "locked": "3.2.2",
+            "transitive": [
+                "commons-beanutils:commons-beanutils"
+            ]
+        },
+        "net.sf.saxon:Saxon-HE": {
+            "locked": "9.8.0-14",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "org.antlr:antlr4-runtime": {
+            "locked": "4.7.1",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.14",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        }
+    },
     "compile": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.10.2",
@@ -191,21 +552,6 @@
             "locked": "2.3.3",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "16.0.1",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.apache.hadoop:hadoop-common",
-                "org.apache.hadoop:hadoop-hdfs",
-                "org.apache.hadoop:hadoop-yarn-api",
-                "org.apache.hadoop:hadoop-yarn-client",
-                "org.apache.hadoop:hadoop-yarn-common",
-                "org.apache.hadoop:hadoop-yarn-server-common",
-                "org.apache.hadoop:hadoop-yarn-server-nodemanager"
             ]
         },
         "com.google.inject:guice": {
@@ -1540,6 +1886,154 @@
             ]
         }
     },
+    "errorprone": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "errorproneJavac": {
+        "com.google.errorprone:javac": {
+            "locked": "9+181-r4173-1",
+            "requested": "9+181-r4173-1"
+        }
+    },
     "runtime": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.10.2",
@@ -1791,6 +2285,148 @@
             "locked": "1.5.0",
             "transitive": [
                 "org.apache.orc:orc-core"
+            ]
+        }
+    },
+    "testAnnotationProcessor": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
             ]
         }
     },

--- a/parquet/dependencies.lock
+++ b/parquet/dependencies.lock
@@ -1,4 +1,365 @@
 {
+    "allProcessors": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "annotationProcessor": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "checkstyle": {
+        "antlr:antlr": {
+            "locked": "2.7.7",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "26.0-jre",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.puppycrawl.tools:checkstyle": {
+            "locked": "8.13"
+        },
+        "commons-beanutils:commons-beanutils": {
+            "locked": "1.9.3",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "commons-cli:commons-cli": {
+            "locked": "1.4",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "commons-collections:commons-collections": {
+            "locked": "3.2.2",
+            "transitive": [
+                "commons-beanutils:commons-beanutils"
+            ]
+        },
+        "net.sf.saxon:Saxon-HE": {
+            "locked": "9.8.0-14",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "org.antlr:antlr4-runtime": {
+            "locked": "4.7.1",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.14",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        }
+    },
     "compile": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.10.2",
@@ -225,21 +586,6 @@
             "locked": "2.3.3",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "16.0.1",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.apache.hadoop:hadoop-common",
-                "org.apache.hadoop:hadoop-hdfs",
-                "org.apache.hadoop:hadoop-yarn-api",
-                "org.apache.hadoop:hadoop-yarn-client",
-                "org.apache.hadoop:hadoop-yarn-common",
-                "org.apache.hadoop:hadoop-yarn-server-common",
-                "org.apache.hadoop:hadoop-yarn-server-nodemanager"
             ]
         },
         "com.google.inject:guice": {
@@ -1625,6 +1971,154 @@
             ]
         }
     },
+    "errorprone": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "errorproneJavac": {
+        "com.google.errorprone:javac": {
+            "locked": "9+181-r4173-1",
+            "requested": "9+181-r4173-1"
+        }
+    },
     "runtime": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.10.2",
@@ -1944,6 +2438,148 @@
             "locked": "1.1.7.3",
             "transitive": [
                 "org.apache.parquet:parquet-hadoop"
+            ]
+        }
+    },
+    "testAnnotationProcessor": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
             ]
         }
     },

--- a/pig/dependencies.lock
+++ b/pig/dependencies.lock
@@ -1,4 +1,365 @@
 {
+    "allProcessors": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "annotationProcessor": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "checkstyle": {
+        "antlr:antlr": {
+            "locked": "2.7.7",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "26.0-jre",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.puppycrawl.tools:checkstyle": {
+            "locked": "8.13"
+        },
+        "commons-beanutils:commons-beanutils": {
+            "locked": "1.9.3",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "commons-cli:commons-cli": {
+            "locked": "1.4",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "commons-collections:commons-collections": {
+            "locked": "3.2.2",
+            "transitive": [
+                "commons-beanutils:commons-beanutils"
+            ]
+        },
+        "net.sf.saxon:Saxon-HE": {
+            "locked": "9.8.0-14",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "org.antlr:antlr4-runtime": {
+            "locked": "4.7.1",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.14",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        }
+    },
     "compile": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.10.2",
@@ -248,22 +609,6 @@
             "locked": "2.3.3",
             "transitive": [
                 "com.github.ben-manes.caffeine:caffeine"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "16.0.1",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.apache.hadoop:hadoop-common",
-                "org.apache.hadoop:hadoop-hdfs",
-                "org.apache.hadoop:hadoop-yarn-api",
-                "org.apache.hadoop:hadoop-yarn-client",
-                "org.apache.hadoop:hadoop-yarn-common",
-                "org.apache.hadoop:hadoop-yarn-server-common",
-                "org.apache.hadoop:hadoop-yarn-server-nodemanager",
-                "org.apache.pig:pig"
             ]
         },
         "com.google.inject.extensions:guice-servlet": {
@@ -1895,6 +2240,154 @@
             ]
         }
     },
+    "errorprone": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "errorproneJavac": {
+        "com.google.errorprone:javac": {
+            "locked": "9+181-r4173-1",
+            "requested": "9+181-r4173-1"
+        }
+    },
     "runtime": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.10.2",
@@ -2244,6 +2737,148 @@
             "locked": "1.1.7.3",
             "transitive": [
                 "org.apache.parquet:parquet-hadoop"
+            ]
+        }
+    },
+    "testAnnotationProcessor": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
             ]
         }
     },

--- a/spark-runtime/dependencies.lock
+++ b/spark-runtime/dependencies.lock
@@ -1,4 +1,365 @@
 {
+    "allProcessors": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "annotationProcessor": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "checkstyle": {
+        "antlr:antlr": {
+            "locked": "2.7.7",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "26.0-jre",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.puppycrawl.tools:checkstyle": {
+            "locked": "8.13"
+        },
+        "commons-beanutils:commons-beanutils": {
+            "locked": "1.9.3",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "commons-cli:commons-cli": {
+            "locked": "1.4",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "commons-collections:commons-collections": {
+            "locked": "3.2.2",
+            "transitive": [
+                "commons-beanutils:commons-beanutils"
+            ]
+        },
+        "net.sf.saxon:Saxon-HE": {
+            "locked": "9.8.0-14",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "org.antlr:antlr4-runtime": {
+            "locked": "4.7.1",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.14",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        }
+    },
     "compile": {
         "com.carrotsearch:hppc": {
             "locked": "0.7.2",
@@ -776,6 +1137,154 @@
             ]
         }
     },
+    "errorprone": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "errorproneJavac": {
+        "com.google.errorprone:javac": {
+            "locked": "9+181-r4173-1",
+            "requested": "9+181-r4173-1"
+        }
+    },
     "runtime": {
         "com.carrotsearch:hppc": {
             "locked": "0.7.2",
@@ -1291,6 +1800,148 @@
             "locked": "1.5.0",
             "transitive": [
                 "org.apache.orc:orc-core"
+            ]
+        }
+    },
+    "testAnnotationProcessor": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
             ]
         }
     },

--- a/spark/dependencies.lock
+++ b/spark/dependencies.lock
@@ -1,4 +1,365 @@
 {
+    "allProcessors": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "annotationProcessor": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "checkstyle": {
+        "antlr:antlr": {
+            "locked": "2.7.7",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "26.0-jre",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.puppycrawl.tools:checkstyle": {
+            "locked": "8.13"
+        },
+        "commons-beanutils:commons-beanutils": {
+            "locked": "1.9.3",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "commons-cli:commons-cli": {
+            "locked": "1.4",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "commons-collections:commons-collections": {
+            "locked": "3.2.2",
+            "transitive": [
+                "commons-beanutils:commons-beanutils"
+            ]
+        },
+        "net.sf.saxon:Saxon-HE": {
+            "locked": "9.8.0-14",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "org.antlr:antlr4-runtime": {
+            "locked": "4.7.1",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.14",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        }
+    },
     "compile": {
         "com.carrotsearch:hppc": {
             "locked": "0.7.2",
@@ -3453,6 +3814,154 @@
             ]
         }
     },
+    "errorprone": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "errorproneJavac": {
+        "com.google.errorprone:javac": {
+            "locked": "9+181-r4173-1",
+            "requested": "9+181-r4173-1"
+        }
+    },
     "jmh": {
         "net.sf.jopt-simple:jopt-simple": {
             "locked": "4.6",
@@ -3516,6 +4025,148 @@
             "transitive": [
                 "org.apache.spark:spark-avro_2.11",
                 "org.apache.spark:spark-tags_2.11"
+            ]
+        }
+    },
+    "jmhAnnotationProcessor": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
             ]
         }
     },
@@ -7648,6 +8299,148 @@
             "locked": "1.1.7.3",
             "transitive": [
                 "org.apache.parquet:parquet-hadoop"
+            ]
+        }
+    },
+    "testAnnotationProcessor": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
             ]
         }
     },

--- a/spark3/dependencies.lock
+++ b/spark3/dependencies.lock
@@ -1,4 +1,365 @@
 {
+    "allProcessors": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "annotationProcessor": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "checkstyle": {
+        "antlr:antlr": {
+            "locked": "2.7.7",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.1.3",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "26.0-jre",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.puppycrawl.tools:checkstyle": {
+            "locked": "8.13"
+        },
+        "commons-beanutils:commons-beanutils": {
+            "locked": "1.9.3",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "commons-cli:commons-cli": {
+            "locked": "1.4",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "commons-collections:commons-collections": {
+            "locked": "3.2.2",
+            "transitive": [
+                "commons-beanutils:commons-beanutils"
+            ]
+        },
+        "net.sf.saxon:Saxon-HE": {
+            "locked": "9.8.0-14",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "org.antlr:antlr4-runtime": {
+            "locked": "4.7.1",
+            "transitive": [
+                "com.puppycrawl.tools:checkstyle"
+            ]
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.2",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.14",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        }
+    },
     "compile": {
         "com.carrotsearch:hppc": {
             "locked": "0.7.2",
@@ -379,13 +740,13 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-paranamer": {
-            "locked": "2.10.0",
+            "locked": "2.10.2",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-scala_2.12"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-scala_2.12": {
-            "locked": "2.10.0",
+            "locked": "2.10.2",
             "transitive": [
                 "org.apache.spark:spark-core_2.12"
             ]
@@ -458,22 +819,6 @@
             "transitive": [
                 "org.apache.arrow:arrow-format",
                 "org.apache.arrow:arrow-vector"
-            ]
-        },
-        "com.google.guava:guava": {
-            "locked": "16.0.1",
-            "transitive": [
-                "org.apache.curator:curator-client",
-                "org.apache.curator:curator-framework",
-                "org.apache.curator:curator-recipes",
-                "org.apache.hadoop:hadoop-common",
-                "org.apache.hadoop:hadoop-hdfs",
-                "org.apache.hadoop:hadoop-yarn-api",
-                "org.apache.hadoop:hadoop-yarn-client",
-                "org.apache.hadoop:hadoop-yarn-common",
-                "org.apache.hadoop:hadoop-yarn-server-common",
-                "org.apache.hadoop:hadoop-yarn-server-nodemanager",
-                "org.apache.hive:hive-vector-code-gen"
             ]
         },
         "com.google.inject:guice": {
@@ -2023,13 +2368,13 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-paranamer": {
-            "locked": "2.10.0",
+            "locked": "2.10.2",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-scala_2.12"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-scala_2.12": {
-            "locked": "2.10.0",
+            "locked": "2.10.2",
             "transitive": [
                 "org.apache.spark:spark-core_2.12"
             ]
@@ -3793,6 +4138,154 @@
             ]
         }
     },
+    "errorprone": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
+    "errorproneJavac": {
+        "com.google.errorprone:javac": {
+            "locked": "9+181-r4173-1",
+            "requested": "9+181-r4173-1"
+        }
+    },
     "runtime": {
         "com.carrotsearch:hppc": {
             "locked": "0.7.2",
@@ -4413,6 +4906,148 @@
             ]
         }
     },
+    "testAnnotationProcessor": {
+        "com.github.kevinstern:software-and-algorithms": {
+            "locked": "1.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.github.stephenc.jcip:jcip-annotations": {
+            "locked": "1.0-1",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.auto:auto-common": {
+            "locked": "0.10",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jFormatString": {
+            "locked": "3.0.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotation": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core",
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.errorprone:error_prone_check_api": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.errorprone:error_prone_core": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.palantir.baseline:baseline-error-prone"
+            ]
+        },
+        "com.google.errorprone:error_prone_type_annotations": {
+            "locked": "2.3.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.guava:guava": {
+            "locked": "27.0.1-jre",
+            "transitive": [
+                "com.google.auto:auto-common",
+                "com.google.errorprone:error_prone_annotation",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.google.guava:listenablefuture": {
+            "locked": "9999.0-empty-to-avoid-conflict-with-guava",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.j2objc:j2objc-annotations": {
+            "locked": "1.1",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "com.google.protobuf:protobuf-java": {
+            "locked": "3.4.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "com.googlecode.java-diff-utils:diffutils": {
+            "locked": "1.3.0",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api"
+            ]
+        },
+        "com.palantir.baseline:baseline-error-prone": {
+            "locked": "0.55.0",
+            "requested": "0.55.0"
+        },
+        "org.checkerframework:checker-qual": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.guava:guava",
+                "org.checkerframework:dataflow",
+                "org.checkerframework:javacutil"
+            ]
+        },
+        "org.checkerframework:dataflow": {
+            "locked": "2.5.3",
+            "transitive": [
+                "com.google.errorprone:error_prone_check_api",
+                "com.google.errorprone:error_prone_core"
+            ]
+        },
+        "org.checkerframework:javacutil": {
+            "locked": "2.5.3",
+            "transitive": [
+                "org.checkerframework:dataflow"
+            ]
+        },
+        "org.codehaus.mojo:animal-sniffer-annotations": {
+            "locked": "1.17",
+            "transitive": [
+                "com.google.guava:guava"
+            ]
+        },
+        "org.pcollections:pcollections": {
+            "locked": "2.1.2",
+            "transitive": [
+                "com.google.errorprone:error_prone_core"
+            ]
+        }
+    },
     "testCompile": {
         "aopalliance:aopalliance": {
             "locked": "1.0",
@@ -4484,13 +5119,13 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-paranamer": {
-            "locked": "2.10.0",
+            "locked": "2.10.2",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-scala_2.12"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-scala_2.12": {
-            "locked": "2.10.0",
+            "locked": "2.10.2",
             "transitive": [
                 "org.apache.spark:spark-core_2.12"
             ]
@@ -6359,13 +6994,13 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-paranamer": {
-            "locked": "2.10.0",
+            "locked": "2.10.2",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-scala_2.12"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-scala_2.12": {
-            "locked": "2.10.0",
+            "locked": "2.10.2",
             "transitive": [
                 "org.apache.spark:spark-core_2.12"
             ]
@@ -8209,13 +8844,13 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-paranamer": {
-            "locked": "2.10.0",
+            "locked": "2.10.2",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-scala_2.12"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-scala_2.12": {
-            "locked": "2.10.0",
+            "locked": "2.10.2",
             "transitive": [
                 "org.apache.spark:spark-core_2.12"
             ]
@@ -10084,13 +10719,13 @@
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-paranamer": {
-            "locked": "2.10.0",
+            "locked": "2.10.2",
             "transitive": [
                 "com.fasterxml.jackson.module:jackson-module-scala_2.12"
             ]
         },
         "com.fasterxml.jackson.module:jackson-module-scala_2.12": {
-            "locked": "2.10.0",
+            "locked": "2.10.2",
             "transitive": [
                 "org.apache.spark:spark-core_2.12"
             ]


### PR DESCRIPTION
#1084 updated Hive to 2.3.7 and #1067 updated dependency locking to use Nebula plugins, but didn't include the change to 2.3.7, so the new locks were still using 2.3.6.