### PR TITLE
Make CharSequenceSet thread safe

### DIFF
--- a/api/src/main/java/org/apache/iceberg/util/CharSequenceSet.java
+++ b/api/src/main/java/org/apache/iceberg/util/CharSequenceSet.java
@@ -38,7 +38,8 @@ public class CharSequenceSet implements Set<CharSequence>, Serializable {
   }
 
   private final Set<CharSequenceWrapper> wrapperSet;
-  private final CharSequenceWrapper containsWrapper = CharSequenceWrapper.wrap(null);
+  private final ThreadLocal<CharSequenceWrapper> containsWrapper = ThreadLocal.withInitial(
+      () -> CharSequenceWrapper.wrap(null));
 
   private CharSequenceSet(Iterable<CharSequence> charSequences) {
     this.wrapperSet = Sets.newHashSet(Iterables.transform(charSequences, CharSequenceWrapper::wrap));
@@ -57,7 +58,7 @@ public class CharSequenceSet implements Set<CharSequence>, Serializable {
   @Override
   public boolean contains(Object obj) {
     if (obj instanceof CharSequence) {
-      return wrapperSet.contains(containsWrapper.set((CharSequence) obj));
+      return wrapperSet.contains(containsWrapper.get().set((CharSequence) obj));
     }
     return false;
   }
@@ -102,7 +103,7 @@ public class CharSequenceSet implements Set<CharSequence>, Serializable {
   @Override
   public boolean remove(Object obj) {
     if (obj instanceof CharSequence) {
-      return wrapperSet.remove(containsWrapper.set((CharSequence) obj));
+      return wrapperSet.remove(containsWrapper.get().set((CharSequence) obj));
     }
     return false;
   }


### PR DESCRIPTION
`MergingSnapshotProducer` was recently refactored to separate out manifest filtering and merging so it could be reused for delete files. That refactor also updated the filter to use a `CharSequenceSet` instead of a `HashSet` and `CharSequenceWrapper`. The `CharSequenceSet` embeds the wrapper and is easier to use, but this introduced a bug where multiple threads using the same `CharSequenceSet` would use the same seq wrapper in `contains`. This was causing deletes of specific files to miss data files if the wrapper was reused while testing a file that should be deleted was in the delete set.

The solution is to make `CharSequenceSet` thread safe by using a thread-local wrapper.

This only affects operations that delete specific files, which are mostly in tests. Spark deletes using an expression and using partition tuples. User-facing operations that are affected are `RewriteFiles` and `SnapshotManager` (when cherry-picking a dynamic overwrite commit). `OverwriteFiles` also exposes the method, but it is only used in tests.