### PR TITLE
Remove conflicting dependency and unnecessary checked exception

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -364,6 +364,11 @@ project(':iceberg-hive') {
 }
 
 project(':iceberg-mr') {
+  configurations {
+    testCompile {
+      exclude group: 'org.apache.parquet', module: 'parquet-hadoop-bundle'
+    }
+  }
   dependencies {
     compile project(':iceberg-api')
     compile project(':iceberg-core')

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
@@ -37,9 +37,8 @@ public class HiveIcebergSerDe extends AbstractSerDe {
 
   @Override
   public void initialize(@Nullable Configuration configuration, Properties serDeProperties) throws SerDeException {
-    final Table table;
 
-    table = TableResolver.resolveTableFromConfiguration(configuration, serDeProperties);
+    Table table = TableResolver.resolveTableFromConfiguration(configuration, serDeProperties);
 
     try {
       this.inspector = IcebergObjectInspector.create(table.schema());

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
@@ -19,8 +19,6 @@
 
 package org.apache.iceberg.mr.hive;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.Properties;
 import javax.annotation.Nullable;
 import org.apache.hadoop.conf.Configuration;
@@ -41,11 +39,7 @@ public class HiveIcebergSerDe extends AbstractSerDe {
   public void initialize(@Nullable Configuration configuration, Properties serDeProperties) throws SerDeException {
     final Table table;
 
-    try {
-      table = TableResolver.resolveTableFromConfiguration(configuration, serDeProperties);
-    } catch (IOException e) {
-      throw new UncheckedIOException("Unable to resolve table from configuration: ", e);
-    }
+    table = TableResolver.resolveTableFromConfiguration(configuration, serDeProperties);
 
     try {
       this.inspector = IcebergObjectInspector.create(table.schema());

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/TableResolver.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/TableResolver.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.mr.hive;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.Properties;
 import org.apache.hadoop.conf.Configuration;
@@ -34,7 +33,7 @@ public final class TableResolver {
   private TableResolver() {
   }
 
-  static Table resolveTableFromConfiguration(Configuration conf, Properties properties) throws IOException {
+  static Table resolveTableFromConfiguration(Configuration conf, Properties properties) {
     Configuration configuration = new Configuration(conf);
     for (Map.Entry<Object, Object> entry : properties.entrySet()) {
       configuration.set(entry.getKey().toString(), entry.getValue().toString());
@@ -42,7 +41,7 @@ public final class TableResolver {
     return resolveTableFromConfiguration(configuration);
   }
 
-  public static Table resolveTableFromConfiguration(Configuration conf) throws IOException {
+  public static Table resolveTableFromConfiguration(Configuration conf) {
     //Default to HadoopTables
     String catalogName = conf.get(InputFormatConfig.CATALOG_NAME, InputFormatConfig.HADOOP_TABLES);
 


### PR DESCRIPTION
I was receiving the following exception when running Hive MR tests from my IDE
```
java.lang.NoSuchMethodError: org.apache.parquet.schema.Types$PrimitiveBuilder.as(Lorg/apache/parquet/schema/LogicalTypeAnnotation;)Lorg/apache/parquet/schema/Types$Builder;

	at org.apache.iceberg.parquet.TypeToMessageType.primitive(TypeToMessageType.java:145)
	at org.apache.iceberg.parquet.TypeToMessageType.field(TypeToMessageType.java:88)
	at org.apache.iceberg.parquet.TypeToMessageType.convert(TypeToMessageType.java:65)
	at org.apache.iceberg.parquet.ParquetSchemaUtil.convert(ParquetSchemaUtil.java:41)
	at org.apache.iceberg.parquet.Parquet$WriteBuilder.build(Parquet.java:210)
	at org.apache.iceberg.mr.TestHelper.writeFile(TestHelper.java:163)
	at org.apache.iceberg.mr.TestHelper.writeFile(TestHelper.java:140)
	at org.apache.iceberg.mr.hive.TestHiveIcebergInputFormat.before(TestHiveIcebergInputFo
```