### PR TITLE
Update sequence number tests to use allManifests

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestSequenceNumberForV2Table.java
+++ b/core/src/test/java/org/apache/iceberg/TestSequenceNumberForV2Table.java
@@ -37,7 +37,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
     table.newAppend().appendFile(FILE_A).commit();
     Snapshot snap1 = table.currentSnapshot();
     long commitId1 = snap1.snapshotId();
-    ManifestFile manifestFile = table.currentSnapshot().manifests().get(0);
+    ManifestFile manifestFile = table.currentSnapshot().allManifests().get(0);
 
     validateSnapshot(null, snap1, 1, FILE_A);
     validateManifest(manifestFile, seqs(1), ids(commitId1), files(FILE_A));
@@ -47,7 +47,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
     table.newAppend().appendFile(FILE_B).commit();
     Snapshot snap2 = table.currentSnapshot();
     long commitId2 = snap2.snapshotId();
-    manifestFile = table.currentSnapshot().manifests().get(0);
+    manifestFile = table.currentSnapshot().allManifests().get(0);
     validateSnapshot(snap1, snap2, 2, FILE_B);
     validateManifest(manifestFile, seqs(2), ids(commitId2), files(FILE_B));
     V2Assert.assertEquals("Snapshot sequence number should be 2", 2, snap2.sequenceNumber());
@@ -59,7 +59,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
         .commit();
     Snapshot snap3 = table.currentSnapshot();
     long commitId3 = snap3.snapshotId();
-    manifestFile = table.currentSnapshot().manifests().get(0);
+    manifestFile = table.currentSnapshot().allManifests().get(0);
     validateManifest(manifestFile, seqs(3), ids(commitId3), files(FILE_C));
     validateSnapshot(snap2, snap3, 3, FILE_C);
     V2Assert.assertEquals("Snapshot sequence number should be 3", 3, snap3.sequenceNumber());
@@ -76,7 +76,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
 
     Snapshot snap4 = table.currentSnapshot();
     long commitId4 = snap4.snapshotId();
