### PR TITLE
Support read data from iceberg table created by SparkSQL using hive

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -375,6 +375,7 @@ project(':iceberg-mr') {
     compile project(':iceberg-orc')
     compile project(':iceberg-parquet')
     compile project(':iceberg-data')
+    compile project(':iceberg-hive')
 
     compileOnly("org.apache.hadoop:hadoop-client") {
       exclude group: 'org.apache.avro', module: 'avro'
@@ -581,6 +582,65 @@ if (jdkVersion == '8') {
     }
   }
 
+  project(':iceberg-hive-runtime') {
+    apply plugin: 'com.github.johnrengelman.shadow'
+
+    tasks.jar.dependsOn tasks.shadowJar
+
+    configurations {
+      compile {
+        exclude group: 'org.apache.hive'
+      }
+    }
+
+    dependencies {
+      compile project(':iceberg-hive')
+      compile project(':iceberg-core')
+      compile project(':iceberg-mr')
+      compile project(':iceberg-common')
+      compile project(':iceberg-api')
+      compile project(':iceberg-bundled-guava')
+    }
+
+    shadowJar {
+      configurations = [project.configurations.compile]
+
+      zip64 true
+
+      // include the LICENSE and NOTICE files for the shaded Jar
+      from(projectDir) {
+        include 'LICENSE'
+        include 'NOTICE'
+      }
+
+      // Relocate dependencies to avoid conflicts
+      relocate 'com.google', 'org.apache.iceberg.shaded.com.google'
+      relocate 'com.fasterxml', 'org.apache.iceberg.shaded.com.fasterxml'
+      relocate 'com.github.benmanes', 'org.apache.iceberg.shaded.com.github.benmanes'
+      relocate 'org.checkerframework', 'org.apache.iceberg.shaded.org.checkerframework'
+      relocate 'org.apache.avro', 'org.apache.iceberg.shaded.org.apache.avro'
+      relocate 'avro.shaded', 'org.apache.iceberg.shaded.org.apache.avro.shaded'
+      relocate 'com.thoughtworks.paranamer', 'org.apache.iceberg.shaded.com.thoughtworks.paranamer'
+      relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'
+      relocate 'shaded.parquet', 'org.apache.iceberg.shaded.org.apache.parquet.shaded'
+      // relocate Avro's jackson dependency to share parquet-jackson locations
+      relocate 'org.codehaus.jackson', 'org.apache.iceberg.shaded.org.apache.parquet.shaded.org.codehaus.jackson'
+      relocate 'org.apache.orc', 'org.apache.iceberg.shaded.org.apache.orc'
+      relocate 'io.airlift', 'org.apache.iceberg.shaded.io.airlift'
+      // relocate Arrow and related deps to shade Iceberg specific version
+      relocate 'io.netty.buffer', 'org.apache.iceberg.shaded.io.netty.buffer'
+      relocate 'org.apache.arrow', 'org.apache.iceberg.shaded.org.apache.arrow'
+      relocate 'com.carrotsearch', 'org.apache.iceberg.shaded.com.carrotsearch'
+      relocate 'org.threeten.extra', 'org.apache.iceberg.shaded.org.threeten.extra'
+
+      classifier null
+    }
+
+    jar {
+      classifier = 'empty'
+    }
+  }
+
   // the runtime jar is a self-contained artifact for testing in a notebook
   project(':iceberg-spark-runtime') {
     apply plugin: 'com.github.johnrengelman.shadow'
@@ -657,6 +717,7 @@ project(':iceberg-spark3') {
     compile project(':iceberg-arrow')
     compile project(':iceberg-hive')
     compile project(':iceberg-spark')
+    compile project(':iceberg-mr')
 
     compileOnly "org.apache.avro:avro"
     compileOnly("org.apache.spark:spark-hive_2.12") {

--- a/mr/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
@@ -55,6 +55,7 @@ public class InputFormatConfig {
   public static final String SNAPSHOT_TABLE = "iceberg.snapshots.table";
   public static final String SNAPSHOT_TABLE_SUFFIX = "__snapshots";
   public static final String TABLE_LOCATION = "location";
+  public static final String HIVE_DATABASE_NAME = "hive.database.name";
   public static final String TABLE_NAME = "name";
 
   public enum InMemoryDataModel {

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergInputFormat.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergInputFormat.java
@@ -51,7 +51,7 @@ public class HiveIcebergInputFormat extends MapredIcebergInputFormat<Record>
 
     forwardConfigSettings(job);
 
-    return Arrays.stream(super.getSplits(job, numSplits))
+    return Arrays.stream(super.getSplits(job, table))
                  .map(split -> new HiveIcebergSplit((IcebergSplit) split, table.location()))
                  .toArray(InputSplit[]::new);
   }

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/TableResolver.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/TableResolver.java
@@ -23,8 +23,10 @@ import java.util.Map;
 import java.util.Properties;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.hive.HiveCatalogs;
 import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
@@ -53,9 +55,11 @@ public final class TableResolver {
         return tables.load(tableLocation);
 
       case InputFormatConfig.HIVE_CATALOG:
+        String dbName = conf.get(InputFormatConfig.HIVE_DATABASE_NAME);
+        Preconditions.checkNotNull(dbName, InputFormatConfig.HIVE_DATABASE_NAME + " is not set using hive catalog.");
         String tableName = conf.get(InputFormatConfig.TABLE_NAME);
-        Preconditions.checkNotNull(tableName, InputFormatConfig.TABLE_NAME + " is not set.");
-        throw new UnsupportedOperationException(InputFormatConfig.HIVE_CATALOG + " is not supported yet");
+        Preconditions.checkNotNull(tableName, InputFormatConfig.TABLE_NAME + " is not set using hive catalog.");
+        return HiveCatalogs.loadCatalog(conf).loadTable(TableIdentifier.of(dbName, tableName));
 
       default:
         throw new NoSuchNamespaceException("Catalog " + catalogName + " not supported.");

--- a/mr/src/main/java/org/apache/iceberg/mr/mapred/MapredIcebergInputFormat.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/mapred/MapredIcebergInputFormat.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.TaskAttemptID;
 import org.apache.hadoop.mapreduce.task.JobContextImpl;
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.iceberg.mr.mapreduce.IcebergSplit;
@@ -61,6 +62,13 @@ public class MapredIcebergInputFormat<T> implements InputFormat<Void, Container<
   public static InputFormatConfig.ConfigBuilder configure(JobConf job) {
     job.setInputFormat(MapredIcebergInputFormat.class);
     return new InputFormatConfig.ConfigBuilder(job);
+  }
+
+  public InputSplit[] getSplits(JobConf job, Table table) throws IOException {
+    return innerInputFormat.getSplits(newJobContext(job), table)
+                           .stream()
+                           .map(InputSplit.class::cast)
+                           .toArray(InputSplit[]::new);
   }
 
   @Override

--- a/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -94,12 +94,10 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
     return new InputFormatConfig.ConfigBuilder(job.getConfiguration());
   }
 
-  @Override
-  public List<InputSplit> getSplits(JobContext context) {
+  public List<InputSplit> getSplits(JobContext context, Table table) {
     Configuration conf = context.getConfiguration();
-    Table table = findTable(conf);
     TableScan scan = table.newScan()
-            .caseSensitive(conf.getBoolean(InputFormatConfig.CASE_SENSITIVE, true));
+        .caseSensitive(conf.getBoolean(InputFormatConfig.CASE_SENSITIVE, true));
     long snapshotId = conf.getLong(InputFormatConfig.SNAPSHOT_ID, -1);
     if (snapshotId != -1) {
       scan = scan.useSnapshot(snapshotId);
@@ -141,6 +139,13 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
     }
 
     return splits;
+  }
+
+  @Override
+  public List<InputSplit> getSplits(JobContext context) {
+    Configuration conf = context.getConfiguration();
+    Table table = findTable(conf);
+    return getSplits(context, table);
   }
 
   private static void checkResiduals(CombinedScanTask task) {

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestTableResolver.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestTableResolver.java
@@ -111,7 +111,7 @@ public class TestTableResolver {
     Assert.assertEquals(tableLocation.getAbsolutePath(), table.location());
   }
 
-  @Test(expected = UnsupportedOperationException.class)
+  @Test(expected = NullPointerException.class)
   public void resolveTableFromConfigurationHiveCatalog() throws IOException {
     Configuration conf = new Configuration();
     conf.set(InputFormatConfig.CATALOG_NAME, InputFormatConfig.HIVE_CATALOG);

--- a/settings.gradle
+++ b/settings.gradle
@@ -33,6 +33,7 @@ include 'spark3'
 include 'spark3-runtime'
 include 'pig'
 include 'hive'
+include 'hive-runtime'
 
 project(':api').name = 'iceberg-api'
 project(':common').name = 'iceberg-common'
@@ -49,6 +50,7 @@ project(':spark3').name = 'iceberg-spark3'
 project(':spark3-runtime').name = 'iceberg-spark3-runtime'
 project(':pig').name = 'iceberg-pig'
 project(':hive').name = 'iceberg-hive'
+project(':hive-runtime').name = 'iceberg-hive-runtime'
 
 if (JavaVersion.current() == JavaVersion.VERSION_1_8) {
   include 'spark2'

--- a/spark3/src/test/java/org/apache/iceberg/spark/SparkCatalogTestBase.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/SparkCatalogTestBase.java
@@ -56,18 +56,18 @@ public abstract class SparkCatalogTestBase extends SparkTestBase {
   @Parameterized.Parameters
   public static Object[][] parameters() {
     return new Object[][] {
+        new Object[] { "spark_catalog", SparkSessionCatalog.class.getName(), ImmutableMap.of(
+            "type", "hive",
+            "default-namespace", "default",
+            "parquet-enabled", "true",
+            "cache-enabled", "false" // Spark will delete tables using v1, leaving the cache out of sync
+        ) },
         new Object[] { "testhive", SparkCatalog.class.getName(), ImmutableMap.of(
             "type", "hive",
             "default-namespace", "default"
         ) },
         new Object[] { "testhadoop", SparkCatalog.class.getName(), ImmutableMap.of(
             "type", "hadoop"
-        ) },
-        new Object[] { "spark_catalog", SparkSessionCatalog.class.getName(), ImmutableMap.of(
-            "type", "hive",
-            "default-namespace", "default",
-            "parquet-enabled", "true",
-            "cache-enabled", "false" // Spark will delete tables using v1, leaving the cache out of sync
         ) }
     };
   }


### PR DESCRIPTION
This PR implements:

- Add default Inputformat/Outputformat/serde (HiveIcebergInputForma,HiveIcebergOutputForma,HiveIcebergSerD) when creating iceberg table using SparkSQL.
- Add Hive Runtime to support read data from hive external table by adding jar in hive.

A hive external table would be created when create a iceberg table in SparkSQL, but its default Inputformat/Outputformat/serde is FileInputFormat/FileOutputFormat/LazySimpleSer, we can't read data from this external table.  With this pr we can read data from the external table in hive (add jar and set mapreduce.input.fileinputformat.input.dir.recursive=true).