### PR TITLE
Spark: mention the limitation of "default catalog" on Spark 3.0 for inspecting table

### DIFF
--- a/site/docs/spark.md
+++ b/site/docs/spark.md
@@ -527,6 +527,9 @@ To inspect a table's history, snapshots, and other metadata, Iceberg supports me
 
 Metadata tables are identified by adding the metadata table name after the original table name. For example, history for `db.table` is read using `db.table.history`.
 
+!!! Note
+    As of Spark 3.0, the format of the table name for inspection (`catalog.database.table.metadata`) doesn't work with Spark's default catalog (`spark_catalog`). If you've replaced the default catalog, you may want to use DataFrameReader API to inspect the table. 
+
 ### History
 
 To show table history, run:


### PR DESCRIPTION
Spark has different approaches to handle multi-part name, between default catalog (spark_catalog) and custom catalog. While the metadata table format for inspection (catalog.database.table.metadata) works for custom catalog, it does not work for default catalog, as of Spark 3.0.0.

This patch documents the limitation so that end users can understand and take a workaround.

Screenshot (change emphasized by red box):
![Screen Shot 2020-07-27 at 8 56 01 PM](https://user-images.githubusercontent.com/1317309/88539923-11ec9d00-d04d-11ea-9132-608ead3fe10a.png)
