### PR TITLE
Add specId to DataFile

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ContentFile.java
+++ b/api/src/main/java/org/apache/iceberg/ContentFile.java
@@ -30,6 +30,11 @@ import java.util.Map;
  */
 public interface ContentFile<F> {
   /**
+   * @return id of the partition spec used for partition metadata
+   */
+  int specId();
+
+  /**
    * @return type of content stored in the file; one of DATA, POSITION_DELETES, or EQUALITY_DELETES
    */
   FileContent content();

--- a/api/src/test/java/org/apache/iceberg/TestHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/TestHelpers.java
@@ -312,6 +312,11 @@ public class TestHelpers {
     }
 
     @Override
+    public int specId() {
+      return 0;
+    }
+
+    @Override
     public CharSequence path() {
       return path;
     }

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -128,8 +128,13 @@ public class AllManifestsTable extends BaseMetadataTable {
         if (snap.manifestListLocation() != null) {
           Expression filter = ignoreResiduals ? Expressions.alwaysTrue() : rowFilter;
           ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(filter);
+          DataFile manifestListAsDataFile = DataFiles.builder(PartitionSpec.unpartitioned())
+              .withInputFile(ops.io().newInputFile(snap.manifestListLocation()))
+              .withRecordCount(1)
+              .withFormat(FileFormat.AVRO)
+              .build();
           return new ManifestListReadTask(ops.io(), table().spec(), new BaseFileScanTask(
-              DataFiles.fromManifestList(ops.io().newInputFile(snap.manifestListLocation())), null,
+              manifestListAsDataFile, null,
               schemaString, specString, residuals));
         } else {
           return StaticDataTask.of(

--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -53,6 +53,7 @@ abstract class BaseFile<F>
   private int[] fromProjectionPos;
   private Types.StructType partitionType;
 
+  private int partitionSpecId = -1;
   private FileContent content = FileContent.DATA;
   private String filePath = null;
   private FileFormat format = null;
@@ -108,11 +109,12 @@ abstract class BaseFile<F>
     this.partitionData = new PartitionData(partitionType);
   }
 
-  BaseFile(FileContent content, String filePath, FileFormat format,
+  BaseFile(int specId, FileContent content, String filePath, FileFormat format,
            PartitionData partition, long fileSizeInBytes, long recordCount,
            Map<Integer, Long> columnSizes, Map<Integer, Long> valueCounts, Map<Integer, Long> nullValueCounts,
            Map<Integer, ByteBuffer> lowerBounds, Map<Integer, ByteBuffer> upperBounds, List<Long> splitOffsets,
            ByteBuffer keyMetadata) {
+    this.partitionSpecId = specId;
     this.content = content;
     this.filePath = filePath;
     this.format = format;
@@ -145,6 +147,7 @@ abstract class BaseFile<F>
    * @param fullCopy whether to copy all fields or to drop column-level stats
    */
   BaseFile(BaseFile<F> toCopy, boolean fullCopy) {
+    this.partitionSpecId = toCopy.partitionSpecId;
     this.content = toCopy.content;
     this.filePath = toCopy.filePath;
     this.format = toCopy.format;
@@ -176,6 +179,15 @@ abstract class BaseFile<F>
    * Constructor for Java serialization.
    */
   BaseFile() {
+  }
+
+  @Override
+  public int specId() {
+    return partitionSpecId;
+  }
+
+  void setSpecId(int specId) {
+    this.partitionSpecId = specId;
   }
 
   protected abstract Schema getAvroSchema(Types.StructType partitionStruct);

--- a/core/src/main/java/org/apache/iceberg/GenericDataFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDataFile.java
@@ -34,26 +34,10 @@ class GenericDataFile extends BaseFile<DataFile> implements DataFile {
     super(avroSchema);
   }
 
-  GenericDataFile(String filePath, FileFormat format, long recordCount,
-                  long fileSizeInBytes) {
-    this(filePath, format, null, recordCount, fileSizeInBytes);
-  }
-
-  GenericDataFile(String filePath, FileFormat format, PartitionData partition,
-                  long recordCount, long fileSizeInBytes) {
-    super(FileContent.DATA, filePath, format, partition, fileSizeInBytes, recordCount,
-        null, null, null, null, null, null, null);
-  }
-
-  GenericDataFile(String filePath, FileFormat format, PartitionData partition,
-                  long fileSizeInBytes, Metrics metrics, List<Long> splitOffsets) {
-    this(filePath, format, partition, fileSizeInBytes, metrics, null, splitOffsets);
-  }
-
-  GenericDataFile(String filePath, FileFormat format, PartitionData partition,
+  GenericDataFile(int specId, String filePath, FileFormat format, PartitionData partition,
                   long fileSizeInBytes, Metrics metrics,
                   ByteBuffer keyMetadata, List<Long> splitOffsets) {
-    super(FileContent.DATA, filePath, format, partition, fileSizeInBytes, metrics.recordCount(),
+    super(specId, FileContent.DATA, filePath, format, partition, fileSizeInBytes, metrics.recordCount(),
         metrics.columnSizes(), metrics.valueCounts(), metrics.nullValueCounts(),
         metrics.lowerBounds(), metrics.upperBounds(), splitOffsets, keyMetadata);
   }

--- a/core/src/main/java/org/apache/iceberg/GenericDeleteFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDeleteFile.java
@@ -34,9 +34,9 @@ class GenericDeleteFile extends BaseFile<DeleteFile> implements DeleteFile {
     super(avroSchema);
   }
 
-  GenericDeleteFile(FileContent content, String filePath, FileFormat format, PartitionData partition,
+  GenericDeleteFile(int specId, FileContent content, String filePath, FileFormat format, PartitionData partition,
                     long fileSizeInBytes, Metrics metrics, ByteBuffer keyMetadata) {
-    super(content, filePath, format, partition, fileSizeInBytes, metrics.recordCount(),
+    super(specId, content, filePath, format, partition, fileSizeInBytes, metrics.recordCount(),
         metrics.columnSizes(), metrics.valueCounts(), metrics.nullValueCounts(),
         metrics.lowerBounds(), metrics.upperBounds(), null, keyMetadata);
   }

--- a/core/src/main/java/org/apache/iceberg/InheritableMetadataFactory.java
+++ b/core/src/main/java/org/apache/iceberg/InheritableMetadataFactory.java
@@ -34,7 +34,7 @@ class InheritableMetadataFactory {
   static InheritableMetadata fromManifest(ManifestFile manifest) {
     Preconditions.checkArgument(manifest.snapshotId() != null,
         "Cannot read from ManifestFile with null (unassigned) snapshot ID");
-    return new BaseInheritableMetadata(manifest.snapshotId(), manifest.sequenceNumber());
+    return new BaseInheritableMetadata(manifest.partitionSpecId(), manifest.snapshotId(), manifest.sequenceNumber());
   }
 
   static InheritableMetadata forCopy(long snapshotId) {
@@ -42,16 +42,22 @@ class InheritableMetadataFactory {
   }
 
   static class BaseInheritableMetadata implements InheritableMetadata {
+    private final int specId;
     private final long snapshotId;
     private final long sequenceNumber;
 
-    private BaseInheritableMetadata(long snapshotId, long sequenceNumber) {
+    private BaseInheritableMetadata(int specId, long snapshotId, long sequenceNumber) {
+      this.specId = specId;
       this.snapshotId = snapshotId;
       this.sequenceNumber = sequenceNumber;
     }
 
     @Override
     public <F extends ContentFile<F>> ManifestEntry<F> apply(ManifestEntry<F> manifestEntry) {
+      if (manifestEntry.file() instanceof BaseFile) {
+        BaseFile<?> file = (BaseFile<?>) manifestEntry.file();
+        file.setSpecId(specId);
+      }
       if (manifestEntry.snapshotId() == null) {
         manifestEntry.setSnapshotId(snapshotId);
       }

--- a/core/src/main/java/org/apache/iceberg/StaticDataTask.java
+++ b/core/src/main/java/org/apache/iceberg/StaticDataTask.java
@@ -42,7 +42,7 @@ class StaticDataTask implements DataTask {
   private final StructLike[] rows;
 
   private StaticDataTask(InputFile metadata, StructLike[] rows) {
-    this.metadataFile = DataFiles.builder()
+    this.metadataFile = DataFiles.builder(PartitionSpec.unpartitioned())
         .withInputFile(metadata)
         .withRecordCount(rows.length)
         .withFormat(FileFormat.METADATA)

--- a/core/src/main/java/org/apache/iceberg/V1Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V1Metadata.java
@@ -365,6 +365,11 @@ class V1Metadata {
     }
 
     @Override
+    public int specId() {
+      return wrapped.specId();
+    }
+
+    @Override
     public FileContent content() {
       return wrapped.content();
     }

--- a/core/src/main/java/org/apache/iceberg/V2Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V2Metadata.java
@@ -413,6 +413,11 @@ class V2Metadata {
     }
 
     @Override
+    public int specId() {
+      return wrapped.specId();
+    }
+
+    @Override
     public FileContent content() {
       return wrapped.content();
     }

--- a/core/src/test/java/org/apache/iceberg/TestManifestWriterVersions.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestWriterVersions.java
@@ -68,10 +68,10 @@ public class TestManifestWriterVersions {
   private static final List<Long> OFFSETS = ImmutableList.of(4L);
 
   private static final DataFile DATA_FILE = new GenericDataFile(
-      PATH, FORMAT, PARTITION, 150972L, METRICS, null, OFFSETS);
+      0, PATH, FORMAT, PARTITION, 150972L, METRICS, null, OFFSETS);
 
   private static final DeleteFile DELETE_FILE = new GenericDeleteFile(
-      FileContent.EQUALITY_DELETES, PATH, FORMAT, PARTITION, 22905L, METRICS, null);
+      0, FileContent.EQUALITY_DELETES, PATH, FORMAT, PARTITION, 22905L, METRICS, null);
 
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();

--- a/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
@@ -681,13 +681,15 @@ public class TestMergeAppend extends TableTestBase {
     V2Assert.assertEquals("Last sequence number should be 1", 1, readMetadata().lastSequenceNumber());
     V1Assert.assertEquals("Table should end with last-sequence-number 0", 0, readMetadata().lastSequenceNumber());
 
-    DataFile newFileC = DataFiles.builder(newSpec)
-        .copy(FILE_C)
+    DataFile newFileY = DataFiles.builder(newSpec)
+        .withPath("/path/to/data-y.parquet")
+        .withFileSizeInBytes(10)
         .withPartitionPath("data_bucket=2/id_bucket=3")
+        .withRecordCount(1)
         .build();
 
     table.newAppend()
-        .appendFile(newFileC)
+        .appendFile(newFileY)
         .commit();
 
     Snapshot lastSnapshot = table.currentSnapshot();
@@ -702,7 +704,7 @@ public class TestMergeAppend extends TableTestBase {
     validateManifest(lastSnapshot.allManifests().get(0),
         seqs(2),
         ids(lastSnapshot.snapshotId()),
-        files(newFileC),
+        files(newFileY),
         statuses(Status.ADDED)
     );
 
@@ -747,13 +749,15 @@ public class TestMergeAppend extends TableTestBase {
     V2Assert.assertEquals("Last sequence number should be 2", 2, readMetadata().lastSequenceNumber());
     V1Assert.assertEquals("Table should end with last-sequence-number 0", 0, readMetadata().lastSequenceNumber());
 
-    DataFile newFileC = DataFiles.builder(newSpec)
-        .copy(FILE_C)
+    DataFile newFileY = DataFiles.builder(newSpec)
+        .withPath("/path/to/data-y.parquet")
+        .withFileSizeInBytes(10)
         .withPartitionPath("data_bucket=2/id_bucket=3")
+        .withRecordCount(1)
         .build();
 
     table.newAppend()
-        .appendFile(newFileC)
+        .appendFile(newFileY)
         .commit();
     Snapshot lastSnapshot = table.currentSnapshot();
     V2Assert.assertEquals("Snapshot sequence number should be 3", 3, lastSnapshot.sequenceNumber());
@@ -768,7 +772,7 @@ public class TestMergeAppend extends TableTestBase {
     validateManifest(lastSnapshot.allManifests().get(0),
         seqs(3),
         ids(lastSnapshot.snapshotId()),
-        files(newFileC),
+        files(newFileY),
         statuses(Status.ADDED)
     );
     validateManifest(lastSnapshot.allManifests().get(1),
@@ -1129,8 +1133,12 @@ public class TestMergeAppend extends TableTestBase {
     V2Assert.assertEquals("Last sequence number should be 1", 1, readMetadata().lastSequenceNumber());
     V1Assert.assertEquals("Table should end with last-sequence-number 0", 0, readMetadata().lastSequenceNumber());
 
+    // create a new with the table's current spec
     DataFile newFile = DataFiles.builder(table.spec())
-        .copy(FILE_B)
+        .withPath("/path/to/data-x.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("id_bucket=1/data_bucket=1")
+        .withRecordCount(1)
         .build();
 
     table.newAppend()

--- a/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
@@ -579,22 +579,26 @@ public class TestRewriteManifests extends TableTestBase {
     // commit the new partition spec to the table manually
     table.ops().commit(base, base.updatePartitionSpec(newSpec));
 
-    DataFile newFileC = DataFiles.builder(newSpec)
-        .copy(FILE_C)
+    DataFile newFileY = DataFiles.builder(newSpec)
+        .withPath("/path/to/data-y.parquet")
+        .withFileSizeInBytes(10)
         .withPartitionPath("data_bucket=2/id_bucket=3")
+        .withRecordCount(1)
         .build();
 
     table.newAppend()
-        .appendFile(newFileC)
+        .appendFile(newFileY)
         .commit();
 
-    DataFile newFileD = DataFiles.builder(newSpec)
-        .copy(FILE_D)
+    DataFile newFileZ = DataFiles.builder(newSpec)
+        .withPath("/path/to/data-z.parquet")
+        .withFileSizeInBytes(10)
         .withPartitionPath("data_bucket=2/id_bucket=4")
+        .withRecordCount(1)
         .build();
 
     table.newAppend()
-        .appendFile(newFileD)
+        .appendFile(newFileZ)
         .commit();
 
     Assert.assertEquals("Should use 3 manifest files",
@@ -648,22 +652,26 @@ public class TestRewriteManifests extends TableTestBase {
     // commit the new partition spec to the table manually
     table.ops().commit(base, base.updatePartitionSpec(newSpec));
 
-    DataFile newFileC = DataFiles.builder(newSpec)
-        .copy(FILE_C)
+    DataFile newFileY = DataFiles.builder(newSpec)
+        .withPath("/path/to/data-y.parquet")
+        .withFileSizeInBytes(10)
         .withPartitionPath("data_bucket=2/id_bucket=3")
+        .withRecordCount(1)
         .build();
 
     table.newAppend()
-        .appendFile(newFileC)
+        .appendFile(newFileY)
         .commit();
 
-    DataFile newFileD = DataFiles.builder(newSpec)
-        .copy(FILE_D)
+    DataFile newFileZ = DataFiles.builder(newSpec)
+        .withPath("/path/to/data-z.parquet")
+        .withFileSizeInBytes(10)
         .withPartitionPath("data_bucket=2/id_bucket=4")
+        .withRecordCount(1)
         .build();
 
     table.newAppend()
-        .appendFile(newFileD)
+        .appendFile(newFileZ)
         .commit();
 
     Assert.assertEquals("Rewrite manifests should produce 3 manifest files",

--- a/data/src/test/java/org/apache/iceberg/data/TestLocalScan.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestLocalScan.java
@@ -255,7 +255,11 @@ public class TestLocalScan {
       }
 
       writeFile(location.toString(), format.addExtension("file-" + fileNum), records);
-      append.appendFile(fromInputFile(HadoopInputFile.fromPath(path, CONF), numRecords));
+      DataFile file = DataFiles.builder(PartitionSpec.unpartitioned())
+          .withRecordCount(numRecords)
+          .withInputFile(HadoopInputFile.fromPath(path, CONF))
+          .build();
+      append.appendFile(file);
 
       fileNum += 1;
     }

--- a/data/src/test/java/org/apache/iceberg/data/TestLocalScan.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestLocalScan.java
@@ -64,7 +64,6 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import static org.apache.iceberg.DataFiles.fromInputFile;
 import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.apache.iceberg.expressions.Expressions.lessThan;
 import static org.apache.iceberg.expressions.Expressions.lessThanOrEqual;

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkDataFile.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkDataFile.java
@@ -88,6 +88,11 @@ public class SparkDataFile implements DataFile {
   }
 
   @Override
+  public int specId() {
+    return -1;
+  }
+
+  @Override
   public CharSequence path() {
     return wrapped.getAs(filePathPosition);
   }

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
@@ -265,7 +265,10 @@ public abstract class TestPartitionValues {
 
     // add the Avro data file to the source table
     source.newAppend()
-        .appendFile(DataFiles.fromInputFile(Files.localInput(avroData), 10))
+        .appendFile(DataFiles.builder(PartitionSpec.unpartitioned())
+            .withRecordCount(10)
+            .withInputFile(Files.localInput(avroData))
+            .build())
         .commit();
 
     Dataset<Row> sourceDF = spark.read().format("iceberg")
@@ -330,7 +333,10 @@ public abstract class TestPartitionValues {
 
     // add the Avro data file to the source table
     source.newAppend()
-        .appendFile(DataFiles.fromInputFile(Files.localInput(avroData), 10))
+        .appendFile(DataFiles.builder(PartitionSpec.unpartitioned())
+            .withRecordCount(10)
+            .withInputFile(Files.localInput(avroData))
+            .build())
         .commit();
 
     Dataset<Row> sourceDF = spark.read().format("iceberg")


### PR DESCRIPTION
Utilities that compare partitions need to also track the partition spec that a partition tuple belongs to because the same set of partition values can be valid for multiple specs, but identify different partitions. Many classes track the partitions of data and delete files, and the easiest way to update those utilities is to pass the spec ID along with the `DataFile` instance. Otherwise, getting the correct spec ID would require updating several public APIs to add a spec ID argument.

This PR adds spec ID to `DataFile` and `DeleteFile`, and adds it to metadata that is inherited from `ManifestFile`, where the spec ID of a manifest is tracked.

This also cleans up unnecessary factory methods in `DataFile` that were used only in tests and were missing spec ID. Now, all data file creation uses the builder.