### PR TITLE
Add incremental scan for iceberg generics scan builder

### DIFF
--- a/data/src/main/java/org/apache/iceberg/data/IcebergGenerics.java
+++ b/data/src/main/java/org/apache/iceberg/data/IcebergGenerics.java
@@ -76,6 +76,16 @@ public class IcebergGenerics {
       return this;
     }
 
+    public ScanBuilder appendsBetween(long fromSnapshotId, long toSnapshotId) {
+      this.tableScan = tableScan.appendsBetween(fromSnapshotId, toSnapshotId);
+      return this;
+    }
+
+    public ScanBuilder appendsAfter(long fromSnapshotId) {
+      this.tableScan = tableScan.appendsAfter(fromSnapshotId);
+      return this;
+    }
+
     public Iterable<Record> build() {
       return new TableScanIterable(
           tableScan,


### PR DESCRIPTION
Currently, `IcebergGenerics.ScanBuilder` doesn't support incremental scan,  this adds the incremental scan support to the iceberg generic scan builder.