### PR TITLE
ORC: fix date metrics to adjust milliseconds to local timezone

### DIFF
--- a/data/src/test/java/org/apache/iceberg/data/TestLocalScan.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestLocalScan.java
@@ -456,6 +456,8 @@ public class TestLocalScan {
 
   @Test
   public void testFilterWithDateAndTimestamp() throws IOException {
+    // TODO: Add multiple timestamp tests - there's an issue with ORC caching TZ in ThreadLocal, so it's not possible
+    //   to change TZ and test with ORC as they will produce incompatible values.
     Schema schema = new Schema(
         required(1, "timestamp_with_zone", Types.TimestampType.withZone()),
         required(2, "timestamp_without_zone", Types.TimestampType.withoutZone()),

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
@@ -21,8 +21,8 @@ package org.apache.iceberg.orc;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.sql.Date;
 import java.sql.Timestamp;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -158,8 +158,7 @@ public class OrcMetrics {
           .orElse(null);
     } else if (columnStats instanceof DateColumnStatistics) {
       min = Optional.ofNullable(((DateColumnStatistics) columnStats).getMinimum())
-          .map(minStats -> DateTimeUtil.daysFromDate(
-              DateTimeUtil.EPOCH.plus(minStats.getTime(), ChronoUnit.MILLIS).toLocalDate()))
+          .map(minStats -> DateTimeUtil.daysFromDate(((Date) minStats).toLocalDate()))
           .orElse(null);
     } else if (columnStats instanceof TimestampColumnStatistics) {
       TimestampColumnStatistics tColStats = (TimestampColumnStatistics) columnStats;
@@ -197,8 +196,7 @@ public class OrcMetrics {
           .orElse(null);
     } else if (columnStats instanceof DateColumnStatistics) {
       max = Optional.ofNullable(((DateColumnStatistics) columnStats).getMaximum())
-          .map(maxStats -> DateTimeUtil.daysFromDate(
-              DateTimeUtil.EPOCH.plus(maxStats.getTime(), ChronoUnit.MILLIS).toLocalDate()))
+          .map(maxStats -> DateTimeUtil.daysFromDate(((Date) maxStats).toLocalDate()))
           .orElse(null);
     } else if (columnStats instanceof TimestampColumnStatistics) {
       TimestampColumnStatistics tColStats = (TimestampColumnStatistics) columnStats;

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.orc;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;
@@ -29,9 +28,11 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.common.DynFields;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.hadoop.HadoopInputFile;
 import org.apache.iceberg.io.InputFile;
@@ -43,7 +44,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
-import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.orc.BooleanColumnStatistics;
 import org.apache.orc.ColumnStatistics;
 import org.apache.orc.DateColumnStatistics;
@@ -55,6 +55,7 @@ import org.apache.orc.StringColumnStatistics;
 import org.apache.orc.TimestampColumnStatistics;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
+import org.apache.orc.impl.ColumnStatisticsImpl;
 
 public class OrcMetrics {
 
@@ -157,9 +158,7 @@ public class OrcMetrics {
               .setScale(((Types.DecimalType) column.type()).scale()))
           .orElse(null);
     } else if (columnStats instanceof DateColumnStatistics) {
-      min = Optional.ofNullable(((DateColumnStatistics) columnStats).getMinimum())
-          .map(minStats -> DateTimeUtil.daysFromDate(((Date) minStats).toLocalDate()))
-          .orElse(null);
+      min = Optional.ofNullable(minDayFromEpoch((DateColumnStatistics) columnStats)).orElse(null);
     } else if (columnStats instanceof TimestampColumnStatistics) {
       TimestampColumnStatistics tColStats = (TimestampColumnStatistics) columnStats;
       Timestamp minValue = tColStats.getMinimumUTC();
@@ -195,9 +194,7 @@ public class OrcMetrics {
               .setScale(((Types.DecimalType) column.type()).scale()))
           .orElse(null);
     } else if (columnStats instanceof DateColumnStatistics) {
-      max = Optional.ofNullable(((DateColumnStatistics) columnStats).getMaximum())
-          .map(maxStats -> DateTimeUtil.daysFromDate(((Date) maxStats).toLocalDate()))
-          .orElse(null);
+      max = Optional.ofNullable(maxDayFromEpoch((DateColumnStatistics) columnStats)).orElse(null);
     } else if (columnStats instanceof TimestampColumnStatistics) {
       TimestampColumnStatistics tColStats = (TimestampColumnStatistics) columnStats;
       Timestamp maxValue = tColStats.getMaximumUTC();
@@ -271,5 +268,28 @@ public class OrcMetrics {
     public TypeDescription primitive(Type.PrimitiveType iPrimitive, TypeDescription primitive) {
       return primitive;
     }
+  }
+
+  private static final Class<?> DATE_STATS_IMPL = Stream.of(ColumnStatisticsImpl.class.getDeclaredClasses())
+      .filter(statsClass -> "DateStatisticsImpl".equals(statsClass.getSimpleName()))
+      .findFirst()
+      .orElse(null);
+
+  private static final DynFields.UnboundField<Integer> DATE_MINIMUM = DynFields.builder()
+      .hiddenImpl(DATE_STATS_IMPL, "minimum")
+      .defaultAlwaysNull() // if the minimum field isn't found, don't add a value
+      .build();
+
+  private static final DynFields.UnboundField<Integer> DATE_MAXIMUM = DynFields.builder()
+      .hiddenImpl(DATE_STATS_IMPL, "maximum")
+      .defaultAlwaysNull() // if the minimum field isn't found, don't add a value
+      .build();
+
+  private static Integer minDayFromEpoch(DateColumnStatistics stats) {
+    return DATE_MINIMUM.get(stats);
+  }
+
+  private static Integer maxDayFromEpoch(DateColumnStatistics stats) {
+    return DATE_MAXIMUM.get(stats);
   }
 }


### PR DESCRIPTION
This PR attempts to solve issues #1116 and #1113 when running in different Time Zones.

I've added a test to check for local scan on different timezones which surfaced an issue with the pushdown predicates with DATE columns, which seem to use incorrect incorrect TZ to read the metrics within the ORC reader. Due to this, disabling ORC lower/upper bound metrics for Date in Iceberg as well.

I've tested by changing system TZ to other timezones and running the tests and they pass.

PTAL @shardulm94 @chenjunjiedada if you have a chance, please pull this branch and run the test suite locally just to double check the build. Thanks!

@rdblue 