### PR TITLE
Spark: Support ORC vectorized reads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ sdist/
 coverage.xml
 .pytest_cache/
 spark/tmp/
-spark/spark-warehouse/
+spark-warehouse/
 
 # vscode/eclipse files
 .classpath

--- a/api/src/main/java/org/apache/iceberg/io/CloseableIterator.java
+++ b/api/src/main/java/org/apache/iceberg/io/CloseableIterator.java
@@ -23,6 +23,8 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.function.Function;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 public interface CloseableIterator<T> extends Iterator<T>, Closeable {
 
@@ -51,6 +53,27 @@ public interface CloseableIterator<T> extends Iterator<T>, Closeable {
       @Override
       public E next() {
         return iterator.next();
+      }
+    };
+  }
+
+  static <I, O> CloseableIterator<O> transform(CloseableIterator<I> iterator, Function<I, O> transform) {
+    Preconditions.checkNotNull(transform, "Cannot apply a null transform");
+
+    return new CloseableIterator<O>() {
+      @Override
+      public void close() throws IOException {
+        iterator.close();
+      }
+
+      @Override
+      public boolean hasNext() {
+        return iterator.hasNext();
+      }
+
+      @Override
+      public O next() {
+        return transform.apply(iterator.next());
       }
     };
   }

--- a/orc/src/main/java/org/apache/iceberg/orc/ORC.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORC.java
@@ -127,6 +127,8 @@ public class ORC {
     private boolean caseSensitive = true;
 
     private Function<TypeDescription, OrcRowReader<?>> readerFunc;
+    private Function<TypeDescription, OrcBatchReader<?>> batchedReaderFunc;
+    private int recordsPerBatch = VectorizedRowBatch.DEFAULT_SIZE;
 
     private ReadBuilder(InputFile file) {
       Preconditions.checkNotNull(file, "Input file cannot be null");
@@ -177,9 +179,20 @@ public class ORC {
       return this;
     }
 
+    public ReadBuilder createBatchedReaderFunc(Function<TypeDescription, OrcBatchReader<?>> batchReaderFunction) {
+      this.batchedReaderFunc = batchReaderFunction;
+      return this;
+    }
+
+    public ReadBuilder recordsPerBatch(int numRecordsPerBatch) {
+      this.recordsPerBatch = numRecordsPerBatch;
+      return this;
+    }
+
     public <D> CloseableIterable<D> build() {
       Preconditions.checkNotNull(schema, "Schema is required");
-      return new OrcIterable<>(file, conf, schema, start, length, readerFunc, caseSensitive, filter);
+      return new OrcIterable<>(file, conf, schema, start, length, readerFunc, caseSensitive, filter, batchedReaderFunc,
+          recordsPerBatch);
     }
   }
 

--- a/orc/src/main/java/org/apache/iceberg/orc/ORC.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORC.java
@@ -170,6 +170,8 @@ public class ORC {
     }
 
     public ReadBuilder createReaderFunc(Function<TypeDescription, OrcRowReader<?>> readerFunction) {
+      Preconditions.checkArgument(this.batchedReaderFunc == null,
+          "Reader function cannot be set since the batched version is already set");
       this.readerFunc = readerFunction;
       return this;
     }
@@ -180,6 +182,8 @@ public class ORC {
     }
 
     public ReadBuilder createBatchedReaderFunc(Function<TypeDescription, OrcBatchReader<?>> batchReaderFunction) {
+      Preconditions.checkArgument(this.readerFunc == null,
+          "Batched reader function cannot be set since the non-batched version is already set");
       this.batchedReaderFunc = batchReaderFunction;
       return this;
     }

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcBatchReader.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcBatchReader.java
@@ -17,10 +17,19 @@
  * under the License.
  */
 
-package org.apache.iceberg.spark.source;
+package org.apache.iceberg.orc;
 
-public class TestIdentityPartitionData3 extends TestIdentityPartitionData {
-  public TestIdentityPartitionData3(String format, boolean vectorized) {
-    super(format, vectorized);
-  }
+import org.apache.orc.storage.ql.exec.vector.VectorizedRowBatch;
+
+/**
+ * Used for implementing ORC batch readers.
+ */
+@FunctionalInterface
+public interface OrcBatchReader<T> {
+
+  /**
+   * Reads a row batch.
+   */
+  T read(VectorizedRowBatch batch);
+
 }

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcIterable.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcIterable.java
@@ -49,10 +49,13 @@ class OrcIterable<T> extends CloseableGroup implements CloseableIterable<T> {
   private final Function<TypeDescription, OrcRowReader<?>> readerFunction;
   private final Expression filter;
   private final boolean caseSensitive;
+  private final Function<TypeDescription, OrcBatchReader<?>> batchReaderFunction;
+  private final int recordsPerBatch;
 
   OrcIterable(InputFile file, Configuration config, Schema schema,
               Long start, Long length,
-              Function<TypeDescription, OrcRowReader<?>> readerFunction, boolean caseSensitive, Expression filter) {
+              Function<TypeDescription, OrcRowReader<?>> readerFunction, boolean caseSensitive, Expression filter,
+              Function<TypeDescription, OrcBatchReader<?>> batchReaderFunction, int recordsPerBatch) {
     this.schema = schema;
     this.readerFunction = readerFunction;
     this.file = file;
@@ -61,6 +64,8 @@ class OrcIterable<T> extends CloseableGroup implements CloseableIterable<T> {
     this.config = config;
     this.caseSensitive = caseSensitive;
     this.filter = (filter == Expressions.alwaysTrue()) ? null : filter;
+    this.batchReaderFunction = batchReaderFunction;
+    this.recordsPerBatch = recordsPerBatch;
   }
 
   @SuppressWarnings("unchecked")
@@ -75,16 +80,20 @@ class OrcIterable<T> extends CloseableGroup implements CloseableIterable<T> {
       Expression boundFilter = Binder.bind(schema.asStruct(), filter, caseSensitive);
       sarg = ExpressionToSearchArgument.convert(boundFilter, readOrcSchema);
     }
-    Iterator<T> iterator = new OrcIterator(
-        newOrcIterator(file, readOrcSchema, start, length, orcFileReader, sarg),
-        readerFunction.apply(readOrcSchema));
+
+    VectorizedRowBatchIterator rowBatchIterator = newOrcIterator(file, readOrcSchema, start, length, orcFileReader,
+        sarg, recordsPerBatch);
+    Iterator<T> iterator = batchReaderFunction != null ?
+        new OrcBatchIterator(rowBatchIterator, batchReaderFunction.apply(readOrcSchema)) :
+        new OrcRowIterator(rowBatchIterator, readerFunction.apply(readOrcSchema));
     return CloseableIterator.withClose(iterator);
   }
 
   private static VectorizedRowBatchIterator newOrcIterator(InputFile file,
                                                            TypeDescription readerSchema,
                                                            Long start, Long length,
-                                                           Reader orcFileReader, SearchArgument sarg) {
+                                                           Reader orcFileReader, SearchArgument sarg,
+                                                           int recordsPerBatch) {
     final Reader.Options options = orcFileReader.options();
     if (start != null) {
       options.range(start, length);
@@ -93,13 +102,14 @@ class OrcIterable<T> extends CloseableGroup implements CloseableIterable<T> {
     options.searchArgument(sarg, new String[]{});
 
     try {
-      return new VectorizedRowBatchIterator(file.location(), readerSchema, orcFileReader.rows(options));
+      return new VectorizedRowBatchIterator(file.location(), readerSchema, orcFileReader.rows(options),
+          recordsPerBatch);
     } catch (IOException ioe) {
       throw new RuntimeIOException(ioe, "Failed to get ORC rows for file: %s", file);
     }
   }
 
-  private static class OrcIterator<T> implements Iterator<T> {
+  private static class OrcRowIterator<T> implements Iterator<T> {
 
     private int nextRow;
     private VectorizedRowBatch current;
@@ -107,7 +117,7 @@ class OrcIterable<T> extends CloseableGroup implements CloseableIterable<T> {
     private final VectorizedRowBatchIterator batchIter;
     private final OrcRowReader<T> reader;
 
-    OrcIterator(VectorizedRowBatchIterator batchIter, OrcRowReader<T> reader) {
+    OrcRowIterator(VectorizedRowBatchIterator batchIter, OrcRowReader<T> reader) {
       this.batchIter = batchIter;
       this.reader = reader;
       current = null;
@@ -127,6 +137,27 @@ class OrcIterable<T> extends CloseableGroup implements CloseableIterable<T> {
       }
 
       return this.reader.read(current, nextRow++);
+    }
+  }
+
+  private static class OrcBatchIterator<T> implements Iterator<T> {
+
+    private final VectorizedRowBatchIterator batchIter;
+    private final OrcBatchReader<T> reader;
+
+    OrcBatchIterator(VectorizedRowBatchIterator batchIter, OrcBatchReader<T> reader) {
+      this.batchIter = batchIter;
+      this.reader = reader;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return batchIter.hasNext();
+    }
+
+    @Override
+    public T next() {
+      return this.reader.read(batchIter.next());
     }
   }
 

--- a/orc/src/main/java/org/apache/iceberg/orc/VectorizedRowBatchIterator.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/VectorizedRowBatchIterator.java
@@ -19,10 +19,9 @@
 
 package org.apache.iceberg.orc;
 
-import java.io.Closeable;
 import java.io.IOException;
-import java.util.Iterator;
 import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.io.CloseableIterator;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.storage.ql.exec.vector.VectorizedRowBatch;
@@ -32,7 +31,7 @@ import org.apache.orc.storage.ql.exec.vector.VectorizedRowBatch;
  * Because the same VectorizedRowBatch is reused on each call to next,
  * it gets changed when hasNext or next is called.
  */
-public class VectorizedRowBatchIterator implements Iterator<VectorizedRowBatch>, Closeable {
+public class VectorizedRowBatchIterator implements CloseableIterator<VectorizedRowBatch> {
   private final String fileLocation;
   private final RecordReader rows;
   private final VectorizedRowBatch batch;

--- a/orc/src/main/java/org/apache/iceberg/orc/VectorizedRowBatchIterator.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/VectorizedRowBatchIterator.java
@@ -38,10 +38,10 @@ public class VectorizedRowBatchIterator implements Iterator<VectorizedRowBatch>,
   private final VectorizedRowBatch batch;
   private boolean advanced = false;
 
-  VectorizedRowBatchIterator(String fileLocation, TypeDescription schema, RecordReader rows) {
+  VectorizedRowBatchIterator(String fileLocation, TypeDescription schema, RecordReader rows, int recordsPerBatch) {
     this.fileLocation = fileLocation;
     this.rows = rows;
-    this.batch = schema.createRowBatch();
+    this.batch = schema.createRowBatch(recordsPerBatch);
   }
 
   @Override

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
@@ -32,7 +32,6 @@ import org.apache.orc.TypeDescription;
 import org.apache.orc.storage.ql.exec.vector.StructColumnVector;
 import org.apache.orc.storage.ql.exec.vector.VectorizedRowBatch;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.types.Decimal;
 
 /**
  * Converts the OrcIterator, which returns ORC's VectorizedRowBatch to a
@@ -103,11 +102,7 @@ public class SparkOrcReader implements OrcRowReader<InternalRow> {
         case TIMESTAMP_INSTANT:
           return SparkOrcValueReaders.timestampTzs();
         case DECIMAL:
-          if (primitive.getPrecision() <= Decimal.MAX_LONG_DIGITS()) {
-            return new SparkOrcValueReaders.Decimal18Reader(primitive.getPrecision(), primitive.getScale());
-          } else {
-            return new SparkOrcValueReaders.Decimal38Reader(primitive.getPrecision(), primitive.getScale());
-          }
+          return SparkOrcValueReaders.decimals(primitive.getPrecision(), primitive.getScale());
         case CHAR:
         case VARCHAR:
         case STRING:

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueReaders.java
@@ -42,17 +42,24 @@ import org.apache.spark.sql.catalyst.util.MapData;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.unsafe.types.UTF8String;
 
-
-class SparkOrcValueReaders {
+public class SparkOrcValueReaders {
   private SparkOrcValueReaders() {
   }
 
-  static OrcValueReader<UTF8String> utf8String() {
+  public static OrcValueReader<UTF8String> utf8String() {
     return StringReader.INSTANCE;
   }
 
-  static OrcValueReader<?> timestampTzs() {
+  public static OrcValueReader<Long> timestampTzs() {
     return TimestampTzReader.INSTANCE;
+  }
+
+  public static OrcValueReader<Decimal> decimals(int precision, int scale) {
+    if (precision <= Decimal.MAX_LONG_DIGITS()) {
+      return new SparkOrcValueReaders.Decimal18Reader(precision, scale);
+    } else {
+      return new SparkOrcValueReaders.Decimal38Reader(precision, scale);
+    }
   }
 
   static OrcValueReader<?> struct(
@@ -164,7 +171,7 @@ class SparkOrcValueReaders {
     }
   }
 
-  static class Decimal18Reader implements OrcValueReader<Decimal> {
+  private static class Decimal18Reader implements OrcValueReader<Decimal> {
     //TODO: these are being unused. check for bug
     private final int precision;
     private final int scale;
@@ -181,7 +188,7 @@ class SparkOrcValueReaders {
     }
   }
 
-  static class Decimal38Reader implements OrcValueReader<Decimal> {
+  private static class Decimal38Reader implements OrcValueReader<Decimal> {
     private final int precision;
     private final int scale;
 

--- a/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ConstantColumnVector.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ConstantColumnVector.java
@@ -21,105 +21,104 @@ package org.apache.iceberg.spark.data.vectorized;
 
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.types.Type;
-import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarArray;
 import org.apache.spark.sql.vectorized.ColumnarMap;
 import org.apache.spark.unsafe.types.UTF8String;
 
-public class NullValuesColumnVector extends ColumnVector {
+class ConstantColumnVector extends ColumnVector {
 
-  private final int numNulls;
-  private static final Type NULL_TYPE = Types.IntegerType.get();
+  private final Object constant;
+  private final int batchSize;
 
-  public NullValuesColumnVector(int nValues) {
-    super(SparkSchemaUtil.convert(NULL_TYPE));
-    this.numNulls = nValues;
+  ConstantColumnVector(Type type, int batchSize, Object constant) {
+    super(SparkSchemaUtil.convert(type));
+    this.constant = constant;
+    this.batchSize = batchSize;
   }
 
   @Override
   public void close() {
-
   }
 
   @Override
   public boolean hasNull() {
-    return true;
+    return constant == null;
   }
 
   @Override
   public int numNulls() {
-    return numNulls;
+    return constant == null ? batchSize : 0;
   }
 
   @Override
   public boolean isNullAt(int rowId) {
-    return true;
+    return constant == null;
   }
 
   @Override
   public boolean getBoolean(int rowId) {
-    throw new UnsupportedOperationException();
+    return constant != null ? (boolean) constant : false;
   }
 
   @Override
   public byte getByte(int rowId) {
-    throw new UnsupportedOperationException();
+    return constant != null ? (byte) constant : 0;
   }
 
   @Override
   public short getShort(int rowId) {
-    throw new UnsupportedOperationException();
+    return constant != null ? (short) constant : 0;
   }
 
   @Override
   public int getInt(int rowId) {
-    throw new UnsupportedOperationException();
+    return constant != null ? (int) constant : 0;
   }
 
   @Override
   public long getLong(int rowId) {
-    throw new UnsupportedOperationException();
+    return constant != null ? (long) constant : 0L;
   }
 
   @Override
   public float getFloat(int rowId) {
-    throw new UnsupportedOperationException();
+    return constant != null ? (float) constant : 0.0F;
   }
 
   @Override
   public double getDouble(int rowId) {
-    throw new UnsupportedOperationException();
+    return constant != null ? (double) constant : 0.0;
   }
 
   @Override
   public ColumnarArray getArray(int rowId) {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException("ConstantColumnVector only supports primitives");
   }
 
   @Override
   public ColumnarMap getMap(int ordinal) {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException("ConstantColumnVector only supports primitives");
   }
 
   @Override
   public Decimal getDecimal(int rowId, int precision, int scale) {
-    throw new UnsupportedOperationException();
+    return (Decimal) constant;
   }
 
   @Override
   public UTF8String getUTF8String(int rowId) {
-    throw new UnsupportedOperationException();
+    return (UTF8String) constant;
   }
 
   @Override
   public byte[] getBinary(int rowId) {
-    throw new UnsupportedOperationException();
+    return (byte[]) constant;
   }
 
   @Override
   protected ColumnVector getChild(int ordinal) {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException("ConstantColumnVector only supports primitives");
   }
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/IcebergArrowColumnVector.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/IcebergArrowColumnVector.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.spark.data.vectorized;
 import org.apache.iceberg.arrow.vectorized.NullabilityHolder;
 import org.apache.iceberg.arrow.vectorized.VectorHolder;
 import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.sql.vectorized.ArrowColumnVector;
 import org.apache.spark.sql.vectorized.ColumnVector;
@@ -143,7 +144,7 @@ public class IcebergArrowColumnVector extends ColumnVector {
   }
 
   static ColumnVector forHolder(VectorHolder holder, int numRows) {
-    return holder.isDummy() ? new NullValuesColumnVector(numRows) :
+    return holder.isDummy() ? new ConstantColumnVector(Types.IntegerType.get(), numRows, null) :
         new IcebergArrowColumnVector(holder);
   }
 

--- a/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkOrcReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkOrcReaders.java
@@ -77,7 +77,7 @@ public class VectorizedSparkOrcReaders {
     @Override
     public Converter record(Types.StructType iStruct, TypeDescription record, List<String> names,
         List<Converter> fields) {
-      return new StructReader(iStruct, fields, idToConstant);
+      return new StructConverter(iStruct, fields, idToConstant);
     }
 
     @Override
@@ -378,12 +378,13 @@ public class VectorizedSparkOrcReaders {
     }
   }
 
-  private static class StructReader implements Converter {
+  private static class StructConverter implements Converter {
     private final Types.StructType structType;
     private final List<Converter> fieldConverters;
     private final Map<Integer, ?> idToConstant;
 
-    private StructReader(Types.StructType structType, List<Converter> fieldConverters, Map<Integer, ?> idToConstant) {
+    private StructConverter(Types.StructType structType, List<Converter> fieldConverters,
+        Map<Integer, ?> idToConstant) {
       this.structType = structType;
       this.fieldConverters = fieldConverters;
       this.idToConstant = idToConstant;

--- a/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkOrcReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkOrcReaders.java
@@ -49,7 +49,7 @@ public class VectorizedSparkOrcReaders {
   }
 
   public static OrcBatchReader<ColumnarBatch> buildReader(Schema expectedSchema, TypeDescription fileSchema,
-      Map<Integer, ?> idToConstant) {
+                                                          Map<Integer, ?> idToConstant) {
     Converter converter = OrcSchemaWithTypeVisitor.visit(expectedSchema, fileSchema, new ReadBuilder(idToConstant));
 
     return batch -> {
@@ -76,7 +76,7 @@ public class VectorizedSparkOrcReaders {
 
     @Override
     public Converter record(Types.StructType iStruct, TypeDescription record, List<String> names,
-        List<Converter> fields) {
+                            List<Converter> fields) {
       return new StructConverter(iStruct, fields, idToConstant);
     }
 
@@ -264,7 +264,7 @@ public class VectorizedSparkOrcReaders {
     private final OrcValueReader<?> primitiveValueReader;
 
     PrimitiveOrcColumnVector(Type type, int batchSize, org.apache.orc.storage.ql.exec.vector.ColumnVector vector,
-        OrcValueReader<?> primitiveValueReader) {
+                             OrcValueReader<?> primitiveValueReader) {
       super(type, batchSize, vector);
       this.vector = vector;
       this.primitiveValueReader = primitiveValueReader;
@@ -384,7 +384,7 @@ public class VectorizedSparkOrcReaders {
     private final Map<Integer, ?> idToConstant;
 
     private StructConverter(Types.StructType structType, List<Converter> fieldConverters,
-        Map<Integer, ?> idToConstant) {
+                            Map<Integer, ?> idToConstant) {
       this.structType = structType;
       this.fieldConverters = fieldConverters;
       this.idToConstant = idToConstant;

--- a/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkOrcReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkOrcReaders.java
@@ -42,7 +42,6 @@ import org.apache.spark.sql.vectorized.ColumnarArray;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.apache.spark.sql.vectorized.ColumnarMap;
 import org.apache.spark.unsafe.types.UTF8String;
-import scala.math.BigDecimal;
 
 public class VectorizedSparkOrcReaders {
 
@@ -303,12 +302,9 @@ public class VectorizedSparkOrcReaders {
 
     @Override
     public Decimal getDecimal(int rowId, int precision, int scale) {
-      Decimal value = (Decimal) primitiveValueReader.read(vector, rowId);
-      if (value == null || value.precision() == precision && value.scale() == scale) {
-        return value;
-      } else {
-        return value.toPrecision(precision, scale, BigDecimal.RoundingMode$.MODULE$.UNNECESSARY());
-      }
+      // TODO: Is it okay to assume that (precision,scale) parameters == (precision,scale) of the decimal type
+      // and return a Decimal with (precision,scale) of the decimal type?
+      return (Decimal) primitiveValueReader.read(vector, rowId);
     }
 
     @Override

--- a/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkOrcReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkOrcReaders.java
@@ -1,0 +1,418 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.data.vectorized;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.orc.OrcBatchReader;
+import org.apache.iceberg.orc.OrcSchemaWithTypeVisitor;
+import org.apache.iceberg.orc.OrcValueReader;
+import org.apache.iceberg.orc.OrcValueReaders;
+import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.spark.data.SparkOrcValueReaders;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.storage.ql.exec.vector.ListColumnVector;
+import org.apache.orc.storage.ql.exec.vector.MapColumnVector;
+import org.apache.orc.storage.ql.exec.vector.StructColumnVector;
+import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.vectorized.ColumnVector;
+import org.apache.spark.sql.vectorized.ColumnarArray;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+import org.apache.spark.sql.vectorized.ColumnarMap;
+import org.apache.spark.unsafe.types.UTF8String;
+import scala.math.BigDecimal;
+
+public class VectorizedSparkOrcReaders {
+
+  private VectorizedSparkOrcReaders() {
+  }
+
+  public static OrcBatchReader<ColumnarBatch> buildReader(Schema expectedSchema, TypeDescription fileSchema,
+      Map<Integer, ?> idToConstant) {
+    Converter converter = OrcSchemaWithTypeVisitor.visit(expectedSchema, fileSchema, new ReadBuilder(idToConstant));
+
+    return batch -> {
+      BaseOrcColumnVector cv = (BaseOrcColumnVector) converter.convert(new StructColumnVector(batch.size, batch.cols),
+          batch.size);
+      ColumnarBatch columnarBatch = new ColumnarBatch(IntStream.range(0, expectedSchema.columns().size())
+          .mapToObj(cv::getChild)
+          .toArray(ColumnVector[]::new));
+      columnarBatch.setNumRows(batch.size);
+      return columnarBatch;
+    };
+  }
+
+  private interface Converter {
+    ColumnVector convert(org.apache.orc.storage.ql.exec.vector.ColumnVector columnVector, int batchSize);
+  }
+
+  private static class ReadBuilder extends OrcSchemaWithTypeVisitor<Converter> {
+    private final Map<Integer, ?> idToConstant;
+
+    private ReadBuilder(Map<Integer, ?> idToConstant) {
+      this.idToConstant = idToConstant;
+    }
+
+    @Override
+    public Converter record(Types.StructType iStruct, TypeDescription record, List<String> names,
+        List<Converter> fields) {
+      return new StructReader(iStruct, fields, idToConstant);
+    }
+
+    @Override
+    public Converter list(Types.ListType iList, TypeDescription array, Converter element) {
+      return new ArrayConverter(iList, element);
+    }
+
+    @Override
+    public Converter map(Types.MapType iMap, TypeDescription map, Converter key, Converter value) {
+      return new MapConverter(iMap, key, value);
+    }
+
+    @Override
+    public Converter primitive(Type.PrimitiveType iPrimitive, TypeDescription primitive) {
+      final OrcValueReader<?> primitiveValueReader;
+      switch (primitive.getCategory()) {
+        case BOOLEAN:
+          primitiveValueReader = OrcValueReaders.booleans();
+          break;
+        case BYTE:
+          // Iceberg does not have a byte type. Use int
+        case SHORT:
+          // Iceberg does not have a short type. Use int
+        case DATE:
+        case INT:
+          primitiveValueReader = OrcValueReaders.ints();
+          break;
+        case LONG:
+          primitiveValueReader = OrcValueReaders.longs();
+          break;
+        case FLOAT:
+          primitiveValueReader = OrcValueReaders.floats();
+          break;
+        case DOUBLE:
+          primitiveValueReader = OrcValueReaders.doubles();
+          break;
+        case TIMESTAMP_INSTANT:
+          primitiveValueReader = SparkOrcValueReaders.timestampTzs();
+          break;
+        case DECIMAL:
+          primitiveValueReader = SparkOrcValueReaders.decimals(primitive.getPrecision(), primitive.getScale());
+          break;
+        case CHAR:
+        case VARCHAR:
+        case STRING:
+          primitiveValueReader = SparkOrcValueReaders.utf8String();
+          break;
+        case BINARY:
+          primitiveValueReader = OrcValueReaders.bytes();
+          break;
+        default:
+          throw new IllegalArgumentException("Unhandled type " + primitive);
+      }
+      return (columnVector, batchSize) ->
+          new PrimitiveOrcColumnVector(iPrimitive, batchSize, columnVector, primitiveValueReader);
+    }
+  }
+
+  private abstract static class BaseOrcColumnVector extends ColumnVector {
+    private final org.apache.orc.storage.ql.exec.vector.ColumnVector vector;
+    private final int batchSize;
+    private Integer numNulls;
+
+    BaseOrcColumnVector(Type type, int batchSize, org.apache.orc.storage.ql.exec.vector.ColumnVector vector) {
+      super(SparkSchemaUtil.convert(type));
+      this.vector = vector;
+      this.batchSize = batchSize;
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public boolean hasNull() {
+      return !vector.noNulls;
+    }
+
+    @Override
+    public int numNulls() {
+      if (numNulls == null) {
+        numNulls = numNullsHelper();
+      }
+      return numNulls;
+    }
+
+    private int numNullsHelper() {
+      if (vector.isRepeating) {
+        if (vector.isNull[0]) {
+          return batchSize;
+        } else {
+          return 0;
+        }
+      } else if (vector.noNulls) {
+        return 0;
+      } else {
+        int count = 0;
+        for (int i = 0; i < batchSize; i++) {
+          if (vector.isNull[i]) {
+            count++;
+          }
+        }
+        return count;
+      }
+    }
+
+    protected int getRowIndex(int rowId) {
+      return vector.isRepeating ? 0 : rowId;
+    }
+
+    @Override
+    public boolean isNullAt(int rowId) {
+      return vector.isNull[getRowIndex(rowId)];
+    }
+
+    @Override
+    public boolean getBoolean(int rowId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte getByte(int rowId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public short getShort(int rowId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getInt(int rowId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getLong(int rowId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public float getFloat(int rowId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public double getDouble(int rowId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Decimal getDecimal(int rowId, int precision, int scale) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public UTF8String getUTF8String(int rowId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[] getBinary(int rowId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ColumnarArray getArray(int rowId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ColumnarMap getMap(int rowId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ColumnVector getChild(int ordinal) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  private static class PrimitiveOrcColumnVector extends BaseOrcColumnVector {
+    private final org.apache.orc.storage.ql.exec.vector.ColumnVector vector;
+    private final OrcValueReader<?> primitiveValueReader;
+
+    PrimitiveOrcColumnVector(Type type, int batchSize, org.apache.orc.storage.ql.exec.vector.ColumnVector vector,
+        OrcValueReader<?> primitiveValueReader) {
+      super(type, batchSize, vector);
+      this.vector = vector;
+      this.primitiveValueReader = primitiveValueReader;
+    }
+
+    @Override
+    public boolean getBoolean(int rowId) {
+      Boolean value = (Boolean) primitiveValueReader.read(vector, rowId);
+      return value != null ? value : false;
+    }
+
+    @Override
+    public int getInt(int rowId) {
+      Integer value = (Integer) primitiveValueReader.read(vector, rowId);
+      return value != null ? value : 0;
+    }
+
+    @Override
+    public long getLong(int rowId) {
+      Long value = (Long) primitiveValueReader.read(vector, rowId);
+      return value != null ? value : 0L;
+    }
+
+    @Override
+    public float getFloat(int rowId) {
+      Float value = (Float) primitiveValueReader.read(vector, rowId);
+      return value != null ? value : 0.0F;
+    }
+
+    @Override
+    public double getDouble(int rowId) {
+      Double value = (Double) primitiveValueReader.read(vector, rowId);
+      return value != null ? value : 0.0;
+    }
+
+    @Override
+    public Decimal getDecimal(int rowId, int precision, int scale) {
+      Decimal value = (Decimal) primitiveValueReader.read(vector, rowId);
+      if (value == null || value.precision() == precision && value.scale() == scale) {
+        return value;
+      } else {
+        return value.toPrecision(precision, scale, BigDecimal.RoundingMode$.MODULE$.UNNECESSARY());
+      }
+    }
+
+    @Override
+    public UTF8String getUTF8String(int rowId) {
+      return (UTF8String) primitiveValueReader.read(vector, rowId);
+    }
+
+    @Override
+    public byte[] getBinary(int rowId) {
+      return (byte[]) primitiveValueReader.read(vector, rowId);
+    }
+  }
+
+  private static class ArrayConverter implements Converter {
+    private final Types.ListType listType;
+    private final Converter elementConverter;
+
+    private ArrayConverter(Types.ListType listType, Converter elementConverter) {
+      this.listType = listType;
+      this.elementConverter = elementConverter;
+    }
+
+    @Override
+    public ColumnVector convert(org.apache.orc.storage.ql.exec.vector.ColumnVector vector, int batchSize) {
+      ListColumnVector listVector = (ListColumnVector) vector;
+      ColumnVector elementVector = elementConverter.convert(listVector.child, batchSize);
+
+      return new BaseOrcColumnVector(listType, batchSize, vector) {
+        @Override
+        public ColumnarArray getArray(int rowId) {
+          if (isNullAt(rowId)) {
+            return null;
+          } else {
+            int index = getRowIndex(rowId);
+            return new ColumnarArray(elementVector, (int) listVector.offsets[index], (int) listVector.lengths[index]);
+          }
+        }
+      };
+    }
+  }
+
+  private static class MapConverter implements Converter {
+    private final Types.MapType mapType;
+    private final Converter keyConverter;
+    private final Converter valueConverter;
+
+    private MapConverter(Types.MapType mapType, Converter keyConverter, Converter valueConverter) {
+      this.mapType = mapType;
+      this.keyConverter = keyConverter;
+      this.valueConverter = valueConverter;
+    }
+
+    @Override
+    public ColumnVector convert(org.apache.orc.storage.ql.exec.vector.ColumnVector vector, int batchSize) {
+      MapColumnVector mapVector = (MapColumnVector) vector;
+      ColumnVector keyVector = keyConverter.convert(mapVector.keys, batchSize);
+      ColumnVector valueVector = valueConverter.convert(mapVector.values, batchSize);
+
+      return new BaseOrcColumnVector(mapType, batchSize, vector) {
+        @Override
+        public ColumnarMap getMap(int rowId) {
+          if (isNullAt(rowId)) {
+            return null;
+          } else {
+            int index = getRowIndex(rowId);
+            return new ColumnarMap(keyVector, valueVector, (int) mapVector.offsets[index],
+                (int) mapVector.lengths[index]);
+          }
+        }
+      };
+    }
+  }
+
+  private static class StructReader implements Converter {
+    private final Types.StructType structType;
+    private final List<Converter> fieldConverters;
+    private final Map<Integer, ?> idToConstant;
+
+    private StructReader(Types.StructType structType, List<Converter> fieldConverters, Map<Integer, ?> idToConstant) {
+      this.structType = structType;
+      this.fieldConverters = fieldConverters;
+      this.idToConstant = idToConstant;
+    }
+
+    @Override
+    public ColumnVector convert(org.apache.orc.storage.ql.exec.vector.ColumnVector vector, int batchSize) {
+      StructColumnVector structVector = (StructColumnVector) vector;
+      List<ColumnVector> fieldVectors = IntStream.range(0, structVector.fields.length)
+          .mapToObj(i -> {
+            Types.NestedField field = structType.fields().get(i);
+            if (idToConstant.containsKey(field.fieldId())) {
+              return new ConstantColumnVector(field.type(), batchSize, idToConstant.get(field.fieldId()));
+            } else {
+              return fieldConverters.get(i).convert(structVector.fields[i], batchSize);
+            }
+          })
+          .collect(Collectors.toList());
+
+      return new BaseOrcColumnVector(structType, batchSize, vector) {
+        @Override
+        public ColumnVector getChild(int ordinal) {
+          return fieldVectors.get(ordinal);
+        }
+      };
+    }
+  }
+}

--- a/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
@@ -104,8 +104,9 @@ class BatchDataReader extends BaseDataReader<ColumnarBatch> {
 
       iter = builder.build();
     } else if (task.file().format() == FileFormat.ORC) {
+      Schema schemaWithoutConstants = TypeUtil.selectNot(expectedSchema, idToConstant.keySet());
       iter = ORC.read(location)
-          .project(expectedSchema)
+          .project(schemaWithoutConstants)
           .split(task.start(), task.length())
           .createBatchedReaderFunc(fileSchema -> VectorizedSparkOrcReaders.buildReader(expectedSchema, fileSchema,
               idToConstant))

--- a/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
@@ -19,10 +19,14 @@
 
 package org.apache.iceberg.spark.source;
 
+import java.util.Map;
+import java.util.Set;
 import org.apache.arrow.vector.NullCheckingForGet;
 import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.io.CloseableIterable;
@@ -30,9 +34,15 @@ import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.mapping.NameMappingParser;
+import org.apache.iceberg.orc.ORC;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.spark.data.vectorized.VectorizedSparkOrcReaders;
 import org.apache.iceberg.spark.data.vectorized.VectorizedSparkParquetReaders;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.util.PartitionUtil;
+import org.apache.spark.rdd.InputFileBlockHolder;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 
 class BatchDataReader extends BaseDataReader<ColumnarBatch> {
@@ -53,6 +63,24 @@ class BatchDataReader extends BaseDataReader<ColumnarBatch> {
 
   @Override
   CloseableIterator<ColumnarBatch> open(FileScanTask task) {
+    DataFile file = task.file();
+
+    // update the current file for Spark's filename() function
+    InputFileBlockHolder.set(file.path().toString(), task.start(), task.length());
+
+    // schema or rows returned by readers
+    PartitionSpec spec = task.spec();
+    Set<Integer> idColumns = spec.identitySourceIds();
+    Schema partitionSchema = TypeUtil.select(expectedSchema, idColumns);
+    boolean projectsIdentityPartitionColumns = !partitionSchema.columns().isEmpty();
+
+    Map<Integer, ?> idToConstant;
+    if (projectsIdentityPartitionColumns) {
+      idToConstant = PartitionUtil.constantsMap(task, BatchDataReader::convertConstant);
+    } else {
+      idToConstant = ImmutableMap.of();
+    }
+
     CloseableIterable<ColumnarBatch> iter;
     InputFile location = getInputFile(task);
     Preconditions.checkNotNull(location, "Could not find InputFile associated with FileScanTask");
@@ -75,6 +103,16 @@ class BatchDataReader extends BaseDataReader<ColumnarBatch> {
       }
 
       iter = builder.build();
+    } else if (task.file().format() == FileFormat.ORC) {
+      iter = ORC.read(location)
+          .project(expectedSchema)
+          .split(task.start(), task.length())
+          .createBatchedReaderFunc(fileSchema -> VectorizedSparkOrcReaders.buildReader(expectedSchema, fileSchema,
+              idToConstant))
+          .recordsPerBatch(batchSize)
+          .filter(task.residual())
+          .caseSensitive(caseSensitive)
+          .build();
     } else {
       throw new UnsupportedOperationException(
           "Format: " + task.file().format() + " not supported for batched reads");

--- a/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -19,13 +19,9 @@
 
 package org.apache.iceberg.spark.source;
 
-import java.math.BigDecimal;
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.avro.generic.GenericData;
-import org.apache.avro.util.Utf8;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataTask;
@@ -49,19 +45,15 @@ import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.data.SparkAvroReader;
 import org.apache.iceberg.spark.data.SparkOrcReader;
 import org.apache.iceberg.spark.data.SparkParquetReaders;
-import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
-import org.apache.iceberg.util.ByteBuffers;
 import org.apache.iceberg.util.PartitionUtil;
 import org.apache.spark.rdd.InputFileBlockHolder;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.Attribute;
 import org.apache.spark.sql.catalyst.expressions.AttributeReference;
 import org.apache.spark.sql.catalyst.expressions.UnsafeProjection;
-import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.sql.types.StructType;
-import org.apache.spark.unsafe.types.UTF8String;
 import scala.collection.JavaConverters;
 
 class RowDataReader extends BaseDataReader<InternalRow> {
@@ -216,33 +208,5 @@ class RowDataReader extends BaseDataReader<InternalRow> {
     return UnsafeProjection.create(
         JavaConverters.asScalaBufferConverter(exprs).asScala().toSeq(),
         JavaConverters.asScalaBufferConverter(attrs).asScala().toSeq());
-  }
-
-  private static Object convertConstant(Type type, Object value) {
-    if (value == null) {
-      return null;
-    }
-
-    switch (type.typeId()) {
-      case DECIMAL:
-        return Decimal.apply((BigDecimal) value);
-      case STRING:
-        if (value instanceof Utf8) {
-          Utf8 utf8 = (Utf8) value;
-          return UTF8String.fromBytes(utf8.getBytes(), 0, utf8.getByteLength());
-        }
-        return UTF8String.fromString(value.toString());
-      case FIXED:
-        if (value instanceof byte[]) {
-          return value;
-        } else if (value instanceof GenericData.Fixed) {
-          return ((GenericData.Fixed) value).bytes();
-        }
-        return ByteBuffers.toByteArray((ByteBuffer) value);
-      case BINARY:
-        return ByteBuffers.toByteArray((ByteBuffer) value);
-      default:
-    }
-    return value;
   }
 }

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -638,7 +638,9 @@ public class TestHelpers {
     for (int i = 0; i < actual.numFields(); i += 1) {
       StructField field = struct.fields()[i];
       DataType type = field.dataType();
-      assertEquals(context + "." + field.name(), type, expected.get(i, type), actual.get(i, type));
+      assertEquals(context + "." + field.name(), type,
+          expected.isNullAt(i) ? null : expected.get(i, type),
+          actual.isNullAt(i) ? null : actual.get(i, type));
     }
   }
 

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
@@ -62,9 +62,11 @@ public abstract class TestPartitionValues {
   @Parameterized.Parameters
   public static Object[][] parameters() {
     return new Object[][] {
-        new Object[] { "parquet" },
-        new Object[] { "avro" },
-        new Object[] { "orc" }
+        new Object[] { "parquet", false },
+        new Object[] { "parquet", true },
+        new Object[] { "avro", false },
+        new Object[] { "orc", false },
+        new Object[] { "orc", true }
     };
   }
 
@@ -111,9 +113,11 @@ public abstract class TestPartitionValues {
   public TemporaryFolder temp = new TemporaryFolder();
 
   private final String format;
+  private final boolean vectorized;
 
-  public TestPartitionValues(String format) {
+  public TestPartitionValues(String format, boolean vectorized) {
     this.format = format;
+    this.vectorized = vectorized;
   }
 
   @Test
@@ -144,6 +148,7 @@ public abstract class TestPartitionValues {
 
     Dataset<Row> result = spark.read()
         .format("iceberg")
+        .option("vectorization-enabled", String.valueOf(vectorized))
         .load(location.toString());
 
     List<SimpleRecord> actual = result
@@ -183,6 +188,7 @@ public abstract class TestPartitionValues {
 
     Dataset<Row> result = spark.read()
             .format("iceberg")
+            .option("vectorization-enabled", String.valueOf(vectorized))
             .load(location.toString());
 
     List<SimpleRecord> actual = result
@@ -223,6 +229,7 @@ public abstract class TestPartitionValues {
 
     Dataset<Row> result = spark.read()
             .format("iceberg")
+            .option("vectorization-enabled", String.valueOf(vectorized))
             .load(location.toString());
 
     List<SimpleRecord> actual = result
@@ -261,7 +268,9 @@ public abstract class TestPartitionValues {
         .appendFile(DataFiles.fromInputFile(Files.localInput(avroData), 10))
         .commit();
 
-    Dataset<Row> sourceDF = spark.read().format("iceberg").load(sourceLocation);
+    Dataset<Row> sourceDF = spark.read().format("iceberg")
+        .option("vectorization-enabled", String.valueOf(vectorized))
+        .load(sourceLocation);
 
     for (String column : columnNames) {
       String desc = "partition_by_" + SUPPORTED_PRIMITIVES.findType(column).toString();
@@ -283,6 +292,7 @@ public abstract class TestPartitionValues {
 
       List<Row> actual = spark.read()
           .format("iceberg")
+          .option("vectorization-enabled", String.valueOf(vectorized))
           .load(location.toString())
           .collectAsList();
 
@@ -323,7 +333,9 @@ public abstract class TestPartitionValues {
         .appendFile(DataFiles.fromInputFile(Files.localInput(avroData), 10))
         .commit();
 
-    Dataset<Row> sourceDF = spark.read().format("iceberg").load(sourceLocation);
+    Dataset<Row> sourceDF = spark.read().format("iceberg")
+        .option("vectorization-enabled", String.valueOf(vectorized))
+        .load(sourceLocation);
 
     for (String column : columnNames) {
       String desc = "partition_by_" + SUPPORTED_PRIMITIVES.findType(column).toString();
@@ -345,6 +357,7 @@ public abstract class TestPartitionValues {
 
       List<Row> actual = spark.read()
           .format("iceberg")
+          .option("vectorization-enabled", String.valueOf(vectorized))
           .load(location.toString())
           .collectAsList();
 
@@ -403,6 +416,7 @@ public abstract class TestPartitionValues {
     // verify
     List<Row> actual = spark.read()
         .format("iceberg")
+        .option("vectorization-enabled", String.valueOf(vectorized))
         .load(baseLocation)
         .collectAsList();
 

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadProjection.java
@@ -31,7 +31,6 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.data.avro.DataWriter;
@@ -70,7 +69,8 @@ public abstract class TestSparkReadProjection extends TestReadProjection {
         new Object[] { "parquet", false },
         new Object[] { "parquet", true },
         new Object[] { "avro", false },
-        new Object[] { "orc", false }
+        new Object[] { "orc", false },
+        new Object[] { "orc", true }
     };
   }
 
@@ -148,8 +148,6 @@ public abstract class TestSparkReadProjection extends TestReadProjection {
 
       table.newAppend().appendFile(file).commit();
 
-      table.updateProperties().set(TableProperties.PARQUET_VECTORIZATION_ENABLED, String.valueOf(vectorized)).commit();
-
       // rewrite the read schema for the table's reassigned ids
       Map<Integer, Integer> idMapping = Maps.newHashMap();
       for (int id : allIds(writeSchema)) {
@@ -166,6 +164,7 @@ public abstract class TestSparkReadProjection extends TestReadProjection {
       Dataset<Row> df = spark.read()
           .format("org.apache.iceberg.spark.source.TestIcebergSource")
           .option("iceberg.table.name", desc)
+          .option("vectorization-enabled", String.valueOf(vectorized))
           .load();
 
       return SparkValueConverter.convert(readSchema, df.collectAsList().get(0));

--- a/spark2/src/jmh/java/org/apache/iceberg/spark/source/orc/IcebergSourceFlatORCDataReadBenchmark.java
+++ b/spark2/src/jmh/java/org/apache/iceberg/spark/source/orc/IcebergSourceFlatORCDataReadBenchmark.java
@@ -66,12 +66,25 @@ public class IcebergSourceFlatORCDataReadBenchmark extends IcebergSourceFlatORCD
 
   @Benchmark
   @Threads(1)
-  public void readIceberg() {
+  public void readIcebergNonVectorized() {
     Map<String, String> tableProperties = Maps.newHashMap();
     tableProperties.put(SPLIT_OPEN_FILE_COST, Integer.toString(128 * 1024 * 1024));
     withTableProperties(tableProperties, () -> {
       String tableLocation = table().location();
       Dataset<Row> df = spark().read().format("iceberg").load(tableLocation);
+      materialize(df);
+    });
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void readIcebergVectorized() {
+    Map<String, String> tableProperties = Maps.newHashMap();
+    tableProperties.put(SPLIT_OPEN_FILE_COST, Integer.toString(128 * 1024 * 1024));
+    withTableProperties(tableProperties, () -> {
+      String tableLocation = table().location();
+      Dataset<Row> df = spark().read().option("vectorization-enabled", "true")
+          .format("iceberg").load(tableLocation);
       materialize(df);
     });
   }
@@ -102,7 +115,7 @@ public class IcebergSourceFlatORCDataReadBenchmark extends IcebergSourceFlatORCD
 
   @Benchmark
   @Threads(1)
-  public void readWithProjectionIceberg() {
+  public void readWithProjectionIcebergNonVectorized() {
     Map<String, String> tableProperties = Maps.newHashMap();
     tableProperties.put(SPLIT_OPEN_FILE_COST, Integer.toString(128 * 1024 * 1024));
     withTableProperties(tableProperties, () -> {
@@ -111,6 +124,20 @@ public class IcebergSourceFlatORCDataReadBenchmark extends IcebergSourceFlatORCD
       materialize(df);
     });
   }
+
+  @Benchmark
+  @Threads(1)
+  public void readWithProjectionIcebergVectorized() {
+    Map<String, String> tableProperties = Maps.newHashMap();
+    tableProperties.put(SPLIT_OPEN_FILE_COST, Integer.toString(128 * 1024 * 1024));
+    withTableProperties(tableProperties, () -> {
+      String tableLocation = table().location();
+      Dataset<Row> df = spark().read().option("vectorization-enabled", "true")
+          .format("iceberg").load(tableLocation).select("longCol");
+      materialize(df);
+    });
+  }
+
 
   @Benchmark
   @Threads(1)

--- a/spark2/src/jmh/java/org/apache/iceberg/spark/source/orc/IcebergSourceNestedORCDataReadBenchmark.java
+++ b/spark2/src/jmh/java/org/apache/iceberg/spark/source/orc/IcebergSourceNestedORCDataReadBenchmark.java
@@ -93,18 +93,6 @@ public class IcebergSourceNestedORCDataReadBenchmark extends IcebergSourceNested
 
   @Benchmark
   @Threads(1)
-  public void readFileSourceVectorized() {
-    Map<String, String> conf = Maps.newHashMap();
-    conf.put(SQLConf.ORC_VECTORIZED_READER_ENABLED().key(), "true");
-    conf.put(SQLConf.FILES_OPEN_COST_IN_BYTES().key(), Integer.toString(128 * 1024 * 1024));
-    withSQLConf(conf, () -> {
-      Dataset<Row> df = spark().read().orc(dataLocation());
-      materialize(df);
-    });
-  }
-
-  @Benchmark
-  @Threads(1)
   public void readFileSourceNonVectorized() {
     Map<String, String> conf = Maps.newHashMap();
     conf.put(SQLConf.ORC_VECTORIZED_READER_ENABLED().key(), "false");
@@ -136,18 +124,6 @@ public class IcebergSourceNestedORCDataReadBenchmark extends IcebergSourceNested
       String tableLocation = table().location();
       Dataset<Row> df = spark().read().option("vectorization-enabled", "true")
           .format("iceberg").load(tableLocation).selectExpr("nested.col3");
-      materialize(df);
-    });
-  }
-
-  @Benchmark
-  @Threads(1)
-  public void readWithProjectionFileSourceVectorized() {
-    Map<String, String> conf = Maps.newHashMap();
-    conf.put(SQLConf.ORC_VECTORIZED_READER_ENABLED().key(), "true");
-    conf.put(SQLConf.FILES_OPEN_COST_IN_BYTES().key(), Integer.toString(128 * 1024 * 1024));
-    withSQLConf(conf, () -> {
-      Dataset<Row> df = spark().read().orc(dataLocation()).selectExpr("nested.col3");
       materialize(df);
     });
   }

--- a/spark2/src/jmh/java/org/apache/iceberg/spark/source/orc/IcebergSourceNestedORCDataReadBenchmark.java
+++ b/spark2/src/jmh/java/org/apache/iceberg/spark/source/orc/IcebergSourceNestedORCDataReadBenchmark.java
@@ -68,12 +68,25 @@ public class IcebergSourceNestedORCDataReadBenchmark extends IcebergSourceNested
 
   @Benchmark
   @Threads(1)
-  public void readIceberg() {
+  public void readIcebergNonVectorized() {
     Map<String, String> tableProperties = Maps.newHashMap();
     tableProperties.put(SPLIT_OPEN_FILE_COST, Integer.toString(128 * 1024 * 1024));
     withTableProperties(tableProperties, () -> {
       String tableLocation = table().location();
       Dataset<Row> df = spark().read().format("iceberg").load(tableLocation);
+      materialize(df);
+    });
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void readIcebergVectorized() {
+    Map<String, String> tableProperties = Maps.newHashMap();
+    tableProperties.put(SPLIT_OPEN_FILE_COST, Integer.toString(128 * 1024 * 1024));
+    withTableProperties(tableProperties, () -> {
+      String tableLocation = table().location();
+      Dataset<Row> df = spark().read().option("vectorization-enabled", "true")
+          .format("iceberg").load(tableLocation);
       materialize(df);
     });
   }
@@ -104,12 +117,25 @@ public class IcebergSourceNestedORCDataReadBenchmark extends IcebergSourceNested
 
   @Benchmark
   @Threads(1)
-  public void readWithProjectionIceberg() {
+  public void readWithProjectionIcebergNonVectorized() {
     Map<String, String> tableProperties = Maps.newHashMap();
     tableProperties.put(SPLIT_OPEN_FILE_COST, Integer.toString(128 * 1024 * 1024));
     withTableProperties(tableProperties, () -> {
       String tableLocation = table().location();
       Dataset<Row> df = spark().read().format("iceberg").load(tableLocation).selectExpr("nested.col3");
+      materialize(df);
+    });
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void readWithProjectionIcebergVectorized() {
+    Map<String, String> tableProperties = Maps.newHashMap();
+    tableProperties.put(SPLIT_OPEN_FILE_COST, Integer.toString(128 * 1024 * 1024));
+    withTableProperties(tableProperties, () -> {
+      String tableLocation = table().location();
+      Dataset<Row> df = spark().read().option("vectorization-enabled", "true")
+          .format("iceberg").load(tableLocation).selectExpr("nested.col3");
       materialize(df);
     });
   }

--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
@@ -299,6 +299,13 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
                   .allMatch(fileScanTask -> fileScanTask.file().format().equals(
                       FileFormat.PARQUET)));
 
+      boolean allOrcFileScanTasks =
+          tasks().stream()
+              .allMatch(combinedScanTask -> !combinedScanTask.isDataTask() && combinedScanTask.files()
+                  .stream()
+                  .allMatch(fileScanTask -> fileScanTask.file().format().equals(
+                      FileFormat.ORC)));
+
       boolean atLeastOneColumn = lazySchema().columns().size() > 0;
 
       boolean hasNoIdentityProjections = tasks().stream()
@@ -308,8 +315,8 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
 
       boolean onlyPrimitives = lazySchema().columns().stream().allMatch(c -> c.type().isPrimitiveType());
 
-      this.readUsingBatch = batchReadsEnabled && allParquetFileScanTasks && atLeastOneColumn &&
-          hasNoIdentityProjections && onlyPrimitives;
+      this.readUsingBatch = batchReadsEnabled && (allOrcFileScanTasks ||
+          (allParquetFileScanTasks && atLeastOneColumn && hasNoIdentityProjections && onlyPrimitives));
     }
     return readUsingBatch;
   }

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestIdentityPartitionData24.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestIdentityPartitionData24.java
@@ -20,7 +20,7 @@
 package org.apache.iceberg.spark.source;
 
 public class TestIdentityPartitionData24 extends TestIdentityPartitionData {
-  public TestIdentityPartitionData24(String format) {
-    super(format);
+  public TestIdentityPartitionData24(String format, boolean vectorized) {
+    super(format, vectorized);
   }
 }

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues24.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues24.java
@@ -20,7 +20,7 @@
 package org.apache.iceberg.spark.source;
 
 public class TestPartitionValues24 extends TestPartitionValues {
-  public TestPartitionValues24(String format) {
-    super(format);
+  public TestPartitionValues24(String format, boolean vectorized) {
+    super(format, vectorized);
   }
 }

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
@@ -155,6 +155,13 @@ class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
                 .allMatch(fileScanTask -> fileScanTask.file().format().equals(
                     FileFormat.PARQUET)));
 
+    boolean allOrcFileScanTasks =
+        tasks().stream()
+            .allMatch(combinedScanTask -> !combinedScanTask.isDataTask() && combinedScanTask.files()
+                .stream()
+                .allMatch(fileScanTask -> fileScanTask.file().format().equals(
+                    FileFormat.ORC)));
+
     boolean atLeastOneColumn = expectedSchema.columns().size() > 0;
 
     boolean hasNoIdentityProjections = tasks().stream()
@@ -164,8 +171,8 @@ class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
 
     boolean onlyPrimitives = expectedSchema.columns().stream().allMatch(c -> c.type().isPrimitiveType());
 
-    boolean readUsingBatch = batchReadsEnabled && allParquetFileScanTasks && atLeastOneColumn &&
-        hasNoIdentityProjections && onlyPrimitives;
+    boolean readUsingBatch = batchReadsEnabled && (allOrcFileScanTasks ||
+        (allParquetFileScanTasks && atLeastOneColumn && hasNoIdentityProjections && onlyPrimitives));
 
     return new ReaderFactory(readUsingBatch ? batchSize : 0);
   }

--- a/spark3/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues3.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues3.java
@@ -20,7 +20,7 @@
 package org.apache.iceberg.spark.source;
 
 public class TestPartitionValues3 extends TestPartitionValues {
-  public TestPartitionValues3(String format) {
-    super(format);
+  public TestPartitionValues3(String format, boolean vectorized) {
+    super(format, vectorized);
   }
 }


### PR DESCRIPTION
- Most of the new code is added in `VectorizedSparkOrcReaders`
- Replaced `NullValuesColumnVector` with `ConstantColumnVector` which can support any constant (including nulls)
- Moved the Iceberg to Spark constant conversion logic from `RowDataReader` into `BaseDataReader` so that it can be reused in `BatchDataReader`
- Modified many of the Spark read test cases to test for both vectorized and non vectorized codepaths
- Modified `TestFilteredScan` in Spark3 to use IcebergGenerics instead of Avro just like in Spark2. This enables use to test ORC reads/writes which do not have Avro GenericRecord writer.

Benchmark results:
Tests reads of 10 files with 5M records each
```
Benchmark                                                                          Mode  Cnt    Score    Error  Units
IcebergSourceFlatORCDataReadBenchmark.readFileSourceNonVectorized                    ss    5   42.789 ±  3.294   s/op
IcebergSourceFlatORCDataReadBenchmark.readFileSourceVectorized                       ss    5   18.566 ±  1.450   s/op
IcebergSourceFlatORCDataReadBenchmark.readIcebergNonVectorized                       ss    5   30.186 ±  1.007   s/op
IcebergSourceFlatORCDataReadBenchmark.readIcebergVectorized                          ss    5   18.835 ±  0.818   s/op
IcebergSourceFlatORCDataReadBenchmark.readWithProjectionFileSourceNonVectorized      ss    5    8.935 ±  0.801   s/op
IcebergSourceFlatORCDataReadBenchmark.readWithProjectionFileSourceVectorized         ss    5    2.387 ±  0.195   s/op
IcebergSourceFlatORCDataReadBenchmark.readWithProjectionIcebergNonVectorized         ss    5   10.691 ±  0.603   s/op
IcebergSourceFlatORCDataReadBenchmark.readWithProjectionIcebergVectorized            ss    5    2.653 ±  0.511   s/op
IcebergSourceNestedORCDataReadBenchmark.readFileSourceNonVectorized                  ss    5  118.318 ±  1.583   s/op
IcebergSourceNestedORCDataReadBenchmark.readFileSourceVectorized                     ss    5   98.858 ± 12.668   s/op
IcebergSourceNestedORCDataReadBenchmark.readIcebergNonVectorized                     ss    5   18.943 ±  1.305   s/op
IcebergSourceNestedORCDataReadBenchmark.readIcebergVectorized                        ss    5    9.330 ±  0.938   s/op
IcebergSourceNestedORCDataReadBenchmark.readWithProjectionFileSourceNonVectorized    ss    5   86.136 ±  1.139   s/op
IcebergSourceNestedORCDataReadBenchmark.readWithProjectionFileSourceVectorized       ss    5   81.307 ± 14.090   s/op
IcebergSourceNestedORCDataReadBenchmark.readWithProjectionIcebergNonVectorized       ss    5   16.671 ±  0.855   s/op
IcebergSourceNestedORCDataReadBenchmark.readWithProjectionIcebergVectorized          ss    5    6.710 ±  0.679   s/op
```