### PR TITLE
Support namespaces in SparkCatalog

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -214,13 +214,13 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
         !namespace.isEmpty(),
         "Cannot create namespace with invalid name: %s", namespace);
     if (!meta.isEmpty()) {
-      throw new UnsupportedOperationException("Cannot create namespace " + namespace + " : metadata is not supported");
+      throw new UnsupportedOperationException("Cannot create namespace " + namespace + ": metadata is not supported");
     }
 
     Path nsPath = new Path(warehouseLocation, SLASH.join(namespace.levels()));
 
     if (isNamespace(nsPath)) {
-      throw new AlreadyExistsException("Namespace '%s' already exists!", namespace);
+      throw new AlreadyExistsException("Namespace already exists: %s", namespace);
     }
 
     try {

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
@@ -177,7 +177,7 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
 
     AssertHelpers.assertThrows("Should fail to create when namespace already exist: " + tbl1.namespace(),
         org.apache.iceberg.exceptions.AlreadyExistsException.class,
-        "Namespace '" + tbl1.namespace() + "' already exists!", () -> {
+        "Namespace already exists: " + tbl1.namespace(), () -> {
           catalog.createNamespace(tbl1.namespace());
         });
   }

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -222,8 +222,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable, Supp
       return ImmutableList.of();
     }
     try {
-      return clients.run(
-          HiveMetaStoreClient::getAllDatabases)
+      return clients.run(HiveMetaStoreClient::getAllDatabases)
           .stream()
           .map(Namespace::of)
           .collect(Collectors.toList());
@@ -373,7 +372,9 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable, Supp
 
     meta.putAll(database.getParameters());
     meta.put("location", database.getLocationUri());
-    meta.put("comment", database.getDescription());
+    if (database.getDescription() != null) {
+      meta.put("comment", database.getDescription());
+    }
 
     return meta;
   }

--- a/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.iceberg.hive.HiveCatalog;
+import org.apache.iceberg.hive.TestHiveMetastore;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS;
+
+public class SparkTestBase {
+
+  private static TestHiveMetastore metastore = null;
+  private static HiveConf hiveConf = null;
+  protected static SparkSession spark = null;
+  protected static HiveCatalog catalog = null;
+
+  @BeforeClass
+  public static void startMetastoreAndSpark() {
+    SparkTestBase.metastore = new TestHiveMetastore();
+    metastore.start();
+    SparkTestBase.hiveConf = metastore.hiveConf();
+
+    SparkTestBase.spark = SparkSession.builder()
+        .master("local[2]")
+        .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
+        .enableHiveSupport()
+        .getOrCreate();
+
+    SparkTestBase.catalog = new HiveCatalog(spark.sessionState().newHadoopConf());
+  }
+
+  @AfterClass
+  public static void stopMetastoreAndSpark() {
+    catalog.close();
+    SparkTestBase.catalog = null;
+    metastore.stop();
+    SparkTestBase.metastore = null;
+    spark.stop();
+    SparkTestBase.spark = null;
+  }
+
+  protected List<String[]> sql(String query, Object... args) {
+    List<Row> rows = spark.sql(String.format(query, args)).collectAsList();
+    if (rows.size() < 1) {
+      return ImmutableList.of();
+    }
+
+    return rows.stream()
+        .map(row -> IntStream.range(0, row.size())
+            .mapToObj(pos -> row.isNullAt(pos) ? null : row.get(pos).toString())
+            .toArray(String[]::new)
+        ).collect(Collectors.toList());
+  }
+
+  protected static String dbPath(String dbName) {
+    return metastore.getDatabasePath(dbName);
+  }
+}

--- a/spark3/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.spark;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CachingCatalog;
 import org.apache.iceberg.Schema;
@@ -28,18 +29,25 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.hadoop.HadoopCatalog;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Splitter;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.iceberg.spark.source.StagedSparkTable;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.analysis.NamespaceAlreadyExistsException;
+import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
 import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.NamespaceChange;
 import org.apache.spark.sql.connector.catalog.StagedTable;
 import org.apache.spark.sql.connector.catalog.StagingTableCatalog;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
