### PR TITLE
Fix NPE while estimating statistics on empty table

### DIFF
--- a/spark/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction.java
@@ -955,14 +955,13 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
 
   @Test
   public void testExpireOnEmptyTable() {
-
     Set<String> deletedFiles = Sets.newHashSet();
 
     // table has no data, testing ExpireSnapshots should not fail with no snapshot
     ExpireSnapshotsActionResult result = Actions.forTable(table).expireSnapshots()
-            .expireOlderThan(System.currentTimeMillis())
-            .deleteWith(deletedFiles::add)
-            .execute();
+        .expireOlderThan(System.currentTimeMillis())
+        .deleteWith(deletedFiles::add)
+        .execute();
 
     checkExpirationResults(0, 0, 0, result);
   }

--- a/spark/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction.java
@@ -952,5 +952,19 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
 
     checkExpirationResults(1, 1, 1, result);
   }
+
+  @Test
+  public void testExpireOnEmptyTable() {
+
+    Set<String> deletedFiles = Sets.newHashSet();
+
+    // table has no data, testing ExpireSnapshots should not fail with no snapshot
+    ExpireSnapshotsActionResult result = Actions.forTable(table).expireSnapshots()
+            .expireOlderThan(System.currentTimeMillis())
+            .deleteWith(deletedFiles::add)
+            .execute();
+
+    checkExpirationResults(0, 0, 0, result);
+  }
 }
 

--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
@@ -278,6 +278,11 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
 
   @Override
   public Statistics estimateStatistics() {
+    // its a fresh table, no data
+    if (table.currentSnapshot() == null) {
+      return new Stats(0L, 0L);
+    }
+
     if (filterExpressions == null || filterExpressions == Expressions.alwaysTrue()) {
       long totalRecords = PropertyUtil.propertyAsLong(table.currentSnapshot().summary(),
           SnapshotSummary.TOTAL_RECORDS_PROP, Long.MAX_VALUE);

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
@@ -176,6 +176,11 @@ class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
 
   @Override
   public Statistics estimateStatistics() {
+    // its a fresh table, no data
+    if (table.currentSnapshot() == null) {
+      return new Stats(0L, 0L);
+    }
+
     if (filterExpressions == null || filterExpressions.isEmpty()) {
       LOG.debug("using table metadata to estimate table statistics");
       long totalRecords = PropertyUtil.propertyAsLong(table.currentSnapshot().summary(),


### PR DESCRIPTION
Encountered this NPE issue, while running ExpireSnapshots Action on an empty table ( no data is pushed yet ).
Added a test for ExpireSnapshotAction with empty table.