### PR TITLE
Fix partition sets

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseReplacePartitions.java
+++ b/core/src/main/java/org/apache/iceberg/BaseReplacePartitions.java
@@ -42,7 +42,7 @@ public class BaseReplacePartitions
 
   @Override
   public ReplacePartitions addFile(DataFile file) {
-    dropPartition(file.partition());
+    dropPartition(file.specId(), file.partition());
     add(file);
     return this;
   }

--- a/core/src/main/java/org/apache/iceberg/ManifestGroup.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestGroup.java
@@ -172,10 +172,10 @@ class ManifestGroup {
       ResidualEvaluator residuals = residualCache.get(specId);
       if (dropStats) {
         return CloseableIterable.transform(entries, e -> new BaseFileScanTask(
-            e.file().copyWithoutStats(), deleteFiles.forEntry(specId, e), schemaString, specString, residuals));
+            e.file().copyWithoutStats(), deleteFiles.forEntry(e), schemaString, specString, residuals));
       } else {
         return CloseableIterable.transform(entries, e -> new BaseFileScanTask(
-            e.file().copy(), deleteFiles.forEntry(specId, e), schemaString, specString, residuals));
+            e.file().copy(), deleteFiles.forEntry(e), schemaString, specString, residuals));
       }
     });
 

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -132,10 +132,10 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
   /**
    * Add a partition tuple to drop from the table during the delete phase.
    */
-  protected void dropPartition(StructLike partition) {
+  protected void dropPartition(int specId, StructLike partition) {
     // dropping the data in a partition also drops all deletes in the partition
-    filterManager.dropPartition(partition);
-    deleteFilterManager.dropPartition(partition);
+    filterManager.dropPartition(specId, partition);
+    deleteFilterManager.dropPartition(specId, partition);
   }
 
   /**
@@ -368,9 +368,8 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
   }
 
   private class DataFileFilterManager extends ManifestFilterManager<DataFile> {
-    @Override
-    protected PartitionSpec spec(int specId) {
-      return ops.current().spec(specId);
+    private DataFileFilterManager() {
+      super(ops.current().specsById());
     }
 
     @Override
@@ -421,9 +420,8 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
   }
 
   private class DeleteFileFilterManager extends ManifestFilterManager<DeleteFile> {
-    @Override
-    protected PartitionSpec spec(int specId) {
-      return ops.current().spec(specId);
+    private DeleteFileFilterManager() {
+      super(ops.current().specsById());
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/util/StructLikeWrapper.java
+++ b/core/src/main/java/org/apache/iceberg/util/StructLikeWrapper.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.util;
 
 import java.util.Comparator;
-import java.util.Objects;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.JavaHash;
@@ -31,10 +30,6 @@ import org.apache.iceberg.types.Types;
  */
 public class StructLikeWrapper {
 
-  public static StructLikeWrapper wrap(StructLike struct) {
-    return new StructLikeWrapper(struct);
-  }
-
   public static StructLikeWrapper forType(Types.StructType struct) {
     return new StructLikeWrapper(struct);
   }
@@ -44,19 +39,9 @@ public class StructLikeWrapper {
   private Integer hashCode;
   private StructLike struct;
 
-  private StructLikeWrapper(StructLike struct) {
-    this((Types.StructType) null);
-    set(struct);
-  }
-
   private StructLikeWrapper(Types.StructType type) {
-    if (type != null) {
-      this.comparator = Comparators.forType(type);
-      this.structHash = JavaHash.forType(type);
-    } else {
-      this.comparator = null;
-      this.structHash = null;
-    }
+    this.comparator = Comparators.forType(type);
+    this.structHash = JavaHash.forType(type);
     this.hashCode = null;
   }
 
@@ -93,33 +78,13 @@ public class StructLikeWrapper {
       return false;
     }
 
-    if (comparator != null) {
-      return comparator.compare(this.struct, that.struct) == 0;
-    }
-
-    for (int i = 0; i < len; i += 1) {
-      if (!Objects.equals(struct.get(i, Object.class), that.struct.get(i, Object.class))) {
-        return false;
-      }
-    }
-
-    return true;
+    return comparator.compare(this.struct, that.struct) == 0;
   }
 
   @Override
   public int hashCode() {
     if (hashCode == null) {
-      if (structHash != null) {
-        this.hashCode = structHash.hash(struct);
-      } else {
-        int result = 97;
-        int len = struct.size();
-        result = 41 * result + len;
-        for (int i = 0; i < len; i += 1) {
-          result = 41 * result + Objects.hashCode(struct.get(i, Object.class));
-        }
-        this.hashCode = result;
-      }
+      this.hashCode = structHash.hash(struct);
     }
 
     return hashCode;


### PR DESCRIPTION
This PR updates classes that use `StructLikeWrapper` to correctly track partitions using both ID and tuple, using `DataFile.specId` from #1317 and `PartitionSet` added by #1307.

This is needed to correctly track partitions because tuples can be valid for more than one spec. For example, `(12974)` is a valid partition for both `hours(ts)` and `days(ts)` partition specs, but does not represent the same logical partition in both.