### PR TITLE
ORC: skip non-iceberg columns when converting schema to Iceberg

### DIFF
--- a/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
@@ -219,7 +219,7 @@ public final class ORCSchemaUtil {
     }
 
     if (icebergFields.size() == 0) {
-      throw new IllegalArgumentException("ORC schema has no Iceberg mappings");
+      throw new IllegalArgumentException("ORC schema does not contain Iceberg IDs");
     }
 
     return new Schema(icebergFields);
@@ -411,7 +411,7 @@ public final class ORCSchemaUtil {
                                               List<Optional<Types.NestedField>> fields) {
       boolean isOptional = isOptional(record);
       Optional<Integer> icebergIdOpt = icebergID(record);
-      if (!icebergIdOpt.isPresent() || fields.size() == 0) {
+      if (!icebergIdOpt.isPresent() || fields.stream().noneMatch(Optional::isPresent)) {
         return Optional.empty();
       }
 

--- a/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
@@ -200,10 +200,11 @@ public final class ORCSchemaUtil {
 
   /**
    * Convert an ORC schema to an Iceberg schema. This method handles the convertion from the original
-   * Iceberg column mapping IDs if present in the ORC column attributes, otherwise, ORC column IDs
-   * will be assigned following ORCs pre-order ID assignment.
+   * Iceberg column mapping IDs if present in the ORC column attributes, otherwise, ORC columns with no
+   * Iceberg IDs will be ignored and skipped in the conversion.
    *
    * @return the Iceberg schema
+   * @throws IllegalArgumentException if ORC schema has no columns with Iceberg ID attributes
    */
   public static Schema convert(TypeDescription orcSchema) {
     List<TypeDescription> children = orcSchema.getChildren();

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaVisitor.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaVisitor.java
@@ -37,12 +37,10 @@ public abstract class OrcSchemaVisitor<T> {
         throw new UnsupportedOperationException("Cannot handle " + schema);
 
       case LIST:
-        return visitor.list(
-            schema, visit(schema.getChildren().get(0), visitor));
+        return visitor.list(schema, visit(schema.getChildren().get(0), visitor));
 
       case MAP:
-        return visitor.map(
-            schema,
+        return visitor.map(schema,
             visit(schema.getChildren().get(0), visitor),
             visit(schema.getChildren().get(1), visitor));
 

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaVisitor.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaVisitor.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.orc;
+
+import java.util.List;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.orc.TypeDescription;
+
+/**
+ * Generic visitor of an ORC Schema.
+ */
+public abstract class OrcSchemaVisitor<T> {
+
+  public static <T> T visit(TypeDescription schema, OrcSchemaVisitor<T> visitor) {
+    switch (schema.getCategory()) {
+      case STRUCT:
+        return visitRecord(schema, visitor);
+
+      case UNION:
+        throw new UnsupportedOperationException("Cannot handle " + schema);
+
+      case LIST:
+        return visitor.list(
+            schema, visit(schema.getChildren().get(0), visitor));
+
+      case MAP:
+        return visitor.map(
+            schema,
+            visit(schema.getChildren().get(0), visitor),
+            visit(schema.getChildren().get(1), visitor));
+
+      default:
+        return visitor.primitive(schema);
+    }
+  }
+
+  private static <T> T visitRecord(TypeDescription record, OrcSchemaVisitor<T> visitor) {
+    List<TypeDescription> fields = record.getChildren();
+    List<String> names = record.getFieldNames();
+    List<T> results = Lists.newArrayListWithExpectedSize(fields.size());
+    List<String> includedNames = Lists.newArrayListWithExpectedSize(names.size());
+    for (int i = 0; i < fields.size(); ++i) {
+      TypeDescription field = fields.get(i);
+      String name = names.get(i);
+      results.add(visit(field, visitor));
+      includedNames.add(name);
+    }
+    return visitor.record(record, includedNames, results);
+  }
+
+  public T record(TypeDescription record, List<String> names, List<T> fields) {
+    return null;
+  }
+
+  public T list(TypeDescription array, T element) {
+    return null;
+  }
+
+  public T map(TypeDescription map, T key, T value) {
+    return null;
+  }
+
+  public T primitive(TypeDescription primitive) {
+    return null;
+  }
+}

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaWithTypeVisitor.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaWithTypeVisitor.java
@@ -44,7 +44,7 @@ public abstract class OrcSchemaWithTypeVisitor<T> {
         Types.ListType list = iType != null ? iType.asListType() : null;
         return visitor.list(
             list, schema,
-            visit(list.elementType(), schema.getChildren().get(0), visitor));
+            visit(list != null ? list.elementType() : null, schema.getChildren().get(0), visitor));
 
       case MAP:
         Types.MapType map = iType != null ? iType.asMapType() : null;

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaWithTypeVisitor.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcSchemaWithTypeVisitor.java
@@ -20,13 +20,18 @@
 package org.apache.iceberg.orc;
 
 import java.util.List;
+import java.util.Optional;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.orc.TypeDescription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public abstract class OrcSchemaWithTypeVisitor<T> {
+  private static final Logger LOG = LoggerFactory.getLogger(OrcSchemaWithTypeVisitor.class);
+
   public static <T> T visit(
       org.apache.iceberg.Schema iSchema, TypeDescription schema, OrcSchemaWithTypeVisitor<T> visitor) {
     return visit(iSchema.asStruct(), schema, visitor);
@@ -63,12 +68,20 @@ public abstract class OrcSchemaWithTypeVisitor<T> {
     List<TypeDescription> fields = record.getChildren();
     List<String> names = record.getFieldNames();
     List<T> results = Lists.newArrayListWithExpectedSize(fields.size());
-    for (TypeDescription field : fields) {
-      int fieldId = ORCSchemaUtil.fieldId(field);
-      Types.NestedField iField = struct != null ? struct.field(fieldId) : null;
+    List<String> includedNames = Lists.newArrayListWithExpectedSize(names.size());
+    for (int i = 0; i < fields.size(); ++i) {
+      TypeDescription field = fields.get(i);
+      String name = names.get(i);
+      Optional<Integer> fieldId = ORCSchemaUtil.icebergID(field);
+      if (!fieldId.isPresent()) {
+        LOG.warn("Missing expected '{}' property - skipping field {}", ORCSchemaUtil.ICEBERG_ID_ATTRIBUTE, name);
+        continue;
+      }
+      Types.NestedField iField = struct != null ? struct.field(fieldId.get()) : null;
       results.add(visit(iField != null ? iField.type() : null, field, visitor));
+      includedNames.add(name);
     }
-    return visitor.record(struct, record, names, results);
+    return visitor.record(struct, record, includedNames, results);
   }
 
   public T record(Types.StructType iStruct, TypeDescription record, List<String> names, List<T> fields) {

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcToIcebergVisitor.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcToIcebergVisitor.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.orc;
+
+import java.util.Deque;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.apache.orc.TypeDescription;
+
+/**
+ * Converts an ORC schema to Iceberg.
+ */
+class OrcToIcebergVisitor extends OrcSchemaVisitor<Optional<Types.NestedField>> {
+
+  private final Deque<String> fieldNames;
+
+  OrcToIcebergVisitor() {
+    this.fieldNames = Lists.newLinkedList();
+  }
+
+  @Override
+  public void beforeField(String name, TypeDescription type) {
+    fieldNames.push(name);
+  }
+
+  @Override
+  public void afterField(String name, TypeDescription type) {
+    fieldNames.pop();
+  }
+
+  private String currentFieldName() {
+    return fieldNames.peek();
+  }
+
+  @Override
+  public Optional<Types.NestedField> record(TypeDescription record, List<String> names,
+                                            List<Optional<Types.NestedField>> fields) {
+    boolean isOptional = ORCSchemaUtil.isOptional(record);
+    Optional<Integer> icebergIdOpt = ORCSchemaUtil.icebergID(record);
+    if (!icebergIdOpt.isPresent() || fields.stream().noneMatch(Optional::isPresent)) {
+      return Optional.empty();
+    }
+
+    Types.StructType structType = Types.StructType.of(
+        fields.stream().filter(Optional::isPresent).map(Optional::get).collect(Collectors.toList()));
+    return Optional.of(Types.NestedField.of(icebergIdOpt.get(), isOptional, currentFieldName(), structType));
+  }
+
+  @Override
+  public Optional<Types.NestedField> list(TypeDescription array,
+                                          Optional<Types.NestedField> element) {
+    boolean isOptional = ORCSchemaUtil.isOptional(array);
+    Optional<Integer> icebergIdOpt = ORCSchemaUtil.icebergID(array);
+
+    if (!icebergIdOpt.isPresent() || !element.isPresent()) {
+      return Optional.empty();
+    }
+
+    Types.NestedField foundElement = element.get();
+    Types.ListType listTypeWithElem = ORCSchemaUtil.isOptional(array.getChildren().get(0)) ?
+        Types.ListType.ofOptional(foundElement.fieldId(), foundElement.type()) :
+        Types.ListType.ofRequired(foundElement.fieldId(), foundElement.type());
+
+    return Optional.of(Types.NestedField.of(icebergIdOpt.get(), isOptional, currentFieldName(), listTypeWithElem));
+  }
+
+  @Override
+  public Optional<Types.NestedField> map(TypeDescription map, Optional<Types.NestedField> key,
+                                         Optional<Types.NestedField> value) {
+    boolean isOptional = ORCSchemaUtil.isOptional(map);
+    Optional<Integer> icebergIdOpt = ORCSchemaUtil.icebergID(map);
+
+    if (!icebergIdOpt.isPresent() || !key.isPresent() || !value.isPresent()) {
+      return Optional.empty();
+    }
+
+    Types.NestedField foundKey = key.get();
+    Types.NestedField foundValue = value.get();
+    Types.MapType mapTypeWithKV = ORCSchemaUtil.isOptional(map.getChildren().get(1)) ?
+        Types.MapType.ofOptional(foundKey.fieldId(), foundValue.fieldId(), foundKey.type(), foundValue.type()) :
+        Types.MapType.ofRequired(foundKey.fieldId(), foundValue.fieldId(), foundKey.type(), foundValue.type());
+
+    return Optional.of(Types.NestedField.of(icebergIdOpt.get(), isOptional, currentFieldName(), mapTypeWithKV));
+  }
+
+  @Override
+  public Optional<Types.NestedField> primitive(TypeDescription primitive) {
+    boolean isOptional = ORCSchemaUtil.isOptional(primitive);
+    Optional<Integer> icebergIdOpt = ORCSchemaUtil.icebergID(primitive);
+
+    if (!icebergIdOpt.isPresent()) {
+      return Optional.empty();
+    }
+
+    final Types.NestedField foundField;
+    int icebergID = icebergIdOpt.get();
+    String name = currentFieldName();
+    switch (primitive.getCategory()) {
+      case BOOLEAN:
+        foundField = Types.NestedField.of(icebergID, isOptional, name, Types.BooleanType.get());
+        break;
+      case BYTE:
+      case SHORT:
+      case INT:
+        foundField = Types.NestedField.of(icebergID, isOptional, name, Types.IntegerType.get());
+        break;
+      case LONG:
+        String longAttributeValue = primitive.getAttributeValue(ORCSchemaUtil.ICEBERG_LONG_TYPE_ATTRIBUTE);
+        ORCSchemaUtil.LongType longType = longAttributeValue == null ?
+            ORCSchemaUtil.LongType.LONG : ORCSchemaUtil.LongType.valueOf(longAttributeValue);
+        switch (longType) {
+          case TIME:
+            foundField = Types.NestedField.of(icebergID, isOptional, name, Types.TimeType.get());
+            break;
+          case LONG:
+            foundField = Types.NestedField.of(icebergID, isOptional, name, Types.LongType.get());
+            break;
+          default:
+            throw new IllegalStateException("Invalid Long type found in ORC type attribute");
+        }
+        break;
+      case FLOAT:
+        foundField = Types.NestedField.of(icebergID, isOptional, name, Types.FloatType.get());
+        break;
+      case DOUBLE:
+        foundField = Types.NestedField.of(icebergID, isOptional, name, Types.DoubleType.get());
+        break;
+      case STRING:
+      case CHAR:
+      case VARCHAR:
+        foundField = Types.NestedField.of(icebergID, isOptional, name, Types.StringType.get());
+        break;
+      case BINARY:
+        String binaryAttributeValue = primitive.getAttributeValue(ORCSchemaUtil.ICEBERG_BINARY_TYPE_ATTRIBUTE);
+        ORCSchemaUtil.BinaryType binaryType = binaryAttributeValue == null ? ORCSchemaUtil.BinaryType.BINARY :
+            ORCSchemaUtil.BinaryType.valueOf(binaryAttributeValue);
+        switch (binaryType) {
+          case UUID:
+            foundField = Types.NestedField.of(icebergID, isOptional, name, Types.UUIDType.get());
+            break;
+          case FIXED:
+            int fixedLength = Integer.parseInt(primitive.getAttributeValue(ORCSchemaUtil.ICEBERG_FIELD_LENGTH));
+            foundField = Types.NestedField.of(icebergID, isOptional, name, Types.FixedType.ofLength(fixedLength));
+            break;
+          case BINARY:
+            foundField = Types.NestedField.of(icebergID, isOptional, name, Types.BinaryType.get());
+            break;
+          default:
+            throw new IllegalStateException("Invalid Binary type found in ORC type attribute");
+        }
+        break;
+      case DATE:
+        foundField = Types.NestedField.of(icebergID, isOptional, name, Types.DateType.get());
+        break;
+      case TIMESTAMP:
+        foundField = Types.NestedField.of(icebergID, isOptional, name, Types.TimestampType.withoutZone());
+        break;
+      case TIMESTAMP_INSTANT:
+        foundField = Types.NestedField.of(icebergID, isOptional, name, Types.TimestampType.withZone());
+        break;
+      case DECIMAL:
+        foundField = Types.NestedField.of(icebergID, isOptional, name,
+            Types.DecimalType.of(primitive.getPrecision(), primitive.getScale()));
+        break;
+      default:
+        throw new IllegalArgumentException("Can't handle " + primitive);
+    }
+    return Optional.of(foundField);
+  }
+}


### PR DESCRIPTION
As mentioned in https://github.com/apache/iceberg/pull/989#discussion_r420996718 and referenced in #1055 ORC previously assigned an ID based on an `AtomicCounter` to assign Iceberg IDs if they were not found in ORC type attributes.

This PR changes the implementation to use the ORC type visitor and skips types that do not have an Iceberg ID in the type attribute as follows:
* Primitives: if the type does not have an Iceberg ID it is skipped
* Lists: only included if element and the list type itself have an Iceberg ID, otherwise it is skipped
* Maps: only included if key, value and the map type itself have an Iceberg ID, otherwise it is skipped
* Structs: included as long as any of the fields in the struct has an Iceberg ID, otherwise it is skipped 

If the schema as a whole does not have any Iceberg IDs, it fails with Exception.

Additional changes are:
* Fixed NPE in ORC visitor when visiting lists
* Added new generic `OrcSchemaVisitor` to traverse `TypeDescription` tree.

PTAL @rdsr @rdblue - Thanks!