### PR TITLE
Fix executor memory leak in Parquet row group filter

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
@@ -116,7 +116,18 @@ public class ParquetDictionaryRowGroupFilter {
         }
       }
 
-      return ExpressionVisitors.visitEvaluator(expr, this);
+      try {
+        return ExpressionVisitors.visitEvaluator(expr, this);
+
+      } finally {
+        // allow temporary state to be collected because this is in a thread-local
+        this.dictionaries = null;
+        this.dictCache = null;
+        this.isFallback = null;
+        this.mayContainNulls = null;
+        this.cols = null;
+        this.conversions = null;
+      }
     }
 
     @Override


### PR DESCRIPTION
Spark executors use a new thread for each task, and Iceberg reuses a thread-local evaluator when running row group filters. The combination of new threads and thread-local prevents those evaluators from being garbage collected.

The evaluator holds state for the current row group, which can be large for the dictionary row group filter. This PR avoids a large memory leak by cleaning up references to the row group's dictionaries and other state after each evaluation.