### PR TITLE
End to end read support for int96 parquet timestamps

### DIFF
--- a/data/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
+++ b/data/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
@@ -356,7 +356,7 @@ public abstract class BaseParquetReaders<T> {
     }
   }
 
-  private static class TimestampInt96Reader extends ParquetValueReaders.PrimitiveReader<LocalDateTime> {
+  private static class TimestampInt96Reader extends ParquetValueReaders.PrimitiveReader<OffsetDateTime> {
     private static final long UNIX_EPOCH_JULIAN = 2_440_588L;
 
     private TimestampInt96Reader(ColumnDescriptor desc) {
@@ -364,14 +364,14 @@ public abstract class BaseParquetReaders<T> {
     }
 
     @Override
-    public LocalDateTime read(LocalDateTime reuse) {
+    public OffsetDateTime read(OffsetDateTime reuse) {
       final ByteBuffer byteBuffer = column.nextBinary().toByteBuffer().order(ByteOrder.LITTLE_ENDIAN);
       final long timeOfDayNanos = byteBuffer.getLong();
       final int julianDay = byteBuffer.getInt();
 
       return Instant
               .ofEpochMilli(TimeUnit.DAYS.toMillis(julianDay - UNIX_EPOCH_JULIAN))
-              .plusNanos(timeOfDayNanos).atOffset(ZoneOffset.UTC).toLocalDateTime();
+              .plusNanos(timeOfDayNanos).atOffset(ZoneOffset.UTC);
     }
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/MessageTypeToType.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/MessageTypeToType.java
@@ -156,6 +156,8 @@ class MessageTypeToType extends ParquetTypeVisitor<Type> {
         return Types.DoubleType.get();
       case FIXED_LEN_BYTE_ARRAY:
         return Types.FixedType.ofLength(primitive.getTypeLength());
+      case INT96:
+        return Types.TimestampType.withZone();
       case BINARY:
         return Types.BinaryType.get();
     }


### PR DESCRIPTION
## Summary

Fixes https://github.com/apache/iceberg/issues/1138#issuecomment-670717050 by making sure that we can convert from `org.apache.parquet.schema.MessageType` to `org.apache.iceberg.types.Type`.

The issue was occurring due to Iceberg not being able to map the `int96` type to an Iceberg Timestamp. Also added an end to end test to verify that we can read through Iceberg API the imported parquet file.

While doing this, I noticed that the Iceberg generic parquet reader was reading the timestamp as timestamp without timezone instead of a timestamp with timezone.

## Testing

Improved our current unit-test to handle this issue

## Reviewers

to: @rdblue 
cc: @thesquelched @aokolnychyi 