### PR TITLE
Introduce GenericAppenderFactory and GenericAppenderHelper

### DIFF
--- a/data/src/main/java/org/apache/iceberg/data/GenericAppenderFactory.java
+++ b/data/src/main/java/org/apache/iceberg/data/GenericAppenderFactory.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.data;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Map;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.MetricsConfig;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.avro.Avro;
+import org.apache.iceberg.data.avro.DataWriter;
+import org.apache.iceberg.data.orc.GenericOrcWriter;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.io.FileAppenderFactory;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.orc.ORC;
+import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+
+/**
+ * Factory to create a new {@link FileAppender} to write {@link Record}s.
+ */
+public class GenericAppenderFactory implements FileAppenderFactory<Record> {
+
+  private final Schema schema;
+  private final Map<String, String> config = Maps.newHashMap();
+
+  public GenericAppenderFactory(Schema schema) {
+    this.schema = schema;
+  }
+
+  public GenericAppenderFactory set(String property, String value) {
+    config.put(property, value);
+    return this;
+  }
+
+  public GenericAppenderFactory setAll(Map<String, String> properties) {
+    config.putAll(properties);
+    return this;
+  }
+
+  @Override
+  public FileAppender<Record> newAppender(OutputFile outputFile, FileFormat fileFormat) {
+    MetricsConfig metricsConfig = MetricsConfig.fromProperties(config);
+    try {
+      switch (fileFormat) {
+        case AVRO:
+          return Avro.write(outputFile)
+              .schema(schema)
+              .createWriterFunc(DataWriter::create)
+              .setAll(config)
+              .overwrite()
+              .build();
+
+        case PARQUET:
+          return Parquet.write(outputFile)
+              .schema(schema)
+              .createWriterFunc(GenericParquetWriter::buildWriter)
+              .setAll(config)
+              .metricsConfig(metricsConfig)
+              .overwrite()
+              .build();
+
+        case ORC:
+          return ORC.write(outputFile)
+              .schema(schema)
+              .createWriterFunc(GenericOrcWriter::buildWriter)
+              .setAll(config)
+              .overwrite()
+              .build();
+
+        default:
+          throw new UnsupportedOperationException("Cannot write format: " + fileFormat);
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/data/src/test/java/org/apache/iceberg/data/GenericAppenderHelper.java
+++ b/data/src/test/java/org/apache/iceberg/data/GenericAppenderHelper.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.data;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.junit.Assert;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Helper for appending {@link DataFile} to a table or appending {@link Record}s to a table.
+ */
+public class GenericAppenderHelper {
+
+  private final Table table;
+  private final FileFormat fileFormat;
+  private final TemporaryFolder tmp;
+
+  public GenericAppenderHelper(Table table, FileFormat fileFormat, TemporaryFolder tmp) {
+    this.table = table;
+    this.fileFormat = fileFormat;
+    this.tmp = tmp;
+  }
+
+  public void appendToTable(DataFile... dataFiles) {
+    Preconditions.checkNotNull(table, "table not set");
+
+    AppendFiles append = table.newAppend();
+
+    for (DataFile dataFile : dataFiles) {
+      append = append.appendFile(dataFile);
+    }
+
+    append.commit();
+  }
+
+  public void appendToTable(List<Record> records) throws IOException {
+    appendToTable(null, records);
+  }
+
+  public void appendToTable(StructLike partition, List<Record> records) throws IOException {
+    appendToTable(writeFile(partition, records));
+  }
+
+  public DataFile writeFile(StructLike partition, List<Record> records) throws IOException {
+    Preconditions.checkNotNull(table, "table not set");
+    File file = tmp.newFile();
+    Assert.assertTrue(file.delete());
+    return appendToLocalFile(table, file, fileFormat, partition, records);
+  }
+
+  private static DataFile appendToLocalFile(
+      Table table, File file, FileFormat format, StructLike partition, List<Record> records)
+      throws IOException {
+    FileAppender<Record> appender = new GenericAppenderFactory(table.schema()).newAppender(
+        Files.localOutput(file), format);
+    try (FileAppender<Record> fileAppender = appender) {
+      fileAppender.addAll(records);
+    }
+
+    return DataFiles.builder(table.spec())
+        .withRecordCount(records.size())
+        .withFileSizeInBytes(file.length())
+        .withPath(file.toURI().toString())
+        .withMetrics(appender.metrics())
+        .withFormat(format)
+        .withPartition(partition)
+        .build();
+  }
+}

--- a/spark3/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
@@ -33,16 +33,11 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.avro.Avro;
+import org.apache.iceberg.data.GenericAppenderFactory;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
-import org.apache.iceberg.data.avro.DataWriter;
-import org.apache.iceberg.data.orc.GenericOrcWriter;
-import org.apache.iceberg.data.parquet.GenericParquetWriter;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.FileAppender;
-import org.apache.iceberg.orc.ORC;
-import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.data.GenericsHelpers;
@@ -188,33 +183,9 @@ public class TestFilteredScan {
 
     this.records = testRecords(tableSchema);
 
-    switch (fileFormat) {
-      case AVRO:
-        try (FileAppender<Record> writer = Avro.write(localOutput(testFile))
-            .createWriterFunc(DataWriter::create)
-            .schema(tableSchema)
-            .build()) {
-          writer.addAll(records);
-        }
-        break;
-
-      case PARQUET:
-        try (FileAppender<Record> writer = Parquet.write(localOutput(testFile))
-            .createWriterFunc(GenericParquetWriter::buildWriter)
-            .schema(tableSchema)
-            .build()) {
-          writer.addAll(records);
-        }
-        break;
-
-      case ORC:
-        try (FileAppender<Record> writer = ORC.write(localOutput(testFile))
-            .createWriterFunc(GenericOrcWriter::buildWriter)
-            .schema(tableSchema)
-            .build()) {
-          writer.addAll(records);
-        }
-        break;
+    try (FileAppender<Record> writer = new GenericAppenderFactory(tableSchema).newAppender(
+        localOutput(testFile), fileFormat)) {
+      writer.addAll(records);
     }
 
     DataFile file = DataFiles.builder(PartitionSpec.unpartitioned())


### PR DESCRIPTION
In #1293, we found lot of places use `switch case avro orc parquet` to create appender, these logicals can be extract to `GenericAppenderFactory`.