### PR TITLE
Flink: Introduce CatalogLoader and TableLoader

### DIFF
--- a/flink/src/main/java/org/apache/iceberg/flink/CatalogLoader.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/CatalogLoader.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink;
+
+import java.io.Serializable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.apache.iceberg.hive.HiveCatalog;
+
+/**
+ * Serializable loader to load an Iceberg {@link Catalog}.
+ */
+public interface CatalogLoader extends Serializable {
+
+  Catalog loadCatalog(Configuration hadoopConf);
+
+  static CatalogLoader hadoop(String name, String warehouseLocation) {
+    return conf -> new HadoopCatalog(name, conf, warehouseLocation);
+  }
+
+  static CatalogLoader hive(String name, String uri, int clientPoolSize) {
+    return conf -> new HiveCatalog(name, uri, clientPoolSize, conf);
+  }
+}

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -105,8 +105,7 @@ public class FlinkCatalogFactory implements CatalogFactory {
 
   @Override
   public Catalog createCatalog(String name, Map<String, String> properties) {
-    Configuration hadoopConf = HadoopUtils.getHadoopConfiguration(GlobalConfiguration.loadConfiguration());
-    return createCatalog(name, properties, hadoopConf);
+    return createCatalog(name, properties, clusterHadoopConf());
   }
 
   protected Catalog createCatalog(String name, Map<String, String> properties, Configuration hadoopConf) {
@@ -117,5 +116,9 @@ public class FlinkCatalogFactory implements CatalogFactory {
         new String[0];
     boolean cacheEnabled = Boolean.parseBoolean(properties.getOrDefault("cache-enabled", "true"));
     return new FlinkCatalog(name, defaultDatabase, baseNamespace, catalogLoader, hadoopConf, cacheEnabled);
+  }
+
+  public static Configuration clusterHadoopConf() {
+    return HadoopUtils.getHadoopConfiguration(GlobalConfiguration.loadConfiguration());
   }
 }

--- a/flink/src/main/java/org/apache/iceberg/flink/TableLoader.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/TableLoader.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.Serializable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.hadoop.HadoopTables;
+
+/**
+ * Serializable loader to load an Iceberg {@link Table}.
+ * Flink needs to get {@link Table} objects in the cluster (for example, to get splits), not just on the client side.
+ * So we need an Iceberg table loader to get the {@link Table} object.
+ */
+public interface TableLoader extends Closeable, Serializable {
+
+  void open(Configuration configuration);
+
+  Table loadTable();
+
+  static TableLoader fromCatalog(CatalogLoader catalogLoader, TableIdentifier identifier) {
+    return new CatalogTableLoader(catalogLoader, identifier);
+  }
+
+  static TableLoader fromHadoopTable(String location) {
+    return new HadoopTableLoader(location);
+  }
+
+  class HadoopTableLoader implements TableLoader {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String location;
+    private transient HadoopTables tables;
+
+    private HadoopTableLoader(String location) {
+      this.location = location;
+    }
+
+    @Override
+    public void open(Configuration configuration) {
+      tables = new HadoopTables(configuration);
+    }
+
+    @Override
+    public Table loadTable() {
+      return tables.load(location);
+    }
+
+    @Override
+    public void close() {
+    }
+  }
+
+  class CatalogTableLoader implements TableLoader {
+
+    private static final long serialVersionUID = 1L;
+
+    private final CatalogLoader catalogLoader;
+    private final String identifier;
+
+    private transient Catalog catalog;
+
+    private CatalogTableLoader(CatalogLoader catalogLoader, TableIdentifier tableIdentifier) {
+      this.catalogLoader = catalogLoader;
+      this.identifier = tableIdentifier.toString();
+    }
+
+    @Override
+    public void open(Configuration configuration) {
+      catalog = catalogLoader.loadCatalog(configuration);
+    }
+
+    @Override
+    public Table loadTable() {
+      return catalog.loadTable(TableIdentifier.parse(identifier));
+    }
+
+    @Override
+    public void close() throws IOException {
+      if (catalog instanceof Closeable) {
+        ((Closeable) catalog).close();
+      }
+    }
+  }
+}

--- a/flink/src/test/java/org/apache/iceberg/flink/FlinkCatalogTestBase.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/FlinkCatalogTestBase.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.api.TableResult;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.ArrayUtils;
 import org.apache.flink.util.CloseableIterator;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
@@ -103,10 +104,9 @@ public abstract class FlinkCatalogTestBase extends FlinkTestBase {
 
     FlinkCatalogFactory factory = new FlinkCatalogFactory() {
       @Override
-      protected Catalog buildIcebergCatalog(String name, Map<String, String> options) {
-        // Flink hadoop configuration depends on system env, it is quiet hard to set from testing. So directly pass
-        // correct hadoop configuration.
-        return super.buildIcebergCatalog(name, options, hiveConf);
+      protected org.apache.flink.table.catalog.Catalog createCatalog(
+          String name, Map<String, String> properties, Configuration hadoopConf) {
+        return super.createCatalog(name, properties, hiveConf);
       }
     };
     tEnv.registerCatalog(


### PR DESCRIPTION
Fixes #1303
Unlike Spark catalog table (Table is only required on the client/driver side), Flink needs obtain `Table` object in Job Manager or Task.
- For writer (https://github.com/apache/iceberg/pull/1185): Flink needs obtain `Table` in committer task for appending files.
- For reader (https://github.com/apache/iceberg/pull/1293): Flink needs obtain `Table` in Job Manager for planing tasks.

So we can introduce a `CatalogLoader` for reader and writer, users can define a custom catalog loader in `FlinkCatalogFactory`.
```
public interface CatalogLoader extends Serializable {
  Catalog loadCatalog(Configuration hadoopConf);
}
```

For support hadoop table based on location. Introduce `TableLoader` for both catalog table and hadoop location table.

Q: Can/Should we introduce `CatalogLoader` and `TableLoader` to an Iceberg common module.