### PR TITLE
Add TypeToFlinkType: convert iceberg types to Flink types

### DIFF
--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkSchemaUtil.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkSchemaUtil.java
@@ -36,11 +36,12 @@ import org.apache.iceberg.types.TypeUtil;
  * This inconsistent types:
  * <ul>
  *   <li>map Iceberg UUID type to Flink BinaryType(16)</li>
- *   <li>map Flink VarCharType and CharType to Iceberg String type (lost precision)</li>
- *   <li>map Flink VarBinaryType to Iceberg Binary type (lost precision)</li>
- *   <li>map Flink TimeType to Iceberg Time type (lost precision)</li>
- *   <li>map Flink TimestampType to Iceberg Timestamp without zone type (lost precision)</li>
- *   <li>map Flink LocalZonedTimestampType to Iceberg Timestamp with zone type (lost precision)</li>
+ *   <li>map Flink VarCharType(_) and CharType(_) to Iceberg String type</li>
+ *   <li>map Flink VarBinaryType(_) to Iceberg Binary type</li>
+ *   <li>map Flink TimeType(_) to Iceberg Time type (microseconds)</li>
+ *   <li>map Flink TimestampType(_) to Iceberg Timestamp without zone type (microseconds)</li>
+ *   <li>map Flink LocalZonedTimestampType(_) to Iceberg Timestamp with zone type (microseconds)</li>
+ *   <li>map Flink MultiSetType to Iceberg Map type(element, int)</li>
  * </ul>
  * <p>
  */

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkSchemaUtil.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkSchemaUtil.java
@@ -22,10 +22,17 @@ package org.apache.iceberg.flink;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.TypeUtil;
 
