### PR TITLE
ORC: Support row position as a metadata column

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetadataColumns.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataColumns.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.Map;
+import java.util.Set;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.types.Types.NestedField;
+
+public class MetadataColumns {
+
+  private MetadataColumns() {
+  }
+
+  public static final NestedField FILE_PATH = NestedField.required(
+      Integer.MAX_VALUE - 1, "_file", Types.StringType.get(), "Path of the file in which a row is stored");
+  public static final NestedField ROW_POSITION = NestedField.required(
+      Integer.MAX_VALUE - 2, "_pos", Types.LongType.get(), "Ordinal position of a row in the source data file");
+
+  private static final Map<String, NestedField> META_COLUMNS = ImmutableMap.of(
+      FILE_PATH.name(), FILE_PATH,
+      ROW_POSITION.name(), ROW_POSITION);
+
+  private static final Set<Integer> META_IDS = META_COLUMNS.values().stream().map(NestedField::fieldId)
+      .collect(ImmutableSet.toImmutableSet());
+
+  public static Set<Integer> metadataFieldIds() {
+    return META_IDS;
+  }
+}

--- a/data/src/main/java/org/apache/iceberg/data/orc/GenericOrcReader.java
+++ b/data/src/main/java/org/apache/iceberg/data/orc/GenericOrcReader.java
@@ -56,6 +56,11 @@ public class GenericOrcReader implements OrcRowReader<Record> {
     return (Record) reader.read(new StructColumnVector(batch.size, batch.cols), row);
   }
 
+  @Override
+  public void setBatchContext(long batchOffsetInFile) {
+    reader.setBatchContext(batchOffsetInFile);
+  }
+
   private static class ReadBuilder extends OrcSchemaWithTypeVisitor<OrcValueReader<?>> {
     private final Map<Integer, ?> idToConstant;
 

--- a/data/src/main/java/org/apache/iceberg/data/orc/GenericOrcReaders.java
+++ b/data/src/main/java/org/apache/iceberg/data/orc/GenericOrcReaders.java
@@ -248,6 +248,12 @@ public class GenericOrcReaders {
       }
       return map;
     }
+
+    @Override
+    public void setBatchContext(long batchOffsetInFile) {
+      keyReader.setBatchContext(batchOffsetInFile);
+      valueReader.setBatchContext(batchOffsetInFile);
+    }
   }
 
   private static class ListReader implements OrcValueReader<List<?>> {
@@ -267,6 +273,11 @@ public class GenericOrcReaders {
         elements.add(elementReader.read(listVector.child, offset + c));
       }
       return elements;
+    }
+
+    @Override
+    public void setBatchContext(long batchOffsetInFile) {
+      elementReader.setBatchContext(batchOffsetInFile);
     }
   }
 }

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcBatchReader.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcBatchReader.java
@@ -24,7 +24,6 @@ import org.apache.orc.storage.ql.exec.vector.VectorizedRowBatch;
 /**
  * Used for implementing ORC batch readers.
  */
-@FunctionalInterface
 public interface OrcBatchReader<T> {
 
   /**
@@ -32,4 +31,5 @@ public interface OrcBatchReader<T> {
    */
   T read(VectorizedRowBatch batch);
 
+  void setBatchContext(long batchOffsetInFile);
 }

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcRowReader.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcRowReader.java
@@ -31,4 +31,5 @@ public interface OrcRowReader<T> {
    */
   T read(VectorizedRowBatch batch, int row);
 
+  void setBatchContext(long batchOffsetInFile);
 }

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcValueReader.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcValueReader.java
@@ -33,4 +33,7 @@ public interface OrcValueReader<T> {
   }
 
   T nonNullRead(ColumnVector vector, int row);
+
+  default void setBatchContext(long batchOffsetInFile) {
+  }
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcReader.java
@@ -57,6 +57,11 @@ public class SparkOrcReader implements OrcRowReader<InternalRow> {
     return (InternalRow) reader.read(new StructColumnVector(batch.size, batch.cols), row);
   }
 
+  @Override
+  public void setBatchContext(long batchOffsetInFile) {
+    reader.setBatchContext(batchOffsetInFile);
+  }
+
   private static class ReadBuilder extends OrcSchemaWithTypeVisitor<OrcValueReader<?>> {
     private final Map<Integer, ?> idToConstant;
 

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueReaders.java
@@ -93,6 +93,11 @@ public class SparkOrcValueReaders {
       }
       return new GenericArrayData(elements.toArray());
     }
