### PR TITLE
Static Table Operations

### DIFF
--- a/core/src/main/java/org/apache/iceberg/StaticTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/StaticTableOperations.java
@@ -20,13 +20,13 @@
 
 package org.apache.iceberg;
 
-import java.nio.file.Paths;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 
 /**
- * Representation of an immutable snapshot of Table State that can be used in
- * other Iceberg Functions.
+ * TableOperations implementation that provides access to metadata for a Table at some point in time, using a
+ * table metadata location. It will never refer to a different Metadata object than the one it was created with
+ * and cannot be used to create or delete files.
  */
 public class StaticTableOperations implements TableOperations {
   private final TableMetadata staticMetadata;
@@ -35,9 +35,9 @@ public class StaticTableOperations implements TableOperations {
   /**
    * Creates a StaticTableOperations tied to a specific static version of the TableMetadata
    */
-  public StaticTableOperations(String location, FileIO io) {
+  public StaticTableOperations(String metadataFileLocation, FileIO io) {
     this.io = io;
-    this.staticMetadata = TableMetadataParser.read(io, location);
+    this.staticMetadata = TableMetadataParser.read(io, metadataFileLocation);
   }
 
   @Override
@@ -52,7 +52,7 @@ public class StaticTableOperations implements TableOperations {
 
   @Override
   public void commit(TableMetadata base, TableMetadata metadata) {
-    throw new UnsupportedOperationException("This TableOperations is static, it cannot be modified");
+    throw new UnsupportedOperationException("Cannot modify a static table");
   }
 
   @Override
@@ -62,11 +62,11 @@ public class StaticTableOperations implements TableOperations {
 
   @Override
   public String metadataFileLocation(String fileName) {
-    throw new UnsupportedOperationException("New files cannot be created in a Static Table Operations");
+    throw new UnsupportedOperationException("Cannot modify a static table");
   }
 
   @Override
   public LocationProvider locationProvider() {
-    throw new UnsupportedOperationException("New files cannot be created in a Static Table Operations");
+    throw new UnsupportedOperationException("Cannot modify a static table");
   }
 }

--- a/core/src/main/java/org/apache/iceberg/StaticTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/StaticTableOperations.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.iceberg;
+
+import java.nio.file.Paths;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.LocationProvider;
+
+/**
+ * Representation of an immutable snapshot of Table State that can be used in
+ * other Iceberg Functions.
+ */
+public class StaticTableOperations implements TableOperations {
+  private final TableMetadata staticMetadata;
+  private final FileIO io;
+
+  /**
+   * Creates a StaticTableOperations tied to a specific static version of the TableMetadata
+   */
+  public StaticTableOperations(String location, FileIO io) {
+    this.io = io;
+    this.staticMetadata = TableMetadataParser.read(io, location);
+  }
+
+  @Override
+  public TableMetadata current() {
+    return staticMetadata;
+  }
+
+  @Override
+  public TableMetadata refresh() {
+    return staticMetadata;
+  }
+
+  @Override
+  public void commit(TableMetadata base, TableMetadata metadata) {
+    throw new UnsupportedOperationException("This TableOperations is static, it cannot be modified");
+  }
+
+  @Override
+  public FileIO io() {
+    return this.io;
+  }
+
+  @Override
+  public String metadataFileLocation(String fileName) {
+    throw new UnsupportedOperationException("New files cannot be created in a Static Table Operations");
+  }
+
+  @Override
+  public LocationProvider locationProvider() {
+    throw new UnsupportedOperationException("New files cannot be created in a Static Table Operations");
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestStaticTable.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestStaticTable.java
@@ -1,11 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.iceberg.hadoop;
 
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
+import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.StaticTableOperations;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -26,21 +45,23 @@ public class TestStaticTable extends HadoopTableTestBase {
         ((HasTableOperations) staticTable).operations() instanceof StaticTableOperations);
   }
 
-  @Test(expected = UnsupportedOperationException.class)
-  public void testCannotBeAddedTo(){
+  @Test
+  public void testCannotBeAddedTo() {
     Table staticTable = getStaticTable();
-    staticTable.newOverwrite().addFile(FILE_A).commit();
-  }
-
-  @Test(expected = UnsupportedOperationException.class)
-  public void testCannotBeDeletedFrom(){
-    table.newAppend().appendFile(FILE_A).commit();
-    Table staticTable = getStaticTable();
-    staticTable.newDelete().deleteFile(FILE_A).commit();
+    AssertHelpers.assertThrows("Cannot modify a static table", UnsupportedOperationException.class,
+        () -> staticTable.newOverwrite().addFile(FILE_A).commit());
   }
 
   @Test
-  public void testHasSameProperties(){
+  public void testCannotBeDeletedFrom() {
+    table.newAppend().appendFile(FILE_A).commit();
+    Table staticTable = getStaticTable();
+    AssertHelpers.assertThrows("Cannot modify a static table", UnsupportedOperationException.class,
+        () -> staticTable.newDelete().deleteFile(FILE_A).commit());
+  }
+
+  @Test
+  public void testHasSameProperties() {
     table.newAppend().appendFile(FILE_A).commit();
     table.newAppend().appendFile(FILE_B).commit();
     table.newOverwrite().deleteFile(FILE_B).addFile(FILE_C).commit();
@@ -61,6 +82,7 @@ public class TestStaticTable extends HadoopTableTestBase {
 
     table.newAppend().appendFile(FILE_B).commit();
     table.newOverwrite().deleteFile(FILE_B).addFile(FILE_C).commit();
+    staticTable.refresh();
 
     Assert.assertEquals("Snapshot unchanged after table modified",
         staticTable.currentSnapshot().snapshotId(), originalSnapshot);
@@ -68,8 +90,8 @@ public class TestStaticTable extends HadoopTableTestBase {
 
   @Test
   public void testMetadataTables() {
-    for (MetadataTableType type: MetadataTableType.values()) {
-      String enumName = type.name().replace("_","").toLowerCase();
+    for (MetadataTableType type : MetadataTableType.values()) {
+      String enumName = type.name().replace("_", "").toLowerCase();
       Assert.assertTrue("Should be able to get MetadataTable of type : " + type,
           getStaticTable(type).getClass().getName().toLowerCase().contains(enumName));
     }

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestStaticTable.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestStaticTable.java
@@ -1,0 +1,79 @@
+package org.apache.iceberg.hadoop;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.StaticTableOperations;
+import org.apache.iceberg.Table;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestStaticTable extends HadoopTableTestBase {
+
+  private Table getStaticTable() {
+    return TABLES.load(((HasTableOperations) table).operations().current().metadataFileLocation());
+  }
+
+  private Table getStaticTable(MetadataTableType type) {
+    return TABLES.load(((HasTableOperations) table).operations().current().metadataFileLocation() + "#" + type);
+  }
+
+  @Test
+  public void testLoadFromMetadata() {
+    Table staticTable = getStaticTable();
+    Assert.assertTrue("Loading a metadata file based table should return StaticTableOperations",
+        ((HasTableOperations) staticTable).operations() instanceof StaticTableOperations);
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testCannotBeAddedTo(){
+    Table staticTable = getStaticTable();
+    staticTable.newOverwrite().addFile(FILE_A).commit();
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testCannotBeDeletedFrom(){
+    table.newAppend().appendFile(FILE_A).commit();
+    Table staticTable = getStaticTable();
+    staticTable.newDelete().deleteFile(FILE_A).commit();
+  }
+
+  @Test
+  public void testHasSameProperties(){
+    table.newAppend().appendFile(FILE_A).commit();
+    table.newAppend().appendFile(FILE_B).commit();
+    table.newOverwrite().deleteFile(FILE_B).addFile(FILE_C).commit();
+    Table staticTable = getStaticTable();
+    Assert.assertTrue("Same history?",
+        table.history().containsAll(staticTable.history()));
+    Assert.assertTrue("Same snapshot?",
+        table.currentSnapshot().snapshotId() ==  staticTable.currentSnapshot().snapshotId());
+    Assert.assertTrue("Same properties?",
+        Maps.difference(table.properties(), staticTable.properties()).areEqual());
+  }
+
+  @Test
+  public void testImmutable() {
+    table.newAppend().appendFile(FILE_A).commit();
+    Table staticTable = getStaticTable();
+    long originalSnapshot = table.currentSnapshot().snapshotId();
+
+    table.newAppend().appendFile(FILE_B).commit();
+    table.newOverwrite().deleteFile(FILE_B).addFile(FILE_C).commit();
+
+    Assert.assertEquals("Snapshot unchanged after table modified",
+        staticTable.currentSnapshot().snapshotId(), originalSnapshot);
+  }
+
+  @Test
+  public void testMetadataTables() {
+    for (MetadataTableType type: MetadataTableType.values()) {
+      String enumName = type.name().replace("_","").toLowerCase();
+      Assert.assertTrue("Should be able to get MetadataTable of type : " + type,
+          getStaticTable(type).getClass().getName().toLowerCase().contains(enumName));
+    }
+  }
+
+
+}


### PR DESCRIPTION
Allows for a Table Operations which references a specfic metadata version
file. This operation will not change even if the base table it was derived
from is changed. This enables it to act like a ReadOnly view of the table's
state at a given time.