### PR TITLE
Avro: Fix pruning columns when a logical-map array's value type is nested

### DIFF
--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroNameMapping.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroNameMapping.java
@@ -281,6 +281,12 @@ public class TestAvroNameMapping extends TestAvroReadProjection {
     Assert.assertEquals(record, projected);
   }
 
+  @Test
+  @Override
+  public void testAvroArrayAsLogicalMap() {
+    // no-op
+  }
+
   @Override
   protected Record writeAndRead(String desc,
                                 Schema writeSchema,


### PR DESCRIPTION
Added a unit test which fails without the change

-----
Consider type `map(long, list<long>)` (a logical-map array in Iceberg-Avro) and a full projection.

In `GetProjectedIds::map`, the key id and value id won't be added if the value type is nested.
```java
  public Set<Integer> map(Types.MapType map, Set<Integer> keyResult, Set<Integer> valueResult) {
    if (valueResult == null) {
      for (Types.NestedField field : map.fields()) {
        fieldIds.add(field.fieldId());
      }
    }
    return fieldIds;
  }
```
Missing the key id can pose a problem in `PruneColumns::array`, since the array's child record's key field will be omitted.