### PR TITLE
Fix schema name conflicts

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Schema.java
+++ b/api/src/main/java/org/apache/iceberg/Schema.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.BiMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableBiMap;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
@@ -47,21 +48,22 @@ public class Schema implements Serializable {
   private final StructType struct;
   private transient BiMap<String, Integer> aliasToId = null;
   private transient Map<Integer, NestedField> idToField = null;
-  private transient BiMap<String, Integer> nameToId = null;
-  private transient BiMap<String, Integer> lowerCaseNameToId = null;
+  private transient Map<String, Integer> nameToId = null;
+  private transient Map<String, Integer> lowerCaseNameToId = null;
   private transient Map<Integer, Accessor<StructLike>> idToAccessor = null;
+  private transient Map<Integer, String> idToName = null;
 
   public Schema(List<NestedField> columns, Map<String, Integer> aliases) {
     this.struct = StructType.of(columns);
     this.aliasToId = aliases != null ? ImmutableBiMap.copyOf(aliases) : null;
 
     // validate the schema through IndexByName visitor
-    lazyNameToId();
+    lazyIdToName();
   }
 
   public Schema(List<NestedField> columns) {
     this.struct = StructType.of(columns);
-    lazyNameToId();
+    lazyIdToName();
   }
 
   public Schema(NestedField... columns) {
@@ -75,16 +77,23 @@ public class Schema implements Serializable {
     return idToField;
   }
 
-  private BiMap<String, Integer> lazyNameToId() {
+  private Map<String, Integer> lazyNameToId() {
     if (nameToId == null) {
-      this.nameToId = ImmutableBiMap.copyOf(TypeUtil.indexByName(struct));
+      this.nameToId = ImmutableMap.copyOf(TypeUtil.indexByName(struct));
     }
     return nameToId;
   }
 
-  private BiMap<String, Integer> lazyLowerCaseNameToId() {
+  private Map<Integer, String> lazyIdToName() {
+    if (idToName == null) {
+      this.idToName = ImmutableMap.copyOf(TypeUtil.indexNameById(struct));
+    }
+    return idToName;
+  }
+
+  private Map<String, Integer> lazyLowerCaseNameToId() {
     if (lowerCaseNameToId == null) {
-      this.lowerCaseNameToId = ImmutableBiMap.copyOf(TypeUtil.indexByLowerCaseName(struct));
+      this.lowerCaseNameToId = ImmutableMap.copyOf(TypeUtil.indexByLowerCaseName(struct));
     }
     return lowerCaseNameToId;
   }
@@ -206,7 +215,7 @@ public class Schema implements Serializable {
    * @return the full column name in this schema that resolves to the id
    */
   public String findColumnName(int id) {
-    return lazyNameToId().inverse().get(id);
+    return lazyIdToName().get(id);
   }
 
   /**

--- a/api/src/main/java/org/apache/iceberg/types/IndexByName.java
+++ b/api/src/main/java/org/apache/iceberg/types/IndexByName.java
@@ -37,6 +37,14 @@ public class IndexByName extends TypeUtil.SchemaVisitor<Map<String, Integer>> {
   private final Map<String, Integer> nameToId = Maps.newHashMap();
   private final Map<String, Integer> shortNameToId = Maps.newHashMap();
 
+  /**
+   * Returns a mapping from full field name to ID.
+   * <p>
+   * Short names for maps and lists are included for any name that does not conflict with a canonical name. For example,
+   * a list, 'l', with of structs with field 'x' will produce short name 'l.x' in addition to 'l.element.x'.
+   *
+   * @return a map from name to field ID
+   */
   public Map<String, Integer> byName() {
     ImmutableMap.Builder<String, Integer> builder = ImmutableMap.builder();
     builder.putAll(nameToId);
@@ -47,6 +55,13 @@ public class IndexByName extends TypeUtil.SchemaVisitor<Map<String, Integer>> {
     return builder.build();
   }
 
+  /**
+   * Returns a mapping from field ID to full name.
+   * <p>
+   * Canonical names, not short names are returned, for example 'list.element.field' instead of 'list.field'.
+   *
+   * @return a map from field ID to name
+   */
   public Map<Integer, String> byId() {
     ImmutableMap.Builder<Integer, String> builder = ImmutableMap.builder();
     nameToId.forEach((key, value) -> builder.put(value, key));
@@ -160,7 +175,7 @@ public class IndexByName extends TypeUtil.SchemaVisitor<Map<String, Integer>> {
     ValidationException.check(existingFieldId == null,
         "Invalid schema: multiple fields for name %s: %s and %s", fullName, existingFieldId, fieldId);
 
-    // if the short name is not
+    // also track the short name, if this is a nested field
     if (!shortFieldNames.isEmpty()) {
       String shortName = DOT.join(DOT.join(shortFieldNames.descendingIterator()), name);
       if (!shortNameToId.containsKey(shortName)) {

--- a/api/src/main/java/org/apache/iceberg/types/IndexByName.java
+++ b/api/src/main/java/org/apache/iceberg/types/IndexByName.java
@@ -41,7 +41,7 @@ public class IndexByName extends TypeUtil.SchemaVisitor<Map<String, Integer>> {
    * Returns a mapping from full field name to ID.
    * <p>
    * Short names for maps and lists are included for any name that does not conflict with a canonical name. For example,
-   * a list, 'l', with of structs with field 'x' will produce short name 'l.x' in addition to 'l.element.x'.
+   * a list, 'l', of structs with field 'x' will produce short name 'l.x' in addition to canonical name 'l.element.x'.
    *
    * @return a map from name to field ID
    */

--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -106,7 +106,15 @@ public class TypeUtil {
   }
 
   public static Map<String, Integer> indexByName(Types.StructType struct) {
-    return visit(struct, new IndexByName());
+    IndexByName indexer = new IndexByName();
+    visit(struct, indexer);
+    return indexer.byName();
+  }
+
+  public static Map<Integer, String> indexNameById(Types.StructType struct) {
+    IndexByName indexer = new IndexByName();
+    visit(struct, indexer);
+    return indexer.byId();
   }
 
   public static Map<String, Integer> indexByLowerCaseName(Types.StructType struct) {


### PR DESCRIPTION
Iceberg indexes schemas by name to look up fields, but uses short names by omitting "element" and "value" names when a list or map has a struct element or value. For example, a list, `locations`, of structs `struct<lat: double, long: double>` will use names `locations.lat` instead of `locations.element.lat`.

This works most of the time, but can lead to conflicts when a map value contains a field name `key`. In that case, the schema is rejected with a failure message like this: `ValidationException: Invalid schema: multiple fields for name some_map.key: 146 and 144`

In addition, Spark passes names through `alterTable` that include the `value` and `element` names that are omitted.

This PR fixes the problem by keeping track of two names, the full name with `element` and `value`, and secondary "short" names that omit them. Indexing now uses all of the full names and adds any short names that are not ambiguous.

This change also requires indexing IDs separately rather than using a `BiMap` because IDs can have multiple names, which is not valid when inverting the `BiMap`.