### PR TITLE
Parquet: Fix NPE in value reader building for projections

### DIFF
--- a/data/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
+++ b/data/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
@@ -211,6 +211,7 @@ public abstract class BaseParquetReaders<T> {
     }
 
     @Override
+    @SuppressWarnings("checkstyle:CyclomaticComplexity")
     public ParquetValueReader<?> primitive(org.apache.iceberg.types.Type.PrimitiveType expected,
                                            PrimitiveType primitive) {
       if (expected == null) {

--- a/data/src/test/java/org/apache/iceberg/data/TestReadProjection.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestReadProjection.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.data;
 
 import java.io.IOException;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.Schema;
@@ -192,12 +193,14 @@ public abstract class TestReadProjection {
   public void testBasicProjection() throws Exception {
     Schema writeSchema = new Schema(
         Types.NestedField.required(0, "id", Types.LongType.get()),
-        Types.NestedField.optional(1, "data", Types.StringType.get())
+        Types.NestedField.optional(1, "data", Types.StringType.get()),
+        Types.NestedField.optional(2, "time", Types.TimestampType.withZone())
     );
 
     Record record = GenericRecord.create(writeSchema.asStruct());
     record.setField("id", 34L);
     record.setField("data", "test");
+    record.setField("time", OffsetDateTime.now());
 
     Schema idOnly = new Schema(
         Types.NestedField.required(0, "id", Types.LongType.get())


### PR DESCRIPTION
The visitor that builds Parquet value readers for Iceberg generics did not handle cases where the expected type was null because a field was is not projected. This was not a problem for most primitive types that did not use the expected type, but cases that did would throw a `NullPointerException`.

Fixes #1117.