### PR TITLE
Fix errors when reading options in Avro files with non-null defaults

### DIFF
--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroOptionsWithNonNullDefaults.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroOptionsWithNonNullDefaults.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.avro;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.apache.avro.Schema.Type.INT;
+import static org.apache.avro.Schema.Type.LONG;
+import static org.apache.avro.Schema.Type.NULL;
+
+public class TestAvroOptionsWithNonNullDefaults {
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  @Test
+  public void writeAndValidateOptionWithNonNullDefaultsPruning() throws IOException {
+    Schema writeSchema = Schema.createRecord("root", null, null, false,
+        ImmutableList.of(
+            new Schema.Field("field", Schema.createUnion(Schema.createArray(Schema.create(INT)), Schema.create(NULL)),
+                null, ImmutableList.of())
+        )
+    );
+
+    GenericData.Record record1 = new GenericData.Record(writeSchema);
+    record1.put("field", ImmutableList.of(1, 2, 3));
+    GenericData.Record record2 = new GenericData.Record(writeSchema);
+    record2.put("field", null);
+
+    File testFile = temp.newFile();
+    Assert.assertTrue("Delete should succeed", testFile.delete());
+
+    try (DataFileWriter<GenericData.Record> writer = new DataFileWriter<>(new GenericDatumWriter<>())) {
+      writer.create(writeSchema, testFile);
+      writer.append(record1);
+      writer.append(record2);
+    }
+
+    List<GenericData.Record> expected = ImmutableList.of(record1, record2);
+
+    org.apache.iceberg.Schema readIcebergSchema = AvroSchemaUtil.toIceberg(writeSchema);
+    List<GenericData.Record> rows;
+    try (AvroIterable<GenericData.Record> reader = Avro.read(Files.localInput(testFile))
+        .project(readIcebergSchema).build()) {
+      rows = Lists.newArrayList(reader);
+    }
+
+    for (int i = 0; i < expected.size(); i += 1) {
+      AvroTestHelpers.assertEquals(readIcebergSchema.asStruct(), expected.get(i), rows.get(i));
+    }
+  }
+
+  @Test
+  public void writeAndValidateOptionWithNonNullDefaultsEvolution() throws IOException {
+    Schema writeSchema = Schema.createRecord("root", null, null, false,
+        ImmutableList.of(
+            new Schema.Field("field", Schema.createUnion(Schema.create(INT), Schema.create(NULL)), null, -1)
+        )
+    );
+
+    GenericData.Record record1 = new GenericData.Record(writeSchema);
+    record1.put("field", 1);
+    GenericData.Record record2 = new GenericData.Record(writeSchema);
+    record2.put("field", null);
+
+    File testFile = temp.newFile();
+    Assert.assertTrue("Delete should succeed", testFile.delete());
+
+    try (DataFileWriter<GenericData.Record> writer = new DataFileWriter<>(new GenericDatumWriter<>())) {
+      writer.create(writeSchema, testFile);
+      writer.append(record1);
+      writer.append(record2);
+    }
+
+    Schema readSchema = Schema.createRecord("root", null, null, false,
+        ImmutableList.of(
+            new Schema.Field("field", Schema.createUnion(Schema.create(LONG), Schema.create(NULL)), null, -1L)
+        )
+    );
+
+    GenericData.Record expectedRecord1 = new GenericData.Record(readSchema);
+    expectedRecord1.put("field", 1L);
+    GenericData.Record expectedRecord2 = new GenericData.Record(readSchema);
+    expectedRecord2.put("field", null);
+    List<GenericData.Record> expected = ImmutableList.of(expectedRecord1, expectedRecord2);
+
+    org.apache.iceberg.Schema readIcebergSchema = AvroSchemaUtil.toIceberg(readSchema);
+    List<GenericData.Record> rows;
+    try (AvroIterable<GenericData.Record> reader = Avro.read(Files.localInput(testFile))
+        .project(readIcebergSchema).build()) {
+      rows = Lists.newArrayList(reader);
+    }
+
+    for (int i = 0; i < expected.size(); i += 1) {
+      AvroTestHelpers.assertEquals(readIcebergSchema.asStruct(), expected.get(i), rows.get(i));
+    }
+  }
+}


