### PR TITLE
Add in missing Override annotations according to Error Prone

### DIFF
--- a/core/src/main/java/org/apache/iceberg/GenericDataFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDataFile.java
@@ -84,6 +84,7 @@ class GenericDataFile extends BaseFile<DataFile> implements DataFile {
     return new GenericDataFile(this, true /* full copy */);
   }
 
+  @Override
   protected Schema getAvroSchema(Types.StructType partitionStruct) {
     Types.StructType type = DataFile.getType(partitionStruct);
     return AvroSchemaUtil.convert(type, ImmutableMap.of(

--- a/core/src/main/java/org/apache/iceberg/GenericDeleteFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDeleteFile.java
@@ -67,6 +67,7 @@ class GenericDeleteFile extends BaseFile<DeleteFile> implements DeleteFile {
     return new GenericDeleteFile(this, true /* full copy */);
   }
 
+  @Override
   protected Schema getAvroSchema(Types.StructType partitionStruct) {
     Types.StructType type = DataFile.getType(partitionStruct);
     return AvroSchemaUtil.convert(type, ImmutableMap.of(

--- a/parquet/src/main/java/org/apache/iceberg/parquet/PageIterator.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/PageIterator.java
@@ -61,6 +61,7 @@ abstract class PageIterator<T> extends BasePageIterator implements TripleIterato
         };
       case INT96:
         return (PageIterator<T>) new PageIterator<Binary>(desc, writerVersion) {
+          @Override
           public Binary next() {
             return nextBinary();
           }

--- a/spark/src/main/java/org/apache/iceberg/spark/source/BaseDataReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/BaseDataReader.java
@@ -91,6 +91,7 @@ abstract class BaseDataReader<T> implements Closeable {
 
   abstract CloseableIterator<T> open(FileScanTask task);
 
+  @Override
   public void close() throws IOException {
     InputFileBlockHolder.unset();
 

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchWrite.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchWrite.java
@@ -271,10 +271,12 @@ class SparkBatchWrite implements BatchWrite {
       this.dsSchema = dsSchema;
     }
 
+    @Override
     public DataWriter<InternalRow> createWriter(int partitionId, long taskId) {
       return createWriter(partitionId, taskId, 0);
     }
 
+    @Override
     public DataWriter<InternalRow> createWriter(int partitionId, long taskId, long epochId) {
       OutputFileFactory fileFactory = new OutputFileFactory(
           spec, format, locations, io.value(), encryptionManager.value(), partitionId, taskId);


### PR DESCRIPTION
This adds in the missing Override annotations according to Error Prone when running `./gradlew clean && ./gradlew build`. It also closes out https://github.com/apache/iceberg/issues/1248 for the time being, until somebody merges in something that's missing an Override annotation 🙃. 

There are still a few Error Prone warnings that I'd like to fix, but I'm wondering if we'd like to possibly add an additional blocking check on PRs for specific error prone warnings / errors. These missing override annotations are relatively benign, but some of the other warnings that I'm going through to clean up include potentially lossy conversions, e.g. [NarrowingCompoundAssignment](https://errorprone.info/bugpattern/NarrowingCompoundAssignment), on what appear to be relatively important fields as well as one [try-catch-finally](https://errorprone.info/bugpattern/Finally) block  where an exception is thrown in the finally block that's entirely swallowed (on closing a metadata writer I believe it was). While I've no doubt that the code is likely correct in most of these cases, as the number of contributors grows that statement will be harder and harder to make.

This is likely something that could be configured with with the other checks of the CI build system and test runner. Alternatively we could use a Github action in order to reduce the amount of CPU time dedicated to each PR in the test runner system (I think it's Travis but I'd have to double check as this is only my 2nd or 3rd PR).