### PR TITLE
Fix TestHiveTableConcurrency test failure: Increase the timeout to 3min

### DIFF
--- a/hive/src/test/java/org/apache/iceberg/hive/TestHiveTableConcurrency.java
+++ b/hive/src/test/java/org/apache/iceberg/hive/TestHiveTableConcurrency.java
@@ -103,7 +103,7 @@ public class TestHiveTableConcurrency extends HiveTableBaseTest {
     }
 
     executorService.shutdown();
-    Assert.assertTrue("Timeout", executorService.awaitTermination(2, TimeUnit.MINUTES));
+    Assert.assertTrue("Timeout", executorService.awaitTermination(3, TimeUnit.MINUTES));
     Assert.assertEquals(7, Iterables.size(icebergTable.snapshots()));
   }
 }


### PR DESCRIPTION
In my local env, this test testConcurrentConnections fails with a timeout.   

```
org.apache.iceberg.hive.TestHiveTableConcurrency > testConcurrentConnections FAILED
    java.lang.AssertionError: Timeout
        at org.junit.Assert.fail(Assert.java:88)
        at org.junit.Assert.assertTrue(Assert.java:41)
        at org.apache.iceberg.hive.TestHiveTableConcurrency.testConcurrentConnections(TestHiveTableConcurrency.java:106)

```
Increasing the timeout to 3 min fixes this.   

Fixes #1225 
