### PR TITLE
Add ignoreResiduals to TableScan

### DIFF
--- a/api/src/main/java/org/apache/iceberg/TableScan.java
+++ b/api/src/main/java/org/apache/iceberg/TableScan.java
@@ -132,6 +132,13 @@ public interface TableScan {
   Expression filter();
 
   /**
+   * Create a new {@link TableScan} from this that applies data filtering to files but not to rows in those files.
+   *
+   * @return a new scan based on this that does not filter rows in files.
+   */
+  TableScan ignoreResiduals();
+
+  /**
    * Create a new {@link TableScan} to read appended data from {@code fromSnapshotId} exclusive to {@code toSnapshotId}
    * inclusive.
    *

--- a/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -85,19 +86,23 @@ public class AllDataFilesTable extends BaseMetadataTable {
 
     private AllDataFilesTableScan(
         TableOperations ops, Table table, Long snapshotId, Schema schema, Expression rowFilter,
-        boolean caseSensitive, boolean colStats, Collection<String> selectedColumns, Schema fileSchema,
+        boolean ignoreResiduals, boolean caseSensitive, boolean colStats,
+        Collection<String> selectedColumns, Schema fileSchema,
         ImmutableMap<String, String> options) {
-      super(ops, table, snapshotId, schema, rowFilter, caseSensitive, colStats, selectedColumns, options);
+      super(
+          ops, table, snapshotId, schema, rowFilter, ignoreResiduals,
+          caseSensitive, colStats, selectedColumns, options);
       this.fileSchema = fileSchema;
     }
 
     @Override
     protected TableScan newRefinedScan(
         TableOperations ops, Table table, Long snapshotId, Schema schema, Expression rowFilter,
-        boolean caseSensitive, boolean colStats, Collection<String> selectedColumns,
+        boolean ignoreResiduals, boolean caseSensitive, boolean colStats, Collection<String> selectedColumns,
         ImmutableMap<String, String> options) {
       return new AllDataFilesTableScan(
-          ops, table, snapshotId, schema, rowFilter, caseSensitive, colStats, selectedColumns, fileSchema, options);
+          ops, table, snapshotId, schema, rowFilter, ignoreResiduals,
+          caseSensitive, colStats, selectedColumns, fileSchema, options);
     }
 
     @Override
@@ -118,11 +123,13 @@ public class AllDataFilesTable extends BaseMetadataTable {
 
     @Override
     protected CloseableIterable<FileScanTask> planFiles(
-        TableOperations ops, Snapshot snapshot, Expression rowFilter, boolean caseSensitive, boolean colStats) {
+        TableOperations ops, Snapshot snapshot, Expression rowFilter,
+        boolean ignoreResiduals, boolean caseSensitive, boolean colStats) {
       CloseableIterable<ManifestFile> manifests = allDataManifestFiles(ops.current().snapshots());
       String schemaString = SchemaParser.toJson(schema());
       String specString = PartitionSpecParser.toJson(PartitionSpec.unpartitioned());
-      ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(rowFilter);
+      Expression filter = ignoreResiduals ? Expressions.alwaysTrue() : rowFilter;
+      ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(filter);
 
       // Data tasks produce the table schema, not the projection schema and projection is done by processing engines.
       // This data task needs to use the table schema, which may not include a partition schema to avoid having an

--- a/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -82,18 +83,21 @@ public class AllEntriesTable extends BaseMetadataTable {
 
     private Scan(
         TableOperations ops, Table table, Long snapshotId, Schema schema, Expression rowFilter,
-        boolean caseSensitive, boolean colStats, Collection<String> selectedColumns,
-        ImmutableMap<String, String> options) {
-      super(ops, table, snapshotId, schema, rowFilter, caseSensitive, colStats, selectedColumns, options);
+        boolean ignoreResiduals, boolean caseSensitive, boolean colStats,
+        Collection<String> selectedColumns, ImmutableMap<String, String> options) {
+      super(
+          ops, table, snapshotId, schema, rowFilter, ignoreResiduals,
+          caseSensitive, colStats, selectedColumns, options);
     }
 
     @Override
     protected TableScan newRefinedScan(
         TableOperations ops, Table table, Long snapshotId, Schema schema, Expression rowFilter,
-        boolean caseSensitive, boolean colStats, Collection<String> selectedColumns,
+        boolean ignoreResiduals, boolean caseSensitive, boolean colStats, Collection<String> selectedColumns,
         ImmutableMap<String, String> options) {
       return new Scan(
-          ops, table, snapshotId, schema, rowFilter, caseSensitive, colStats, selectedColumns, options);
+          ops, table, snapshotId, schema, rowFilter, ignoreResiduals,
+          caseSensitive, colStats, selectedColumns, options);
     }
 
     @Override
@@ -104,12 +108,14 @@ public class AllEntriesTable extends BaseMetadataTable {
 
     @Override
     protected CloseableIterable<FileScanTask> planFiles(
-        TableOperations ops, Snapshot snapshot, Expression rowFilter, boolean caseSensitive, boolean colStats) {
+        TableOperations ops, Snapshot snapshot, Expression rowFilter,
+        boolean ignoreResiduals, boolean caseSensitive, boolean colStats) {
       CloseableIterable<ManifestFile> manifests = allManifestFiles(ops.current().snapshots());
       Schema fileSchema = new Schema(schema().findType("data_file").asStructType().fields());
       String schemaString = SchemaParser.toJson(schema());
       String specString = PartitionSpecParser.toJson(PartitionSpec.unpartitioned());
-      ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(rowFilter);
+      Expression filter = ignoreResiduals ? Expressions.alwaysTrue() : rowFilter;
+      ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(filter);
 
       return CloseableIterable.transform(manifests, manifest -> new ManifestEntriesTable.ManifestReadTask(
           ops.io(), manifest, fileSchema, schemaString, specString, residuals));

--- a/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
@@ -37,9 +37,11 @@ abstract class BaseAllMetadataTableScan extends BaseTableScan {
 
   BaseAllMetadataTableScan(
       TableOperations ops, Table table, Long snapshotId, Schema schema, Expression rowFilter,
-      boolean caseSensitive, boolean colStats, Collection<String> selectedColumns,
+      boolean ignoreResiduals, boolean caseSensitive, boolean colStats, Collection<String> selectedColumns,
       ImmutableMap<String, String> options) {
-    super(ops, table, snapshotId, schema, rowFilter, caseSensitive, colStats, selectedColumns, options);
+    super(
+        ops, table, snapshotId, schema, rowFilter, ignoreResiduals,
+        caseSensitive, colStats, selectedColumns, options);
   }
 
   @Override
@@ -47,6 +49,6 @@ abstract class BaseAllMetadataTableScan extends BaseTableScan {
     LOG.info("Scanning metadata table {} with filter {}.", table(), filter());
     Listeners.notifyAll(new ScanEvent(table().toString(), 0L, filter(), schema()));
 
-    return planFiles(tableOps(), snapshot(), filter(), isCaseSensitive(), colStats());
+    return planFiles(tableOps(), snapshot(), filter(), shouldIgnoreResiduals(), isCaseSensitive(), colStats());
   }
 }

--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -44,9 +44,11 @@ public class DataTableScan extends BaseTableScan {
   }
 
   protected DataTableScan(TableOperations ops, Table table, Long snapshotId, Schema schema,
-                          Expression rowFilter, boolean caseSensitive, boolean colStats,
+                          Expression rowFilter, boolean ignoreResiduals, boolean caseSensitive, boolean colStats,
                           Collection<String> selectedColumns, ImmutableMap<String, String> options) {
-    super(ops, table, snapshotId, schema, rowFilter, caseSensitive, colStats, selectedColumns, options);
+    super(
+        ops, table, snapshotId, schema, rowFilter, ignoreResiduals,
+        caseSensitive, colStats, selectedColumns, options);
   }
 
   @Override
@@ -55,7 +57,8 @@ public class DataTableScan extends BaseTableScan {
     Preconditions.checkState(scanSnapshotId == null,
         "Cannot enable incremental scan, scan-snapshot set to id=%s", scanSnapshotId);
     return new IncrementalDataTableScan(
-        tableOps(), table(), schema(), filter(), isCaseSensitive(), colStats(), selectedColumns(), options(),
+        tableOps(), table(), schema(), filter(), shouldIgnoreResiduals(),
+        isCaseSensitive(), colStats(), selectedColumns(), options(),
         fromSnapshotId, toSnapshotId);
   }
 
@@ -70,21 +73,26 @@ public class DataTableScan extends BaseTableScan {
   @Override
   protected TableScan newRefinedScan(
       TableOperations ops, Table table, Long snapshotId, Schema schema, Expression rowFilter,
-      boolean caseSensitive, boolean colStats, Collection<String> selectedColumns,
+      boolean ignoreResiduals, boolean caseSensitive, boolean colStats, Collection<String> selectedColumns,
       ImmutableMap<String, String> options) {
     return new DataTableScan(
-        ops, table, snapshotId, schema, rowFilter, caseSensitive, colStats, selectedColumns, options);
+        ops, table, snapshotId, schema, rowFilter, ignoreResiduals, caseSensitive, colStats, selectedColumns, options);
   }
 
   @Override
   public CloseableIterable<FileScanTask> planFiles(TableOperations ops, Snapshot snapshot,
-                                                   Expression rowFilter, boolean caseSensitive, boolean colStats) {
+                                                   Expression rowFilter, boolean ignoreResiduals,
+                                                   boolean caseSensitive, boolean colStats) {
     ManifestGroup manifestGroup = new ManifestGroup(ops.io(), snapshot.dataManifests())
         .caseSensitive(caseSensitive)
         .select(colStats ? SCAN_WITH_STATS_COLUMNS : SCAN_COLUMNS)
         .filterData(rowFilter)
         .specsById(ops.current().specsById())
         .ignoreDeleted();
+
+    if (ignoreResiduals) {
+      manifestGroup = manifestGroup.ignoreResiduals();
+    }
 
     if (PLAN_SCANS_WITH_WORKER_POOL && snapshot.dataManifests().size() > 1) {
       manifestGroup = manifestGroup.planWith(ThreadPools.getWorkerPool());

--- a/core/src/main/java/org/apache/iceberg/ManifestGroup.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestGroup.java
@@ -54,6 +54,7 @@ class ManifestGroup {
   private Expression partitionFilter;
   private boolean ignoreDeleted;
   private boolean ignoreExisting;
+  private boolean ignoreResiduals;
   private List<String> columns;
   private boolean caseSensitive;
   private ExecutorService executorService;
@@ -66,6 +67,7 @@ class ManifestGroup {
     this.partitionFilter = Expressions.alwaysTrue();
     this.ignoreDeleted = false;
     this.ignoreExisting = false;
+    this.ignoreResiduals = false;
     this.columns = BaseManifestReader.ALL_COLUMNS;
     this.caseSensitive = true;
     this.manifestPredicate = m -> true;
@@ -112,6 +114,11 @@ class ManifestGroup {
     return this;
   }
 
+  ManifestGroup ignoreResiduals() {
+    this.ignoreResiduals = true;
+    return this;
+  }
+
   ManifestGroup select(List<String> newColumns) {
     this.columns = Lists.newArrayList(newColumns);
     return this;
@@ -136,7 +143,8 @@ class ManifestGroup {
   public CloseableIterable<FileScanTask> planFiles() {
     LoadingCache<Integer, ResidualEvaluator> residualCache = Caffeine.newBuilder().build(specId -> {
       PartitionSpec spec = specsById.get(specId);
-      return ResidualEvaluator.of(spec, dataFilter, caseSensitive);
+      Expression filter = ignoreResiduals ? Expressions.alwaysTrue() : dataFilter;
+      return ResidualEvaluator.of(spec, filter, caseSensitive);
     });
     boolean dropStats = BaseManifestReader.dropStats(dataFilter, columns);
     Iterable<CloseableIterable<FileScanTask>> tasks = entries((manifest, entries) -> {

--- a/core/src/main/java/org/apache/iceberg/StaticTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/StaticTableScan.java
@@ -35,9 +35,11 @@ class StaticTableScan extends BaseTableScan {
 
   private StaticTableScan(
       TableOperations ops, Table table, Long snapshotId, Schema schema, Expression rowFilter,
-      boolean caseSensitive, boolean colStats, Collection<String> selectedColumns,
+      boolean ignoreResiduals, boolean caseSensitive, boolean colStats, Collection<String> selectedColumns,
       Function<StaticTableScan, DataTask> buildTask, ImmutableMap<String, String> options) {
-    super(ops, table, snapshotId, schema, rowFilter, caseSensitive, colStats, selectedColumns, options);
+    super(
+        ops, table, snapshotId, schema, rowFilter, ignoreResiduals,
+        caseSensitive, colStats, selectedColumns, options);
     this.buildTask = buildTask;
   }
 
@@ -50,15 +52,17 @@ class StaticTableScan extends BaseTableScan {
   @Override
   protected TableScan newRefinedScan(
       TableOperations ops, Table table, Long snapshotId, Schema schema, Expression rowFilter,
-      boolean caseSensitive, boolean colStats, Collection<String> selectedColumns,
-      ImmutableMap<String, String> options) {
+      boolean ignoreResiduals, boolean caseSensitive, boolean colStats,
+      Collection<String> selectedColumns, ImmutableMap<String, String> options) {
     return new StaticTableScan(
-        ops, table, snapshotId, schema, rowFilter, caseSensitive, colStats, selectedColumns, buildTask, options);
+        ops, table, snapshotId, schema, rowFilter, ignoreResiduals,
+        caseSensitive, colStats, selectedColumns, buildTask, options);
   }
 
   @Override
   protected CloseableIterable<FileScanTask> planFiles(
-      TableOperations ops, Snapshot snapshot, Expression rowFilter, boolean caseSensitive, boolean colStats) {
+      TableOperations ops, Snapshot snapshot, Expression rowFilter,
+      boolean ignoreResiduals, boolean caseSensitive, boolean colStats) {
     return CloseableIterable.withNoopClose(buildTask.apply(this));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TableTestBase.java
@@ -56,25 +56,25 @@ public class TableTestBase {
 
   static final DataFile FILE_A = DataFiles.builder(SPEC)
       .withPath("/path/to/data-a.parquet")
-      .withFileSizeInBytes(0)
+      .withFileSizeInBytes(10)
       .withPartitionPath("data_bucket=0") // easy way to set partition data for now
       .withRecordCount(1)
       .build();
   static final DataFile FILE_B = DataFiles.builder(SPEC)
       .withPath("/path/to/data-b.parquet")
-      .withFileSizeInBytes(0)
+      .withFileSizeInBytes(10)
       .withPartitionPath("data_bucket=1") // easy way to set partition data for now
       .withRecordCount(1)
       .build();
   static final DataFile FILE_C = DataFiles.builder(SPEC)
       .withPath("/path/to/data-c.parquet")
-      .withFileSizeInBytes(0)
+      .withFileSizeInBytes(10)
       .withPartitionPath("data_bucket=2") // easy way to set partition data for now
       .withRecordCount(1)
       .build();
   static final DataFile FILE_D = DataFiles.builder(SPEC)
       .withPath("/path/to/data-d.parquet")
-      .withFileSizeInBytes(0)
+      .withFileSizeInBytes(10)
       .withPartitionPath("data_bucket=3") // easy way to set partition data for now
       .withRecordCount(1)
       .build();

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.io.IOException;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestMetadataTableScans extends TableTestBase {
+
+  @Parameterized.Parameters
+  public static Object[][] parameters() {
+    return new Object[][] {
+        new Object[] { 1 },
+        new Object[] { 2 },
+    };
+  }
+
+  public TestMetadataTableScans(int formatVersion) {
+    super(formatVersion);
+  }
+
+  @Test
+  public void testManifestsTableAlwaysIgnoresResiduals() throws IOException {
+    table.newFastAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    Table manifestsTable = new ManifestsTable(table.ops(), table);
+
+    TableScan scan = manifestsTable.newScan()
+        .filter(Expressions.equal("id", 5));
+
+    try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
+      Assert.assertTrue("Tasks should not be empty", Iterables.size(tasks) > 0);
+      for (FileScanTask task : tasks) {
+        Assert.assertEquals("Residuals must be ignored", Expressions.alwaysTrue(), task.residual());
+      }
+    }
+  }
+
+  @Test
+  public void testDataFilesTableHonorsIgnoreResiduals() throws IOException {
+    table.newFastAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    Table dataFilesTable = new DataFilesTable(table.ops(), table);
+
+    TableScan scan1 = dataFilesTable.newScan()
+        .filter(Expressions.equal("id", 5));
+    validateTaskScanResiduals(scan1, false);
+
+    TableScan scan2 = dataFilesTable.newScan()
+        .filter(Expressions.equal("id", 5))
+        .ignoreResiduals();
+    validateTaskScanResiduals(scan2, true);
+  }
+
+  @Test
+  public void testManifestEntriesTableHonorsIgnoreResiduals() throws IOException {
+    table.newFastAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    Table manifestEntriesTable = new ManifestEntriesTable(table.ops(), table);
+
+    TableScan scan1 = manifestEntriesTable.newScan()
+        .filter(Expressions.equal("id", 5));
+    validateTaskScanResiduals(scan1, false);
+
+    TableScan scan2 = manifestEntriesTable.newScan()
+        .filter(Expressions.equal("id", 5))
+        .ignoreResiduals();
+    validateTaskScanResiduals(scan2, true);
+  }
+
+  @Test
+  public void testAllDataFilesTableHonorsIgnoreResiduals() throws IOException {
+    table.newFastAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    Table allDataFilesTable = new AllDataFilesTable(table.ops(), table);
+
+    TableScan scan1 = allDataFilesTable.newScan()
+        .filter(Expressions.equal("id", 5));
+    validateTaskScanResiduals(scan1, false);
+
+    TableScan scan2 = allDataFilesTable.newScan()
+        .filter(Expressions.equal("id", 5))
+        .ignoreResiduals();
+    validateTaskScanResiduals(scan2, true);
+  }
+
+  @Test
+  public void testAllEntriesTableHonorsIgnoreResiduals() throws IOException {
+    table.newFastAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    Table allEntriesTable = new AllEntriesTable(table.ops(), table);
+
+    TableScan scan1 = allEntriesTable.newScan()
+        .filter(Expressions.equal("id", 5));
+    validateTaskScanResiduals(scan1, false);
+
+    TableScan scan2 = allEntriesTable.newScan()
+        .filter(Expressions.equal("id", 5))
+        .ignoreResiduals();
+    validateTaskScanResiduals(scan2, true);
+  }
+
+  @Test
+  public void testAllManifestsTableHonorsIgnoreResiduals() throws IOException {
+    table.newFastAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    Table allManifestsTable = new AllManifestsTable(table.ops(), table);
+
+    TableScan scan1 = allManifestsTable.newScan()
+        .filter(Expressions.equal("id", 5));
+    validateTaskScanResiduals(scan1, false);
+
+    TableScan scan2 = allManifestsTable.newScan()
+        .filter(Expressions.equal("id", 5))
+        .ignoreResiduals();
+    validateTaskScanResiduals(scan2, true);
+  }
+
+  private void validateTaskScanResiduals(TableScan scan, boolean ignoreResiduals) throws IOException {
+    try (CloseableIterable<CombinedScanTask> tasks = scan.planTasks()) {
+      Assert.assertTrue("Tasks should not be empty", Iterables.size(tasks) > 0);
+      for (CombinedScanTask combinedScanTask : tasks) {
+        for (FileScanTask fileScanTask : combinedScanTask.files()) {
+          if (ignoreResiduals) {
+            Assert.assertEquals("Residuals must be ignored", Expressions.alwaysTrue(), fileScanTask.residual());
+          } else {
+            Assert.assertNotEquals("Residuals must be preserved", Expressions.alwaysTrue(), fileScanTask.residual());
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a way to ignore residuals and read full files that is needed for data compaction and eager updates/deletes/upserts.