### PR TITLE
Default warehouse location of a table should be a subdirectory in database location

### DIFF
--- a/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.MetaStoreUtils;
 import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
@@ -376,6 +377,28 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable, Supp
 
   @Override
   protected String defaultWarehouseLocation(TableIdentifier tableIdentifier) {
+    // This is a little edgy since we basically duplicate the HMS location generation logic.
+    // Sadly I do not see a good way around this if we want to keep the order of events, like:
+    // - Create meta files
+    // - Create the metadata in HMS, and thous commit the changes
+
+    // Create a new location based on the namespace / database if it is set on database level
+    try {
+      Database databaseData = clients.run(client -> client.getDatabase(tableIdentifier.namespace().levels()[0]));
+      if (databaseData.getLocationUri() != null) {
+        // If the database location is set use it as a base.
+        return String.format("%s/%s", databaseData.getLocationUri(), tableIdentifier.name());
+      }
+
+    } catch (TException e) {
+      throw new RuntimeException(String.format("Metastore operation failed for %s", tableIdentifier), e);
+
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Interrupted during commit", e);
+    }
+
+    // Otherwise stick to the {WAREHOUSE_DIR}/{DB_NAME}.db/{TABLE_NAME} path
     String warehouseLocation = conf.get("hive.metastore.warehouse.dir");
     Preconditions.checkNotNull(
         warehouseLocation,

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -379,7 +379,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable, Supp
     // This is a little edgy since we basically duplicate the HMS location generation logic.
     // Sadly I do not see a good way around this if we want to keep the order of events, like:
     // - Create meta files
-    // - Create the metadata in HMS, and thous commit the changes
+    // - Create the metadata in HMS, and this way committing the changes
 
     // Create a new location based on the namespace / database if it is set on database level
     try {

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -28,7 +28,6 @@ import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
-import org.apache.hadoop.hive.metastore.MetaStoreUtils;
 import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.InvalidOperationException;

--- a/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -144,6 +144,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
       Table tbl;
       if (base != null) {
         tbl = metaClients.run(client -> client.getTable(database, tableName));
+        tbl.setSd(storageDescriptor(metadata)); // set to pickup any schema changes
       } else {
         final long currentTimeMillis = System.currentTimeMillis();
         tbl = new Table(tableName,
@@ -161,7 +162,6 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
         tbl.getParameters().put("EXTERNAL", "TRUE"); // using the external table type also requires this
       }
 
-      tbl.setSd(storageDescriptor(metadata)); // set to pickup any schema changes
       String metadataLocation = tbl.getParameters().get(METADATA_LOCATION_PROP);
       String baseMetadataLocation = base != null ? base.metadataFileLocation() : null;
       if (!Objects.equals(baseMetadataLocation, metadataLocation)) {

--- a/hive/src/test/java/org/apache/iceberg/hive/HiveTableBaseTest.java
+++ b/hive/src/test/java/org/apache/iceberg/hive/HiveTableBaseTest.java
@@ -66,6 +66,7 @@ public class HiveTableBaseTest extends HiveMetastoreTest {
     tableLocation.getFileSystem(hiveConf).delete(tableLocation, true);
     catalog.dropTable(TABLE_IDENTIFIER, false /* metadata only, location was already deleted */);
   }
+
   private static String getTableBasePath(String tableName) {
     String databasePath = metastore.getDatabasePath(DB_NAME);
     return Paths.get(databasePath, tableName).toAbsolutePath().toString();

--- a/hive/src/test/java/org/apache/iceberg/hive/HiveTableBaseTest.java
+++ b/hive/src/test/java/org/apache/iceberg/hive/HiveTableBaseTest.java
@@ -66,7 +66,6 @@ public class HiveTableBaseTest extends HiveMetastoreTest {
     tableLocation.getFileSystem(hiveConf).delete(tableLocation, true);
     catalog.dropTable(TABLE_IDENTIFIER, false /* metadata only, location was already deleted */);
   }
-
   private static String getTableBasePath(String tableName) {
     String databasePath = metastore.getDatabasePath(DB_NAME);
     return Paths.get(databasePath, tableName).toAbsolutePath().toString();

--- a/hive/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
+++ b/hive/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
@@ -306,7 +306,8 @@ public class HiveTableTest extends HiveTableBaseTest {
   @Test
   public void testNonDefaultDatabaseLocation() throws IOException, TException {
     // Create a new location and a non-default database / namespace for it
-    File nonDefaultLocation = createTempDirectory(NON_DEFAULT_DATABASE, asFileAttribute(fromString("rwxrwxrwx"))).toFile();
+    File nonDefaultLocation = createTempDirectory(NON_DEFAULT_DATABASE,
+        asFileAttribute(fromString("rwxrwxrwx"))).toFile();
     Database database = new Database();
 
     database.setName(NON_DEFAULT_DATABASE);

--- a/hive/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
+++ b/hive/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
@@ -36,6 +37,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.io.FileAppender;
@@ -45,6 +47,9 @@ import org.apache.thrift.TException;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static java.nio.file.Files.createTempDirectory;
+import static java.nio.file.attribute.PosixFilePermissions.asFileAttribute;
+import static java.nio.file.attribute.PosixFilePermissions.fromString;
 import static org.apache.iceberg.BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE;
 import static org.apache.iceberg.BaseMetastoreTableOperations.METADATA_LOCATION_PROP;
 import static org.apache.iceberg.BaseMetastoreTableOperations.TABLE_TYPE_PROP;
@@ -52,6 +57,8 @@ import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class HiveTableTest extends HiveTableBaseTest {
+  static final String NON_DEFAULT_DATABASE =  "nondefault";
+
   @Test
   public void testCreate() throws TException {
     // Table should be created in hive metastore
@@ -295,4 +302,28 @@ public class HiveTableTest extends HiveTableBaseTest {
     Assert.assertEquals(1, expectedIdents.size());
     Assert.assertTrue(catalog.tableExists(TABLE_IDENTIFIER));
   }
+
+  @Test
+  public void testNonDefaultDatabaseLocation() throws IOException, TException {
+    // Create a new location and a non-default database / namespace for it
+    File nonDefaultLocation = createTempDirectory(NON_DEFAULT_DATABASE, asFileAttribute(fromString("rwxrwxrwx"))).toFile();
+    Database database = new Database();
+
+    database.setName(NON_DEFAULT_DATABASE);
+    database.setLocationUri(nonDefaultLocation.getPath());
+    metastoreClient.createDatabase(database);
+
+    Namespace namespace = Namespace.of(NON_DEFAULT_DATABASE);
+    TableIdentifier tableIdentifier = TableIdentifier.of(namespace, TABLE_NAME);
+    catalog.createTable(tableIdentifier, schema);
+
+    // Let's check the data loaded through the catalog
+    Table table = catalog.loadTable(tableIdentifier);
+    Map<String, String> namespaceMeta = catalog.loadNamespaceMetadata(namespace);
+    Assert.assertEquals(namespaceMeta.get("location") + "/" + TABLE_NAME, table.location());
+
+    // Drop the database and purge the files
+    metastoreClient.dropDatabase(NON_DEFAULT_DATABASE, true, true, true);
+  }
+
 }


### PR DESCRIPTION
Pull request for issue for issue #954 

- Fixes HiveCatalog.defaultWarehouseLocation method
- Creates a test for it
- A simple formatting fix
- Moves an unnecessary SD conversion