### PR TITLE
Fix Handling of SparkPartitions with Whitepsace in Location

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/Util.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/Util.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.hadoop;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
@@ -77,5 +78,19 @@ public class Util {
     }
 
     return locations.toArray(HadoopInputFile.NO_LOCATION_PREFERENCE);
+  }
+
+  /**
+   * From Apache Spark
+   *
+   * Convert URI to String.
+   * Since URI.toString does not decode the uri, e.g. change '%25' to '%'.
+   * Here we create a hadoop Path with the given URI, and rely on Path.toString
+   * to decode the uri
+   * @param uri the URI of the path
+   * @return the String of the path
+   */
+  public static String uriToString(URI uri) {
+    return new Path(uri).toString();
   }
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -49,6 +49,7 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.hadoop.HadoopInputFile;
 import org.apache.iceberg.hadoop.SerializableConfiguration;
+import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.orc.OrcMetrics;
@@ -103,20 +104,6 @@ public class SparkTableUtil {
       p -> !p.getName().startsWith("_") && !p.getName().startsWith(".");
 
   private SparkTableUtil() {
-  }
-
-  /**
-   * From Apache Spark
-   *
-   * Convert URI to String.
-   * Since URI.toString does not decode the uri, e.g. change '%25' to '%'.
-   * Here we create a hadoop Path with the given URI, and rely on Path.toString
-   * to decode the uri
-   * @param uri the URI of the path
-   * @return the String of the path
-   */
-  public static String uriToString(URI uri) {
-    return new Path(uri).toString();
   }
 
   /**
@@ -400,7 +387,7 @@ public class SparkTableUtil {
     Preconditions.checkArgument(serde.nonEmpty() || table.provider().nonEmpty(),
         "Partition format should be defined");
 
-    String uri = uriToString(locationUri.get());
+    String uri = Util.uriToString(locationUri.get());
     String format = serde.nonEmpty() ? serde.get() : table.provider().get();
 
     Map<String, String> partitionSpec = JavaConverters.mapAsJavaMapConverter(partition.spec()).asJava();
@@ -509,7 +496,7 @@ public class SparkTableUtil {
       MetricsConfig metricsConfig = MetricsConfig.fromProperties(targetTable.properties());
 
       List<DataFile> files = listPartition(
-          partition, uriToString(sourceTable.location()), format.get(), spec, conf, metricsConfig);
+          partition, Util.uriToString(sourceTable.location()), format.get(), spec, conf, metricsConfig);
 
       AppendFiles append = targetTable.newAppend();
       files.forEach(append::appendFile);

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -271,7 +271,7 @@ public class SparkTableUtil {
    * @param metricsConfig a metrics conf
    * @return a List of DataFile
    */
-  public static List<DataFile> listPartition(Map<String, String> partition, String uri, String format,
+  public static List<DataFile> listPartition(Map<String, String> partition, URI uri, String format,
                                              PartitionSpec spec, Configuration conf, MetricsConfig metricsConfig) {
     if (format.contains("avro")) {
       return listAvroPartition(partition, uri, spec, conf);
@@ -286,7 +286,7 @@ public class SparkTableUtil {
   }
 
   private static List<DataFile> listAvroPartition(
-      Map<String, String> partitionPath, String partitionUri, PartitionSpec spec, Configuration conf) {
+      Map<String, String> partitionPath, URI partitionUri, PartitionSpec spec, Configuration conf) {
     try {
       Path partition = new Path(partitionUri);
       FileSystem fs = partition.getFileSystem(conf);
@@ -313,7 +313,7 @@ public class SparkTableUtil {
     }
   }
 
-  private static List<DataFile> listParquetPartition(Map<String, String> partitionPath, String partitionUri,
+  private static List<DataFile> listParquetPartition(Map<String, String> partitionPath, URI partitionUri,
                                                      PartitionSpec spec, Configuration conf,
                                                      MetricsConfig metricsSpec) {
     try {
@@ -350,7 +350,7 @@ public class SparkTableUtil {
   }
 
   private static List<DataFile> listOrcPartition(
-      Map<String, String> partitionPath, String partitionUri, PartitionSpec spec, Configuration conf) {
+      Map<String, String> partitionPath, URI partitionUri, PartitionSpec spec, Configuration conf) {
     try {
       Path partition = new Path(partitionUri);
       FileSystem fs = partition.getFileSystem(conf);
@@ -386,7 +386,7 @@ public class SparkTableUtil {
     Preconditions.checkArgument(serde.nonEmpty() || table.provider().nonEmpty(),
         "Partition format should be defined");
 
-    String uri = String.valueOf(locationUri.get());
+    URI uri = locationUri.get();
     String format = serde.nonEmpty() ? serde.get() : table.provider().get();
 
     Map<String, String> partitionSpec = JavaConverters.mapAsJavaMapConverter(partition.spec()).asJava();
@@ -495,7 +495,7 @@ public class SparkTableUtil {
       MetricsConfig metricsConfig = MetricsConfig.fromProperties(targetTable.properties());
 
       List<DataFile> files = listPartition(
-          partition, sourceTable.location().toString(), format.get(), spec, conf, metricsConfig);
+          partition, sourceTable.location(), format.get(), spec, conf, metricsConfig);
 
       AppendFiles append = targetTable.newAppend();
       files.forEach(append::appendFile);
@@ -580,10 +580,10 @@ public class SparkTableUtil {
    */
   public static class SparkPartition implements Serializable {
     private final Map<String, String> values;
-    private final String uri;
+    private final URI uri;
     private final String format;
 
-    public SparkPartition(Map<String, String> values, String uri, String format) {
+    public SparkPartition(Map<String, String> values, URI uri, String format) {
       this.values = ImmutableMap.copyOf(values);
       this.uri = uri;
       this.format = format;
@@ -593,7 +593,7 @@ public class SparkTableUtil {
       return values;
     }
 
-    public String getUri() {
+    public URI getUri() {
       return uri;
     }
 

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestSparkTableUtil.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestSparkTableUtil.java
@@ -40,6 +40,7 @@ import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.SparkTableUtil.SparkPartition;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SQLContext;
 import org.apache.spark.sql.SparkSession;
@@ -299,14 +300,14 @@ public class TestSparkTableUtil extends HiveTableBaseTest {
   }
 
   @Test
-  public void testImportFilesWithWhitespace() throws Exception {
+  public void testImportPartitionedWithWhitespace() throws Exception {
     String partitionCol = "dAtA sPaced";
     String spacedTableName = "whitespacetable";
     String whiteSpaceKey = "some key value";
 
     List<SimpleRecord> spacedRecords = Lists.newArrayList(new SimpleRecord(1, whiteSpaceKey));
 
-    File location = temp.newFolder("partitioned_table");
+    File icebergLocation = temp.newFolder("partitioned_table");
 
     spark.createDataFrame(spacedRecords, SimpleRecord.class)
         .withColumnRenamed("data", partitionCol)
@@ -319,12 +320,44 @@ public class TestSparkTableUtil extends HiveTableBaseTest {
     Table table = tables.create(SparkSchemaUtil.schemaForTable(spark, spacedTableName),
         SparkSchemaUtil.specForTable(spark, spacedTableName),
         ImmutableMap.of(),
-        location.getCanonicalPath());
+        icebergLocation.getCanonicalPath());
     File stagingDir = temp.newFolder("staging-dir");
     SparkTableUtil.importSparkTable(spark, source, table, stagingDir.toString());
-    List<Row> results = spark.read().format("iceberg").load(location.toString()).collectAsList();
+    List<SimpleRecord> results = spark.read().format("iceberg").load(icebergLocation.toString())
+        .withColumnRenamed(partitionCol, "data")
+        .as(Encoders.bean(SimpleRecord.class))
+        .collectAsList();
 
-    Assert.assertEquals("One row", 1, results.size());
-    Assert.assertEquals("Data should match", whiteSpaceKey, results.get(0).get(1));
+    Assert.assertEquals("Data should match", spacedRecords, results);
+  }
+
+  @Test
+  public void testImportUnpartitionedWithWhitespace() throws Exception {
+    String spacedTableName = "whitespacetable";
+    String whiteSpaceKey = "some key value";
+
+    List<SimpleRecord> spacedRecords = Lists.newArrayList(new SimpleRecord(1, whiteSpaceKey));
+
+    File whiteSpaceOldLocation = temp.newFolder("white space location");
+    File icebergLocation = temp.newFolder("partitioned_table");
+
+    spark.createDataFrame(spacedRecords, SimpleRecord.class)
+        .write().mode("overwrite").parquet(whiteSpaceOldLocation.getPath());
+
+    spark.catalog().createExternalTable(spacedTableName, whiteSpaceOldLocation.getPath());
+
+    TableIdentifier source = spark.sessionState().sqlParser()
+        .parseTableIdentifier(spacedTableName);
+    HadoopTables tables = new HadoopTables(spark.sessionState().newHadoopConf());
+    Table table = tables.create(SparkSchemaUtil.schemaForTable(spark, spacedTableName),
+        SparkSchemaUtil.specForTable(spark, spacedTableName),
+        ImmutableMap.of(),
+        icebergLocation.getCanonicalPath());
+    File stagingDir = temp.newFolder("staging-dir");
+    SparkTableUtil.importSparkTable(spark, source, table, stagingDir.toString());
+    List<SimpleRecord> results = spark.read().format("iceberg").load(icebergLocation.toString())
+        .as(Encoders.bean(SimpleRecord.class)).collectAsList();
+
+    Assert.assertEquals("Data should match", spacedRecords, results);
   }
 }


### PR DESCRIPTION
More info at apache/iceberg#1224 

Previously the listPartition method would use a string representation
of the Partition's URI when creating the Hadoop Path. This constructor would
handle the string as the literal input for the path and ignore any encoded
characters. This casues an issue if the directory or filename has whitespace
or some other special character being reported as it's encoded version
 resulting in FNF exceptions. By switching to passing a URI as
the SparkPartition's location uri, the escaped characters are correctly handled
by the Hadoop Path class..