### PR TITLE
Add test case for deleting column in hive metastore 

### DIFF
--- a/hive/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
+++ b/hive/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.avro.AvroSchemaUtil;
@@ -47,6 +48,8 @@ import org.junit.Test;
 import static org.apache.iceberg.BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE;
 import static org.apache.iceberg.BaseMetastoreTableOperations.METADATA_LOCATION_PROP;
 import static org.apache.iceberg.BaseMetastoreTableOperations.TABLE_TYPE_PROP;
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class HiveTableTest extends HiveTableBaseTest {
   @Test
@@ -238,6 +241,37 @@ public class HiveTableTest extends HiveTableBaseTest {
         .map(Types.NestedField::name)
         .collect(Collectors.toList());
     Assert.assertEquals(icebergColumns, hiveColumns);
+  }
+
+  @Test
+  public void testColumnTypeChangeInMetastore() throws TException {
+    Table icebergTable = catalog.loadTable(TABLE_IDENTIFIER);
+
+    Schema expectedSchema = new Schema(Types.StructType.of(
+            required(1, "id", Types.LongType.get()),
+            optional(2, "data", Types.LongType.get()),
+            optional(3, "string", Types.StringType.get()),
+            optional(4, "int", Types.IntegerType.get())).fields());
+    // Add columns with different types, then verify we could delete one column in hive metastore
+    // as hive conf METASTORE_DISALLOW_INCOMPATIBLE_COL_TYPE_CHANGES was set to false. If this was set to true,
+    // an InvalidOperationException would thrown in method MetaStoreUtils#throwExceptionIfIncompatibleColTypeChange()
+    icebergTable.updateSchema()
+            .addColumn("data", Types.LongType.get())
+            .addColumn("string", Types.StringType.get())
+            .addColumn("int", Types.IntegerType.get())
+            .commit();
+
+    icebergTable = catalog.loadTable(TABLE_IDENTIFIER);
+    Assert.assertEquals("Schema should match expected", expectedSchema.asStruct(), icebergTable.schema().asStruct());
+
+    expectedSchema = new Schema(Types.StructType.of(
+            required(1, "id", Types.LongType.get()),
+            optional(2, "data", Types.LongType.get()),
+            optional(4, "int", Types.IntegerType.get())).fields());
+    icebergTable.updateSchema().deleteColumn("string").commit();
+
+    icebergTable = catalog.loadTable(TABLE_IDENTIFIER);
+    Assert.assertEquals("Schema should match expected", expectedSchema.asStruct(), icebergTable.schema().asStruct());
   }
 
   @Test(expected = CommitFailedException.class)

--- a/hive/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
+++ b/hive/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
@@ -261,7 +261,6 @@ public class HiveTableTest extends HiveTableBaseTest {
             .addColumn("int", Types.IntegerType.get())
             .commit();
 
-    icebergTable = catalog.loadTable(TABLE_IDENTIFIER);
     Assert.assertEquals("Schema should match expected", expectedSchema.asStruct(), icebergTable.schema().asStruct());
 
     expectedSchema = new Schema(Types.StructType.of(
@@ -270,7 +269,6 @@ public class HiveTableTest extends HiveTableBaseTest {
             optional(4, "int", Types.IntegerType.get())).fields());
     icebergTable.updateSchema().deleteColumn("string").commit();
 
-    icebergTable = catalog.loadTable(TABLE_IDENTIFIER);
     Assert.assertEquals("Schema should match expected", expectedSchema.asStruct(), icebergTable.schema().asStruct());
   }
 

--- a/hive/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/hive/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -112,6 +112,7 @@ public class TestHiveMetastore {
     newHiveConf.set(HiveConf.ConfVars.METASTOREURIS.varname, "thrift://localhost:" + port);
     newHiveConf.set(HiveConf.ConfVars.METASTOREWAREHOUSE.varname, "file:" + hiveLocalDir.getAbsolutePath());
     newHiveConf.set(HiveConf.ConfVars.METASTORE_TRY_DIRECT_SQL.varname, "false");
+    newHiveConf.set(HiveConf.ConfVars.METASTORE_DISALLOW_INCOMPATIBLE_COL_TYPE_CHANGES.varname, "false");
     newHiveConf.set("iceberg.hive.client-pool-size", "2");
     return newHiveConf;
   }


### PR DESCRIPTION
When deleting a table's column in Hive Metastore, which has different type against next column, it will fail  as METASTORE_DISALLOW_INCOMPATIBLE_COL_TYPE_CHANGES  is set to true by default. 

This pull request adds a test case to cover this case with METASTORE_DISALLOW_INCOMPATIBLE_COL_TYPE_CHANGES set to false.

Refer to issue https://github.com/apache/iceberg/issues/1092.

