### PR TITLE
Plumbing to add extra custom metadata to snapshot summary

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
@@ -47,7 +47,7 @@ public class SnapshotSummary {
   public static final String PUBLISHED_WAP_ID_PROP = "published-wap-id";
   public static final String SOURCE_SNAPSHOT_ID_PROP = "source-snapshot-id";
   public static final String REPLACE_PARTITIONS_PROP = "replace-partitions";
-  public static final String EXTRA_METADATA_PREFIX = "extra-metadata.";
+  public static final String EXTRA_METADATA_PREFIX = "snapshot.property.";
 
   private SnapshotSummary() {
   }

--- a/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
@@ -47,7 +47,7 @@ public class SnapshotSummary {
   public static final String PUBLISHED_WAP_ID_PROP = "published-wap-id";
   public static final String SOURCE_SNAPSHOT_ID_PROP = "source-snapshot-id";
   public static final String REPLACE_PARTITIONS_PROP = "replace-partitions";
-  public static final String EXTRA_METADATA_PREFIX = "snapshot.property.";
+  public static final String EXTRA_METADATA_PREFIX = "snapshot-property.";
 
   private SnapshotSummary() {
   }

--- a/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
@@ -47,6 +47,7 @@ public class SnapshotSummary {
   public static final String PUBLISHED_WAP_ID_PROP = "published-wap-id";
   public static final String SOURCE_SNAPSHOT_ID_PROP = "source-snapshot-id";
   public static final String REPLACE_PARTITIONS_PROP = "replace-partitions";
+  public static final String EXTRA_METADATA_PREFIX = "extra-metadata.";
 
   private SnapshotSummary() {
   }

--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -133,4 +133,5 @@ df.write
 | write-format           | Table write.format.default | File format to use for this write operation; parquet or avro |
 | target-file-size-bytes | As per table property      | Overrides this table's write.target-file-size-bytes          |
 | check-nullability      | true                       | Sets the nullable check on fields                            |
+| snapshot-property.<custom-key>    | null            | Adds an entry with custom-key and corresponding value in the snapshot summary  |
 

--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -133,5 +133,5 @@ df.write
 | write-format           | Table write.format.default | File format to use for this write operation; parquet or avro |
 | target-file-size-bytes | As per table property      | Overrides this table's write.target-file-size-bytes          |
 | check-nullability      | true                       | Sets the nullable check on fields                            |
-| snapshot-property.<custom-key>    | null            | Adds an entry with custom-key and corresponding value in the snapshot summary  |
+| snapshot-property._custom-key_    | null            | Adds an entry with custom-key and corresponding value in the snapshot summary  |
 

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -379,8 +379,8 @@ public abstract class TestDataSourceOptions {
     originalDf.select("id", "data").write()
             .format("iceberg")
             .mode("append")
-            .option("extra-metadata.extra-key", "someValue")
-            .option("extra-metadata.another-key", "anotherValue")
+            .option("snapshot.property.extra-key", "someValue")
+            .option("snapshot.property.another-key", "anotherValue")
             .save(tableLocation);
 
     Table table = tables.load(tableLocation);

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -379,8 +379,8 @@ public abstract class TestDataSourceOptions {
     originalDf.select("id", "data").write()
             .format("iceberg")
             .mode("append")
-            .option("snapshot.property.extra-key", "someValue")
-            .option("snapshot.property.another-key", "anotherValue")
+            .option("snapshot-property.extra-key", "someValue")
+            .option("snapshot-property.another-key", "anotherValue")
             .save(tableLocation);
 
     Table table = tables.load(tableLocation);

--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Writer.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Writer.java
@@ -20,8 +20,10 @@
 package org.apache.iceberg.spark.source;
 
 import java.io.IOException;
-import java.util.*;
-
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;

--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Writer.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Writer.java
@@ -20,10 +20,8 @@
 package org.apache.iceberg.spark.source;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
+
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
@@ -39,6 +37,7 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 import org.apache.spark.broadcast.Broadcast;
@@ -79,6 +78,7 @@ class Writer implements DataSourceWriter {
   private final long targetFileSize;
   private final Schema writeSchema;
   private final StructType dsSchema;
+  private final Map<String, String> extraSnapshotMetadata;
 
   Writer(Table table, Broadcast<FileIO> io, Broadcast<EncryptionManager> encryptionManager,
          DataSourceOptions options, boolean replacePartitions, String applicationId, Schema writeSchema,
@@ -98,6 +98,13 @@ class Writer implements DataSourceWriter {
     this.wapId = wapId;
     this.writeSchema = writeSchema;
     this.dsSchema = dsSchema;
+    this.extraSnapshotMetadata = Maps.newHashMap();
+
+    options.asMap().forEach((key, value) -> {
+      if (key.startsWith(SnapshotSummary.EXTRA_METADATA_PREFIX)) {
+        extraSnapshotMetadata.put(key.substring(SnapshotSummary.EXTRA_METADATA_PREFIX.length()), value);
+      }
+    });
 
     long tableTargetFileSize = PropertyUtil.propertyAsLong(
         table.properties(), WRITE_TARGET_FILE_SIZE_BYTES, WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT);
@@ -136,6 +143,10 @@ class Writer implements DataSourceWriter {
     LOG.info("Committing {} with {} files to table {}", description, numFiles, table);
     if (applicationId != null) {
       operation.set("spark.app.id", applicationId);
+    }
+
+    if (!extraSnapshotMetadata.isEmpty()) {
+      extraSnapshotMetadata.forEach((key, value) -> operation.set(key, value));
     }
 
     if (isWapTable() && wapId != null) {

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchWrite.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchWrite.java
@@ -20,8 +20,10 @@
 package org.apache.iceberg.spark.source;
 
 import java.io.IOException;
-import java.util.*;
-
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchWrite.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchWrite.java
@@ -20,10 +20,8 @@
 package org.apache.iceberg.spark.source;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
+
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
@@ -41,6 +39,7 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 import org.apache.spark.broadcast.Broadcast;
@@ -84,6 +83,7 @@ class SparkBatchWrite implements BatchWrite {
   private final long targetFileSize;
   private final Schema writeSchema;
   private final StructType dsSchema;
+  private final Map<String, String> extraSnapshotMetadata;
 
   SparkBatchWrite(Table table, Broadcast<FileIO> io, Broadcast<EncryptionManager> encryptionManager,
                   CaseInsensitiveStringMap options, boolean overwriteDynamic, boolean overwriteByFilter,
@@ -100,6 +100,13 @@ class SparkBatchWrite implements BatchWrite {
     this.wapId = wapId;
     this.writeSchema = writeSchema;
     this.dsSchema = dsSchema;
+    this.extraSnapshotMetadata = Maps.newHashMap();
+
+    options.forEach((key, value) -> {
+      if (key.startsWith(SnapshotSummary.EXTRA_METADATA_PREFIX)) {
+        extraSnapshotMetadata.put(key.substring(SnapshotSummary.EXTRA_METADATA_PREFIX.length()), value);
+      }
+    });
 
     long tableTargetFileSize = PropertyUtil.propertyAsLong(
         table.properties(), WRITE_TARGET_FILE_SIZE_BYTES, WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT);
@@ -140,6 +147,10 @@ class SparkBatchWrite implements BatchWrite {
     LOG.info("Committing {} with {} files to table {}", description, numFiles, table);
     if (applicationId != null) {
       operation.set("spark.app.id", applicationId);
+    }
+
+    if (!extraSnapshotMetadata.isEmpty()) {
+      extraSnapshotMetadata.forEach((key, value) -> operation.set(key, value));
     }
 
     if (isWapTable() && wapId != null) {


### PR DESCRIPTION
Plumbing to add extra custom metadata to snapshot summary via write options https://github.com/apache/iceberg/issues/1242

Context: At Stripe we make use of airflow to run spark jobs, and want to pass a separate external ID and some versioning information linking an airflow run for each snapshot created. Currently to do this, we have to fork the Writer just to override the commitOperation. 

The changes in this PR would allow custom metadata via write options which start with a particular prefix (`extra-metadata.`). 

cc? @rdblue 