### PR TITLE
Fix test timeout by logging tests that pass

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,7 @@ subprojects {
 
   test {
     testLogging {
-      events "failed"
+      events "failed", "passed"
       exceptionFormat "full"
     }
   }


### PR DESCRIPTION
This implements option 4 from #1198. Each passing test case will be logged so that Travis CI gets updates that tests are still running.