### PR TITLE
Fix struct comparison and add struct and partition set implementations

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Comparators.java
+++ b/api/src/main/java/org/apache/iceberg/types/Comparators.java
@@ -21,6 +21,10 @@ package org.apache.iceberg.types;
 
 import java.nio.ByteBuffer;
 import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.IntFunction;
+import org.apache.iceberg.StructLike;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.util.UnicodeUtil;
 
@@ -44,6 +48,14 @@ public class Comparators {
       .put(Types.BinaryType.get(), Comparators.unsignedBytes())
       .build();
 
+  public static Comparator<StructLike> forType(Types.StructType struct) {
+    return new StructLikeComparator(struct);
+  }
+
+  public static <T> Comparator<List<T>> forType(Types.ListType list) {
+    return new ListComparator<>(list);
+  }
+
   @SuppressWarnings("unchecked")
   public static <T> Comparator<T> forType(Type.PrimitiveType type) {
     Comparator<?> cmp = COMPARATORS.get(type);
@@ -56,6 +68,82 @@ public class Comparators {
     }
 
     throw new UnsupportedOperationException("Cannot determine comparator for type: " + type);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> Comparator<T> internal(Type type) {
+    if (type.isPrimitiveType()) {
+      return forType(type.asPrimitiveType());
+    } else if (type.isStructType()) {
+      return (Comparator<T>) forType(type.asStructType());
+    } else if (type.isListType()) {
+      return (Comparator<T>) forType(type.asListType());
+    }
+
+    throw new UnsupportedOperationException("Cannot determine comparator for type: " + type);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> Class<T> internalClass(Type type) {
+    if (type.isPrimitiveType()) {
+      return (Class<T>) type.typeId().javaClass();
+    } else if (type.isStructType()) {
+      return (Class<T>) StructLike.class;
+    } else if (type.isListType()) {
+      return (Class<T>) List.class;
+    } else if (type.isMapType()) {
+      return (Class<T>) Map.class;
+    }
+
+    throw new UnsupportedOperationException("Cannot determine expected class for type: " + type);
+  }
+
+  private static class StructLikeComparator implements Comparator<StructLike> {
+    private final Comparator<Object>[] comparators;
+    private final Class<?>[] classes;
+
+    private StructLikeComparator(Types.StructType struct) {
+      this.comparators = struct.fields().stream()
+          .map(field -> internal(field.type()))
+          .toArray((IntFunction<Comparator<Object>[]>) Comparator[]::new);
+      this.classes = struct.fields().stream()
+          .map(field -> internalClass(field.type()))
+          .toArray(Class<?>[]::new);
+    }
+
+    @Override
+    public int compare(StructLike o1, StructLike o2) {
+      for (int i = 0; i < comparators.length; i += 1) {
+        Class<?> valueClass = classes[i];
+        int cmp = comparators[i].compare(o1.get(i, valueClass), o2.get(i, valueClass));
+        if (cmp != 0) {
+          return cmp;
+        }
+      }
+
+      return 0;
+    }
+  }
+
+  private static class ListComparator<T> implements Comparator<List<T>> {
+    private final Comparator<T> elementComparator;
+
+    private ListComparator(Types.ListType list) {
+      this.elementComparator = internal(list.elementType());
+    }
+
+    @Override
+    public int compare(List<T> o1, List<T> o2) {
+      int length = Math.min(o1.size(), o2.size());
+      for (int i = 0; i < length; i += 1) {
+        int cmp = elementComparator.compare(o1.get(i), o2.get(i));
+        if (cmp != 0) {
+          return cmp;
+        }
+      }
+
+      return Integer.compare(o1.size(), o2.size());
+    }
   }
 
   public static Comparator<ByteBuffer> unsignedBytes() {

--- a/api/src/main/java/org/apache/iceberg/types/JavaHash.java
+++ b/api/src/main/java/org/apache/iceberg/types/JavaHash.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.types;
+
+import java.util.Objects;
+
+@FunctionalInterface
+public interface JavaHash<T> {
+  int hash(T value);
+
+  @SuppressWarnings("unchecked")
+  static <T> JavaHash<T> forType(Type type) {
+    switch (type.typeId()) {
+      case STRING:
+        return (JavaHash<T>) JavaHashes.strings();
+      case STRUCT:
+        return (JavaHash<T>) JavaHashes.struct(type.asStructType());
+      case LIST:
+        return (JavaHash<T>) JavaHashes.list(type.asListType());
+      default:
+        return Objects::hashCode;
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/types/JavaHashes.java
+++ b/api/src/main/java/org/apache/iceberg/types/JavaHashes.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.types;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.function.IntFunction;
+import org.apache.iceberg.StructLike;
+
+public class JavaHashes {
+  public static int hashCode(CharSequence str) {
+    int result = 177;
+    for (int i = 0; i < str.length(); i += 1) {
+      char ch = str.charAt(i);
+      result = 31 * result + (int) ch;
+    }
+    return result;
+  }
+
+  static JavaHash<CharSequence> strings() {
+    return CharSequenceHash.INSTANCE;
+  }
+
+  static JavaHash<StructLike> struct(Types.StructType struct) {
+    return new StructLikeHash(struct);
+  }
+
+  static JavaHash<List<?>> list(Types.ListType list) {
+    return new ListHash(list);
+  }
+
+  private static class CharSequenceHash implements JavaHash<CharSequence> {
+    private static final CharSequenceHash INSTANCE = new CharSequenceHash();
+
+    private CharSequenceHash() {
+    }
+
+    @Override
+    public int hash(CharSequence str) {
+      if (str == null) {
+        return 0;
+      }
+
+      return JavaHashes.hashCode(str);
+    }
+  }
+
+  private static class StructLikeHash implements JavaHash<StructLike> {
+    private final JavaHash<Object>[] hashes;
+
+    private StructLikeHash(Types.StructType struct) {
+      this.hashes = struct.fields().stream()
+          .map(field ->
+            "unknown-partition".equals(field.doc()) ?
+                (JavaHash<Object>) Objects::hashCode :
+                JavaHash.forType(field.type()))
+          .toArray((IntFunction<JavaHash<Object>[]>) JavaHash[]::new);
+    }
+
+    @Override
+    public int hash(StructLike struct) {
+      int result = 97;
+      int len = hashes.length;
+      result = 41 * result + len;
+      for (int i = 0; i < len; i += 1) {
+        result = 41 * result + hashes[i].hash(struct.get(i, Object.class));
+      }
+      return result;
+    }
+  }
+
+  private static class ListHash implements JavaHash<List<?>> {
+    private final JavaHash<Object> elementHash;
+
+    private ListHash(Types.ListType list) {
+      this.elementHash = JavaHash.forType(list.elementType());
+    }
+
+    @Override
+    public int hash(List<?> list) {
+      int result = 17;
+      int len = list.size();
+      result = 37 * result + len;
+      for (int i = 0; i < len; i += 1) {
+        result = 37 * result + elementHash.hash(list.get(i));
+      }
+      return result;
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/types/JavaHashes.java
+++ b/api/src/main/java/org/apache/iceberg/types/JavaHashes.java
@@ -25,6 +25,9 @@ import java.util.function.IntFunction;
 import org.apache.iceberg.StructLike;
 
 public class JavaHashes {
+  private JavaHashes() {
+  }
+
   public static int hashCode(CharSequence str) {
     int result = 177;
     for (int i = 0; i < str.length(); i += 1) {

--- a/api/src/main/java/org/apache/iceberg/util/CharSequenceWrapper.java
+++ b/api/src/main/java/org/apache/iceberg/util/CharSequenceWrapper.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.util;
 
 import java.io.Serializable;
 import org.apache.iceberg.types.Comparators;
+import org.apache.iceberg.types.JavaHashes;
 
 /**
  * Wrapper class to adapt CharSequence for use in maps and sets.
@@ -59,12 +60,7 @@ public class CharSequenceWrapper implements CharSequence, Serializable {
 
   @Override
   public int hashCode() {
-    int result = 177;
-    for (int i = 0; i < wrapped.length(); i += 1) {
-      char ch = wrapped.charAt(i);
-      result = 31 * result + (int) ch;
-    }
-    return result;
+    return JavaHashes.hashCode(wrapped);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -75,7 +75,7 @@ public class PartitionsTable extends BaseMetadataTable {
   }
 
   private static Iterable<Partition> partitions(Table table, Long snapshotId) {
-    PartitionSet partitions = new PartitionSet();
+    PartitionMap partitions = new PartitionMap(table.spec().partitionType());
     TableScan scan = table.newScan();
 
     if (snapshotId != null) {
@@ -95,15 +95,21 @@ public class PartitionsTable extends BaseMetadataTable {
     }
   }
 
-  static class PartitionSet {
+  static class PartitionMap {
     private final Map<StructLikeWrapper, Partition> partitions = Maps.newHashMap();
-    private final StructLikeWrapper reused = StructLikeWrapper.wrap(null);
+    private final Types.StructType type;
+    private final StructLikeWrapper reused;
+
+    PartitionMap(Types.StructType type) {
+      this.type = type;
+      this.reused = StructLikeWrapper.forType(type);
+    }
 
     Partition get(StructLike key) {
       Partition partition = partitions.get(reused.set(key));
       if (partition == null) {
         partition = new Partition(key);
-        partitions.put(StructLikeWrapper.wrap(key), partition);
+        partitions.put(StructLikeWrapper.forType(type).set(key), partition);
       }
       return partition;
     }

--- a/core/src/main/java/org/apache/iceberg/util/PartitionSet.java
+++ b/core/src/main/java/org/apache/iceberg/util/PartitionSet.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.Types;
+
+public class PartitionSet implements Set<Pair<Integer, StructLike>> {
+  public static PartitionSet create(Map<Integer, PartitionSpec> specsById) {
+    return new PartitionSet(specsById);
+  }
+
+  private final Map<Integer, Types.StructType> partitionTypeById;
+  private final Map<Integer, Set<StructLike>> partitionSetById;
+
+  private PartitionSet(Map<Integer, PartitionSpec> specsById) {
+    ImmutableMap.Builder<Integer, Types.StructType> builder = ImmutableMap.builder();
+    specsById.forEach((specId, spec) -> builder.put(specId, spec.partitionType()));
+    this.partitionTypeById = builder.build();
+    this.partitionSetById = Maps.newHashMap();
+  }
+
+  @Override
+  public int size() {
+    return partitionSetById.values().stream().mapToInt(Set::size).sum();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return partitionSetById.values().stream().allMatch(Set::isEmpty);
+  }
+
+  @Override
+  public boolean contains(Object o) {
+    if (o instanceof Pair) {
+      Object first = ((Pair<?, ?>) o).first();
+      Object second = ((Pair<?, ?>) o).second();
+      if (first instanceof Integer && second instanceof StructLike) {
+        return contains((Integer) first, (StructLike) second);
+      }
+    }
+
+    return false;
+  }
+
+  public boolean contains(int specId, StructLike struct) {
+    Set<StructLike> partitionSet = partitionSetById.get(specId);
+    if (partitionSet != null) {
+      return partitionSet.contains(struct);
+    }
+
+    return false;
+  }
+
+  @Override
+  public boolean add(Pair<Integer, StructLike> pair) {
+    Preconditions.checkArgument(pair.first() != null, "Cannot track partition with null spec id");
+    return add(pair.first(), pair.second());
+  }
+
+  public boolean add(int specId, StructLike struct) {
+    Set<StructLike> partitionSet = partitionSetById.computeIfAbsent(specId,
+        id -> StructLikeSet.create(partitionTypeById.get(id)));
+    return partitionSet.add(struct);
+  }
+
+  @Override
+  public boolean remove(Object o) {
+    if (o instanceof Pair) {
+      Object first = ((Pair<?, ?>) o).first();
+      Object second = ((Pair<?, ?>) o).second();
+      if (first instanceof Integer && second instanceof StructLike) {
+        return remove((Integer) first, (StructLike) second);
+      }
+    }
+
+    return false;
+  }
+
+  public boolean remove(int specId, StructLike struct) {
+    Set<StructLike> partitionSet = partitionSetById.get(specId);
+    if (partitionSet != null) {
+      return partitionSet.remove(struct);
+    }
+
+    return false;
+  }
+
+  @Override
+  public Iterator<Pair<Integer, StructLike>> iterator() {
+    Iterable<Iterable<Pair<Integer, StructLike>>> setsAsPairs = Iterables.transform(partitionSetById.entrySet(),
+        idAndSet -> Iterables.transform(idAndSet.getValue(), struct -> Pair.of(idAndSet.getKey(), struct)));
+
+    return Iterables.concat(setsAsPairs).iterator();
+  }
+
+  @Override
+  public Object[] toArray() {
+    return Iterators.toArray(iterator(), Pair.class);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> T[] toArray(T[] destArray) {
+    int size = size();
+    if (destArray.length < size) {
+      return (T[]) toArray();
+    }
+
+    Iterator<Pair<Integer, StructLike>> iter = iterator();
+    int ind = 0;
+    while (iter.hasNext()) {
+      destArray[ind] = (T) iter.next();
+      ind += 1;
+    }
+
+    if (destArray.length > size) {
+      destArray[size] = null;
+    }
+
+    return destArray;
+  }
+
+  @Override
+  public boolean containsAll(Collection<?> objects) {
+    if (objects != null) {
+      return Iterables.all(objects, this::contains);
+    }
+    return false;
+  }
+
+  @Override
+  public boolean addAll(Collection<? extends Pair<Integer, StructLike>> pairs) {
+    boolean changed = false;
+    if (pairs != null) {
+      for (Pair<Integer, StructLike> pair : pairs) {
+        changed |= add(pair);
+      }
+    }
+    return changed;
+  }
+
+  @Override
+  public boolean retainAll(Collection<?> c) {
+    throw new UnsupportedOperationException("retainAll is not supported");
+  }
+
+  @Override
+  public boolean removeAll(Collection<?> objects) {
+    boolean changed = false;
+    if (objects != null) {
+      for (Object object : objects) {
+        changed |= remove(object);
+      }
+    }
+    return changed;
+  }
+
+  @Override
+  public void clear() {
+    partitionSetById.clear();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/util/StructLikeSet.java
+++ b/core/src/main/java/org/apache/iceberg/util/StructLikeSet.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Set;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.Types;
+
+public class StructLikeSet implements Set<StructLike> {
+  public static StructLikeSet create(Types.StructType type) {
+    return new StructLikeSet(type);
+  }
+
+  private final Types.StructType type;
+  private final Set<StructLikeWrapper> wrapperSet;
+  private final ThreadLocal<StructLikeWrapper> wrappers;
+
+  private StructLikeSet(Types.StructType type) {
+    this.type = type;
+    this.wrapperSet = Sets.newHashSet();
+    this.wrappers = ThreadLocal.withInitial(() -> StructLikeWrapper.forType(type));
+  }
+
+  @Override
+  public int size() {
+    return wrapperSet.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return wrapperSet.isEmpty();
+  }
+
+  @Override
+  public boolean contains(Object obj) {
+    if (obj instanceof StructLike) {
+      StructLikeWrapper wrapper = wrappers.get();
+      boolean result = wrapperSet.contains(wrapper.set((StructLike) obj));
+      wrapper.set(null); // don't hold a reference to the value
+      return result;
+    }
+    return false;
+  }
+
+  @Override
+  public Iterator<StructLike> iterator() {
+    return Iterators.transform(wrapperSet.iterator(), StructLikeWrapper::get);
+  }
+
+  @Override
+  public Object[] toArray() {
+    return Iterators.toArray(iterator(), StructLike.class);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> T[] toArray(T[] destArray) {
+    int size = wrapperSet.size();
+    if (destArray.length < size) {
+      return (T[]) toArray();
+    }
+
+    Iterator<StructLike> iter = iterator();
+    int ind = 0;
+    while (iter.hasNext()) {
+      destArray[ind] = (T) iter.next();
+      ind += 1;
+    }
+
+    if (destArray.length > size) {
+      destArray[size] = null;
+    }
+
+    return destArray;
+  }
+
+  @Override
+  public boolean add(StructLike struct) {
+    return wrapperSet.add(StructLikeWrapper.forType(type).set(struct));
+  }
+
+  @Override
+  public boolean remove(Object obj) {
+    if (obj instanceof CharSequence) {
+      StructLikeWrapper wrapper = wrappers.get();
+      boolean result = wrapperSet.remove(wrapper.set((StructLike) obj));
+      wrapper.set(null); // don't hold a reference to the value
+      return result;
+    }
+    return false;
+  }
+
+  @Override
+  public boolean containsAll(Collection<?> objects) {
+    if (objects != null) {
+      return Iterables.all(objects, this::contains);
+    }
+    return false;
+  }
+
+  @Override
+  public boolean addAll(Collection<? extends StructLike> structs) {
+    if (structs != null) {
+      return Iterables.addAll(wrapperSet,
+          Iterables.transform(structs, struct -> StructLikeWrapper.forType(type).set(struct)));
+    }
+    return false;
+  }
+
+  @Override
+  public boolean retainAll(Collection<?> objects) {
+    throw new UnsupportedOperationException("retailAll is not supported");
+  }
+
+  @Override
+  public boolean removeAll(Collection<?> objects) {
+    boolean changed = false;
+    if (objects != null) {
+      for (Object object : objects) {
+        changed |= remove(object);
+      }
+    }
+    return changed;
+  }
+
+  @Override
+  public void clear() {
+    wrapperSet.clear();
+  }
+}

--- a/spark/src/main/java/org/apache/iceberg/actions/RewriteDataFilesAction.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/RewriteDataFilesAction.java
@@ -247,7 +247,7 @@ public class RewriteDataFilesAction
 
     try {
       tasksIter.forEachRemaining(task -> {
-        StructLikeWrapper structLike = StructLikeWrapper.wrap(task.file().partition());
+        StructLikeWrapper structLike = StructLikeWrapper.forType(spec.partitionType()).set(task.file().partition());
         tasksGroupedByPartition.put(structLike, task);
       });
 


### PR DESCRIPTION
`StructLikeWrapper` is used to provide `equals` and `hashCode` methods that are consistent across all `StructLike` implementations. But, the implementation did not handle different implementations of `CharSequence` correctly. This fixes the implementations by adding a `Comparator` implementation for structs, and adding classes to implement Java's `hashCode`. These implementations depend on the Iceberg type of an object.

The type of a struct is not always passed to `StructLikeWrapper`, so this includes a temporary work-around to use the existing implementation for code paths that do not currently have a struct's type.

This also adds two helper classes, `StructLikeSet` and `PartitionSet`. The struct set hides `StructLikeWrapper` from callers and is based on `CharSequenceSet`. `PartitionSet` is a set implementation for partitions, which are identified by a partition spec id and a partition tuple. `PartitionSet` is needed because there are some cases where a partition tuple for different specs is identical. Updating existing classes to use these will be done in a follow-up PR.