### PR TITLE
Apply table import test suites to Spark 3

### DIFF
--- a/spark/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction.java
@@ -41,23 +41,21 @@ import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.hadoop.HiddenPathFilter;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.SparkTestBase;
 import org.apache.iceberg.spark.source.ThreeColumnRecord;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.SparkSession;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 
-public class TestRemoveOrphanFilesAction {
+public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
 
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());
   private static final Schema SCHEMA = new Schema(
@@ -69,22 +67,6 @@ public class TestRemoveOrphanFilesAction {
       .truncate("c2", 2)
       .identity("c3")
       .build();
-
-  private static SparkSession spark;
-
-  @BeforeClass
-  public static void startSpark() {
-    TestRemoveOrphanFilesAction.spark = SparkSession.builder()
-        .master("local[2]")
-        .getOrCreate();
-  }
-
-  @AfterClass
-  public static void stopSpark() {
-    SparkSession currentSpark = TestRemoveOrphanFilesAction.spark;
-    TestRemoveOrphanFilesAction.spark = null;
-    currentSpark.stop();
-  }
 
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();

--- a/spark/src/test/java/org/apache/iceberg/actions/TestRewriteDataFilesAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestRewriteDataFilesAction.java
@@ -34,23 +34,21 @@ import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.SparkTestBase;
 import org.apache.iceberg.spark.source.ThreeColumnRecord;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.SparkSession;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 
-public class TestRewriteDataFilesAction {
+public abstract class TestRewriteDataFilesAction extends SparkTestBase {
 
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());
   private static final Schema SCHEMA = new Schema(
@@ -58,22 +56,6 @@ public class TestRewriteDataFilesAction {
       optional(2, "c2", Types.StringType.get()),
       optional(3, "c3", Types.StringType.get())
   );
-
-  private static SparkSession spark;
-
-  @BeforeClass
-  public static void startSpark() {
-    TestRewriteDataFilesAction.spark = SparkSession.builder()
-        .master("local[2]")
-        .getOrCreate();
-  }
-
-  @AfterClass
-  public static void stopSpark() {
-    SparkSession currentSpark = TestRewriteDataFilesAction.spark;
-    TestRewriteDataFilesAction.spark = null;
-    currentSpark.stop();
-  }
 
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();

--- a/spark/src/test/java/org/apache/iceberg/actions/TestRewriteManifestsAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestRewriteManifestsAction.java
@@ -34,17 +34,15 @@ import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.SparkTableUtil;
+import org.apache.iceberg.spark.SparkTestBase;
 import org.apache.iceberg.spark.source.ThreeColumnRecord;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.TableIdentifier;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -54,7 +52,7 @@ import org.junit.runners.Parameterized;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 
 @RunWith(Parameterized.class)
-public class TestRewriteManifestsAction {
+public abstract class TestRewriteManifestsAction extends SparkTestBase {
 
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());
   private static final Schema SCHEMA = new Schema(
@@ -63,28 +61,12 @@ public class TestRewriteManifestsAction {
       optional(3, "c3", Types.StringType.get())
   );
 
-  private static SparkSession spark;
-
   @Parameterized.Parameters
   public static Object[][] parameters() {
     return new Object[][] {
         new Object[] { "true" },
         new Object[] { "false" }
     };
-  }
-
-  @BeforeClass
-  public static void startSpark() {
-    TestRewriteManifestsAction.spark = SparkSession.builder()
-        .master("local[2]")
-        .getOrCreate();
-  }
-
-  @AfterClass
-  public static void stopSpark() {
-    SparkSession currentSpark = TestRewriteManifestsAction.spark;
-    TestRewriteManifestsAction.spark = null;
-    currentSpark.stop();
   }
 
   @Rule
@@ -123,7 +105,7 @@ public class TestRewriteManifestsAction {
   }
 
   @Test
-  public void testRewriteSmallManifestsNonPartitionedTable() throws IOException {
+  public void testRewriteSmallManifestsNonPartitionedTable() {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     Map<String, String> options = Maps.newHashMap();
     options.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, snapshotIdInheritanceEnabled);
@@ -177,7 +159,7 @@ public class TestRewriteManifestsAction {
   }
 
   @Test
-  public void testRewriteSmallManifestsPartitionedTable() throws IOException {
+  public void testRewriteSmallManifestsPartitionedTable() {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA)
         .identity("c1")
         .truncate("c2", 2)

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHadoopTables.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHadoopTables.java
@@ -26,32 +26,11 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.hadoop.HadoopTables;
-import org.apache.spark.sql.SparkSession;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
 
-public class TestIcebergSourceHadoopTables extends TestIcebergSourceTablesBase {
+public abstract class TestIcebergSourceHadoopTables extends TestIcebergSourceTablesBase {
 
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());
-
-  @BeforeClass
-  public static void startSpark() {
-    TestIcebergSourceHadoopTables.spark = SparkSession.builder()
-        .master("local[2]")
-        .getOrCreate();
-  }
-
-  @AfterClass
-  public static void stopSpark() {
-    TestIcebergSourceHadoopTables.spark.stop();
-    TestIcebergSourceHadoopTables.spark = null;
-  }
-
-  @Rule
-  public TemporaryFolder temp = new TemporaryFolder();
 
   File tableDir = null;
   String tableLocation = null;

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables.java
@@ -20,71 +20,33 @@
 package org.apache.iceberg.spark.source;
 
 import java.io.IOException;
-import java.util.HashMap;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.hive.HiveCatalog;
-import org.apache.iceberg.hive.HiveClientPool;
-import org.apache.iceberg.hive.TestHiveMetastore;
-import org.apache.spark.sql.SparkSession;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
-import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS;
+public abstract class TestIcebergSourceHiveTables extends TestIcebergSourceTablesBase {
 
-public class TestIcebergSourceHiveTables extends TestIcebergSourceTablesBase {
-
-  private static TestHiveMetastore metastore;
-  private static HiveClientPool clients;
-  private static HiveConf hiveConf;
-  private static HiveCatalog catalog;
   private static TableIdentifier currentIdentifier;
 
   @BeforeClass
-  public static void startMetastoreAndSpark() throws Exception {
-    TestIcebergSourceHiveTables.metastore = new TestHiveMetastore();
-    metastore.start();
-    TestIcebergSourceHiveTables.hiveConf = metastore.hiveConf();
-    String dbPath = metastore.getDatabasePath("db");
-    Database db = new Database("db", "desc", dbPath, new HashMap<>());
-    TestIcebergSourceHiveTables.clients = new HiveClientPool(1, hiveConf);
-    clients.run(client -> {
-      client.createDatabase(db);
-      return null;
-    });
-
-    TestIcebergSourceHiveTables.spark = SparkSession.builder()
-        .master("local[2]")
-        .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
-        .getOrCreate();
-
-    TestIcebergSourceHiveTables.catalog = new HiveCatalog(hiveConf);
-  }
-
-  @AfterClass
-  public static void stopMetastoreAndSpark() {
-    catalog.close();
-    TestIcebergSourceHiveTables.catalog = null;
-    clients.close();
-    TestIcebergSourceHiveTables.clients = null;
-    metastore.stop();
-    TestIcebergSourceHiveTables.metastore = null;
-    spark.stop();
-    TestIcebergSourceHiveTables.spark = null;
+  public static void start() {
+    Namespace db = Namespace.of("db");
+    if (!catalog.namespaceExists(db)) {
+      catalog.createNamespace(db);
+    }
   }
 
   @After
   public void dropTable() throws IOException {
     Table table = catalog.loadTable(currentIdentifier);
     Path tablePath = new Path(table.location());
-    FileSystem fs = tablePath.getFileSystem(hiveConf);
+    FileSystem fs = tablePath.getFileSystem(spark.sparkContext().hadoopConfiguration());
     fs.delete(tablePath, true);
     catalog.dropTable(currentIdentifier, false);
   }

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -42,25 +42,29 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.SparkTableUtil;
+import org.apache.iceberg.spark.SparkTestBase;
 import org.apache.iceberg.spark.data.TestHelpers;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SaveMode;
-import org.apache.spark.sql.SparkSession;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 
-public abstract class TestIcebergSourceTablesBase {
+public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
-  protected static SparkSession spark;
   private static final Schema SCHEMA = new Schema(
       optional(1, "id", Types.IntegerType.get()),
       optional(2, "data", Types.StringType.get())
   );
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
 
   public abstract Table createTable(TableIdentifier ident, Schema schema, PartitionSpec spec);
 
@@ -243,6 +247,8 @@ public abstract class TestIcebergSourceTablesBase {
 
   @Test
   public void testFilesTableWithSnapshotIdInheritance() throws Exception {
+    spark.sql("DROP TABLE IF EXISTS parquet_table");
+
     TableIdentifier tableIdentifier = TableIdentifier.of("db", "files_inheritance_test");
     Table table = createTable(tableIdentifier, SCHEMA, PartitionSpec.builderFor(SCHEMA).identity("id").build());
     table.updateProperties()
@@ -251,17 +257,20 @@ public abstract class TestIcebergSourceTablesBase {
     Table entriesTable = loadTable(tableIdentifier, "entries");
     Table filesTable = loadTable(tableIdentifier, "files");
 
+    spark.sql(String.format(
+        "CREATE TABLE parquet_table (data string, id int) " +
+            "USING parquet PARTITIONED BY (id) LOCATION '%s'",
+        temp.newFolder()));
+
     List<SimpleRecord> records = Lists.newArrayList(
         new SimpleRecord(1, "a"),
         new SimpleRecord(2, "b")
      );
 
     Dataset<Row> inputDF = spark.createDataFrame(records, SimpleRecord.class);
-    inputDF.select("id", "data").write()
-        .format("parquet")
+    inputDF.select("data", "id").write()
         .mode("overwrite")
-        .partitionBy("id")
-        .saveAsTable("parquet_table");
+        .insertInto("parquet_table");
 
     try {
       String stagingLocation = table.location() + "/metadata";
@@ -297,7 +306,9 @@ public abstract class TestIcebergSourceTablesBase {
   }
 
   @Test
-  public void testEntriesTableWithSnapshotIdInheritance() {
+  public void testEntriesTableWithSnapshotIdInheritance() throws Exception {
+    spark.sql("DROP TABLE IF EXISTS parquet_table");
+
     TableIdentifier tableIdentifier = TableIdentifier.of("db", "entries_inheritance_test");
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("id").build();
     Table table = createTable(tableIdentifier, SCHEMA, spec);
@@ -306,17 +317,20 @@ public abstract class TestIcebergSourceTablesBase {
         .set(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, "true")
         .commit();
 
+    spark.sql(String.format(
+        "CREATE TABLE parquet_table (data string, id int) " +
+            "USING parquet PARTITIONED BY (id) LOCATION '%s'",
+        temp.newFolder()));
+
     List<SimpleRecord> records = Lists.newArrayList(
         new SimpleRecord(1, "a"),
         new SimpleRecord(2, "b")
     );
 
     Dataset<Row> inputDF = spark.createDataFrame(records, SimpleRecord.class);
-    inputDF.select("id", "data").write()
-        .format("parquet")
+    inputDF.select("data", "id").write()
         .mode("overwrite")
-        .partitionBy("id")
-        .saveAsTable("parquet_table");
+        .insertInto("parquet_table");
 
     try {
       String stagingLocation = table.location() + "/metadata";

--- a/spark2/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction24.java
+++ b/spark2/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction24.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.actions;
+
+public class TestRemoveOrphanFilesAction24 extends TestRemoveOrphanFilesAction {
+}

--- a/spark2/src/test/java/org/apache/iceberg/actions/TestRewriteDataFilesAction24.java
+++ b/spark2/src/test/java/org/apache/iceberg/actions/TestRewriteDataFilesAction24.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.actions;
+
+public class TestRewriteDataFilesAction24 extends TestRewriteDataFilesAction {
+}

--- a/spark2/src/test/java/org/apache/iceberg/actions/TestRewriteManifestsAction24.java
+++ b/spark2/src/test/java/org/apache/iceberg/actions/TestRewriteManifestsAction24.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.actions;
+
+public class TestRewriteManifestsAction24 extends TestRewriteManifestsAction {
+  public TestRewriteManifestsAction24(String snapshotIdInheritanceEnabled) {
+    super(snapshotIdInheritanceEnabled);
+  }
+}

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHadoopTables24.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHadoopTables24.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+public class TestIcebergSourceHadoopTables24 extends TestIcebergSourceHadoopTables {
+}

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables24.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables24.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+public class TestIcebergSourceHiveTables24 extends TestIcebergSourceHiveTables {
+}

--- a/spark3/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction3.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction3.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.actions;
+
+import org.apache.iceberg.actions.TestRemoveOrphanFilesAction;
+
+public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
+}

--- a/spark3/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction3.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction3.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.actions;
+
+import org.apache.iceberg.actions.TestRewriteDataFilesAction;
+
+public class TestRewriteDataFilesAction3 extends TestRewriteDataFilesAction {
+}

--- a/spark3/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction3.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction3.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.actions;
+
+import org.apache.iceberg.actions.TestRewriteManifestsAction;
+
+public class TestRewriteManifestsAction3 extends TestRewriteManifestsAction {
+  public TestRewriteManifestsAction3(String snapshotIdInheritanceEnabled) {
+    super(snapshotIdInheritanceEnabled);
+  }
+}

--- a/spark3/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHadoopTables3.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHadoopTables3.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+public class TestIcebergSourceHadoopTables3 extends TestIcebergSourceHadoopTables {
+}

--- a/spark3/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables3.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables3.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+public class TestIcebergSourceHiveTables3 extends TestIcebergSourceHiveTables {
+}


### PR DESCRIPTION
When refactoring Spark support into modules for 2.4 and 3.0, any tests that used `SparkTableUtil` were moved to iceberg-spark2 to avoid needing Scala in the iceberg-spark3 module. Now that #1126 is finished, the tests need to be moved back to the common module and applied in both version-specific modules.

This makes the tests abstract and creates concrete test classes for both Spark versions.