### PR TITLE
Refactor TableScan optional arguments into an immutable context object

### DIFF
--- a/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
@@ -20,14 +20,12 @@
 package org.apache.iceberg;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.List;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
@@ -84,25 +82,15 @@ public class AllDataFilesTable extends BaseMetadataTable {
       this.fileSchema = fileSchema;
     }
 
-    private AllDataFilesTableScan(
-        TableOperations ops, Table table, Long snapshotId, Schema schema, Expression rowFilter,
-        boolean ignoreResiduals, boolean caseSensitive, boolean colStats,
-        Collection<String> selectedColumns, Schema fileSchema,
-        ImmutableMap<String, String> options) {
-      super(
-          ops, table, snapshotId, schema, rowFilter, ignoreResiduals,
-          caseSensitive, colStats, selectedColumns, options);
+    private AllDataFilesTableScan(TableOperations ops, Table table, Schema schema, Schema fileSchema,
+                                  TableScanContext context) {
+      super(ops, table, schema, context);
       this.fileSchema = fileSchema;
     }
 
     @Override
-    protected TableScan newRefinedScan(
-        TableOperations ops, Table table, Long snapshotId, Schema schema, Expression rowFilter,
-        boolean ignoreResiduals, boolean caseSensitive, boolean colStats, Collection<String> selectedColumns,
-        ImmutableMap<String, String> options) {
-      return new AllDataFilesTableScan(
-          ops, table, snapshotId, schema, rowFilter, ignoreResiduals,
-          caseSensitive, colStats, selectedColumns, fileSchema, options);
+    protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
+      return new AllDataFilesTableScan(ops, table, schema, fileSchema, context.copy());
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
@@ -90,7 +90,7 @@ public class AllDataFilesTable extends BaseMetadataTable {
 
     @Override
     protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      return new AllDataFilesTableScan(ops, table, schema, fileSchema, context.copy());
+      return new AllDataFilesTableScan(ops, table, schema, fileSchema, context);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
@@ -20,14 +20,12 @@
 package org.apache.iceberg;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.List;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
@@ -81,23 +79,14 @@ public class AllEntriesTable extends BaseMetadataTable {
       super(ops, table, schema);
     }
 
-    private Scan(
-        TableOperations ops, Table table, Long snapshotId, Schema schema, Expression rowFilter,
-        boolean ignoreResiduals, boolean caseSensitive, boolean colStats,
-        Collection<String> selectedColumns, ImmutableMap<String, String> options) {
-      super(
-          ops, table, snapshotId, schema, rowFilter, ignoreResiduals,
-          caseSensitive, colStats, selectedColumns, options);
+    private Scan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
+      super(ops, table, schema, context);
     }
 
     @Override
-    protected TableScan newRefinedScan(
-        TableOperations ops, Table table, Long snapshotId, Schema schema, Expression rowFilter,
-        boolean ignoreResiduals, boolean caseSensitive, boolean colStats, Collection<String> selectedColumns,
-        ImmutableMap<String, String> options) {
-      return new Scan(
-          ops, table, snapshotId, schema, rowFilter, ignoreResiduals,
-          caseSensitive, colStats, selectedColumns, options);
+    protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema,
+                                       TableScanContext context) {
+      return new Scan(ops, table, schema, context.copy());
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
@@ -86,7 +86,7 @@ public class AllEntriesTable extends BaseMetadataTable {
     @Override
     protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema,
                                        TableScanContext context) {
-      return new Scan(ops, table, schema, context.copy());
+      return new Scan(ops, table, schema, context);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg;
 
 import java.io.IOException;
-import java.util.Collection;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Expression;
@@ -29,7 +28,6 @@ import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.types.Types;
 
@@ -90,23 +88,15 @@ public class AllManifestsTable extends BaseMetadataTable {
       super(ops, table, fileSchema);
     }
 
-    private AllManifestsTableScan(
-        TableOperations ops, Table table, Long snapshotId, Schema schema, Expression rowFilter,
-        boolean ignoreResiduals, boolean caseSensitive, boolean colStats, Collection<String> selectedColumns,
-        ImmutableMap<String, String> options) {
-      super(
-          ops, table, snapshotId, schema, rowFilter, ignoreResiduals,
-          caseSensitive, colStats, selectedColumns, options);
+    private AllManifestsTableScan(TableOperations ops, Table table, Schema schema,
+                                  TableScanContext context) {
+      super(ops, table, schema, context);
     }
 
     @Override
-    protected TableScan newRefinedScan(
-        TableOperations ops, Table table, Long snapshotId, Schema schema, Expression rowFilter,
-        boolean ignoreResiduals, boolean caseSensitive, boolean colStats, Collection<String> selectedColumns,
-        ImmutableMap<String, String> options) {
-      return new AllManifestsTableScan(
-          ops, table, snapshotId, schema, rowFilter, ignoreResiduals,
-          caseSensitive, colStats, selectedColumns, options);
+    protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema,
+                                       TableScanContext context) {
+      return new AllManifestsTableScan(ops, table, schema, context.copy());
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -96,7 +96,7 @@ public class AllManifestsTable extends BaseMetadataTable {
     @Override
     protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema,
                                        TableScanContext context) {
-      return new AllManifestsTableScan(ops, table, schema, context.copy());
+      return new AllManifestsTableScan(ops, table, schema, context);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
@@ -19,12 +19,9 @@
 
 package org.apache.iceberg;
 
-import java.util.Collection;
 import org.apache.iceberg.events.Listeners;
 import org.apache.iceberg.events.ScanEvent;
-import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.CloseableIterable;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,13 +32,8 @@ abstract class BaseAllMetadataTableScan extends BaseTableScan {
     super(ops, table, fileSchema);
   }
 
-  BaseAllMetadataTableScan(
-      TableOperations ops, Table table, Long snapshotId, Schema schema, Expression rowFilter,
-      boolean ignoreResiduals, boolean caseSensitive, boolean colStats, Collection<String> selectedColumns,
-      ImmutableMap<String, String> options) {
-    super(
-        ops, table, snapshotId, schema, rowFilter, ignoreResiduals,
-        caseSensitive, colStats, selectedColumns, options);
+  BaseAllMetadataTableScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
+    super(ops, table, schema, context);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -52,32 +52,19 @@ abstract class BaseTableScan implements TableScan {
 
   private final TableOperations ops;
   private final Table table;
-  private final Long snapshotId;
   private final Schema schema;
-  private final Expression rowFilter;
-  private final boolean ignoreResiduals;
-  private final boolean caseSensitive;
-  private final boolean colStats;
-  private final Collection<String> selectedColumns;
-  private final ImmutableMap<String, String> options;
+  private final TableScanContext context;
+
 
   protected BaseTableScan(TableOperations ops, Table table, Schema schema) {
-    this(ops, table, null, schema, Expressions.alwaysTrue(), false, true, false, null, ImmutableMap.of());
+    this(ops, table, schema, TableScanContext.builder().caseSensitive(true).build());
   }
 
-  protected BaseTableScan(TableOperations ops, Table table, Long snapshotId, Schema schema,
-                          Expression rowFilter, boolean ignoreResiduals, boolean caseSensitive, boolean colStats,
-                          Collection<String> selectedColumns, ImmutableMap<String, String> options) {
+  protected BaseTableScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
     this.ops = ops;
     this.table = table;
-    this.snapshotId = snapshotId;
     this.schema = schema;
-    this.rowFilter = rowFilter;
-    this.ignoreResiduals = ignoreResiduals;
-    this.caseSensitive = caseSensitive;
-    this.colStats = colStats;
-    this.selectedColumns = selectedColumns;
-    this.options = options != null ? options : ImmutableMap.of();
+    this.context = context;
   }
 
   protected TableOperations tableOps() {
@@ -85,23 +72,27 @@ abstract class BaseTableScan implements TableScan {
   }
 
   protected Long snapshotId() {
-    return snapshotId;
+    return context.snapshotId();
   }
 
   protected boolean colStats() {
-    return colStats;
+    return context.colStats();
   }
 
   protected boolean shouldIgnoreResiduals() {
-    return ignoreResiduals;
+    return context.ignoreResiduals();
   }
 
   protected Collection<String> selectedColumns() {
-    return selectedColumns;
+    return context.selectedColumns();
   }
 
   protected ImmutableMap<String, String> options() {
-    return options;
+    return ImmutableMap.copyOf(context.options());
+  }
+
+  protected  TableScanContext context() {
+    return context;
   }
 
   @SuppressWarnings("checkstyle:HiddenField")
@@ -109,9 +100,7 @@ abstract class BaseTableScan implements TableScan {
 
   @SuppressWarnings("checkstyle:HiddenField")
   protected abstract TableScan newRefinedScan(
-      TableOperations ops, Table table, Long snapshotId, Schema schema, Expression rowFilter,
-      boolean ignoreResiduals, boolean caseSensitive, boolean colStats, Collection<String> selectedColumns,
-      ImmutableMap<String, String> options);
+      TableOperations ops, Table table, Schema schema, TableScanContext context);
 
   @SuppressWarnings("checkstyle:HiddenField")
   protected abstract CloseableIterable<FileScanTask> planFiles(
@@ -135,19 +124,18 @@ abstract class BaseTableScan implements TableScan {
 
   @Override
   public TableScan useSnapshot(long scanSnapshotId) {
-    Preconditions.checkArgument(this.snapshotId == null,
-        "Cannot override snapshot, already set to id=%s", snapshotId);
+    Preconditions.checkState(context.snapshotId() == null,
+        "Cannot override snapshot, already set to id=%s", context.snapshotId());
     Preconditions.checkArgument(ops.current().snapshot(scanSnapshotId) != null,
         "Cannot find snapshot with ID %s", scanSnapshotId);
     return newRefinedScan(
-        ops, table, scanSnapshotId, schema, rowFilter, ignoreResiduals,
-        caseSensitive, colStats, selectedColumns, options);
+        ops, table, schema, TableScanContext.builder(context).snapshotId(scanSnapshotId).build());
   }
 
   @Override
   public TableScan asOfTime(long timestampMillis) {
-    Preconditions.checkArgument(this.snapshotId == null,
-        "Cannot override snapshot, already set to id=%s", snapshotId);
+    Preconditions.checkState(context.snapshotId() == null,
+        "Cannot override snapshot, already set to id=%s", context.snapshotId());
 
     Long lastSnapshotId = null;
     for (HistoryEntry logEntry : ops.current().snapshotLog()) {
@@ -167,59 +155,52 @@ abstract class BaseTableScan implements TableScan {
   @Override
   public TableScan option(String property, String value) {
     ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
-    builder.putAll(options);
+    builder.putAll(context.options());
     builder.put(property, value);
 
     return newRefinedScan(
-        ops, table, snapshotId, schema, rowFilter, ignoreResiduals,
-        caseSensitive, colStats, selectedColumns, builder.build());
+        ops, table, schema, TableScanContext.builder(context).options(builder.build()).build());
   }
 
   @Override
   public TableScan project(Schema projectedSchema) {
     return newRefinedScan(
-        ops, table, snapshotId, projectedSchema, rowFilter, ignoreResiduals,
-        caseSensitive, colStats, selectedColumns, options);
+        ops, table, projectedSchema, TableScanContext.builder(context).build());
   }
 
   @Override
   public TableScan caseSensitive(boolean scanCaseSensitive) {
     return newRefinedScan(
-        ops, table, snapshotId, schema, rowFilter, ignoreResiduals,
-        scanCaseSensitive, colStats, selectedColumns, options);
+        ops, table, schema, TableScanContext.builder(context).caseSensitive(scanCaseSensitive).build());
   }
 
   @Override
   public TableScan includeColumnStats() {
     return newRefinedScan(
-        ops, table, snapshotId, schema, rowFilter, ignoreResiduals,
-        caseSensitive, true, selectedColumns, options);
+        ops, table, schema, TableScanContext.builder(context).colStats(true).build());
   }
 
   @Override
   public TableScan select(Collection<String> columns) {
     return newRefinedScan(
-        ops, table, snapshotId, schema, rowFilter, ignoreResiduals,
-        caseSensitive, colStats, columns, options);
+        ops, table, schema, TableScanContext.builder(context).selectedColumns(columns).build());
   }
 
   @Override
   public TableScan filter(Expression expr) {
-    return newRefinedScan(
-        ops, table, snapshotId, schema, Expressions.and(rowFilter, expr),
-        ignoreResiduals, caseSensitive, colStats, selectedColumns, options);
+    return newRefinedScan(ops, table, schema,
+        TableScanContext.builder(context).rowFilter(Expressions.and(context.rowFilter(), expr)).build());
   }
 
   @Override
   public Expression filter() {
-    return rowFilter;
+    return context.rowFilter();
   }
 
   @Override
   public TableScan ignoreResiduals() {
     return newRefinedScan(
-        ops, table, snapshotId, schema, rowFilter, true,
-        caseSensitive, colStats, selectedColumns, options);
+        ops, table, schema, TableScanContext.builder(context).ignoreResiduals(true).build());
   }
 
   @Override
@@ -228,12 +209,13 @@ abstract class BaseTableScan implements TableScan {
     if (snapshot != null) {
       LOG.info("Scanning table {} snapshot {} created at {} with filter {}", table,
           snapshot.snapshotId(), formatTimestampMillis(snapshot.timestampMillis()),
-          rowFilter);
+          context.rowFilter());
 
       Listeners.notifyAll(
-          new ScanEvent(table.toString(), snapshot.snapshotId(), rowFilter, schema()));
+          new ScanEvent(table.toString(), snapshot.snapshotId(), context.rowFilter(), schema()));
 
-      return planFiles(ops, snapshot, rowFilter, ignoreResiduals, caseSensitive, colStats);
+      return planFiles(ops, snapshot,
+          context.rowFilter(), context.ignoreResiduals(), context.caseSensitive(), context.colStats());
 
     } else {
       LOG.info("Scanning empty table {}", table);
@@ -243,6 +225,7 @@ abstract class BaseTableScan implements TableScan {
 
   @Override
   public CloseableIterable<CombinedScanTask> planTasks() {
+    ImmutableMap<String, String> options = context.options();
     long splitSize;
     if (options.containsKey(TableProperties.SPLIT_SIZE)) {
       splitSize = Long.parseLong(options.get(TableProperties.SPLIT_SIZE));
@@ -276,14 +259,14 @@ abstract class BaseTableScan implements TableScan {
 
   @Override
   public Snapshot snapshot() {
-    return snapshotId != null ?
-        ops.current().snapshot(snapshotId) :
+    return context.snapshotId() != null ?
+        ops.current().snapshot(context.snapshotId()) :
         ops.current().currentSnapshot();
   }
 
   @Override
   public boolean isCaseSensitive() {
-    return caseSensitive;
+    return context.caseSensitive();
   }
 
   @Override
@@ -291,9 +274,9 @@ abstract class BaseTableScan implements TableScan {
     return MoreObjects.toStringHelper(this)
         .add("table", table)
         .add("projection", schema().asStruct())
-        .add("filter", rowFilter)
-        .add("ignoreResiduals", ignoreResiduals)
-        .add("caseSensitive", caseSensitive)
+        .add("filter", context.rowFilter())
+        .add("ignoreResiduals", context.ignoreResiduals())
+        .add("caseSensitive", context.caseSensitive())
         .toString();
   }
 
@@ -304,19 +287,21 @@ abstract class BaseTableScan implements TableScan {
    * @return the Schema to project
    */
   private Schema lazyColumnProjection() {
-    if (selectedColumns != null) {
+    Collection<String> selectedCols = context.selectedColumns();
+    if (selectedCols != null) {
       Set<Integer> requiredFieldIds = Sets.newHashSet();
 
       // all of the filter columns are required
       requiredFieldIds.addAll(
-          Binder.boundReferences(table.schema().asStruct(), Collections.singletonList(rowFilter), caseSensitive));
+          Binder.boundReferences(table.schema().asStruct(),
+              Collections.singletonList(context.rowFilter()), context.caseSensitive()));
 
       // all of the projection columns are required
       Set<Integer> selectedIds;
-      if (caseSensitive) {
-        selectedIds = TypeUtil.getProjectedIds(table.schema().select(selectedColumns));
+      if (context.caseSensitive()) {
+        selectedIds = TypeUtil.getProjectedIds(table.schema().select(selectedCols));
       } else {
-        selectedIds = TypeUtil.getProjectedIds(table.schema().caseInsensitiveSelect(selectedColumns));
+        selectedIds = TypeUtil.getProjectedIds(table.schema().caseInsensitiveSelect(selectedCols));
       }
       requiredFieldIds.addAll(selectedIds);
 

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -55,7 +55,6 @@ abstract class BaseTableScan implements TableScan {
   private final Schema schema;
   private final TableScanContext context;
 
-
   protected BaseTableScan(TableOperations ops, Table table, Schema schema) {
     this(ops, table, schema, TableScanContext.builder().caseSensitive(true).build());
   }
@@ -88,7 +87,7 @@ abstract class BaseTableScan implements TableScan {
   }
 
   protected ImmutableMap<String, String> options() {
-    return ImmutableMap.copyOf(context.options());
+    return context.options();
   }
 
   protected  TableScanContext context() {
@@ -165,7 +164,7 @@ abstract class BaseTableScan implements TableScan {
   @Override
   public TableScan project(Schema projectedSchema) {
     return newRefinedScan(
-        ops, table, projectedSchema, TableScanContext.builder(context).build());
+        ops, table, projectedSchema, context.copy());
   }
 
   @Override
@@ -287,8 +286,8 @@ abstract class BaseTableScan implements TableScan {
    * @return the Schema to project
    */
   private Schema lazyColumnProjection() {
-    Collection<String> selectedCols = context.selectedColumns();
-    if (selectedCols != null) {
+    Collection<String> selectedColumns = context.selectedColumns();
+    if (selectedColumns != null) {
       Set<Integer> requiredFieldIds = Sets.newHashSet();
 
       // all of the filter columns are required
@@ -299,9 +298,9 @@ abstract class BaseTableScan implements TableScan {
       // all of the projection columns are required
       Set<Integer> selectedIds;
       if (context.caseSensitive()) {
-        selectedIds = TypeUtil.getProjectedIds(table.schema().select(selectedCols));
+        selectedIds = TypeUtil.getProjectedIds(table.schema().select(selectedColumns));
       } else {
-        selectedIds = TypeUtil.getProjectedIds(table.schema().caseInsensitiveSelect(selectedCols));
+        selectedIds = TypeUtil.getProjectedIds(table.schema().caseInsensitiveSelect(selectedColumns));
       }
       requiredFieldIds.addAll(selectedIds);
 

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -56,7 +56,7 @@ abstract class BaseTableScan implements TableScan {
   private final TableScanContext context;
 
   protected BaseTableScan(TableOperations ops, Table table, Schema schema) {
-    this(ops, table, schema, TableScanContext.builder().caseSensitive(true).build());
+    this(ops, table, schema, new TableScanContext());
   }
 
   protected BaseTableScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
@@ -128,7 +128,7 @@ abstract class BaseTableScan implements TableScan {
     Preconditions.checkArgument(ops.current().snapshot(scanSnapshotId) != null,
         "Cannot find snapshot with ID %s", scanSnapshotId);
     return newRefinedScan(
-        ops, table, schema, TableScanContext.builder(context).snapshotId(scanSnapshotId).build());
+        ops, table, schema, context.snapshotId(scanSnapshotId));
   }
 
   @Override
@@ -158,7 +158,7 @@ abstract class BaseTableScan implements TableScan {
     builder.put(property, value);
 
     return newRefinedScan(
-        ops, table, schema, TableScanContext.builder(context).options(builder.build()).build());
+        ops, table, schema, context.options(builder.build()));
   }
 
   @Override
@@ -170,25 +170,25 @@ abstract class BaseTableScan implements TableScan {
   @Override
   public TableScan caseSensitive(boolean scanCaseSensitive) {
     return newRefinedScan(
-        ops, table, schema, TableScanContext.builder(context).caseSensitive(scanCaseSensitive).build());
+        ops, table, schema, context.caseSensitive(scanCaseSensitive));
   }
 
   @Override
   public TableScan includeColumnStats() {
     return newRefinedScan(
-        ops, table, schema, TableScanContext.builder(context).colStats(true).build());
+        ops, table, schema, context.colStats(true));
   }
 
   @Override
   public TableScan select(Collection<String> columns) {
     return newRefinedScan(
-        ops, table, schema, TableScanContext.builder(context).selectedColumns(columns).build());
+        ops, table, schema, context.selectedColumns(columns));
   }
 
   @Override
   public TableScan filter(Expression expr) {
     return newRefinedScan(ops, table, schema,
-        TableScanContext.builder(context).rowFilter(Expressions.and(context.rowFilter(), expr)).build());
+        context.rowFilter(Expressions.and(context.rowFilter(), expr)));
   }
 
   @Override
@@ -199,7 +199,7 @@ abstract class BaseTableScan implements TableScan {
   @Override
   public TableScan ignoreResiduals() {
     return newRefinedScan(
-        ops, table, schema, TableScanContext.builder(context).ignoreResiduals(true).build());
+        ops, table, schema, context.ignoreResiduals(true));
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/DataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DataFilesTable.java
@@ -81,10 +81,8 @@ public class DataFilesTable extends BaseMetadataTable {
     }
 
     @Override
-    protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema,
-                                       TableScanContext context) {
-      return new FilesTableScan(
-          ops, table, schema, fileSchema, context.copy());
+    protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
+      return new FilesTableScan(ops, table, schema, fileSchema, context);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/DataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DataFilesTable.java
@@ -19,14 +19,12 @@
 
 package org.apache.iceberg;
 
-import java.util.Collection;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
 
@@ -76,24 +74,17 @@ public class DataFilesTable extends BaseMetadataTable {
       this.fileSchema = fileSchema;
     }
 
-    private FilesTableScan(
-        TableOperations ops, Table table, Long snapshotId, Schema schema, Expression rowFilter,
-        boolean ignoreResiduals, boolean caseSensitive, boolean colStats,
-        Collection<String> selectedColumns, Schema fileSchema, ImmutableMap<String, String> options) {
-      super(
-          ops, table, snapshotId, schema, rowFilter, ignoreResiduals,
-          caseSensitive, colStats, selectedColumns, options);
+    private FilesTableScan(TableOperations ops, Table table, Schema schema, Schema fileSchema,
+                           TableScanContext context) {
+      super(ops, table, schema, context);
       this.fileSchema = fileSchema;
     }
 
     @Override
-    protected TableScan newRefinedScan(
-        TableOperations ops, Table table, Long snapshotId, Schema schema, Expression rowFilter,
-        boolean ignoreResiduals, boolean caseSensitive, boolean colStats, Collection<String> selectedColumns,
-        ImmutableMap<String, String> options) {
+    protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema,
+                                       TableScanContext context) {
       return new FilesTableScan(
-          ops, table, snapshotId, schema, rowFilter, ignoreResiduals,
-          caseSensitive, colStats, selectedColumns, fileSchema, options);
+          ops, table, schema, fileSchema, context.copy());
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -51,8 +51,7 @@ public class DataTableScan extends BaseTableScan {
     Preconditions.checkState(scanSnapshotId == null,
         "Cannot enable incremental scan, scan-snapshot set to id=%s", scanSnapshotId);
     return new IncrementalDataTableScan(tableOps(), table(), schema(),
-        TableScanContext.builder(context())
-            .fromSnapshotId(fromSnapshotId).toSnapshotId(toSnapshotId).build());
+        context().fromSnapshotId(fromSnapshotId).toSnapshotId(toSnapshotId));
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -19,12 +19,10 @@
 
 package org.apache.iceberg;
 
-import java.util.Collection;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.util.ThreadPools;
 
 public class DataTableScan extends BaseTableScan {
@@ -43,12 +41,8 @@ public class DataTableScan extends BaseTableScan {
     super(ops, table, table.schema());
   }
 
-  protected DataTableScan(TableOperations ops, Table table, Long snapshotId, Schema schema,
-                          Expression rowFilter, boolean ignoreResiduals, boolean caseSensitive, boolean colStats,
-                          Collection<String> selectedColumns, ImmutableMap<String, String> options) {
-    super(
-        ops, table, snapshotId, schema, rowFilter, ignoreResiduals,
-        caseSensitive, colStats, selectedColumns, options);
+  protected DataTableScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
+    super(ops, table, schema, context);
   }
 
   @Override
@@ -57,9 +51,7 @@ public class DataTableScan extends BaseTableScan {
     Preconditions.checkState(scanSnapshotId == null,
         "Cannot enable incremental scan, scan-snapshot set to id=%s", scanSnapshotId);
     return new IncrementalDataTableScan(
-        tableOps(), table(), schema(), filter(), shouldIgnoreResiduals(),
-        isCaseSensitive(), colStats(), selectedColumns(), options(),
-        fromSnapshotId, toSnapshotId);
+        tableOps(), table(), schema(), fromSnapshotId, toSnapshotId, context().copy());
   }
 
   @Override
@@ -71,12 +63,8 @@ public class DataTableScan extends BaseTableScan {
   }
 
   @Override
-  protected TableScan newRefinedScan(
-      TableOperations ops, Table table, Long snapshotId, Schema schema, Expression rowFilter,
-      boolean ignoreResiduals, boolean caseSensitive, boolean colStats, Collection<String> selectedColumns,
-      ImmutableMap<String, String> options) {
-    return new DataTableScan(
-        ops, table, snapshotId, schema, rowFilter, ignoreResiduals, caseSensitive, colStats, selectedColumns, options);
+  protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
+    return new DataTableScan(ops, table, schema, context.copy());
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -64,7 +64,7 @@ public class DataTableScan extends BaseTableScan {
 
   @Override
   protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
-    return new DataTableScan(ops, table, schema, context.copy());
+    return new DataTableScan(ops, table, schema, context);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -50,8 +50,9 @@ public class DataTableScan extends BaseTableScan {
     Long scanSnapshotId = snapshotId();
     Preconditions.checkState(scanSnapshotId == null,
         "Cannot enable incremental scan, scan-snapshot set to id=%s", scanSnapshotId);
-    return new IncrementalDataTableScan(
-        tableOps(), table(), schema(), fromSnapshotId, toSnapshotId, context().copy());
+    return new IncrementalDataTableScan(tableOps(), table(), schema(),
+        TableScanContext.builder(context())
+            .fromSnapshotId(fromSnapshotId).toSnapshotId(toSnapshotId).build());
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
@@ -33,7 +33,7 @@ import org.apache.iceberg.util.ThreadPools;
 class IncrementalDataTableScan extends DataTableScan {
 
   IncrementalDataTableScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
-    super(ops, table, schema, context.snapshotId(null));
+    super(ops, table, schema, context.useSnapshotId(null));
     validateSnapshotIds(table, context.fromSnapshotId(), context.toSnapshotId());
   }
 
@@ -103,7 +103,7 @@ class IncrementalDataTableScan extends DataTableScan {
   @Override
   @SuppressWarnings("checkstyle:HiddenField")
   protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
-    return new IncrementalDataTableScan(ops, table, schema, context.copy());
+    return new IncrementalDataTableScan(ops, table, schema, context);
   }
 
   private static List<Snapshot> snapshotsWithin(Table table, long fromSnapshotId, long toSnapshotId) {

--- a/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
@@ -33,7 +33,7 @@ import org.apache.iceberg.util.ThreadPools;
 class IncrementalDataTableScan extends DataTableScan {
 
   IncrementalDataTableScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
-    super(ops, table, schema, TableScanContext.builder(context).snapshotId(null).build());
+    super(ops, table, schema, context.snapshotId(null));
     validateSnapshotIds(table, context.fromSnapshotId(), context.toSnapshotId());
   }
 
@@ -55,8 +55,7 @@ class IncrementalDataTableScan extends DataTableScan {
   public TableScan appendsBetween(long newFromSnapshotId, long newToSnapshotId) {
     validateSnapshotIdsRefinement(newFromSnapshotId, newToSnapshotId);
     return new IncrementalDataTableScan(tableOps(), table(), schema(),
-        TableScanContext.builder(context())
-            .fromSnapshotId(newFromSnapshotId).toSnapshotId(newToSnapshotId).build());
+        context().fromSnapshotId(newFromSnapshotId).toSnapshotId(newToSnapshotId));
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
@@ -19,14 +19,12 @@
 
 package org.apache.iceberg;
 
-import java.util.Collection;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
 
@@ -77,23 +75,14 @@ public class ManifestEntriesTable extends BaseMetadataTable {
       super(ops, table, schema);
     }
 
-    private EntriesTableScan(
-        TableOperations ops, Table table, Long snapshotId, Schema schema, Expression rowFilter,
-        boolean ignoreResiduals, boolean caseSensitive, boolean colStats, Collection<String> selectedColumns,
-        ImmutableMap<String, String> options) {
-      super(
-          ops, table, snapshotId, schema, rowFilter, ignoreResiduals,
-          caseSensitive, colStats, selectedColumns, options);
+    private EntriesTableScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
+      super(ops, table, schema, context);
     }
 
     @Override
-    protected TableScan newRefinedScan(
-        TableOperations ops, Table table, Long snapshotId, Schema schema, Expression rowFilter,
-        boolean ignoreResiduals, boolean caseSensitive, boolean colStats, Collection<String> selectedColumns,
-        ImmutableMap<String, String> options) {
-      return new EntriesTableScan(
-          ops, table, snapshotId, schema, rowFilter, ignoreResiduals,
-          caseSensitive, colStats, selectedColumns, options);
+    protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema,
+                                       TableScanContext context) {
+      return new EntriesTableScan(ops, table, schema, context.copy());
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
@@ -82,7 +82,7 @@ public class ManifestEntriesTable extends BaseMetadataTable {
     @Override
     protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema,
                                        TableScanContext context) {
-      return new EntriesTableScan(ops, table, schema, context.copy());
+      return new EntriesTableScan(ops, table, schema, context);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/StaticTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/StaticTableScan.java
@@ -46,7 +46,7 @@ class StaticTableScan extends BaseTableScan {
   @Override
   protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
     return new StaticTableScan(
-        ops, table, schema, buildTask, context.copy());
+        ops, table, schema, buildTask, context);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/StaticTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/StaticTableScan.java
@@ -19,11 +19,9 @@
 
 package org.apache.iceberg;
 
-import java.util.Collection;
 import java.util.function.Function;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.CloseableIterable;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 
 class StaticTableScan extends BaseTableScan {
   private final Function<StaticTableScan, DataTask> buildTask;
@@ -33,13 +31,9 @@ class StaticTableScan extends BaseTableScan {
     this.buildTask = buildTask;
   }
 
-  private StaticTableScan(
-      TableOperations ops, Table table, Long snapshotId, Schema schema, Expression rowFilter,
-      boolean ignoreResiduals, boolean caseSensitive, boolean colStats, Collection<String> selectedColumns,
-      Function<StaticTableScan, DataTask> buildTask, ImmutableMap<String, String> options) {
-    super(
-        ops, table, snapshotId, schema, rowFilter, ignoreResiduals,
-        caseSensitive, colStats, selectedColumns, options);
+  private StaticTableScan(TableOperations ops, Table table, Schema schema,
+                          Function<StaticTableScan, DataTask> buildTask, TableScanContext context) {
+    super(ops, table, schema, context);
     this.buildTask = buildTask;
   }
 
@@ -50,13 +44,9 @@ class StaticTableScan extends BaseTableScan {
   }
 
   @Override
-  protected TableScan newRefinedScan(
-      TableOperations ops, Table table, Long snapshotId, Schema schema, Expression rowFilter,
-      boolean ignoreResiduals, boolean caseSensitive, boolean colStats,
-      Collection<String> selectedColumns, ImmutableMap<String, String> options) {
+  protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
     return new StaticTableScan(
-        ops, table, snapshotId, schema, rowFilter, ignoreResiduals,
-        caseSensitive, colStats, selectedColumns, buildTask, options);
+        ops, table, schema, buildTask, context.copy());
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/TableScanContext.java
+++ b/core/src/main/java/org/apache/iceberg/TableScanContext.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.Collection;
+import java.util.Map;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+
+/**
+ * Context object with arguments required for a TableScan.
+ */
+final class TableScanContext {
+  private final Long snapshotId;
+  private final Expression rowFilter;
+  private final boolean ignoreResiduals;
+  private final boolean caseSensitive;
+  private final boolean colStats;
+  private final Collection<String> selectedColumns;
+  private final ImmutableMap<String, String> options;
+
+
+  private TableScanContext(Long snapshotId, Expression rowFilter, boolean ignoreResiduals,
+                           boolean caseSensitive, boolean colStats, Collection<String> selectedColumns,
+                           ImmutableMap<String, String> options) {
+    this.snapshotId = snapshotId;
+    this.rowFilter = rowFilter;
+    this.ignoreResiduals = ignoreResiduals;
+    this.caseSensitive = caseSensitive;
+    this.colStats = colStats;
+    this.selectedColumns = selectedColumns;
+    this.options = options;
+  }
+
+  Long snapshotId() {
+    return snapshotId;
+  }
+
+  Expression rowFilter() {
+    return rowFilter;
+  }
+
+  boolean ignoreResiduals() {
+    return ignoreResiduals;
+  }
+
+  boolean caseSensitive() {
+    return caseSensitive;
+  }
+
+  boolean colStats() {
+    return colStats;
+  }
+
+  Collection<String> selectedColumns() {
+    return selectedColumns;
+  }
+
+  ImmutableMap<String, String> options() {
+    return options;
+  }
+
+  TableScanContext copy() {
+    return TableScanContext.builder(this).build();
+  }
+
+  static Builder builder() {
+    return new Builder();
+  }
+
+  static Builder builder(TableScanContext other) {
+    return new Builder(other);
+  }
+
+  static class Builder {
+    private Long snapshotId;
+    private Expression rowFilter;
+    private boolean ignoreResiduals;
+    private boolean caseSensitive;
+    private boolean colStats;
+    private Collection<String> selectedColumns;
+    private ImmutableMap<String, String> options;
+
+    private Builder() {
+      this.snapshotId = null;
+      this.rowFilter = Expressions.alwaysTrue();
+      this.ignoreResiduals = false;
+      this.caseSensitive = false;
+      this.colStats = false;
+      this.selectedColumns = null;
+      this.options = ImmutableMap.of();
+    }
+
+    private Builder(TableScanContext other) {
+      this.snapshotId = other.snapshotId;
+      this.rowFilter = other.rowFilter;
+      this.ignoreResiduals = other.ignoreResiduals;
+      this.caseSensitive = other.caseSensitive;
+      this.colStats = other.colStats;
+      this.selectedColumns = other.selectedColumns;
+      this.options = ImmutableMap.copyOf(other.options);
+    }
+
+    Builder snapshotId(Long id) {
+      this.snapshotId = id;
+      return this;
+    }
+
+    Builder rowFilter(Expression filter) {
+      this.rowFilter = filter;
+      return this;
+    }
+
+    Builder ignoreResiduals(boolean shouldIgnoreResiduals) {
+      this.ignoreResiduals = shouldIgnoreResiduals;
+      return this;
+    }
+
+    Builder caseSensitive(boolean isCaseSensitive) {
+      this.caseSensitive = isCaseSensitive;
+      return this;
+    }
+
+    Builder colStats(boolean shouldUseColumnStats) {
+      this.colStats = shouldUseColumnStats;
+      return this;
+    }
+
+    Builder selectedColumns(Collection<String> columns) {
+      this.selectedColumns = columns;
+      return this;
+    }
+
+    Builder options(Map<String, String> extraOptions) {
+      this.options = ImmutableMap.copyOf(extraOptions);
+      return this;
+    }
+
+    TableScanContext build() {
+      return new TableScanContext(snapshotId, rowFilter, ignoreResiduals, caseSensitive, colStats,
+          selectedColumns, options);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/TableScanContext.java
+++ b/core/src/main/java/org/apache/iceberg/TableScanContext.java
@@ -26,7 +26,7 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 
 /**
- * Context object with arguments required for a TableScan.
+ * Context object with optional arguments for a TableScan.
  */
 final class TableScanContext {
   private final Long snapshotId;
@@ -36,11 +36,12 @@ final class TableScanContext {
   private final boolean colStats;
   private final Collection<String> selectedColumns;
   private final ImmutableMap<String, String> options;
-
+  private final Long fromSnapshotId;
+  private final Long toSnapshotId;
 
   private TableScanContext(Long snapshotId, Expression rowFilter, boolean ignoreResiduals,
                            boolean caseSensitive, boolean colStats, Collection<String> selectedColumns,
-                           ImmutableMap<String, String> options) {
+                           ImmutableMap<String, String> options, Long fromSnapshotId, Long toSnapshotId) {
     this.snapshotId = snapshotId;
     this.rowFilter = rowFilter;
     this.ignoreResiduals = ignoreResiduals;
@@ -48,6 +49,8 @@ final class TableScanContext {
     this.colStats = colStats;
     this.selectedColumns = selectedColumns;
     this.options = options;
+    this.fromSnapshotId = fromSnapshotId;
+    this.toSnapshotId = toSnapshotId;
   }
 
   Long snapshotId() {
@@ -78,6 +81,14 @@ final class TableScanContext {
     return options;
   }
 
+  Long fromSnapshotId() {
+    return fromSnapshotId;
+  }
+
+  Long toSnapshotId() {
+    return toSnapshotId;
+  }
+
   TableScanContext copy() {
     return TableScanContext.builder(this).build();
   }
@@ -98,6 +109,8 @@ final class TableScanContext {
     private boolean colStats;
     private Collection<String> selectedColumns;
     private ImmutableMap<String, String> options;
+    private Long fromSnapshotId;
+    private Long toSnapshotId;
 
     private Builder() {
       this.snapshotId = null;
@@ -107,6 +120,8 @@ final class TableScanContext {
       this.colStats = false;
       this.selectedColumns = null;
       this.options = ImmutableMap.of();
+      this.fromSnapshotId = null;
+      this.toSnapshotId = null;
     }
 
     private Builder(TableScanContext other) {
@@ -117,6 +132,8 @@ final class TableScanContext {
       this.colStats = other.colStats;
       this.selectedColumns = other.selectedColumns;
       this.options = ImmutableMap.copyOf(other.options);
+      this.fromSnapshotId = other.fromSnapshotId;
+      this.toSnapshotId = other.toSnapshotId;
     }
 
     Builder snapshotId(Long id) {
@@ -154,9 +171,19 @@ final class TableScanContext {
       return this;
     }
 
+    Builder fromSnapshotId(Long id) {
+      this.fromSnapshotId = id;
+      return this;
+    }
+
+    Builder toSnapshotId(Long id) {
+      this.toSnapshotId = id;
+      return this;
+    }
+
     TableScanContext build() {
       return new TableScanContext(snapshotId, rowFilter, ignoreResiduals, caseSensitive, colStats,
-          selectedColumns, options);
+          selectedColumns, options, fromSnapshotId, toSnapshotId);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/TableScanContext.java
+++ b/core/src/main/java/org/apache/iceberg/TableScanContext.java
@@ -39,6 +39,10 @@ final class TableScanContext {
   private final Long fromSnapshotId;
   private final Long toSnapshotId;
 
+  TableScanContext() {
+    this(null, Expressions.alwaysTrue(), false, true, false, null, ImmutableMap.of(), null, null);
+  }
+
   private TableScanContext(Long snapshotId, Expression rowFilter, boolean ignoreResiduals,
                            boolean caseSensitive, boolean colStats, Collection<String> selectedColumns,
                            ImmutableMap<String, String> options, Long fromSnapshotId, Long toSnapshotId) {
@@ -57,133 +61,86 @@ final class TableScanContext {
     return snapshotId;
   }
 
+  TableScanContext snapshotId(Long id) {
+    return new TableScanContext(id, rowFilter, ignoreResiduals,
+        caseSensitive, colStats, selectedColumns, options, fromSnapshotId, toSnapshotId);
+  }
+
   Expression rowFilter() {
     return rowFilter;
+  }
+
+  TableScanContext rowFilter(Expression filter) {
+    return new TableScanContext(snapshotId, filter, ignoreResiduals,
+        caseSensitive, colStats, selectedColumns, options, fromSnapshotId, toSnapshotId);
   }
 
   boolean ignoreResiduals() {
     return ignoreResiduals;
   }
 
+  TableScanContext ignoreResiduals(boolean shouldIgnoreResiduals) {
+    return new TableScanContext(snapshotId, rowFilter, shouldIgnoreResiduals,
+        caseSensitive, colStats, selectedColumns, options, fromSnapshotId, toSnapshotId);
+  }
+
   boolean caseSensitive() {
     return caseSensitive;
+  }
+
+  TableScanContext caseSensitive(boolean isCaseSensitive) {
+    return new TableScanContext(snapshotId, rowFilter, ignoreResiduals,
+        isCaseSensitive, colStats, selectedColumns, options, fromSnapshotId, toSnapshotId);
   }
 
   boolean colStats() {
     return colStats;
   }
 
+  TableScanContext colStats(boolean shouldUseColumnStats) {
+    return new TableScanContext(snapshotId, rowFilter, ignoreResiduals,
+        caseSensitive, shouldUseColumnStats, selectedColumns, options, fromSnapshotId, toSnapshotId);
+  }
+
   Collection<String> selectedColumns() {
     return selectedColumns;
+  }
+
+  TableScanContext selectedColumns(Collection<String> columns) {
+    return new TableScanContext(snapshotId, rowFilter, ignoreResiduals,
+        caseSensitive, colStats, columns, options, fromSnapshotId, toSnapshotId);
   }
 
   ImmutableMap<String, String> options() {
     return options;
   }
 
+  TableScanContext options(Map<String, String> extraOptions) {
+    return new TableScanContext(snapshotId, rowFilter, ignoreResiduals,
+        caseSensitive, colStats, selectedColumns, ImmutableMap.copyOf(extraOptions),
+        fromSnapshotId, toSnapshotId);
+  }
+
   Long fromSnapshotId() {
     return fromSnapshotId;
+  }
+
+  TableScanContext fromSnapshotId(Long id) {
+    return new TableScanContext(snapshotId, rowFilter, ignoreResiduals,
+        caseSensitive, colStats, selectedColumns, options, id, toSnapshotId);
   }
 
   Long toSnapshotId() {
     return toSnapshotId;
   }
 
+  TableScanContext toSnapshotId(Long id) {
+    return new TableScanContext(snapshotId, rowFilter, ignoreResiduals,
+        caseSensitive, colStats, selectedColumns, options, fromSnapshotId, id);
+  }
+
   TableScanContext copy() {
-    return TableScanContext.builder(this).build();
-  }
-
-  static Builder builder() {
-    return new Builder();
-  }
-
-  static Builder builder(TableScanContext other) {
-    return new Builder(other);
-  }
-
-  static class Builder {
-    private Long snapshotId;
-    private Expression rowFilter;
-    private boolean ignoreResiduals;
-    private boolean caseSensitive;
-    private boolean colStats;
-    private Collection<String> selectedColumns;
-    private ImmutableMap<String, String> options;
-    private Long fromSnapshotId;
-    private Long toSnapshotId;
-
-    private Builder() {
-      this.snapshotId = null;
-      this.rowFilter = Expressions.alwaysTrue();
-      this.ignoreResiduals = false;
-      this.caseSensitive = false;
-      this.colStats = false;
-      this.selectedColumns = null;
-      this.options = ImmutableMap.of();
-      this.fromSnapshotId = null;
-      this.toSnapshotId = null;
-    }
-
-    private Builder(TableScanContext other) {
-      this.snapshotId = other.snapshotId;
-      this.rowFilter = other.rowFilter;
-      this.ignoreResiduals = other.ignoreResiduals;
-      this.caseSensitive = other.caseSensitive;
-      this.colStats = other.colStats;
-      this.selectedColumns = other.selectedColumns;
-      this.options = ImmutableMap.copyOf(other.options);
-      this.fromSnapshotId = other.fromSnapshotId;
-      this.toSnapshotId = other.toSnapshotId;
-    }
-
-    Builder snapshotId(Long id) {
-      this.snapshotId = id;
-      return this;
-    }
-
-    Builder rowFilter(Expression filter) {
-      this.rowFilter = filter;
-      return this;
-    }
-
-    Builder ignoreResiduals(boolean shouldIgnoreResiduals) {
-      this.ignoreResiduals = shouldIgnoreResiduals;
-      return this;
-    }
-
-    Builder caseSensitive(boolean isCaseSensitive) {
-      this.caseSensitive = isCaseSensitive;
-      return this;
-    }
-
-    Builder colStats(boolean shouldUseColumnStats) {
-      this.colStats = shouldUseColumnStats;
-      return this;
-    }
-
-    Builder selectedColumns(Collection<String> columns) {
-      this.selectedColumns = columns;
-      return this;
-    }
-
-    Builder options(Map<String, String> extraOptions) {
-      this.options = ImmutableMap.copyOf(extraOptions);
-      return this;
-    }
-
-    Builder fromSnapshotId(Long id) {
-      this.fromSnapshotId = id;
-      return this;
-    }
-
-    Builder toSnapshotId(Long id) {
-      this.toSnapshotId = id;
-      return this;
-    }
-
-    TableScanContext build() {
-      return new TableScanContext(snapshotId, rowFilter, ignoreResiduals, caseSensitive, colStats,
-          selectedColumns, options, fromSnapshotId, toSnapshotId);
-    }
+    return new TableScanContext(snapshotId, rowFilter, ignoreResiduals,
+        caseSensitive, colStats, selectedColumns, options, fromSnapshotId, toSnapshotId);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/TableScanContext.java
+++ b/core/src/main/java/org/apache/iceberg/TableScanContext.java
@@ -40,7 +40,15 @@ final class TableScanContext {
   private final Long toSnapshotId;
 
   TableScanContext() {
-    this(null, Expressions.alwaysTrue(), false, true, false, null, ImmutableMap.of(), null, null);
+    this.snapshotId = null;
+    this.rowFilter = Expressions.alwaysTrue();
+    this.ignoreResiduals = false;
+    this.caseSensitive = true;
+    this.colStats = false;
+    this.selectedColumns = null;
+    this.options = ImmutableMap.of();
+    this.fromSnapshotId = null;
+    this.toSnapshotId = null;
   }
 
   private TableScanContext(Long snapshotId, Expression rowFilter, boolean ignoreResiduals,
@@ -61,8 +69,8 @@ final class TableScanContext {
     return snapshotId;
   }
 
-  TableScanContext snapshotId(Long id) {
-    return new TableScanContext(id, rowFilter, ignoreResiduals,
+  TableScanContext useSnapshotId(Long scanSnapshotId) {
+    return new TableScanContext(scanSnapshotId, rowFilter, ignoreResiduals,
         caseSensitive, colStats, selectedColumns, options, fromSnapshotId, toSnapshotId);
   }
 
@@ -70,7 +78,7 @@ final class TableScanContext {
     return rowFilter;
   }
 
-  TableScanContext rowFilter(Expression filter) {
+  TableScanContext filterRows(Expression filter) {
     return new TableScanContext(snapshotId, filter, ignoreResiduals,
         caseSensitive, colStats, selectedColumns, options, fromSnapshotId, toSnapshotId);
   }
@@ -88,44 +96,46 @@ final class TableScanContext {
     return caseSensitive;
   }
 
-  TableScanContext caseSensitive(boolean isCaseSensitive) {
+  TableScanContext setCaseSensitive(boolean isCaseSensitive) {
     return new TableScanContext(snapshotId, rowFilter, ignoreResiduals,
         isCaseSensitive, colStats, selectedColumns, options, fromSnapshotId, toSnapshotId);
   }
 
-  boolean colStats() {
+  boolean returnColumnStats() {
     return colStats;
   }
 
-  TableScanContext colStats(boolean shouldUseColumnStats) {
+  TableScanContext shouldReturnColumnStats(boolean returnColumnStats) {
     return new TableScanContext(snapshotId, rowFilter, ignoreResiduals,
-        caseSensitive, shouldUseColumnStats, selectedColumns, options, fromSnapshotId, toSnapshotId);
+        caseSensitive, returnColumnStats, selectedColumns, options, fromSnapshotId, toSnapshotId);
   }
 
   Collection<String> selectedColumns() {
     return selectedColumns;
   }
 
-  TableScanContext selectedColumns(Collection<String> columns) {
+  TableScanContext selectColumns(Collection<String> columns) {
     return new TableScanContext(snapshotId, rowFilter, ignoreResiduals,
         caseSensitive, colStats, columns, options, fromSnapshotId, toSnapshotId);
   }
 
-  ImmutableMap<String, String> options() {
+  Map<String, String> options() {
     return options;
   }
 
-  TableScanContext options(Map<String, String> extraOptions) {
+  TableScanContext withOption(String property, String value) {
+    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+    builder.putAll(options);
+    builder.put(property, value);
     return new TableScanContext(snapshotId, rowFilter, ignoreResiduals,
-        caseSensitive, colStats, selectedColumns, ImmutableMap.copyOf(extraOptions),
-        fromSnapshotId, toSnapshotId);
+        caseSensitive, colStats, selectedColumns, builder.build(), fromSnapshotId, toSnapshotId);
   }
 
   Long fromSnapshotId() {
     return fromSnapshotId;
   }
 
-  TableScanContext fromSnapshotId(Long id) {
+  TableScanContext fromSnapshotId(long id) {
     return new TableScanContext(snapshotId, rowFilter, ignoreResiduals,
         caseSensitive, colStats, selectedColumns, options, id, toSnapshotId);
   }
@@ -134,13 +144,8 @@ final class TableScanContext {
     return toSnapshotId;
   }
 
-  TableScanContext toSnapshotId(Long id) {
+  TableScanContext toSnapshotId(long id) {
     return new TableScanContext(snapshotId, rowFilter, ignoreResiduals,
         caseSensitive, colStats, selectedColumns, options, fromSnapshotId, id);
-  }
-
-  TableScanContext copy() {
-    return new TableScanContext(snapshotId, rowFilter, ignoreResiduals,
-        caseSensitive, colStats, selectedColumns, options, fromSnapshotId, toSnapshotId);
   }
 }


### PR DESCRIPTION
This PR is a refactor of `TableScan` implementations to use a `TableScanContext` object for the optional arguments used.

As discussed in https://github.com/apache/iceberg/pull/1094#discussion_r435532764, when new arguments are added to a `TableScan` the number of changes needed is really large only to pass down the arguments through the refinement calls. 

This change will make such changes more straightforward minimizing the number of changes required to add an argument, which would only be required now in the context object and in the specific `TableScan` that would use it, leading to more maintainable code.

PTAL @aokolnychyi @rdblue 