### PR TITLE
Add equality field IDs to DeleteFile

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ContentFile.java
+++ b/api/src/main/java/org/apache/iceberg/ContentFile.java
@@ -102,6 +102,18 @@ public interface ContentFile<F> {
    */
   List<Long> splitOffsets();
 
+  /**
+   * Returns the set of field IDs used for equality comparison, in equality delete files.
+   * <p>
+   * An equality delete file may contain additional data fields that are not used by equality
+   * comparison. The subset of columns in a delete file to be used in equality comparison are
+   * tracked by ID. Extra columns can be used to reconstruct changes and metrics from extra
+   * columns are used during job planning.
+   *
+   * @return IDs of the fields used in equality comparison with the records in this delete file
+   */
+  List<Integer> equalityFieldIds();
+
 
   /**
    * Copies this file. Manifest readers can reuse file instances; use

--- a/api/src/main/java/org/apache/iceberg/DataFile.java
+++ b/api/src/main/java/org/apache/iceberg/DataFile.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg;
 
+import java.util.List;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.BinaryType;
 import org.apache.iceberg.types.Types.IntegerType;
@@ -56,10 +57,12 @@ public interface DataFile extends ContentFile<DataFile> {
   Types.NestedField KEY_METADATA = optional(131, "key_metadata", BinaryType.get(), "Encryption key metadata blob");
   Types.NestedField SPLIT_OFFSETS = optional(132, "split_offsets", ListType.ofRequired(133, LongType.get()),
       "Splittable offsets");
+  Types.NestedField EQUALITY_IDS = optional(135, "equality_ids", ListType.ofRequired(136, IntegerType.get()),
+      "Equality comparison field IDs");
   int PARTITION_ID = 102;
   String PARTITION_NAME = "partition";
   String PARTITION_DOC = "Partition data tuple, schema based on the partition spec";
-  // NEXT ID TO ASSIGN: 135
+  // NEXT ID TO ASSIGN: 137
 
   static StructType getType(StructType partitionType) {
     // IDs start at 100 to leave room for changes to ManifestEntry
@@ -76,7 +79,8 @@ public interface DataFile extends ContentFile<DataFile> {
         LOWER_BOUNDS,
         UPPER_BOUNDS,
         KEY_METADATA,
-        SPLIT_OFFSETS
+        SPLIT_OFFSETS,
+        EQUALITY_IDS
     );
   }
 
@@ -86,5 +90,10 @@ public interface DataFile extends ContentFile<DataFile> {
   @Override
   default FileContent content() {
     return FileContent.DATA;
+  }
+
+  @Override
+  default List<Integer> equalityFieldIds() {
+    return null;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/FileMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/FileMetadata.java
@@ -43,6 +43,7 @@ class FileMetadata {
     private final boolean isPartitioned;
     private final int specId;
     private FileContent content = null;
+    private int[] equalityFieldIds = null;
     private PartitionData partitionData;
     private String filePath = null;
     private FileFormat format = null;
@@ -101,11 +102,13 @@ class FileMetadata {
 
     public Builder ofPositionDeletes() {
       this.content = FileContent.POSITION_DELETES;
+      this.equalityFieldIds = null;
       return this;
     }
 
-    public Builder ofEqualityDeletes() {
+    public Builder ofEqualityDeletes(int... fieldIds) {
       this.content = FileContent.EQUALITY_DELETES;
+      this.equalityFieldIds = fieldIds;
       return this;
     }
 
@@ -204,7 +207,7 @@ class FileMetadata {
           specId, content, filePath, format, isPartitioned ? DataFiles.copy(spec, partitionData) : null,
           fileSizeInBytes, new Metrics(
           recordCount, columnSizes, valueCounts, nullValueCounts, lowerBounds, upperBounds),
-          keyMetadata);
+          equalityFieldIds, keyMetadata);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/GenericDataFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDataFile.java
@@ -39,7 +39,7 @@ class GenericDataFile extends BaseFile<DataFile> implements DataFile {
                   ByteBuffer keyMetadata, List<Long> splitOffsets) {
     super(specId, FileContent.DATA, filePath, format, partition, fileSizeInBytes, metrics.recordCount(),
         metrics.columnSizes(), metrics.valueCounts(), metrics.nullValueCounts(),
-        metrics.lowerBounds(), metrics.upperBounds(), splitOffsets, keyMetadata);
+        metrics.lowerBounds(), metrics.upperBounds(), splitOffsets, null, keyMetadata);
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/GenericDeleteFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDeleteFile.java
@@ -35,10 +35,10 @@ class GenericDeleteFile extends BaseFile<DeleteFile> implements DeleteFile {
   }
 
   GenericDeleteFile(int specId, FileContent content, String filePath, FileFormat format, PartitionData partition,
-                    long fileSizeInBytes, Metrics metrics, ByteBuffer keyMetadata) {
+                    long fileSizeInBytes, Metrics metrics, int[] equalityFieldIds, ByteBuffer keyMetadata) {
     super(specId, content, filePath, format, partition, fileSizeInBytes, metrics.recordCount(),
         metrics.columnSizes(), metrics.valueCounts(), metrics.nullValueCounts(),
-        metrics.lowerBounds(), metrics.upperBounds(), null, keyMetadata);
+        metrics.lowerBounds(), metrics.upperBounds(), null, equalityFieldIds, keyMetadata);
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/V2Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V2Metadata.java
@@ -253,7 +253,8 @@ class V2Metadata {
         DataFile.LOWER_BOUNDS,
         DataFile.UPPER_BOUNDS,
         DataFile.KEY_METADATA,
-        DataFile.SPLIT_OFFSETS
+        DataFile.SPLIT_OFFSETS,
+        DataFile.EQUALITY_IDS
     );
   }
 
@@ -403,6 +404,8 @@ class V2Metadata {
           return wrapped.keyMetadata();
         case 12:
           return wrapped.splitOffsets();
+        case 13:
+          return wrapped.equalityFieldIds();
       }
       throw new IllegalArgumentException("Unknown field ordinal: " + pos);
     }
@@ -480,6 +483,11 @@ class V2Metadata {
     @Override
     public List<Long> splitOffsets() {
       return wrapped.splitOffsets();
+    }
+
+    @Override
+    public List<Integer> equalityFieldIds() {
+      return wrapped.equalityFieldIds();
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/util/ArrayUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/ArrayUtil.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+
+public class ArrayUtil {
+  private ArrayUtil() {
+  }
+
+  public static List<Integer> toIntList(int[] ints) {
+    if (ints != null) {
+      return IntStream.of(ints).boxed().collect(Collectors.toList());
+    } else {
+      return null;
+    }
+  }
+
+  public static int[] toIntArray(List<Integer> ints) {
+    if (ints != null) {
+      return ints.stream().mapToInt(v -> v).toArray();
+    } else {
+      return null;
+    }
+  }
+
+  public static List<Long> toLongList(long[] longs) {
+    if (longs != null) {
+      return LongStream.of(longs).boxed().collect(Collectors.toList());
+    } else {
+      return null;
+    }
+  }
+
+  public static long[] toLongArray(List<Long> longs) {
+    if (longs != null) {
+      return longs.stream().mapToLong(v -> v).toArray();
+    } else {
+      return null;
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestManifestWriterVersions.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestWriterVersions.java
@@ -70,8 +70,11 @@ public class TestManifestWriterVersions {
   private static final DataFile DATA_FILE = new GenericDataFile(
       0, PATH, FORMAT, PARTITION, 150972L, METRICS, null, OFFSETS);
 
+  private static final List<Integer> EQUALITY_IDS = ImmutableList.of(1);
+  private static final int[] EQUALITY_ID_ARR = new int[] { 1 };
+
   private static final DeleteFile DELETE_FILE = new GenericDeleteFile(
-      0, FileContent.EQUALITY_DELETES, PATH, FORMAT, PARTITION, 22905L, METRICS, null);
+      0, FileContent.EQUALITY_DELETES, PATH, FORMAT, PARTITION, 22905L, METRICS, EQUALITY_ID_ARR, null);
 
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
@@ -195,6 +198,11 @@ public class TestManifestWriterVersions {
     Assert.assertEquals("Null value counts", METRICS.nullValueCounts(), dataFile.nullValueCounts());
     Assert.assertEquals("Lower bounds", METRICS.lowerBounds(), dataFile.lowerBounds());
     Assert.assertEquals("Upper bounds", METRICS.upperBounds(), dataFile.upperBounds());
+    if (dataFile.content() == FileContent.EQUALITY_DELETES) {
+      Assert.assertEquals(EQUALITY_IDS, dataFile.equalityFieldIds());
+    } else {
+      Assert.assertNull(dataFile.equalityFieldIds());
+    }
   }
 
   void checkManifest(ManifestFile manifest, long expectedSequenceNumber) {

--- a/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
@@ -241,8 +241,8 @@ public class TestMergeAppend extends TableTestBase {
   public void testManifestMergeMinCount() throws IOException {
     Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
     table.updateProperties().set(TableProperties.MANIFEST_MIN_MERGE_COUNT, "2")
-        // each manifest file is 4554 bytes, so 10000 bytes limit will give us 2 bins with 3 manifest/data files.
-        .set(TableProperties.MANIFEST_TARGET_SIZE_BYTES, "10000")
+        // each manifest file is 5227 bytes, so 12000 bytes limit will give us 2 bins with 3 manifest/data files.
+        .set(TableProperties.MANIFEST_TARGET_SIZE_BYTES, "12000")
         .commit();
 
     TableMetadata base = readMetadata();


### PR DESCRIPTION
This adds a list of equality field IDs to `DeleteFile` metadata that is tracked in manifests.

The equality field ID list identifies the subset of a delete file's fields (by ID) that should be used when comparing rows against the rows deleted in an equality delete file. The remaining fields are informational and store the values that were deleted by an equality delete. These may be used, for example, to reconstruct CDC events that contained deleted row values.

Additional fields will also be used for min/max stats filtering and are required to be accurate. When finding files for a table scan, the min/max values for non-comparison columns can still be used to filter delete files, even if the delete file applies to a data file that will be read.

For example, if a table contains columns `id` and `data`, a delete file may delete the row `(5, "bees!")` using only the `id` field for equality. A scan filter like `data like 'a%'` can cause the delete file to be ignored, even for a data file that contains ID `5` because the scan filter will remove the row.