### PR TITLE
Gradle: Do not print test names in non-CI environments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,11 @@ subprojects {
 
   test {
     testLogging {
-      events "failed", "passed"
+      if ("true".equalsIgnoreCase(System.getenv('CI'))) {
+        events "failed", "passed"
+      } else {
+        events "failed"
+      }
       exceptionFormat "full"
     }
   }


### PR DESCRIPTION
This is a followup on #1210
This change avoids printing the test name in non-CI environments to reduce noise in local builds 