### PR TITLE
Spark: refactor serialization test suites

### DIFF
--- a/spark/src/test/java/org/apache/iceberg/SerializationCheckHelper.java
+++ b/spark/src/test/java/org/apache/iceberg/SerializationCheckHelper.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Assert;
+
+public final class SerializationCheckHelper {
+  private SerializationCheckHelper() {
+  }
+
+  public static void checkBaseCombinedScanTask(BaseCombinedScanTask expected, BaseCombinedScanTask actual) {
+    List<FileScanTask> expectedTasks = getFileScanTasksInFilePathOrder(expected);
+    List<FileScanTask> actualTasks = getFileScanTasksInFilePathOrder(actual);
+
+    Assert.assertEquals("The number of file scan tasks should match",
+        expectedTasks.size(), actualTasks.size());
+
+    for (int i = 0; i < expectedTasks.size(); i++) {
+      FileScanTask expectedTask = expectedTasks.get(i);
+      FileScanTask actualTask = actualTasks.get(i);
+      checkFileScanTask(expectedTask, actualTask);
+    }
+  }
+
+  private static List<FileScanTask> getFileScanTasksInFilePathOrder(BaseCombinedScanTask task) {
+    return task.files().stream()
+        // use file path + start position to differentiate the tasks
+        .sorted(Comparator.comparing(o -> o.file().path().toString() + "##" + o.start()))
+        .collect(Collectors.toList());
+  }
+
+  public static void checkFileScanTask(FileScanTask expected, FileScanTask actual) {
+    checkDataFile(expected.file(), actual.file());
+
+    // PartitionSpec implements its own equals method
+    Assert.assertEquals("PartitionSpec doesn't match", expected.spec(), actual.spec());
+
+    Assert.assertEquals("starting position doesn't match", expected.start(), actual.start());
+
+    Assert.assertEquals("the number of bytes to scan doesn't match", expected.start(), actual.start());
+
+    // simplify comparison on residual expression via comparing toString
+    Assert.assertEquals("Residual expression doesn't match",
+        expected.residual().toString(), actual.residual().toString());
+  }
+
+  public static void checkDataFile(DataFile expected, DataFile actual) {
+    Assert.assertEquals("Should match the serialized record path",
+        expected.path(), actual.path());
+    Assert.assertEquals("Should match the serialized record format",
+        expected.format(), actual.format());
+    Assert.assertEquals("Should match the serialized record partition",
+        expected.partition().get(0, Object.class), actual.partition().get(0, Object.class));
+    Assert.assertEquals("Should match the serialized record count",
+        expected.recordCount(), actual.recordCount());
+    Assert.assertEquals("Should match the serialized record size",
+        expected.fileSizeInBytes(), actual.fileSizeInBytes());
+    Assert.assertEquals("Should match the serialized record value counts",
+        expected.valueCounts(), actual.valueCounts());
+    Assert.assertEquals("Should match the serialized record null value counts",
+        expected.nullValueCounts(), actual.nullValueCounts());
+    Assert.assertEquals("Should match the serialized record lower bounds",
+        expected.lowerBounds(), actual.lowerBounds());
+    Assert.assertEquals("Should match the serialized record upper bounds",
+        expected.upperBounds(), actual.upperBounds());
+    Assert.assertEquals("Should match the serialized record key metadata",
+        expected.keyMetadata(), actual.keyMetadata());
+    Assert.assertEquals("Should match the serialized record offsets",
+        expected.splitOffsets(), actual.splitOffsets());
+    Assert.assertEquals("Should match the serialized record offsets",
+        expected.keyMetadata(), actual.keyMetadata());
+  }
+}

--- a/spark/src/test/java/org/apache/iceberg/TaskCheckHelper.java
+++ b/spark/src/test/java/org/apache/iceberg/TaskCheckHelper.java
@@ -24,11 +24,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.Assert;
 
