### PR TITLE
API: Fix PartitionSpec hashCode

### DIFF
--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -222,7 +222,7 @@ public class PartitionSpec implements Serializable {
 
   @Override
   public int hashCode() {
-    return Integer.hashCode(Arrays.hashCode(fields));
+    return 31 * Integer.hashCode(specId) + Arrays.hashCode(fields);
   }
 
   private List<PartitionField> lazyFieldList() {


### PR DESCRIPTION
This PR fixes `hashCode` in `PartitionSpec` and makes it consistent with `equals`.