### PR TITLE
Fix the conf property name in docs

### DIFF
--- a/site/docs/getting-started.md
+++ b/site/docs/getting-started.md
@@ -44,7 +44,7 @@ spark-sql --packages org.apache.iceberg:iceberg-spark3-runtime:0.9.0 \
     --conf spark.sql.catalog.spark_catalog.type=hive \
     --conf spark.sql.catalog.local=org.apache.iceberg.spark.SparkCatalog \
     --conf spark.sql.catalog.local.type=hadoop \
-    --conf spark.sql.catalog.local.uri=$PWD/warehouse
+    --conf spark.sql.catalog.local.warehouse=$PWD/warehouse
 ```
 
 ### Creating a table


### PR DESCRIPTION
Minor typo fix to the conf property name in the getting started guide. 
Change spark.sql.catalog.local.uri to spark.sql.catalog.local.warehouse