### PR DESCRIPTION
Avro files written by non-Iceberg writers can contain optional schemas where the NULL schema is second in the options list. If there is a default value associated with the field, we need to ensure that our visitors preserve this ordering else it can lead to issues like `org.apache.avro.AvroTypeException: Invalid default for field field: [] not a ["null",{"type":"array","items":"long"}]`. This is because the Avro [spec requires](https://avro.apache.org/docs/current/spec.html#Unions) the type of the default value to match the first option in the schema.

The changes should be limited to the codepaths which interact with non-Iceberg Avro files so I believe the visitors used in `ProjectionDatumReader` are the only ones affected.

Error stacktraces:
```
org.apache.avro.AvroTypeException: Invalid default for field field: [] not a ["null",{"type":"array","items":"int","element-id":1}]

	at org.apache.avro.Schema.validateDefault(Schema.java:1540)
	at org.apache.avro.Schema.access$500(Schema.java:87)
	at org.apache.avro.Schema$Field.<init>(Schema.java:521)
	at org.apache.avro.Schema$Field.<init>(Schema.java:567)
	at org.apache.iceberg.avro.PruneColumns.copyField(PruneColumns.java:252)
	at org.apache.iceberg.avro.PruneColumns.record(PruneColumns.java:83)
	at org.apache.iceberg.avro.PruneColumns.record(PruneColumns.java:34)
	at org.apache.iceberg.avro.AvroSchemaVisitor.visit(AvroSchemaVisitor.java:50)
	at org.apache.iceberg.avro.PruneColumns.rootSchema(PruneColumns.java:46)
	at org.apache.iceberg.avro.AvroSchemaUtil.pruneColumns(AvroSchemaUtil.java:99)
	at org.apache.iceberg.avro.ProjectionDatumReader.setSchema(ProjectionDatumReader.java:59)


org.apache.avro.AvroTypeException: Invalid default for field field: [] not a ["null",{"type":"array","items":"long"}]

	at org.apache.avro.Schema.validateDefault(Schema.java:1540)
	at org.apache.avro.Schema.access$500(Schema.java:87)
	at org.apache.avro.Schema$Field.<init>(Schema.java:521)
	at org.apache.avro.Schema$Field.<init>(Schema.java:567)
	at org.apache.iceberg.avro.AvroSchemaUtil.copyField(AvroSchemaUtil.java:362)
	at org.apache.iceberg.avro.BuildAvroProjection.field(BuildAvroProjection.java:134)
	at org.apache.iceberg.avro.BuildAvroProjection.field(BuildAvroProjection.java:41)
	at org.apache.iceberg.avro.AvroCustomOrderSchemaVisitor$VisitFieldFuture.get(AvroCustomOrderSchemaVisitor.java:124)
	at org.apache.iceberg.relocated.com.google.common.collect.Iterators$6.transform(Iterators.java:783)
	at org.apache.iceberg.relocated.com.google.common.collect.TransformedIterator.next(TransformedIterator.java:47)
	at org.apache.iceberg.relocated.com.google.common.collect.Iterators.addAll(Iterators.java:356)
	at org.apache.iceberg.relocated.com.google.common.collect.Lists.newArrayList(Lists.java:143)
	at org.apache.iceberg.relocated.com.google.common.collect.Lists.newArrayList(Lists.java:130)
	at org.apache.iceberg.avro.BuildAvroProjection.record(BuildAvroProjection.java:60)
	at org.apache.iceberg.avro.BuildAvroProjection.record(BuildAvroProjection.java:41)
	at org.apache.iceberg.avro.AvroCustomOrderSchemaVisitor.visit(AvroCustomOrderSchemaVisitor.java:51)
	at org.apache.iceberg.avro.AvroSchemaUtil.buildAvroProjection(AvroSchemaUtil.java:104)
	at org.apache.iceberg.avro.ProjectionDatumReader.setSchema(ProjectionDatumReader.java:60)
```