### PR TITLE
Add spark-warehouse directories under spark2 and spark3 modules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ coverage.xml
 .pytest_cache/
 spark/tmp/
 spark/spark-warehouse/
+spark2/spark-warehouse/
+spark3/spark-warehouse/
 
 # vscode/eclipse files
 .classpath


### PR DESCRIPTION
Spark tests run under `spark2` and `spark3` modules sometimes create the `spark-warehouse` directory. Previously we had a `.gitignore` rule for the `spark` module. This PR adds the same for `spark2` and `spark3` modules.