### PR TITLE
Move Hive-related classes to mr.hive package

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergInputFormat.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergInputFormat.java
@@ -35,7 +35,6 @@ import org.apache.iceberg.data.Record;
 import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.iceberg.mr.mapred.Container;
 import org.apache.iceberg.mr.mapred.MapredIcebergInputFormat;
-import org.apache.iceberg.mr.mapred.TableResolver;
 import org.apache.iceberg.mr.mapreduce.IcebergSplit;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iceberg.mr.mapred;
+package org.apache.iceberg.mr.hive;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -30,9 +30,10 @@ import org.apache.hadoop.hive.serde2.SerDeStats;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.io.Writable;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.mr.mapred.serde.objectinspector.IcebergObjectInspector;
+import org.apache.iceberg.mr.hive.serde.objectinspector.IcebergObjectInspector;
+import org.apache.iceberg.mr.mapred.Container;
 
-public class IcebergSerDe extends AbstractSerDe {
+public class HiveIcebergSerDe extends AbstractSerDe {
 
   private ObjectInspector inspector;
 

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.hive.serde2.Deserializer;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.OutputFormat;
-import org.apache.iceberg.mr.mapred.IcebergSerDe;
 
 public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, HiveStorageHandler {
 
@@ -53,7 +52,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
 
   @Override
   public Class<? extends AbstractSerDe> getSerDeClass() {
-    return IcebergSerDe.class;
+    return HiveIcebergSerDe.class;
   }
 
   @Override

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/TableResolver.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/TableResolver.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iceberg.mr.mapred;
+package org.apache.iceberg.mr.hive;
 
 import java.io.IOException;
 import java.util.Map;

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergBinaryObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergBinaryObjectInspector.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iceberg.mr.mapred.serde.objectinspector;
+package org.apache.iceberg.mr.hive.serde.objectinspector;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergDateObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergDateObjectInspector.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iceberg.mr.mapred.serde.objectinspector;
+package org.apache.iceberg.mr.hive.serde.objectinspector;
 
 import java.sql.Date;
 import java.time.LocalDate;

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergDecimalObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergDecimalObjectInspector.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iceberg.mr.mapred.serde.objectinspector;
+package org.apache.iceberg.mr.hive.serde.objectinspector;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergObjectInspector.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iceberg.mr.mapred.serde.objectinspector;
+package org.apache.iceberg.mr.hive.serde.objectinspector;
 
 import java.util.List;
 import javax.annotation.Nullable;

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergRecordObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergRecordObjectInspector.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iceberg.mr.mapred.serde.objectinspector;
+package org.apache.iceberg.mr.hive.serde.objectinspector;
 
 import java.util.Collections;
 import java.util.List;

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampObjectInspector.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iceberg.mr.mapred.serde.objectinspector;
+package org.apache.iceberg.mr.hive.serde.objectinspector;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSerDe.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSerDe.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iceberg.mr.mapred;
+package org.apache.iceberg.mr.hive;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,7 +31,8 @@ import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.mr.InputFormatConfig;
-import org.apache.iceberg.mr.mapred.serde.objectinspector.IcebergObjectInspector;
+import org.apache.iceberg.mr.hive.serde.objectinspector.IcebergObjectInspector;
+import org.apache.iceberg.mr.mapred.Container;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -40,7 +41,7 @@ import org.junit.rules.TemporaryFolder;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
 
-public class TestIcebergSerDe {
+public class TestHiveIcebergSerDe {
 
   private static final Schema schema = new Schema(required(1, "string_field", Types.StringType.get()));
 
@@ -61,7 +62,7 @@ public class TestIcebergSerDe {
     HadoopTables tables = new HadoopTables(conf);
     tables.create(schema, PartitionSpec.unpartitioned(), Collections.emptyMap(), location.toString());
 
-    IcebergSerDe serDe = new IcebergSerDe();
+    HiveIcebergSerDe serDe = new HiveIcebergSerDe();
     serDe.initialize(conf, properties);
 
     Assert.assertEquals(IcebergObjectInspector.create(schema), serDe.getObjectInspector());
@@ -69,7 +70,7 @@ public class TestIcebergSerDe {
 
   @Test
   public void testDeserialize() {
-    IcebergSerDe serDe = new IcebergSerDe();
+    HiveIcebergSerDe serDe = new HiveIcebergSerDe();
 
     Record record = RandomGenericData.generate(schema, 1, 0).get(0);
     Container<Record> container = new Container<>();

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestTableResolver.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestTableResolver.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iceberg.mr.mapred;
+package org.apache.iceberg.mr.hive;
 
 import java.io.File;
 import java.io.IOException;

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergBinaryObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergBinaryObjectInspector.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iceberg.mr.mapred.serde.objectinspector;
+package org.apache.iceberg.mr.hive.serde.objectinspector;
 
 import java.nio.ByteBuffer;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergDateObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergDateObjectInspector.java
@@ -17,47 +17,47 @@
  * under the License.
  */
 
-package org.apache.iceberg.mr.mapred.serde.objectinspector;
+package org.apache.iceberg.mr.hive.serde.objectinspector;
 
-import java.sql.Timestamp;
-import java.time.LocalDateTime;
-import org.apache.hadoop.hive.serde2.io.TimestampWritable;
+import java.sql.Date;
+import java.time.LocalDate;
+import org.apache.hadoop.hive.serde2.io.DateWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.DateObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class TestIcebergTimestampObjectInspector {
+public class TestIcebergDateObjectInspector {
 
   @Test
-  public void testIcebergTimestampObjectInspector() {
-    TimestampObjectInspector oi = IcebergTimestampObjectInspector.get(false);
+  public void testIcebergDateObjectInspector() {
+    DateObjectInspector oi = IcebergDateObjectInspector.get();
 
     Assert.assertEquals(ObjectInspector.Category.PRIMITIVE, oi.getCategory());
-    Assert.assertEquals(PrimitiveObjectInspector.PrimitiveCategory.TIMESTAMP, oi.getPrimitiveCategory());
+    Assert.assertEquals(PrimitiveObjectInspector.PrimitiveCategory.DATE, oi.getPrimitiveCategory());
 
-    Assert.assertEquals(TypeInfoFactory.timestampTypeInfo, oi.getTypeInfo());
-    Assert.assertEquals(TypeInfoFactory.timestampTypeInfo.getTypeName(), oi.getTypeName());
+    Assert.assertEquals(TypeInfoFactory.dateTypeInfo, oi.getTypeInfo());
+    Assert.assertEquals(TypeInfoFactory.dateTypeInfo.getTypeName(), oi.getTypeName());
 
-    Assert.assertEquals(Timestamp.class, oi.getJavaPrimitiveClass());
-    Assert.assertEquals(TimestampWritable.class, oi.getPrimitiveWritableClass());
+    Assert.assertEquals(Date.class, oi.getJavaPrimitiveClass());
+    Assert.assertEquals(DateWritable.class, oi.getPrimitiveWritableClass());
 
     Assert.assertNull(oi.copyObject(null));
     Assert.assertNull(oi.getPrimitiveJavaObject(null));
     Assert.assertNull(oi.getPrimitiveWritableObject(null));
 
-    LocalDateTime local = LocalDateTime.of(2020, 1, 1, 0, 0);
-    Timestamp ts = Timestamp.valueOf("2020-01-01 00:00:00");
+    LocalDate local = LocalDate.of(2020, 1, 1);
+    Date date = Date.valueOf("2020-01-01");
 
-    Assert.assertEquals(ts, oi.getPrimitiveJavaObject(local));
-    Assert.assertEquals(new TimestampWritable(ts), oi.getPrimitiveWritableObject(local));
+    Assert.assertEquals(date, oi.getPrimitiveJavaObject(local));
+    Assert.assertEquals(new DateWritable(date), oi.getPrimitiveWritableObject(local));
 
-    Timestamp copy = (Timestamp) oi.copyObject(ts);
+    Date copy = (Date) oi.copyObject(date);
 
-    Assert.assertEquals(ts, copy);
-    Assert.assertNotSame(ts, copy);
+    Assert.assertEquals(date, copy);
+    Assert.assertNotSame(date, copy);
 
     Assert.assertFalse(oi.preferWritable());
   }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergDecimalObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergDecimalObjectInspector.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iceberg.mr.mapred.serde.objectinspector;
+package org.apache.iceberg.mr.hive.serde.objectinspector;
 
 import java.math.BigDecimal;
 import org.apache.hadoop.hive.common.type.HiveDecimal;

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergObjectInspector.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iceberg.mr.mapred.serde.objectinspector;
+package org.apache.iceberg.mr.hive.serde.objectinspector;
 
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergRecordObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergRecordObjectInspector.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iceberg.mr.mapred.serde.objectinspector;
+package org.apache.iceberg.mr.hive.serde.objectinspector;
 
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampObjectInspector.java
@@ -17,47 +17,47 @@
  * under the License.
  */
 
-package org.apache.iceberg.mr.mapred.serde.objectinspector;
+package org.apache.iceberg.mr.hive.serde.objectinspector;
 
-import java.sql.Date;
-import java.time.LocalDate;
-import org.apache.hadoop.hive.serde2.io.DateWritable;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import org.apache.hadoop.hive.serde2.io.TimestampWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.primitive.DateObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class TestIcebergDateObjectInspector {
+public class TestIcebergTimestampObjectInspector {
 
   @Test
-  public void testIcebergDateObjectInspector() {
-    DateObjectInspector oi = IcebergDateObjectInspector.get();
+  public void testIcebergTimestampObjectInspector() {
+    TimestampObjectInspector oi = IcebergTimestampObjectInspector.get(false);
 
     Assert.assertEquals(ObjectInspector.Category.PRIMITIVE, oi.getCategory());
-    Assert.assertEquals(PrimitiveObjectInspector.PrimitiveCategory.DATE, oi.getPrimitiveCategory());
+    Assert.assertEquals(PrimitiveObjectInspector.PrimitiveCategory.TIMESTAMP, oi.getPrimitiveCategory());
 
-    Assert.assertEquals(TypeInfoFactory.dateTypeInfo, oi.getTypeInfo());
-    Assert.assertEquals(TypeInfoFactory.dateTypeInfo.getTypeName(), oi.getTypeName());
+    Assert.assertEquals(TypeInfoFactory.timestampTypeInfo, oi.getTypeInfo());
+    Assert.assertEquals(TypeInfoFactory.timestampTypeInfo.getTypeName(), oi.getTypeName());
 
-    Assert.assertEquals(Date.class, oi.getJavaPrimitiveClass());
-    Assert.assertEquals(DateWritable.class, oi.getPrimitiveWritableClass());
+    Assert.assertEquals(Timestamp.class, oi.getJavaPrimitiveClass());
+    Assert.assertEquals(TimestampWritable.class, oi.getPrimitiveWritableClass());
 
     Assert.assertNull(oi.copyObject(null));
     Assert.assertNull(oi.getPrimitiveJavaObject(null));
     Assert.assertNull(oi.getPrimitiveWritableObject(null));
 
-    LocalDate local = LocalDate.of(2020, 1, 1);
-    Date date = Date.valueOf("2020-01-01");
+    LocalDateTime local = LocalDateTime.of(2020, 1, 1, 0, 0);
+    Timestamp ts = Timestamp.valueOf("2020-01-01 00:00:00");
 
-    Assert.assertEquals(date, oi.getPrimitiveJavaObject(local));
-    Assert.assertEquals(new DateWritable(date), oi.getPrimitiveWritableObject(local));
+    Assert.assertEquals(ts, oi.getPrimitiveJavaObject(local));
+    Assert.assertEquals(new TimestampWritable(ts), oi.getPrimitiveWritableObject(local));
 
-    Date copy = (Date) oi.copyObject(date);
+    Timestamp copy = (Timestamp) oi.copyObject(ts);
 
-    Assert.assertEquals(date, copy);
-    Assert.assertNotSame(date, copy);
+    Assert.assertEquals(ts, copy);
+    Assert.assertNotSame(ts, copy);
 
     Assert.assertFalse(oi.preferWritable());
   }


### PR DESCRIPTION
This PR moves Hive-related classes to the `*.mr.hive` package and renames the `IcebergSerDe` class to `HiveIcebergSerDe` for consistency.

@massdosage @rdsr 