### PR TITLE
Add HadoopCatalog example to create/load tables in the Iceberg User docs

### DIFF
--- a/site/docs/api-quickstart.md
+++ b/site/docs/api-quickstart.md
@@ -50,14 +50,14 @@ The logs [schema](#create-a-schema) and [partition spec](#create-a-partition-spe
 
 ### Using a Hadoop catalog
 
-The Hadoop catalog doesn't need to connects to a Hive MetaStore. To get a Hadoop catalog see:
+A Hadoop catalog doesn't need to connect to a Hive MetaStore, but can only be used with HDFS or similar file systems that support atomic rename. To get a Hadoop catalog see:
 
 ```scala
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.hadoop.HadoopCatalog;
 
 val conf = new Configuration();
-val warehousePath = "hdfs://warehouse_path";
+val warehousePath = "hdfs://host:8020/warehouse_path";
 val catalog = new HadoopCatalog(conf, warehousePath);
 ```
 

--- a/site/docs/api-quickstart.md
+++ b/site/docs/api-quickstart.md
@@ -50,7 +50,7 @@ The logs [schema](#create-a-schema) and [partition spec](#create-a-partition-spe
 
 ### Using a Hadoop catalog
 
-A Hadoop catalog doesn't need to connect to a Hive MetaStore, but can only be used with HDFS or similar file systems that support atomic rename. To get a Hadoop catalog see:
+A Hadoop catalog doesn't need to connect to a Hive MetaStore, but can only be used with HDFS or similar file systems that support atomic rename. Concurrent writes with a Hadoop catalog are not safe with a local FS or S3. To create a Hadoop catalog:
 
 ```scala
 import org.apache.hadoop.conf.Configuration;
@@ -61,9 +61,9 @@ val warehousePath = "hdfs://host:8020/warehouse_path";
 val catalog = new HadoopCatalog(conf, warehousePath);
 ```
 
-Like Hive catalog, Hadoop catalog implements the interface `Catalog`. So it also contains methods for working with tables, like createTable, loadTable, and dropTable.
+Like the Hive catalog, `HadoopCatalog` implements `Catalog`, so it also has methods for working with tables, like `createTable`, `loadTable`, and `dropTable`.
                                                                                        
-This example create a table with Hadoop catalog:
+This example creates a table with the Hadoop catalog:
 
 ```scala
 val name = TableIdentifier.of("logging", "logs")
@@ -73,14 +73,14 @@ val table = catalog.createTable(name, schema, spec)
 logsDF.write
     .format("iceberg")
     .mode("append")
-    .save("hdfs://warehouse_path/logging/logs")
+    .save("hdfs://host:8020/warehouse_path/logging.db/logs")
 ```
 
 The logs [schema](#create-a-schema) and [partition spec](#create-a-partition-spec) are created below.
 
 ### Using Hadoop tables
 
-Iceberg also supports tables that are stored in a directory in HDFS or the local file system. Directory tables don't support all catalog operations, like rename, so they use the `Tables` interface instead of `Catalog`.
+Iceberg also supports tables that are stored in a directory in HDFS. Concurrent writes with a Hadoop tables are not safe when stored in the local FS or S3. Directory tables don't support all catalog operations, like rename, so they use the `Tables` interface instead of `Catalog`.
 
 To create a table in HDFS, use `HadoopTables`:
 

--- a/site/docs/api-quickstart.md
+++ b/site/docs/api-quickstart.md
@@ -61,7 +61,7 @@ val warehousePath = "hdfs://host:8020/warehouse_path";
 val catalog = new HadoopCatalog(conf, warehousePath);
 ```
 
-Like Hive catalog, Hadoop catalog implements the interface `Catalog`. So it also contains methods for working with tables, like createTable, loadTable, renameTable, and dropTable.
+Like Hive catalog, Hadoop catalog implements the interface `Catalog`. So it also contains methods for working with tables, like createTable, loadTable, and dropTable.
                                                                                        
 This example create a table with Hadoop catalog:
 

--- a/site/docs/api-quickstart.md
+++ b/site/docs/api-quickstart.md
@@ -48,6 +48,36 @@ logsDF.write
 
 The logs [schema](#create-a-schema) and [partition spec](#create-a-partition-spec) are created below.
 
+### Using a Hadoop catalog
+
+The Hadoop catalog doesn't need to connects to a Hive MetaStore. To get a Hadoop catalog see:
+
+```scala
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+
+val conf = new Configuration();
+val warehousePath = "hdfs://warehouse_path";
+val catalog = new HadoopCatalog(conf, warehousePath);
+```
+
+Like Hive catalog, Hadoop catalog implements the interface `Catalog`. So it also contains methods for working with tables, like createTable, loadTable, renameTable, and dropTable.
+                                                                                       
+This example create a table with Hadoop catalog:
+
+```scala
+val name = TableIdentifier.of("logging", "logs")
+val table = catalog.createTable(name, schema, spec)
+
+// write into the new logs table with Spark 2.4
+logsDF.write
+    .format("iceberg")
+    .mode("append")
+    .save("hdfs://warehouse_path/logging/logs")
+```
+
+The logs [schema](#create-a-schema) and [partition spec](#create-a-partition-spec) are created below.
+
 ### Using Hadoop tables
 
 Iceberg also supports tables that are stored in a directory in HDFS or the local file system. Directory tables don't support all catalog operations, like rename, so they use the `Tables` interface instead of `Catalog`.

--- a/site/docs/java-api-quickstart.md
+++ b/site/docs/java-api-quickstart.md
@@ -48,7 +48,7 @@ The logs [schema](#create-a-schema) and [partition spec](#create-a-partition-spe
 
 ### Using a Hadoop catalog
 
-A Hadoop catalog doesn't need to connect to a Hive MetaStore, but can only be used with HDFS or similar file systems that support atomic rename. To get a Hadoop catalog see:
+A Hadoop catalog doesn't need to connect to a Hive MetaStore, but can only be used with HDFS or similar file systems that support atomic rename. Concurrent writes with a Hadoop catalog are not safe with a local FS or S3. To create a Hadoop catalog:
 
 ```java
 import org.apache.hadoop.conf.Configuration;
@@ -59,9 +59,9 @@ String warehousePath = "hdfs://host:8020/warehouse_path";
 HadoopCatalog catalog = new HadoopCatalog(conf, warehousePath);
 ```
 
-Like Hive catalog, Hadoop catalog implements the interface `Catalog`. So it also contains methods for working with tables, like createTable, loadTable, and dropTable.
+Like the Hive catalog, `HadoopCatalog` implements `Catalog`, so it also has methods for working with tables, like `createTable`, `loadTable`, and `dropTable`.
                                                                                        
-This example create a table with Hadoop catalog:
+This example creates a table with Hadoop catalog:
 
 ```java
 import org.apache.iceberg.Table;
@@ -76,7 +76,7 @@ The logs [schema](#create-a-schema) and [partition spec](#create-a-partition-spe
 
 ### Using Hadoop tables
 
-Iceberg also supports tables that are stored in a directory in HDFS or the local file system. Directory tables don't support all catalog operations, like rename, so they use the `Tables` interface instead of `Catalog`.
+Iceberg also supports tables that are stored in a directory in HDFS. Concurrent writes with a Hadoop tables are not safe when stored in the local FS or S3. Directory tables don't support all catalog operations, like rename, so they use the `Tables` interface instead of `Catalog`.
 
 To create a table in HDFS, use `HadoopTables`:
 

--- a/site/docs/java-api-quickstart.md
+++ b/site/docs/java-api-quickstart.md
@@ -48,14 +48,14 @@ The logs [schema](#create-a-schema) and [partition spec](#create-a-partition-spe
 
 ### Using a Hadoop catalog
 
-The Hadoop catalog doesn't need to connects to a Hive MetaStore. To get a Hadoop catalog see:
+A Hadoop catalog doesn't need to connect to a Hive MetaStore, but can only be used with HDFS or similar file systems that support atomic rename. To get a Hadoop catalog see:
 
 ```java
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.hadoop.HadoopCatalog;
 
 Configuration conf = new Configuration();
-String warehousePath = "hdfs://warehouse_path";
+String warehousePath = "hdfs://host:8020/warehouse_path";
 HadoopCatalog catalog = new HadoopCatalog(conf, warehousePath);
 ```
 

--- a/site/docs/java-api-quickstart.md
+++ b/site/docs/java-api-quickstart.md
@@ -46,6 +46,34 @@ Table table = catalog.createTable(name, schema, spec);
 The logs [schema](#create-a-schema) and [partition spec](#create-a-partition-spec) are created below.
 
 
+### Using a Hadoop catalog
+
+The Hadoop catalog doesn't need to connects to a Hive MetaStore. To get a Hadoop catalog see:
+
+```java
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+
+Configuration conf = new Configuration();
+String warehousePath = "hdfs://warehouse_path";
+HadoopCatalog catalog = new HadoopCatalog(conf, warehousePath);
+```
+
+Like Hive catalog, Hadoop catalog implements the interface `Catalog`. So it also contains methods for working with tables, like createTable, loadTable, renameTable, and dropTable.
+                                                                                       
+This example create a table with Hadoop catalog:
+
+```java
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.TableIdentifier;
+
+TableIdentifier name = TableIdentifier.of("logging", "logs");
+Table table = catalog.createTable(name, schema, spec);
+```
+
+The logs [schema](#create-a-schema) and [partition spec](#create-a-partition-spec) are created below.
+
+
 ### Using Hadoop tables
 
 Iceberg also supports tables that are stored in a directory in HDFS or the local file system. Directory tables don't support all catalog operations, like rename, so they use the `Tables` interface instead of `Catalog`.

--- a/site/docs/java-api-quickstart.md
+++ b/site/docs/java-api-quickstart.md
@@ -59,7 +59,7 @@ String warehousePath = "hdfs://host:8020/warehouse_path";
 HadoopCatalog catalog = new HadoopCatalog(conf, warehousePath);
 ```
 
-Like Hive catalog, Hadoop catalog implements the interface `Catalog`. So it also contains methods for working with tables, like createTable, loadTable, renameTable, and dropTable.
+Like Hive catalog, Hadoop catalog implements the interface `Catalog`. So it also contains methods for working with tables, like createTable, loadTable, and dropTable.
                                                                                        
 This example create a table with Hadoop catalog:
 


### PR DESCRIPTION
This PR propose to add HadoopCatalog example to create/load tables in the Iceberg User docs.