+/**
+ * Converter between Flink types and Iceberg type.
+ * The conversion is not a 1:1 mapping that not allows back-and-forth conversion. So some information might get lost
+ * during the back-and-forth conversion.
+ */
 public class FlinkSchemaUtil {
 
   private FlinkSchemaUtil() {
@@ -42,5 +49,41 @@ public class FlinkSchemaUtil {
     Type converted = root.accept(new FlinkTypeToType(root));
 
     return new Schema(converted.asStructType().fields());
+  }
+
+  /**
+   * Convert a {@link Schema} to a {@link RowType Flink type}.
+   *
+   * @param schema a Schema
+   * @return the equivalent Flink type
+   * @throws IllegalArgumentException if the type cannot be converted to Flink
+   */
+  public static RowType convert(Schema schema) {
+    return (RowType) TypeUtil.visit(schema, new TypeToFlinkType());
+  }
+
+  /**
+   * Convert a {@link Type} to a {@link LogicalType Flink type}.
+   *
+   * @param type a Type
+   * @return the equivalent Flink type
+   * @throws IllegalArgumentException if the type cannot be converted to Flink
+   */
+  public static LogicalType convert(Type type) {
+    return TypeUtil.visit(type, new TypeToFlinkType());
+  }
+
+  /**
+   * Convert a {@link RowType} to a {@link TableSchema}.
+   *
+   * @param rowType a RowType
+   * @return Flink TableSchema
+   */
+  public static TableSchema toSchema(RowType rowType) {
+    TableSchema.Builder builder = TableSchema.builder();
+    for (RowType.RowField field : rowType.getFields()) {
+      builder.field(field.getName(), TypeConversions.fromLogicalToDataType(field.getType()));
+    }
+    return builder.build();
   }
 }

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkSchemaUtil.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkSchemaUtil.java
@@ -32,6 +32,17 @@ import org.apache.iceberg.types.TypeUtil;
  * Converter between Flink types and Iceberg type.
  * The conversion is not a 1:1 mapping that not allows back-and-forth conversion. So some information might get lost
  * during the back-and-forth conversion.
+ * <p>
+ * This inconsistent types:
+ * <ul>
+ *   <li>map Iceberg UUID type to Flink BinaryType(16)</li>
+ *   <li>map Flink VarCharType and CharType to Iceberg String type (lost precision)</li>
+ *   <li>map Flink VarBinaryType to Iceberg Binary type (lost precision)</li>
+ *   <li>map Flink TimeType to Iceberg Time type (lost precision)</li>
+ *   <li>map Flink TimestampType to Iceberg Timestamp without zone type (lost precision)</li>
+ *   <li>map Flink LocalZonedTimestampType to Iceberg Timestamp with zone type (lost precision)</li>
+ * </ul>
+ * <p>
  */
 public class FlinkSchemaUtil {
 

--- a/flink/src/main/java/org/apache/iceberg/flink/TypeToFlinkType.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/TypeToFlinkType.java
@@ -24,7 +24,6 @@ import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.BooleanType;
-import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.DateType;
 import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
@@ -116,7 +115,7 @@ class TypeToFlinkType extends TypeUtil.SchemaVisitor<LogicalType> {
         return new VarCharType(VarCharType.MAX_LENGTH);
       case UUID:
         // UUID length is 16
-        return new CharType(16);
+        return new BinaryType(16);
       case FIXED:
         Types.FixedType fixedType = (Types.FixedType) primitive;
         return new BinaryType(fixedType.length());

--- a/flink/src/main/java/org/apache/iceberg/flink/TypeToFlinkType.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/TypeToFlinkType.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink;
+
+import java.util.List;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BinaryType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimeType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.VarBinaryType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
+
+class TypeToFlinkType extends TypeUtil.SchemaVisitor<LogicalType> {
+  TypeToFlinkType() {
+  }
+
+  @Override
+  public LogicalType schema(Schema schema, LogicalType structType) {
+    return structType;
+  }
+
+  @Override
+  public LogicalType struct(Types.StructType struct, List<LogicalType> fieldResults) {
+    List<Types.NestedField> fields = struct.fields();
+
+    List<RowType.RowField> flinkFields = Lists.newArrayListWithExpectedSize(fieldResults.size());
+    for (int i = 0; i < fields.size(); i += 1) {
+      Types.NestedField field = fields.get(i);
+      LogicalType type = fieldResults.get(i);
+      RowType.RowField flinkField = new RowType.RowField(
+          field.name(), type.copy(field.isOptional()), field.doc());
+      flinkFields.add(flinkField);
+    }
+
+    return new RowType(flinkFields);
+  }
+
+  @Override
+  public LogicalType field(Types.NestedField field, LogicalType fieldResult) {
+    return fieldResult;
+  }
+
+  @Override
+  public LogicalType list(Types.ListType list, LogicalType elementResult) {
+    return new ArrayType(elementResult.copy(list.isElementOptional()));
+  }
+
+  @Override
+  public LogicalType map(Types.MapType map, LogicalType keyResult, LogicalType valueResult) {
+    // keys in map are not allowed to be null.
+    return new MapType(keyResult.copy(false), valueResult.copy(map.isValueOptional()));
+  }
+
+  @Override
+  public LogicalType primitive(Type.PrimitiveType primitive) {
+    switch (primitive.typeId()) {
+      case BOOLEAN:
+        return new BooleanType();
+      case INTEGER:
+        return new IntType();
+      case LONG:
+        return new BigIntType();
+      case FLOAT:
+        return new FloatType();
+      case DOUBLE:
+        return new DoubleType();
+      case DATE:
+        return new DateType();
+      case TIME:
+        // MICROS
+        return new TimeType(6);
+      case TIMESTAMP:
+        Types.TimestampType timestamp = (Types.TimestampType) primitive;
+        if (timestamp.shouldAdjustToUTC()) {
+          // MICROS
+          return new LocalZonedTimestampType(6);
+        } else {
+          // MICROS
+          return new TimestampType(6);
+        }
+      case STRING:
+        return new VarCharType(VarCharType.MAX_LENGTH);
+      case UUID:
+        // UUID length is 16
+        return new CharType(16);
+      case FIXED:
+        Types.FixedType fixedType = (Types.FixedType) primitive;
+        return new BinaryType(fixedType.length());
+      case BINARY:
+        return new VarBinaryType(VarBinaryType.MAX_LENGTH);
+      case DECIMAL:
+        Types.DecimalType decimal = (Types.DecimalType) primitive;
+        return new DecimalType(decimal.precision(), decimal.scale());
+      default:
+        throw new UnsupportedOperationException(
+            "Cannot convert unknown type to Flink: " + primitive);
+    }
+  }
+}


### PR DESCRIPTION
Converter between Flink types and Iceberg type.
The conversion is not a 1:1 mapping that not allows back-and-forth conversion. So some information might get lost during the back-and-forth conversion.
(background: FlinkCatalog need convert iceberg tables to Flink tables)