### PR TITLE
Add support to parallelise the execution of tasks of metadata and data files delete operations

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ExpireSnapshots.java
+++ b/api/src/main/java/org/apache/iceberg/ExpireSnapshots.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg;
 
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
 /**
@@ -82,4 +83,18 @@ public interface ExpireSnapshots extends PendingUpdate<List<Snapshot>> {
    * @return this for method chaining
    */
   ExpireSnapshots deleteWith(Consumer<String> deleteFunc);
+
+  /**
+   * Passes an alternative executor service that will be used for manifests and data files deletion.
+   * <p>
+   * Manifest files that are no longer used by valid snapshots will be deleted. Data files that were
+   * deleted by snapshots that are expired will be deleted.
+   * <p>
+   * If this method is not called, unnecessary manifests and data files will still be deleted using a single threaded
+   * executor service.
+   *
+   * @param executorService an executor service to parallelize tasks to delete manifests and data files
+   * @return this for method chaining
+   */
+  ExpireSnapshots deleteWith(ExecutorService executorService);
 }

--- a/api/src/main/java/org/apache/iceberg/ExpireSnapshots.java
+++ b/api/src/main/java/org/apache/iceberg/ExpireSnapshots.java
@@ -96,5 +96,5 @@ public interface ExpireSnapshots extends PendingUpdate<List<Snapshot>> {
    * @param executorService an executor service to parallelize tasks to delete manifests and data files
    * @return this for method chaining
    */
-  ExpireSnapshots deleteWith(ExecutorService executorService);
+  ExpireSnapshots executeWith(ExecutorService executorService);
 }

--- a/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
+++ b/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
@@ -24,7 +24,9 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.ManifestEntry.Status;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -443,16 +445,26 @@ public class TestRemoveSnapshots extends TableTestBase {
     rewriteManifests.commit();
 
     Set<String> deletedFiles = Sets.newHashSet();
+    Set<String> deleteThreads = ConcurrentHashMap.newKeySet();
+    AtomicInteger deleteThreadsIndex = new AtomicInteger(0);
 
     table.expireSnapshots()
-        .deleteWith(Executors.newFixedThreadPool(8, runnable -> {
+        .executeWith(Executors.newFixedThreadPool(4, runnable -> {
           Thread thread = new Thread(runnable);
-          thread.setDaemon(true);
+          thread.setName("remove-snapshot-" + deleteThreadsIndex.getAndIncrement());
+          thread.setDaemon(true); // daemon threads will be terminated abruptly when the JVM exits
           return thread;
         }))
         .expireOlderThan(t4)
-        .deleteWith(deletedFiles::add)
+        .deleteWith(s -> {
+          deleteThreads.add(Thread.currentThread().getName());
+          deletedFiles.add(s);
+        })
         .commit();
+
+    // Verifies that the delete methods ran in the threads created by the provided ExecutorService ThreadFactory
+    Assert.assertEquals(deleteThreads,
+            Sets.newHashSet("remove-snapshot-0", "remove-snapshot-1", "remove-snapshot-2", "remove-snapshot-3"));
 
     Assert.assertTrue("FILE_A should be deleted", deletedFiles.contains(FILE_A.path().toString()));
     Assert.assertTrue("FILE_B should be deleted", deletedFiles.contains(FILE_B.path().toString()));


### PR DESCRIPTION
This PR aims to support https://github.com/apache/iceberg/issues/1178

By default execution of delete tasks of metadata and data files is single threaded.