### PR TITLE
ORC: Use MetricsConfig

### DIFF
--- a/data/src/test/java/org/apache/iceberg/orc/TestOrcMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/orc/TestOrcMetrics.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Metrics;
+import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TestMetrics;
 import org.apache.iceberg.data.Record;
@@ -58,8 +59,8 @@ public class TestOrcMetrics extends TestMetrics {
   }
 
   @Override
-  public Metrics getMetrics(InputFile file) {
-    return OrcMetrics.fromInputFile(file);
+  public Metrics getMetrics(InputFile file, MetricsConfig metricsConfig) {
+    return OrcMetrics.fromInputFile(file, metricsConfig);
   }
 
   @Override

--- a/data/src/test/java/org/apache/iceberg/parquet/TestParquetMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/parquet/TestParquetMetrics.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Metrics;
+import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TestMetrics;
@@ -56,8 +57,8 @@ public class TestParquetMetrics extends TestMetrics {
   }
 
   @Override
-  public Metrics getMetrics(InputFile file) {
-    return ParquetUtil.fileMetrics(file);
+  public Metrics getMetrics(InputFile file, MetricsConfig metricsConfig) {
+    return ParquetUtil.fileMetrics(file, metricsConfig);
   }
 
   @Override

--- a/orc/src/main/java/org/apache/iceberg/orc/ORC.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORC.java
@@ -27,6 +27,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Expression;
@@ -63,6 +64,7 @@ public class ORC {
     private Schema schema = null;
     private BiFunction<Schema, TypeDescription, OrcRowWriter<?>> createWriterFunc;
     private Map<String, byte[]> metadata = new HashMap<>();
+    private MetricsConfig metricsConfig;
 
     private WriteBuilder(OutputFile file) {
       this.file = file;
@@ -107,11 +109,16 @@ public class ORC {
       return this;
     }
 
+    public WriteBuilder metricsConfig(MetricsConfig newMetricsConfig) {
+      this.metricsConfig = newMetricsConfig;
+      return this;
+    }
+
     public <D> FileAppender<D> build() {
       Preconditions.checkNotNull(schema, "Schema is required");
       return new OrcFileAppender<>(schema,
           this.file, createWriterFunc, conf, metadata,
-          conf.getInt(VECTOR_ROW_BATCH_SIZE, VectorizedRowBatch.DEFAULT_SIZE));
+          conf.getInt(VECTOR_ROW_BATCH_SIZE, VectorizedRowBatch.DEFAULT_SIZE), metricsConfig);
     }
   }
 

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
@@ -31,16 +31,22 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.Metrics;
+import org.apache.iceberg.MetricsConfig;
+import org.apache.iceberg.MetricsModes;
+import org.apache.iceberg.MetricsModes.MetricsMode;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.common.DynFields;
 import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.hadoop.HadoopInputFile;
 import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.UnicodeUtil;
 import org.apache.orc.BooleanColumnStatistics;
 import org.apache.orc.ColumnStatistics;
 import org.apache.orc.DateColumnStatistics;
@@ -56,35 +62,45 @@ import org.apache.orc.impl.ColumnStatisticsImpl;
 
 public class OrcMetrics {
 
+  private enum Bound {
+    LOWER, UPPER
+  }
+
   private OrcMetrics() {
   }
 
   public static Metrics fromInputFile(InputFile file) {
-    final Configuration config = (file instanceof HadoopInputFile) ?
-        ((HadoopInputFile) file).getConf() : new Configuration();
-    return fromInputFile(file, config);
+    return fromInputFile(file, MetricsConfig.getDefault());
   }
 
-  static Metrics fromInputFile(InputFile file, Configuration config) {
+  public static Metrics fromInputFile(InputFile file, MetricsConfig metricsConfig) {
+    final Configuration config = (file instanceof HadoopInputFile) ?
+        ((HadoopInputFile) file).getConf() : new Configuration();
+    return fromInputFile(file, config, metricsConfig);
+  }
+
+  static Metrics fromInputFile(InputFile file, Configuration config, MetricsConfig metricsConfig) {
     try (Reader orcReader = ORC.newFileReader(file, config)) {
-      return buildOrcMetrics(orcReader.getNumberOfRows(), orcReader.getSchema(), orcReader.getStatistics());
+      return buildOrcMetrics(orcReader.getNumberOfRows(), orcReader.getSchema(), orcReader.getStatistics(),
+          metricsConfig);
     } catch (IOException ioe) {
       throw new RuntimeIOException(ioe, "Failed to open file: %s", file.location());
     }
   }
 
-  static Metrics fromWriter(Writer writer) {
+  static Metrics fromWriter(Writer writer, MetricsConfig metricsConfig) {
     try {
-      return buildOrcMetrics(writer.getNumberOfRows(), writer.getSchema(), writer.getStatistics());
+      return buildOrcMetrics(writer.getNumberOfRows(), writer.getSchema(), writer.getStatistics(), metricsConfig);
     } catch (IOException ioe) {
       throw new RuntimeIOException(ioe, "Failed to get statistics from writer");
     }
   }
 
-  private static Metrics buildOrcMetrics(final long numOfRows, final TypeDescription orcSchema,
-                                         final ColumnStatistics[] colStats) {
+  private static Metrics buildOrcMetrics(long numOfRows, TypeDescription orcSchema,
+                                         ColumnStatistics[] colStats, MetricsConfig metricsConfig) {
     final Schema schema = ORCSchemaUtil.convert(orcSchema);
     final Set<Integer> statsColumns = statsColumns(orcSchema);
+    final MetricsConfig effectiveMetricsConfig = Optional.ofNullable(metricsConfig).orElse(MetricsConfig.getDefault());
     Map<Integer, Long> columnSizes = Maps.newHashMapWithExpectedSize(colStats.length);
     Map<Integer, Long> valueCounts = Maps.newHashMapWithExpectedSize(colStats.length);
     Map<Integer, Long> nullCounts = Maps.newHashMapWithExpectedSize(colStats.length);
@@ -100,8 +116,13 @@ public class OrcMetrics {
       if (icebergColOpt.isPresent()) {
         final Types.NestedField icebergCol = icebergColOpt.get();
         final int fieldId = icebergCol.fieldId();
+        final MetricsMode metricsMode = effectiveMetricsConfig.columnMode(icebergCol.name());
 
         columnSizes.put(fieldId, colStat.getBytesOnDisk());
+
+        if (metricsMode == MetricsModes.None.get()) {
+          continue;
+        }
 
         if (statsColumns.contains(fieldId)) {
           // Since ORC does not track null values nor repeated ones, the value count for columns in
@@ -115,12 +136,14 @@ public class OrcMetrics {
           }
           valueCounts.put(fieldId, colStat.getNumberOfValues() + nullCounts.get(fieldId));
 
-          Optional<ByteBuffer> orcMin = (colStat.getNumberOfValues() > 0) ?
-              fromOrcMin(icebergCol, colStat) : Optional.empty();
-          orcMin.ifPresent(byteBuffer -> lowerBounds.put(icebergCol.fieldId(), byteBuffer));
-          Optional<ByteBuffer> orcMax = (colStat.getNumberOfValues() > 0) ?
-              fromOrcMax(icebergCol, colStat) : Optional.empty();
-          orcMax.ifPresent(byteBuffer -> upperBounds.put(icebergCol.fieldId(), byteBuffer));
+          if (metricsMode != MetricsModes.Counts.get()) {
+            Optional<ByteBuffer> orcMin = (colStat.getNumberOfValues() > 0) ?
+                fromOrcMin(icebergCol.type(), colStat, metricsMode) : Optional.empty();
+            orcMin.ifPresent(byteBuffer -> lowerBounds.put(icebergCol.fieldId(), byteBuffer));
+            Optional<ByteBuffer> orcMax = (colStat.getNumberOfValues() > 0) ?
+                fromOrcMax(icebergCol.type(), colStat, metricsMode) : Optional.empty();
+            orcMax.ifPresent(byteBuffer -> upperBounds.put(icebergCol.fieldId(), byteBuffer));
+          }
         }
       }
     }
@@ -133,17 +156,17 @@ public class OrcMetrics {
         upperBounds);
   }
 
-  private static Optional<ByteBuffer> fromOrcMin(Types.NestedField column,
-                                                 ColumnStatistics columnStats) {
+  private static Optional<ByteBuffer> fromOrcMin(Type type, ColumnStatistics columnStats,
+                                                 MetricsMode metricsMode) {
     Object min = null;
     if (columnStats instanceof IntegerColumnStatistics) {
       min = ((IntegerColumnStatistics) columnStats).getMinimum();
-      if (column.type().typeId() == Type.TypeID.INTEGER) {
+      if (type.typeId() == Type.TypeID.INTEGER) {
         min = Math.toIntExact((long) min);
       }
     } else if (columnStats instanceof DoubleColumnStatistics) {
       min = ((DoubleColumnStatistics) columnStats).getMinimum();
-      if (column.type().typeId() == Type.TypeID.FLOAT) {
+      if (type.typeId() == Type.TypeID.FLOAT) {
         min = ((Double) min).floatValue();
       }
     } else if (columnStats instanceof StringColumnStatistics) {
@@ -152,7 +175,7 @@ public class OrcMetrics {
       min = Optional
           .ofNullable(((DecimalColumnStatistics) columnStats).getMinimum())
           .map(minStats -> minStats.bigDecimalValue()
-              .setScale(((Types.DecimalType) column.type()).scale()))
+              .setScale(((Types.DecimalType) type).scale()))
           .orElse(null);
     } else if (columnStats instanceof DateColumnStatistics) {
       min = Optional.ofNullable(minDayFromEpoch((DateColumnStatistics) columnStats)).orElse(null);
@@ -166,20 +189,21 @@ public class OrcMetrics {
       BooleanColumnStatistics booleanStats = (BooleanColumnStatistics) columnStats;
       min = booleanStats.getFalseCount() <= 0;
     }
-    return Optional.ofNullable(Conversions.toByteBuffer(column.type(), min));
+
+    return Optional.ofNullable(Conversions.toByteBuffer(type, truncateIfNeeded(Bound.LOWER, type, min, metricsMode)));
   }
 
-  private static Optional<ByteBuffer> fromOrcMax(Types.NestedField column,
-                                                 ColumnStatistics columnStats) {
+  private static Optional<ByteBuffer> fromOrcMax(Type type, ColumnStatistics columnStats,
+                                                 MetricsMode metricsMode) {
     Object max = null;
     if (columnStats instanceof IntegerColumnStatistics) {
       max = ((IntegerColumnStatistics) columnStats).getMaximum();
-      if (column.type().typeId() == Type.TypeID.INTEGER) {
+      if (type.typeId() == Type.TypeID.INTEGER) {
         max = Math.toIntExact((long) max);
       }
     } else if (columnStats instanceof DoubleColumnStatistics) {
       max = ((DoubleColumnStatistics) columnStats).getMaximum();
-      if (column.type().typeId() == Type.TypeID.FLOAT) {
+      if (type.typeId() == Type.TypeID.FLOAT) {
         max = ((Double) max).floatValue();
       }
     } else if (columnStats instanceof StringColumnStatistics) {
@@ -188,7 +212,7 @@ public class OrcMetrics {
       max = Optional
           .ofNullable(((DecimalColumnStatistics) columnStats).getMaximum())
           .map(maxStats -> maxStats.bigDecimalValue()
-              .setScale(((Types.DecimalType) column.type()).scale()))
+              .setScale(((Types.DecimalType) type).scale()))
           .orElse(null);
     } else if (columnStats instanceof DateColumnStatistics) {
       max = Optional.ofNullable(maxDayFromEpoch((DateColumnStatistics) columnStats)).orElse(null);
@@ -203,7 +227,29 @@ public class OrcMetrics {
       BooleanColumnStatistics booleanStats = (BooleanColumnStatistics) columnStats;
       max = booleanStats.getTrueCount() > 0;
     }
-    return Optional.ofNullable(Conversions.toByteBuffer(column.type(), max));
+    return Optional.ofNullable(Conversions.toByteBuffer(type, truncateIfNeeded(Bound.UPPER, type, max, metricsMode)));
+  }
+
+  private static Object truncateIfNeeded(Bound bound, Type type, Object value, MetricsMode metricsMode) {
+    // ORC only stores min/max for String columns
+    if (value == null || metricsMode == MetricsModes.Full.get() || type.typeId() != Type.TypeID.STRING) {
+      return value;
+    }
+
+    CharSequence charSequence = (CharSequence) value;
+    Preconditions.checkArgument(metricsMode instanceof MetricsModes.Truncate, "Expected Truncate MetricsMode");
+    MetricsModes.Truncate truncateMode = (MetricsModes.Truncate) metricsMode;
+    int truncateLength = truncateMode.length();
+
+    switch (bound) {
+      case UPPER:
+        return Optional.ofNullable(UnicodeUtil.truncateStringMax(Literal.of(charSequence), truncateLength))
+            .map(Literal::value).orElse(charSequence);
+      case LOWER:
+        return UnicodeUtil.truncateStringMin(Literal.of(charSequence), truncateLength).value();
+      default:
+        throw new RuntimeException("No other bound is defined.");
+    }
   }
 
   private static Set<Integer> statsColumns(TypeDescription schema) {

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
@@ -40,7 +40,6 @@ import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.hadoop.HadoopInputFile;
 import org.apache.iceberg.io.InputFile;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Conversions;
@@ -231,13 +230,13 @@ public class OrcMetrics {
   }
 
   private static Object truncateIfNeeded(Bound bound, Type type, Object value, MetricsMode metricsMode) {
-    // ORC only stores min/max for String columns
-    if (value == null || metricsMode == MetricsModes.Full.get() || type.typeId() != Type.TypeID.STRING) {
+    // Out of the two types which could be truncated, string or binary, ORC only supports string bounds.
+    // Therefore, truncation will be applied if needed only on string type.
+    if (!(metricsMode instanceof MetricsModes.Truncate) || type.typeId() != Type.TypeID.STRING || value == null) {
       return value;
     }
 
     CharSequence charSequence = (CharSequence) value;
-    Preconditions.checkArgument(metricsMode instanceof MetricsModes.Truncate, "Expected Truncate MetricsMode");
     MetricsModes.Truncate truncateMode = (MetricsModes.Truncate) metricsMode;
     int truncateLength = truncateMode.length();
 

--- a/spark/src/main/java/org/apache/iceberg/spark/source/SparkAppenderFactory.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/SparkAppenderFactory.java
@@ -74,6 +74,7 @@ class SparkAppenderFactory implements FileAppenderFactory<InternalRow> {
           return ORC.write(file)
               .createWriterFunc(SparkOrcWriter::new)
               .setAll(properties)
+              .metricsConfig(metricsConfig)
               .schema(writeSchema)
               .overwrite()
               .build();


### PR DESCRIPTION
Unlike Parquet metrics, ORC was not using `MetricsConfig` to let the user configure which metrics to collect or truncate string column metrics.

This PR fixes #1268 by adding `MetricsConfig` support in ORC metrics. I've also added unit tests to `TestMetrics`, which runs for both Parquet and ORC, to check the different `MetricsModes` and the truncation of string and binary (not supported in ORC) columns.

PTAL @aokolnychyi @rdsr @shardulm94 Thanks!