### PR TITLE
Reuse the common methods in serveral RandomData classes.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/RandomUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/RandomUtil.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Random;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+
+public class RandomUtil {
+
+  private RandomUtil() {
+
+  }
+
+  @SuppressWarnings("RandomModInteger")
+  public static Object generatePrimitive(Type.PrimitiveType primitive,
+                                         Random random) {
+    int choice = random.nextInt(20);
+
+    switch (primitive.typeId()) {
+      case BOOLEAN:
+        return choice < 10;
+
+      case INTEGER:
+        switch (choice) {
+          case 1:
+            return Integer.MIN_VALUE;
+          case 2:
+            return Integer.MAX_VALUE;
+          case 3:
+            return 0;
+          default:
+            return random.nextInt();
+        }
+
+      case LONG:
+        switch (choice) {
+          case 1:
+            return Long.MIN_VALUE;
+          case 2:
+            return Long.MAX_VALUE;
+          case 3:
+            return 0L;
+          default:
+            return random.nextLong();
+        }
+
+      case FLOAT:
+        switch (choice) {
+          case 1:
+            return Float.MIN_VALUE;
+          case 2:
+            return -Float.MIN_VALUE;
+          case 3:
+            return Float.MAX_VALUE;
+          case 4:
+            return -Float.MAX_VALUE;
+          case 5:
+            return Float.NEGATIVE_INFINITY;
+          case 6:
+            return Float.POSITIVE_INFINITY;
+          case 7:
+            return 0.0F;
+          case 8:
+            return Float.NaN;
+          default:
+            return random.nextFloat();
+        }
+
+      case DOUBLE:
+        switch (choice) {
+          case 1:
+            return Double.MIN_VALUE;
+          case 2:
+            return -Double.MIN_VALUE;
+          case 3:
+            return Double.MAX_VALUE;
+          case 4:
+            return -Double.MAX_VALUE;
+          case 5:
+            return Double.NEGATIVE_INFINITY;
+          case 6:
+            return Double.POSITIVE_INFINITY;
+          case 7:
+            return 0.0D;
+          case 8:
+            return Double.NaN;
+          default:
+            return random.nextDouble();
+        }
+
+      case DATE:
+        // this will include negative values (dates before 1970-01-01)
+        return random.nextInt() % ABOUT_380_YEARS_IN_DAYS;
+
+      case TIME:
+        return (random.nextLong() & Integer.MAX_VALUE) % ONE_DAY_IN_MICROS;
+
+      case TIMESTAMP:
+        return random.nextLong() % FIFTY_YEARS_IN_MICROS;
+
+      case STRING:
+        return randomString(random);
+
+      case UUID:
+        byte[] uuidBytes = new byte[16];
+        random.nextBytes(uuidBytes);
+        // this will hash the uuidBytes
+        return uuidBytes;
+
+      case FIXED:
+        byte[] fixed = new byte[((Types.FixedType) primitive).length()];
+        random.nextBytes(fixed);
+        return fixed;
+
+      case BINARY:
+        byte[] binary = new byte[random.nextInt(50)];
+        random.nextBytes(binary);
+        return binary;
+
+      case DECIMAL:
+        Types.DecimalType type = (Types.DecimalType) primitive;
+        BigInteger unscaled = randomUnscaled(type.precision(), random);
+        return new BigDecimal(unscaled, type.scale());
+
+      default:
+        throw new IllegalArgumentException(
+            "Cannot generate random value for unknown type: " + primitive);
+    }
+  }
+
+  private static final long FIFTY_YEARS_IN_MICROS =
+      (50L * (365 * 3 + 366) * 24 * 60 * 60 * 1_000_000) / 4;
+  private static final int ABOUT_380_YEARS_IN_DAYS = 380 * 365;
+  private static final long ONE_DAY_IN_MICROS = 24 * 60 * 60 * 1_000_000L;
+  private static final String CHARS =
+      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-.!?";
+
+  private static String randomString(Random random) {
+    int length = random.nextInt(50);
+    byte[] buffer = new byte[length];
+
+    for (int i = 0; i < length; i += 1) {
+      buffer[i] = (byte) CHARS.charAt(random.nextInt(CHARS.length()));
+    }
+
+    return new String(buffer);
+  }
+
+  private static final String DIGITS = "0123456789";
+
+  private static BigInteger randomUnscaled(int precision, Random random) {
+    int length = random.nextInt(precision);
+    if (length == 0) {
+      return BigInteger.ZERO;
+    }
+
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < length; i += 1) {
+      sb.append(DIGITS.charAt(random.nextInt(DIGITS.length())));
+    }
+
+    return new BigInteger(sb.toString());
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/avro/RandomAvroData.java
+++ b/core/src/test/java/org/apache/iceberg/avro/RandomAvroData.java
@@ -19,8 +19,6 @@
 
 package org.apache.iceberg.avro;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +36,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.RandomUtil;
 
 public class RandomAvroData {
 
@@ -140,10 +139,12 @@ public class RandomAvroData {
 
     @Override
     public Object primitive(Type.PrimitiveType primitive) {
-      Object result = generatePrimitive(primitive, random);
+      Object result = RandomUtil.generatePrimitive(primitive, random);
       // For the primitives that Avro needs a different type than Spark, fix
       // them here.
       switch (primitive.typeId()) {
+        case STRING:
+          return new Utf8((String) result);
         case FIXED:
           return new GenericData.Fixed(typeToSchema.get(primitive),
               (byte[]) result);
@@ -155,156 +156,5 @@ public class RandomAvroData {
           return result;
       }
     }
-  }
-
-  @SuppressWarnings("RandomModInteger")
-  private static Object generatePrimitive(Type.PrimitiveType primitive,
-                                         Random random) {
-    int choice = random.nextInt(20);
-
-    switch (primitive.typeId()) {
-      case BOOLEAN:
-        return choice < 10;
-
-      case INTEGER:
-        switch (choice) {
-          case 1:
-            return Integer.MIN_VALUE;
-          case 2:
-            return Integer.MAX_VALUE;
-          case 3:
-            return 0;
-          default:
-            return random.nextInt();
-        }
-
-      case LONG:
-        switch (choice) {
-          case 1:
-            return Long.MIN_VALUE;
-          case 2:
-            return Long.MAX_VALUE;
-          case 3:
-            return 0L;
-          default:
-            return random.nextLong();
-        }
-
-      case FLOAT:
-        switch (choice) {
-          case 1:
-            return Float.MIN_VALUE;
-          case 2:
-            return -Float.MIN_VALUE;
-          case 3:
-            return Float.MAX_VALUE;
-          case 4:
-            return -Float.MAX_VALUE;
-          case 5:
-            return Float.NEGATIVE_INFINITY;
-          case 6:
-            return Float.POSITIVE_INFINITY;
-          case 7:
-            return 0.0F;
-          case 8:
-            return Float.NaN;
-          default:
-            return random.nextFloat();
-        }
-
-      case DOUBLE:
-        switch (choice) {
-          case 1:
-            return Double.MIN_VALUE;
-          case 2:
-            return -Double.MIN_VALUE;
-          case 3:
-            return Double.MAX_VALUE;
-          case 4:
-            return -Double.MAX_VALUE;
-          case 5:
-            return Double.NEGATIVE_INFINITY;
-          case 6:
-            return Double.POSITIVE_INFINITY;
-          case 7:
-            return 0.0D;
-          case 8:
-            return Double.NaN;
-          default:
-            return random.nextDouble();
-        }
-
-      case DATE:
-        // this will include negative values (dates before 1970-01-01)
-        return random.nextInt() % ABOUT_380_YEARS_IN_DAYS;
-
-      case TIME:
-        return (random.nextLong() & Integer.MAX_VALUE) % ONE_DAY_IN_MICROS;
-
-      case TIMESTAMP:
-        return random.nextLong() % FIFTY_YEARS_IN_MICROS;
-
-      case STRING:
-        return randomString(random);
-
-      case UUID:
-        byte[] uuidBytes = new byte[16];
-        random.nextBytes(uuidBytes);
-        // this will hash the uuidBytes
-        return uuidBytes;
-
-      case FIXED:
-        byte[] fixed = new byte[((Types.FixedType) primitive).length()];
-        random.nextBytes(fixed);
-        return fixed;
-
-      case BINARY:
-        byte[] binary = new byte[random.nextInt(50)];
-        random.nextBytes(binary);
-        return binary;
-
-      case DECIMAL:
-        Types.DecimalType type = (Types.DecimalType) primitive;
-        BigInteger unscaled = randomUnscaled(type.precision(), random);
-        return new BigDecimal(unscaled, type.scale());
-
-      default:
-        throw new IllegalArgumentException(
-            "Cannot generate random value for unknown type: " + primitive);
-    }
-  }
-
-  private static final long FIFTY_YEARS_IN_MICROS =
-      (50L * (365 * 3 + 366) * 24 * 60 * 60 * 1_000_000) / 4;
-  private static final int ABOUT_380_YEARS_IN_DAYS = 380 * 365;
-  private static final long ONE_DAY_IN_MICROS = 24 * 60 * 60 * 1_000_000L;
-  private static final String CHARS =
-      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-.!?";
-
-  private static Utf8 randomString(Random random) {
-    int length = random.nextInt(50);
-    byte[] buffer = new byte[length];
-
-    for (int i = 0; i < length; i += 1) {
-      buffer[i] = (byte) CHARS.charAt(random.nextInt(CHARS.length()));
-    }
-
-    return new Utf8(buffer);
-  }
-
-  private static final String DIGITS = "0123456789";
-
-  private static BigInteger randomUnscaled(int precision, Random random) {
-    int length = random.nextInt(precision);
-    if (length == 0) {
-      return BigInteger.ZERO;
-    }
-
-    StringBuilder sb = new StringBuilder();
-    for (int i = 0; i < length; i += 1) {
-      sb.append(DIGITS.charAt(random.nextInt(DIGITS.length())));
-    }
-
-    return new BigInteger(sb.toString());
   }
 }

--- a/data/src/test/java/org/apache/iceberg/data/RandomGenericData.java
+++ b/data/src/test/java/org/apache/iceberg/data/RandomGenericData.java
@@ -19,13 +19,8 @@
 
 package org.apache.iceberg.data;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
@@ -41,6 +36,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.RandomUtil;
 
 import static java.time.temporal.ChronoUnit.MICROS;
 
@@ -142,174 +138,26 @@ public class RandomGenericData {
 
     @Override
     public Object primitive(Type.PrimitiveType primitive) {
-      Object result = generatePrimitive(primitive, random);
+      Object result = RandomUtil.generatePrimitive(primitive, random);
       switch (primitive.typeId()) {
         case BINARY:
           return ByteBuffer.wrap((byte[]) result);
         case UUID:
           return UUID.nameUUIDFromBytes((byte[]) result);
+        case TIMESTAMP:
+          Types.TimestampType ts = (Types.TimestampType) primitive;
+          if (ts.shouldAdjustToUTC()) {
+            return EPOCH.plus(random.nextLong() % FIFTY_YEARS_IN_MICROS, MICROS);
+          } else {
+            return EPOCH.plus(random.nextLong() % FIFTY_YEARS_IN_MICROS, MICROS).toLocalDateTime();
+          }
         default:
           return result;
       }
     }
   }
 
-  @SuppressWarnings("RandomModInteger")
-  private static Object generatePrimitive(Type.PrimitiveType primitive, Random random) {
-    int choice = random.nextInt(20);
-
-    switch (primitive.typeId()) {
-      case BOOLEAN:
-        return choice < 10;
-
-      case INTEGER:
-        switch (choice) {
-          case 1:
-            return Integer.MIN_VALUE;
-          case 2:
-            return Integer.MAX_VALUE;
-          case 3:
-            return 0;
-          default:
-            return random.nextInt();
-        }
-
-      case LONG:
-        switch (choice) {
-          case 1:
-            return Long.MIN_VALUE;
-          case 2:
-            return Long.MAX_VALUE;
-          case 3:
-            return 0L;
-          default:
-            return random.nextLong();
-        }
-
-      case FLOAT:
-        switch (choice) {
-          case 1:
-            return Float.MIN_VALUE;
-          case 2:
-            return -Float.MIN_VALUE;
-          case 3:
-            return Float.MAX_VALUE;
-          case 4:
-            return -Float.MAX_VALUE;
-          case 5:
-            return Float.NEGATIVE_INFINITY;
-          case 6:
-            return Float.POSITIVE_INFINITY;
-          case 7:
-            return 0.0F;
-          case 8:
-            return Float.NaN;
-          default:
-            return random.nextFloat();
-        }
-
-      case DOUBLE:
-        switch (choice) {
-          case 1:
-            return Double.MIN_VALUE;
-          case 2:
-            return -Double.MIN_VALUE;
-          case 3:
-            return Double.MAX_VALUE;
-          case 4:
-            return -Double.MAX_VALUE;
-          case 5:
-            return Double.NEGATIVE_INFINITY;
-          case 6:
-            return Double.POSITIVE_INFINITY;
-          case 7:
-            return 0.0D;
-          case 8:
-            return Double.NaN;
-          default:
-            return random.nextDouble();
-        }
-
-      case DATE:
-        // this will include negative values (dates before 1970-01-01)
-        return EPOCH_DAY.plusDays(random.nextInt() % ABOUT_380_YEARS_IN_DAYS);
-
-      case TIME:
-        return LocalTime.ofNanoOfDay(
-            ((random.nextLong() & Integer.MAX_VALUE) % ONE_DAY_IN_MICROS) * 1000);
-
-      case TIMESTAMP:
-        Types.TimestampType ts = (Types.TimestampType) primitive;
-        if (ts.shouldAdjustToUTC()) {
-          return EPOCH.plus(random.nextLong() % FIFTY_YEARS_IN_MICROS, MICROS);
-        } else {
-          return EPOCH.plus(random.nextLong() % FIFTY_YEARS_IN_MICROS, MICROS).toLocalDateTime();
-        }
-
-      case STRING:
-        return randomString(random);
-
-      case UUID:
-        byte[] uuidBytes = new byte[16];
-        random.nextBytes(uuidBytes);
-        // this will hash the uuidBytes
-        return uuidBytes;
-
-      case FIXED:
-        byte[] fixed = new byte[((Types.FixedType) primitive).length()];
-        random.nextBytes(fixed);
-        return fixed;
-
-      case BINARY:
-        byte[] binary = new byte[random.nextInt(50)];
-        random.nextBytes(binary);
-        return binary;
-
-      case DECIMAL:
-        Types.DecimalType type = (Types.DecimalType) primitive;
-        BigInteger unscaled = randomUnscaled(type.precision(), random);
-        return new BigDecimal(unscaled, type.scale());
-
-      default:
-        throw new IllegalArgumentException(
-            "Cannot generate random value for unknown type: " + primitive);
-    }
-  }
-
   private static final OffsetDateTime EPOCH = Instant.ofEpochSecond(0).atOffset(ZoneOffset.UTC);
-  private static final LocalDate EPOCH_DAY = EPOCH.toLocalDate();
-
   private static final long FIFTY_YEARS_IN_MICROS =
       (50L * (365 * 3 + 366) * 24 * 60 * 60 * 1_000_000) / 4;
-  private static final int ABOUT_380_YEARS_IN_DAYS = 380 * 365;
-  private static final long ONE_DAY_IN_MICROS = 24 * 60 * 60 * 1_000_000L;
-  private static final String CHARS =
-      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-.!?";
-
-  private static String randomString(Random random) {
-    int length = random.nextInt(50);
-    byte[] buffer = new byte[length];
-
-    for (int i = 0; i < length; i += 1) {
-      buffer[i] = (byte) CHARS.charAt(random.nextInt(CHARS.length()));
-    }
-
-    return new String(buffer, StandardCharsets.UTF_8);
-  }
-
-  private static final String DIGITS = "0123456789";
-
-  private static BigInteger randomUnscaled(int precision, Random random) {
-    int length = random.nextInt(precision);
-    if (length == 0) {
-      return BigInteger.ZERO;
-    }
-
-    StringBuilder sb = new StringBuilder();
-    for (int i = 0; i < length; i += 1) {
-      sb.append(DIGITS.charAt(random.nextInt(DIGITS.length())));
-    }
-
-    return new BigInteger(sb.toString());
-  }
 }

--- a/data/src/test/java/org/apache/iceberg/data/RandomGenericData.java
+++ b/data/src/test/java/org/apache/iceberg/data/RandomGenericData.java
@@ -21,6 +21,8 @@ package org.apache.iceberg.data;
 
 import java.nio.ByteBuffer;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
@@ -144,12 +146,16 @@ public class RandomGenericData {
           return ByteBuffer.wrap((byte[]) result);
         case UUID:
           return UUID.nameUUIDFromBytes((byte[]) result);
+        case DATE:
+          return EPOCH_DAY.plusDays((Integer) result);
+        case TIME:
+          return LocalTime.ofNanoOfDay((long) result * 1000);
         case TIMESTAMP:
           Types.TimestampType ts = (Types.TimestampType) primitive;
           if (ts.shouldAdjustToUTC()) {
-            return EPOCH.plus(random.nextLong() % FIFTY_YEARS_IN_MICROS, MICROS);
+            return EPOCH.plus((long) result, MICROS);
           } else {
-            return EPOCH.plus(random.nextLong() % FIFTY_YEARS_IN_MICROS, MICROS).toLocalDateTime();
+            return EPOCH.plus((long) result, MICROS).toLocalDateTime();
           }
         default:
           return result;
@@ -158,6 +164,5 @@ public class RandomGenericData {
   }
 
   private static final OffsetDateTime EPOCH = Instant.ofEpochSecond(0).atOffset(ZoneOffset.UTC);
-  private static final long FIFTY_YEARS_IN_MICROS =
-      (50L * (365 * 3 + 366) * 24 * 60 * 60 * 1_000_000) / 4;
+  private static final LocalDate EPOCH_DAY = EPOCH.toLocalDate();
 }

--- a/spark/src/test/java/org/apache/iceberg/spark/data/RandomData.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/RandomData.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.spark.data;
 
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.List;
@@ -40,6 +39,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.RandomUtil;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.catalyst.util.ArrayBasedMapData;
@@ -183,7 +183,7 @@ public class RandomData {
 
     @Override
     public Object primitive(Type.PrimitiveType primitive) {
-      Object result = generatePrimitive(primitive, random);
+      Object result = RandomUtil.generatePrimitive(primitive, random);
       // For the primitives that Avro needs a different type than Spark, fix
       // them here.
       switch (primitive.typeId()) {
@@ -288,158 +288,15 @@ public class RandomData {
 
     @Override
     public Object primitive(Type.PrimitiveType primitive) {
-      return generatePrimitive(primitive, random);
+      Object obj = RandomUtil.generatePrimitive(primitive, random);
+      switch (primitive.typeId()) {
+        case STRING:
+          return UTF8String.fromString((String) obj);
+        case DECIMAL:
+          return Decimal.apply((BigDecimal) obj);
+        default:
+          return obj;
+      }
     }
-  }
-
-  @SuppressWarnings("RandomModInteger")
-  private static Object generatePrimitive(Type.PrimitiveType primitive,
-                                         Random random) {
-    int choice = random.nextInt(20);
-
-    switch (primitive.typeId()) {
-      case BOOLEAN:
-        return choice < 10;
-
-      case INTEGER:
-        switch (choice) {
-          case 1:
-            return Integer.MIN_VALUE;
-          case 2:
-            return Integer.MAX_VALUE;
-          case 3:
-            return 0;
-          default:
-            return random.nextInt();
-        }
-
-      case LONG:
-        switch (choice) {
-          case 1:
-            return Long.MIN_VALUE;
-          case 2:
-            return Long.MAX_VALUE;
-          case 3:
-            return 0L;
-          default:
-            return random.nextLong();
-        }
-
-      case FLOAT:
-        switch (choice) {
-          case 1:
-            return Float.MIN_VALUE;
-          case 2:
-            return -Float.MIN_VALUE;
-          case 3:
-            return Float.MAX_VALUE;
-          case 4:
-            return -Float.MAX_VALUE;
-          case 5:
-            return Float.NEGATIVE_INFINITY;
-          case 6:
-            return Float.POSITIVE_INFINITY;
-          case 7:
-            return 0.0F;
-          case 8:
-            return Float.NaN;
-          default:
-            return random.nextFloat();
-        }
-
-      case DOUBLE:
-        switch (choice) {
-          case 1:
-            return Double.MIN_VALUE;
-          case 2:
-            return -Double.MIN_VALUE;
-          case 3:
-            return Double.MAX_VALUE;
-          case 4:
-            return -Double.MAX_VALUE;
-          case 5:
-            return Double.NEGATIVE_INFINITY;
-          case 6:
-            return Double.POSITIVE_INFINITY;
-          case 7:
-            return 0.0D;
-          case 8:
-            return Double.NaN;
-          default:
-            return random.nextDouble();
-        }
-
-      case DATE:
-        // this will include negative values (dates before 1970-01-01)
-        return random.nextInt() % ABOUT_380_YEARS_IN_DAYS;
-
-      case TIME:
-        return (random.nextLong() & Integer.MAX_VALUE) % ONE_DAY_IN_MICROS;
-
-      case TIMESTAMP:
-        return random.nextLong() % FIFTY_YEARS_IN_MICROS;
-
-      case STRING:
-        return randomString(random);
-
-      case UUID:
-        byte[] uuidBytes = new byte[16];
-        random.nextBytes(uuidBytes);
-        // this will hash the uuidBytes
-        return uuidBytes;
-
-      case FIXED:
-        byte[] fixed = new byte[((Types.FixedType) primitive).length()];
-        random.nextBytes(fixed);
-        return fixed;
-
-      case BINARY:
-        byte[] binary = new byte[random.nextInt(50)];
-        random.nextBytes(binary);
-        return binary;
-
-      case DECIMAL:
-        Types.DecimalType type = (Types.DecimalType) primitive;
-        BigInteger unscaled = randomUnscaled(type.precision(), random);
-        return Decimal.apply(new BigDecimal(unscaled, type.scale()));
-
-      default:
-        throw new IllegalArgumentException(
-            "Cannot generate random value for unknown type: " + primitive);
-    }
-  }
-
-  private static final long FIFTY_YEARS_IN_MICROS =
-      (50L * (365 * 3 + 366) * 24 * 60 * 60 * 1_000_000) / 4;
-  private static final int ABOUT_380_YEARS_IN_DAYS = 380 * 365;
-  private static final long ONE_DAY_IN_MICROS = 24 * 60 * 60 * 1_000_000L;
-  private static final String CHARS =
-      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-.!?";
-
-  private static UTF8String randomString(Random random) {
-    int length = random.nextInt(50);
-    byte[] buffer = new byte[length];
-
-    for (int i = 0; i < length; i += 1) {
-      buffer[i] = (byte) CHARS.charAt(random.nextInt(CHARS.length()));
-    }
-
-    return UTF8String.fromBytes(buffer);
-  }
-
-  private static final String DIGITS = "0123456789";
-
-  private static BigInteger randomUnscaled(int precision, Random random) {
-    int length = random.nextInt(precision);
-    if (length == 0) {
-      return BigInteger.ZERO;
-    }
-
-    StringBuilder sb = new StringBuilder();
-    for (int i = 0; i < length; i += 1) {
-      sb.append(DIGITS.charAt(random.nextInt(DIGITS.length())));
-    }
-
-    return new BigInteger(sb.toString());
   }
 }


### PR DESCRIPTION
When I try to pull request the flink parquet reader & writer (https://github.com/apache/iceberg/pull/1096),  I scanned the unit test and found that the RandomData was copied and pasted in several unit test files. So I made this pull request to put it into the utility class and let the unit test files share it. 