+
+    @Override
+    public void setBatchContext(long batchOffsetInFile) {
+      elementReader.setBatchContext(batchOffsetInFile);
+    }
   }
 
   private static class MapReader implements OrcValueReader<MapData> {
@@ -119,6 +124,12 @@ public class SparkOrcValueReaders {
       return new ArrayBasedMapData(
           new GenericArrayData(keys.toArray()),
           new GenericArrayData(values.toArray()));
+    }
+
+    @Override
+    public void setBatchContext(long batchOffsetInFile) {
+      keyReader.setBatchContext(batchOffsetInFile);
+      valueReader.setBatchContext(batchOffsetInFile);
     }
   }
 

--- a/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/RowPostitionColumnVector.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/RowPostitionColumnVector.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.data.vectorized;
+
+import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.vectorized.ColumnVector;
+import org.apache.spark.sql.vectorized.ColumnarArray;
+import org.apache.spark.sql.vectorized.ColumnarMap;
+import org.apache.spark.unsafe.types.UTF8String;
+
+public class RowPostitionColumnVector extends ColumnVector {
+
+  private final long batchOffsetInFile;
+
+  RowPostitionColumnVector(long batchOffsetInFile) {
+    super(SparkSchemaUtil.convert(Types.LongType.get()));
+    this.batchOffsetInFile = batchOffsetInFile;
+  }
+
+  @Override
+  public void close() {
+  }
+
+  @Override
+  public boolean hasNull() {
+    return false;
+  }
+
+  @Override
+  public int numNulls() {
+    return 0;
+  }
+
+  @Override
+  public boolean isNullAt(int rowId) {
+    return false;
+  }
+
+  @Override
+  public boolean getBoolean(int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public byte getByte(int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public short getShort(int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int getInt(int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long getLong(int rowId) {
+    return batchOffsetInFile + rowId;
+  }
+
+  @Override
+  public float getFloat(int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public double getDouble(int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ColumnarArray getArray(int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ColumnarMap getMap(int ordinal) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Decimal getDecimal(int rowId, int precision, int scale) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public UTF8String getUTF8String(int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public byte[] getBinary(int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  protected ColumnVector getChild(int ordinal) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReadMetadataColumns.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkOrcReadMetadataColumns.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.data;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.orc.ORC;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.data.vectorized.VectorizedSparkOrcReaders;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
+import org.apache.orc.OrcConf;
+import org.apache.orc.OrcFile;
+import org.apache.orc.Reader;
+import org.apache.orc.StripeInformation;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+import org.apache.spark.unsafe.types.UTF8String;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+@RunWith(Parameterized.class)
+public class TestSparkOrcReadMetadataColumns {
+  private static final Schema DATA_SCHEMA = new Schema(
+      required(100, "id", Types.LongType.get()),
+      required(101, "data", Types.StringType.get())
+  );
+
+  private static final Schema PROJECTION_SCHEMA = new Schema(
+      required(100, "id", Types.LongType.get()),
+      required(101, "data", Types.StringType.get()),
+      MetadataColumns.ROW_POSITION
+  );
+
+  private static final int NUM_ROWS = 1000;
+  private static final List<InternalRow> DATA_ROWS;
+  private static final List<InternalRow> EXPECTED_ROWS;
+
+  static {
+    DATA_ROWS = Lists.newArrayListWithCapacity(NUM_ROWS);
+    for (long i = 0; i < NUM_ROWS; i++) {
+      InternalRow row = new GenericInternalRow(DATA_SCHEMA.columns().size());
+      row.update(0, i);
+      row.update(1, UTF8String.fromString("str" + i));
+      DATA_ROWS.add(row);
+    }
+
+    EXPECTED_ROWS = Lists.newArrayListWithCapacity(NUM_ROWS);
+    for (long i = 0; i < NUM_ROWS; i++) {
+      InternalRow row = new GenericInternalRow(PROJECTION_SCHEMA.columns().size());
+      row.update(0, i);
+      row.update(1, UTF8String.fromString("str" + i));
+      row.update(2, i);
+      EXPECTED_ROWS.add(row);
+    }
+  }
+
+  @Parameterized.Parameters
+  public static Object[][] parameters() {
+    return new Object[][] {
+        new Object[] { false },
+        new Object[] { true }
+    };
+  }
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  private boolean vectorized;
+  private File testFile;
+
+  public TestSparkOrcReadMetadataColumns(boolean vectorized) {
+    this.vectorized = vectorized;
+  }
+
+  @Before
+  public void writeFile() throws IOException {
+    testFile = temp.newFile();
+    Assert.assertTrue("Delete should succeed", testFile.delete());
+
+    try (FileAppender<InternalRow> writer = ORC.write(Files.localOutput(testFile))
+        .createWriterFunc(SparkOrcWriter::new)
+        .schema(DATA_SCHEMA)
+        // write in such a way that the file contains 10 stripes each with 100 rows
+        .config("iceberg.orc.vectorbatch.size", "100")
+        .config(OrcConf.ROWS_BETWEEN_CHECKS.getAttribute(), "100")
+        .config(OrcConf.STRIPE_SIZE.getAttribute(), "1")
+        .build()) {
+      writer.addAll(DATA_ROWS);
+    }
+  }
+
+  @Test
+  public void testReadRowNumbers() throws IOException {
+    readAndValidate(null, null, null, EXPECTED_ROWS);
+  }
+
+  @Test
+  public void testReadRowNumbersWithFilter() throws IOException {
+    readAndValidate(Expressions.greaterThanOrEqual("id", 500), null, null, EXPECTED_ROWS.subList(500, 1000));
+  }
+
+  @Test
+  public void testReadRowNumbersWithSplits() throws IOException {
+    Reader reader;
+    try {
+      OrcFile.ReaderOptions readerOptions = OrcFile.readerOptions(new Configuration()).useUTCTimestamp(true);
+      reader =  OrcFile.createReader(new Path(testFile.toString()), readerOptions);
+    } catch (IOException ioe) {
+      throw new RuntimeIOException(ioe, "Failed to open file: %s", testFile);
+    }
+    List<Long> splitOffsets = reader.getStripes().stream().map(StripeInformation::getOffset)
+        .collect(Collectors.toList());
+    List<Long> splitLengths = reader.getStripes().stream().map(StripeInformation::getLength)
+        .collect(Collectors.toList());
+
+    for (int i = 0; i < 10; i++) {
+      readAndValidate(null, splitOffsets.get(i), splitLengths.get(i), EXPECTED_ROWS.subList(i * 100, (i + 1) * 100));
+    }
+  }
+
+  private void readAndValidate(Expression filter, Long splitStart, Long splitLength, List<InternalRow> expected)
+      throws IOException {
+    Schema projectionWithoutMetadataFields = TypeUtil.selectNot(PROJECTION_SCHEMA, MetadataColumns.metadataFieldIds());
+    CloseableIterable<InternalRow> reader = null;
+    try {
+      ORC.ReadBuilder builder = ORC.read(Files.localInput(testFile))
+          .project(projectionWithoutMetadataFields);
+
+      if (vectorized) {
+        builder = builder.createBatchedReaderFunc(readOrcSchema ->
+            VectorizedSparkOrcReaders.buildReader(PROJECTION_SCHEMA, readOrcSchema, ImmutableMap.of()));
+      } else {
+        builder = builder.createReaderFunc(readOrcSchema -> new SparkOrcReader(PROJECTION_SCHEMA, readOrcSchema));
+      }
+
+      if (filter != null) {
+        builder = builder.filter(filter);
+      }
+
+      if (splitStart != null && splitLength != null) {
+        builder = builder.split(splitStart, splitLength);
+      }
+
+      if (vectorized) {
+        reader = batchesToRows(builder.build());
+      } else {
+        reader = builder.build();
+      }
+
+      final Iterator<InternalRow> actualRows = reader.iterator();
+      final Iterator<InternalRow> expectedRows = expected.iterator();
+      while (expectedRows.hasNext()) {
+        Assert.assertTrue("Should have expected number of rows", actualRows.hasNext());
+        TestHelpers.assertEquals(PROJECTION_SCHEMA, expectedRows.next(), actualRows.next());
+      }
+      Assert.assertFalse("Should not have extra rows", actualRows.hasNext());
+    } finally {
+      if (reader != null) {
+        reader.close();
+      }
+    }
+  }
+
+  private CloseableIterable<InternalRow> batchesToRows(CloseableIterable<ColumnarBatch> batches) {
+    return CloseableIterable.combine(
+        Iterables.concat(Iterables.transform(batches, b -> (Iterable<InternalRow>) b::rowIterator)),
+        batches);
+  }
+}


### PR DESCRIPTION
Completes a part of #1021

Adds support to output the row position within the file as a `_pos` column in the data record through ORC readers when the metadata column is provided in the expected schema 
Main changes:
- Add a `MetadataColumns` class to `iceberg-core` which will define the metadata columns supported by Iceberg
- Expose row batch offset in the file to `OrcValueReader`s so that the we can create a new ValueReader which returns the row position
- Add logic in the `StructReader` to check if a field is a metadata field and provide the correct reader for it