### PR TITLE
Remove thread local objects and use new visitors

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
@@ -35,14 +35,6 @@ import org.apache.iceberg.types.Types.StructType;
  */
 public class Evaluator implements Serializable {
   private final Expression expr;
-  private transient ThreadLocal<EvalVisitor> visitors = null;
-
-  private EvalVisitor visitor() {
-    if (visitors == null) {
-      this.visitors = ThreadLocal.withInitial(EvalVisitor::new);
-    }
-    return visitors.get();
-  }
 
   public Evaluator(StructType struct, Expression unbound) {
     this.expr = Binder.bind(struct, unbound, true);
@@ -53,7 +45,7 @@ public class Evaluator implements Serializable {
   }
 
   public boolean eval(StructLike data) {
-    return visitor().eval(data);
+    return new EvalVisitor().eval(data);
   }
 
   private class EvalVisitor extends BoundVisitor<Boolean> {

--- a/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
@@ -47,14 +47,6 @@ import static org.apache.iceberg.expressions.Expressions.rewriteNot;
  */
 public class InclusiveMetricsEvaluator {
   private final Expression expr;
-  private transient ThreadLocal<MetricsEvalVisitor> visitors = null;
-
-  private MetricsEvalVisitor visitor() {
-    if (visitors == null) {
-      this.visitors = ThreadLocal.withInitial(MetricsEvalVisitor::new);
-    }
-    return visitors.get();
-  }
 
   public InclusiveMetricsEvaluator(Schema schema, Expression unbound) {
     this(schema, unbound, true);
@@ -73,7 +65,7 @@ public class InclusiveMetricsEvaluator {
    */
   public boolean eval(ContentFile<?> file) {
     // TODO: detect the case where a column is missing from the file using file's max field id.
-    return visitor().eval(file);
+    return new MetricsEvalVisitor().eval(file);
   }
 
   private static final boolean ROWS_MIGHT_MATCH = true;

--- a/api/src/main/java/org/apache/iceberg/expressions/ManifestEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ManifestEvaluator.java
@@ -50,14 +50,6 @@ import static org.apache.iceberg.expressions.Expressions.rewriteNot;
 public class ManifestEvaluator {
   private final StructType struct;
   private final Expression expr;
-  private transient ThreadLocal<ManifestEvalVisitor> visitors = null;
-
-  private ManifestEvalVisitor visitor() {
-    if (visitors == null) {
-      this.visitors = ThreadLocal.withInitial(ManifestEvalVisitor::new);
-    }
-    return visitors.get();
-  }
 
   public static ManifestEvaluator forRowFilter(Expression rowFilter, PartitionSpec spec, boolean caseSensitive) {
     return new ManifestEvaluator(spec, Projections.inclusive(spec, caseSensitive).project(rowFilter), caseSensitive);
@@ -80,7 +72,7 @@ public class ManifestEvaluator {
    * @return false if the file cannot contain rows that match the expression, true otherwise.
    */
   public boolean eval(ManifestFile manifest) {
-    return visitor().eval(manifest);
+    return new ManifestEvalVisitor().eval(manifest);
   }
 
   private static final boolean ROWS_MIGHT_MATCH = true;

--- a/api/src/main/java/org/apache/iceberg/expressions/ResidualEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ResidualEvaluator.java
@@ -92,14 +92,6 @@ public class ResidualEvaluator implements Serializable {
   private final PartitionSpec spec;
   private final Expression expr;
   private final boolean caseSensitive;
-  private transient ThreadLocal<ResidualVisitor> visitors = null;
-
-  private ResidualVisitor visitor() {
-    if (visitors == null) {
-      this.visitors = ThreadLocal.withInitial(ResidualVisitor::new);
-    }
-    return visitors.get();
-  }
 
   private ResidualEvaluator(PartitionSpec spec, Expression expr, boolean caseSensitive) {
     this.spec = spec;
@@ -114,7 +106,7 @@ public class ResidualEvaluator implements Serializable {
    * @return the residual of this evaluator's expression from the partition values
    */
   public Expression residualFor(StructLike partitionData) {
-    return visitor().eval(partitionData);
+    return new ResidualVisitor().eval(partitionData);
   }
 
   private class ResidualVisitor extends BoundExpressionVisitor<Expression> {

--- a/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
@@ -49,14 +49,6 @@ public class StrictMetricsEvaluator {
   private final Schema schema;
   private final StructType struct;
   private final Expression expr;
-  private transient ThreadLocal<MetricsEvalVisitor> visitors = null;
-
-  private MetricsEvalVisitor visitor() {
-    if (visitors == null) {
-      this.visitors = ThreadLocal.withInitial(MetricsEvalVisitor::new);
-    }
-    return visitors.get();
-  }
 
   public StrictMetricsEvaluator(Schema schema, Expression unbound) {
     this.schema = schema;
@@ -72,7 +64,7 @@ public class StrictMetricsEvaluator {
    */
   public boolean eval(ContentFile<?> file) {
     // TODO: detect the case where a column is missing from the file using file's max field id.
-    return visitor().eval(file);
+    return new MetricsEvalVisitor().eval(file);
   }
 
   private static final boolean ROWS_MUST_MATCH = true;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
@@ -49,14 +49,6 @@ import org.apache.parquet.schema.PrimitiveType;
 public class ParquetMetricsRowGroupFilter {
   private final Schema schema;
   private final Expression expr;
-  private transient ThreadLocal<MetricsEvalVisitor> visitors = null;
-
-  private MetricsEvalVisitor visitor() {
-    if (visitors == null) {
-      this.visitors = ThreadLocal.withInitial(MetricsEvalVisitor::new);
-    }
-    return visitors.get();
-  }
 
   public ParquetMetricsRowGroupFilter(Schema schema, Expression unbound) {
     this(schema, unbound, true);
@@ -76,7 +68,7 @@ public class ParquetMetricsRowGroupFilter {
    * @return false if the file cannot contain rows that match the expression, true otherwise.
    */
   public boolean shouldRead(MessageType fileSchema, BlockMetaData rowGroup) {
-    return visitor().eval(fileSchema, rowGroup);
+    return new MetricsEvalVisitor().eval(fileSchema, rowGroup);
   }
 
   private static final boolean ROWS_MIGHT_MATCH = true;


### PR DESCRIPTION
Follow up the discussion in #1139, this change remove thread local objects and use new visitors to keep the code straightforward.