### PR TITLE
Add docker demo for Iceberg

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,118 @@
+<!--
+  - Licensed to the Apache Software Foundation (ASF) under one
+  - or more contributor license agreements.  See the NOTICE file
+  - distributed with this work for additional information
+  - regarding copyright ownership.  The ASF licenses this file
+  - to you under the Apache License, Version 2.0 (the
+  - "License"); you may not use this file except in compliance
+  - with the License.  You may obtain a copy of the License at
+  -
+  -   http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing,
+  - software distributed under the License is distributed on an
+  - "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  - KIND, either express or implied.  See the License for the
+  - specific language governing permissions and limitations
+  - under the License.
+  -->
+
+# Version
+
+| Framework | Version |
+| :--------- | :------- |
+| Hadoop    | 2.7.4   |
+| Spark     | 2.4.5   |
+| Iceberg   | 0.8.0   |
+
+# Setting up Docker Demo
+
+```$xslt
+# start the docker demo
+cd docker
+./start_demo.sh
+
+# You can see the output below if the docker demo starts successfully
+Creating network "compose_default" with the default driver
+Creating namenode ... done
+Creating datanode ... done
+Creating spark    ... done
+```
+
+# Demo
+
+At this point, you can enter the container and try something with Spark and Iceberg.
+
+```$xslt
+docker exec -it spark /bin/bash
+
+# After getting into the container, we start with spark-shell
+spark-shell --master local[2]
+```
+
+## Test Data
+
+You can check the data located on /opt/data/logs.json, which shows a few records of logging data.
+
+```$xslt
+{"level": "INFO", "event_time": 1591430621, "message": "Containers are ready.", "call_stack": []}
+{"level": "INFO", "event_time": 1591430621, "message": "Start working with Iceberg!", "call_stack": []}
+{"level": "WARN", "event_time": 1591430621, "message": "This is a warn meesage", "call_stack": ["functionA", "functionB"]}
+{"level": "ERROR", "event_time": 1591430621, "message": "NullPointerException", "call_stack": ["String.substring(int, int)"]}
+{"level": "ERROR", "event_time": 1591430621, "message": "IllegalArgumentException", "call_stack": ["unknow stack"]}
+{"level": "INFO", "event_time": 1591430621, "message": "The cluster is shutting donw.", "call_stack": []}
+``` 
+
+## Create an Iceberg Table
+
+Let's start with creating an Iceberg table on HDFS.
+
+```$xslt
+import org.apache.iceberg.Schema
+import org.apache.iceberg.types.Types._
+
+val schema = new Schema(
+    NestedField.required(1, "level", StringType.get()),
+    NestedField.required(2, "event_time", TimestampType.withZone()),
+    NestedField.required(3, "message", StringType.get()),
+    NestedField.optional(4, "call_stack", ListType.ofRequired(5, StringType.get()))
+)
+
+import org.apache.iceberg.PartitionSpec
+val spec = PartitionSpec.builderFor(schema).hour("event_time").build()
+
+import org.apache.iceberg.hadoop.HadoopTables
+val tables = new HadoopTables(spark.sessionState.newHadoopConf())
+val table = tables.create(schema, spec, "hdfs:/tables/logging/logs")
+```
+
+## Load Data
+
+The data can loaded as a dataframe with Spark.(We use sparkSchema here because the schema of the dataframe should be 
+compatitable with the Iceberg schema we used above.)
+
+```$xslt
+import org.apache.spark.sql.types._
+val sparkSchema = StructType(Seq(
+        StructField("level", StringType, nullable = false),
+        StructField("event_time", TimestampType, nullable = false),
+        StructField("message", StringType, nullable = false),
+        StructField("call_stack", ArrayType(StringType, containsNull = false), nullable = false)
+))
+val logsDF = spark.read.schema(sparkSchema).json("file:///opt/data/logs.json")
+val df = spark.createDataFrame(logsDF.rdd, sparkSchema)
+``` 
+
+## Write Data
+
+```$xslt
+df.write.format("iceberg").mode("append").save("hdfs:/tables/logging/logs")
+```
+
+After this you can exit the spark-shell and check the directory structure on the HDFS.
+
+```$xslt
+hadoop fs -ls /tables/logging/logs
+```
+
+

