### PR TITLE
Add position delete filter and utils

### DIFF
--- a/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.deletes;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import org.apache.iceberg.Accessor;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.io.CloseableGroup;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.Comparators;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.Filter;
+import org.apache.iceberg.util.FilterIterator;
+import org.apache.iceberg.util.SortedMerge;
+import org.apache.iceberg.util.StructLikeWrapper;
+
+public class Deletes {
+  private static final Schema POSITION_DELETE_SCHEMA = new Schema(
+      Types.NestedField.required(1, "filename", Types.StringType.get(), "Data file location of the deleted row"),
+      Types.NestedField.required(2, "pos", Types.LongType.get(), "Row position in the data file of the deleted row")
+  );
+
+  private static final Accessor<StructLike> FILENAME_ACCESSOR = POSITION_DELETE_SCHEMA.accessorForField(1);
+  private static final Accessor<StructLike> POSITION_ACCESSOR = POSITION_DELETE_SCHEMA.accessorForField(2);
+
+  private Deletes() {
+  }
+
+  public static <T> CloseableIterable<T> positionFilter(CloseableIterable<T> rows, Function<T, Long> rowToPosition,
+                                                        CloseableIterable<Long> posDeletes) {
+    return new PositionDeleteFilter<>(rows, rowToPosition, posDeletes);
+  }
+
+  public static CloseableIterable<Long> deletePositions(String dataLocation, CloseableIterable<StructLike> posDeletes) {
+    return deletePositions(dataLocation, ImmutableList.of(posDeletes));
+  }
+
+  public static CloseableIterable<Long> deletePositions(String dataLocation,
+                                                        List<CloseableIterable<StructLike>> deleteFiles) {
+    DataFileFilter locationFilter = new DataFileFilter(dataLocation);
+    List<CloseableIterable<Long>> positions = Lists.transform(deleteFiles, deletes ->
+        CloseableIterable.transform(locationFilter.filter(deletes), row -> (Long) POSITION_ACCESSOR.get(row)));
+
+    return new SortedMerge<>(Long::compare, positions);
+  }
+
+  private static class PositionDeleteFilter<T> extends CloseableGroup implements CloseableIterable<T> {
+    private final CloseableIterable<T> rows;
+    private final Function<T, Long> extractPos;
+    private final CloseableIterable<Long> deletePositions;
+
+    private PositionDeleteFilter(CloseableIterable<T> rows, Function<T, Long> extractPos, CloseableIterable<Long> deletePositions) {
+      this.rows = rows;
+      this.extractPos = extractPos;
+      this.deletePositions = deletePositions;
+    }
+
+    @Override
+    public CloseableIterator<T> iterator() {
+      CloseableIterator<Long> deletePosIterator = deletePositions.iterator();
+
+      CloseableIterator<T> iter;
+      if (deletePosIterator.hasNext()) {
+        iter = new PositionFilterIterator(rows.iterator(), deletePosIterator);
+      } else {
+        iter = rows.iterator();
+        try {
+          deletePosIterator.close();
+        } catch (IOException e) {
+          throw new UncheckedIOException("Failed to close delete positions iterator", e);
+        }
+      }
+
+      addCloseable(iter);
+
+      return iter;
+    }
+
+    private class PositionFilterIterator extends FilterIterator<T> {
+      private final CloseableIterator<Long> deletePosIterator;
+      private long nextDeletePos;
+
+      protected PositionFilterIterator(CloseableIterator<T> items, CloseableIterator<Long> deletePositions) {
+        super(items);
+        this.deletePosIterator = deletePositions;
+        this.nextDeletePos = deletePosIterator.next();
+      }
+
+      @Override
+      protected boolean shouldKeep(T row) {
+        long currentPos = extractPos.apply(row);
+        if (currentPos < nextDeletePos) {
+          return true;
+        }
+
+        // consume delete positions until the next is past the current position
+        boolean keep = currentPos != nextDeletePos;
+        while (deletePosIterator.hasNext() && nextDeletePos <= currentPos) {
+          this.nextDeletePos = deletePosIterator.next();
+          if (keep && currentPos == nextDeletePos) {
+            // if any delete position matches the current position, discard
+            keep = false;
+          }
+        }
+
+        return keep;
+      }
+
+      @Override
+      public void close() {
+        super.close();
+        try {
+          deletePosIterator.close();
+        } catch (IOException e) {
+          throw new UncheckedIOException("Failed to close delete positions iterator", e);
+        }
+      }
+    }
+  }
+
+  private static class DataFileFilter extends Filter<StructLike> {
+    private static final Comparator<CharSequence> CHARSEQ_COMPARATOR = Comparators.charSequences();
+    private final String dataLocation;
+
+    DataFileFilter(String dataLocation) {
+      this.dataLocation = dataLocation;
+    }
+
+    @Override
+    protected boolean shouldKeep(StructLike posDelete) {
+      return CHARSEQ_COMPARATOR.compare(dataLocation, (CharSequence) FILENAME_ACCESSOR.get(posDelete)) == 0;
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
@@ -40,7 +40,7 @@ import org.apache.iceberg.util.SortedMerge;
 
 public class Deletes {
   private static final Schema POSITION_DELETE_SCHEMA = new Schema(
-      Types.NestedField.required(1, "filename", Types.StringType.get(), "Data file location of the deleted row"),
+      Types.NestedField.required(1, "file_path", Types.StringType.get(), "Data file location of the deleted row"),
       Types.NestedField.required(2, "pos", Types.LongType.get(), "Row position in the data file of the deleted row")
   );
 

--- a/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Function;
 import org.apache.iceberg.Accessor;
 import org.apache.iceberg.Schema;
@@ -31,17 +30,13 @@ import org.apache.iceberg.StructLike;
 import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.Filter;
 import org.apache.iceberg.util.FilterIterator;
 import org.apache.iceberg.util.SortedMerge;
-import org.apache.iceberg.util.StructLikeWrapper;
 
 public class Deletes {
   private static final Schema POSITION_DELETE_SCHEMA = new Schema(

--- a/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
@@ -73,7 +73,8 @@ public class Deletes {
     private final Function<T, Long> extractPos;
     private final CloseableIterable<Long> deletePositions;
 
-    private PositionDeleteFilter(CloseableIterable<T> rows, Function<T, Long> extractPos, CloseableIterable<Long> deletePositions) {
+    private PositionDeleteFilter(CloseableIterable<T> rows, Function<T, Long> extractPos,
+                                 CloseableIterable<Long> deletePositions) {
       this.rows = rows;
       this.extractPos = extractPos;
       this.deletePositions = deletePositions;

--- a/core/src/main/java/org/apache/iceberg/util/Filter.java
+++ b/core/src/main/java/org/apache/iceberg/util/Filter.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import org.apache.iceberg.io.CloseableIterable;
+
+/**
+ *
+ * @param <T> the type of objects filtered by this Filter
+ */
+public abstract class Filter<T> {
+
+  protected abstract boolean shouldKeep(T item);
+
+  public Iterable<T> filter(Iterable<T> items) {
+    return () -> new Iterator(items.iterator());
+  }
+
+  public CloseableIterable<T> filter(CloseableIterable<T> items) {
+    return CloseableIterable.combine(filter((Iterable<T>) items), items);
+  }
+
+  private class Iterator extends FilterIterator<T> {
+    protected Iterator(java.util.Iterator<T> items) {
+      super(items);
+    }
+
+    @Override
+    protected boolean shouldKeep(T item) {
+      return Filter.this.shouldKeep(item);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/util/FilterIterator.java
+++ b/core/src/main/java/org/apache/iceberg/util/FilterIterator.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import org.apache.iceberg.io.CloseableIterator;
+
+/**
+ * An Iterator that filters another Iterator.
+ *
+ * @param <T> the type of objects produced by this Iterator
+ */
+public abstract class FilterIterator<T> implements CloseableIterator<T> {
+  private final Iterator<T> items;
+  private boolean closed;
+  private boolean hasNext;
+  private T next;
+
+  protected FilterIterator(Iterator<T> items) {
+    this.items = items;
+    this.closed = false;
+    this.next = null;
+    this.hasNext = false;
+  }
+
+  protected abstract boolean shouldKeep(T item);
+
+  @Override
+  public boolean hasNext() {
+    return hasNext || advance();
+  }
+
+  @Override
+  public T next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+
+    T returnVal = next;
+
+    advance();
+
+    return returnVal;
+  }
+
+  private boolean advance() {
+    while (!closed && items.hasNext()) {
+      this.next = items.next();
+      if (shouldKeep(next)) {
+        this.hasNext = true;
+        return true;
+      }
+    }
+
+    close();
+
+    this.hasNext = false;
+    return false;
+  }
+
+  @Override
+  public void close() {
+    if (!closed) {
+      try {
+        ((Closeable) items).close();
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+
+      this.closed = true;
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/util/SortedMerge.java
+++ b/core/src/main/java/org/apache/iceberg/util/SortedMerge.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.PriorityQueue;
+import java.util.stream.Collectors;
+import org.apache.iceberg.io.CloseableGroup;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
+
+/**
+ * An Iterable that merges the items from other Iterables in order.
+ * <p>
+ * This assumes that the Iterables passed in produce items in sorted order.
+ *
+ * @param <T> the type of objects produced by this Iterable
+ */
+public class SortedMerge<T> extends CloseableGroup implements CloseableIterable<T> {
+  private final Comparator<T> comparator;
+  private final List<CloseableIterable<T>> iterables;
+
+  public SortedMerge(Comparator<T> comparator, List<CloseableIterable<T>> iterables) {
+    this.comparator = comparator;
+    this.iterables = iterables;
+  }
+
+  @Override
+  public CloseableIterator<T> iterator() {
+    List<CloseableIterator<T>> iterators = iterables.stream()
+        .map(CloseableIterable::iterator)
+        .filter(Iterator::hasNext)
+        .collect(Collectors.toList());
+
+    if (iterators.size() == 1) {
+      addCloseable(iterators.get(0));
+      return iterators.get(0);
+    } else {
+      CloseableIterator<T> merge = new MergeIterator(iterators);
+      addCloseable(merge);
+      return merge;
+    }
+  }
+
+  /**
+   * An Iterator that merges the items from other Iterators in order.
+   * <p>
+   * This assumes that the Iterators passed in produce items in sorted order.
+   */
+  private class MergeIterator implements CloseableIterator<T> {
+    private final PriorityQueue<Pair<T, Iterator<T>>> heap;
+
+    private MergeIterator(Iterable<CloseableIterator<T>> iterators) {
+      this.heap = new PriorityQueue<>(Comparator.comparing(Pair::first, comparator));
+      iterators.forEach(this::addNext);
+    }
+
+    @Override
+    public boolean hasNext() {
+      return !heap.isEmpty();
+    }
+
+    @Override
+    public T next() {
+      if (heap.isEmpty()) {
+        throw new NoSuchElementException();
+      }
+
+      Pair<T, Iterator<T>> pair = heap.poll();
+
+      addNext(pair.second());
+
+      return pair.first();
+    }
+
+    private void addNext(Iterator<T> iter) {
+      if (iter.hasNext()) {
+        heap.add(Pair.of(iter.next(), iter));
+      } else {
+        close(iter);
+      }
+    }
+
+    @Override
+    public void close() throws IOException {
+      while (!heap.isEmpty()) {
+        Pair<T, Iterator<T>> pair = heap.poll();
+        close(pair.second());
+      }
+    }
+
+    private void close(Iterator<?> iter) {
+      if (iter instanceof Closeable) {
+        try {
+          ((Closeable) iter).close();
+        } catch (IOException e) {
+          throw new UncheckedIOException(e);
+        }
+      }
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/deletes/TestPositionFilter.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestPositionFilter.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.deletes;
+
+import com.google.common.collect.Iterables;
+import java.util.List;
+import org.apache.avro.util.Utf8;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.TestHelpers.Row;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestPositionFilter {
+  @Test
+  public void testPositionFileFilter() {
+    List<StructLike> positionDeletes = Lists.newArrayList(
+        Row.of("file_a.avro", 0L),
+        Row.of("file_a.avro", 3L),
+        Row.of(new Utf8("file_a.avro"), 9L),
+        Row.of("file_a.avro", 22L),
+        Row.of("file_a.avro", 56L),
+        Row.of(new Utf8("file_b.avro"), 16L),
+        Row.of("file_b.avro", 19L),
+        Row.of("file_b.avro", 63L),
+        Row.of("file_b.avro", 70L),
+        Row.of("file_b.avro", 91L)
+    );
+
+    Assert.assertEquals("Should contain only file_a positions",
+        Lists.newArrayList(0L, 3L, 9L, 22L, 56L),
+        Lists.newArrayList(Deletes.deletePositions("file_a.avro", CloseableIterable.withNoopClose(positionDeletes))));
+
+    Assert.assertEquals("Should contain only file_b positions",
+        Lists.newArrayList(16L, 19L, 63L, 70L, 91L),
+        Lists.newArrayList(Deletes.deletePositions("file_b.avro", CloseableIterable.withNoopClose(positionDeletes))));
+
+    Assert.assertEquals("Should contain no positions for file_c",
+        Lists.newArrayList(),
+        Lists.newArrayList(Deletes.deletePositions("file_c.avro", CloseableIterable.withNoopClose(positionDeletes))));
+  }
+
+  @Test
+  public void testPositionMerging() {
+    List<StructLike> positionDeletes1 = Lists.newArrayList(
+        Row.of("file_a.avro", 0L),
+        Row.of("file_a.avro", 3L),
+        Row.of("file_a.avro", 9L),
+        Row.of("file_a.avro", 22L),
+        Row.of("file_a.avro", 56L)
+    );
+
+    List<StructLike> positionDeletes2 = Lists.newArrayList(
+        Row.of("file_a.avro", 16L),
+        Row.of("file_a.avro", 19L),
+        Row.of("file_a.avro", 63L),
+        Row.of("file_a.avro", 70L),
+        Row.of("file_a.avro", 91L)
+    );
+
+    List<StructLike> positionDeletes3 = Lists.newArrayList(
+        Row.of("file_a.avro", 3L),
+        Row.of("file_a.avro", 19L),
+        Row.of("file_a.avro", 22L)
+    );
+
+    List<CloseableIterable<StructLike>> deletes = Lists.newArrayList(
+        CloseableIterable.withNoopClose(positionDeletes1),
+        CloseableIterable.withNoopClose(positionDeletes2),
+        CloseableIterable.withNoopClose(positionDeletes3)
+    );
+
+    Assert.assertEquals("Should merge deletes in order, with duplicates",
+        Lists.newArrayList(0L, 3L, 3L, 9L, 16L, 19L, 19L, 22L, 22L, 56L, 63L, 70L, 91L),
+        Lists.newArrayList(Deletes.deletePositions("file_a.avro", deletes)));
+  }
+
+  @Test
+  public void testPositionRowFilter() {
+    CloseableIterable<StructLike> rows = CloseableIterable.withNoopClose(Lists.newArrayList(
+        Row.of(0L, "a"),
+        Row.of(1L, "b"),
+        Row.of(2L, "c"),
+        Row.of(3L, "d"),
+        Row.of(4L, "e"),
+        Row.of(5L, "f"),
+        Row.of(6L, "g"),
+        Row.of(7L, "h"),
+        Row.of(8L, "i"),
+        Row.of(9L, "j")
+    ));
+
+    CloseableIterable<Long> deletes = CloseableIterable.withNoopClose(Lists.newArrayList(0L, 3L, 4L, 7L, 9L));
+
+    CloseableIterable<StructLike> actual = Deletes.positionFilter(rows, row -> row.get(0, Long.class), deletes);
+    Assert.assertEquals("Filter should produce expected rows",
+        Lists.newArrayList(1L, 2L, 5L, 6L, 8L),
+        Lists.newArrayList(Iterables.transform(actual, row -> row.get(0, Long.class))));
+  }
+
+  @Test
+  public void testPositionRowFilterWithDuplicates() {
+    CloseableIterable<StructLike> rows = CloseableIterable.withNoopClose(Lists.newArrayList(
+        Row.of(0L, "a"),
+        Row.of(1L, "b"),
+        Row.of(2L, "c"),
+        Row.of(3L, "d"),
+        Row.of(4L, "e"),
+        Row.of(5L, "f"),
+        Row.of(6L, "g"),
+        Row.of(7L, "h"),
+        Row.of(8L, "i"),
+        Row.of(9L, "j")
+    ));
+
+    CloseableIterable<Long> deletes = CloseableIterable.withNoopClose(
+        Lists.newArrayList(0L, 0L, 0L, 3L, 4L, 7L, 7L, 9L, 9L, 9L));
+
+    CloseableIterable<StructLike> actual = Deletes.positionFilter(rows, row -> row.get(0, Long.class), deletes);
+    Assert.assertEquals("Filter should produce expected rows",
+        Lists.newArrayList(1L, 2L, 5L, 6L, 8L),
+        Lists.newArrayList(Iterables.transform(actual, row -> row.get(0, Long.class))));
+  }
+
+  @Test
+  public void testPositionRowFilterWithRowGaps() {
+    // test the case where row position is greater than the delete position
+    CloseableIterable<StructLike> rows = CloseableIterable.withNoopClose(Lists.newArrayList(
+        Row.of(2L, "c"),
+        Row.of(3L, "d"),
+        Row.of(5L, "f"),
+        Row.of(6L, "g")
+    ));
+
+    CloseableIterable<Long> deletes = CloseableIterable.withNoopClose(Lists.newArrayList(0L, 3L, 4L, 7L, 9L));
+
+    CloseableIterable<StructLike> actual = Deletes.positionFilter(rows, row -> row.get(0, Long.class), deletes);
+    Assert.assertEquals("Filter should produce expected rows",
+        Lists.newArrayList(2L, 5L, 6L),
+        Lists.newArrayList(Iterables.transform(actual, row -> row.get(0, Long.class))));
+  }
+
+  @Test
+  public void testCombinedPositionRowFilter() {
+    CloseableIterable<StructLike> positionDeletes1 = CloseableIterable.withNoopClose(Lists.newArrayList(
+        Row.of("file_a.avro", 0L),
+        Row.of("file_a.avro", 3L),
+        Row.of("file_a.avro", 9L),
+        Row.of("file_b.avro", 5L),
+        Row.of("file_b.avro", 6L)
+    ));
+
+    CloseableIterable<StructLike> positionDeletes2 = CloseableIterable.withNoopClose(Lists.newArrayList(
+        Row.of("file_a.avro", 3L),
+        Row.of("file_a.avro", 4L),
+        Row.of("file_a.avro", 7L),
+        Row.of("file_b.avro", 2L)
+    ));
+
+    CloseableIterable<StructLike> rows = CloseableIterable.withNoopClose(Lists.newArrayList(
+        Row.of(0L, "a"),
+        Row.of(1L, "b"),
+        Row.of(2L, "c"),
+        Row.of(3L, "d"),
+        Row.of(4L, "e"),
+        Row.of(5L, "f"),
+        Row.of(6L, "g"),
+        Row.of(7L, "h"),
+        Row.of(8L, "i"),
+        Row.of(9L, "j")
+    ));
+
+    CloseableIterable<StructLike> actual = Deletes.positionFilter(
+        rows,
+        row -> row.get(0, Long.class),
+        Deletes.deletePositions("file_a.avro", ImmutableList.of(positionDeletes1, positionDeletes2)));
+
+    Assert.assertEquals("Filter should produce expected rows",
+        Lists.newArrayList(1L, 2L, 5L, 6L, 8L),
+        Lists.newArrayList(Iterables.transform(actual, row -> row.get(0, Long.class))));
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/deletes/TestPositionFilter.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestPositionFilter.java
@@ -19,13 +19,13 @@
 
 package org.apache.iceberg.deletes;
 
-import com.google.common.collect.Iterables;
 import java.util.List;
 import org.apache.avro.util.Utf8;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.TestHelpers.Row;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.Test;


### PR DESCRIPTION
This adds a position delete row filter and helpers for constructing a row filter that will filter deletes to a specific data file and merge deletes from multiple delete files. These utilities are written using `CloseableIterable` and handle file closing.