### PR TITLE
Spark: Fix estimateStatistics when called without filters

### DIFF
--- a/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
@@ -272,7 +272,8 @@ public class SparkSchemaUtil {
     for (StructField sparkField : tableSchema.fields()) {
       approximateSize += sparkField.dataType().defaultSize();
     }
-    Long result = approximateSize * totalRecords;
+
+    long result = approximateSize * totalRecords;
     return result > 0 ? result : Long.MAX_VALUE;
   }
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
@@ -37,6 +37,7 @@ import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalog.Column;
 import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
 /**
@@ -255,4 +256,23 @@ public class SparkSchemaUtil {
     return builder.build();
   }
 
+  /**
+   * estimate approximate table size based on spark schema and total records.
+   *
+   * @param tableSchema  spark schema
+   * @param totalRecords total records in the table
+   * @return approxiate size based on table schema
+   */
+  public static long estimateSize(StructType tableSchema, long totalRecords) {
+    if (totalRecords == Long.MAX_VALUE) {
+      return totalRecords;
+    }
+
+    long approximateSize = 0;
+    for (StructField sparkField : tableSchema.fields()) {
+      approximateSize += sparkField.dataType().defaultSize();
+    }
+    Long result = approximateSize * totalRecords;
+    return result > 0 ? result : Long.MAX_VALUE;
+  }
 }

--- a/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark;
+
+import java.io.IOException;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Types;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+
+public class TestSparkSchemaUtil {
+  Schema testSchema = new Schema(
+      optional(1, "id", Types.IntegerType.get()),
+      optional(2, "data", Types.StringType.get())
+  );
+
+  @Test
+  public void testEstiamteSizeMaxValue() throws IOException {
+    Assert.assertEquals("estimateSize returns Long max value", Long.MAX_VALUE,
+        SparkSchemaUtil.estimateSize(
+            null,
+            Long.MAX_VALUE));
+  }
+
+  @Test
+  public void testEstiamteSizeWithOverflow() throws IOException {
+    long tableSize = SparkSchemaUtil.estimateSize(SparkSchemaUtil.convert(testSchema), Long.MAX_VALUE - 1);
+    Assert.assertEquals("estimateSize handles overflow", Long.MAX_VALUE, tableSize);
+  }
+
+  @Test
+  public void testEstiamteSize() throws IOException {
+    long tableSize = SparkSchemaUtil.estimateSize(SparkSchemaUtil.convert(testSchema), 1);
+    Assert.assertEquals("estimateSize matches with expected approximation", 24, tableSize);
+  }
+}

--- a/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 
 public class TestSparkSchemaUtil {
-  Schema testSchema = new Schema(
+  private static final Schema TEST_SCHEMA = new Schema(
       optional(1, "id", Types.IntegerType.get()),
       optional(2, "data", Types.StringType.get())
   );
@@ -43,13 +43,13 @@ public class TestSparkSchemaUtil {
 
   @Test
   public void testEstiamteSizeWithOverflow() throws IOException {
-    long tableSize = SparkSchemaUtil.estimateSize(SparkSchemaUtil.convert(testSchema), Long.MAX_VALUE - 1);
+    long tableSize = SparkSchemaUtil.estimateSize(SparkSchemaUtil.convert(TEST_SCHEMA), Long.MAX_VALUE - 1);
     Assert.assertEquals("estimateSize handles overflow", Long.MAX_VALUE, tableSize);
   }
 
   @Test
   public void testEstiamteSize() throws IOException {
-    long tableSize = SparkSchemaUtil.estimateSize(SparkSchemaUtil.convert(testSchema), 1);
+    long tableSize = SparkSchemaUtil.estimateSize(SparkSchemaUtil.convert(TEST_SCHEMA), 1);
     Assert.assertEquals("estimateSize matches with expected approximation", 24, tableSize);
   }
 }

--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableScan;
@@ -276,6 +277,12 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
 
   @Override
   public Statistics estimateStatistics() {
+    if (filterExpressions == null || filterExpressions == Expressions.alwaysTrue()) {
+      long totalRecords = PropertyUtil.propertyAsLong(table.currentSnapshot().summary(),
+          SnapshotSummary.TOTAL_RECORDS_PROP, Long.MAX_VALUE);
+      return new Stats(SparkSchemaUtil.estimateSize(lazyType(), totalRecords), totalRecords);
+    }
+
     long sizeInBytes = 0L;
     long numRows = 0L;
 

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
@@ -186,7 +186,9 @@ class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
       long totalRecords = PropertyUtil.propertyAsLong(table.currentSnapshot().summary(),
           SnapshotSummary.TOTAL_RECORDS_PROP, Long.MAX_VALUE);
       Schema projectedSchema = expectedSchema != null ? expectedSchema : table.schema();
-      return new Stats(SparkSchemaUtil.estimateSize(SparkSchemaUtil.convert(projectedSchema), totalRecords), totalRecords);
+      return new Stats(
+          SparkSchemaUtil.estimateSize(SparkSchemaUtil.convert(projectedSchema), totalRecords),
+          totalRecords);
     }
 
     long sizeInBytes = 0L;

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableScan;
@@ -44,6 +45,7 @@ import org.apache.iceberg.mapping.NameMappingParser;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.util.PropertyUtil;
 import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.read.Batch;
@@ -179,6 +181,14 @@ class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
 
   @Override
   public Statistics estimateStatistics() {
+    if (filterExpressions == null || filterExpressions.isEmpty()) {
+      LOG.debug("using table metadata to estimate table statistics");
+      long totalRecords = PropertyUtil.propertyAsLong(table.currentSnapshot().summary(),
+          SnapshotSummary.TOTAL_RECORDS_PROP, Long.MAX_VALUE);
+      Schema projectedSchema = expectedSchema != null ? expectedSchema : table.schema();
+      return new Stats(SparkSchemaUtil.estimateSize(SparkSchemaUtil.convert(projectedSchema), totalRecords), totalRecords);
+    }
+
     long sizeInBytes = 0L;
     long numRows = 0L;
 


### PR DESCRIPTION
…tistics call

https://github.com/apache/iceberg/issues/1220
this commits add support for table property "read.spark.use-approximate-statistics"
which returns table statistics based on table rows and approximate row size and avoid reading manifest and data files
to get table size and row count.
this feature is useful for spark2 as spark2 does not perform predicate pushdown before calling
estimateStatistics which ends up scanning entire table.
this feature may be useful for spark3 if table manifest list is large even after predicate pushdown.