### PR TITLE
Support DeleteFile in MergingSnapshotProducer

### DIFF
--- a/api/src/main/java/org/apache/iceberg/RowDelta.java
+++ b/api/src/main/java/org/apache/iceberg/RowDelta.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+/**
+ * API for encoding row-level changes to a table.
+ * <p>
+ * This API accumulates data and delete file changes, produces a new {@link Snapshot} of the table, and commits
+ * that snapshot as the current.
+ * <p>
+ * When committing, these changes will be applied to the latest table snapshot. Commit conflicts
+ * will be resolved by applying the changes to the new latest snapshot and reattempting the commit.
+ */
+public interface RowDelta extends SnapshotUpdate<RowDelta> {
+  /**
+   * Add a {@link DataFile} to the table.
+   *
+   * @param inserts a data file of rows to insert
+   * @return this for method chaining
+   */
+  RowDelta addRows(DataFile inserts);
+
+  /**
+   * Add a {@link DeleteFile} to the table.
+   *
+   * @param deletes a delete file of rows to delete
+   * @return this for method chaining
+   */
+  RowDelta addDeletes(DeleteFile deletes);
+}

--- a/api/src/main/java/org/apache/iceberg/Table.java
+++ b/api/src/main/java/org/apache/iceberg/Table.java
@@ -175,6 +175,13 @@ public interface Table {
   OverwriteFiles newOverwrite();
 
   /**
+   * Create a new {@link RowDelta row-level delta API} to remove or replace rows in existing data files.
+   *
+   * @return a new {@link RowDelta}
+   */
+  RowDelta newRowDelta();
+
+  /**
    * Not recommended: Create a new {@link ReplacePartitions replace partitions API} to dynamically
    * overwrite partitions in the table with new data.
    * <p>

--- a/api/src/main/java/org/apache/iceberg/Transaction.java
+++ b/api/src/main/java/org/apache/iceberg/Transaction.java
@@ -99,6 +99,13 @@ public interface Transaction {
   OverwriteFiles newOverwrite();
 
   /**
+   * Create a new {@link RowDelta row-level delta API} to remove or replace rows in existing data files.
+   *
+   * @return a new {@link RowDelta}
+   */
+  RowDelta newRowDelta();
+
+  /**
    * Not recommended: Create a new {@link ReplacePartitions replace partitions API} to dynamically
    * overwrite partitions in the table with new data.
    * <p>

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -128,6 +128,11 @@ abstract class BaseMetadataTable implements Table {
   }
 
   @Override
+  public RowDelta newRowDelta() {
+    throw new UnsupportedOperationException("Cannot remove or replace rows in a metadata table");
+  }
+
+  @Override
   public ReplacePartitions newReplacePartitions() {
     throw new UnsupportedOperationException("Cannot replace partitions in a metadata table");
   }

--- a/core/src/main/java/org/apache/iceberg/BaseRowDelta.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRowDelta.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+public class BaseRowDelta extends MergingSnapshotProducer<RowDelta> implements RowDelta {
+  public BaseRowDelta(String tableName, TableOperations ops) {
+    super(tableName, ops);
+  }
+
+  @Override
+  protected BaseRowDelta self() {
+    return this;
+  }
+
+  @Override
+  protected String operation() {
+    return DataOperations.OVERWRITE;
+  }
+
+  @Override
+  public RowDelta addRows(DataFile inserts) {
+    add(inserts);
+    return this;
+  }
+
+  @Override
+  public RowDelta addDeletes(DeleteFile deletes) {
+    add(deletes);
+    return this;
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/BaseTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTable.java
@@ -140,6 +140,11 @@ public class BaseTable implements Table, HasTableOperations {
   }
 
   @Override
+  public RowDelta newRowDelta() {
+    return new BaseRowDelta(name, ops);
+  }
+
+  @Override
   public ReplacePartitions newReplacePartitions() {
     return new BaseReplacePartitions(name, ops);
   }

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -163,6 +163,15 @@ class BaseTransaction implements Transaction {
   }
 
   @Override
+  public RowDelta newRowDelta() {
+    checkLastOperationCommitted("RowDelta");
+    RowDelta delta = new BaseRowDelta(tableName, transactionOps);
+    delta.deleteWith(enqueueDelete);
+    updates.add(delta);
+    return delta;
+  }
+
+  @Override
   public ReplacePartitions newReplacePartitions() {
     checkLastOperationCommitted("ReplacePartitions");
     ReplacePartitions replacePartitions = new BaseReplacePartitions(tableName, transactionOps);
@@ -565,6 +574,11 @@ class BaseTransaction implements Transaction {
     @Override
     public OverwriteFiles newOverwrite() {
       return BaseTransaction.this.newOverwrite();
+    }
+
+    @Override
+    public RowDelta newRowDelta() {
+      return BaseTransaction.this.newRowDelta();
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/CommitCallbackTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/CommitCallbackTransaction.java
@@ -78,6 +78,11 @@ class CommitCallbackTransaction implements Transaction {
   }
 
   @Override
+  public RowDelta newRowDelta() {
+    return wrapped.newRowDelta();
+  }
+
+  @Override
   public ReplacePartitions newReplacePartitions() {
     return wrapped.newReplacePartitions();
   }

--- a/core/src/main/java/org/apache/iceberg/DataFiles.java
+++ b/core/src/main/java/org/apache/iceberg/DataFiles.java
@@ -37,11 +37,11 @@ public class DataFiles {
 
   private DataFiles() {}
 
-  private static PartitionData newPartitionData(PartitionSpec spec) {
+  static PartitionData newPartitionData(PartitionSpec spec) {
     return new PartitionData(spec.partitionType());
   }
 
-  private static PartitionData copyPartitionData(PartitionSpec spec, StructLike partitionData, PartitionData reuse) {
+  static PartitionData copyPartitionData(PartitionSpec spec, StructLike partitionData, PartitionData reuse) {
     PartitionData data = reuse;
     if (data == null) {
       data = newPartitionData(spec);
@@ -56,7 +56,7 @@ public class DataFiles {
     return data;
   }
 
-  private static PartitionData fillFromPath(PartitionSpec spec, String partitionPath, PartitionData reuse) {
+  static PartitionData fillFromPath(PartitionSpec spec, String partitionPath, PartitionData reuse) {
     PartitionData data = reuse;
     if (data == null) {
       data = newPartitionData(spec);

--- a/core/src/main/java/org/apache/iceberg/FileMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/FileMetadata.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.nio.ByteBuffer;
+import java.util.Locale;
+import java.util.Map;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.iceberg.encryption.EncryptedOutputFile;
+import org.apache.iceberg.encryption.EncryptionKeyMetadata;
+import org.apache.iceberg.hadoop.HadoopInputFile;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.ByteBuffers;
+
+class FileMetadata {
+  private FileMetadata() {
+  }
+
+  public static Builder deleteFileBuilder(PartitionSpec spec) {
+    return new Builder(spec);
+  }
+
+  static Builder deleteFileBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private final PartitionSpec spec;
+    private final boolean isPartitioned;
+    private FileContent content = null;
+    private PartitionData partitionData;
+    private String filePath = null;
+    private FileFormat format = null;
+    private long recordCount = -1L;
+    private long fileSizeInBytes = -1L;
+
+    // optional fields
+    private Map<Integer, Long> columnSizes = null;
+    private Map<Integer, Long> valueCounts = null;
+    private Map<Integer, Long> nullValueCounts = null;
+    private Map<Integer, ByteBuffer> lowerBounds = null;
+    private Map<Integer, ByteBuffer> upperBounds = null;
+    private ByteBuffer keyMetadata = null;
+
+    Builder() {
+      this.spec = null;
+      this.partitionData = null;
+      this.isPartitioned = false;
+    }
+
+    Builder(PartitionSpec spec) {
+      this.spec = spec;
+      this.isPartitioned = spec.fields().size() > 0;
+      this.partitionData = isPartitioned ? DataFiles.newPartitionData(spec) : null;
+    }
+
+    public void clear() {
+      if (isPartitioned) {
+        partitionData.clear();
+      }
+      this.filePath = null;
+      this.format = null;
+      this.recordCount = -1L;
+      this.fileSizeInBytes = -1L;
+      this.columnSizes = null;
+      this.valueCounts = null;
+      this.nullValueCounts = null;
+      this.lowerBounds = null;
+      this.upperBounds = null;
+    }
+
+    public Builder copy(DeleteFile toCopy) {
+      if (isPartitioned) {
+        this.partitionData = DataFiles.copyPartitionData(spec, toCopy.partition(), partitionData);
+      }
+      this.content = toCopy.content();
+      this.filePath = toCopy.path().toString();
+      this.format = toCopy.format();
+      this.recordCount = toCopy.recordCount();
+      this.fileSizeInBytes = toCopy.fileSizeInBytes();
+      this.columnSizes = toCopy.columnSizes();
+      this.valueCounts = toCopy.valueCounts();
+      this.nullValueCounts = toCopy.nullValueCounts();
+      this.lowerBounds = toCopy.lowerBounds();
+      this.upperBounds = toCopy.upperBounds();
+      this.keyMetadata = toCopy.keyMetadata() == null ? null
+          : ByteBuffers.copy(toCopy.keyMetadata());
+      return this;
+    }
+
+    public Builder ofPositionDeletes() {
+      this.content = FileContent.POSITION_DELETES;
+      return this;
+    }
+
+    public Builder ofEqualityDeletes() {
+      this.content = FileContent.EQUALITY_DELETES;
+      return this;
+    }
+
+    public Builder withStatus(FileStatus stat) {
+      this.filePath = stat.getPath().toString();
+      this.fileSizeInBytes = stat.getLen();
+      return this;
+    }
+
+    public Builder withInputFile(InputFile file) {
+      if (file instanceof HadoopInputFile) {
+        return withStatus(((HadoopInputFile) file).getStat());
+      }
+
+      this.filePath = file.location();
+      this.fileSizeInBytes = file.getLength();
+      return this;
+    }
+
+    public Builder withEncryptedOutputFile(EncryptedOutputFile newEncryptedFile) {
+      withInputFile(newEncryptedFile.encryptingOutputFile().toInputFile());
+      withEncryptionKeyMetadata(newEncryptedFile.keyMetadata());
+      return this;
+    }
+
+    public Builder withPath(String newFilePath) {
+      this.filePath = newFilePath;
+      return this;
+    }
+
+    public Builder withFormat(String newFormat) {
+      this.format = FileFormat.valueOf(newFormat.toUpperCase(Locale.ENGLISH));
+      return this;
+    }
+
+    public Builder withFormat(FileFormat newFormat) {
+      this.format = newFormat;
+      return this;
+    }
+
+    public Builder withPartition(StructLike newPartition) {
+      this.partitionData = DataFiles.copyPartitionData(spec, newPartition, partitionData);
+      return this;
+    }
+
+    public Builder withRecordCount(long newRecordCount) {
+      this.recordCount = newRecordCount;
+      return this;
+    }
+
+    public Builder withFileSizeInBytes(long newFileSizeInBytes) {
+      this.fileSizeInBytes = newFileSizeInBytes;
+      return this;
+    }
+
+    public Builder withPartitionPath(String newPartitionPath) {
+      Preconditions.checkArgument(isPartitioned || newPartitionPath.isEmpty(),
+          "Cannot add partition data for an unpartitioned table");
+      if (!newPartitionPath.isEmpty()) {
+        this.partitionData = DataFiles.fillFromPath(spec, newPartitionPath, partitionData);
+      }
+      return this;
+    }
+
+    public Builder withMetrics(Metrics metrics) {
+      // check for null to avoid NPE when unboxing
+      this.recordCount = metrics.recordCount() == null ? -1 : metrics.recordCount();
+      this.columnSizes = metrics.columnSizes();
+      this.valueCounts = metrics.valueCounts();
+      this.nullValueCounts = metrics.nullValueCounts();
+      this.lowerBounds = metrics.lowerBounds();
+      this.upperBounds = metrics.upperBounds();
+      return this;
+    }
+
+    public Builder withEncryptionKeyMetadata(ByteBuffer newKeyMetadata) {
+      this.keyMetadata = newKeyMetadata;
+      return this;
+    }
+
+    public Builder withEncryptionKeyMetadata(EncryptionKeyMetadata newKeyMetadata) {
+      return withEncryptionKeyMetadata(newKeyMetadata.buffer());
+    }
+
+    public DeleteFile build() {
+      Preconditions.checkArgument(filePath != null, "File path is required");
+      if (format == null) {
+        this.format = FileFormat.fromFileName(filePath);
+      }
+      Preconditions.checkArgument(content != null, "Delete type is required");
+      Preconditions.checkArgument(format != null, "File format is required");
+      Preconditions.checkArgument(fileSizeInBytes >= 0, "File size is required");
+      Preconditions.checkArgument(recordCount >= 0, "Record count is required");
+
+      return new GenericDeleteFile(
+          content, filePath, format, isPartitioned ? DataFiles.copy(spec, partitionData) : null,
+          fileSizeInBytes, new Metrics(
+          recordCount, columnSizes, valueCounts, nullValueCounts, lowerBounds, upperBounds),
+          keyMetadata);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
@@ -385,7 +385,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
           F file = entry.file();
           boolean fileDelete = deletePaths.contains(file.path()) ||
               dropPartitions.contains(partitionWrapper.set(file.partition())) ||
-              (isDelete && entry.sequenceNumber() < minSequenceNumber);
+              (isDelete && entry.sequenceNumber() > 0 && entry.sequenceNumber() < minSequenceNumber);
           if (entry.status() != ManifestEntry.Status.DELETED) {
             if (fileDelete || inclusive.eval(file.partition())) {
               ValidationException.check(

--- a/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
@@ -69,6 +69,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
   private final Set<StructLikeWrapper> deleteFilePartitions = Sets.newHashSet();
   private final Set<StructLikeWrapper> dropPartitions = Sets.newHashSet();
   private Expression deleteExpression = Expressions.alwaysFalse();
+  private long minSequenceNumber = 0;
   private boolean hasPathOnlyDeletes = false;
   private boolean failAnyDelete = false;
   private boolean failMissingDeletePaths = false;
@@ -113,6 +114,21 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
     Preconditions.checkNotNull(partition, "Cannot delete files in invalid partition: null");
     invalidateFilteredCache();
     dropPartitions.add(StructLikeWrapper.wrap(partition));
+  }
+
+  /**
+   * Set the sequence number used to remove old delete files.
+   * <p>
+   * Delete files with a sequence number older than the given value will be removed. By setting this to the sequence
+   * number of the oldest data file in the table, this will continuously remove delete files that are no longer needed
+   * because deletes cannot match any existing rows in the table.
+   *
+   * @param sequenceNumber a sequence number used to remove old delete files
+   */
+  protected void dropDeleteFilesOlderThan(long sequenceNumber) {
+    Preconditions.checkArgument(sequenceNumber >= 0,
+        "Invalid minimum data sequence number: %s", sequenceNumber);
+    this.minSequenceNumber = sequenceNumber;
   }
 
   /**
@@ -266,25 +282,19 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
     }
 
     try (ManifestReader<F> reader = newManifestReader(manifest)) {
-
-      // this is reused to compare file paths with the delete set
-      CharSequenceWrapper pathWrapper = CharSequenceWrapper.wrap("");
-
       // reused to compare file partitions with the drop set
       StructLikeWrapper partitionWrapper = StructLikeWrapper.wrap(null);
 
       // this assumes that the manifest doesn't have files to remove and streams through the
       // manifest without copying data. if a manifest does have a file to remove, this will break
       // out of the loop and move on to filtering the manifest.
-      boolean hasDeletedFiles =
-          manifestHasDeletedFiles(metricsEvaluator, reader, pathWrapper, partitionWrapper);
-
+      boolean hasDeletedFiles = manifestHasDeletedFiles(metricsEvaluator, reader, partitionWrapper);
       if (!hasDeletedFiles) {
         filteredManifests.put(manifest, manifest);
         return manifest;
       }
 
-      return filterManifestWithDeletedFiles(metricsEvaluator, manifest, reader, pathWrapper, partitionWrapper);
+      return filterManifestWithDeletedFiles(metricsEvaluator, manifest, reader, partitionWrapper);
 
     } catch (IOException e) {
       throw new RuntimeIOException("Failed to close manifest: " + manifest, e);
@@ -324,19 +334,23 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
       canContainDroppedFiles = false;
     }
 
-    return canContainExpressionDeletes || canContainDroppedPartitions || canContainDroppedFiles;
+    boolean canContainDropBySeq = manifest.content() == ManifestContent.DELETES &&
+        manifest.minSequenceNumber() < minSequenceNumber;
+
+    return canContainExpressionDeletes || canContainDroppedPartitions || canContainDroppedFiles || canContainDropBySeq;
   }
 
   private boolean manifestHasDeletedFiles(
-      StrictMetricsEvaluator metricsEvaluator, ManifestReader<F> reader,
-      CharSequenceWrapper pathWrapper, StructLikeWrapper partitionWrapper) {
+      StrictMetricsEvaluator metricsEvaluator, ManifestReader<F> reader, StructLikeWrapper partitionWrapper) {
+    boolean isDelete = reader.isDeleteManifestReader();
     Evaluator inclusive = inclusiveDeleteEvaluator(reader.spec());
     Evaluator strict = strictDeleteEvaluator(reader.spec());
     boolean hasDeletedFiles = false;
     for (ManifestEntry<F> entry : reader.entries()) {
       F file = entry.file();
-      boolean fileDelete = deletePaths.contains(pathWrapper.set(file.path())) ||
-          dropPartitions.contains(partitionWrapper.set(file.partition()));
+      boolean fileDelete = deletePaths.contains(file.path()) ||
+          dropPartitions.contains(partitionWrapper.set(file.partition())) ||
+          (isDelete && entry.sequenceNumber() > 0 && entry.sequenceNumber() < minSequenceNumber);
       if (fileDelete || inclusive.eval(file.partition())) {
         ValidationException.check(
             fileDelete || strict.eval(file.partition()) || metricsEvaluator.eval(file),
@@ -355,7 +369,8 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
 
   private ManifestFile filterManifestWithDeletedFiles(
       StrictMetricsEvaluator metricsEvaluator, ManifestFile manifest, ManifestReader<F> reader,
-      CharSequenceWrapper pathWrapper, StructLikeWrapper partitionWrapper) {
+      StructLikeWrapper partitionWrapper) {
+    boolean isDelete = reader.isDeleteManifestReader();
     Evaluator inclusive = inclusiveDeleteEvaluator(reader.spec());
     Evaluator strict = strictDeleteEvaluator(reader.spec());
     // when this point is reached, there is at least one file that will be deleted in the
@@ -368,8 +383,9 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
       try {
         reader.entries().forEach(entry -> {
           F file = entry.file();
-          boolean fileDelete = deletePaths.contains(pathWrapper.set(file.path())) ||
-              dropPartitions.contains(partitionWrapper.set(file.partition()));
+          boolean fileDelete = deletePaths.contains(file.path()) ||
+              dropPartitions.contains(partitionWrapper.set(file.partition())) ||
+              (isDelete && entry.sequenceNumber() < minSequenceNumber);
           if (entry.status() != ManifestEntry.Status.DELETED) {
             if (fileDelete || inclusive.eval(file.partition())) {
               ValidationException.check(

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -120,6 +120,10 @@ public class ManifestReader<F extends ContentFile<F>>
     this.fileSchema = new Schema(DataFile.getType(spec.partitionType()).fields());
   }
 
+  public boolean isDeleteManifestReader() {
+    return content == FileType.DELETE_FILES;
+  }
+
   public InputFile file() {
     return file;
   }

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -29,6 +29,8 @@ import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Predicate;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -47,71 +49,23 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
   private final SnapshotSummary.Builder summaryBuilder = SnapshotSummary.builder();
   private final ManifestMergeManager<DataFile> mergeManager;
   private final ManifestFilterManager<DataFile> filterManager;
+  private final ManifestMergeManager<DeleteFile> deleteMergeManager;
+  private final ManifestFilterManager<DeleteFile> deleteFilterManager;
   private final boolean snapshotIdInheritanceEnabled;
-
-  private class DataFileFilterManager extends ManifestFilterManager<DataFile> {
-    @Override
-    protected PartitionSpec spec(int specId) {
-      return ops.current().spec(specId);
-    }
-
-    @Override
-    protected void deleteFile(String location) {
-      MergingSnapshotProducer.this.deleteFile(location);
-    }
-
-    @Override
-    protected ManifestWriter<DataFile> newManifestWriter(PartitionSpec manifestSpec) {
-      return MergingSnapshotProducer.this.newManifestWriter(manifestSpec);
-    }
-
-    @Override
-    protected ManifestReader<DataFile> newManifestReader(ManifestFile manifest) {
-      return ManifestFiles.read(manifest, ops.io(), ops.current().specsById());
-    }
-  }
-
-  private class DataFileMergeManager extends ManifestMergeManager<DataFile> {
-    DataFileMergeManager(long targetSizeBytes, int minCountToMerge, boolean mergeEnabled) {
-      super(targetSizeBytes, minCountToMerge, mergeEnabled);
-    }
-
-    @Override
-    protected long snapshotId() {
-      return MergingSnapshotProducer.this.snapshotId();
-    }
-
-    @Override
-    protected PartitionSpec spec(int specId) {
-      return ops.current().spec(specId);
-    }
-
-    @Override
-    protected void deleteFile(String location) {
-      MergingSnapshotProducer.this.deleteFile(location);
-    }
-
-    @Override
-    protected ManifestWriter<DataFile> newManifestWriter(PartitionSpec manifestSpec) {
-      return MergingSnapshotProducer.this.newManifestWriter(manifestSpec);
-    }
-
-    @Override
-    protected ManifestReader<DataFile> newManifestReader(ManifestFile manifest) {
-      return ManifestFiles.read(manifest, ops.io(), ops.current().specsById());
-    }
-  }
 
   // update data
   private final List<DataFile> newFiles = Lists.newArrayList();
+  private final List<DeleteFile> newDeleteFiles = Lists.newArrayList();
   private final List<ManifestFile> appendManifests = Lists.newArrayList();
   private final List<ManifestFile> rewrittenAppendManifests = Lists.newArrayList();
   private final SnapshotSummary.Builder appendedManifestsSummary = SnapshotSummary.builder();
   private Expression deleteExpression = Expressions.alwaysFalse();
 
-  // cache the new manifest once it is written
+  // cache new manifests after writing
   private ManifestFile cachedNewManifest = null;
   private boolean hasNewFiles = false;
+  private ManifestFile cachedNewDeleteManifest = null;
+  private boolean hasNewDeleteFiles = false;
 
   MergingSnapshotProducer(String tableName, TableOperations ops) {
     super(ops);
@@ -126,6 +80,8 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
         .propertyAsBoolean(TableProperties.MANIFEST_MERGE_ENABLED, TableProperties.MANIFEST_MERGE_ENABLED_DEFAULT);
     this.mergeManager = new DataFileMergeManager(targetSizeBytes, minCountToMerge, mergeEnabled);
     this.filterManager = new DataFileFilterManager();
+    this.deleteMergeManager = new DeleteFileMergeManager(targetSizeBytes, minCountToMerge, mergeEnabled);
+    this.deleteFilterManager = new DeleteFileFilterManager();
     this.snapshotIdInheritanceEnabled = ops.current()
         .propertyAsBoolean(SNAPSHOT_ID_INHERITANCE_ENABLED, SNAPSHOT_ID_INHERITANCE_ENABLED_DEFAULT);
   }
@@ -151,10 +107,12 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
 
   protected void failAnyDelete() {
     filterManager.failAnyDelete();
+    deleteFilterManager.failAnyDelete();
   }
 
   protected void failMissingDeletePaths() {
     filterManager.failMissingDeletePaths();
+    deleteFilterManager.failMissingDeletePaths();
   }
 
   /**
@@ -166,31 +124,44 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
   protected void deleteByRowFilter(Expression expr) {
     this.deleteExpression = expr;
     filterManager.deleteByRowFilter(expr);
+    // if a delete file matches the row filter, then it can be deleted because the rows will also be deleted
+    deleteFilterManager.deleteByRowFilter(expr);
   }
 
   /**
    * Add a partition tuple to drop from the table during the delete phase.
    */
   protected void dropPartition(StructLike partition) {
+    // dropping the data in a partition also drops all deletes in the partition
     filterManager.dropPartition(partition);
+    deleteFilterManager.dropPartition(partition);
   }
 
   /**
-   * Add a specific path to be deleted in the new snapshot.
+   * Add a specific data file to be deleted in the new snapshot.
    */
   protected void delete(DataFile file) {
     filterManager.delete(file);
   }
 
   /**
-   * Add a specific path to be deleted in the new snapshot.
+   * Add a specific delete file to be deleted in the new snapshot.
    */
-  protected void delete(CharSequence path) {
-    filterManager.delete(path);
+  protected void delete(DeleteFile file) {
+    deleteFilterManager.delete(file);
   }
 
   /**
-   * Add a file to the new snapshot.
+   * Add a specific path to be deleted in the new snapshot.
+   */
+  protected void delete(CharSequence path) {
+    // because this is a location, it may be a data file or a delete file and must be added to both filter managers
+    filterManager.delete(path);
+    deleteFilterManager.delete(path);
+  }
+
+  /**
+   * Add a data file to the new snapshot.
    */
   protected void add(DataFile file) {
     hasNewFiles = true;
@@ -198,9 +169,19 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
   }
 
   /**
+   * Add a delete file to the new snapshot.
+   */
+  protected void add(DeleteFile file) {
+    hasNewDeleteFiles = true;
+    newDeleteFiles.add(file);
+  }
+
+  /**
    * Add all files in a manifest to the new snapshot.
    */
   protected void add(ManifestFile manifest) {
+    Preconditions.checkArgument(manifest.content() == ManifestContent.DATA,
+        "Cannot append delete manifest: %s", manifest);
     if (snapshotIdInheritanceEnabled && manifest.snapshotId() == null) {
       appendedManifestsSummary.addedManifest(manifest);
       appendManifests.add(manifest);
@@ -226,29 +207,36 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
 
   @Override
   public List<ManifestFile> apply(TableMetadata base) {
-    summaryBuilder.clear();
-    summaryBuilder.merge(appendedManifestsSummary);
-    Iterable<ManifestFile> newManifests = prepareNewManifests();
-
     Snapshot current = base.currentSnapshot();
 
     // filter any existing manifests
     List<ManifestFile> filtered = filterManager.filterManifests(
         base.schema(), current != null ? current.dataManifests() : null);
+    long minDataSequenceNumber = filtered.stream()
+        .map(ManifestFile::minSequenceNumber)
+        .filter(seq -> seq > 0) // filter out unassigned sequence numbers in rewritten manifests
+        .reduce(base.lastSequenceNumber(), Math::min);
+    deleteFilterManager.dropDeleteFilesOlderThan(minDataSequenceNumber);
+    List<ManifestFile> filteredDeletes = deleteFilterManager.filterManifests(
+        base.schema(), current != null ? current.deleteManifests() : null);
 
+    // only keep manifests that have live data files or that were written by this commit
+    Predicate<ManifestFile> shouldKeep = manifest ->
+        manifest.hasAddedFiles() || manifest.hasExistingFiles() || manifest.snapshotId() == snapshotId();
     Iterable<ManifestFile> unmergedManifests = Iterables.filter(
-        Iterables.concat(newManifests, filtered),
-        // only keep manifests that have live data files or that were written by this commit
-        manifest -> manifest.hasAddedFiles() || manifest.hasExistingFiles() || manifest.snapshotId() == snapshotId());
+        Iterables.concat(prepareNewManifests(), filtered), shouldKeep);
+    Iterable<ManifestFile> unmergedDeleteManifests = Iterables.filter(
+        Iterables.concat(prepareDeleteManifests(), filteredDeletes), shouldKeep);
 
-    summaryBuilder.merge(filterManager.buildSummary(unmergedManifests));
+    // update the snapshot summary
+    summaryBuilder.clear();
+    summaryBuilder.merge(appendedManifestsSummary);
+    summaryBuilder.merge(filterManager.buildSummary(filtered));
+    summaryBuilder.merge(deleteFilterManager.buildSummary(filteredDeletes));
 
     List<ManifestFile> manifests = Lists.newArrayList();
     Iterables.addAll(manifests, mergeManager.mergeManifests(unmergedManifests));
-
-    if (current != null) {
-      manifests.addAll(current.deleteManifests());
-    }
+    Iterables.addAll(manifests, deleteMergeManager.mergeManifests(unmergedDeleteManifests));
 
     return manifests;
   }
@@ -269,6 +257,11 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
     if (cachedNewManifest != null && !committed.contains(cachedNewManifest)) {
       deleteFile(cachedNewManifest.path());
       this.cachedNewManifest = null;
+    }
+
+    if (cachedNewDeleteManifest != null && !committed.contains(cachedNewDeleteManifest)) {
+      deleteFile(cachedNewDeleteManifest.path());
+      this.cachedNewDeleteManifest = null;
     }
 
     // rewritten manifests are always owned by the table
@@ -294,6 +287,8 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
   protected void cleanUncommitted(Set<ManifestFile> committed) {
     mergeManager.cleanUncommitted(committed);
     filterManager.cleanUncommitted(committed);
+    deleteMergeManager.cleanUncommitted(committed);
+    deleteFilterManager.cleanUncommitted(committed);
     cleanUncommittedAppends(committed);
   }
 
@@ -339,5 +334,144 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
     }
 
     return cachedNewManifest;
+  }
+
+  private Iterable<ManifestFile> prepareDeleteManifests() {
+    if (newDeleteFiles.isEmpty()) {
+      return ImmutableList.of();
+    }
+
+    return ImmutableList.of(newDeleteFilesAsManifest());
+  }
+
+  private ManifestFile newDeleteFilesAsManifest() {
+    if (hasNewDeleteFiles && cachedNewDeleteManifest != null) {
+      deleteFile(cachedNewDeleteManifest.path());
+      cachedNewDeleteManifest = null;
+    }
+
+    if (cachedNewDeleteManifest == null) {
+      try {
+        ManifestWriter<DeleteFile> writer = newDeleteManifestWriter(spec);
+        try {
+          writer.addAll(newDeleteFiles);
+        } finally {
+          writer.close();
+        }
+
+        this.cachedNewDeleteManifest = writer.toManifestFile();
+        this.hasNewDeleteFiles = false;
+      } catch (IOException e) {
+        throw new RuntimeIOException("Failed to close manifest writer", e);
+      }
+    }
+
+    return cachedNewDeleteManifest;
+  }
+
+  private class DataFileFilterManager extends ManifestFilterManager<DataFile> {
+    @Override
+    protected PartitionSpec spec(int specId) {
+      return ops.current().spec(specId);
+    }
+
+    @Override
+    protected void deleteFile(String location) {
+      MergingSnapshotProducer.this.deleteFile(location);
+    }
+
+    @Override
+    protected ManifestWriter<DataFile> newManifestWriter(PartitionSpec manifestSpec) {
+      return MergingSnapshotProducer.this.newManifestWriter(manifestSpec);
+    }
+
+    @Override
+    protected ManifestReader<DataFile> newManifestReader(ManifestFile manifest) {
+      return MergingSnapshotProducer.this.newManifestReader(manifest);
+    }
+  }
+
+  private class DataFileMergeManager extends ManifestMergeManager<DataFile> {
+    DataFileMergeManager(long targetSizeBytes, int minCountToMerge, boolean mergeEnabled) {
+      super(targetSizeBytes, minCountToMerge, mergeEnabled);
+    }
+
+    @Override
+    protected long snapshotId() {
+      return MergingSnapshotProducer.this.snapshotId();
+    }
+
+    @Override
+    protected PartitionSpec spec(int specId) {
+      return ops.current().spec(specId);
+    }
+
+    @Override
+    protected void deleteFile(String location) {
+      MergingSnapshotProducer.this.deleteFile(location);
+    }
+
+    @Override
+    protected ManifestWriter<DataFile> newManifestWriter(PartitionSpec manifestSpec) {
+      return MergingSnapshotProducer.this.newManifestWriter(manifestSpec);
+    }
+
+    @Override
+    protected ManifestReader<DataFile> newManifestReader(ManifestFile manifest) {
+      return MergingSnapshotProducer.this.newManifestReader(manifest);
+    }
+  }
+
+  private class DeleteFileFilterManager extends ManifestFilterManager<DeleteFile> {
+    @Override
+    protected PartitionSpec spec(int specId) {
+      return ops.current().spec(specId);
+    }
+
+    @Override
+    protected void deleteFile(String location) {
+      MergingSnapshotProducer.this.deleteFile(location);
+    }
+
+    @Override
+    protected ManifestWriter<DeleteFile> newManifestWriter(PartitionSpec manifestSpec) {
+      return MergingSnapshotProducer.this.newDeleteManifestWriter(manifestSpec);
+    }
+
+    @Override
+    protected ManifestReader<DeleteFile> newManifestReader(ManifestFile manifest) {
+      return MergingSnapshotProducer.this.newDeleteManifestReader(manifest);
+    }
+  }
+
+  private class DeleteFileMergeManager extends ManifestMergeManager<DeleteFile> {
+    DeleteFileMergeManager(long targetSizeBytes, int minCountToMerge, boolean mergeEnabled) {
+      super(targetSizeBytes, minCountToMerge, mergeEnabled);
+    }
+
+    @Override
+    protected long snapshotId() {
+      return MergingSnapshotProducer.this.snapshotId();
+    }
+
+    @Override
+    protected PartitionSpec spec(int specId) {
+      return ops.current().spec(specId);
+    }
+
+    @Override
+    protected void deleteFile(String location) {
+      MergingSnapshotProducer.this.deleteFile(location);
+    }
+
+    @Override
+    protected ManifestWriter<DeleteFile> newManifestWriter(PartitionSpec manifestSpec) {
+      return MergingSnapshotProducer.this.newDeleteManifestWriter(manifestSpec);
+    }
+
+    @Override
+    protected ManifestReader<DeleteFile> newManifestReader(ManifestFile manifest) {
+      return MergingSnapshotProducer.this.newDeleteManifestReader(manifest);
+    }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -153,12 +153,11 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
   }
 
   /**
-   * Add a specific path to be deleted in the new snapshot.
+   * Add a specific data path to be deleted in the new snapshot.
    */
   protected void delete(CharSequence path) {
-    // because this is a location, it may be a data file or a delete file and must be added to both filter managers
+    // this is an old call that never worked for delete files and can only be used to remove data files.
     filterManager.delete(path);
-    deleteFilterManager.delete(path);
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -335,6 +335,18 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
     return ManifestFiles.write(ops.current().formatVersion(), spec, newManifestOutput(), snapshotId());
   }
 
+  protected ManifestWriter<DeleteFile> newDeleteManifestWriter(PartitionSpec spec) {
+    return ManifestFiles.writeDeleteManifest(ops.current().formatVersion(), spec, newManifestOutput(), snapshotId());
+  }
+
+  protected ManifestReader<DataFile> newManifestReader(ManifestFile manifest) {
+    return ManifestFiles.read(manifest, ops.io(), ops.current().specsById());
+  }
+
+  protected ManifestReader<DeleteFile> newDeleteManifestReader(ManifestFile manifest) {
+    return ManifestFiles.readDeleteManifest(manifest, ops.io(), ops.current().specsById());
+  }
+
   protected long snapshotId() {
     if (snapshotId == null) {
       synchronized (this) {

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -206,7 +206,10 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
       // if there was no previous snapshot, default the summary to start totals at 0
       previousSummary = ImmutableMap.of(
           SnapshotSummary.TOTAL_RECORDS_PROP, "0",
-          SnapshotSummary.TOTAL_FILES_PROP, "0");
+          SnapshotSummary.TOTAL_DATA_FILES_PROP, "0",
+          SnapshotSummary.TOTAL_DELETE_FILES_PROP, "0",
+          SnapshotSummary.TOTAL_POS_DELETES_PROP, "0",
+          SnapshotSummary.TOTAL_EQ_DELETES_PROP, "0");
     }
 
     ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
@@ -218,8 +221,17 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
         builder, previousSummary, SnapshotSummary.TOTAL_RECORDS_PROP,
         summary, SnapshotSummary.ADDED_RECORDS_PROP, SnapshotSummary.DELETED_RECORDS_PROP);
     updateTotal(
-        builder, previousSummary, SnapshotSummary.TOTAL_FILES_PROP,
+        builder, previousSummary, SnapshotSummary.TOTAL_DATA_FILES_PROP,
         summary, SnapshotSummary.ADDED_FILES_PROP, SnapshotSummary.DELETED_FILES_PROP);
+    updateTotal(
+        builder, previousSummary, SnapshotSummary.TOTAL_DELETE_FILES_PROP,
+        summary, SnapshotSummary.ADDED_DELETE_FILES_PROP, SnapshotSummary.REMOVED_DELETE_FILES_PROP);
+    updateTotal(
+        builder, previousSummary, SnapshotSummary.TOTAL_POS_DELETES_PROP,
+        summary, SnapshotSummary.ADDED_POS_DELETES_PROP, SnapshotSummary.REMOVED_POS_DELETES_PROP);
+    updateTotal(
+        builder, previousSummary, SnapshotSummary.TOTAL_EQ_DELETES_PROP,
+        summary, SnapshotSummary.ADDED_EQ_DELETES_PROP, SnapshotSummary.REMOVED_EQ_DELETES_PROP);
 
     return builder.build();
   }

