### PR TITLE
Add Avro row position reader

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/AvroIO.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroIO.java
@@ -21,13 +21,26 @@ package org.apache.iceberg.avro;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.apache.avro.InvalidAvroMagicException;
 import org.apache.avro.file.SeekableInput;
+import org.apache.avro.io.BinaryDecoder;
+import org.apache.avro.io.DecoderFactory;
 import org.apache.iceberg.common.DynClasses;
 import org.apache.iceberg.common.DynConstructors;
+import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.DelegatingInputStream;
 import org.apache.iceberg.io.SeekableInputStream;
 
 class AvroIO {
+  private static final byte[] AVRO_MAGIC = new byte[] { 'O', 'b', 'j', 1 };
+  private static final ValueReader<byte[]> MAGIC_READER = ValueReaders.fixed(AVRO_MAGIC.length);
+  private static final ValueReader<Map<String, String>> META_READER = ValueReaders.map(
+      ValueReaders.strings(), ValueReaders.strings());
+  private static final ValueReader<byte[]> SYNC_READER = ValueReaders.fixed(16);
+
   private AvroIO() {
   }
 
@@ -129,6 +142,57 @@ class AvroIO {
     @Override
     public boolean markSupported() {
       return stream.markSupported();
+    }
+  }
+
+  static long findStartingRowPos(Supplier<SeekableInputStream> open, long start) {
+    try (SeekableInputStream in = open.get()) {
+      // use a direct decoder that will not buffer so the position of the input stream is accurate
+      BinaryDecoder decoder = DecoderFactory.get().directBinaryDecoder(in, null);
+
+      // an Avro file's layout looks like this:
+      //   header|block|block|...
+      // the header contains:
+      //   magic|string-map|sync
+      // each block consists of:
+      //   row-count|compressed-size-in-bytes|block-bytes|sync
+
+      // it is necessary to read the header here because this is the only way to get the expected file sync bytes
+      byte[] magic = MAGIC_READER.read(decoder, null);
+      if (!Arrays.equals(AVRO_MAGIC, magic)) {
+        throw new InvalidAvroMagicException("Not an Avro file");
+      }
+
+      META_READER.read(decoder, null); // ignore the file metadata, it isn't needed
+      byte[] fileSync = SYNC_READER.read(decoder, null);
+
+      // the while loop reads row counts and seeks past the block bytes until the next sync pos is >= start, which
+      // indicates that the next sync is the start of the split.
+      byte[] blockSync = new byte[16];
+      long totalRows = 0;
+      long nextSyncPos = in.getPos();
+
+      while (nextSyncPos < start) {
+        if (nextSyncPos != in.getPos()) {
+          in.seek(nextSyncPos);
+          SYNC_READER.read(decoder, blockSync);
+
+          if (!Arrays.equals(fileSync, blockSync)) {
+            throw new RuntimeIOException("Invalid sync at %s", nextSyncPos);
+          }
+        }
+
+        long rowCount = decoder.readLong();
+        long compressedBlockSize = decoder.readLong();
+
+        totalRows += rowCount;
+        nextSyncPos = in.getPos() + compressedBlockSize;
+      }
+
+      return totalRows;
+
+    } catch (IOException e) {
+      throw new RuntimeIOException(e, "Failed to read stream while finding starting row position");
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/avro/AvroIterable.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroIterable.java
@@ -77,7 +77,13 @@ public class AvroIterable<D> extends CloseableGroup implements CloseableIterable
     FileReader<D> fileReader = initMetadata(newFileReader());
 
     if (start != null) {
+      if (reader instanceof SupportsRowPosition) {
+        ((SupportsRowPosition) reader).setRowPositionSupplier(
+            () -> AvroIO.findStartingRowPos(file::newStream, start));
+      }
       fileReader = new AvroRangeIterator<>(fileReader, start, end);
+    } else if (reader instanceof SupportsRowPosition) {
+      ((SupportsRowPosition) reader).setRowPositionSupplier(() -> 0L);
     }
 
     addCloseable(fileReader);

--- a/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
+++ b/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 import org.apache.avro.JsonProperties;
 import org.apache.avro.Schema;
+import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -93,7 +94,9 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
         updatedFields.add(avroField);
 
       } else {
-        Preconditions.checkArgument(field.isOptional(), "Missing required field: %s", field.name());
+        Preconditions.checkArgument(
+            field.isOptional() || field.fieldId() == MetadataColumns.ROW_POSITION.fieldId(),
+            "Missing required field: %s", field.name());
         // Create a field that will be defaulted to null. We assign a unique suffix to the field
         // to make sure that even if records in the file have the field it is not projected.
         Schema.Field newField = new Schema.Field(

--- a/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
+++ b/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
@@ -49,6 +49,7 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
   }
 
   @Override
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
   public Schema record(Schema record, List<String> names, Iterable<Schema.Field> schemaIterable) {
     Preconditions.checkArgument(
         current.isNestedType() && current.asNestedType().isStructType(),

--- a/core/src/main/java/org/apache/iceberg/avro/ProjectionDatumReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ProjectionDatumReader.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import org.apache.avro.Schema;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.Decoder;
@@ -30,7 +31,7 @@ import org.apache.iceberg.mapping.MappingUtil;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.types.TypeUtil;
 
-public class ProjectionDatumReader<D> implements DatumReader<D> {
+public class ProjectionDatumReader<D> implements DatumReader<D>, SupportsRowPosition {
   private final Function<Schema, DatumReader<?>> getReader;
   private final org.apache.iceberg.Schema expectedSchema;
   private final Map<String, String> renames;
@@ -47,6 +48,13 @@ public class ProjectionDatumReader<D> implements DatumReader<D> {
     this.expectedSchema = expectedSchema;
     this.renames = renames;
     this.nameMapping = nameMapping;
+  }
+
+  @Override
+  public void setRowPositionSupplier(Supplier<Long> posSupplier) {
+    if (wrapped instanceof SupportsRowPosition) {
+      ((SupportsRowPosition) wrapped).setRowPositionSupplier(posSupplier);
+    }
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/avro/SupportsRowPosition.java
+++ b/core/src/main/java/org/apache/iceberg/avro/SupportsRowPosition.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.avro;
+
+import java.util.function.Supplier;
+
+/**
+ * Interface for readers that accept a callback to determine the starting row position of an Avro split.
+ */
+public interface SupportsRowPosition {
+  void setRowPositionSupplier(Supplier<Long> posSupplier);
+}

--- a/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
@@ -586,8 +586,7 @@ public class ValueReaders {
           positionList.add(pos);
           constantList.add(idToConstant.get(field.fieldId()));
         } else if (field.fieldId() == MetadataColumns.ROW_POSITION.fieldId()) {
-          // replace the _pos field reader with a position reader
-          // only if the position reader is set and this is a top-level field
+          // track where the _pos field is located for setRowPositionSupplier
           this.posField = pos;
         }
       }

--- a/core/src/main/java/org/apache/iceberg/data/avro/DataReader.java
+++ b/core/src/main/java/org/apache/iceberg/data/avro/DataReader.java
@@ -126,7 +126,6 @@ public class DataReader<T> implements DatumReader<T>, SupportsRowPosition {
     @Override
     public ValueReader<?> record(Types.StructType struct, Schema record,
                                  List<String> names, List<ValueReader<?>> fields) {
-
       return createStructReader(struct, fields, idToConstant);
     }
 

--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroFileSplit.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroFileSplit.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.avro;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.avro.DataReader;
+import org.apache.iceberg.data.avro.DataWriter;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.types.Types.NestedField;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestAvroFileSplit {
+  private static final Schema SCHEMA = new Schema(
+      NestedField.required(1, "id", Types.LongType.get()),
+      NestedField.required(2, "data", Types.StringType.get()));
+
+  private static final int NUM_RECORDS = 100_000;
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  public List<Record> expected = null;
+  public InputFile file = null;
+
+  @Before
+  public void writeDataFile() throws IOException {
+    this.expected = Lists.newArrayList();
+
+    OutputFile out = Files.localOutput(temp.newFile());
+
+    try (FileAppender<Object> writer = Avro.write(out)
+        .set(TableProperties.AVRO_COMPRESSION, "uncompressed")
+        .createWriterFunc(DataWriter::create)
+        .schema(SCHEMA)
+        .overwrite()
+        .build()) {
+
+      Record record = GenericRecord.create(SCHEMA);
+      for (long i = 0; i < NUM_RECORDS; i += 1) {
+        Record next = record.copy(ImmutableMap.of(
+            "id", i,
+            "data", UUID.randomUUID().toString()));
+        expected.add(next);
+        writer.add(next);
+      }
+    }
+
+    this.file = out.toInputFile();
+  }
+
+  @Test
+  public void testSplitDataSkipping() throws IOException {
+    long end = file.getLength();
+    long splitLocation = end / 2;
+
+    List<Record> firstHalf = readAvro(file, SCHEMA, 0, splitLocation);
+    Assert.assertNotEquals("First split should not be empty", 0, firstHalf.size());
+
+    List<Record> secondHalf = readAvro(file, SCHEMA, splitLocation + 1, end - splitLocation - 1);
+    Assert.assertNotEquals("Second split should not be empty", 0, secondHalf.size());
+
+    Assert.assertEquals("Total records should match expected",
+        expected.size(), firstHalf.size() + secondHalf.size());
+
+    for (int i = 0; i < firstHalf.size(); i += 1) {
+      Assert.assertEquals(expected.get(i), firstHalf.get(i));
+    }
+
+    for (int i = 0; i < secondHalf.size(); i += 1) {
+      Assert.assertEquals(expected.get(firstHalf.size() + i), secondHalf.get(i));
+    }
+  }
+
+  @Test
+  public void testPosField() throws IOException {
+    Schema projection = new Schema(
+        SCHEMA.columns().get(0),
+        MetadataColumns.ROW_POSITION,
+        SCHEMA.columns().get(1));
+
+    List<Record> records = readAvro(file, projection, 0, file.getLength());
+
+    for (int i = 0; i < expected.size(); i += 1) {
+      Assert.assertEquals("Field _pos should match",
+          (long) i, records.get(i).getField(MetadataColumns.ROW_POSITION.name()));
+      Assert.assertEquals("Field id should match",
+          expected.get(i).getField("id"), records.get(i).getField("id"));
+      Assert.assertEquals("Field data should match",
+          expected.get(i).getField("data"), records.get(i).getField("data"));
+    }
+  }
+
+  @Test
+  public void testPosFieldWithSplits() throws IOException {
+    Schema projection = new Schema(
+        SCHEMA.columns().get(0),
+        MetadataColumns.ROW_POSITION,
+        SCHEMA.columns().get(1));
+
+    long end = file.getLength();
+    long splitLocation = end / 2;
+
+    List<Record> secondHalf = readAvro(file, projection, splitLocation + 1, end - splitLocation - 1);
+    Assert.assertNotEquals("Second split should not be empty", 0, secondHalf.size());
+
+    List<Record> firstHalf = readAvro(file, projection, 0, splitLocation);
+    Assert.assertNotEquals("First split should not be empty", 0, firstHalf.size());
+
+    Assert.assertEquals("Total records should match expected",
+        expected.size(), firstHalf.size() + secondHalf.size());
+
+    for (int i = 0; i < firstHalf.size(); i += 1) {
+      Assert.assertEquals("Field _pos should match",
+          (long) i, firstHalf.get(i).getField(MetadataColumns.ROW_POSITION.name()));
+      Assert.assertEquals("Field id should match",
+          expected.get(i).getField("id"), firstHalf.get(i).getField("id"));
+      Assert.assertEquals("Field data should match",
+          expected.get(i).getField("data"), firstHalf.get(i).getField("data"));
+    }
+
+    for (int i = 0; i < secondHalf.size(); i += 1) {
+      Assert.assertEquals("Field _pos should match",
+          (long) (firstHalf.size() + i), secondHalf.get(i).getField(MetadataColumns.ROW_POSITION.name()));
+      Assert.assertEquals("Field id should match",
+          expected.get(firstHalf.size() + i).getField("id"), secondHalf.get(i).getField("id"));
+      Assert.assertEquals("Field data should match",
+          expected.get(firstHalf.size() + i).getField("data"), secondHalf.get(i).getField("data"));
+    }
+  }
+
+  public List<Record> readAvro(InputFile in, Schema projection, long start, long length) throws IOException {
+    try (AvroIterable<Record> reader = Avro.read(in)
+        .createReaderFunc(DataReader::create)
+        .split(start, length)
+        .project(projection)
+        .build()) {
+      return Lists.newArrayList(reader);
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroFileSplit.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroFileSplit.java
@@ -162,6 +162,19 @@ public class TestAvroFileSplit {
     }
   }
 
+  @Test
+  public void testPosWithEOFSplit() throws IOException {
+    Schema projection = new Schema(
+        SCHEMA.columns().get(0),
+        MetadataColumns.ROW_POSITION,
+        SCHEMA.columns().get(1));
+
+    long end = file.getLength();
+
+    List<Record> records = readAvro(file, projection, end - 10, 10);
+    Assert.assertEquals("Should not read any records", 0, records.size());
+  }
+
   public List<Record> readAvro(InputFile in, Schema projection, long start, long length) throws IOException {
     try (AvroIterable<Record> reader = Avro.read(in)
         .createReaderFunc(DataReader::create)


### PR DESCRIPTION
This adds an Avro `ValueReader` that returns the position of a row within a file.

The position reader's initial position is set from a callback that returns the starting row position of the split that is being read. The callback is passed to classes that implement a new interface, `SupportsRowPosition`. This uses a callback so that if there is no position reader, the starting row position does not need to be calculated, which is expensive.

Finding the row position at the start of a split requires scanning through an Avro file stream. `AvroIO` now includes a utility method that keeps track of the number of rows in each Avro block and seeks past the block content until the next block is after the given split starting point. This validates Avro sync bytes to ensure the count is accurate.

Fixes #1019.