-    manifestFile = snap4.manifests().stream()
+    manifestFile = snap4.allManifests().stream()
         .filter(manifest -> manifest.snapshotId() == commitId4)
         .collect(Collectors.toList()).get(0);
     validateManifest(manifestFile, seqs(4, 3, 2, 1), ids(commitId4, commitId3, commitId2, commitId1),
@@ -90,7 +90,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
     table.newFastAppend().appendFile(FILE_A).commit();
     Snapshot snap1 = table.currentSnapshot();
     long commitId1 = snap1.snapshotId();
-    ManifestFile manifestFile = table.currentSnapshot().manifests().get(0);
+    ManifestFile manifestFile = table.currentSnapshot().allManifests().get(0);
     validateSnapshot(null, snap1, 1, FILE_A);
     validateManifest(manifestFile, seqs(1), ids(commitId1), files(FILE_A));
     V2Assert.assertEquals("Snapshot sequence number should be 1", 1, snap1.sequenceNumber());
@@ -99,7 +99,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
     table.newFastAppend().appendFile(FILE_B).commit();
     Snapshot snap2 = table.currentSnapshot();
     long commitId2 = snap2.snapshotId();
-    manifestFile = table.currentSnapshot().manifests().get(0);
+    manifestFile = table.currentSnapshot().allManifests().get(0);
     validateSnapshot(snap1, snap2, 2, FILE_B);
     validateManifest(manifestFile, seqs(2), ids(commitId2), files(FILE_B));
     V2Assert.assertEquals("Snapshot sequence number should be 2", 2, snap2.sequenceNumber());
@@ -107,7 +107,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
 
     table.rewriteManifests().clusterBy(file -> "").commit();
     Snapshot snap3 = table.currentSnapshot();
-    ManifestFile newManifest = snap3.manifests().stream()
+    ManifestFile newManifest = snap3.allManifests().stream()
         .filter(manifest -> manifest.snapshotId() == snap3.snapshotId())
         .collect(Collectors.toList()).get(0);
 
@@ -149,7 +149,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
     appendA.commit();
     Snapshot snap1 = table.currentSnapshot();
     long commitId1 = snap1.snapshotId();
-    ManifestFile manifestFile = table.currentSnapshot().manifests().get(0);
+    ManifestFile manifestFile = table.currentSnapshot().allManifests().get(0);
     validateSnapshot(null, snap1, 1, FILE_A);
     validateManifest(manifestFile, seqs(1), ids(commitId1), files(FILE_A));
     V2Assert.assertEquals("Snapshot sequence number should be 1", 1, snap1.sequenceNumber());
@@ -160,7 +160,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
     table.newFastAppend().appendFile(FILE_D).commit();
     Snapshot snap2 = table.currentSnapshot();
     long commitId2 = snap2.snapshotId();
-    manifestFile = table.currentSnapshot().manifests().get(0);
+    manifestFile = table.currentSnapshot().allManifests().get(0);
     validateSnapshot(snap1, snap2, 2, FILE_D);
     validateManifest(manifestFile, seqs(2), ids(commitId2), files(FILE_D));
     V2Assert.assertEquals("Snapshot sequence number should be 2", 2, snap2.sequenceNumber());
@@ -169,7 +169,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
     appendFiles.commit();
     Snapshot snap3 = table.currentSnapshot();
     long commitId3 = snap3.snapshotId();
-    manifestFile = table.currentSnapshot().manifests().get(0);
+    manifestFile = table.currentSnapshot().allManifests().get(0);
     validateManifest(manifestFile, seqs(3), ids(commitId3), files(FILE_C));
     validateSnapshot(snap2, snap3, 3, FILE_C);
     V2Assert.assertEquals("Snapshot sequence number should be 3", 3, snap3.sequenceNumber());
@@ -181,7 +181,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
     table.newFastAppend().appendFile(FILE_A).commit();
     Snapshot snap1 = table.currentSnapshot();
     long commitId1 = snap1.snapshotId();
-    ManifestFile manifestFile = table.currentSnapshot().manifests().get(0);
+    ManifestFile manifestFile = table.currentSnapshot().allManifests().get(0);
     validateSnapshot(null, snap1, 1, FILE_A);
     validateManifest(manifestFile, seqs(1), ids(commitId1), files(FILE_A));
     V2Assert.assertEquals("Snapshot sequence number should be 1", 1, snap1.sequenceNumber());
@@ -190,7 +190,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
     table.newFastAppend().appendFile(FILE_B).commit();
     Snapshot snap2 = table.currentSnapshot();
     long commitId2 = snap2.snapshotId();
-    manifestFile = table.currentSnapshot().manifests().get(0);
+    manifestFile = table.currentSnapshot().allManifests().get(0);
     validateSnapshot(snap1, snap2, 2, FILE_B);
     validateManifest(manifestFile, seqs(2), ids(commitId2), files(FILE_B));
     V2Assert.assertEquals("Snapshot sequence number should be 2", 2, snap2.sequenceNumber());
@@ -204,7 +204,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
     table.newFastAppend().appendFile(FILE_C).commit();
     Snapshot snap4 = table.currentSnapshot();
     long commitId4 = snap4.snapshotId();
-    manifestFile = table.currentSnapshot().manifests().get(0);
+    manifestFile = table.currentSnapshot().allManifests().get(0);
     validateSnapshot(snap3, snap4, 3, FILE_C);
     validateManifest(manifestFile, seqs(3), ids(commitId4), files(FILE_C));
     V2Assert.assertEquals("Snapshot sequence number should be 1", 3, snap4.sequenceNumber());
@@ -218,7 +218,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
     txn.commitTransaction();
     Snapshot snap = table.currentSnapshot();
     long commitId = snap.snapshotId();
-    ManifestFile manifestFile = table.currentSnapshot().manifests().get(0);
+    ManifestFile manifestFile = table.currentSnapshot().allManifests().get(0);
     validateSnapshot(null, snap, 1, FILE_A);
     validateManifest(manifestFile, seqs(1), ids(commitId), files(FILE_A));
     V2Assert.assertEquals("Snapshot sequence number should be 1", 1, snap.sequenceNumber());
@@ -240,7 +240,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
     txn1.commitTransaction();
     Snapshot snap1 = table.currentSnapshot();
     long commitId1 = snap1.snapshotId();
-    ManifestFile manifestFile1 = table.currentSnapshot().manifests().get(0);
+    ManifestFile manifestFile1 = table.currentSnapshot().allManifests().get(0);
     validateSnapshot(null, snap1, 1, FILE_A);
     validateManifest(manifestFile1, seqs(1), ids(commitId1), files(FILE_A));
     V2Assert.assertEquals("Snapshot sequence number should be 1", 1, snap1.sequenceNumber());
@@ -249,7 +249,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
     txn2.commitTransaction();
     Snapshot snap2 = table.currentSnapshot();
     long commitId2 = snap2.snapshotId();
-    ManifestFile manifestFile = table.currentSnapshot().manifests().get(0);
+    ManifestFile manifestFile = table.currentSnapshot().allManifests().get(0);
     validateSnapshot(snap1, snap2, 2, FILE_B);
     validateManifest(manifestFile, seqs(2), ids(commitId2), files(FILE_B));
     V2Assert.assertEquals("Snapshot sequence number should be 2", 2, snap2.sequenceNumber());
@@ -258,7 +258,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
     txn3.commitTransaction();
     Snapshot snap3 = table.currentSnapshot();
     long commitId3 = snap3.snapshotId();
-    manifestFile = table.currentSnapshot().manifests().stream()
+    manifestFile = table.currentSnapshot().allManifests().stream()
         .filter(manifest -> manifest.snapshotId() == commitId3)
         .collect(Collectors.toList()).get(0);
     validateManifest(manifestFile, seqs(3), ids(commitId3), files(FILE_C));
@@ -269,7 +269,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
     txn4.commitTransaction();
     Snapshot snap4 = table.currentSnapshot();
     long commitId4 = snap4.snapshotId();
-    manifestFile = table.currentSnapshot().manifests().stream()
+    manifestFile = table.currentSnapshot().allManifests().stream()
         .filter(manifest -> manifest.snapshotId() == commitId4)
         .collect(Collectors.toList()).get(0);
     validateManifest(manifestFile, seqs(3, 2, 4), ids(commitId3, commitId2, commitId4), files(FILE_C, FILE_B, FILE_A));
@@ -283,7 +283,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
     txn.newFastAppend().appendFile(FILE_A).commit();
     Snapshot snap1 = txn.table().currentSnapshot();
     long commitId1 = snap1.snapshotId();
-    ManifestFile manifestFile = snap1.manifests().get(0);
+    ManifestFile manifestFile = snap1.allManifests().get(0);
     validateSnapshot(null, snap1, 1, FILE_A);
     validateManifest(manifestFile, seqs(1), ids(commitId1), files(FILE_A));
     V2Assert.assertEquals("Snapshot sequence number should be 1", 1, snap1.sequenceNumber());
@@ -298,7 +298,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
 
     Snapshot snap2 = table.currentSnapshot();
     long commitId2 = snap2.snapshotId();
-    manifestFile = snap2.manifests().stream()
+    manifestFile = snap2.allManifests().stream()
         .filter(manifest -> manifest.snapshotId() == commitId2)
         .collect(Collectors.toList()).get(0);
 
@@ -312,7 +312,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
     table.newFastAppend().appendFile(FILE_A).commit();
     Snapshot snap1 = table.currentSnapshot();
     long commitId1 = snap1.snapshotId();
-    ManifestFile manifestFile = table.currentSnapshot().manifests().get(0);
+    ManifestFile manifestFile = table.currentSnapshot().allManifests().get(0);
     validateSnapshot(null, snap1, 1, FILE_A);
     validateManifest(manifestFile, seqs(1), ids(commitId1), files(FILE_A));
     V2Assert.assertEquals("Snapshot sequence number should be 1", 1, snap1.sequenceNumber());
@@ -321,7 +321,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
     table.newAppend().appendFile(FILE_B).commit();
     Snapshot snap2 = table.currentSnapshot();
     long commitId2 = snap2.snapshotId();
-    manifestFile = table.currentSnapshot().manifests().get(0);
+    manifestFile = table.currentSnapshot().allManifests().get(0);
     validateSnapshot(snap1, snap2, 2, FILE_B);
     validateManifest(manifestFile, seqs(2), ids(commitId2), files(FILE_B));
     V2Assert.assertEquals("Snapshot sequence number should be 2", 2, snap2.sequenceNumber());
@@ -341,7 +341,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
         .commit();
     Snapshot snap1 = table.currentSnapshot();
     long commitId1 = snap1.snapshotId();
-    ManifestFile manifestFile = table.currentSnapshot().manifests().get(0);
+    ManifestFile manifestFile = table.currentSnapshot().allManifests().get(0);
     validateSnapshot(null, snap1, 1, FILE_A, FILE_B);
     validateManifest(manifestFile, seqs(1, 1), ids(commitId1, commitId1), files(FILE_A, FILE_B));
     V2Assert.assertEquals("Snapshot sequence number should be 1", 1, snap1.sequenceNumber());
@@ -369,7 +369,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
         .commit();
     Snapshot snap1 = table.currentSnapshot();
     long commitId1 = snap1.snapshotId();
-    ManifestFile manifestFile = snap1.manifests().get(0);
+    ManifestFile manifestFile = snap1.allManifests().get(0);
     validateSnapshot(null, snap1, 1, FILE_A);
     validateManifest(manifestFile, seqs(1), ids(commitId1), files(FILE_A));
     V2Assert.assertEquals("Snapshot sequence number should be 1", 1, snap1.sequenceNumber());
@@ -395,7 +395,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
 
     Snapshot snap3 = table.currentSnapshot();
     long commitId3 = snap3.snapshotId();
-    manifestFile = snap3.manifests().get(0);
+    manifestFile = snap3.allManifests().get(0);
     validateManifest(manifestFile, seqs(3), ids(commitId3), files(FILE_C));
     validateSnapshot(snap2, snap3, 3, FILE_C);
     V2Assert.assertEquals("Snapshot sequence number should be 3", 3, snap3.sequenceNumber());
@@ -405,7 +405,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
     table.manageSnapshots().cherrypick(stagedSnapshot.snapshotId()).commit();
     Snapshot snap4 = table.currentSnapshot();
     long commitId4 = snap4.snapshotId();
-    manifestFile = table.currentSnapshot().manifests().get(0);
+    manifestFile = table.currentSnapshot().allManifests().get(0);
     validateManifest(manifestFile, seqs(4), ids(commitId4), files(FILE_B));
     validateSnapshot(snap3, snap4, 4, FILE_B);
     V2Assert.assertEquals("Snapshot sequence number should be 4", 4, snap4.sequenceNumber());
@@ -419,7 +419,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
         .commit();
     Snapshot snap1 = table.currentSnapshot();
     long commitId1 = snap1.snapshotId();
-    ManifestFile manifestFile = snap1.manifests().get(0);
+    ManifestFile manifestFile = snap1.allManifests().get(0);
     validateSnapshot(null, snap1, 1, FILE_A);
     validateManifest(manifestFile, seqs(1), ids(commitId1), files(FILE_A));
     V2Assert.assertEquals("Snapshot sequence number should be 1", 1, snap1.sequenceNumber());
@@ -441,7 +441,7 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
     table.manageSnapshots().cherrypick(stagedSnapshot.snapshotId()).commit();
     Snapshot snap3 = table.currentSnapshot();
     long commitId3 = snap3.snapshotId();
-    manifestFile = snap3.manifests().get(0);
+    manifestFile = snap3.allManifests().get(0);
     validateManifest(manifestFile, seqs(2), ids(commitId3), files(FILE_B));
     validateSnapshot(snap2, snap3, 2, FILE_B);
     V2Assert.assertEquals("Snapshot sequence number should be 2", 2, snap3.sequenceNumber());


### PR DESCRIPTION
There was a merge conflict between #974 and #1080. This updates the test class to use the new `allManifests` method instead of `manifests`.