### PR TITLE
Add delete file writers for Avro

### DIFF
--- a/core/src/main/java/org/apache/iceberg/FileMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/FileMetadata.java
@@ -30,7 +30,7 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.ByteBuffers;
 
-class FileMetadata {
+public class FileMetadata {
   private FileMetadata() {
   }
 

--- a/core/src/main/java/org/apache/iceberg/MetadataColumns.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataColumns.java
@@ -31,10 +31,19 @@ public class MetadataColumns {
   private MetadataColumns() {
   }
 
+  // IDs Integer.MAX_VALUE - (1-100) are used for metadata columns
   public static final NestedField FILE_PATH = NestedField.required(
       Integer.MAX_VALUE - 1, "_file", Types.StringType.get(), "Path of the file in which a row is stored");
   public static final NestedField ROW_POSITION = NestedField.required(
       Integer.MAX_VALUE - 2, "_pos", Types.LongType.get(), "Ordinal position of a row in the source data file");
+
+  // IDs Integer.MAX_VALUE - (101-200) are used for reserved columns
+  public static final NestedField DELETE_FILE_PATH = NestedField.required(
+      Integer.MAX_VALUE - 101, "file_path", Types.StringType.get(), "Path of a file in which a deleted row is stored");
+  public static final NestedField DELETE_FILE_POS = NestedField.required(
+      Integer.MAX_VALUE - 102, "pos", Types.LongType.get(), "Ordinal position of a deleted row in the data file");
+  public static final int DELETE_FILE_ROW_FIELD_ID = Integer.MAX_VALUE - 103;
+  public static final String DELETE_FILE_ROW_DOC = "Deleted row values";
 
   private static final Map<String, NestedField> META_COLUMNS = ImmutableMap.of(
       FILE_PATH.name(), FILE_PATH,

--- a/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import org.apache.iceberg.Accessor;
+import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.io.CloseableGroup;
@@ -44,12 +45,14 @@ import org.apache.iceberg.util.StructLikeSet;
 
 public class Deletes {
   private static final Schema POSITION_DELETE_SCHEMA = new Schema(
-      Types.NestedField.required(1, "file_path", Types.StringType.get(), "Data file location of the deleted row"),
-      Types.NestedField.required(2, "pos", Types.LongType.get(), "Row position in the data file of the deleted row")
+      MetadataColumns.DELETE_FILE_PATH,
+      MetadataColumns.DELETE_FILE_POS
   );
 
-  private static final Accessor<StructLike> FILENAME_ACCESSOR = POSITION_DELETE_SCHEMA.accessorForField(1);
-  private static final Accessor<StructLike> POSITION_ACCESSOR = POSITION_DELETE_SCHEMA.accessorForField(2);
+  private static final Accessor<StructLike> FILENAME_ACCESSOR = POSITION_DELETE_SCHEMA
+      .accessorForField(MetadataColumns.DELETE_FILE_PATH.fieldId());
+  private static final Accessor<StructLike> POSITION_ACCESSOR = POSITION_DELETE_SCHEMA
+      .accessorForField(MetadataColumns.DELETE_FILE_POS.fieldId());
 
   private Deletes() {
   }

--- a/core/src/main/java/org/apache/iceberg/deletes/EqualityDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/EqualityDeleteWriter.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.deletes;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileMetadata;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.encryption.EncryptionKeyMetadata;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+public class EqualityDeleteWriter<T> implements Closeable {
+  private final FileAppender<T> appender;
+  private final FileFormat format;
+  private final String location;
+  private final PartitionSpec spec;
+  private final StructLike partition;
+  private final ByteBuffer keyMetadata;
+  private final int[] equalityFieldIds;
+  private DeleteFile deleteFile = null;
+
+  public EqualityDeleteWriter(FileAppender<T> appender, FileFormat format, String location,
+                              PartitionSpec spec, StructLike partition, EncryptionKeyMetadata keyMetadata,
+                              int... equalityFieldIds) {
+    this.appender = appender;
+    this.format = format;
+    this.location = location;
+    this.spec = spec;
+    this.partition = partition;
+    this.keyMetadata = keyMetadata != null ? keyMetadata.buffer() : null;
+    this.equalityFieldIds = equalityFieldIds;
+  }
+
+  public void deleteAll(Iterable<T> rows) {
+    appender.addAll(rows);
+  }
+
+  public void delete(T row) {
+    appender.add(row);
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (deleteFile == null) {
+      appender.close();
+      this.deleteFile = FileMetadata.deleteFileBuilder(spec)
+          .ofEqualityDeletes(equalityFieldIds)
+          .withFormat(format)
+          .withPath(location)
+          .withPartition(partition)
+          .withEncryptionKeyMetadata(keyMetadata)
+          .withFileSizeInBytes(appender.length())
+          .withMetrics(appender.metrics())
+          .build();
+    }
+  }
+
+  public DeleteFile toDeleteFile() {
+    Preconditions.checkState(deleteFile != null, "Cannot create delete file from unclosed writer");
+    return deleteFile;
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDelete.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDelete.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.deletes;
+
+import org.apache.iceberg.StructLike;
+
+@SuppressWarnings("checkstyle:OverloadMethodsDeclarationOrder")
+public class PositionDelete<R> implements StructLike {
+  static <T> PositionDelete<T> create() {
+    return new PositionDelete<>();
+  }
+
+  private CharSequence path;
+  private long pos;
+  private R row;
+
+  public PositionDelete<R> set(CharSequence newPath, long newPos, R newRow) {
+    this.path = newPath;
+    this.pos = newPos;
+    this.row = newRow;
+    return this;
+  }
+
+  @Override
+  public int size() {
+    return 3;
+  }
+
+  public CharSequence path() {
+    return path;
+  }
+
+  public long pos() {
+    return pos;
+  }
+
+  public R row() {
+    return row;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T> T get(int colPos, Class<T> javaClass) {
+    switch (colPos) {
+      case 0:
+        return (T) path;
+      case 1:
+        return (T) (Long) pos;
+      case 2:
+        return (T) row;
+      default:
+        throw new IllegalArgumentException("No column at position " + colPos);
+    }
+  }
+
+  @Override
+  public <T> void set(int colPos, T value) {
+    switch (colPos) {
+      case 0:
+        this.path = (CharSequence) value;
+        break;
+      case 1:
+        this.pos = (Long) value;
+        break;
+      case 2:
+        this.row = (R) value;
+        break;
+      default:
+        throw new IllegalArgumentException("No column at position " + colPos);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteWriter.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.deletes;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileMetadata;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.encryption.EncryptionKeyMetadata;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+public class PositionDeleteWriter<T> implements Closeable {
+  private final FileAppender<StructLike> appender;
+  private final FileFormat format;
+  private final String location;
+  private final PartitionSpec spec;
+  private final StructLike partition;
+  private final ByteBuffer keyMetadata;
+  private final PositionDelete<T> delete;
+  private DeleteFile deleteFile = null;
+
+  public PositionDeleteWriter(FileAppender<StructLike> appender, FileFormat format, String location,
+                              PartitionSpec spec, StructLike partition, EncryptionKeyMetadata keyMetadata) {
+    this.appender = appender;
+    this.format = format;
+    this.location = location;
+    this.spec = spec;
+    this.partition = partition;
+    this.keyMetadata = keyMetadata != null ? keyMetadata.buffer() : null;
+    this.delete = PositionDelete.create();
+  }
+
+  public void delete(CharSequence path, long pos) {
+    delete(path, pos, null);
+  }
+
+  public void delete(CharSequence path, long pos, T row) {
+    appender.add(delete.set(path, pos, row));
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (deleteFile == null) {
+      appender.close();
+      this.deleteFile = FileMetadata.deleteFileBuilder(spec)
+          .ofPositionDeletes()
+          .withFormat(format)
+          .withPath(location)
+          .withPartition(partition)
+          .withEncryptionKeyMetadata(keyMetadata)
+          .withFileSizeInBytes(appender.length())
+          .withMetrics(appender.metrics())
+          .build();
+    }
+  }
+
+  public DeleteFile toDeleteFile() {
+    Preconditions.checkState(deleteFile != null, "Cannot create delete file from unclosed writer");
+    return deleteFile;
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroDeleteWriters.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroDeleteWriters.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.avro;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.avro.DataReader;
+import org.apache.iceberg.data.avro.DataWriter;
+import org.apache.iceberg.deletes.EqualityDeleteWriter;
+import org.apache.iceberg.deletes.PositionDeleteWriter;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.types.Types.NestedField;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestAvroDeleteWriters {
+  private static final Schema SCHEMA = new Schema(
+      NestedField.required(1, "id", Types.LongType.get()),
+      NestedField.optional(2, "data", Types.StringType.get()));
+
+  private List<Record> records;
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  @Before
+  public void createDeleteRecords() {
+    GenericRecord record = GenericRecord.create(SCHEMA);
+
+    ImmutableList.Builder<Record> builder = ImmutableList.builder();
+    builder.add(record.copy(ImmutableMap.of("id", 1L, "data", "a")));
+    builder.add(record.copy(ImmutableMap.of("id", 2L, "data", "b")));
+    builder.add(record.copy(ImmutableMap.of("id", 3L, "data", "c")));
+    builder.add(record.copy(ImmutableMap.of("id", 4L, "data", "d")));
+    builder.add(record.copy(ImmutableMap.of("id", 5L, "data", "e")));
+
+    this.records = builder.build();
+  }
+
+  @Test
+  public void testEqualityDeleteWriter() throws IOException {
+    File deleteFile = temp.newFile();
+
+    OutputFile out = Files.localOutput(deleteFile);
+    EqualityDeleteWriter<Record> deleteWriter = Avro.writeDeletes(out)
+        .createWriterFunc(DataWriter::create)
+        .overwrite()
+        .rowSchema(SCHEMA)
+        .withSpec(PartitionSpec.unpartitioned())
+        .equalityFieldIds(1)
+        .buildEqualityWriter();
+
+    try (EqualityDeleteWriter<Record> writer = deleteWriter) {
+      writer.deleteAll(records);
+    }
+
+    DeleteFile metadata = deleteWriter.toDeleteFile();
+    Assert.assertEquals("Format should be Avro", FileFormat.AVRO, metadata.format());
+    Assert.assertEquals("Should be equality deletes", FileContent.EQUALITY_DELETES, metadata.content());
+    Assert.assertEquals("Record count should be correct", records.size(), metadata.recordCount());
+    Assert.assertEquals("Partition should be empty", 0, metadata.partition().size());
+    Assert.assertNull("Key metadata should be null", metadata.keyMetadata());
+
+    List<Record> deletedRecords;
+    try (AvroIterable<Record> reader = Avro.read(out.toInputFile())
+        .project(SCHEMA)
+        .createReaderFunc(DataReader::create)
+        .build()) {
+      deletedRecords = Lists.newArrayList(reader);
+    }
+
+    Assert.assertEquals("Deleted records should match expected", records, deletedRecords);
+  }
+
+  @Test
+  public void testPositionDeleteWriter() throws IOException {
+    File deleteFile = temp.newFile();
+
+    Schema deleteSchema = new Schema(
+        MetadataColumns.DELETE_FILE_PATH,
+        MetadataColumns.DELETE_FILE_POS,
+        NestedField.optional(MetadataColumns.DELETE_FILE_ROW_FIELD_ID, "row", SCHEMA.asStruct()));
+
+    String deletePath = "s3://bucket/path/file.parquet";
+    GenericRecord posDelete = GenericRecord.create(deleteSchema);
+    List<Record> expectedDeleteRecords = Lists.newArrayList();
+
+    OutputFile out = Files.localOutput(deleteFile);
+    PositionDeleteWriter<Record> deleteWriter = Avro.writeDeletes(out)
+        .createWriterFunc(DataWriter::create)
+        .overwrite()
+        .rowSchema(SCHEMA)
+        .withSpec(PartitionSpec.unpartitioned())
+        .buildPositionWriter();
+
+    try (PositionDeleteWriter<Record> writer = deleteWriter) {
+      for (int i = 0; i < records.size(); i += 1) {
+        int pos = i * 3 + 2;
+        writer.delete(deletePath, pos, records.get(i));
+        expectedDeleteRecords.add(posDelete.copy(ImmutableMap.of(
+            "file_path", deletePath,
+            "pos", (long) pos,
+            "row", records.get(i))));
+      }
+    }
+
+    DeleteFile metadata = deleteWriter.toDeleteFile();
+    Assert.assertEquals("Format should be Avro", FileFormat.AVRO, metadata.format());
+    Assert.assertEquals("Should be position deletes", FileContent.POSITION_DELETES, metadata.content());
+    Assert.assertEquals("Record count should be correct", records.size(), metadata.recordCount());
+    Assert.assertEquals("Partition should be empty", 0, metadata.partition().size());
+    Assert.assertNull("Key metadata should be null", metadata.keyMetadata());
+
+    List<Record> deletedRecords;
+    try (AvroIterable<Record> reader = Avro.read(out.toInputFile())
+        .project(deleteSchema)
+        .createReaderFunc(DataReader::create)
+        .build()) {
+      deletedRecords = Lists.newArrayList(reader);
+    }
+
+    Assert.assertEquals("Deleted records should match expected", expectedDeleteRecords, deletedRecords);
+  }
+
+  @Test
+  public void testPositionDeleteWriterWithEmptyRow() throws IOException {
+    File deleteFile = temp.newFile();
+
+    Schema deleteSchema = new Schema(
+        MetadataColumns.DELETE_FILE_PATH,
+        MetadataColumns.DELETE_FILE_POS);
+
+    String deletePath = "s3://bucket/path/file.parquet";
+    GenericRecord posDelete = GenericRecord.create(deleteSchema);
+    List<Record> expectedDeleteRecords = Lists.newArrayList();
+
+    OutputFile out = Files.localOutput(deleteFile);
+    PositionDeleteWriter<Void> deleteWriter = Avro.writeDeletes(out)
+        .createWriterFunc(DataWriter::create)
+        .overwrite()
+        .withSpec(PartitionSpec.unpartitioned())
+        .buildPositionWriter();
+
+    try (PositionDeleteWriter<Void> writer = deleteWriter) {
+      for (int i = 0; i < records.size(); i += 1) {
+        int pos = i * 3 + 2;
+        writer.delete(deletePath, pos, null);
+        expectedDeleteRecords.add(posDelete.copy(ImmutableMap.of(
+            "file_path", deletePath,
+            "pos", (long) pos)));
+      }
+    }
+
+    DeleteFile metadata = deleteWriter.toDeleteFile();
+    Assert.assertEquals("Format should be Avro", FileFormat.AVRO, metadata.format());
+    Assert.assertEquals("Should be position deletes", FileContent.POSITION_DELETES, metadata.content());
+    Assert.assertEquals("Record count should be correct", records.size(), metadata.recordCount());
+    Assert.assertEquals("Partition should be empty", 0, metadata.partition().size());
+    Assert.assertNull("Key metadata should be null", metadata.keyMetadata());
+
+    List<Record> deletedRecords;
+    try (AvroIterable<Record> reader = Avro.read(out.toInputFile())
+        .project(deleteSchema)
+        .createReaderFunc(DataReader::create)
+        .build()) {
+      deletedRecords = Lists.newArrayList(reader);
+    }
+
+    Assert.assertEquals("Deleted records should match expected", expectedDeleteRecords, deletedRecords);
+  }
+}


### PR DESCRIPTION
This adds delete file writers that wrap file format appenders and create `DeleteFile` instances, and Avro builders to produce position and equality delete files in Avro.

Equality delete writers write rows, like other writers created using `Avro.write`. Position delete writers delete a path, position, and row triple. Both writers support the `createWriterFunc` just like `Avro.write` to create a value writer to deconstruct the row, which enables engines to plug in their own object models. The tests use Iceberg generics.

Because the position delete files also contain row data, this changes the position delete schema to use reserved field IDs that will not conflict with table field IDs. These IDs will be added to the spec as reserved IDs, along with the `_file` and `_pos` metadata column IDs.