### PR TITLE
Add file stats range optimizations for DeleteFileIndex

### DIFF
--- a/api/src/main/java/org/apache/iceberg/data/Record.java
+++ b/api/src/main/java/org/apache/iceberg/data/Record.java
@@ -44,14 +44,14 @@ public interface Record extends StructLike {
   }
 
   default Record copy(String field1, Object value1, String field2, Object value2) {
-    Map<String, Object> overwriteValues = Maps.newHashMapWithExpectedSize(1);
+    Map<String, Object> overwriteValues = Maps.newHashMapWithExpectedSize(2);
     overwriteValues.put(field1, value1);
     overwriteValues.put(field2, value2);
     return copy(overwriteValues);
   }
 
   default Record copy(String field1, Object value1, String field2, Object value2, String field3, Object value3) {
-    Map<String, Object> overwriteValues = Maps.newHashMapWithExpectedSize(1);
+    Map<String, Object> overwriteValues = Maps.newHashMapWithExpectedSize(3);
     overwriteValues.put(field1, value1);
     overwriteValues.put(field2, value2);
     overwriteValues.put(field3, value3);

--- a/api/src/main/java/org/apache/iceberg/data/Record.java
+++ b/api/src/main/java/org/apache/iceberg/data/Record.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.data;
 
 import java.util.Map;
 import org.apache.iceberg.StructLike;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types.StructType;
 
 public interface Record extends StructLike {
@@ -35,4 +36,26 @@ public interface Record extends StructLike {
   Record copy();
 
   Record copy(Map<String, Object> overwriteValues);
+
+  default Record copy(String field, Object value) {
+    Map<String, Object> overwriteValues = Maps.newHashMapWithExpectedSize(1);
+    overwriteValues.put(field, value);
+    return copy(overwriteValues);
+  }
+
+  default Record copy(String field1, Object value1, String field2, Object value2) {
+    Map<String, Object> overwriteValues = Maps.newHashMapWithExpectedSize(1);
+    overwriteValues.put(field1, value1);
+    overwriteValues.put(field2, value2);
+    return copy(overwriteValues);
+  }
+
+  default Record copy(String field1, Object value1, String field2, Object value2, String field3, Object value3) {
+    Map<String, Object> overwriteValues = Maps.newHashMapWithExpectedSize(1);
+    overwriteValues.put(field1, value1);
+    overwriteValues.put(field2, value2);
+    overwriteValues.put(field3, value3);
+    return copy(overwriteValues);
+  }
+
 }

--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -175,6 +175,7 @@ abstract class BaseFile<F>
     this.keyMetadata = toCopy.keyMetadata == null ? null : Arrays.copyOf(toCopy.keyMetadata, toCopy.keyMetadata.length);
     this.splitOffsets = toCopy.splitOffsets == null ? null :
         Arrays.copyOf(toCopy.splitOffsets, toCopy.splitOffsets.length);
+    this.equalityIds = toCopy.equalityIds != null ? Arrays.copyOf(toCopy.equalityIds, toCopy.equalityIds.length) : null;
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -157,6 +157,7 @@ class DeleteFileIndex {
     return true;
   }
 
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
   private static boolean canContainEqDeletesForFile(DataFile dataFile, DeleteFile deleteFile, Schema schema) {
     if (dataFile.lowerBounds() == null || dataFile.upperBounds() == null ||
         deleteFile.lowerBounds() == null || deleteFile.upperBounds() == null) {

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -142,15 +142,14 @@ class DeleteFileIndex {
 
     Type pathType = MetadataColumns.DELETE_FILE_PATH.type();
     int pathId = MetadataColumns.DELETE_FILE_PATH.fieldId();
+    Comparator<CharSequence> comparator = Comparators.charSequences();
     ByteBuffer lower = lowers.get(pathId);
-    if (lower != null &&
-        Comparators.charSequences().compare(dataFile.path(), Conversions.fromByteBuffer(pathType, lower)) < 0) {
+    if (lower != null && comparator.compare(dataFile.path(), Conversions.fromByteBuffer(pathType, lower)) < 0) {
       return false;
     }
 
     ByteBuffer upper = uppers.get(pathId);
-    if (upper != null &&
-        Comparators.charSequences().compare(dataFile.path(), Conversions.fromByteBuffer(pathType, upper)) > 0) {
+    if (upper != null && comparator.compare(dataFile.path(), Conversions.fromByteBuffer(pathType, upper)) > 0) {
       return false;
     }
 

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -245,7 +245,7 @@ class DeleteFileIndex {
     Long nullValueCount = nullValueCounts.get(field.fieldId());
     Long valueCount = valueCounts.get(field.fieldId());
     if (nullValueCount == null || valueCount == null) {
-      return true;
+      return false;
     }
 
     return nullValueCount.equals(valueCount);

--- a/core/src/main/java/org/apache/iceberg/ManifestGroup.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestGroup.java
@@ -27,6 +27,8 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.iceberg.expressions.Evaluator;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
@@ -38,6 +40,7 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ParallelIterable;
 
@@ -163,6 +166,9 @@ class ManifestGroup {
     DeleteFileIndex deleteFiles = deleteIndexBuilder.build();
 
     boolean dropStats = ManifestReader.dropStats(dataFilter, columns);
+    if (!deleteFiles.isEmpty()) {
+      select(Streams.concat(columns.stream(), ManifestReader.STATS_COLUMNS.stream()).collect(Collectors.toList()));
+    }
 
     Iterable<CloseableIterable<FileScanTask>> tasks = entries((manifest, entries) -> {
       int specId = manifest.partitionSpecId();

--- a/core/src/main/java/org/apache/iceberg/ManifestGroup.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestGroup.java
@@ -28,7 +28,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.iceberg.expressions.Evaluator;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -52,7 +52,7 @@ import static org.apache.iceberg.expressions.Expressions.alwaysTrue;
 public class ManifestReader<F extends ContentFile<F>>
     extends CloseableGroup implements CloseableIterable<F> {
   static final ImmutableList<String> ALL_COLUMNS = ImmutableList.of("*");
-  private static final Set<String> STATS_COLUMNS = Sets.newHashSet(
+  static final Set<String> STATS_COLUMNS = Sets.newHashSet(
       "value_counts", "null_value_counts", "lower_bounds", "upper_bounds");
 
   protected enum FileType {

--- a/core/src/main/java/org/apache/iceberg/avro/Avro.java
+++ b/core/src/main/java/org/apache/iceberg/avro/Avro.java
@@ -300,10 +300,7 @@ public class Avro {
 
       meta("delete-type", "position");
 
-      if (rowSchema != null) {
-        Preconditions.checkState(createWriterFunc != null,
-            "Cannot create delete file with deletes rows unless createWriterFunc is set");
-
+      if (rowSchema != null && createWriterFunc != null) {
         // the appender uses the row schema wrapped with position fields
         appenderBuilder.schema(new org.apache.iceberg.Schema(
             MetadataColumns.DELETE_FILE_PATH,

--- a/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
@@ -87,11 +87,11 @@ public class Deletes {
     }
   }
 
-  public static Set<Long> toPositionSet(String dataLocation, CloseableIterable<StructLike> deleteFile) {
+  public static Set<Long> toPositionSet(CharSequence dataLocation, CloseableIterable<StructLike> deleteFile) {
     return toPositionSet(dataLocation, ImmutableList.of(deleteFile));
   }
 
-  public static Set<Long> toPositionSet(String dataLocation, List<CloseableIterable<StructLike>> deleteFiles) {
+  public static Set<Long> toPositionSet(CharSequence dataLocation, List<CloseableIterable<StructLike>> deleteFiles) {
     DataFileFilter locationFilter = new DataFileFilter(dataLocation);
     List<CloseableIterable<Long>> positions = Lists.transform(deleteFiles, deletes ->
         CloseableIterable.transform(locationFilter.filter(deletes), row -> (Long) POSITION_ACCESSOR.get(row)));
@@ -112,11 +112,12 @@ public class Deletes {
     return new PositionStreamDeleteFilter<>(rows, rowToPosition, posDeletes);
   }
 
-  public static CloseableIterable<Long> deletePositions(String dataLocation, CloseableIterable<StructLike> deleteFile) {
+  public static CloseableIterable<Long> deletePositions(CharSequence dataLocation,
+                                                        CloseableIterable<StructLike> deleteFile) {
     return deletePositions(dataLocation, ImmutableList.of(deleteFile));
   }
 
-  public static CloseableIterable<Long> deletePositions(String dataLocation,
+  public static CloseableIterable<Long> deletePositions(CharSequence dataLocation,
                                                         List<CloseableIterable<StructLike>> deleteFiles) {
     DataFileFilter locationFilter = new DataFileFilter(dataLocation);
     List<CloseableIterable<Long>> positions = Lists.transform(deleteFiles, deletes ->
@@ -233,9 +234,9 @@ public class Deletes {
 
   private static class DataFileFilter extends Filter<StructLike> {
     private static final Comparator<CharSequence> CHARSEQ_COMPARATOR = Comparators.charSequences();
-    private final String dataLocation;
+    private final CharSequence dataLocation;
 
-    DataFileFilter(String dataLocation) {
+    DataFileFilter(CharSequence dataLocation) {
       this.dataLocation = dataLocation;
     }
 

--- a/core/src/test/java/org/apache/iceberg/TestDeleteFileIndex.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeleteFileIndex.java
@@ -79,7 +79,6 @@ public class TestDeleteFileIndex extends TableTestBase {
   @Test
   public void testUnpartitionedDeletes() {
     DeleteFileIndex index = new DeleteFileIndex(
-        SCHEMA,
         ImmutableMap.of(
             PartitionSpec.unpartitioned().specId(), PartitionSpec.unpartitioned(),
             1, SPEC),
@@ -110,7 +109,6 @@ public class TestDeleteFileIndex extends TableTestBase {
   @Test
   public void testPartitionedDeleteIndex() {
     DeleteFileIndex index = new DeleteFileIndex(
-        SCHEMA,
         ImmutableMap.of(
             SPEC.specId(), SPEC,
             1, PartitionSpec.unpartitioned()),

--- a/core/src/test/java/org/apache/iceberg/TestDeleteFileIndex.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeleteFileIndex.java
@@ -79,6 +79,7 @@ public class TestDeleteFileIndex extends TableTestBase {
   @Test
   public void testUnpartitionedDeletes() {
     DeleteFileIndex index = new DeleteFileIndex(
+        SCHEMA,
         ImmutableMap.of(
             PartitionSpec.unpartitioned().specId(), PartitionSpec.unpartitioned(),
             1, SPEC),
@@ -109,6 +110,7 @@ public class TestDeleteFileIndex extends TableTestBase {
   @Test
   public void testPartitionedDeleteIndex() {
     DeleteFileIndex index = new DeleteFileIndex(
+        SCHEMA,
         ImmutableMap.of(
             SPEC.specId(), SPEC,
             1, PartitionSpec.unpartitioned()),

--- a/core/src/test/java/org/apache/iceberg/TestTables.java
+++ b/core/src/test/java/org/apache/iceberg/TestTables.java
@@ -107,7 +107,7 @@ public class TestTables {
   private static final Map<String, TableMetadata> METADATA = Maps.newHashMap();
   private static final Map<String, Integer> VERSIONS = Maps.newHashMap();
 
-  static void clearTables() {
+  public static void clearTables() {
     synchronized (METADATA) {
       METADATA.clear();
       VERSIONS.clear();

--- a/data/src/test/java/org/apache/iceberg/data/TestDataFileIndexStatsFilters.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestDataFileIndexStatsFilters.java
@@ -24,7 +24,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DeleteFile;
@@ -34,30 +33,26 @@ import org.apache.iceberg.Files;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TestTables;
 import org.apache.iceberg.data.parquet.GenericParquetWriter;
 import org.apache.iceberg.deletes.EqualityDeleteWriter;
-import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.parquet.Parquet;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.Pair;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 public class TestDataFileIndexStatsFilters {
-  private final Schema SCHEMA = new Schema(
+  private static final Schema SCHEMA = new Schema(
       Types.NestedField.optional(1, "id", Types.IntegerType.get()),
       Types.NestedField.optional(2, "data", Types.StringType.get()),
       Types.NestedField.required(3, "category", Types.StringType.get()));
@@ -320,7 +315,7 @@ public class TestDataFileIndexStatsFilters {
     return writer.toDeleteFile();
   }
 
-  public DataFile writeDataFile(List<Record> records) throws IOException {
+  public DataFile writeDataFile(List<Record> rows) throws IOException {
     OutputFile out = Files.localOutput(temp.newFile());
     FileAppender<Record> writer = Parquet.write(out)
         .createWriterFunc(GenericParquetWriter::buildWriter)
@@ -329,7 +324,7 @@ public class TestDataFileIndexStatsFilters {
         .build();
 
     try (Closeable toClose = writer) {
-      writer.addAll(records);
+      writer.addAll(rows);
     }
 
     return DataFiles.builder(table.spec())

--- a/data/src/test/java/org/apache/iceberg/data/TestDataFileIndexStatsFilters.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestDataFileIndexStatsFilters.java
@@ -1,0 +1,343 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.data;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.TestTables;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
+import org.apache.iceberg.deletes.EqualityDeleteWriter;
+import org.apache.iceberg.deletes.PositionDelete;
+import org.apache.iceberg.deletes.PositionDeleteWriter;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.Pair;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestDataFileIndexStatsFilters {
+  private final Schema SCHEMA = new Schema(
+      Types.NestedField.optional(1, "id", Types.IntegerType.get()),
+      Types.NestedField.optional(2, "data", Types.StringType.get()),
+      Types.NestedField.required(3, "category", Types.StringType.get()));
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  private Table table;
+  private List<Record> records = null;
+  private DataFile dataFile = null;
+  private DataFile dataFileWithoutNulls = null;
+  private DataFile dataFileOnlyNulls = null;
+
+  @Before
+  public void createTableAndData() throws IOException {
+    File location = temp.newFolder();
+    this.table = TestTables.create(location, "test", SCHEMA, PartitionSpec.unpartitioned(), 2);
+
+    this.records = Lists.newArrayList();
+
+    Record record = GenericRecord.create(table.schema());
+    records.add(record.copy("id", 1, "data", "a", "category", "odd"));
+    records.add(record.copy("id", 2, "data", "b", "category", "even"));
+    records.add(record.copy("id", 3, "data", "c", "category", "odd"));
+    records.add(record.copy("id", 4, "data", "d", "category", "even"));
+    records.add(record.copy("id", 5, "data", "e", "category", "odd"));
+    records.add(record.copy("id", 6, "data", "f", "category", "even"));
+    records.add(record.copy("id", 7, "data", "g", "category", "odd"));
+    records.add(record.copy("id", 8, "data", null, "category", "even"));
+
+    this.dataFile = writeDataFile(records);
+    this.dataFileWithoutNulls = writeDataFile(
+        records.stream().filter(rec -> rec.getField("data") != null).collect(Collectors.toList()));
+    this.dataFileOnlyNulls = writeDataFile(
+        records.stream().filter(rec -> rec.getField("data") == null).collect(Collectors.toList()));
+  }
+
+  @After
+  public void dropTable() {
+    TestTables.clearTables();
+  }
+
+  @Test
+  public void testPositionDeletePlanningPath() throws IOException {
+    table.newAppend()
+        .appendFile(dataFile)
+        .commit();
+
+    List<Pair<CharSequence, Long>> deletes = Lists.newArrayList();
+    deletes.add(Pair.of(dataFile.path(), 0L));
+    deletes.add(Pair.of(dataFile.path(), 1L));
+
+    DeleteFile posDeletes = writeDeleteFile(deletes);
+    table.newRowDelta()
+        .addDeletes(posDeletes)
+        .commit();
+
+    List<FileScanTask> tasks;
+    try (CloseableIterable<FileScanTask> tasksIterable = table.newScan().planFiles()) {
+      tasks = Lists.newArrayList(tasksIterable);
+    }
+
+    Assert.assertEquals("Should produce one task", 1, tasks.size());
+    FileScanTask task = tasks.get(0);
+    Assert.assertEquals("Should have one delete file, file_path matches", 1, task.deletes().size());
+  }
+
+  @Test
+  public void testPositionDeletePlanningPathFilter() throws IOException {
+    table.newAppend()
+        .appendFile(dataFile)
+        .commit();
+
+    List<Pair<CharSequence, Long>> deletes = Lists.newArrayList();
+    deletes.add(Pair.of("some-other-file.parquet", 0L));
+    deletes.add(Pair.of("some-other-file.parquet", 1L));
+
+    DeleteFile posDeletes = writeDeleteFile(deletes);
+    table.newRowDelta()
+        .addDeletes(posDeletes)
+        .commit();
+
+    List<FileScanTask> tasks;
+    try (CloseableIterable<FileScanTask> tasksIterable = table.newScan().planFiles()) {
+      tasks = Lists.newArrayList(tasksIterable);
+    }
+
+    Assert.assertEquals("Should produce one task", 1, tasks.size());
+    FileScanTask task = tasks.get(0);
+    Assert.assertEquals("Should not have delete file, filtered by file_path stats", 0, task.deletes().size());
+  }
+
+  @Test
+  public void testEqualityDeletePlanningStats() throws IOException {
+    table.newAppend()
+        .appendFile(dataFile)
+        .commit();
+
+    List<Record> deletes = Lists.newArrayList();
+    Schema deleteRowSchema = SCHEMA.select("data");
+    Record delete = GenericRecord.create(deleteRowSchema);
+    deletes.add(delete.copy("data", "d"));
+
+    DeleteFile posDeletes = writeDeleteFile(deletes, deleteRowSchema);
+
+    table.newRowDelta()
+        .addDeletes(posDeletes)
+        .commit();
+
+    List<FileScanTask> tasks;
+    try (CloseableIterable<FileScanTask> tasksIterable = table.newScan().planFiles()) {
+      tasks = Lists.newArrayList(tasksIterable);
+    }
+
+    Assert.assertEquals("Should produce one task", 1, tasks.size());
+    FileScanTask task = tasks.get(0);
+    Assert.assertEquals("Should have one delete file, data contains a matching value", 1, task.deletes().size());
+  }
+
+  @Test
+  public void testEqualityDeletePlanningStatsFilter() throws IOException {
+    table.newAppend()
+        .appendFile(dataFile)
+        .commit();
+
+    List<Record> deletes = Lists.newArrayList();
+    Schema deleteRowSchema = table.schema().select("data");
+    Record delete = GenericRecord.create(deleteRowSchema);
+    deletes.add(delete.copy("data", "x"));
+    deletes.add(delete.copy("data", "y"));
+    deletes.add(delete.copy("data", "z"));
+
+    DeleteFile posDeletes = writeDeleteFile(deletes, deleteRowSchema);
+
+    table.newRowDelta()
+        .addDeletes(posDeletes)
+        .commit();
+
+    List<FileScanTask> tasks;
+    try (CloseableIterable<FileScanTask> tasksIterable = table.newScan().planFiles()) {
+      tasks = Lists.newArrayList(tasksIterable);
+    }
+
+    Assert.assertEquals("Should produce one task", 1, tasks.size());
+    FileScanTask task = tasks.get(0);
+    Assert.assertEquals("Should not have delete file, filtered by data column stats", 0, task.deletes().size());
+  }
+
+  @Test
+  public void testEqualityDeletePlanningStatsNullValueWithAllNullDeletes() throws IOException {
+    table.newAppend()
+        .appendFile(dataFile)
+        .commit();
+
+    List<Record> deletes = Lists.newArrayList();
+    Schema deleteRowSchema = SCHEMA.select("data");
+    Record delete = GenericRecord.create(deleteRowSchema);
+    deletes.add(delete.copy("data", null));
+
+    DeleteFile posDeletes = writeDeleteFile(deletes, deleteRowSchema);
+
+    table.newRowDelta()
+        .addDeletes(posDeletes)
+        .commit();
+
+    List<FileScanTask> tasks;
+    try (CloseableIterable<FileScanTask> tasksIterable = table.newScan().planFiles()) {
+      tasks = Lists.newArrayList(tasksIterable);
+    }
+
+    Assert.assertEquals("Should produce one task", 1, tasks.size());
+    FileScanTask task = tasks.get(0);
+    Assert.assertEquals("Should have delete file, data contains a null value", 1, task.deletes().size());
+  }
+
+  @Test
+  public void testEqualityDeletePlanningStatsNoNullValuesWithAllNullDeletes() throws IOException {
+    table.newAppend()
+        .appendFile(dataFileWithoutNulls) // note that there are no nulls in the data column
+        .commit();
+
+    List<Record> deletes = Lists.newArrayList();
+    Schema deleteRowSchema = SCHEMA.select("data");
+    Record delete = GenericRecord.create(deleteRowSchema);
+    deletes.add(delete.copy("data", null));
+
+    DeleteFile posDeletes = writeDeleteFile(deletes, deleteRowSchema);
+
+    table.newRowDelta()
+        .addDeletes(posDeletes)
+        .commit();
+
+    List<FileScanTask> tasks;
+    try (CloseableIterable<FileScanTask> tasksIterable = table.newScan().planFiles()) {
+      tasks = Lists.newArrayList(tasksIterable);
+    }
+
+    Assert.assertEquals("Should produce one task", 1, tasks.size());
+    FileScanTask task = tasks.get(0);
+    Assert.assertEquals("Should have no delete files, data contains no null values", 0, task.deletes().size());
+  }
+
+  @Test
+  public void testEqualityDeletePlanningStatsAllNullValuesWithNoNullDeletes() throws IOException {
+    table.newAppend()
+        .appendFile(dataFileOnlyNulls) // note that there are only nulls in the data column
+        .commit();
+
+    List<Record> deletes = Lists.newArrayList();
+    Schema deleteRowSchema = SCHEMA.select("data");
+    Record delete = GenericRecord.create(deleteRowSchema);
+    deletes.add(delete.copy("data", "d"));
+
+    DeleteFile posDeletes = writeDeleteFile(deletes, deleteRowSchema);
+
+    table.newRowDelta()
+        .addDeletes(posDeletes)
+        .commit();
+
+    List<FileScanTask> tasks;
+    try (CloseableIterable<FileScanTask> tasksIterable = table.newScan().planFiles()) {
+      tasks = Lists.newArrayList(tasksIterable);
+    }
+
+    Assert.assertEquals("Should produce one task", 1, tasks.size());
+    FileScanTask task = tasks.get(0);
+    Assert.assertEquals("Should have no delete files, data contains no null values", 0, task.deletes().size());
+  }
+
+  public DeleteFile writeDeleteFile(List<Pair<CharSequence, Long>> deletes) throws IOException {
+    OutputFile out = Files.localOutput(temp.newFile());
+    PositionDeleteWriter<?> writer = Parquet.writeDeletes(out)
+        .forTable(table)
+        .overwrite()
+        .buildPositionWriter();
+
+    try (Closeable toClose = writer) {
+      for (Pair<CharSequence, Long> delete : deletes) {
+        writer.delete(delete.first(), delete.second());
+      }
+    }
+
+    return writer.toDeleteFile();
+  }
+
+  public DeleteFile writeDeleteFile(List<Record> deletes, Schema deleteRowSchema) throws IOException {
+    OutputFile out = Files.localOutput(temp.newFile());
+    EqualityDeleteWriter<Record> writer = Parquet.writeDeletes(out)
+        .forTable(table)
+        .rowSchema(deleteRowSchema)
+        .createWriterFunc(GenericParquetWriter::buildWriter)
+        .overwrite()
+        .equalityFieldIds(deleteRowSchema.columns().stream().mapToInt(Types.NestedField::fieldId).toArray())
+        .buildEqualityWriter();
+
+    try (Closeable toClose = writer) {
+      writer.deleteAll(deletes);
+    }
+
+    return writer.toDeleteFile();
+  }
+
+  public DataFile writeDataFile(List<Record> records) throws IOException {
+    OutputFile out = Files.localOutput(temp.newFile());
+    FileAppender<Record> writer = Parquet.write(out)
+        .createWriterFunc(GenericParquetWriter::buildWriter)
+        .schema(table.schema())
+        .overwrite()
+        .build();
+
+    try (Closeable toClose = writer) {
+      writer.addAll(records);
+    }
+
+    return DataFiles.builder(table.spec())
+        .withFormat(FileFormat.PARQUET)
+        .withPath(out.location())
+        .withFileSizeInBytes(writer.length())
+        .withSplitOffsets(writer.splitOffsets())
+        .withMetrics(writer.metrics())
+        .build();
+  }
+}

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -270,7 +270,7 @@ public class Parquet {
     return new DeleteWriteBuilder(file);
   }
 
-  public static class DeleteWriteBuilder extends WriteBuilder {
+  public static class DeleteWriteBuilder {
     private final WriteBuilder appenderBuilder;
     private final String location;
     private Function<MessageType, ParquetValueWriter<?>> createWriterFunc = null;
@@ -281,13 +281,13 @@ public class Parquet {
     private int[] equalityFieldIds = null;
 
     private DeleteWriteBuilder(OutputFile file) {
-      super(file);
       this.appenderBuilder = write(file);
       this.location = file.location();
     }
 
     public DeleteWriteBuilder forTable(Table table) {
-      schema(table.schema());
+      rowSchema(table.schema());
+      withSpec(table.spec());
       setAll(table.properties());
       metricsConfig(MetricsConfig.fromProperties(table.properties()));
       return this;
@@ -383,10 +383,7 @@ public class Parquet {
 
       meta("delete-type", "position");
 
-      if (rowSchema != null) {
-        Preconditions.checkState(createWriterFunc != null,
-            "Cannot create delete file with deletes rows unless createWriterFunc is set");
-
+      if (rowSchema != null && createWriterFunc != null) {
         // the appender uses the row schema wrapped with position fields
         appenderBuilder.schema(new org.apache.iceberg.Schema(
             MetadataColumns.DELETE_FILE_PATH,


### PR DESCRIPTION
This adds two optimizations for `DeleteFileIndex`:

* For position deletes, if the data file path is not in the range of values for a delete file's `file_path` column, ignore the delete file
* For equality deletes, if the data file and delete file value ranges for any equality column do not overlap, ignore the delete file