### PR TITLE
Update scan planning with DeleteFiles in each task

### DIFF
--- a/api/src/main/java/org/apache/iceberg/FileScanTask.java
+++ b/api/src/main/java/org/apache/iceberg/FileScanTask.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg;
 
+import java.util.List;
 import org.apache.iceberg.expressions.Expression;
 
 /**
@@ -31,6 +32,13 @@ public interface FileScanTask extends ScanTask {
    * @return the file to scan
    */
   DataFile file();
+
+  /**
+   * A list of {@link DeleteFile delete files} to apply when reading the task's data file.
+   *
+   * @return a list of delete files to apply
+   */
+  List<DeleteFile> deletes();
 
   /**
    * The {@link PartitionSpec spec} used to store this file.

--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -92,6 +92,10 @@ public class PartitionSpec implements Serializable {
     return lazyFieldList();
   }
 
+  public boolean isUnpartitioned() {
+    return fields.length < 1;
+  }
+
   int lastAssignedFieldId() {
     return lastAssignedFieldId;
   }

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg;
 
 import java.io.IOException;
+import java.util.List;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Expression;
@@ -128,7 +129,7 @@ public class AllManifestsTable extends BaseMetadataTable {
           Expression filter = ignoreResiduals ? Expressions.alwaysTrue() : rowFilter;
           ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(filter);
           return new ManifestListReadTask(ops.io(), table().spec(), new BaseFileScanTask(
-              DataFiles.fromManifestList(ops.io().newInputFile(snap.manifestListLocation())),
+              DataFiles.fromManifestList(ops.io().newInputFile(snap.manifestListLocation())), null,
               schemaString, specString, residuals));
         } else {
           return StaticDataTask.of(
@@ -149,6 +150,11 @@ public class AllManifestsTable extends BaseMetadataTable {
       this.io = io;
       this.spec = spec;
       this.manifestListTask = manifestListTask;
+    }
+
+    @Override
+    public List<DeleteFile> deletes() {
+      return manifestListTask.deletes();
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
@@ -31,14 +31,17 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 
 class BaseFileScanTask implements FileScanTask {
   private final DataFile file;
+  private final DeleteFile[] deletes;
   private final String schemaString;
   private final String specString;
   private final ResidualEvaluator residuals;
 
   private transient PartitionSpec spec = null;
 
-  BaseFileScanTask(DataFile file, String schemaString, String specString, ResidualEvaluator residuals) {
+  BaseFileScanTask(DataFile file, DeleteFile[] deletes, String schemaString, String specString,
+                   ResidualEvaluator residuals) {
     this.file = file;
+    this.deletes = deletes != null ? deletes : new DeleteFile[0];
     this.schemaString = schemaString;
     this.specString = specString;
     this.residuals = residuals;
@@ -47,6 +50,11 @@ class BaseFileScanTask implements FileScanTask {
   @Override
   public DataFile file() {
     return file;
+  }
+
+  @Override
+  public List<DeleteFile> deletes() {
+    return ImmutableList.copyOf(deletes);
   }
 
   @Override
@@ -183,6 +191,11 @@ class BaseFileScanTask implements FileScanTask {
     @Override
     public DataFile file() {
       return fileScanTask.file();
+    }
+
+    @Override
+    public List<DeleteFile> deletes() {
+      return fileScanTask.deletes();
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/DataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DataFilesTable.java
@@ -117,7 +117,7 @@ public class DataFilesTable extends BaseMetadataTable {
 
     ManifestReadTask(FileIO io, ManifestFile manifest, Schema schema, String schemaString,
                      String specString, ResidualEvaluator residuals) {
-      super(DataFiles.fromManifest(manifest), schemaString, specString, residuals);
+      super(DataFiles.fromManifest(manifest), null, schemaString, specString, residuals);
       this.io = io;
       this.manifest = manifest;
       this.schema = schema;

--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -71,7 +71,7 @@ public class DataTableScan extends BaseTableScan {
   public CloseableIterable<FileScanTask> planFiles(TableOperations ops, Snapshot snapshot,
                                                    Expression rowFilter, boolean ignoreResiduals,
                                                    boolean caseSensitive, boolean colStats) {
-    ManifestGroup manifestGroup = new ManifestGroup(ops.io(), snapshot.dataManifests())
+    ManifestGroup manifestGroup = new ManifestGroup(ops.io(), snapshot.dataManifests(), snapshot.deleteManifests())
         .caseSensitive(caseSensitive)
         .select(colStats ? SCAN_WITH_STATS_COLUMNS : SCAN_COLUMNS)
         .filterData(rowFilter)

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -217,7 +217,8 @@ class DeleteFileIndex {
           List<Pair<Long, DeleteFile>> filesSortedBySeq = deleteFilesByPartition.get(partition).stream()
               .map(entry -> {
                 // a delete file is indexed by the sequence number it should be applied to
-                long applySeq = entry.sequenceNumber() - (entry.file().content() == FileContent.EQUALITY_DELETES ? 1 : 0);
+                long applySeq = entry.sequenceNumber() -
+                    (entry.file().content() == FileContent.EQUALITY_DELETES ? 1 : 0);
                 return Pair.of(applySeq, entry.file());
               })
               .sorted(Comparator.comparingLong(Pair::first))
@@ -234,13 +235,13 @@ class DeleteFileIndex {
     }
 
     private Iterable<Pair<Integer, CloseableIterable<ManifestEntry<DeleteFile>>>> deleteManifestReaders() {
-      LoadingCache<Integer, ManifestEvaluator> evalCache = specsById == null ?
-          null : Caffeine.newBuilder().build(specId -> {
-        PartitionSpec spec = specsById.get(specId);
-        return ManifestEvaluator.forPartitionFilter(
-            Expressions.and(partitionFilter, Projections.inclusive(spec, caseSensitive).project(dataFilter)),
-            spec, caseSensitive);
-      });
+      LoadingCache<Integer, ManifestEvaluator> evalCache = specsById == null ? null :
+          Caffeine.newBuilder().build(specId -> {
+            PartitionSpec spec = specsById.get(specId);
+            return ManifestEvaluator.forPartitionFilter(
+                Expressions.and(partitionFilter, Projections.inclusive(spec, caseSensitive).project(dataFilter)),
+                spec, caseSensitive);
+          });
 
       Iterable<ManifestFile> matchingManifests = evalCache == null ? deleteManifests :
           Iterables.filter(deleteManifests, manifest ->

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -77,8 +77,8 @@ class DeleteFileIndex {
   }
 
   DeleteFile[] forDataFile(int specId, long sequenceNumber, DataFile file) {
-    Pair<long[], DeleteFile[]> partitionDeletes = sortedDeletesByPartition
-        .get(Pair.of(specId, lookupWrapper.get().set(file.partition())));
+    Pair<Integer, StructLikeWrapper> partition = Pair.of(specId, lookupWrapper.get().set(file.partition()));
+    Pair<long[], DeleteFile[]> partitionDeletes = sortedDeletesByPartition.get(partition);
 
     if (partitionDeletes == null) {
       return limitBySequenceNumber(sequenceNumber, globalSeqs, globalDeletes);

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.stream.Collectors;
+import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.ManifestEvaluator;
+import org.apache.iceberg.expressions.Projections;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.ListMultimap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Multimaps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.util.Pair;
+import org.apache.iceberg.util.StructLikeWrapper;
+import org.apache.iceberg.util.Tasks;
+
+/**
+ * An index of {@link DeleteFile delete files} by sequence number.
+ * <p>
+ * Use {@link #builderFor(FileIO, Iterable)} to construct an index, and {@link #forDataFile(long, DataFile)} or
+ * {@link #forEntry(ManifestEntry)} to get the the delete files to apply to a given data file.
+ */
+class DeleteFileIndex {
+  private static final DeleteFile[] NO_DELETE_FILES = new DeleteFile[0];
+
+  private final Map<StructLikeWrapper, Pair<long[], DeleteFile[]>> index;
+  private final ThreadLocal<StructLikeWrapper> lookupWrapper = ThreadLocal.withInitial(
+      () -> StructLikeWrapper.wrap(null));
+
+  DeleteFileIndex(Map<StructLikeWrapper, Pair<long[], DeleteFile[]>> index) {
+    this.index = index;
+  }
+
+  DeleteFile[] forEntry(ManifestEntry<DataFile> entry) {
+    return forDataFile(entry.sequenceNumber(), entry.file());
+  }
+
+  DeleteFile[] forDataFile(long sequenceNumber, DataFile file) {
+    Pair<long[], DeleteFile[]> partitionDeletes = index.get(lookupWrapper.get().set(file.partition()));
+    if (partitionDeletes == null) {
+      return NO_DELETE_FILES;
+    }
+
+    long[] seqs = partitionDeletes.first();
+    DeleteFile[] files = partitionDeletes.second();
+
+    int pos = Arrays.binarySearch(seqs, sequenceNumber);
+    int start;
+    if (pos < 0) {
+      // the sequence number was not found, where it would be inserted is -(pos + 1)
+      start = -(pos + 1);
+    } else {
+      // the sequence number was found, but may not be the first
+      // find the first delete file with the given sequence number by decrementing the position
+      start = pos;
+      while (start > 0 && seqs[start - 1] >= sequenceNumber) {
+        start -= 1;
+      }
+    }
+
+    return Arrays.copyOfRange(files, start, files.length);
+  }
+
+  static Builder builderFor(FileIO io, Iterable<ManifestFile> deleteManifests) {
+    return new Builder(io, Sets.newHashSet(deleteManifests));
+  }
+
+  static class Builder {
+    private final FileIO io;
+    private final Set<ManifestFile> deleteManifests;
+    private Map<Integer, PartitionSpec> specsById;
+    private Expression dataFilter;
+    private Expression partitionFilter;
+    private boolean caseSensitive;
+    private ExecutorService executorService;
+
+    Builder(FileIO io, Set<ManifestFile> deleteManifests) {
+      this.io = io;
+      this.deleteManifests = Sets.newHashSet(deleteManifests);
+      this.specsById = null;
+      this.dataFilter = Expressions.alwaysTrue();
+      this.partitionFilter = Expressions.alwaysTrue();
+      this.caseSensitive = true;
+      this.executorService = null;
+    }
+
+    Builder specsById(Map<Integer, PartitionSpec> newSpecsById) {
+      this.specsById = newSpecsById;
+      return this;
+    }
+
+    Builder filterData(Expression newDataFilter) {
+      this.dataFilter = Expressions.and(dataFilter, newDataFilter);
+      return this;
+    }
+
+    Builder filterPartitions(Expression newPartitionFilter) {
+      this.partitionFilter = Expressions.and(partitionFilter, newPartitionFilter);
+      return this;
+    }
+
+    Builder caseSensitive(boolean newCaseSensitive) {
+      this.caseSensitive = newCaseSensitive;
+      return this;
+    }
+
+    Builder planWith(ExecutorService newExecutorService) {
+      this.executorService = newExecutorService;
+      return this;
+    }
+
+    DeleteFileIndex build() {
+      Queue<ManifestEntry<DeleteFile>> deleteEntries = new ConcurrentLinkedQueue<>();
+      Tasks.foreach(deleteManifestReaders())
+          .stopOnFailure().throwFailureWhenFinished()
+          .executeWith(executorService)
+          .run(deleteManifest -> {
+            try (CloseableIterable<ManifestEntry<DeleteFile>> reader = deleteManifest) {
+              for (ManifestEntry<DeleteFile> entry : reader) {
+                // copy with stats for better filtering against data file stats
+                deleteEntries.add(entry.copy());
+              }
+            } catch (IOException e) {
+              throw new RuntimeIOException("Failed to close", e);
+            }
+          });
+
+      ListMultimap<StructLikeWrapper, ManifestEntry<DeleteFile>> deleteFilesByPartition = Multimaps.newListMultimap(
+          Maps.newHashMap(), Lists::newArrayList);
+      for (ManifestEntry<DeleteFile> deleteEntry : deleteEntries) {
+        deleteFilesByPartition.put(StructLikeWrapper.wrap(deleteEntry.file().partition()), deleteEntry);
+      }
+
+      Map<StructLikeWrapper, Pair<long[], DeleteFile[]>> deletesByPartition = Maps.newHashMap();
+      for (StructLikeWrapper partition : deleteFilesByPartition.keySet()) {
+        List<Pair<Long, DeleteFile>> filesSortedBySeq = deleteFilesByPartition.get(partition).stream()
+            .map(entry -> {
+              // a delete file is indexed by the sequence number it should be applied to
+              long applySeq = entry.sequenceNumber() - (entry.file().content() == FileContent.EQUALITY_DELETES ? 1 : 0);
+              return Pair.of(applySeq, entry.file());
+            })
+            .sorted(Comparator.comparingLong(Pair::first))
+            .collect(Collectors.toList());
+
+        long[] seqs = filesSortedBySeq.stream().mapToLong(Pair::first).toArray();
+        DeleteFile[] files = filesSortedBySeq.stream().map(Pair::second).toArray(DeleteFile[]::new);
+
+        deletesByPartition.put(partition, Pair.of(seqs, files));
+      }
+
+      return new DeleteFileIndex(deletesByPartition);
+    }
+
+    private Iterable<CloseableIterable<ManifestEntry<DeleteFile>>> deleteManifestReaders() {
+      LoadingCache<Integer, ManifestEvaluator> evalCache = specsById == null ?
+          null : Caffeine.newBuilder().build(specId -> {
+        PartitionSpec spec = specsById.get(specId);
+        return ManifestEvaluator.forPartitionFilter(
+            Expressions.and(partitionFilter, Projections.inclusive(spec, caseSensitive).project(dataFilter)),
+            spec, caseSensitive);
+      });
+
+      Iterable<ManifestFile> matchingManifests = evalCache == null ? deleteManifests :
+          Iterables.filter(deleteManifests, manifest ->
+              manifest.content() == ManifestContent.DELETES &&
+                  (manifest.hasAddedFiles() || manifest.hasDeletedFiles()) &&
+                  evalCache.get(manifest.partitionSpecId()).eval(manifest));
+
+      Iterable<CloseableIterable<ManifestEntry<DeleteFile>>> readers = Iterables.transform(
+          matchingManifests,
+          manifest ->
+              ManifestFiles.readDeleteManifest(manifest, io, specsById)
+                  .filterRows(dataFilter)
+                  .filterPartitions(partitionFilter)
+                  .caseSensitive(caseSensitive)
+                  .liveEntries()
+      );
+
+      return readers;
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
+++ b/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
@@ -45,6 +45,7 @@ class GenericManifestEntry<F extends ContentFile<F>>
     this.schema = toCopy.schema;
     this.status = toCopy.status;
     this.snapshotId = toCopy.snapshotId;
+    this.sequenceNumber = toCopy.sequenceNumber;
     if (fullCopy) {
       this.file = toCopy.file().copy();
     } else {

--- a/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
@@ -117,7 +117,7 @@ public class ManifestEntriesTable extends BaseMetadataTable {
 
     ManifestReadTask(FileIO io, ManifestFile manifest, Schema fileSchema, String schemaString,
                      String specString, ResidualEvaluator residuals) {
-      super(DataFiles.fromManifest(manifest), schemaString, specString, residuals);
+      super(DataFiles.fromManifest(manifest), null, schemaString, specString, residuals);
       this.fileSchema = fileSchema;
       this.io = io;
       this.manifest = manifest;

--- a/core/src/main/java/org/apache/iceberg/ManifestGroup.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestGroup.java
@@ -165,17 +165,17 @@ class ManifestGroup {
     boolean dropStats = ManifestReader.dropStats(dataFilter, columns);
 
     Iterable<CloseableIterable<FileScanTask>> tasks = entries((manifest, entries) -> {
-      int partitionSpecId = manifest.partitionSpecId();
-      PartitionSpec spec = specsById.get(partitionSpecId);
+      int specId = manifest.partitionSpecId();
+      PartitionSpec spec = specsById.get(specId);
       String schemaString = SchemaParser.toJson(spec.schema());
       String specString = PartitionSpecParser.toJson(spec);
-      ResidualEvaluator residuals = residualCache.get(partitionSpecId);
+      ResidualEvaluator residuals = residualCache.get(specId);
       if (dropStats) {
         return CloseableIterable.transform(entries, e -> new BaseFileScanTask(
-            e.file().copyWithoutStats(), deleteFiles.forEntry(e), schemaString, specString, residuals));
+            e.file().copyWithoutStats(), deleteFiles.forEntry(specId, e), schemaString, specString, residuals));
       } else {
         return CloseableIterable.transform(entries, e -> new BaseFileScanTask(
-            e.file().copy(), deleteFiles.forEntry(e), schemaString, specString, residuals));
+            e.file().copy(), deleteFiles.forEntry(specId, e), schemaString, specString, residuals));
       }
     });
 

--- a/core/src/main/java/org/apache/iceberg/ManifestGroup.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestGroup.java
@@ -45,7 +45,8 @@ class ManifestGroup {
   private static final Types.StructType EMPTY_STRUCT = Types.StructType.of();
 
   private final FileIO io;
-  private final Set<ManifestFile> manifests;
+  private final Set<ManifestFile> dataManifests;
+  private final DeleteFileIndex.Builder deleteIndexBuilder;
   private Predicate<ManifestFile> manifestPredicate;
   private Predicate<ManifestEntry<DataFile>> manifestEntryPredicate;
   private Map<Integer, PartitionSpec> specsById;
@@ -60,8 +61,15 @@ class ManifestGroup {
   private ExecutorService executorService;
 
   ManifestGroup(FileIO io, Iterable<ManifestFile> manifests) {
+    this(io,
+        Iterables.filter(manifests, manifest -> manifest.content() == ManifestContent.DATA),
+        Iterables.filter(manifests, manifest -> manifest.content() == ManifestContent.DELETES));
+  }
+
+  ManifestGroup(FileIO io, Iterable<ManifestFile> dataManifests, Iterable<ManifestFile> deleteManifests) {
     this.io = io;
-    this.manifests = Sets.newHashSet(manifests);
+    this.dataManifests = Sets.newHashSet(dataManifests);
+    this.deleteIndexBuilder = DeleteFileIndex.builderFor(io, deleteManifests);
     this.dataFilter = Expressions.alwaysTrue();
     this.fileFilter = Expressions.alwaysTrue();
     this.partitionFilter = Expressions.alwaysTrue();
@@ -76,11 +84,13 @@ class ManifestGroup {
 
   ManifestGroup specsById(Map<Integer, PartitionSpec> newSpecsById) {
     this.specsById = newSpecsById;
+    deleteIndexBuilder.specsById(newSpecsById);
     return this;
   }
 
   ManifestGroup filterData(Expression newDataFilter) {
     this.dataFilter = Expressions.and(dataFilter, newDataFilter);
+    deleteIndexBuilder.filterData(newDataFilter);
     return this;
   }
 
@@ -91,6 +101,7 @@ class ManifestGroup {
 
   ManifestGroup filterPartitions(Expression newPartitionFilter) {
     this.partitionFilter = Expressions.and(partitionFilter, newPartitionFilter);
+    deleteIndexBuilder.filterPartitions(newPartitionFilter);
     return this;
   }
 
@@ -126,11 +137,13 @@ class ManifestGroup {
 
   ManifestGroup caseSensitive(boolean newCaseSensitive) {
     this.caseSensitive = newCaseSensitive;
+    deleteIndexBuilder.caseSensitive(newCaseSensitive);
     return this;
   }
 
   ManifestGroup planWith(ExecutorService newExecutorService) {
     this.executorService = newExecutorService;
+    deleteIndexBuilder.planWith(newExecutorService);
     return this;
   }
 
@@ -146,7 +159,11 @@ class ManifestGroup {
       Expression filter = ignoreResiduals ? Expressions.alwaysTrue() : dataFilter;
       return ResidualEvaluator.of(spec, filter, caseSensitive);
     });
+
+    DeleteFileIndex deleteFiles = deleteIndexBuilder.build();
+
     boolean dropStats = ManifestReader.dropStats(dataFilter, columns);
+
     Iterable<CloseableIterable<FileScanTask>> tasks = entries((manifest, entries) -> {
       int partitionSpecId = manifest.partitionSpecId();
       PartitionSpec spec = specsById.get(partitionSpecId);
@@ -155,10 +172,10 @@ class ManifestGroup {
       ResidualEvaluator residuals = residualCache.get(partitionSpecId);
       if (dropStats) {
         return CloseableIterable.transform(entries, e -> new BaseFileScanTask(
-            e.file().copyWithoutStats(), null, schemaString, specString, residuals));
+            e.file().copyWithoutStats(), deleteFiles.forEntry(e), schemaString, specString, residuals));
       } else {
         return CloseableIterable.transform(entries, e -> new BaseFileScanTask(
-            e.file().copy(), null, schemaString, specString, residuals));
+            e.file().copy(), deleteFiles.forEntry(e), schemaString, specString, residuals));
       }
     });
 
@@ -193,8 +210,8 @@ class ManifestGroup {
 
     Evaluator evaluator = new Evaluator(DataFile.getType(EMPTY_STRUCT), fileFilter, caseSensitive);
 
-    Iterable<ManifestFile> matchingManifests = evalCache == null ? manifests : Iterables.filter(manifests,
-        manifest -> evalCache.get(manifest.partitionSpecId()).eval(manifest));
+    Iterable<ManifestFile> matchingManifests = evalCache == null ? dataManifests :
+        Iterables.filter(dataManifests, manifest -> evalCache.get(manifest.partitionSpecId()).eval(manifest));
 
     if (ignoreDeleted) {
       // only scan manifests that have entries other than deletes
@@ -214,10 +231,10 @@ class ManifestGroup {
 
     matchingManifests = Iterables.filter(matchingManifests, manifestPredicate::test);
 
-    Iterable<CloseableIterable<T>> readers = Iterables.transform(
+    return Iterables.transform(
         matchingManifests,
         manifest -> {
-          ManifestReader reader = ManifestFiles.read(manifest, io, specsById)
+          ManifestReader<DataFile> reader = ManifestFiles.read(manifest, io, specsById)
               .filterRows(dataFilter)
               .filterPartitions(partitionFilter)
               .caseSensitive(caseSensitive)
@@ -241,7 +258,5 @@ class ManifestGroup {
           entries = CloseableIterable.filter(entries, manifestEntryPredicate);
           return entryFn.apply(manifest, entries);
         });
-
-    return readers;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/ManifestGroup.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestGroup.java
@@ -155,10 +155,10 @@ class ManifestGroup {
       ResidualEvaluator residuals = residualCache.get(partitionSpecId);
       if (dropStats) {
         return CloseableIterable.transform(entries, e -> new BaseFileScanTask(
-            e.file().copyWithoutStats(), schemaString, specString, residuals));
+            e.file().copyWithoutStats(), null, schemaString, specString, residuals));
       } else {
         return CloseableIterable.transform(entries, e -> new BaseFileScanTask(
-            e.file().copy(), schemaString, specString, residuals));
+            e.file().copy(), null, schemaString, specString, residuals));
       }
     });
 

--- a/core/src/main/java/org/apache/iceberg/StaticDataTask.java
+++ b/core/src/main/java/org/apache/iceberg/StaticDataTask.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.Function;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
@@ -47,6 +48,11 @@ class StaticDataTask implements DataTask {
         .withFormat(FileFormat.METADATA)
         .build();
     this.rows = rows;
+  }
+
+  @Override
+  public List<DeleteFile> deletes() {
+    return ImmutableList.of();
   }
 
   @Override

--- a/core/src/test/java/org/apache/iceberg/MockFileScanTask.java
+++ b/core/src/test/java/org/apache/iceberg/MockFileScanTask.java
@@ -24,7 +24,7 @@ public class MockFileScanTask extends BaseFileScanTask {
   private final long length;
 
   public MockFileScanTask(long length) {
-    super(null, null, null, null);
+    super(null, null, null, null, null);
     this.length = length;
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestDeleteFileIndex.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeleteFileIndex.java
@@ -79,59 +79,59 @@ public class TestDeleteFileIndex extends TableTestBase {
     StructLike emptyPartition = new PartitionData(PartitionSpec.unpartitioned().partitionType());
 
     DeleteFileIndex index = new DeleteFileIndex(ImmutableMap.of(
-        StructLikeWrapper.wrap(emptyPartition), Pair.of(
-            new long[] { 3, 5, 5, 6 },
-            DELETE_FILES)));
+        Pair.of(1, StructLikeWrapper.wrap(emptyPartition)),
+        Pair.of(new long[] { 3, 5, 5, 6 }, DELETE_FILES)));
 
     Assert.assertArrayEquals("All deletes should apply to seq 0",
-        DELETE_FILES, index.forDataFile(0, UNPARTITIONED_FILE));
+        DELETE_FILES, index.forDataFile(1, 0, UNPARTITIONED_FILE));
     Assert.assertArrayEquals("All deletes should apply to seq 3",
-        DELETE_FILES, index.forDataFile(3, UNPARTITIONED_FILE));
+        DELETE_FILES, index.forDataFile(1, 3, UNPARTITIONED_FILE));
     Assert.assertArrayEquals("Last 3 deletes should apply to seq 4",
-        Arrays.copyOfRange(DELETE_FILES, 1, 4), index.forDataFile(4, UNPARTITIONED_FILE));
+        Arrays.copyOfRange(DELETE_FILES, 1, 4), index.forDataFile(1, 4, UNPARTITIONED_FILE));
     Assert.assertArrayEquals("Last 3 deletes should apply to seq 5",
-        Arrays.copyOfRange(DELETE_FILES, 1, 4), index.forDataFile(5, UNPARTITIONED_FILE));
+        Arrays.copyOfRange(DELETE_FILES, 1, 4), index.forDataFile(1, 5, UNPARTITIONED_FILE));
     Assert.assertArrayEquals("Last delete should apply to seq 6",
-        Arrays.copyOfRange(DELETE_FILES, 3, 4), index.forDataFile(6, UNPARTITIONED_FILE));
+        Arrays.copyOfRange(DELETE_FILES, 3, 4), index.forDataFile(1, 6, UNPARTITIONED_FILE));
     Assert.assertArrayEquals("No deletes should apply to seq 7",
-        new DataFile[0], index.forDataFile(7, UNPARTITIONED_FILE));
+        new DataFile[0], index.forDataFile(1, 7, UNPARTITIONED_FILE));
     Assert.assertArrayEquals("No deletes should apply to seq 10",
-        new DataFile[0], index.forDataFile(10, UNPARTITIONED_FILE));
+        new DataFile[0], index.forDataFile(1, 10, UNPARTITIONED_FILE));
 
     Assert.assertEquals("No deletes should apply to partitioned files, partition not in index",
-        0, index.forDataFile(0, FILE_B).length);
+        0, index.forDataFile(1, 0, FILE_B).length);
   }
 
   @Test
   public void testPartitionedDeleteIndex() {
     DeleteFileIndex index = new DeleteFileIndex(ImmutableMap.of(
-        StructLikeWrapper.wrap(FILE_A.partition()), Pair.of(
-            new long[] { 3, 5, 5, 6 },
-            DELETE_FILES),
-        StructLikeWrapper.wrap(FILE_C.partition()), Pair.of(
-            new long[0],
-            new DeleteFile[0])));
+        Pair.of(1, StructLikeWrapper.wrap(FILE_A.partition())),
+        Pair.of(new long[] { 3, 5, 5, 6 }, DELETE_FILES),
+        Pair.of(1, StructLikeWrapper.wrap(FILE_C.partition())),
+        Pair.of(new long[0], new DeleteFile[0])));
 
     Assert.assertArrayEquals("All deletes should apply to seq 0",
-        DELETE_FILES, index.forDataFile(0, FILE_A));
+        DELETE_FILES, index.forDataFile(1, 0, FILE_A));
     Assert.assertArrayEquals("All deletes should apply to seq 3",
-        DELETE_FILES, index.forDataFile(3, FILE_A));
+        DELETE_FILES, index.forDataFile(1, 3, FILE_A));
     Assert.assertArrayEquals("Last 3 deletes should apply to seq 4",
-        Arrays.copyOfRange(DELETE_FILES, 1, 4), index.forDataFile(4, FILE_A));
+        Arrays.copyOfRange(DELETE_FILES, 1, 4), index.forDataFile(1, 4, FILE_A));
     Assert.assertArrayEquals("Last 3 deletes should apply to seq 5",
-        Arrays.copyOfRange(DELETE_FILES, 1, 4), index.forDataFile(5, FILE_A));
+        Arrays.copyOfRange(DELETE_FILES, 1, 4), index.forDataFile(1, 5, FILE_A));
     Assert.assertArrayEquals("Last delete should apply to seq 6",
-        Arrays.copyOfRange(DELETE_FILES, 3, 4), index.forDataFile(6, FILE_A));
+        Arrays.copyOfRange(DELETE_FILES, 3, 4), index.forDataFile(1, 6, FILE_A));
     Assert.assertArrayEquals("No deletes should apply to seq 7",
-        new DataFile[0], index.forDataFile(7, FILE_A));
+        new DataFile[0], index.forDataFile(1, 7, FILE_A));
     Assert.assertArrayEquals("No deletes should apply to seq 10",
-        new DataFile[0], index.forDataFile(10, FILE_A));
+        new DataFile[0], index.forDataFile(1, 10, FILE_A));
 
     Assert.assertEquals("No deletes should apply to FILE_B, partition not in index",
-        0, index.forDataFile(0, FILE_B).length);
+        0, index.forDataFile(1, 0, FILE_B).length);
 
     Assert.assertEquals("No deletes should apply to FILE_C, no indexed delete files",
-        0, index.forDataFile(0, FILE_C).length);
+        0, index.forDataFile(1, 0, FILE_C).length);
+
+    Assert.assertEquals("No deletes should apply to FILE_A with a different specId",
+        0, index.forDataFile(2, 0, FILE_A).length);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestDeleteFileIndex.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeleteFileIndex.java
@@ -19,11 +19,13 @@
 
 package org.apache.iceberg;
 