--- a/docker/compose/docker-compose.yml
+++ b/docker/compose/docker-compose.yml
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+version: "3.3"
+
+services:
+
+  namenode:
+    image: liaojiayidocker/hadoop-namenode:latest
+    hostname: namenode
+    container_name: namenode
+    ports:
+      - "50070:50070"
+      - "8020:8020"
+    env_file:
+      - ./hadoop.env
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://namenode:50070"]
+      interval: 20s
+      timeout: 10s
+      retries: 3
+
+  datanode:
+    image: liaojiayidocker/hadoop-datanode:latest
+    hostname: datanode
+    container_name: datanode
+    ports:
+      - "50075:50075"
+    env_file:
+      - ./hadoop.env
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://datanode:50075"]
+      interval: 20s
+      timeout: 10s
+      retries: 3
+    environment:
+      SERVICE_PRECONDITION: "namenode:50070"
+
+  spark:
+    image: liaojiayidocker/spark:latest
+    hostname: spark
+    container_name: spark
+    ports:
+      - "4040:4040"
+    env_file:
+      - ./hadoop.env
+    environment:
+      SERVICE_PRECONDITION: "namenode:50070"

--- a/docker/compose/hadoop.env
+++ b/docker/compose/hadoop.env
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+HDFS_CONF_dfs_webhdfs_enabled=true
+HDFS_CONF_dfs_permissions_enabled=false
+HDFS_CONF_dfs_client_use_datanode_hostname=false
+HDFS_CONF_dfs_namenode_use_datanode_hostname=false
+
+CORE_CONF_fs_defaultFS=hdfs://namenode:8020
+CORE_CONF_hadoop_http_staticuser_user=root
+CORE_CONF_hadoop_proxyuser_hue_hosts=*
+CORE_CONF_hadoop_proxyuser_hue_groups=*

--- a/docker/images/build.sh
+++ b/docker/images/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+docker build -t liaojiayidocker/hadoop-base:latest ./hadoop/base
+docker build -t liaojiayidocker/hadoop-namenode:latest ./hadoop/namenode
+docker build -t liaojiayidocker/hadoop-datanode:latest ./hadoop/datanode
+docker build -t liaojiayidocker/spark:latest ./spark

--- a/docker/images/hadoop/base/Dockerfile
+++ b/docker/images/hadoop/base/Dockerfile
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM openjdk:8u252-jdk-buster
+MAINTAINER Iceberg
+USER root
+
+ARG HADOOP_VERSION=2.7.4
+ARG HADOOP_URL=https://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get -y update && apt-get -y install curl vim wget net-tools netcat
+
+# configure hadoop
+RUN set -x \
+    && curl -fSL "${HADOOP_URL}" -o /tmp/hadoop.tar.gz \
+    && tar -xvf /tmp/hadoop.tar.gz -C /opt/ \
+    && rm /tmp/hadoop.tar.gz \
+    && ln -s /opt/hadoop-${HADOOP_VERSION} /opt/hadoop
+
+# set environment variables
+ENV HADOOP_HOME=/opt/hadoop
+ENV HADOOP_CONF_DIR=/opt/hadoop/etc/hadoop
+ENV PATH=/usr/bin:/bin:$HADOOP_HOME/bin/:$PATH
+
+ADD entrypoint.sh /opt/entrypoint.sh
+RUN chmod a+x /opt/entrypoint.sh
+ENTRYPOINT ["/opt/entrypoint.sh"]

