### PR TITLE
Site: Fixes

### DIFF
--- a/site/docs/api.md
+++ b/site/docs/api.md
@@ -99,6 +99,8 @@ Available operations to update a table are:
 
 ### Transactions
 
+`Table` also enables to commit multiple table operations at once.
+
 ## Types
 
 Iceberg data types are located in the [`org.apache.iceberg.types` package](/javadoc/master/index.html?org/apache/iceberg/types/package-summary.html).

--- a/site/docs/api.md
+++ b/site/docs/api.md
@@ -99,8 +99,7 @@ Available operations to update a table are:
 
 ### Transactions
 
-Transactions are used to commit multiple table changes in a single atomic operation. A transaction is used to create individual operations using factory methods, like `newAppend`, just like working with a `Table`.
-Operations created by a transaction are committed as a group when `commitTransaction` is called.
+Transactions are used to commit multiple table changes in a single atomic operation. A transaction is used to create individual operations using factory methods, like `newAppend`, just like working with a `Table`. Operations created by a transaction are committed as a group when `commitTransaction` is called.
 
 For example, deleting and appending a file in the same transaction:
 ```java

--- a/site/docs/api.md
+++ b/site/docs/api.md
@@ -99,7 +99,20 @@ Available operations to update a table are:
 
 ### Transactions
 
-`Table` also enables to commit multiple table operations at once.
+Transactions are used to commit multiple table changes in a single atomic operation. A transaction is used to create individual operations using factory methods, like `newAppend`, just like working with a `Table`.
+Operations created by a transaction are committed as a group when `commitTransaction` is called.
+
+For example, deleting and appending a file in the same transaction:
+```java
+Transaction t = table.newTrasaction();
+
+// commit operations to the transaction
+t.newDelete().deleteFromRowFilter(filter).commit();
+t.newAppend().appendFile(data).commit();
+
+// commit all the changes to the table
+t.commitTransaction();
+```
 
 ## Types
 

--- a/site/docs/api.md
+++ b/site/docs/api.md
@@ -202,7 +202,8 @@ Iceberg table support is organized in library modules:
 
 This project Iceberg also has modules for adding Iceberg support to processing engines:
 
-* `iceberg-spark` is an implementation of Spark's Datasource V2 API for Iceberg (use iceberg-runtime for a shaded version)
+* `iceberg-spark2` is an implementation of Spark's Datasource V2 API in 2.4 for Iceberg (use iceberg-spark-runtime for a shaded version)
+* `iceberg-spark3` is an implementation of Spark's Datasource V2 API in 3.0 for Iceberg (use iceberg-spark3-runtime for a shaded version)
 * `iceberg-data` is a client library used to read Iceberg tables from JVM applications
 * `iceberg-pig` is an implementation of Pig's LoadFunc API for Iceberg
 * `iceberg-runtime` generates a shaded runtime jar for Spark to integrate with iceberg tables

--- a/site/docs/javadoc/0.9.0/search.js
+++ b/site/docs/javadoc/0.9.0/search.js
@@ -324,3 +324,7 @@ $(function() {
         }
     });
 });
+
+getURLPrefix = function(ui) {
+    return '';
+};

--- a/site/docs/reliability.md
+++ b/site/docs/reliability.md
@@ -23,7 +23,7 @@ Hive tables track data files using both a central metastore for partitions and a
 
 Iceberg tracks the complete list of data files in each [snapshot](../terms#snapshot) using a persistent tree structure. Every write or delete produces a new snapshot that reuses as much of the previous snapshot's metadata tree as possible to avoid high write volumes.
 
-Valid snapshots in an Iceberg table are stored the table metadata file, along with a reference to the current snapshot. Commits replace the path of the current table metadata file using an atomic operation. This ensures that all updates to table data and metadata are atomic, and is the basis for [serializable isolation](https://en.wikipedia.org/wiki/Isolation_(database_systems)#Serializable).
+Valid snapshots in an Iceberg table are stored in the table metadata file, along with a reference to the current snapshot. Commits replace the path of the current table metadata file using an atomic operation. This ensures that all updates to table data and metadata are atomic, and is the basis for [serializable isolation](https://en.wikipedia.org/wiki/Isolation_(database_systems)#Serializable).
 
 This results in improved reliability guarantees:
 

--- a/tasks.gradle
+++ b/tasks.gradle
@@ -25,6 +25,20 @@ task aggregateJavadoc(type: Javadoc) {
   source subprojects.javadoc.source
   destinationDir project.rootProject.file("site/docs/javadoc/${getJavadocVersion()}")
   classpath = project.rootProject.files(subprojects.javadoc.classpath)
+
+  final JAVADOC_FIX_SEARCH_STR = '\n\n' +
+          'getURLPrefix = function(ui) {\n' +
+          '    return \'\';\n' +
+          '};\n'
+
+  doLast {
+    // Fix bug with search
+    if (JavaVersion.current() >= JavaVersion.VERSION_11) {
+      // Append the fix to the file
+      def searchScript = new File("site/docs/javadoc/${getJavadocVersion()}" + '/search.js')
+      searchScript.append JAVADOC_FIX_SEARCH_STR
+    }
+  }
 }
 
 task removeJavadoc(type: Exec) {


### PR DESCRIPTION
This PR includes some minor fixes to the documentation site:

- Javadoc bug which makes the search form unusable - 
When using JDK 11 the Javadoc is generated using HTML 5 and has a search bar, due to a bug some of the links redirect to invalid locations, for example:
```
https://iceberg.apache.org/javadoc/0.9.0/undefined/org/apache/iceberg/Transaction.html
```
instead of:
```
https://iceberg.apache.org/javadoc/0.9.0/org/apache/iceberg/Transaction.html
```
The bug was fixed manually for version 0.9.0 and for future release I have modified the gradle task to make the necessary changes according to the solution suggested [here](https://stackoverflow.com/questions/52326318/maven-javadoc-search-redirects-to-undefined-url/52603413#52603413).

- Java API page changes:
  - Adding documentation for transactions support
  - Adding documentation for `iceberg-spark3`

- Minor typo fixes