### PR TITLE
Add HiveIcebergOutputFormat placeholder

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputFormat.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputFormat.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.mr.hive;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.OutputFormat;
+import org.apache.hadoop.mapred.RecordWriter;
+import org.apache.hadoop.util.Progressable;
+
+public class HiveIcebergOutputFormat<T> implements OutputFormat<Void, T> {
+
+  @Override
+  public RecordWriter<Void, T> getRecordWriter(FileSystem ignored, JobConf job, String name, Progressable progress) {
+    throw new UnsupportedOperationException("Writing to an Iceberg table with Hive is not supported");
+  }
+
+  @Override
+  public void checkOutputSpecs(FileSystem ignored, JobConf job) {
+    throw new UnsupportedOperationException("Writing to an Iceberg table with Hive is not supported");
+  }
+}

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -22,7 +22,6 @@ package org.apache.iceberg.mr.hive;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.HiveMetaHook;
-import org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.metadata.HiveStorageHandler;
 import org.apache.hadoop.hive.ql.metadata.HiveStoragePredicateHandler;
@@ -48,7 +47,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
 
   @Override
   public Class<? extends OutputFormat> getOutputFormatClass() {
-    return HiveIgnoreKeyTextOutputFormat.class;
+    return HiveIcebergOutputFormat.class;
   }
 
   @Override


### PR DESCRIPTION
As suggested by @massdosage and @pvary, add HiveIcebergOutputFormat placeholder that throws `UnsupportedOperationException` when `getRecordWriter` is called.

 @massdosage @pvary @rdsr