--- a/docker/images/hadoop/base/entrypoint.sh
+++ b/docker/images/hadoop/base/entrypoint.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+function addProperty() {
+  local path=$1
+  local name=$2
+  local value=$3
+
+  local entry="<property><name>$name</name><value>${value}</value></property>"
+  local escapedEntry=$(echo $entry | sed 's/\//\\\//g')
+  sed -i "/<\/configuration>/ s/.*/${escapedEntry}\n&/" $path
+}
+
+function configure() {
+    local path=$1
+    local envPrefix=$2
+
+    local var
+    local value
+
+    echo "Configuring $path"
+    for c in `printenv | perl -sne 'print "$1 " if m/^${envPrefix}_(.+?)=.*/' -- -envPrefix=$envPrefix`; do
+        name=`echo ${c} | perl -pe 's/___/-/g; s/__/@/g; s/_/./g; s/@/_/g;'`
+        var="${envPrefix}_${c}"
+        value=${!var}
+        echo " - Setting $name=$value"
+        addProperty $path $name "$value"
+    done
+}
+
+configure ${HADOOP_CONF_DIR}/core-site.xml CORE_CONF
+configure ${HADOOP_CONF_DIR}/hdfs-site.xml HDFS_CONF
+configure ${HADOOP_CONF_DIR}/yarn-site.xml YARN_CONF
+
+
+# HDFS
+addProperty ${HADOOP_CONF_DIR}/hdfs-site.xml dfs.namenode.rpc-bind-host 0.0.0.0
+addProperty ${HADOOP_CONF_DIR}/hdfs-site.xml dfs.namenode.servicerpc-bind-host 0.0.0.0
+addProperty ${HADOOP_CONF_DIR}/hdfs-site.xml dfs.namenode.http-bind-host 0.0.0.0
+addProperty ${HADOOP_CONF_DIR}/hdfs-site.xml dfs.namenode.https-bind-host 0.0.0.0
+addProperty ${HADOOP_CONF_DIR}/hdfs-site.xml dfs.client.use.datanode.hostname true
+addProperty ${HADOOP_CONF_DIR}/hdfs-site.xml dfs.datanode.use.datanode.hostname true
+
+function wait_for_it()
+{
+    local serviceport=$1
+    local service=${serviceport%%:*}
+    local port=${serviceport#*:}
+    local retry_seconds=5
+    local max_try=100
+    let i=1
+
+    nc -z $service $port
+    result=$?
+
+    until [ $result -eq 0 ]; do
+      echo "[$i/$max_try] check for ${service}:${port}..."
+      echo "[$i/$max_try] ${service}:${port} is not available yet"
+      if (( $i == $max_try )); then
+        echo "[$i/$max_try] ${service}:${port} is still not available; giving up after ${max_try} tries. :/"
+        exit 1
+      fi
+
+      echo "[$i/$max_try] try in ${retry_seconds}s once again ..."
+      let "i++"
+      sleep $retry_seconds
+
+      nc -z $service $port
+      result=$?
+    done
+    echo "[$i/$max_try] $service:${port} is available."
+}
+
+for i in ${SERVICE_PRECONDITION[@]}
+do
+    wait_for_it ${i}
+done
+
+
+exec "$@"

--- a/docker/images/hadoop/datanode/Dockerfile
+++ b/docker/images/hadoop/datanode/Dockerfile
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM liaojiayidocker/hadoop-base:latest
+
+ENV HDFS_CONF_dfs_datanode_data_dir file:///hadoop/dfs/data
+
+RUN mkdir -p /hadoop/dfs/data
+VOLUME /hadoop/dfs/data
+
+EXPOSE 9864
+
+ADD run_datanode.sh /opt/run_datanode.sh
+RUN chmod a+x /opt/run_datanode.sh
+CMD ["/opt/run_datanode.sh"]

--- a/docker/images/hadoop/datanode/run_datanode.sh
+++ b/docker/images/hadoop/datanode/run_datanode.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+$HADOOP_HOME/bin/hdfs --config $HADOOP_CONF_DIR datanode

--- a/docker/images/hadoop/namenode/Dockerfile
+++ b/docker/images/hadoop/namenode/Dockerfile
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM liaojiayidocker/hadoop-base:latest
+
+ENV HDFS_CONF_dfs_namenode_name_dir file:///hadoop/dfs/name
+
+RUN mkdir -p /hadoop/dfs/name
+VOLUME /hadoop/dfs/name
+
+EXPOSE 50070
+
+ADD run_namenode.sh /opt/run_namenode.sh
+RUN chmod a+x /opt/run_namenode.sh
+CMD ["/opt/run_namenode.sh"]

--- a/docker/images/hadoop/namenode/run_namenode.sh
+++ b/docker/images/hadoop/namenode/run_namenode.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# format namenode
+$HADOOP_HOME/bin/hdfs --config $HADOOP_CONF_DIR namenode -format
+
+$HADOOP_HOME/bin/hdfs --config $HADOOP_CONF_DIR namenode

--- a/docker/images/spark/Dockerfile
+++ b/docker/images/spark/Dockerfile
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM liaojiayidocker/hadoop-base:latest
+
+ENV SPARK_VERSION=2.4.5
+ENV SPARK_HADOOP_VERSION=2.7
+ENV ICEBERG_VERSION=0.8.0
+
+ARG SPARK_URL=https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${SPARK_HADOOP_VERSION}.tgz
+
+# download spark
+RUN set -x \
+    && curl -fSL ${SPARK_URL} -o /tmp/spark.tar.gz \
+    && tar -xvf /tmp/spark.tar.gz -C /opt/ \
+    && rm /tmp/spark.tar.gz \
+    && ln -s /opt/spark-${SPARK_VERSION}-bin-hadoop${SPARK_HADOOP_VERSION} /opt/spark
+
+
+# download iceberg-spark-runtime
+ARG ICEBERG_SPARK_URL=https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime/${ICEBERG_VERSION}-incubating/iceberg-spark-runtime-${ICEBERG_VERSION}-incubating.jar
+RUN set -x \
+    && curl -fSL ${ICEBERG_SPARK_URL} -o /opt/spark/jars/iceberg-spark-runtime-${ICEBERG_VERSION}-incubating.jar
+
+
+ENV SPARK_HOME=/opt/spark
+ENV PATH=${SPARK_HOME}/bin:${PATH}
+
+EXPOSE 4040
+
+RUN mkdir /opt/data
+ADD logs.json /opt/data/logs.json
+
+ADD run_spark.sh /opt/run_spark.sh
+RUN chmod a+x /opt/run_spark.sh
+CMD ["/opt/run_spark.sh"]

--- a/docker/images/spark/logs.json
+++ b/docker/images/spark/logs.json
@@ -1,0 +1,6 @@
+{"level": "INFO", "event_time": 1591430621, "message": "Containers are ready.", "call_stack": []}
+{"level": "INFO", "event_time": 1591430621, "message": "Start working with Iceberg!", "call_stack": []}
+{"level": "WARN", "event_time": 1591430621, "message": "This is a warn meesage", "call_stack": ["functionA", "functionB"]}
+{"level": "ERROR", "event_time": 1591430621, "message": "NullPointerException", "call_stack": ["String.substring(int, int)"]}
+{"level": "ERROR", "event_time": 1591430621, "message": "IllegalArgumentException", "call_stack": ["unknow stack"]}
+{"level": "INFO", "event_time": 1591430621, "message": "The cluster is shutting donw.", "call_stack": []}

--- a/docker/images/spark/run_spark.sh
+++ b/docker/images/spark/run_spark.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+echo "Start working with Iceberg now!" > /opt/message
+tail -f /opt/message

--- a/docker/start_demo.sh
+++ b/docker/start_demo.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+DIR=$(cd `dirname $0`; pwd)
+
+docker-compose -f $DIR/compose/docker-compose.yml down
+docker-compose -f $DIR/compose/docker-compose.yml pull
+sleep 3
+docker-compose -f $DIR/compose/docker-compose.yml up -d

--- a/docker/stop_demo.sh
+++ b/docker/stop_demo.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+DIR=$(cd `dirname $0`; pwd)
+
+docker-compose -f $DIR/compose/docker-compose.yml down


### PR DESCRIPTION
# The Purpose of the Change

Users can only work with iceberg on an existing hadoop / hdfs / hive / spark cluster or deploying a new one. It's not very friendly to starters, especially those who want to know more about iceberg but don't have an available environment to make iceberg work well. See more in https://github.com/apache/iceberg/issues/1081.

This change is to add a docker demo for starters of Iceberg.

# Brief Change Log

* Add namenode/datanode/spark container and use docker-compose to setup the cluster
* Add scripts for the docker demo such as build.sh, start_demo.sh and stop_demo.sh
* Add README.md to show users how to use the docker demo


# Other things you may need to know:

* The docker id should be replaced with iceberg's docker id in DockerHub when being merged. (I've already pushed the latest stable image to my own dockerhub, which can be used when you want to take a try)