### PR TITLE
ExpireSnapshots executeWith renamed executeDeleteWith

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ExpireSnapshots.java
+++ b/api/src/main/java/org/apache/iceberg/ExpireSnapshots.java
@@ -96,7 +96,7 @@ public interface ExpireSnapshots extends PendingUpdate<List<Snapshot>> {
    * @param executorService an executor service to parallelize tasks to delete manifests and data files
    * @return this for method chaining
    */
-  ExpireSnapshots executeWith(ExecutorService executorService);
+  ExpireSnapshots executeDeleteWith(ExecutorService executorService);
 
   /**
    * Allows expiration of snapshots without any cleanup of underlying manifest or data files.

--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -121,7 +121,7 @@ class RemoveSnapshots implements ExpireSnapshots {
   }
 
   @Override
-  public ExpireSnapshots executeWith(ExecutorService executorService) {
+  public ExpireSnapshots executeDeleteWith(ExecutorService executorService) {
     this.deleteExecutorService = executorService;
     return this;
   }

--- a/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
+++ b/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
@@ -517,7 +517,7 @@ public class TestRemoveSnapshots extends TableTestBase {
     AtomicInteger deleteThreadsIndex = new AtomicInteger(0);
 
     table.expireSnapshots()
-        .executeWith(Executors.newFixedThreadPool(4, runnable -> {
+        .executeDeleteWith(Executors.newFixedThreadPool(4, runnable -> {
           Thread thread = new Thread(runnable);
           thread.setName("remove-snapshot-" + deleteThreadsIndex.getAndIncrement());
           thread.setDaemon(true); // daemon threads will be terminated abruptly when the JVM exits


### PR DESCRIPTION
The executor passed in executeWith is only used for deletes so we will rename it
to executeDeleteWith. The JavaDoc already states it will only effect deletes and
the implementation already match this name so no other changes are needed.

cc @rdblue  + @aokolnychyi  Just a rename refactor as we discussed in https://github.com/apache/iceberg/pull/1264