### PR TITLE
Fix missing Override warnings in org.apache.iceberg.BaseFile

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -295,54 +295,67 @@ abstract class BaseFile<F>
     return DataFile.getType(EMPTY_STRUCT_TYPE).fields().size();
   }
 
+  @Override
   public FileContent content() {
     return content;
   }
 
+  @Override
   public CharSequence path() {
     return filePath;
   }
 
+  @Override
   public FileFormat format() {
     return format;
   }
 
+  @Override
   public StructLike partition() {
     return partitionData;
   }
 
+  @Override
   public long recordCount() {
     return recordCount;
   }
 
+  @Override
   public long fileSizeInBytes() {
     return fileSizeInBytes;
   }
 
+  @Override
   public Map<Integer, Long> columnSizes() {
     return columnSizes;
   }
 
+  @Override
   public Map<Integer, Long> valueCounts() {
     return valueCounts;
   }
 
+  @Override
   public Map<Integer, Long> nullValueCounts() {
     return nullValueCounts;
   }
 
+  @Override
   public Map<Integer, ByteBuffer> lowerBounds() {
     return lowerBounds;
   }
 
+  @Override
   public Map<Integer, ByteBuffer> upperBounds() {
     return upperBounds;
   }
 
+  @Override
   public ByteBuffer keyMetadata() {
     return keyMetadata != null ? ByteBuffer.wrap(keyMetadata) : null;
   }
 
+  @Override
   public List<Long> splitOffsets() {
     return splitOffsets;
   }


### PR DESCRIPTION
When building the project for the first time, the compiler warns that there are several places that are missing overrides.

I've discussed the issue here: https://github.com/apache/iceberg/issues/1248

I have taken a shot at removing these warnings and adding the `@Override` annotation to non-abstract methods in `BaseFile` from the `iceberg-core` module. There are more warnings than just this one file, but I wanted to keep the workload light in this first PR in case the missing Overrides were intentional (in which case we might consider the use of `@SuppressWarnings`).

As I'm relatively new to the project, I'd love any feedback possible. I'm tagging @openinx as I've recently commented on their PR's.