--- a/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
@@ -87,22 +87,6 @@ public class SnapshotSummary {
       this.deletedDuplicateFiles += increment;
     }
 
-    public void deletedFile(PartitionSpec spec, ContentFile<?> file) {
-      if (file instanceof DataFile) {
-        deletedFile(spec, (DataFile) file);
-      } else if (file instanceof DeleteFile) {
-        deletedFile(spec, (DeleteFile) file);
-      } else {
-        throw new IllegalArgumentException("Unsupported file type: " + file.getClass().getSimpleName());
-      }
-    }
-
-    public void deletedFile(PartitionSpec spec, DataFile file) {
-      changedPartitions.add(spec.partitionToPath(file.partition()));
-      this.deletedFiles += 1;
-      this.deletedRecords += file.recordCount();
-    }
-
     public void addedFile(PartitionSpec spec, DataFile file) {
       changedPartitions.add(spec.partitionToPath(file.partition()));
       this.addedFiles += 1;
@@ -117,6 +101,22 @@ public class SnapshotSummary {
       } else {
         this.addedEqDeletes += file.recordCount();
       }
+    }
+
+    public void deletedFile(PartitionSpec spec, ContentFile<?> file) {
+      if (file instanceof DataFile) {
+        deletedFile(spec, (DataFile) file);
+      } else if (file instanceof DeleteFile) {
+        deletedFile(spec, (DeleteFile) file);
+      } else {
+        throw new IllegalArgumentException("Unsupported file type: " + file.getClass().getSimpleName());
+      }
+    }
+
+    public void deletedFile(PartitionSpec spec, DataFile file) {
+      changedPartitions.add(spec.partitionToPath(file.partition()));
+      this.deletedFiles += 1;
+      this.deletedRecords += file.recordCount();
     }
 
     public void deletedFile(PartitionSpec spec, DeleteFile file) {

--- a/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
@@ -28,10 +28,19 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 public class SnapshotSummary {
   public static final String ADDED_FILES_PROP = "added-data-files";
   public static final String DELETED_FILES_PROP = "deleted-data-files";
-  public static final String TOTAL_FILES_PROP = "total-data-files";
+  public static final String TOTAL_DATA_FILES_PROP = "total-data-files";
+  public static final String ADDED_DELETE_FILES_PROP = "added-delete-files";
+  public static final String REMOVED_DELETE_FILES_PROP = "removed-delete-files";
+  public static final String TOTAL_DELETE_FILES_PROP = "total-delete-files";
   public static final String ADDED_RECORDS_PROP = "added-records";
   public static final String DELETED_RECORDS_PROP = "deleted-records";
   public static final String TOTAL_RECORDS_PROP = "total-records";
+  public static final String ADDED_POS_DELETES_PROP = "added-position-deletes";
+  public static final String REMOVED_POS_DELETES_PROP = "removed-position-deletes";
+  public static final String TOTAL_POS_DELETES_PROP = "total-position-deletes";
+  public static final String ADDED_EQ_DELETES_PROP = "added-equality-deletes";
+  public static final String REMOVED_EQ_DELETES_PROP = "removed-equality-deletes";
+  public static final String TOTAL_EQ_DELETES_PROP = "total-equality-deletes";
   public static final String DELETED_DUPLICATE_FILES = "deleted-duplicate-files";
   public static final String CHANGED_PARTITION_COUNT_PROP = "changed-partition-count";
   public static final String STAGED_WAP_ID_PROP = "wap.id";
@@ -50,9 +59,15 @@ public class SnapshotSummary {
     private Set<String> changedPartitions = Sets.newHashSet();
     private long addedFiles = 0L;
     private long deletedFiles = 0L;
+    private long addedDeleteFiles = 0L;
+    private long removedDeleteFiles = 0L;
     private long deletedDuplicateFiles = 0L;
     private long addedRecords = 0L;
     private long deletedRecords = 0L;
+    private long addedPosDeletes = 0L;
+    private long removedPosDeletes = 0L;
+    private long addedEqDeletes = 0L;
+    private long removedEqDeletes = 0L;
     private Map<String, String> properties = Maps.newHashMap();
 
     public void clear() {
@@ -75,6 +90,8 @@ public class SnapshotSummary {
     public void deletedFile(PartitionSpec spec, ContentFile<?> file) {
       if (file instanceof DataFile) {
         deletedFile(spec, (DataFile) file);
+      } else if (file instanceof DeleteFile) {
+        deletedFile(spec, (DeleteFile) file);
       } else {
         throw new IllegalArgumentException("Unsupported file type: " + file.getClass().getSimpleName());
       }
@@ -90,6 +107,26 @@ public class SnapshotSummary {
       changedPartitions.add(spec.partitionToPath(file.partition()));
       this.addedFiles += 1;
       this.addedRecords += file.recordCount();
+    }
+
+    public void addedFile(PartitionSpec spec, DeleteFile file) {
+      changedPartitions.add(spec.partitionToPath(file.partition()));
+      this.addedDeleteFiles += 1;
+      if (file.content() == FileContent.POSITION_DELETES) {
+        this.addedPosDeletes += file.recordCount();
+      } else {
+        this.addedEqDeletes += file.recordCount();
+      }
+    }
+
+    public void deletedFile(PartitionSpec spec, DeleteFile file) {
+      changedPartitions.add(spec.partitionToPath(file.partition()));
+      this.removedDeleteFiles += 1;
+      if (file.content() == FileContent.POSITION_DELETES) {
+        this.removedPosDeletes += file.recordCount();
+      } else {
+        this.removedEqDeletes += file.recordCount();
+      }
     }
 
     public void addedManifest(ManifestFile manifest) {
@@ -124,9 +161,15 @@ public class SnapshotSummary {
 
       setIf(addedFiles > 0, builder, ADDED_FILES_PROP, addedFiles);
       setIf(deletedFiles > 0, builder, DELETED_FILES_PROP, deletedFiles);
+      setIf(addedDeleteFiles > 0, builder, ADDED_DELETE_FILES_PROP, addedDeleteFiles);
+      setIf(removedDeleteFiles > 0, builder, REMOVED_DELETE_FILES_PROP, removedDeleteFiles);
       setIf(deletedDuplicateFiles > 0, builder, DELETED_DUPLICATE_FILES, deletedDuplicateFiles);
       setIf(addedRecords > 0, builder, ADDED_RECORDS_PROP, addedRecords);
       setIf(deletedRecords > 0, builder, DELETED_RECORDS_PROP, deletedRecords);
+      setIf(addedPosDeletes > 0, builder, ADDED_POS_DELETES_PROP, addedPosDeletes);
+      setIf(removedPosDeletes > 0, builder, REMOVED_POS_DELETES_PROP, removedPosDeletes);
+      setIf(addedEqDeletes > 0, builder, ADDED_EQ_DELETES_PROP, addedEqDeletes);
+      setIf(removedEqDeletes > 0, builder, REMOVED_EQ_DELETES_PROP, removedEqDeletes);
       setIf(true, builder, CHANGED_PARTITION_COUNT_PROP, changedPartitions.size());
 
       return builder.build();

--- a/core/src/test/java/org/apache/iceberg/TestRowDelta.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowDelta.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import org.apache.iceberg.ManifestEntry.Status;
+import org.apache.iceberg.expressions.Expressions;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestRowDelta extends V2TableTestBase {
+  @Test
+  public void testAddDeleteFile() {
+    table.newRowDelta()
+        .addRows(FILE_A)
+        .addDeletes(FILE_A_DELETES)
+        .addDeletes(FILE_B_DELETES)
+        .commit();
+
+    Snapshot snap = table.currentSnapshot();
+    Assert.assertEquals("Commit should produce sequence number 1", 1, snap.sequenceNumber());
+    Assert.assertEquals("Last sequence number should be 1", 1, table.ops().current().lastSequenceNumber());
+    Assert.assertEquals("Delta commit should use operation 'overwrite'", DataOperations.OVERWRITE, snap.operation());
+
+    Assert.assertEquals("Should produce 1 data manifest", 1, snap.dataManifests().size());
+    validateManifest(
+        snap.dataManifests().get(0),
+        seqs(1),
+        ids(snap.snapshotId()),
+        files(FILE_A),
+        statuses(Status.ADDED));
+
+    Assert.assertEquals("Should produce 1 delete manifest", 1, snap.deleteManifests().size());
+    validateDeleteManifest(
+        snap.deleteManifests().get(0),
+        seqs(1, 1),
+        ids(snap.snapshotId(), snap.snapshotId()),
+        files(FILE_A_DELETES, FILE_B_DELETES),
+        statuses(Status.ADDED, Status.ADDED));
+  }
+
+  @Test
+  public void testOverwriteWithDeleteFile() {
+    table.newRowDelta()
+        .addRows(FILE_A)
+        .addDeletes(FILE_A_DELETES)
+        .addDeletes(FILE_B_DELETES)
+        .commit();
+
+    long deltaSnapshotId = table.currentSnapshot().snapshotId();
+    Assert.assertEquals("Commit should produce sequence number 1", 1, table.currentSnapshot().sequenceNumber());
+    Assert.assertEquals("Last sequence number should be 1", 1, table.ops().current().lastSequenceNumber());
+
+    // overwriting by a filter will also remove delete files that match because all matching data files are removed.
+    table.newOverwrite()
+        .overwriteByRowFilter(Expressions.equal(Expressions.bucket("data", 16), 0))
+        .commit();
+
+    Snapshot snap = table.currentSnapshot();
+    Assert.assertEquals("Commit should produce sequence number 2", 2, snap.sequenceNumber());
+    Assert.assertEquals("Last sequence number should be 2", 2, table.ops().current().lastSequenceNumber());
+
+    Assert.assertEquals("Should produce 1 data manifest", 1, snap.dataManifests().size());
+    validateManifest(
+        snap.dataManifests().get(0),
+        seqs(2),
+        ids(snap.snapshotId()),
+        files(FILE_A),
+        statuses(Status.DELETED));
+
+    Assert.assertEquals("Should produce 1 delete manifest", 1, snap.deleteManifests().size());
+    validateDeleteManifest(
+        snap.deleteManifests().get(0),
+        seqs(2, 1),
+        ids(snap.snapshotId(), deltaSnapshotId),
+        files(FILE_A_DELETES, FILE_B_DELETES),
+        statuses(Status.DELETED, Status.EXISTING));
+  }
+
+  @Test
+  public void testReplacePartitionsWithDeleteFile() {
+    table.newRowDelta()
+        .addRows(FILE_A)
+        .addDeletes(FILE_A_DELETES)
+        .addDeletes(FILE_B_DELETES)
+        .commit();
+
+    long deltaSnapshotId = table.currentSnapshot().snapshotId();
+    Assert.assertEquals("Commit should produce sequence number 1", 1, table.currentSnapshot().sequenceNumber());
+    Assert.assertEquals("Last sequence number should be 1", 1, table.ops().current().lastSequenceNumber());
+
+    // overwriting the partition will also remove delete files that match because all matching data files are removed.
+    table.newReplacePartitions()
+        .addFile(FILE_A2)
+        .commit();
+
+    Snapshot snap = table.currentSnapshot();
+    Assert.assertEquals("Commit should produce sequence number 2", 2, snap.sequenceNumber());
+    Assert.assertEquals("Last sequence number should be 2", 2, table.ops().current().lastSequenceNumber());
+
+    Assert.assertEquals("Should produce 2 data manifests", 2, snap.dataManifests().size());
+    int deleteManifestPos = snap.dataManifests().get(0).deletedFilesCount() > 0 ? 0 : 1;
+    validateManifest(
+        snap.dataManifests().get(deleteManifestPos),
+        seqs(2),
+        ids(snap.snapshotId()),
+        files(FILE_A),
+        statuses(Status.DELETED));
+    int appendManifestPos = deleteManifestPos == 0 ? 1 : 0;
+    validateManifest(
+        snap.dataManifests().get(appendManifestPos),
+        seqs(2),
+        ids(snap.snapshotId()),
+        files(FILE_A2),
+        statuses(Status.ADDED));
+
+    Assert.assertEquals("Should produce 1 delete manifest", 1, snap.deleteManifests().size());
+    validateDeleteManifest(
+        snap.deleteManifests().get(0),
+        seqs(2, 1),
+        ids(snap.snapshotId(), deltaSnapshotId),
+        files(FILE_A_DELETES, FILE_B_DELETES),
+        statuses(Status.DELETED, Status.EXISTING));
+  }
+
+  @Test
+  public void testDeleteByExpressionWithDeleteFile() {
+    table.newRowDelta()
+        .addRows(FILE_A)
+        .addDeletes(FILE_A_DELETES)
+        .addDeletes(FILE_B_DELETES)
+        .commit();
+
+    long deltaSnapshotId = table.currentSnapshot().snapshotId();
+    Assert.assertEquals("Commit should produce sequence number 1", 1, table.currentSnapshot().sequenceNumber());
+    Assert.assertEquals("Last sequence number should be 1", 1, table.ops().current().lastSequenceNumber());
+
+    // deleting with a filter will also remove delete files that match because all matching data files are removed.
+    table.newDelete()
+        .deleteFromRowFilter(Expressions.alwaysTrue())
+        .commit();
+
+    Snapshot snap = table.currentSnapshot();
+    Assert.assertEquals("Commit should produce sequence number 2", 2, snap.sequenceNumber());
+    Assert.assertEquals("Last sequence number should be 2", 2, table.ops().current().lastSequenceNumber());
+
+    Assert.assertEquals("Should produce 1 data manifest", 1, snap.dataManifests().size());
+    validateManifest(
+        snap.dataManifests().get(0),
+        seqs(2),
+        ids(snap.snapshotId()),
+        files(FILE_A),
+        statuses(Status.DELETED));
+
+    Assert.assertEquals("Should produce 1 delete manifest", 1, snap.deleteManifests().size());
+    validateDeleteManifest(
+        snap.deleteManifests().get(0),
+        seqs(2, 2),
+        ids(snap.snapshotId(), snap.snapshotId()),
+        files(FILE_A_DELETES, FILE_B_DELETES),
+        statuses(Status.DELETED, Status.DELETED));
+  }
+
+  @Test
+  public void testDeleteDataFileWithDeleteFile() {
+    table.newRowDelta()
+        .addRows(FILE_A)
+        .addDeletes(FILE_A_DELETES)
+        .commit();
+
+    long deltaSnapshotId = table.currentSnapshot().snapshotId();
+    Assert.assertEquals("Commit should produce sequence number 1", 1, table.currentSnapshot().sequenceNumber());
+    Assert.assertEquals("Last sequence number should be 1", 1, table.ops().current().lastSequenceNumber());
+
+    // deleting a specific data file will not affect a delete file
+    table.newDelete()
+        .deleteFile(FILE_A)
+        .commit();
+
+    Snapshot deleteSnap = table.currentSnapshot();
+    Assert.assertEquals("Commit should produce sequence number 2", 2, deleteSnap.sequenceNumber());
+    Assert.assertEquals("Last sequence number should be 2", 2, table.ops().current().lastSequenceNumber());
+
+    Assert.assertEquals("Should produce 1 data manifest", 1, deleteSnap.dataManifests().size());
+    validateManifest(
+        deleteSnap.dataManifests().get(0),
+        seqs(2),
+        ids(deleteSnap.snapshotId()),
+        files(FILE_A),
+        statuses(Status.DELETED));
+
+    Assert.assertEquals("Should produce 1 delete manifest", 1, deleteSnap.deleteManifests().size());
+    validateDeleteManifest(
+        deleteSnap.deleteManifests().get(0),
+        seqs(1),
+        ids(deltaSnapshotId),
+        files(FILE_A_DELETES),
+        statuses(Status.ADDED));
+
+    // the manifest that removed FILE_A will be dropped next commit, causing the min sequence number of all data files
+    // to be 2, the largest known sequence number. this will cause FILE_A_DELETES to be removed because it is too old
+    // to apply to any data files.
+    table.newDelete()
+        .deleteFile("no-such-file")
+        .commit();
+
+    Snapshot nextSnap = table.currentSnapshot();
+    Assert.assertEquals("Append should produce sequence number 3", 3, nextSnap.sequenceNumber());
+    Assert.assertEquals("Last sequence number should be 3", 3, table.ops().current().lastSequenceNumber());
+
+    Assert.assertEquals("Should have 0 data manifests", 0, nextSnap.dataManifests().size());
+    Assert.assertEquals("Should produce 1 delete manifest", 1, nextSnap.deleteManifests().size());
+    validateDeleteManifest(
+        nextSnap.deleteManifests().get(0),
+        seqs(3),
+        ids(nextSnap.snapshotId()),
+        files(FILE_A_DELETES),
+        statuses(Status.DELETED));
+  }
+
+  @Test
+  public void testFastAppendDoesNotRemoveStaleDeleteFiles() {
+    table.newRowDelta()
+        .addRows(FILE_A)
+        .addDeletes(FILE_A_DELETES)
+        .commit();
+
+    long deltaSnapshotId = table.currentSnapshot().snapshotId();
+    Assert.assertEquals("Commit should produce sequence number 1", 1, table.currentSnapshot().sequenceNumber());
+    Assert.assertEquals("Last sequence number should be 1", 1, table.ops().current().lastSequenceNumber());
+
+    // deleting a specific data file will not affect a delete file
+    table.newDelete()
+        .deleteFile(FILE_A)
+        .commit();
+
+    Snapshot deleteSnap = table.currentSnapshot();
+    Assert.assertEquals("Commit should produce sequence number 2", 2, deleteSnap.sequenceNumber());
+    Assert.assertEquals("Last sequence number should be 2", 2, table.ops().current().lastSequenceNumber());
+
+    Assert.assertEquals("Should produce 1 data manifest", 1, deleteSnap.dataManifests().size());
+    validateManifest(
+        deleteSnap.dataManifests().get(0),
+        seqs(2),
+        ids(deleteSnap.snapshotId()),
+        files(FILE_A),
+        statuses(Status.DELETED));
+
+    Assert.assertEquals("Should produce 1 delete manifest", 1, deleteSnap.deleteManifests().size());
+    validateDeleteManifest(
+        deleteSnap.deleteManifests().get(0),
+        seqs(1),
+        ids(deltaSnapshotId),
+        files(FILE_A_DELETES),
+        statuses(Status.ADDED));
+
+    // the manifest that removed FILE_A will be dropped next merging commit, but FastAppend will not remove it
+    table.newFastAppend()
+        .appendFile(FILE_B)
+        .commit();
+
+    Snapshot nextSnap = table.currentSnapshot();
+    Assert.assertEquals("Append should produce sequence number 3", 3, nextSnap.sequenceNumber());
+    Assert.assertEquals("Last sequence number should be 3", 3, table.ops().current().lastSequenceNumber());
+
+    Assert.assertEquals("Should have 2 data manifests", 2, nextSnap.dataManifests().size());
+    int deleteManifestPos = nextSnap.dataManifests().get(0).deletedFilesCount() > 0 ? 0 : 1;
+    validateManifest(
+        nextSnap.dataManifests().get(deleteManifestPos),
+        seqs(2),
+        ids(deleteSnap.snapshotId()),
+        files(FILE_A),
+        statuses(Status.DELETED));
+    int appendManifestPos = deleteManifestPos == 0 ? 1 : 0;
+    validateManifest(
+        nextSnap.dataManifests().get(appendManifestPos),
+        seqs(3),
+        ids(nextSnap.snapshotId()),
+        files(FILE_B),
+        statuses(Status.ADDED));
+
+    Assert.assertEquals("Should produce 1 delete manifest", 1, nextSnap.deleteManifests().size());
+    validateDeleteManifest(
+        nextSnap.deleteManifests().get(0),
+        seqs(1),
+        ids(deltaSnapshotId),
+        files(FILE_A_DELETES),
+        statuses(Status.ADDED));
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/V2TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/V2TableTestBase.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+public class V2TableTestBase extends TableTestBase {
+  public V2TableTestBase() {
+    super(2);
+  }
+}


### PR DESCRIPTION
This adds support for `DeleteFile` to `MergingSnapshotProducer`, which is the base class used to implement most operations that update Iceberg table data.

To test the updates, this adds a new `RowDelta` operation to `Table` and `Transaction` that adds `DeleteFile` and `DataFile` instances to the table. The tests are in `TestRowDelta` and mainly test the behavior of operations when there are delete files in table metadata. This doesn't add new tests for `DeleteFile` compaction or cleanup because the same code is used for delete and data files. There is no need to duplicate the testing done for data files.