### PR TITLE
Remove table cache expiration

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -23,7 +23,6 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
@@ -40,10 +39,7 @@ public class CachingCatalog implements Catalog {
     return new CachingCatalog(catalog, caseSensitive);
   }
 
-  private final Cache<TableIdentifier, Table> tableCache = Caffeine.newBuilder()
-      .softValues()
-      .expireAfterAccess(1, TimeUnit.MINUTES)
-      .build();
+  private final Cache<TableIdentifier, Table> tableCache = Caffeine.newBuilder().softValues().build();
   private final Catalog catalog;
   private final boolean caseSensitive;
 


### PR DESCRIPTION
This removes table expiration from cache in `CachingCatalog`. As long as a reference to a table exists, the cache should continue to use that reference so that writes update the table for all queries. The cache still uses soft values, so once other references are removed it can be garbage collected if memory is needed.