### PR TITLE
Spark3: Enable Parquet vectorized reads with identity partition values

### DIFF
--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
@@ -166,15 +166,10 @@ class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
 
     boolean atLeastOneColumn = expectedSchema.columns().size() > 0;
 
-    boolean hasNoIdentityProjections = tasks().stream()
-        .allMatch(combinedScanTask -> combinedScanTask.files()
-            .stream()
-            .allMatch(fileScanTask -> fileScanTask.spec().identitySourceIds().isEmpty()));
-
     boolean onlyPrimitives = expectedSchema.columns().stream().allMatch(c -> c.type().isPrimitiveType());
 
     boolean readUsingBatch = batchReadsEnabled && (allOrcFileScanTasks ||
-        (allParquetFileScanTasks && atLeastOneColumn && hasNoIdentityProjections && onlyPrimitives));
+        (allParquetFileScanTasks && atLeastOneColumn && onlyPrimitives));
 
     return new ReaderFactory(readUsingBatch ? batchSize : 0);
   }


### PR DESCRIPTION
Support for Parquet vectorized reads with identity partition values was added in https://github.com/apache/iceberg/pull/1287 but the Spark3 read path was missed. This PR also enables vectorized reads for such tables in Spark3. The test case added in #1287 also runs for Spark3 and should test this change.

cc: @RussellSpitzer