@@ -50,13 +58,30 @@ import org.apache.spark.sql.connector.catalog.TableChange.SetProperty;
 import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.glassfish.jersey.internal.guava.Sets;
+import org.sparkproject.guava.collect.Maps;
 
 /**
- * A Spark TableCatalog implementation that wraps Iceberg's {@link Catalog} interface.
+ * A Spark TableCatalog implementation that wraps an Iceberg {@link Catalog}.
+ * <p>
+ * This supports the following catalog configuration options:
+ * <ul>
+ *   <li><tt>type</tt> - catalog type, "hive" or "hadoop"</li>
+ *   <li><tt>uri</tt> - the Hive Metastore URI (Hive catalog only)</li>
+ *   <li><tt>warehouse</tt> - the warehouse path (Hadoop catalog only)</li>
+ *   <li><tt>default-namespace</tt> - a namespace to use as the default</li>
+ * </ul>
+ * <p>
+ * To use a custom catalog that is not a Hive or Hadoop catalog, extend this class and override
+ * {@link #buildIcebergCatalog(String, CaseInsensitiveStringMap)}.
  */
-public class SparkCatalog implements StagingTableCatalog {
+public class SparkCatalog implements StagingTableCatalog, org.apache.spark.sql.connector.catalog.SupportsNamespaces {
+  private static final Set<String> DEFAULT_NS_KEYS = ImmutableSet.of(TableCatalog.PROP_OWNER);
+
   private String catalogName = null;
   private Catalog icebergCatalog = null;
+  private SupportsNamespaces asNamespaceCatalog = null;
+  private String[] defaultNamespace = null;
 
   /**
    * Build an Iceberg {@link Catalog} to be used by this Spark catalog adapter.
@@ -92,12 +117,6 @@ public class SparkCatalog implements StagingTableCatalog {
    */
   protected TableIdentifier buildIdentifier(Identifier identifier) {
     return TableIdentifier.of(Namespace.of(identifier.namespace()), identifier.name());
-  }
-
-  @Override
-  public Identifier[] listTables(String[] namespace) {
-    // TODO: handle namespaces
-    return new Identifier[0];
   }
 
   @Override
@@ -229,12 +248,140 @@ public class SparkCatalog implements StagingTableCatalog {
   }
 
   @Override
+  public Identifier[] listTables(String[] namespace) {
+    return icebergCatalog.listTables(Namespace.of(namespace)).stream()
+        .map(ident -> Identifier.of(ident.namespace().levels(), ident.name()))
+        .toArray(Identifier[]::new);
+  }
+
+  @Override
+  public String[] defaultNamespace() {
+    if (defaultNamespace != null) {
+      return defaultNamespace;
+    }
+
+    return new String[0];
+  }
+
+  @Override
+  public String[][] listNamespaces() {
+    if (asNamespaceCatalog != null) {
+      return asNamespaceCatalog.listNamespaces().stream()
+          .map(Namespace::levels)
+          .toArray(String[][]::new);
+    }
+
+    return new String[0][];
+  }
+
+  @Override
+  public String[][] listNamespaces(String[] namespace) throws NoSuchNamespaceException {
+    if (asNamespaceCatalog != null) {
+      try {
+        return asNamespaceCatalog.listNamespaces(Namespace.of(namespace)).stream()
+            .map(Namespace::levels)
+            .toArray(String[][]::new);
+      } catch (org.apache.iceberg.exceptions.NoSuchNamespaceException e) {
+        throw new NoSuchNamespaceException(namespace);
+      }
+    }
+
+    throw new NoSuchNamespaceException(namespace);
+  }
+
+  @Override
+  public Map<String, String> loadNamespaceMetadata(String[] namespace) throws NoSuchNamespaceException {
+    if (asNamespaceCatalog != null) {
+      try {
+        return asNamespaceCatalog.loadNamespaceMetadata(Namespace.of(namespace));
+      } catch (org.apache.iceberg.exceptions.NoSuchNamespaceException e) {
+        throw new NoSuchNamespaceException(namespace);
+      }
+    }
+
+    throw new NoSuchNamespaceException(namespace);
+  }
+
+  @Override
+  public void createNamespace(String[] namespace, Map<String, String> metadata) throws NamespaceAlreadyExistsException {
+    if (asNamespaceCatalog != null) {
+      try {
+        if (asNamespaceCatalog instanceof HadoopCatalog && DEFAULT_NS_KEYS.equals(metadata.keySet())) {
+          // Hadoop catalog will reject metadata properties, but Spark automatically adds "owner".
+          // If only the automatic properties are present, replace metadata with an empty map.
+          asNamespaceCatalog.createNamespace(Namespace.of(namespace), ImmutableMap.of());
+        } else {
+          asNamespaceCatalog.createNamespace(Namespace.of(namespace), metadata);
+        }
+      } catch (AlreadyExistsException e) {
+        throw new NamespaceAlreadyExistsException(namespace);
+      }
+    } else {
+      throw new UnsupportedOperationException("Namespaces are not supported by catalog: " + catalogName);
+    }
+  }
+
+  @Override
+  public void alterNamespace(String[] namespace, NamespaceChange... changes) throws NoSuchNamespaceException {
+    if (asNamespaceCatalog != null) {
+      Map<String, String> updates = Maps.newHashMap();
+      Set<String> removals = Sets.newHashSet();
+      for (NamespaceChange change : changes) {
+        if (change instanceof NamespaceChange.SetProperty) {
+          NamespaceChange.SetProperty set = (NamespaceChange.SetProperty) change;
+          updates.put(set.property(), set.value());
+        } else if (change instanceof NamespaceChange.RemoveProperty) {
+          removals.add(((NamespaceChange.RemoveProperty) change).property());
+        } else {
+          throw new UnsupportedOperationException("Cannot apply unknown namespace change: " + change);
+        }
+      }
+
+      try {
+        if (!updates.isEmpty()) {
+          asNamespaceCatalog.setProperties(Namespace.of(namespace), updates);
+        }
+
+        if (!removals.isEmpty()) {
+          asNamespaceCatalog.removeProperties(Namespace.of(namespace), removals);
+        }
+
+      } catch (org.apache.iceberg.exceptions.NoSuchNamespaceException e) {
+        throw new NoSuchNamespaceException(namespace);
+      }
+    } else {
+      throw new NoSuchNamespaceException(namespace);
+    }
+  }
+
+  @Override
+  public boolean dropNamespace(String[] namespace) throws NoSuchNamespaceException {
+    if (asNamespaceCatalog != null) {
+      try {
+        return asNamespaceCatalog.dropNamespace(Namespace.of(namespace));
+      } catch (org.apache.iceberg.exceptions.NoSuchNamespaceException e) {
+        throw new NoSuchNamespaceException(namespace);
+      }
+    }
+
+    return false;
+  }
+
+  @Override
   public final void initialize(String name, CaseInsensitiveStringMap options) {
     boolean cacheEnabled = Boolean.parseBoolean(options.getOrDefault("cache-enabled", "true"));
     Catalog catalog = buildIcebergCatalog(name, options);
 
     this.catalogName = name;
     this.icebergCatalog = cacheEnabled ? CachingCatalog.wrap(catalog) : catalog;
+    if (catalog instanceof SupportsNamespaces) {
+      this.asNamespaceCatalog = (SupportsNamespaces) catalog;
+      if (options.containsKey("default-namespace")) {
+        this.defaultNamespace = Splitter.on('.')
+            .splitToList(options.get("default-namespace"))
+            .toArray(new String[0]);
+      }
+    }
   }
 
   @Override

--- a/spark3/src/test/java/org/apache/iceberg/spark/SparkCatalogTestBase.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/SparkCatalogTestBase.java
@@ -35,7 +35,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
-public class SparkCatalogTestBase extends SparkTestBase {
+public abstract class SparkCatalogTestBase extends SparkTestBase {
   private static File warehouse = null;
 
   @BeforeClass

--- a/spark3/src/test/java/org/apache/iceberg/spark/SparkCatalogTestBase.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/SparkCatalogTestBase.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.SupportsNamespaces;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class SparkCatalogTestBase extends SparkTestBase {
+  private static File warehouse = null;
+
+  @BeforeClass
+  public static void createWarehouse() throws IOException {
+    SparkCatalogTestBase.warehouse = File.createTempFile("warehouse", null);
+    Assert.assertTrue(warehouse.delete());
+  }
+
+  @AfterClass
+  public static void dropWarehouse() {
+    if (warehouse != null && warehouse.exists()) {
+      warehouse.delete();
+    }
+  }
+
+  @Parameterized.Parameters
+  public static Object[][] parameters() {
+    return new Object[][] {
+        new Object[] { "testhive", SparkCatalog.class.getName(), ImmutableMap.of(
+            "type", "hive",
+            "default-namespace", "default"
+        ) },
+        new Object[] { "testhadoop", SparkCatalog.class.getName(), ImmutableMap.of(
+            "type", "hadoop"
+        ) },
+        new Object[] { "spark_catalog", SparkSessionCatalog.class.getName(), ImmutableMap.of(
+            "type", "hive",
+            "default-namespace", "default",
+            "parquet-enabled", "true",
+            "cache-enabled", "false" // Spark will delete tables using v1, leaving the cache out of sync
+        ) }
+    };
+  }
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  protected final String catalogName;
+  protected final Catalog validationCatalog;
+  protected final SupportsNamespaces validationNamespaceCatalog;
+
+  public SparkCatalogTestBase(String catalogName, String implementation, Map<String, String> config) {
+    this.catalogName = catalogName;
+    this.validationCatalog = catalogName.equals("testhadoop") ?
+        new HadoopCatalog(spark.sessionState().newHadoopConf(), "file:" + warehouse) :
+        catalog;
+    this.validationNamespaceCatalog = (SupportsNamespaces) validationCatalog;
+
+    spark.conf().set("spark.sql.catalog." + catalogName, implementation);
+    config.forEach((key, value) -> spark.conf().set("spark.sql.catalog." + catalogName + "." + key, value));
+
+    if (config.get("type").equalsIgnoreCase("hadoop")) {
+      spark.conf().set("spark.sql.catalog." + catalogName + ".warehouse", "file:" + warehouse);
+    }
+  }
+}

--- a/spark3/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.spark.sql;
 
-import com.google.common.collect.Iterables;
 import java.io.File;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +28,7 @@ import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.spark.SparkCatalogTestBase;
 import org.apache.spark.SparkException;
 import org.junit.After;

--- a/spark3/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.sql;
+
+import com.google.common.collect.Iterables;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.spark.SparkCatalogTestBase;
+import org.apache.spark.SparkException;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
+public class TestNamespaceSQL extends SparkCatalogTestBase {
+  private static final Namespace NS = Namespace.of("db");
+
+  private final String fullNamespace;
+  private final boolean isHadoopCatalog;
+
+  public TestNamespaceSQL(String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
+    this.fullNamespace = ("spark_catalog".equals(catalogName) ? "" : catalogName + ".") + NS;
+    this.isHadoopCatalog = "testhadoop".equals(catalogName);
+  }
+
+  @After
+  public void cleanNamespaces() {
+    sql("DROP TABLE IF EXISTS %s.table", fullNamespace);
+    sql("DROP NAMESPACE IF EXISTS %s", fullNamespace);
+  }
+
+  @Test
+  public void testCreateNamespace() {
+    Assert.assertFalse("Namespace should not already exist", validationNamespaceCatalog.namespaceExists(NS));
+
+    sql("CREATE NAMESPACE %s", fullNamespace);
+
+    Assert.assertTrue("Namespace should exist", validationNamespaceCatalog.namespaceExists(NS));
+  }
+
+  @Test
+  public void testDefaultNamespace() {
+    Assume.assumeFalse("Hadoop has no default namespace configured", isHadoopCatalog);
+
+    sql("USE %s", catalogName);
+
+    String[] current = Iterables.getOnlyElement(sql("SHOW CURRENT NAMESPACE"));
+    Assert.assertEquals("Should use the current catalog", current[0], catalogName);
+    Assert.assertEquals("Should use the configured default namespace", current[1], "default");
+  }
+
+  @Test
+  public void testDropEmptyNamespace() {
+    Assert.assertFalse("Namespace should not already exist", validationNamespaceCatalog.namespaceExists(NS));
+
+    sql("CREATE NAMESPACE %s", fullNamespace);
+
+    Assert.assertTrue("Namespace should exist", validationNamespaceCatalog.namespaceExists(NS));
+
+    sql("DROP NAMESPACE %s", fullNamespace);
+
+    Assert.assertFalse("Namespace should have been dropped", validationNamespaceCatalog.namespaceExists(NS));
+  }
+
+  @Test
+  public void testDropNonEmptyNamespace() {
+    Assume.assumeFalse("Session catalog has flaky behavior", "spark_catalog".equals(catalogName));
+
+    Assert.assertFalse("Namespace should not already exist", validationNamespaceCatalog.namespaceExists(NS));
+
+    sql("CREATE NAMESPACE %s", fullNamespace);
+    sql("CREATE TABLE %s.table (id bigint) USING iceberg", fullNamespace);
+
+    Assert.assertTrue("Namespace should exist", validationNamespaceCatalog.namespaceExists(NS));
+    Assert.assertTrue("Table should exist", validationCatalog.tableExists(TableIdentifier.of(NS, "table")));
+
+    AssertHelpers.assertThrows("Should fail if trying to delete a non-empty namespace",
+        SparkException.class, "non-empty namespace",
+        () -> sql("DROP NAMESPACE %s", fullNamespace));
+
+    sql("DROP TABLE %s.table", fullNamespace);
+  }
+
+  @Test
+  public void testListTables() {
+    Assert.assertFalse("Namespace should not already exist", validationNamespaceCatalog.namespaceExists(NS));
+
+    sql("CREATE NAMESPACE %s", fullNamespace);
+
+    Assert.assertTrue("Namespace should exist", validationNamespaceCatalog.namespaceExists(NS));
+
+    List<String[]> rows = sql("SHOW TABLES IN %s", fullNamespace);
+    Assert.assertEquals("Should not list any tables", 0, rows.size());
+
+    sql("CREATE TABLE %s.table (id bigint) USING iceberg", fullNamespace);
+
+    String[] row = Iterables.getOnlyElement(sql("SHOW TABLES IN %s", fullNamespace));
+    Assert.assertEquals("Namespace should match", "db", row[0]);
+    Assert.assertEquals("Table name should match", "table", row[1]);
+  }
+
+  @Test
+  public void testListNamespace() {
+    Assert.assertFalse("Namespace should not already exist", validationNamespaceCatalog.namespaceExists(NS));
+
+    sql("CREATE NAMESPACE %s", fullNamespace);
+
+    Assert.assertTrue("Namespace should exist", validationNamespaceCatalog.namespaceExists(NS));
+
+    List<String[]> namespaces = sql("SHOW NAMESPACES IN %s", catalogName);
+
+    if (isHadoopCatalog) {
+      Assert.assertEquals("Should have 1 namespace", 1, namespaces.size());
+      Set<String> namespaceNames = namespaces.stream().map(arr -> arr[0]).collect(Collectors.toSet());
+      Assert.assertEquals("Should have only db namespace", ImmutableSet.of("db"), namespaceNames);
+    } else {
+      Assert.assertEquals("Should have 2 namespaces", 2, namespaces.size());
+      Set<String> namespaceNames = namespaces.stream().map(arr -> arr[0]).collect(Collectors.toSet());
+      Assert.assertEquals("Should have default and db namespaces", ImmutableSet.of("default", "db"), namespaceNames);
+    }
+
+    List<String[]> nestedNamespaces = sql("SHOW NAMESPACES IN %s", fullNamespace);
+
+    Set<String> nestedNames = nestedNamespaces.stream().map(arr -> arr[0]).collect(Collectors.toSet());
+    Assert.assertEquals("Should not have nested namespaces", ImmutableSet.of(), nestedNames);
+  }
+
+  @Test
+  public void testCreateNamespaceWithMetadata() {
+    Assume.assumeFalse("HadoopCatalog does not support namespace metadata", isHadoopCatalog);
+
+    Assert.assertFalse("Namespace should not already exist", validationNamespaceCatalog.namespaceExists(NS));
+
+    sql("CREATE NAMESPACE %s WITH PROPERTIES ('prop'='value')", fullNamespace);
+
+    Assert.assertTrue("Namespace should exist", validationNamespaceCatalog.namespaceExists(NS));
+
+    Map<String, String> nsMetadata = validationNamespaceCatalog.loadNamespaceMetadata(NS);
+
+    Assert.assertEquals("Namespace should have expected prop value", "value", nsMetadata.get("prop"));
+  }
+
+  @Test
+  public void testCreateNamespaceWithComment() {
+    Assume.assumeFalse("HadoopCatalog does not support namespace metadata", isHadoopCatalog);
+
+    Assert.assertFalse("Namespace should not already exist", validationNamespaceCatalog.namespaceExists(NS));
+
+    sql("CREATE NAMESPACE %s COMMENT 'namespace doc'", fullNamespace);
+
+    Assert.assertTrue("Namespace should exist", validationNamespaceCatalog.namespaceExists(NS));
+
+    Map<String, String> nsMetadata = validationNamespaceCatalog.loadNamespaceMetadata(NS);
+
+    Assert.assertEquals("Namespace should have expected comment", "namespace doc", nsMetadata.get("comment"));
+  }
+
+  @Test
+  public void testCreateNamespaceWithLocation() throws Exception {
+    Assume.assumeFalse("HadoopCatalog does not support namespace locations", isHadoopCatalog);
+
+    Assert.assertFalse("Namespace should not already exist", validationNamespaceCatalog.namespaceExists(NS));
+
+    File location = temp.newFile();
+    Assert.assertTrue(location.delete());
+
+    sql("CREATE NAMESPACE %s LOCATION '%s'", fullNamespace, location);
+
+    Assert.assertTrue("Namespace should exist", validationNamespaceCatalog.namespaceExists(NS));
+
+    Map<String, String> nsMetadata = validationNamespaceCatalog.loadNamespaceMetadata(NS);
+
+    Assert.assertEquals("Namespace should have expected location",
+        "file:" + location.getPath(), nsMetadata.get("location"));
+  }
+
+  @Test
+  public void testSetProperties() {
+    Assume.assumeFalse("HadoopCatalog does not support namespace metadata", isHadoopCatalog);
+
+    Assert.assertFalse("Namespace should not already exist", validationNamespaceCatalog.namespaceExists(NS));
+
+    sql("CREATE NAMESPACE %s", fullNamespace);
+
+    Assert.assertTrue("Namespace should exist", validationNamespaceCatalog.namespaceExists(NS));
+
+    Map<String, String> defaultMetadata = validationNamespaceCatalog.loadNamespaceMetadata(NS);
+    Assert.assertFalse("Default metadata should not have custom property", defaultMetadata.containsKey("prop"));
+
+    sql("ALTER NAMESPACE %s SET PROPERTIES ('prop'='value')", fullNamespace);
+
+    Map<String, String> nsMetadata = validationNamespaceCatalog.loadNamespaceMetadata(NS);
+
+    Assert.assertEquals("Namespace should have expected prop value", "value", nsMetadata.get("prop"));
+  }
+}


### PR DESCRIPTION
This adds `SupportsNamespaces` to `SparkCatalog` and adds tests in `TestNamespaceSQL`.

This also adds a couple of new base classes for Spark tests that will be used for other SQL test suites.