### PR TITLE
Fix typo in TestOrcMetrics

### DIFF
--- a/data/src/test/java/org/apache/iceberg/orc/TestOrcMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/orc/TestOrcMetrics.java
@@ -101,7 +101,7 @@ public class TestOrcMetrics extends TestMetrics {
       Assert.assertFalse("ORC binary field should not have lower bounds.",
           metrics.lowerBounds().containsKey(fieldId));
       Assert.assertFalse("ORC binary field should not have upper bounds.",
-          metrics.lowerBounds().containsKey(fieldId));
+          metrics.upperBounds().containsKey(fieldId));
       return;
     }
     super.assertBounds(fieldId, type, lowerBound, upperBound, metrics);


### PR DESCRIPTION
We were checking non-existence of lower bounds in both assertions before, one of them should have been an for upper bounds