### PR TITLE
HadoopCatalog.dropNamespace throw NamespaceNotEmptyException when Namespace is not empty

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -277,7 +277,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
     }
 
     try {
-      if (fs.listStatus(nsPath).length != 0) {
+      if (fs.listStatusIterator(nsPath).hasNext()) {
         throw new NamespaceNotEmptyException("Namespace " + namespace + " is not empty.");
       }
 

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -42,6 +42,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
@@ -276,8 +277,11 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
     }
 
     try {
-      return fs.delete(nsPath, false /* recursive */);
+      if (fs.listStatus(nsPath).length != 0) {
+        throw new NamespaceNotEmptyException("Namespace " + namespace + " is not empty.");
+      }
 
+      return fs.delete(nsPath, false /* recursive */);
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Namespace delete failed: %s", namespace);
     }

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
@@ -31,8 +31,8 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
-import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -296,8 +296,8 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
     );
 
     AssertHelpers.assertThrows("Should fail to drop namespace is not empty " + namespace1,
-        RuntimeIOException.class,
-        "Namespace delete failed: " + namespace1, () -> {
+        NamespaceNotEmptyException.class,
+        "Namespace " + namespace1 + " is not empty.", () -> {
           catalog.dropNamespace(Namespace.of("db"));
         });
     Assert.assertFalse("Should fail to drop namespace doesn't exist",


### PR DESCRIPTION
## What is the purpose of the change
In `HadoopCatalog.dropNamespace`, throws `RuntimeIOException("Namespace delete failed")` when Namespace is not empty, but according to `SupportsNamespaces.dropNamespace`, should throw `NamespaceNotEmptyException`.

## Brief change log
Before delete, check `listStatus` first.