### PR TITLE
Support atomic CTAS and RTAS with SparkSessionCatalog

### DIFF
--- a/spark3/src/main/java/org/apache/iceberg/spark/RollbackStagedTable.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/RollbackStagedTable.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.StagedTable;
+import org.apache.spark.sql.connector.catalog.SupportsDelete;
+import org.apache.spark.sql.connector.catalog.SupportsRead;
+import org.apache.spark.sql.connector.catalog.SupportsWrite;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.catalog.TableCapability;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.expressions.Transform;
+import org.apache.spark.sql.connector.read.ScanBuilder;
+import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.connector.write.WriteBuilder;
+import org.apache.spark.sql.sources.Filter;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+/**
+ * An implementation of StagedTable that mimics the behavior of Spark's non-atomic CTAS and RTAS.
+ * <p>
+ * A Spark catalog can implement StagingTableCatalog to support atomic operations by producing StagedTable. But if a
+ * catalog implements StagingTableCatalog, Spark expects the catalog to be able to produce a StagedTable for any table
+ * loaded by the catalog. This assumption doesn't always work, as in the case of {@link SparkSessionCatalog}, which
+ * supports atomic operations can produce a StagedTable for Iceberg tables, but wraps the session catalog and cannot
+ * necessarily produce a working StagedTable implementation for tables that it loads.
+ * <p>
+ * The work-around is this class, which implements the StagedTable interface but does not have atomic behavior. Instead,
+ * the StagedTable interface is used to implement the behavior of the non-atomic SQL plans that will create a table,
+ * write, and will drop the table to roll back.
+ * <p>
+ * This StagedTable implements SupportsRead, SupportsWrite, and SupportsDelete by passing the calls to the real table.
+ * Implementing those interfaces is safe because Spark will not use them unless the table supports them and returns the
+ * corresponding capabilities from {@link #capabilities()}.
+ */
+public class RollbackStagedTable implements StagedTable, SupportsRead, SupportsWrite, SupportsDelete {
+  private final TableCatalog catalog;
+  private final Identifier ident;
+  private final Table table;
+
+  public RollbackStagedTable(TableCatalog catalog, Identifier ident, Table table) {
+    this.catalog = catalog;
+    this.ident = ident;
+    this.table = table;
+  }
+
+  @Override
+  public void commitStagedChanges() {
+    // the changes have already been committed to the table at the end of the write
+  }
+
+  @Override
+  public void abortStagedChanges() {
+    // roll back changes by dropping the table
+    catalog.dropTable(ident);
+  }
+
+  @Override
+  public String name() {
+    return table.name();
+  }
+
+  @Override
+  public StructType schema() {
+    return table.schema();
+  }
+
+  @Override
+  public Transform[] partitioning() {
+    return table.partitioning();
+  }
+
+  @Override
+  public Map<String, String> properties() {
+    return table.properties();
+  }
+
+  @Override
+  public Set<TableCapability> capabilities() {
+    return table.capabilities();
+  }
+
+  @Override
+  public void deleteWhere(Filter[] filters) {
+    call(SupportsDelete.class, t -> t.deleteWhere(filters));
+  }
+
+  @Override
+  public ScanBuilder newScanBuilder(CaseInsensitiveStringMap options) {
+    return callReturning(SupportsRead.class, t -> t.newScanBuilder(options));
+  }
+
+  @Override
+  public WriteBuilder newWriteBuilder(LogicalWriteInfo info) {
+    return callReturning(SupportsWrite.class, t -> t.newWriteBuilder(info));
+  }
+
+  private <T> void call(Class<? extends T> requiredClass, Consumer<T> task) {
+    callReturning(requiredClass, inst -> {
+      task.accept(inst);
+      return null;
+    });
+  }
+
+  private <T, R> R callReturning(Class<? extends T> requiredClass, Function<T, R> task) {
+    if (requiredClass.isInstance(table)) {
+      return task.apply(requiredClass.cast(table));
+    } else {
+      throw new UnsupportedOperationException(String.format(
+          "Table does not implement %s: %s (%s)",
+          requiredClass.getSimpleName(), table.name(), table.getClass().getName()));
+    }
+  }
+}

