### PR TITLE
Spark: Fix USING format with CTAS

### DIFF
--- a/spark3/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -149,8 +149,12 @@ public class SparkCatalog implements StagingTableCatalog, org.apache.spark.sql.c
                                  Map<String, String> properties) throws TableAlreadyExistsException {
     Schema icebergSchema = SparkSchemaUtil.convert(schema);
     try {
-      return new StagedSparkTable(icebergCatalog.newCreateTableTransaction(buildIdentifier(ident), icebergSchema,
-          Spark3Util.toPartitionSpec(icebergSchema, transforms), properties.get("location"), properties));
+      return new StagedSparkTable(icebergCatalog.newCreateTableTransaction(
+          buildIdentifier(ident),
+          icebergSchema,
+          Spark3Util.toPartitionSpec(icebergSchema, transforms),
+          properties.get("location"),
+          Spark3Util.rebuildCreateProperties(properties)));
     } catch (AlreadyExistsException e) {
       throw new TableAlreadyExistsException(ident);
     }
@@ -161,8 +165,12 @@ public class SparkCatalog implements StagingTableCatalog, org.apache.spark.sql.c
                                   Map<String, String> properties) throws NoSuchTableException {
     Schema icebergSchema = SparkSchemaUtil.convert(schema);
     try {
-      return new StagedSparkTable(icebergCatalog.newReplaceTableTransaction(buildIdentifier(ident), icebergSchema,
-          Spark3Util.toPartitionSpec(icebergSchema, transforms), properties.get("location"), properties,
+      return new StagedSparkTable(icebergCatalog.newReplaceTableTransaction(
+          buildIdentifier(ident),
+          icebergSchema,
+          Spark3Util.toPartitionSpec(icebergSchema, transforms),
+          properties.get("location"),
+          Spark3Util.rebuildCreateProperties(properties),
           false /* do not create */));
     } catch (org.apache.iceberg.exceptions.NoSuchTableException e) {
       throw new NoSuchTableException(ident);
@@ -173,8 +181,12 @@ public class SparkCatalog implements StagingTableCatalog, org.apache.spark.sql.c
   public StagedTable stageCreateOrReplace(Identifier ident, StructType schema, Transform[] transforms,
                                           Map<String, String> properties) {
     Schema icebergSchema = SparkSchemaUtil.convert(schema);
-    return new StagedSparkTable(icebergCatalog.newReplaceTableTransaction(buildIdentifier(ident), icebergSchema,
-        Spark3Util.toPartitionSpec(icebergSchema, transforms), properties.get("location"), properties,
+    return new StagedSparkTable(icebergCatalog.newReplaceTableTransaction(
+        buildIdentifier(ident),
+        icebergSchema,
+        Spark3Util.toPartitionSpec(icebergSchema, transforms),
+        properties.get("location"),
+        Spark3Util.rebuildCreateProperties(properties),
         true /* create or replace */));
   }
 


### PR DESCRIPTION
When testing 0.9.0 RC5, I found that when a table is created using CTAS and a USING clause to set a non-Parquet format, the format is ignored because unlike CREATE TABLE, the catalog method used by CTAS doesn't call `Spark3Util.rebuildCreateProperties` to set the table's default format from the USING clause.