### PR TITLE
FlinkTypeVisitor: Use LogicalTypeVisitor and supports MultisetType

### DIFF
--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkSchemaUtil.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkSchemaUtil.java
@@ -20,7 +20,8 @@
 package org.apache.iceberg.flink;
 
 import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.types.FieldsDataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.Type;
@@ -34,10 +35,11 @@ public class FlinkSchemaUtil {
    * Convert the flink table schema to apache iceberg schema.
    */
   public static Schema convert(TableSchema schema) {
-    Preconditions.checkArgument(schema.toRowDataType() instanceof FieldsDataType, "Should be FieldsDataType");
+    LogicalType schemaType = schema.toRowDataType().getLogicalType();
+    Preconditions.checkArgument(schemaType instanceof RowType, "Schema logical type should be RowType.");
 
-    FieldsDataType root = (FieldsDataType) schema.toRowDataType();
-    Type converted = FlinkTypeVisitor.visit(root, new FlinkTypeToType(root));
+    RowType root = (RowType) schemaType;
+    Type converted = root.accept(new FlinkTypeToType(root));
 
     return new Schema(converted.asStructType().fields());
   }

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkTypeToType.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkTypeToType.java
@@ -45,7 +45,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 
-public class FlinkTypeToType extends FlinkTypeVisitor<Type> {
+class FlinkTypeToType extends FlinkTypeVisitor<Type> {
 
   private final RowType root;
   private int nextId;

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkTypeVisitor.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkTypeVisitor.java
@@ -30,7 +30,7 @@ import org.apache.flink.table.types.logical.SymbolType;
 import org.apache.flink.table.types.logical.YearMonthIntervalType;
 import org.apache.flink.table.types.logical.ZonedTimestampType;
 
-public abstract class FlinkTypeVisitor<T> implements LogicalTypeVisitor<T> {
+abstract class FlinkTypeVisitor<T> implements LogicalTypeVisitor<T> {
 
   // ------------------------- Unsupported types ------------------------------
 

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkTypeVisitor.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkTypeVisitor.java
@@ -19,65 +19,63 @@
 
 package org.apache.iceberg.flink;
 
-import java.util.List;
-import java.util.Map;
-import org.apache.flink.table.types.AtomicDataType;
-import org.apache.flink.table.types.CollectionDataType;
-import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.types.FieldsDataType;
-import org.apache.flink.table.types.KeyValueDataType;
-import org.apache.flink.table.types.logical.RowType;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.flink.table.types.logical.DayTimeIntervalType;
+import org.apache.flink.table.types.logical.DistinctType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeVisitor;
+import org.apache.flink.table.types.logical.NullType;
+import org.apache.flink.table.types.logical.RawType;
+import org.apache.flink.table.types.logical.StructuredType;
+import org.apache.flink.table.types.logical.SymbolType;
+import org.apache.flink.table.types.logical.YearMonthIntervalType;
+import org.apache.flink.table.types.logical.ZonedTimestampType;
 
-public class FlinkTypeVisitor<T> {
+public abstract class FlinkTypeVisitor<T> implements LogicalTypeVisitor<T> {
 
-  static <T> T visit(DataType dataType, FlinkTypeVisitor<T> visitor) {
-    if (dataType instanceof FieldsDataType) {
-      FieldsDataType fieldsType = (FieldsDataType) dataType;
-      Map<String, DataType> fields = fieldsType.getFieldDataTypes();
-      List<T> fieldResults = Lists.newArrayList();
+  // ------------------------- Unsupported types ------------------------------
 
-      Preconditions.checkArgument(dataType.getLogicalType() instanceof RowType, "The logical type must be RowType");
-      List<RowType.RowField> rowFields = ((RowType) dataType.getLogicalType()).getFields();
-      // Make sure that we're traveling in the same order as the RowFields because the implementation of
-      // FlinkTypeVisitor#fields may depends on the visit order, please see FlinkTypeToType#fields.
-      for (RowType.RowField rowField : rowFields) {
-        String name = rowField.getName();
-        fieldResults.add(visit(fields.get(name), visitor));
-      }
-
-      return visitor.fields(fieldsType, fieldResults);
-    } else if (dataType instanceof CollectionDataType) {
-      CollectionDataType collectionType = (CollectionDataType) dataType;
-      return visitor.collection(collectionType,
-          visit(collectionType.getElementDataType(), visitor));
-    } else if (dataType instanceof KeyValueDataType) {
-      KeyValueDataType mapType = (KeyValueDataType) dataType;
-      return visitor.map(mapType,
-          visit(mapType.getKeyDataType(), visitor),
-          visit(mapType.getValueDataType(), visitor));
-    } else if (dataType instanceof AtomicDataType) {
-      AtomicDataType atomic = (AtomicDataType) dataType;
-      return visitor.atomic(atomic);
-    } else {
-      throw new UnsupportedOperationException("Unsupported data type: " + dataType);
-    }
+  @Override
+  public T visit(ZonedTimestampType zonedTimestampType) {
+    throw new UnsupportedOperationException("Unsupported ZonedTimestampType.");
   }
 
-  public T fields(FieldsDataType type, List<T> fieldResults) {
-    return null;
+  @Override
+  public T visit(YearMonthIntervalType yearMonthIntervalType) {
+    throw new UnsupportedOperationException("Unsupported YearMonthIntervalType.");
   }
 
-  public T collection(CollectionDataType type, T elementResult) {
-    return null;
+  @Override
+  public T visit(DayTimeIntervalType dayTimeIntervalType) {
+    throw new UnsupportedOperationException("Unsupported DayTimeIntervalType.");
   }
 
-  public T map(KeyValueDataType type, T keyResult, T valueResult) {
-    return null;
+  @Override
+  public T visit(DistinctType distinctType) {
+    throw new UnsupportedOperationException("Unsupported DistinctType.");
   }
 
-  public T atomic(AtomicDataType type) {
-    return null;
+  @Override
+  public T visit(StructuredType structuredType) {
+    throw new UnsupportedOperationException("Unsupported StructuredType.");
+  }
+
+  @Override
+  public T visit(NullType nullType) {
+    throw new UnsupportedOperationException("Unsupported NullType.");
+  }
+
+  @Override
+  public T visit(RawType<?> rawType) {
+    throw new UnsupportedOperationException("Unsupported RawType.");
+  }
+
+  @Override
+  public T visit(SymbolType<?> symbolType) {
+    throw new UnsupportedOperationException("Unsupported SymbolType.");
+  }
+
+  @Override
+  public T visit(LogicalType other) {
+    throw new UnsupportedOperationException("Unsupported type: " + other);
   }
 }

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
@@ -54,6 +54,7 @@ public class TestFlinkSchemaUtil {
         .field("decimal", DataTypes.DECIMAL(2, 2))
         .field("decimal2", DataTypes.DECIMAL(38, 2))
         .field("decimal3", DataTypes.DECIMAL(10, 1))
+        .field("multiset", DataTypes.MULTISET(DataTypes.STRING().notNull()))
         .build();
 
     Schema actualSchema = FlinkSchemaUtil.convert(flinkSchema);
@@ -61,14 +62,14 @@ public class TestFlinkSchemaUtil {
         Types.NestedField.required(0, "id", Types.IntegerType.get(), null),
         Types.NestedField.optional(1, "name", Types.StringType.get(), null),
         Types.NestedField.required(2, "salary", Types.DoubleType.get(), null),
-        Types.NestedField.optional(3, "locations", Types.MapType.ofOptional(23, 24,
+        Types.NestedField.optional(3, "locations", Types.MapType.ofOptional(24, 25,
             Types.StringType.get(),
             Types.StructType.of(
-                Types.NestedField.required(21, "posX", Types.DoubleType.get(), "X field"),
-                Types.NestedField.required(22, "posY", Types.DoubleType.get(), "Y field")
+                Types.NestedField.required(22, "posX", Types.DoubleType.get(), "X field"),
+                Types.NestedField.required(23, "posY", Types.DoubleType.get(), "Y field")
             ))),
-        Types.NestedField.optional(4, "strArray", Types.ListType.ofOptional(25, Types.StringType.get())),
-        Types.NestedField.optional(5, "intArray", Types.ListType.ofOptional(26, Types.IntegerType.get())),
+        Types.NestedField.optional(4, "strArray", Types.ListType.ofOptional(26, Types.StringType.get())),
+        Types.NestedField.optional(5, "intArray", Types.ListType.ofOptional(27, Types.IntegerType.get())),
         Types.NestedField.required(6, "char", Types.StringType.get()),
         Types.NestedField.required(7, "varchar", Types.StringType.get()),
         Types.NestedField.optional(8, "boolean", Types.BooleanType.get()),
@@ -83,7 +84,10 @@ public class TestFlinkSchemaUtil {
         Types.NestedField.optional(17, "date", Types.DateType.get()),
         Types.NestedField.optional(18, "decimal", Types.DecimalType.of(2, 2)),
         Types.NestedField.optional(19, "decimal2", Types.DecimalType.of(38, 2)),
-        Types.NestedField.optional(20, "decimal3", Types.DecimalType.of(10, 1))
+        Types.NestedField.optional(20, "decimal3", Types.DecimalType.of(10, 1)),
+        Types.NestedField.optional(21, "multiset", Types.MapType.ofRequired(28, 29,
+            Types.StringType.get(),
+            Types.IntegerType.get()))
     );
 
     Assert.assertEquals(expectedSchema.asStruct(), actualSchema.asStruct());


### PR DESCRIPTION
This PR wants to improve https://github.com/apache/iceberg/pull/1096

### Use `LogicalTypeVisitor`
Flink has `LogicalTypeVisitor` and `DataTypeVisitor`, they are very useful for visiting types. We don't implement a custom visitor based on `instanceOf`, it's error prone and not very elegant.
And for FieldsDataType, it not has a good design in 1.9 and 1.10, so in Flink 1.11, it has been refactored to be removed getFieldDataTypes. So I think maybe a LogicalTypeVisitor is enough, since we never touch the physical information in the DataTypes.

### Support MultisetType
A `CollectionDataType` may be `MultisetType` too. We can map it to Map<T, Integer>.