### PR TITLE
Use fixed IDs in TestIcebergObjectInspector

### DIFF
--- a/mr/src/test/java/org/apache/iceberg/mr/mapred/serde/objectinspector/TestIcebergObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/mapred/serde/objectinspector/TestIcebergObjectInspector.java
@@ -38,37 +38,33 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class TestIcebergObjectInspector {
 
-  private int id = 0;
-
   private final Schema schema = new Schema(
-          required(id++, "binary_field", Types.BinaryType.get(), "binary comment"),
-          required(id++, "boolean_field", Types.BooleanType.get(), "boolean comment"),
-          required(id++, "date_field", Types.DateType.get(), "date comment"),
-          required(id++, "decimal_field", Types.DecimalType.of(38, 18), "decimal comment"),
-          required(id++, "double_field", Types.DoubleType.get(), "double comment"),
-          required(id++, "fixed_field", Types.FixedType.ofLength(3), "fixed comment"),
-          required(id++, "float_field", Types.FloatType.get(), "float comment"),
-          required(id++, "integer_field", Types.IntegerType.get(), "integer comment"),
-          required(id++, "long_field", Types.LongType.get(), "long comment"),
-          required(id++, "string_field", Types.StringType.get(), "string comment"),
-          required(id++, "timestamp_field", Types.TimestampType.withoutZone(), "timestamp comment"),
-          required(id++, "timestamptz_field", Types.TimestampType.withZone(), "timestamptz comment"),
-          required(id++, "uuid_field", Types.UUIDType.get(), "uuid comment"),
-          required(id++, "list_field",
-                  Types.ListType.ofRequired(id++, Types.StringType.get()), "list comment"),
-          required(id++, "map_field",
-                  Types.MapType.ofRequired(id++, id++, Types.StringType.get(), Types.IntegerType.get()),
+          required(1, "binary_field", Types.BinaryType.get(), "binary comment"),
+          required(2, "boolean_field", Types.BooleanType.get(), "boolean comment"),
+          required(3, "date_field", Types.DateType.get(), "date comment"),
+          required(4, "decimal_field", Types.DecimalType.of(38, 18), "decimal comment"),
+          required(5, "double_field", Types.DoubleType.get(), "double comment"),
+          required(6, "fixed_field", Types.FixedType.ofLength(3), "fixed comment"),
+          required(7, "float_field", Types.FloatType.get(), "float comment"),
+          required(8, "integer_field", Types.IntegerType.get(), "integer comment"),
+          required(9, "long_field", Types.LongType.get(), "long comment"),
+          required(10, "string_field", Types.StringType.get(), "string comment"),
+          required(11, "timestamp_field", Types.TimestampType.withoutZone(), "timestamp comment"),
+          required(12, "timestamptz_field", Types.TimestampType.withZone(), "timestamptz comment"),
+          required(13, "uuid_field", Types.UUIDType.get(), "uuid comment"),
+          required(14, "list_field",
+                  Types.ListType.ofRequired(15, Types.StringType.get()), "list comment"),
+          required(16, "map_field",
+                  Types.MapType.ofRequired(17, 18, Types.StringType.get(), Types.IntegerType.get()),
                   "map comment"),
-          required(id++, "struct_field", Types.StructType.of(
-                  Types.NestedField.required(id++, "nested_field", Types.StringType.get(), "nested field comment")),
+          required(19, "struct_field", Types.StructType.of(
+                  Types.NestedField.required(20, "nested_field", Types.StringType.get(), "nested field comment")),
                   "struct comment"
           )
   );
 
   @Test
   public void testIcebergObjectInspector() {
-    int fieldId = 0;
-
     ObjectInspector oi = IcebergObjectInspector.create(schema);
     Assert.assertNotNull(oi);
     Assert.assertEquals(ObjectInspector.Category.STRUCT, oi.getCategory());
@@ -77,123 +73,117 @@ public class TestIcebergObjectInspector {
 
     // binary
     StructField binaryField = soi.getStructFieldRef("binary_field");
-    Assert.assertEquals(fieldId++, binaryField.getFieldID());
+    Assert.assertEquals(1, binaryField.getFieldID());
     Assert.assertEquals("binary_field", binaryField.getFieldName());
     Assert.assertEquals("binary comment", binaryField.getFieldComment());
     Assert.assertEquals(IcebergBinaryObjectInspector.byteBuffer(), binaryField.getFieldObjectInspector());
 
     // boolean
     StructField booleanField = soi.getStructFieldRef("boolean_field");
-    Assert.assertEquals(fieldId++, booleanField.getFieldID());
+    Assert.assertEquals(2, booleanField.getFieldID());
     Assert.assertEquals("boolean_field", booleanField.getFieldName());
     Assert.assertEquals("boolean comment", booleanField.getFieldComment());
     Assert.assertEquals(getPrimitiveObjectInspector(boolean.class), booleanField.getFieldObjectInspector());
 
     // date
     StructField dateField = soi.getStructFieldRef("date_field");
-    Assert.assertEquals(fieldId++, dateField.getFieldID());
+    Assert.assertEquals(3, dateField.getFieldID());
     Assert.assertEquals("date_field", dateField.getFieldName());
     Assert.assertEquals("date comment", dateField.getFieldComment());
     Assert.assertEquals(IcebergDateObjectInspector.get(), dateField.getFieldObjectInspector());
 
     // decimal
     StructField decimalField = soi.getStructFieldRef("decimal_field");
-    Assert.assertEquals(fieldId++, decimalField.getFieldID());
+    Assert.assertEquals(4, decimalField.getFieldID());
     Assert.assertEquals("decimal_field", decimalField.getFieldName());
     Assert.assertEquals("decimal comment", decimalField.getFieldComment());
     Assert.assertEquals(IcebergDecimalObjectInspector.get(38, 18), decimalField.getFieldObjectInspector());
 
     // double
     StructField doubleField = soi.getStructFieldRef("double_field");
-    Assert.assertEquals(fieldId++, doubleField.getFieldID());
+    Assert.assertEquals(5, doubleField.getFieldID());
     Assert.assertEquals("double_field", doubleField.getFieldName());
     Assert.assertEquals("double comment", doubleField.getFieldComment());
     Assert.assertEquals(getPrimitiveObjectInspector(double.class), doubleField.getFieldObjectInspector());
 
     // fixed
     StructField fixedField = soi.getStructFieldRef("fixed_field");
-    Assert.assertEquals(fieldId++, fixedField.getFieldID());
+    Assert.assertEquals(6, fixedField.getFieldID());
     Assert.assertEquals("fixed_field", fixedField.getFieldName());
     Assert.assertEquals("fixed comment", fixedField.getFieldComment());
     Assert.assertEquals(IcebergBinaryObjectInspector.byteArray(), fixedField.getFieldObjectInspector());
 
     // float
     StructField floatField = soi.getStructFieldRef("float_field");
-    Assert.assertEquals(fieldId++, floatField.getFieldID());
+    Assert.assertEquals(7, floatField.getFieldID());
     Assert.assertEquals("float_field", floatField.getFieldName());
     Assert.assertEquals("float comment", floatField.getFieldComment());
     Assert.assertEquals(getPrimitiveObjectInspector(float.class), floatField.getFieldObjectInspector());
 
     // integer
     StructField integerField = soi.getStructFieldRef("integer_field");
-    Assert.assertEquals(fieldId++, integerField.getFieldID());
+    Assert.assertEquals(8, integerField.getFieldID());
     Assert.assertEquals("integer_field", integerField.getFieldName());
     Assert.assertEquals("integer comment", integerField.getFieldComment());
     Assert.assertEquals(getPrimitiveObjectInspector(int.class), integerField.getFieldObjectInspector());
 
     // long
     StructField longField = soi.getStructFieldRef("long_field");
-    Assert.assertEquals(fieldId++, longField.getFieldID());
+    Assert.assertEquals(9, longField.getFieldID());
     Assert.assertEquals("long_field", longField.getFieldName());
     Assert.assertEquals("long comment", longField.getFieldComment());
     Assert.assertEquals(getPrimitiveObjectInspector(long.class), longField.getFieldObjectInspector());
 
     // string
     StructField stringField = soi.getStructFieldRef("string_field");
-    Assert.assertEquals(fieldId++, stringField.getFieldID());
+    Assert.assertEquals(10, stringField.getFieldID());
     Assert.assertEquals("string_field", stringField.getFieldName());
     Assert.assertEquals("string comment", stringField.getFieldComment());
     Assert.assertEquals(getPrimitiveObjectInspector(String.class), stringField.getFieldObjectInspector());
 
     // timestamp without tz
     StructField timestampField = soi.getStructFieldRef("timestamp_field");
-    Assert.assertEquals(fieldId++, timestampField.getFieldID());
+    Assert.assertEquals(11, timestampField.getFieldID());
     Assert.assertEquals("timestamp_field", timestampField.getFieldName());
     Assert.assertEquals("timestamp comment", timestampField.getFieldComment());
     Assert.assertEquals(IcebergTimestampObjectInspector.get(false), timestampField.getFieldObjectInspector());
 
     // timestamp with tz
     StructField timestampTzField = soi.getStructFieldRef("timestamptz_field");
-    Assert.assertEquals(fieldId++, timestampTzField.getFieldID());
+    Assert.assertEquals(12, timestampTzField.getFieldID());
     Assert.assertEquals("timestamptz_field", timestampTzField.getFieldName());
     Assert.assertEquals("timestamptz comment", timestampTzField.getFieldComment());
     Assert.assertEquals(IcebergTimestampObjectInspector.get(true), timestampTzField.getFieldObjectInspector());
 
     // UUID
     StructField uuidField = soi.getStructFieldRef("uuid_field");
-    Assert.assertEquals(fieldId++, uuidField.getFieldID());
+    Assert.assertEquals(13, uuidField.getFieldID());
     Assert.assertEquals("uuid_field", uuidField.getFieldName());
     Assert.assertEquals("uuid comment", uuidField.getFieldComment());
     Assert.assertEquals(getPrimitiveObjectInspector(String.class), uuidField.getFieldObjectInspector());
 
     // list
     StructField listField = soi.getStructFieldRef("list_field");
-    Assert.assertEquals(fieldId++, listField.getFieldID());
+    Assert.assertEquals(14, listField.getFieldID());
     Assert.assertEquals("list_field", listField.getFieldName());
     Assert.assertEquals("list comment", listField.getFieldComment());
     Assert.assertEquals(getListObjectInspector(String.class), listField.getFieldObjectInspector());
 
-    // skip element id
-    fieldId++;
-
     // map
     StructField mapField = soi.getStructFieldRef("map_field");
-    Assert.assertEquals(fieldId++, mapField.getFieldID());
+    Assert.assertEquals(16, mapField.getFieldID());
     Assert.assertEquals("map_field", mapField.getFieldName());
     Assert.assertEquals("map comment", mapField.getFieldComment());
     Assert.assertEquals(getMapObjectInspector(String.class, int.class), mapField.getFieldObjectInspector());
 
-    // skip key and value ids
-    fieldId += 2;
-
     // struct
     StructField structField = soi.getStructFieldRef("struct_field");
-    Assert.assertEquals(fieldId, structField.getFieldID());
+    Assert.assertEquals(19, structField.getFieldID());
     Assert.assertEquals("struct_field", structField.getFieldName());
     Assert.assertEquals("struct comment", structField.getFieldComment());
 
     ObjectInspector expectedObjectInspector = new IcebergRecordObjectInspector(
-            (Types.StructType) schema.findType(fieldId), ImmutableList.of(getPrimitiveObjectInspector(String.class)));
+            (Types.StructType) schema.findType(19), ImmutableList.of(getPrimitiveObjectInspector(String.class)));
     Assert.assertEquals(expectedObjectInspector, structField.getFieldObjectInspector());
   }
 


### PR DESCRIPTION
Use fixed IDs in TestIcebergObjectInspector. Follow-up PR for a comment left on apache/iceberg#1103.