+import com.google.common.collect.Sets;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.StructLikeWrapper;
@@ -76,11 +78,7 @@ public class TestDeleteFileIndex extends TableTestBase {
 
   @Test
   public void testUnpartitionedDeletes() {
-    StructLike emptyPartition = new PartitionData(PartitionSpec.unpartitioned().partitionType());
-
-    DeleteFileIndex index = new DeleteFileIndex(ImmutableMap.of(
-        Pair.of(1, StructLikeWrapper.wrap(emptyPartition)),
-        Pair.of(new long[] { 3, 5, 5, 6 }, DELETE_FILES)));
+    DeleteFileIndex index = new DeleteFileIndex(new long[] { 3, 5, 5, 6 }, DELETE_FILES, ImmutableMap.of());
 
     Assert.assertArrayEquals("All deletes should apply to seq 0",
         DELETE_FILES, index.forDataFile(1, 0, UNPARTITIONED_FILE));
@@ -97,13 +95,13 @@ public class TestDeleteFileIndex extends TableTestBase {
     Assert.assertArrayEquals("No deletes should apply to seq 10",
         new DataFile[0], index.forDataFile(1, 10, UNPARTITIONED_FILE));
 
-    Assert.assertEquals("No deletes should apply to partitioned files, partition not in index",
-        0, index.forDataFile(1, 0, FILE_B).length);
+    Assert.assertArrayEquals("All global deletes should apply to a partitioned file",
+        DELETE_FILES, index.forDataFile(2, 0, FILE_B));
   }
 
   @Test
   public void testPartitionedDeleteIndex() {
-    DeleteFileIndex index = new DeleteFileIndex(ImmutableMap.of(
+    DeleteFileIndex index = new DeleteFileIndex(null, null, ImmutableMap.of(
         Pair.of(1, StructLikeWrapper.wrap(FILE_A.partition())),
         Pair.of(new long[] { 3, 5, 5, 6 }, DELETE_FILES),
         Pair.of(1, StructLikeWrapper.wrap(FILE_C.partition())),
@@ -173,8 +171,8 @@ public class TestDeleteFileIndex extends TableTestBase {
     Assert.assertEquals("Should have two associated delete files",
         2, task.deletes().size());
     Assert.assertEquals("Should have expected delete files",
-        Lists.newArrayList(UNPARTITIONED_POS_DELETES.path(), UNPARTITIONED_EQ_DELETES.path()),
-        Lists.transform(task.deletes(), ContentFile::path));
+        Sets.newHashSet(UNPARTITIONED_POS_DELETES.path(), UNPARTITIONED_EQ_DELETES.path()),
+        Sets.newHashSet(Iterables.transform(task.deletes(), ContentFile::path)));
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestDeleteFileIndex.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeleteFileIndex.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg;
 
-import com.google.common.collect.Sets;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -27,6 +26,7 @@ import java.util.List;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.StructLikeWrapper;
 import org.junit.Assert;

--- a/core/src/test/java/org/apache/iceberg/TestDeleteFileIndex.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeleteFileIndex.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.Pair;
+import org.apache.iceberg.util.StructLikeWrapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestDeleteFileIndex extends TableTestBase {
+  public TestDeleteFileIndex() {
+    super(2 /* table format version */);
+  }
+
+  static final DeleteFile FILE_A_POS_1 = FileMetadata.deleteFileBuilder(SPEC)
+      .ofPositionDeletes()
+      .withPath("/path/to/data-a-pos-deletes.parquet")
+      .withFileSizeInBytes(10)
+      .withPartition(FILE_A.partition())
+      .withRecordCount(1)
+      .build();
+  static final DeleteFile FILE_A_POS_2 = FILE_A_POS_1.copy();
+
+  static final DeleteFile FILE_A_EQ_1 = FileMetadata.deleteFileBuilder(SPEC)
+      .ofEqualityDeletes()
+      .withPath("/path/to/data-a-eq-deletes.parquet")
+      .withFileSizeInBytes(10)
+      .withPartition(FILE_A.partition())
+      .withRecordCount(1)
+      .build();
+  static final DeleteFile FILE_A_EQ_2 = FILE_A_EQ_1.copy();
+  static final DeleteFile[] DELETE_FILES = new DeleteFile[] { FILE_A_POS_1, FILE_A_EQ_1, FILE_A_POS_2, FILE_A_EQ_2 };
+
+  static final DataFile UNPARTITIONED_FILE = DataFiles.builder(PartitionSpec.unpartitioned())
+      .withPath("/path/to/data-a.parquet")
+      .withFileSizeInBytes(10)
+      .withRecordCount(1)
+      .build();
+
+  static final DeleteFile UNPARTITIONED_POS_DELETES = FileMetadata.deleteFileBuilder(SPEC)
+      .ofPositionDeletes()
+      .withPath("/path/to/data-a-pos-deletes.parquet")
+      .withFileSizeInBytes(10)
+      .withRecordCount(1)
+      .build();
+
+  static final DeleteFile UNPARTITIONED_EQ_DELETES = FileMetadata.deleteFileBuilder(SPEC)
+      .ofEqualityDeletes()
+      .withPath("/path/to/data-a-eq-deletes.parquet")
+      .withFileSizeInBytes(10)
+      .withRecordCount(1)
+      .build();
+
+  @Test
+  public void testUnpartitionedDeletes() {
+    StructLike emptyPartition = new PartitionData(PartitionSpec.unpartitioned().partitionType());
+
+    DeleteFileIndex index = new DeleteFileIndex(ImmutableMap.of(
+        StructLikeWrapper.wrap(emptyPartition), Pair.of(
+            new long[] { 3, 5, 5, 6 },
+            DELETE_FILES)));
+
+    Assert.assertArrayEquals("All deletes should apply to seq 0",
+        DELETE_FILES, index.forDataFile(0, UNPARTITIONED_FILE));
+    Assert.assertArrayEquals("All deletes should apply to seq 3",
+        DELETE_FILES, index.forDataFile(3, UNPARTITIONED_FILE));
+    Assert.assertArrayEquals("Last 3 deletes should apply to seq 4",
+        Arrays.copyOfRange(DELETE_FILES, 1, 4), index.forDataFile(4, UNPARTITIONED_FILE));
+    Assert.assertArrayEquals("Last 3 deletes should apply to seq 5",
+        Arrays.copyOfRange(DELETE_FILES, 1, 4), index.forDataFile(5, UNPARTITIONED_FILE));
+    Assert.assertArrayEquals("Last delete should apply to seq 6",
+        Arrays.copyOfRange(DELETE_FILES, 3, 4), index.forDataFile(6, UNPARTITIONED_FILE));
+    Assert.assertArrayEquals("No deletes should apply to seq 7",
+        new DataFile[0], index.forDataFile(7, UNPARTITIONED_FILE));
+    Assert.assertArrayEquals("No deletes should apply to seq 10",
+        new DataFile[0], index.forDataFile(10, UNPARTITIONED_FILE));
+
+    Assert.assertEquals("No deletes should apply to partitioned files, partition not in index",
+        0, index.forDataFile(0, FILE_B).length);
+  }
+
+  @Test
+  public void testPartitionedDeleteIndex() {
+    DeleteFileIndex index = new DeleteFileIndex(ImmutableMap.of(
+        StructLikeWrapper.wrap(FILE_A.partition()), Pair.of(
+            new long[] { 3, 5, 5, 6 },
+            DELETE_FILES),
+        StructLikeWrapper.wrap(FILE_C.partition()), Pair.of(
+            new long[0],
+            new DeleteFile[0])));
+
+    Assert.assertArrayEquals("All deletes should apply to seq 0",
+        DELETE_FILES, index.forDataFile(0, FILE_A));
+    Assert.assertArrayEquals("All deletes should apply to seq 3",
+        DELETE_FILES, index.forDataFile(3, FILE_A));
+    Assert.assertArrayEquals("Last 3 deletes should apply to seq 4",
+        Arrays.copyOfRange(DELETE_FILES, 1, 4), index.forDataFile(4, FILE_A));
+    Assert.assertArrayEquals("Last 3 deletes should apply to seq 5",
+        Arrays.copyOfRange(DELETE_FILES, 1, 4), index.forDataFile(5, FILE_A));
+    Assert.assertArrayEquals("Last delete should apply to seq 6",
+        Arrays.copyOfRange(DELETE_FILES, 3, 4), index.forDataFile(6, FILE_A));
+    Assert.assertArrayEquals("No deletes should apply to seq 7",
+        new DataFile[0], index.forDataFile(7, FILE_A));
+    Assert.assertArrayEquals("No deletes should apply to seq 10",
+        new DataFile[0], index.forDataFile(10, FILE_A));
+
+    Assert.assertEquals("No deletes should apply to FILE_B, partition not in index",
+        0, index.forDataFile(0, FILE_B).length);
+
+    Assert.assertEquals("No deletes should apply to FILE_C, no indexed delete files",
+        0, index.forDataFile(0, FILE_C).length);
+  }
+
+  @Test
+  public void testUnpartitionedTableScan() throws IOException {
+    File location = temp.newFolder();
+    Assert.assertTrue(location.delete());
+
+    Table unpartitioned = TestTables.create(location, "unpartitioned", SCHEMA, PartitionSpec.unpartitioned(), 2);
+
+    unpartitioned.newAppend()
+        .appendFile(FILE_A)
+        .commit();
+
+    // add a delete file
+    unpartitioned.newRowDelta()
+        .addDeletes(UNPARTITIONED_POS_DELETES)
+        .commit();
+
+    List<FileScanTask> tasks = Lists.newArrayList(unpartitioned.newScan().planFiles().iterator());
+    Assert.assertEquals("Should have one task", 1, tasks.size());
+
+    FileScanTask task = tasks.get(0);
+    Assert.assertEquals("Should have the correct data file path",
+        UNPARTITIONED_FILE.path(), task.file().path());
+    Assert.assertEquals("Should have one associated delete file",
+        1, task.deletes().size());
+    Assert.assertEquals("Should have expected delete file",
+        UNPARTITIONED_POS_DELETES.path(), task.deletes().get(0).path());
+
+    // add a second delete file
+    unpartitioned.newRowDelta()
+        .addDeletes(UNPARTITIONED_EQ_DELETES)
+        .commit();
+
+    tasks = Lists.newArrayList(unpartitioned.newScan().planFiles().iterator());
+    task = tasks.get(0);
+    Assert.assertEquals("Should have the correct data file path",
+        UNPARTITIONED_FILE.path(), task.file().path());
+    Assert.assertEquals("Should have two associated delete files",
+        2, task.deletes().size());
+    Assert.assertEquals("Should have expected delete files",
+        Lists.newArrayList(UNPARTITIONED_POS_DELETES.path(), UNPARTITIONED_EQ_DELETES.path()),
+        Lists.transform(task.deletes(), ContentFile::path));
+  }
+
+  @Test
+  public void testUnpartitionedTableSequenceNumbers() throws IOException {
+    File location = temp.newFolder();
+    Assert.assertTrue(location.delete());
+
+    Table unpartitioned = TestTables.create(location, "unpartitioned", SCHEMA, PartitionSpec.unpartitioned(), 2);
+
+    // add data, pos deletes, and eq deletes in the same sequence number
+    // the position deletes will be applied to the data file, but the equality deletes will not
+    unpartitioned.newRowDelta()
+        .addRows(FILE_A)
+        .addDeletes(UNPARTITIONED_POS_DELETES)
+        .addDeletes(UNPARTITIONED_EQ_DELETES)
+        .commit();
+
+    Assert.assertEquals("Table should contain 2 delete files",
+        2, (long) unpartitioned.currentSnapshot().deleteManifests().get(0).addedFilesCount());
+
+    List<FileScanTask> tasks = Lists.newArrayList(unpartitioned.newScan().planFiles().iterator());
+    Assert.assertEquals("Should have one task", 1, tasks.size());
+
+    FileScanTask task = tasks.get(0);
+    Assert.assertEquals("Should have the correct data file path",
+        UNPARTITIONED_FILE.path(), task.file().path());
+    Assert.assertEquals("Should have one associated delete file",
+        1, task.deletes().size());
+    Assert.assertEquals("Should have only pos delete file",
+        UNPARTITIONED_POS_DELETES.path(), task.deletes().get(0).path());
+  }
+}


### PR DESCRIPTION
This adds `DeleteFileIndex` to scan delete manifests and index delete files, updates `ManifestGroup` to use the index when planning tasks, and adds delete files to `FileScanTask`.

The `DeleteFileIndex` uses a map keyed by partition spec ID and partition tuple. Values of the map are sorted list of sequence numbers and corresponding `DeleteFile` instances. When looking up a `DataFile`, the potentially matching delete files are fetched using its partition tuple, then the sequence numbers are binary searched to find the matching set of delete files with sequence numbers higher than the data file.

The index also supports global equality delete files. If an equality delete file is added to the table with an unpartitioned spec, it will be returned for all data files with a lower sequence number, regardless of partition.