-public final class SerializationCheckHelper {
-  private SerializationCheckHelper() {
+public final class TaskCheckHelper {
+  private TaskCheckHelper() {
   }
 
-  public static void checkBaseCombinedScanTask(BaseCombinedScanTask expected, BaseCombinedScanTask actual) {
+  public static void assertEquals(BaseCombinedScanTask expected, BaseCombinedScanTask actual) {
     List<FileScanTask> expectedTasks = getFileScanTasksInFilePathOrder(expected);
     List<FileScanTask> actualTasks = getFileScanTasksInFilePathOrder(actual);
 
@@ -38,19 +38,12 @@ public final class SerializationCheckHelper {
     for (int i = 0; i < expectedTasks.size(); i++) {
       FileScanTask expectedTask = expectedTasks.get(i);
       FileScanTask actualTask = actualTasks.get(i);
-      checkFileScanTask(expectedTask, actualTask);
+      assertEquals(expectedTask, actualTask);
     }
   }
 
-  private static List<FileScanTask> getFileScanTasksInFilePathOrder(BaseCombinedScanTask task) {
-    return task.files().stream()
-        // use file path + start position to differentiate the tasks
-        .sorted(Comparator.comparing(o -> o.file().path().toString() + "##" + o.start()))
-        .collect(Collectors.toList());
-  }
-
-  public static void checkFileScanTask(FileScanTask expected, FileScanTask actual) {
-    checkDataFile(expected.file(), actual.file());
+  public static void assertEquals(FileScanTask expected, FileScanTask actual) {
+    assertEquals(expected.file(), actual.file());
 
     // PartitionSpec implements its own equals method
     Assert.assertEquals("PartitionSpec doesn't match", expected.spec(), actual.spec());
@@ -64,7 +57,7 @@ public final class SerializationCheckHelper {
         expected.residual().toString(), actual.residual().toString());
   }
 
-  public static void checkDataFile(DataFile expected, DataFile actual) {
+  public static void assertEquals(DataFile expected, DataFile actual) {
     Assert.assertEquals("Should match the serialized record path",
         expected.path(), actual.path());
     Assert.assertEquals("Should match the serialized record format",
@@ -89,5 +82,12 @@ public final class SerializationCheckHelper {
         expected.splitOffsets(), actual.splitOffsets());
     Assert.assertEquals("Should match the serialized record offsets",
         expected.keyMetadata(), actual.keyMetadata());
+  }
+
+  private static List<FileScanTask> getFileScanTasksInFilePathOrder(BaseCombinedScanTask task) {
+    return task.files().stream()
+        // use file path + start position to differentiate the tasks
+        .sorted(Comparator.comparing(o -> o.file().path().toString() + "##" + o.start()))
+        .collect(Collectors.toList());
   }
 }

--- a/spark/src/test/java/org/apache/iceberg/TestDataFileSerialization.java
+++ b/spark/src/test/java/org/apache/iceberg/TestDataFileSerialization.java
@@ -50,7 +50,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static org.apache.iceberg.SerializationCheckHelper.checkDataFile;
+import static org.apache.iceberg.TaskCheckHelper.assertEquals;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
@@ -108,7 +108,7 @@ public class TestDataFileSerialization {
       for (int i = 0; i < 2; i += 1) {
         Object obj = kryo.readClassAndObject(in);
         Assert.assertTrue("Should be a DataFile", obj instanceof DataFile);
-        checkDataFile(DATA_FILE, (DataFile) obj);
+        assertEquals(DATA_FILE, (DataFile) obj);
       }
     }
   }
@@ -125,7 +125,7 @@ public class TestDataFileSerialization {
       for (int i = 0; i < 2; i += 1) {
         Object obj = in.readObject();
         Assert.assertTrue("Should be a DataFile", obj instanceof DataFile);
-        checkDataFile(DATA_FILE, (DataFile) obj);
+        assertEquals(DATA_FILE, (DataFile) obj);
       }
     }
   }

--- a/spark/src/test/java/org/apache/iceberg/TestDataFileSerialization.java
+++ b/spark/src/test/java/org/apache/iceberg/TestDataFileSerialization.java
@@ -50,6 +50,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import static org.apache.iceberg.SerializationCheckHelper.checkDataFile;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
@@ -127,33 +128,6 @@ public class TestDataFileSerialization {
         checkDataFile(DATA_FILE, (DataFile) obj);
       }
     }
-  }
-
-  private void checkDataFile(DataFile expected, DataFile actual) {
-    Assert.assertEquals("Should match the serialized record path",
-        expected.path(), actual.path());
-    Assert.assertEquals("Should match the serialized record format",
-        expected.format(), actual.format());
-    Assert.assertEquals("Should match the serialized record partition",
-        expected.partition().get(0, Object.class), actual.partition().get(0, Object.class));
-    Assert.assertEquals("Should match the serialized record count",
-        expected.recordCount(), actual.recordCount());
-    Assert.assertEquals("Should match the serialized record size",
-        expected.fileSizeInBytes(), actual.fileSizeInBytes());
-    Assert.assertEquals("Should match the serialized record value counts",
-        expected.valueCounts(), actual.valueCounts());
-    Assert.assertEquals("Should match the serialized record null value counts",
-        expected.nullValueCounts(), actual.nullValueCounts());
-    Assert.assertEquals("Should match the serialized record lower bounds",
-        expected.lowerBounds(), actual.lowerBounds());
-    Assert.assertEquals("Should match the serialized record upper bounds",
-        expected.upperBounds(), actual.upperBounds());
-    Assert.assertEquals("Should match the serialized record key metadata",
-        expected.keyMetadata(), actual.keyMetadata());
-    Assert.assertEquals("Should match the serialized record offsets",
-        expected.splitOffsets(), actual.splitOffsets());
-    Assert.assertEquals("Should match the serialized record offsets",
-        expected.keyMetadata(), actual.keyMetadata());
   }
 
   @Test

--- a/spark/src/test/java/org/apache/iceberg/TestScanTaskSerialization.java
+++ b/spark/src/test/java/org/apache/iceberg/TestScanTaskSerialization.java
@@ -49,7 +49,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static org.apache.iceberg.SerializationCheckHelper.checkBaseCombinedScanTask;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 
 public abstract class TestScanTaskSerialization extends SparkTestBase {
@@ -87,7 +86,7 @@ public abstract class TestScanTaskSerialization extends SparkTestBase {
     try (Input in = new Input(new FileInputStream(data))) {
       Object obj = kryo.readClassAndObject(in);
       Assert.assertTrue("Should be a BaseCombinedScanTask", obj instanceof BaseCombinedScanTask);
-      checkBaseCombinedScanTask(scanTask, (BaseCombinedScanTask) obj);
+      TaskCheckHelper.assertEquals(scanTask, (BaseCombinedScanTask) obj);
     }
   }
 
@@ -103,7 +102,7 @@ public abstract class TestScanTaskSerialization extends SparkTestBase {
     try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
       Object obj = in.readObject();
       Assert.assertTrue("Should be a BaseCombinedScanTask", obj instanceof BaseCombinedScanTask);
-      checkBaseCombinedScanTask(scanTask, (BaseCombinedScanTask) obj);
+      TaskCheckHelper.assertEquals(scanTask, (BaseCombinedScanTask) obj);
     }
   }
 

--- a/spark/src/test/java/org/apache/iceberg/TestScanTaskSerialization.java
+++ b/spark/src/test/java/org/apache/iceberg/TestScanTaskSerialization.java
@@ -29,10 +29,8 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.CloseableIterable;
@@ -51,6 +49,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import static org.apache.iceberg.SerializationCheckHelper.checkBaseCombinedScanTask;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 
 public abstract class TestScanTaskSerialization extends SparkTestBase {
@@ -129,70 +128,6 @@ public abstract class TestScanTaskSerialization extends SparkTestBase {
 
     CloseableIterable<FileScanTask> tasks = table.newScan().planFiles();
     return new BaseCombinedScanTask(Lists.newArrayList(tasks));
-  }
-
-  private void checkBaseCombinedScanTask(BaseCombinedScanTask expected, BaseCombinedScanTask actual) {
-    List<FileScanTask> expectedTasks = getFileScanTasksInFilePathOrder(expected);
-    List<FileScanTask> actualTasks = getFileScanTasksInFilePathOrder(actual);
-
-    Assert.assertEquals("The number of file scan tasks should match",
-        expectedTasks.size(), actualTasks.size());
-
-    for (int i = 0; i < expectedTasks.size(); i++) {
-      FileScanTask expectedTask = expectedTasks.get(i);
-      FileScanTask actualTask = actualTasks.get(i);
-      checkFileScanTask(expectedTask, actualTask);
-    }
-  }
-
-  private List<FileScanTask> getFileScanTasksInFilePathOrder(BaseCombinedScanTask task) {
-    return task.files().stream()
-        // use file path + start position to differentiate the tasks
-        .sorted(Comparator.comparing(o -> o.file().path().toString() + "##" + o.start()))
-        .collect(Collectors.toList());
-  }
-
-  private void checkFileScanTask(FileScanTask expected, FileScanTask actual) {
-    checkDataFile(expected.file(), actual.file());
-
-    // PartitionSpec implements its own equals method
-    Assert.assertEquals("PartitionSpec doesn't match", expected.spec(), actual.spec());
-
-    Assert.assertEquals("starting position doesn't match", expected.start(), actual.start());
-
-    Assert.assertEquals("the number of bytes to scan doesn't match", expected.start(), actual.start());
-
-    // simplify comparison on residual expression via comparing toString
-    Assert.assertEquals("Residual expression doesn't match",
-        expected.residual().toString(), actual.residual().toString());
-  }
-
-  // TODO: this is a copy of TestDataFileSerialization.checkDataFile, deduplicate
-  private void checkDataFile(DataFile expected, DataFile actual) {
-    Assert.assertEquals("Should match the serialized record path",
-        expected.path(), actual.path());
-    Assert.assertEquals("Should match the serialized record format",
-        expected.format(), actual.format());
-    Assert.assertEquals("Should match the serialized record partition",
-        expected.partition().get(0, Object.class), actual.partition().get(0, Object.class));
-    Assert.assertEquals("Should match the serialized record count",
-        expected.recordCount(), actual.recordCount());
-    Assert.assertEquals("Should match the serialized record size",
-        expected.fileSizeInBytes(), actual.fileSizeInBytes());
-    Assert.assertEquals("Should match the serialized record value counts",
-        expected.valueCounts(), actual.valueCounts());
-    Assert.assertEquals("Should match the serialized record null value counts",
-        expected.nullValueCounts(), actual.nullValueCounts());
-    Assert.assertEquals("Should match the serialized record lower bounds",
-        expected.lowerBounds(), actual.lowerBounds());
-    Assert.assertEquals("Should match the serialized record upper bounds",
-        expected.upperBounds(), actual.upperBounds());
-    Assert.assertEquals("Should match the serialized record key metadata",
-        expected.keyMetadata(), actual.keyMetadata());
-    Assert.assertEquals("Should match the serialized record offsets",
-        expected.splitOffsets(), actual.splitOffsets());
-    Assert.assertEquals("Should match the serialized record offsets",
-        expected.keyMetadata(), actual.keyMetadata());
   }
 
   private void writeRecords(List<ThreeColumnRecord> records) {


### PR DESCRIPTION
This patch refactors to deduplicate the code:

* Comparing BaseCombinedScanTask needs compare of DataFile, which we already have the method for this, but in other test suite. I created a new helper class to move out comparison methods so that they can be co-used.