### PR TITLE
Spark: Estimate statistics using snapshot summary only for partitioned tables

### DIFF
--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
@@ -284,7 +284,7 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
     }
 
     // estimate stats using snapshot summary only for partitioned tables (metadata tables are unpartitioned)
-    if (table.spec().fields().size() > 0 && filterExpression() == Expressions.alwaysTrue()) {
+    if (!table.spec().isUnpartitioned() && filterExpression() == Expressions.alwaysTrue()) {
       long totalRecords = PropertyUtil.propertyAsLong(table.currentSnapshot().summary(),
           SnapshotSummary.TOTAL_RECORDS_PROP, Long.MAX_VALUE);
       return new Stats(SparkSchemaUtil.estimateSize(lazyType(), totalRecords), totalRecords);

--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
@@ -283,7 +283,8 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
       return new Stats(0L, 0L);
     }
 
-    if (filterExpressions == null || filterExpressions == Expressions.alwaysTrue()) {
+    // estimate stats using snapshot summary only for partitioned tables (metadata tables are unpartitioned)
+    if (table.spec().fields().size() > 0 && filterExpression() == Expressions.alwaysTrue()) {
       long totalRecords = PropertyUtil.propertyAsLong(table.currentSnapshot().summary(),
           SnapshotSummary.TOTAL_RECORDS_PROP, Long.MAX_VALUE);
       return new Stats(SparkSchemaUtil.estimateSize(lazyType(), totalRecords), totalRecords);

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
@@ -181,7 +181,8 @@ class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
       return new Stats(0L, 0L);
     }
 
-    if (filterExpressions == null || filterExpressions.isEmpty()) {
+    // estimate stats using snapshot summary only for partitioned tables (metadata tables are unpartitioned)
+    if (table.spec().fields().size() > 0 && (filterExpressions == null || filterExpressions.isEmpty())) {
       LOG.debug("using table metadata to estimate table statistics");
       long totalRecords = PropertyUtil.propertyAsLong(table.currentSnapshot().summary(),
           SnapshotSummary.TOTAL_RECORDS_PROP, Long.MAX_VALUE);

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
@@ -182,7 +182,7 @@ class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
     }
 
     // estimate stats using snapshot summary only for partitioned tables (metadata tables are unpartitioned)
-    if (table.spec().fields().size() > 0 && (filterExpressions == null || filterExpressions.isEmpty())) {
+    if (!table.spec().isUnpartitioned() && (filterExpressions == null || filterExpressions.isEmpty())) {
       LOG.debug("using table metadata to estimate table statistics");
       long totalRecords = PropertyUtil.propertyAsLong(table.currentSnapshot().summary(),
           SnapshotSummary.TOTAL_RECORDS_PROP, Long.MAX_VALUE);


### PR DESCRIPTION
This PR disables stats estimation for metadata tables using snapshot summary.