### PR TITLE
Speed up ExpireSnapshotAction Test by Reducing Shuffle Paralleism

### DIFF
--- a/spark/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction.java
@@ -103,6 +103,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
     this.tableDir = temp.newFolder();
     this.tableLocation = tableDir.toURI().toString();
     this.table = TABLES.create(SCHEMA, SPEC, Maps.newHashMap(), tableLocation);
+    spark.conf().set("spark.sql.shuffle.partitions", 1);
   }
 
   private Long rightAfterSnapshot() {


### PR DESCRIPTION
Because we use LocalIterator in ExpireSnapshotAction, every partition
runs it's own spark job, almost all of which are completely empty. This
leads to a lot of overhead which we don't need in the Test Suite. Setting
shuffle parallelism to 1 (from 200) greatly reduces the test runtime.