### PR TITLE
 improve code readability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,5 @@
-*.swp
-.DS_Store
-.cache
-
 # intellij files
 .idea
-.idea_modules/
 *.ipr
 *.iws
 *.iml
@@ -34,7 +29,6 @@ sdist/
 coverage.xml
 .pytest_cache/
 spark/tmp/
-spark/spark-warehouse/
 
 # vscode/eclipse files
 .classpath

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
+*.swp
+.DS_Store
+.cache
+
 # intellij files
 .idea
+.idea_modules/
 *.ipr
 *.iws
 *.iml
@@ -29,6 +34,7 @@ sdist/
 coverage.xml
 .pytest_cache/
 spark/tmp/
+spark/spark-warehouse/
 
 # vscode/eclipse files
 .classpath

--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -127,12 +127,9 @@ class BaseSnapshot implements Snapshot {
       this.allManifests = ManifestLists.read(io.newInputFile(manifestListLocation));
     }
 
-    if (dataManifests == null) {
+    if (dataManifests == null || deleteManifests == null) {
       this.dataManifests = ImmutableList.copyOf(Iterables.filter(allManifests,
           manifest -> manifest.content() == ManifestContent.DATA));
-    }
-
-    if (deleteManifests == null) {
       this.deleteManifests = ImmutableList.copyOf(Iterables.filter(allManifests,
           manifest -> manifest.content() == ManifestContent.DELETES));
     }

--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -130,6 +130,9 @@ class BaseSnapshot implements Snapshot {
     if (dataManifests == null) {
       this.dataManifests = ImmutableList.copyOf(Iterables.filter(allManifests,
           manifest -> manifest.content() == ManifestContent.DATA));
+    }
+
+    if (deleteManifests == null) {
       this.deleteManifests = ImmutableList.copyOf(Iterables.filter(allManifests,
           manifest -> manifest.content() == ManifestContent.DELETES));
     }


### PR DESCRIPTION
Add a few items in gitignore;

For BaseSnapshot::cacheManifests, it code implies that deleteManifests will always be set. This change is just to explicitly set deleteManifests if it is null to increase code readability.

Tests: Existing UTs in Core. No need for new UTs.  