### PR TITLE
Throw error when adding non-null columns using the alter table ddl

### DIFF
--- a/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -178,8 +178,12 @@ public class Spark3Util {
 
   private static void apply(UpdateSchema pendingUpdate, TableChange.AddColumn add) {
     Type type = SparkSchemaUtil.convert(add.dataType());
-    pendingUpdate.addColumn(parentName(add.fieldNames()), leafName(add.fieldNames()), type, add.comment());
-
+    if (add.isNullable()) {
+      pendingUpdate.addColumn(parentName(add.fieldNames()), leafName(add.fieldNames()), type, add.comment());
+    } else {
+      pendingUpdate.allowIncompatibleChanges()
+        .addRequiredColumn(parentName(add.fieldNames()), leafName(add.fieldNames()), type, add.comment());
+    }
     if (add.position() instanceof TableChange.After) {
       TableChange.After after = (TableChange.After) add.position();
       String referenceField = peerName(add.fieldNames(), after.column());

--- a/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -177,13 +177,11 @@ public class Spark3Util {
   }
 
   private static void apply(UpdateSchema pendingUpdate, TableChange.AddColumn add) {
+    Preconditions.checkArgument(add.isNullable(),
+        "Incompatible change: cannot add required column: %s", leafName(add.fieldNames()));
     Type type = SparkSchemaUtil.convert(add.dataType());
-    if (add.isNullable()) {
-      pendingUpdate.addColumn(parentName(add.fieldNames()), leafName(add.fieldNames()), type, add.comment());
-    } else {
-      pendingUpdate.allowIncompatibleChanges()
-        .addRequiredColumn(parentName(add.fieldNames()), leafName(add.fieldNames()), type, add.comment());
-    }
+    pendingUpdate.addColumn(parentName(add.fieldNames()), leafName(add.fieldNames()), type, add.comment());
+
     if (add.position() instanceof TableChange.After) {
       TableChange.After after = (TableChange.After) add.position();
       String referenceField = peerName(add.fieldNames(), after.column());

--- a/spark3/src/test/java/org/apache/iceberg/spark/sql/TestAlterTable.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/sql/TestAlterTable.java
@@ -53,6 +53,13 @@ public class TestAlterTable extends SparkCatalogTestBase {
   }
 
   @Test
+  public void testAddColumnNotNull() {
+    sql("ALTER TABLE %s ADD COLUMN c3 INT NOT NULL", tableName);
+    Assert.assertTrue(validationCatalog.loadTable(tableIdent).schema()
+        .caseInsensitiveFindField("c3").isRequired());
+  }
+
+  @Test
   public void testAddColumn() {
     sql("ALTER TABLE %s ADD COLUMN point struct<x: double NOT NULL, y: double NOT NULL> AFTER id", tableName);
 

--- a/spark3/src/test/java/org/apache/iceberg/spark/sql/TestAlterTable.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/sql/TestAlterTable.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.hadoop.HadoopCatalog;
 import org.apache.iceberg.spark.SparkCatalogTestBase;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
+import org.apache.spark.SparkException;
 import org.apache.spark.sql.AnalysisException;
 import org.junit.After;
 import org.junit.Assert;
@@ -54,9 +55,9 @@ public class TestAlterTable extends SparkCatalogTestBase {
 
   @Test
   public void testAddColumnNotNull() {
-    sql("ALTER TABLE %s ADD COLUMN c3 INT NOT NULL", tableName);
-    Assert.assertTrue(validationCatalog.loadTable(tableIdent).schema()
-        .caseInsensitiveFindField("c3").isRequired());
+    AssertHelpers.assertThrows("Should reject adding NOT NULL column",
+        SparkException.class, "Incompatible change: cannot add required column",
+        () -> sql("ALTER TABLE %s ADD COLUMN c3 INT NOT NULL", tableName));
   }
 
   @Test


### PR DESCRIPTION
Fixes https://github.com/apache/iceberg/issues/1324

- Throw error when adding a required column using the Alter table DDL 
- Added a new unit test to verify this scenario

With the fix, 
```
scala> spark.sql("CREATE TABLE local.t1 (id int COMMENT 'unique id', data string not null) USING iceberg")
res0: org.apache.spark.sql.DataFrame = []

scala> spark.sql("ALTER TABLE local.t1 ADD COLUMN time int NOT NULL")
org.apache.spark.SparkException: Unsupported table change: Incompatible change: cannot add required column: time
  at org.apache.spark.sql.execution.datasources.v2.AlterTableExec.run(AlterTableExec.scala:40)
  at org.apache.spark.sql.execution.datasources.v2.V2CommandExec.result$lzycompute(V2CommandExec.scala:39)
  at org.apache.spark.sql.execution.datasources.v2.V2CommandExec.result(V2CommandExec.scala:39)
  at org.apache.spark.sql.execution.datasources.v2.V2CommandExec.executeCollect(V2CommandExec.scala:45)
  at org.apache.spark.sql.Dataset.$anonfun$logicalPlan$1(Dataset.scala:229)
  at org.apache.spark.sql.Dataset.$anonfun$withAction$1(Dataset.scala:3618)
  at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$5(SQLExecution.scala:100)
  at org.apache.spark.sql.execution.SQLExecution$.withSQLConfPropagated(SQLExecution.scala:160)
  at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$1(SQLExecution.scala:87)
  at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:763)
  at org.apache.spark.sql.execution.SQLExecution$.withNewExecutionId(SQLExecution.scala:64)
  at org.apache.spark.sql.Dataset.withAction(Dataset.scala:3616)
  at org.apache.spark.sql.Dataset.<init>(Dataset.scala:229)
  at org.apache.spark.sql.Dataset$.$anonfun$ofRows$2(Dataset.scala:100)
  at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:763)
  at org.apache.spark.sql.Dataset$.ofRows(Dataset.scala:97)
  at org.apache.spark.sql.SparkSession.$anonfun$sql$1(SparkSession.scala:606)
  at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:763)
  at org.apache.spark.sql.SparkSession.sql(SparkSession.scala:601)
  ... 47 elided
Caused by: java.lang.IllegalArgumentException: Incompatible change: cannot add required column: time
  at org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkArgument(Preconditions.java:217)
  at org.apache.iceberg.spark.Spark3Util.apply(Spark3Util.java:180)
  at org.apache.iceberg.spark.Spark3Util.applySchemaChanges(Spark3Util.java:123)
  at org.apache.iceberg.spark.SparkCatalog.commitChanges(SparkCatalog.java:435)
  at org.apache.iceberg.spark.SparkCatalog.alterTable(SparkCatalog.java:224)
  at org.apache.iceberg.spark.SparkCatalog.alterTable(SparkCatalog.java:78)
  at org.apache.spark.sql.execution.datasources.v2.AlterTableExec.run(AlterTableExec.scala:37)
  ... 65 more

```