### PR TITLE
Allow ExpireSnapshots to run without Deleting Files

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ExpireSnapshots.java
+++ b/api/src/main/java/org/apache/iceberg/ExpireSnapshots.java
@@ -103,10 +103,9 @@ public interface ExpireSnapshots extends PendingUpdate<List<Snapshot>> {
    * <p>
    * Allows control in removing data and manifest files which may be more efficiently removed using
    * a distributed framework through the actions API.
-   * </p>
    *
    * @param clean setting this to false will skip deleting expired manifests and files
    * @return this for method chaining
    */
-  ExpireSnapshots deleteExpiredFiles(boolean clean);
+  ExpireSnapshots cleanExpiredFiles(boolean clean);
 }

--- a/api/src/main/java/org/apache/iceberg/ExpireSnapshots.java
+++ b/api/src/main/java/org/apache/iceberg/ExpireSnapshots.java
@@ -97,4 +97,16 @@ public interface ExpireSnapshots extends PendingUpdate<List<Snapshot>> {
    * @return this for method chaining
    */
   ExpireSnapshots executeWith(ExecutorService executorService);
+
+  /**
+   * Allows expiration of snapshots without any cleanup of underlying manifest or data files.
+   * <p>
+   * Allows control in removing data and manifest files which may be more efficiently removed using
+   * a distributed framework through the actions API.
+   * </p>
+   *
+   * @param clean setting this to false will skip deleting expired manifests and files
+   * @return this for method chaining
+   */
+  ExpireSnapshots deleteExpiredFiles(boolean clean);
 }

--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -80,7 +80,7 @@ class RemoveSnapshots implements ExpireSnapshots {
   }
 
   @Override
-  public ExpireSnapshots deleteExpiredFiles(boolean clean) {
+  public ExpireSnapshots cleanExpiredFiles(boolean clean) {
     this.cleanExpiredFiles = clean;
     return this;
   }
@@ -201,11 +201,11 @@ class RemoveSnapshots implements ExpireSnapshots {
 
     LOG.info("Committed snapshot changes; cleaning up expired manifests and data files.");
 
-    cleanExpiredFiles(current.snapshots(), validIds, expiredIds);
+    removeExpiredFiles(current.snapshots(), validIds, expiredIds);
   }
 
   @SuppressWarnings("checkstyle:CyclomaticComplexity")
-  private void cleanExpiredFiles(List<Snapshot> snapshots, Set<Long> validIds, Set<Long> expiredIds) {
+  private void removeExpiredFiles(List<Snapshot> snapshots, Set<Long> validIds, Set<Long> expiredIds) {
     // Reads and deletes are done using Tasks.foreach(...).suppressFailureWhenFinished to complete
     // as much of the delete work as possible and avoid orphaned data or manifest files.
 

--- a/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
+++ b/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
@@ -538,6 +538,43 @@ public class TestRemoveSnapshots extends TableTestBase {
     Assert.assertTrue("FILE_B should be deleted", deletedFiles.contains(FILE_B.path().toString()));
   }
 
+  @Test
+  public void noDataFileCleanup() throws IOException {
+    table.newFastAppend()
+        .appendFile(FILE_A)
+        .commit();
+
+    table.newFastAppend()
+        .appendFile(FILE_B)
+        .commit();
+
+    table.newRewrite()
+        .rewriteFiles(ImmutableSet.of(FILE_B), ImmutableSet.of(FILE_D))
+        .commit();
+    long thirdSnapshotId = table.currentSnapshot().snapshotId();
+
+    table.newRewrite()
+        .rewriteFiles(ImmutableSet.of(FILE_A), ImmutableSet.of(FILE_C))
+        .commit();
+    long fourthSnapshotId = table.currentSnapshot().snapshotId();
+
+    long t4 = System.currentTimeMillis();
+    while (t4 <= table.currentSnapshot().timestampMillis()) {
+      t4 = System.currentTimeMillis();
+    }
+
+    Set<String> deletedFiles = Sets.newHashSet();
+
+    table.expireSnapshots()
+        .deleteExpiredFiles(false)
+        .expireOlderThan(t4)
+        .deleteWith(deletedFiles::add)
+        .commit();
+
+    Assert.assertFalse("FILE_A should not be deleted", deletedFiles.contains(FILE_A.path().toString()));
+    Assert.assertFalse("FILE_B should not be deleted", deletedFiles.contains(FILE_B.path().toString()));
+  }
+
   /**
    * Test on table below, and expiring the staged commit `B` using `expireOlderThan` API.
    * Table: A - C

--- a/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
+++ b/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
@@ -551,12 +551,10 @@ public class TestRemoveSnapshots extends TableTestBase {
     table.newRewrite()
         .rewriteFiles(ImmutableSet.of(FILE_B), ImmutableSet.of(FILE_D))
         .commit();
-    long thirdSnapshotId = table.currentSnapshot().snapshotId();
 
     table.newRewrite()
         .rewriteFiles(ImmutableSet.of(FILE_A), ImmutableSet.of(FILE_C))
         .commit();
-    long fourthSnapshotId = table.currentSnapshot().snapshotId();
 
     long t4 = System.currentTimeMillis();
     while (t4 <= table.currentSnapshot().timestampMillis()) {
@@ -566,13 +564,12 @@ public class TestRemoveSnapshots extends TableTestBase {
     Set<String> deletedFiles = Sets.newHashSet();
 
     table.expireSnapshots()
-        .deleteExpiredFiles(false)
+        .cleanExpiredFiles(false)
         .expireOlderThan(t4)
         .deleteWith(deletedFiles::add)
         .commit();
 
-    Assert.assertFalse("FILE_A should not be deleted", deletedFiles.contains(FILE_A.path().toString()));
-    Assert.assertFalse("FILE_B should not be deleted", deletedFiles.contains(FILE_B.path().toString()));
+    Assert.assertTrue("No files should have been deleted", deletedFiles.isEmpty());
   }
 
   /**


### PR DESCRIPTION
Previously ExpireSnapshots would always follow the expiration of Snapshots
with a deletion of local DataFiles and Manifests which were no longer relevant
to the Table. This patch introduces an API to skip this deletion phase, which
was always run locally, and instead just expire the snapshots. This allows for
future implementations which can read and remove unused files in parallel or
on distributed frameworks.