### PR TITLE
Spark: Fix remaining differences from spark-3 branch

### DIFF
--- a/api/src/main/java/org/apache/iceberg/exceptions/NoSuchIcebergTableException.java
+++ b/api/src/main/java/org/apache/iceberg/exceptions/NoSuchIcebergTableException.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.exceptions;
+
+/**
+ * NoSuchTableException thrown when a table is found but it is not an Iceberg table.
+ */
+public class NoSuchIcebergTableException extends NoSuchTableException {
+  public NoSuchIcebergTableException(String message, Object... args) {
+    super(message, args);
+  }
+
+  public static void check(boolean test, String message, Object... args) {
+    if (!test) {
+      throw new NoSuchIcebergTableException(message, args);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -282,7 +282,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
         });
   }
 
-  private static String fullTableName(String catalogName, TableIdentifier identifier) {
+  protected static String fullTableName(String catalogName, TableIdentifier identifier) {
     StringBuilder sb = new StringBuilder();
 
     if (catalogName.contains("/") || catalogName.contains(":")) {

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -71,7 +71,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
   private static final Joiner SLASH = Joiner.on("/");
   private static final PathFilter TABLE_FILTER = path -> path.getName().endsWith(TABLE_METADATA_FILE_EXTENSION);
 
-  private final String name;
+  private final String catalogName;
   private final Configuration conf;
   private final String warehouseLocation;
   private final FileSystem fs;
@@ -87,7 +87,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
     Preconditions.checkArgument(warehouseLocation != null && !warehouseLocation.equals(""),
         "no location provided for warehouse");
 
-    this.name = name;
+    this.catalogName = name;
     this.conf = conf;
     this.warehouseLocation = warehouseLocation.replaceAll("/*$", "");
     this.fs = Util.getFs(new Path(warehouseLocation), conf);
@@ -116,7 +116,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
 
   @Override
   protected String name() {
-    return name;
+    return catalogName;
   }
 
   @Override

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -54,19 +54,22 @@ import org.slf4j.LoggerFactory;
 public class HiveCatalog extends BaseMetastoreCatalog implements Closeable, SupportsNamespaces {
   private static final Logger LOG = LoggerFactory.getLogger(HiveCatalog.class);
 
+  private final String name;
   private final HiveClientPool clients;
   private final Configuration conf;
   private final StackTraceElement[] createStack;
   private boolean closed;
 
   public HiveCatalog(Configuration conf) {
+    this.name = "hive";
     this.clients = new HiveClientPool(conf);
     this.conf = conf;
     this.createStack = Thread.currentThread().getStackTrace();
     this.closed = false;
   }
 
-  public HiveCatalog(String uri, int clientPoolSize, Configuration conf) {
+  public HiveCatalog(String name, String uri, int clientPoolSize, Configuration conf) {
+    this.name = name;
     this.conf = new Configuration(conf);
     // before building the client pool, overwrite the configuration's URIs if the argument is non-null
     if (uri != null) {
@@ -104,7 +107,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable, Supp
 
   @Override
   protected String name() {
-    return "hive";
+    return name;
   }
 
   @Override

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -307,7 +307,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
 
   static void validateTableIsIceberg(Table table, String fullName) {
     String tableType = table.getParameters().get(TABLE_TYPE_PROP);
-    NoSuchIcebergTableException.check(tableType != null && !tableType.equalsIgnoreCase(ICEBERG_TABLE_TYPE_VALUE),
+    NoSuchIcebergTableException.check(tableType != null && tableType.equalsIgnoreCase(ICEBERG_TABLE_TYPE_VALUE),
         "Not an iceberg table: %s (type=%s)", fullName, tableType);
     NoSuchIcebergTableException.check(table.getParameters().get(METADATA_LOCATION_PROP) != null,
         "Not an iceberg table: %s missing %s", fullName, METADATA_LOCATION_PROP);

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -51,6 +51,7 @@ import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.common.DynMethods;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.NoSuchIcebergTableException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.io.FileIO;
@@ -77,6 +78,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
       .build();
 
   private final HiveClientPool metaClients;
+  private final String fullName;
   private final String database;
   private final String tableName;
   private final Configuration conf;
@@ -84,9 +86,11 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
 
   private FileIO fileIO;
 
-  protected HiveTableOperations(Configuration conf, HiveClientPool metaClients, String database, String table) {
+  protected HiveTableOperations(Configuration conf, HiveClientPool metaClients,
+                                String catalogName, String database, String table) {
     this.conf = conf;
     this.metaClients = metaClients;
+    this.fullName = catalogName + "." + database + "." + table;
     this.database = database;
     this.tableName = table;
     this.lockAcquireTimeout =
@@ -106,20 +110,10 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
   protected void doRefresh() {
     String metadataLocation = null;
     try {
-      final Table table = metaClients.run(client -> client.getTable(database, tableName));
-      String tableType = table.getParameters().get(TABLE_TYPE_PROP);
-
-      if (tableType == null || !tableType.equalsIgnoreCase(ICEBERG_TABLE_TYPE_VALUE)) {
-        throw new IllegalArgumentException(String.format("Type of %s.%s is %s, not %s",
-            database, tableName,
-            tableType /* actual type */, ICEBERG_TABLE_TYPE_VALUE /* expected type */));
-      }
+      Table table = metaClients.run(client -> client.getTable(database, tableName));
+      validateTableIsIceberg(table, fullName);
 
       metadataLocation = table.getParameters().get(METADATA_LOCATION_PROP);
-      if (metadataLocation == null) {
-        String errMsg = String.format("%s.%s is missing %s property", database, tableName, METADATA_LOCATION_PROP);
-        throw new IllegalArgumentException(errMsg);
-      }
 
     } catch (NoSuchObjectException e) {
       if (currentMetadataLocation() != null) {
@@ -309,5 +303,13 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
       client.unlock(lockId);
       return null;
     });
+  }
+
+  static void validateTableIsIceberg(Table table, String fullName) {
+    String tableType = table.getParameters().get(TABLE_TYPE_PROP);
+    NoSuchIcebergTableException.check(tableType != null && !tableType.equalsIgnoreCase(ICEBERG_TABLE_TYPE_VALUE),
+        "Not an iceberg table: %s (type=%s)", fullName, tableType);
+    NoSuchIcebergTableException.check(table.getParameters().get(METADATA_LOCATION_PROP) != null,
+        "Not an iceberg table: %s missing %s", fullName, METADATA_LOCATION_PROP);
   }
 }

--- a/spark3/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -119,7 +119,7 @@ public class SparkCatalog implements StagingTableCatalog {
           icebergSchema,
           Spark3Util.toPartitionSpec(icebergSchema, transforms),
           properties.get("location"),
-          properties));
+          Spark3Util.rebuildCreateProperties(properties)));
     } catch (AlreadyExistsException e) {
       throw new TableAlreadyExistsException(ident);
     }

--- a/spark3/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -66,18 +66,17 @@ public class SparkCatalog implements StagingTableCatalog {
    * @return an Iceberg catalog
    */
   protected Catalog buildIcebergCatalog(String name, CaseInsensitiveStringMap options) {
-    // TODO: add name to catalogs
     Configuration conf = SparkSession.active().sparkContext().hadoopConfiguration();
     String catalogType = options.getOrDefault("type", "hive");
     switch (catalogType) {
       case "hive":
         int clientPoolSize = options.getInt("clients", 2);
         String uri = options.get("uri");
-        return new HiveCatalog(uri, clientPoolSize, conf);
+        return new HiveCatalog(name, uri, clientPoolSize, conf);
 
       case "hadoop":
         String warehouseLocation = options.get("warehouse");
-        return new HadoopCatalog(conf, warehouseLocation);
+        return new HadoopCatalog(name, conf, warehouseLocation);
 
       default:
         throw new UnsupportedOperationException("Unknown catalog type: " + catalogType);

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
@@ -57,7 +57,6 @@ public class IcebergSource implements DataSourceRegister, TableProvider {
 
   @Override
   public SparkTable getTable(StructType schema, Transform[] partitioning, Map<String, String> options) {
-    // TODO: if partitioning is non-null, the table is being created?
     // Get Iceberg table from options
     Configuration conf = new Configuration(SparkSession.active().sparkContext().hadoopConfiguration());
     Table icebergTable = getTableAndResolveHadoopConfiguration(options, conf);

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchWrite.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchWrite.java
@@ -81,7 +81,6 @@ class SparkBatchWrite implements BatchWrite {
   private final Expression overwriteExpr;
   private final String applicationId;
   private final String wapId;
-  private final String genieId;
   private final long targetFileSize;
   private final Schema writeSchema;
   private final StructType dsSchema;
@@ -99,7 +98,6 @@ class SparkBatchWrite implements BatchWrite {
     this.overwriteExpr = overwriteExpr;
     this.applicationId = applicationId;
     this.wapId = wapId;
-    this.genieId = options.get("genie-id");
     this.writeSchema = writeSchema;
     this.dsSchema = dsSchema;
 
@@ -140,10 +138,6 @@ class SparkBatchWrite implements BatchWrite {
 
   protected void commitOperation(SnapshotUpdate<?> operation, int numFiles, String description) {
     LOG.info("Committing {} with {} files to table {}", description, numFiles, table);
-    if (genieId != null) {
-      operation.set("genie-id", genieId);
-    }
-
     if (applicationId != null) {
       operation.set("spark.app.id", applicationId);
     }

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.spark.source;
 
 import java.util.Map;
 import java.util.Set;
-import org.apache.iceberg.DeleteFiles;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.exceptions.ValidationException;

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -153,17 +153,12 @@ public class SparkTable implements org.apache.spark.sql.connector.catalog.Table,
   @Override
   public void deleteWhere(Filter[] filters) {
     Expression deleteExpr = SparkFilters.convert(filters);
-    DeleteFiles delete = icebergTable.newDelete()
-        .set("spark.app.id", sparkSession().sparkContext().applicationId())
-        .deleteFromRowFilter(deleteExpr);
-
-    String genieId = sparkSession().sparkContext().hadoopConfiguration().get("genie.job.id");
-    if (genieId != null) {
-      delete.set("genie-id", genieId);
-    }
 
     try {
-      delete.commit();
+      icebergTable.newDelete()
+          .set("spark.app.id", sparkSession().sparkContext().applicationId())
+          .deleteFromRowFilter(deleteExpr)
+          .commit();
     } catch (ValidationException e) {
       throw new IllegalArgumentException("Failed to cleanly delete data files matching: " + deleteExpr, e);
     }


### PR DESCRIPTION
This is the last set of changes from the spark-3 branch.

* Add name to catalog implementations
* Add `NoSuchIcebergTableException` to Hive when a table is found, but is not Iceberg
* Return `false` from `dropTable` if the identifier is invalid and cannot be a table
* Fix table create properties; provider must always be `iceberg`