### PR TITLE
Improve release script to detect archive list automatically

### DIFF
--- a/dev/source-release.sh
+++ b/dev/source-release.sh
@@ -66,7 +66,11 @@ tarball=$tag.tar.gz
 
 # be conservative and use the release hash, even though git produces the same
 # archive (identical hashes) using the scm tag
-git archive $release_hash --prefix $tag/ -o $tarball .baseline api arrow bundled-guava common core data dev flink gradle gradlew hive mr orc parquet pig spark spark2 spark-runtime spark3 spark3-runtime LICENSE NOTICE README.md build.gradle baseline.gradle deploy.gradle tasks.gradle jmh.gradle gradle.properties settings.gradle versions.lock versions.props version.txt
+adds=" .baseline"  # prefixed with a blank space for each file name including the first one
+excludes="build|examples|jitpack.yml|python|site"
+archives=$(ls | grep -vE ${excludes})${adds}
+echo git archive list: ${archives}
+git archive $release_hash --prefix $tag/ -o $tarball ${archives}
 
 # sign the archive
 gpg --armor --output ${tarball}.asc --detach-sig $tarball

--- a/dev/source-release.sh
+++ b/dev/source-release.sh
@@ -68,7 +68,7 @@ tarball=$tag.tar.gz
 # archive (identical hashes) using the scm tag
 adds=" .baseline"  # prefixed with a blank space for each file name including the first one
 excludes="build|examples|jitpack.yml|python|site"
-archives=$(ls | grep -vE ${excludes})${adds}
+archives=$(ls | grep -vE ${excludes} | tr '\n' ' ')${adds}
 echo git archive list: ${archives}
 git archive $release_hash --prefix $tag/ -o $tarball ${archives}
 

--- a/dev/source-release.sh
+++ b/dev/source-release.sh
@@ -67,7 +67,8 @@ tarball=$tag.tar.gz
 # be conservative and use the release hash, even though git produces the same
 # archive (identical hashes) using the scm tag
 adds=" .baseline"  # prefixed with a blank space for each file name including the first one
-excludes="build|examples|jitpack.yml|python|site"
+excludes="build|examples|jitpack.yml|python|site"  # excluded as they are not of use for releasing jars
+echo WARNING! The following files/directories are to be excluded from git archive: ${excludes}
 archives=$(ls | grep -vE ${excludes} | tr '\n' ' ')${adds}
 echo git archive list: ${archives}
 git archive $release_hash --prefix $tag/ -o $tarball ${archives}

--- a/dev/source-release.sh
+++ b/dev/source-release.sh
@@ -68,9 +68,9 @@ tarball=$tag.tar.gz
 # archive (identical hashes) using the scm tag
 adds=" .baseline"  # prefixed with a blank space for each file name including the first one
 excludes="build|examples|jitpack.yml|python|site"  # excluded as they are not of use for releasing jars
-echo WARNING! The following files/directories are to be excluded from git archive: ${excludes}
-archives=$(ls | grep -vE ${excludes} | tr '\n' ' ')${adds}
-echo git archive list: ${archives}
+echo "Excluded files and directories: ${excludes}"
+archives=$(git ls-tree --name-only -r HEAD | cut -d"/" -f1 | uniq | grep -vE ${excludes} | tr '\n' ' ')${adds}
+echo "Included files and directories: ${archives}"
 git archive $release_hash --prefix $tag/ -o $tarball ${archives}
 
 # sign the archive


### PR DESCRIPTION
This PR is trying to address that sometimes we forget to update the release script when adding/removing sub-projects 