### PR TITLE
Spark: Use SessionState to load Hadoop config

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -37,6 +37,11 @@
         <property name="format" value="^\n\n$"/>
         <property name="message" value="Two consecutive blank lines are not permitted."/>
     </module>
+    <module name="RegexpSingleline">
+        <property name="fileExtensions" value="java"/>
+        <property name="format" value="sparkContext\(\)\.hadoopConfiguration\(\)"/>
+        <property name="message" value="Are you sure that you want to use sparkContext().hadoopConfiguration()? In most cases, you should use sessionState().newHadoopConf() instead, so that the Hadoop configurations specified in the Spark session configuration will come into effect."/>
+    </module>
     <module name="SuppressionFilter"> <!-- baseline-gradle: README.md -->
         <property name="file" value="${config_loc}/checkstyle-suppressions.xml"/>
     </module>

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables.java
@@ -46,7 +46,7 @@ public abstract class TestIcebergSourceHiveTables extends TestIcebergSourceTable
   public void dropTable() throws IOException {
     Table table = catalog.loadTable(currentIdentifier);
     Path tablePath = new Path(table.location());
-    FileSystem fs = tablePath.getFileSystem(spark.sparkContext().hadoopConfiguration());
+    FileSystem fs = tablePath.getFileSystem(spark.sessionState().newHadoopConf());
     fs.delete(tablePath, true);
     catalog.dropTable(currentIdentifier, false);
   }

--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
@@ -133,7 +133,7 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
     if (io.getValue() instanceof HadoopFileIO) {
       String scheme = "no_exist";
       try {
-        Configuration conf = new Configuration(SparkSession.active().sparkContext().hadoopConfiguration());
+        Configuration conf = SparkSession.active().sessionState().newHadoopConf();
         // merge hadoop config set on table
         mergeIcebergHadoopConfs(conf, table.properties());
         // merge hadoop config passed as options and overwrite the one on table
@@ -443,6 +443,7 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
       return expectedSchema;
     }
 
+    @SuppressWarnings("checkstyle:RegexpSingleline")
     private String[] getPreferredLocations() {
       if (!localityPreferred) {
         return new String[0];

--- a/spark2/src/test/java/org/apache/iceberg/examples/ConcurrencyTest.java
+++ b/spark2/src/test/java/org/apache/iceberg/examples/ConcurrencyTest.java
@@ -67,7 +67,7 @@ public class ConcurrencyTest {
     spark = SparkSession.builder().master("local[2]").getOrCreate();
     spark.sparkContext().setLogLevel("WARN");
 
-    HadoopTables tables = new HadoopTables(spark.sparkContext().hadoopConfiguration());
+    HadoopTables tables = new HadoopTables(spark.sessionState().newHadoopConf());
     table = tables.create(schema, tableLocation.toString());
 
     for (int i = 0; i < 1000000; i++) {

--- a/spark2/src/test/java/org/apache/iceberg/examples/ReadAndWriteTablesTest.java
+++ b/spark2/src/test/java/org/apache/iceberg/examples/ReadAndWriteTablesTest.java
@@ -56,7 +56,7 @@ public class ReadAndWriteTablesTest {
     spark = SparkSession.builder().master("local[2]").getOrCreate();
 
     pathToTable = Files.createTempDirectory("temp").toFile();
-    tables = new HadoopTables(spark.sparkContext().hadoopConfiguration());
+    tables = new HadoopTables(spark.sessionState().newHadoopConf());
 
     schema = new Schema(
         optional(1, "id", Types.IntegerType.get()),

--- a/spark2/src/test/java/org/apache/iceberg/examples/SchemaEvolutionTest.java
+++ b/spark2/src/test/java/org/apache/iceberg/examples/SchemaEvolutionTest.java
@@ -67,7 +67,7 @@ public class SchemaEvolutionTest {
         .year("published")
         .build();
 
-    HadoopTables tables = new HadoopTables(spark.sparkContext().hadoopConfiguration());
+    HadoopTables tables = new HadoopTables(spark.sessionState().newHadoopConf());
     table = tables.create(schema, spec, tableLocation.toString());
 
     Dataset<Row> df = spark.read().json(dataLocation + "/books.json");
@@ -144,7 +144,7 @@ public class SchemaEvolutionTest {
     // Set up a new table to test this conversion
     Schema schema = new Schema(optional(1, "float", Types.FloatType.get()));
     File location = Files.createTempDirectory("temp").toFile();
-    HadoopTables tables = new HadoopTables(spark.sparkContext().hadoopConfiguration());
+    HadoopTables tables = new HadoopTables(spark.sessionState().newHadoopConf());
     Table floatTable = tables.create(schema, location.toString());
 
     floatTable.updateSchema().updateColumn("float", Types.DoubleType.get()).commit();

--- a/spark2/src/test/java/org/apache/iceberg/examples/SchemaEvolutionTest.java
+++ b/spark2/src/test/java/org/apache/iceberg/examples/SchemaEvolutionTest.java
@@ -157,7 +157,7 @@ public class SchemaEvolutionTest {
     // Set up a new table to test this conversion
     Schema schema = new Schema(optional(1, "decimal", Types.DecimalType.of(2, 2)));
     File location = Files.createTempDirectory("temp").toFile();
-    HadoopTables tables = new HadoopTables(spark.sparkContext().hadoopConfiguration());
+    HadoopTables tables = new HadoopTables(spark.sessionState().newHadoopConf());
     Table decimalTable = tables.create(schema, location.toString());
 
     decimalTable.updateSchema().updateColumn("decimal", Types.DecimalType.of(4, 2)).commit();

--- a/spark2/src/test/java/org/apache/iceberg/examples/SnapshotFunctionalityTest.java
+++ b/spark2/src/test/java/org/apache/iceberg/examples/SnapshotFunctionalityTest.java
@@ -68,7 +68,7 @@ public class SnapshotFunctionalityTest {
 
     tableLocation = Files.createTempDirectory("temp").toFile();
 
-    HadoopTables tables = new HadoopTables(spark.sparkContext().hadoopConfiguration());
+    HadoopTables tables = new HadoopTables(spark.sessionState().newHadoopConf());
     PartitionSpec spec = PartitionSpec.unpartitioned();
     table = tables.create(schema, spec, tableLocation.toString());
 

--- a/spark3/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -91,7 +91,7 @@ public class SparkCatalog implements StagingTableCatalog, org.apache.spark.sql.c
    * @return an Iceberg catalog
    */
   protected Catalog buildIcebergCatalog(String name, CaseInsensitiveStringMap options) {
-    Configuration conf = SparkSession.active().sparkContext().hadoopConfiguration();
+    Configuration conf = SparkSession.active().sessionState().newHadoopConf();
     String catalogType = options.getOrDefault("type", "hive");
     switch (catalogType) {
       case "hive":

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
@@ -58,7 +58,7 @@ public class IcebergSource implements DataSourceRegister, TableProvider {
   @Override
   public SparkTable getTable(StructType schema, Transform[] partitioning, Map<String, String> options) {
     // Get Iceberg table from options
-    Configuration conf = new Configuration(SparkSession.active().sparkContext().hadoopConfiguration());
+    Configuration conf = SparkSession.active().sessionState().newHadoopConf();
     Table icebergTable = getTableAndResolveHadoopConfiguration(options, conf);
 
     // Build Spark table based on Iceberg table, and return it


### PR DESCRIPTION
We have to use `SessionState` to get a complete Hadoop conf. It is legal to set Hadoop properties directly without the `spark.hadoop` prefix. If we use `SparkContext` directly, we will miss such properties.