--- a/spark3/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
@@ -134,7 +134,9 @@ public class SparkSessionCatalog<T extends TableCatalog & SupportsNamespaces>
   }
 
   @Override
-  public StagedTable stageCreate(Identifier ident, StructType schema, Transform[] partitions, Map<String, String> properties) throws TableAlreadyExistsException, NoSuchNamespaceException {
+  public StagedTable stageCreate(Identifier ident, StructType schema, Transform[] partitions,
+                                 Map<String, String> properties)
+      throws TableAlreadyExistsException, NoSuchNamespaceException {
     String provider = properties.get("provider");
     TableCatalog catalog;
     if (useIceberg(provider)) {
@@ -152,7 +154,9 @@ public class SparkSessionCatalog<T extends TableCatalog & SupportsNamespaces>
   }
 
   @Override
-  public StagedTable stageReplace(Identifier ident, StructType schema, Transform[] partitions, Map<String, String> properties) throws NoSuchNamespaceException, NoSuchTableException {
+  public StagedTable stageReplace(Identifier ident, StructType schema, Transform[] partitions,
+                                  Map<String, String> properties)
+      throws NoSuchNamespaceException, NoSuchTableException {
     String provider = properties.get("provider");
     TableCatalog catalog;
     if (useIceberg(provider)) {
@@ -181,7 +185,8 @@ public class SparkSessionCatalog<T extends TableCatalog & SupportsNamespaces>
   }
 
   @Override
-  public StagedTable stageCreateOrReplace(Identifier ident, StructType schema, Transform[] partitions, Map<String, String> properties) throws NoSuchNamespaceException {
+  public StagedTable stageCreateOrReplace(Identifier ident, StructType schema, Transform[] partitions,
+                                          Map<String, String> properties) throws NoSuchNamespaceException {
     String provider = properties.get("provider");
     TableCatalog catalog;
     if (useIceberg(provider)) {

--- a/spark3/src/test/java/org/apache/iceberg/spark/sql/TestCreateTableAsSelect.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/sql/TestCreateTableAsSelect.java
@@ -108,20 +108,15 @@ public class TestCreateTableAsSelect extends SparkCatalogTestBase {
         "SELECT id, data, CASE WHEN (id %% 2) = 0 THEN 'even' ELSE 'odd' END AS part " +
         "FROM %s ORDER BY 3, 1", tableName, sourceName);
 
-    // spark_catalog does not use an atomic replace, so the table history and old spec is dropped
-    // the other catalogs do use atomic replace, so the spec id is incremented
-    boolean isAtomic = !"spark_catalog".equals(catalogName);
-
     Schema expectedSchema = new Schema(
         Types.NestedField.optional(1, "id", Types.LongType.get()),
         Types.NestedField.optional(2, "data", Types.StringType.get()),
         Types.NestedField.optional(3, "part", Types.StringType.get())
     );
 
-    int specId = isAtomic ? 1 : 0;
     PartitionSpec expectedSpec = PartitionSpec.builderFor(expectedSchema)
         .identity("part")
-        .withSpecId(specId)
+        .withSpecId(1)
         .build();
 
     Table rtasTable = validationCatalog.loadTable(tableIdent);
@@ -138,7 +133,7 @@ public class TestCreateTableAsSelect extends SparkCatalogTestBase {
         sql("SELECT * FROM %s ORDER BY id", tableName));
 
     Assert.assertEquals("Table should have expected snapshots",
-        isAtomic ? 2 : 1, Iterables.size(rtasTable.snapshots()));
+        2, Iterables.size(rtasTable.snapshots()));
   }
 
   @Test
@@ -155,9 +150,6 @@ public class TestCreateTableAsSelect extends SparkCatalogTestBase {
     sql("CREATE OR REPLACE TABLE %s USING iceberg PARTITIONED BY (part) AS " +
         "SELECT 2 * id as id, data, CASE WHEN ((2 * id) %% 2) = 0 THEN 'even' ELSE 'odd' END AS part " +
         "FROM %s ORDER BY 3, 1", tableName, sourceName);
-
-    // spark_catalog does not use an atomic replace, so the table history is dropped
-    boolean isAtomic = !"spark_catalog".equals(catalogName);
 
     Schema expectedSchema = new Schema(
         Types.NestedField.optional(1, "id", Types.LongType.get()),
@@ -184,7 +176,7 @@ public class TestCreateTableAsSelect extends SparkCatalogTestBase {
         sql("SELECT * FROM %s ORDER BY id", tableName));
 
     Assert.assertEquals("Table should have expected snapshots",
-        isAtomic ? 2 : 1, Iterables.size(rtasTable.snapshots()));
+        2, Iterables.size(rtasTable.snapshots()));
   }
 
   @Test
@@ -226,20 +218,15 @@ public class TestCreateTableAsSelect extends SparkCatalogTestBase {
         .using("iceberg")
         .replace();
 
-    // spark_catalog does not use an atomic replace, so the table history and old spec is dropped
-    // the other catalogs do use atomic replace, so the spec id is incremented
-    boolean isAtomic = !"spark_catalog".equals(catalogName);
-
     Schema expectedSchema = new Schema(
         Types.NestedField.optional(1, "id", Types.LongType.get()),
         Types.NestedField.optional(2, "data", Types.StringType.get()),
         Types.NestedField.optional(3, "part", Types.StringType.get())
     );
 
-    int specId = isAtomic ? 1 : 0;
     PartitionSpec expectedSpec = PartitionSpec.builderFor(expectedSchema)
         .identity("part")
-        .withSpecId(specId)
+        .withSpecId(1)
         .build();
 
     Table rtasTable = validationCatalog.loadTable(tableIdent);
@@ -256,7 +243,7 @@ public class TestCreateTableAsSelect extends SparkCatalogTestBase {
         sql("SELECT * FROM %s ORDER BY id", tableName));
 
     Assert.assertEquals("Table should have expected snapshots",
-        isAtomic ? 2 : 1, Iterables.size(rtasTable.snapshots()));
+        2, Iterables.size(rtasTable.snapshots()));
   }
 
   @Test
@@ -289,9 +276,6 @@ public class TestCreateTableAsSelect extends SparkCatalogTestBase {
         .using("iceberg")
         .createOrReplace();
 
-    // spark_catalog does not use an atomic replace, so the table history is dropped
-    boolean isAtomic = !"spark_catalog".equals(catalogName);
-
     Schema expectedSchema = new Schema(
         Types.NestedField.optional(1, "id", Types.LongType.get()),
         Types.NestedField.optional(2, "data", Types.StringType.get()),
@@ -317,6 +301,6 @@ public class TestCreateTableAsSelect extends SparkCatalogTestBase {
         sql("SELECT * FROM %s ORDER BY id", tableName));
 
     Assert.assertEquals("Table should have expected snapshots",
-        isAtomic ? 2 : 1, Iterables.size(rtasTable.snapshots()));
+        2, Iterables.size(rtasTable.snapshots()));
   }
 }


### PR DESCRIPTION
This adds support for atomic CTAS and RTAS commands when using SparkSessionCatalog in Spark 3.

If a TableCatalog in Spark 3 implements StagingTableCatalog, then all CTAS/RTAS operations will use the staging table methods, assuming that all tables in the catalog support the same capabilities. Iceberg tables support atomic operations, but tables loaded by the wrapped session catalog do not. The work-around is to mimic Spark's non-atomic behavior by creating a table immediately, using it for the write, and rolling back by dropping the table.

This PR doesn't contain new tests because the session catalog in Spark 3 does not work with v2 tables. It will always return a [`V1Table`](https://github.com/apache/spark/blob/v3.0.0/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/V2SessionCatalog.scala#L72). Because a v1 table is always returned, there are no code paths that will load non-Iceberg tables using the session catalog. When the provider for a table is not a v2 provider, Spark will bypass the v2 plugin. A plugin can define and load v2 tables, but v2 will never be used for tables loaded by the wrapped session catalog.