### PR TITLE
Fix new snapshot expiration with rollback tests

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
+++ b/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
@@ -228,11 +228,9 @@ public class TestRemoveSnapshots extends TableTestBase {
         .rollbackTo(firstSnapshot.snapshotId())
         .commit();
 
-    waitUntilAfter(table.currentSnapshot().timestampMillis());
+    long tAfterCommits = waitUntilAfter(secondSnapshot.timestampMillis());
 
     long snapshotId = table.currentSnapshot().snapshotId();
-
-    long tAfterCommits = waitUntilAfter(table.currentSnapshot().timestampMillis());
 
     Set<String> deletedFiles = Sets.newHashSet();
 
@@ -277,11 +275,9 @@ public class TestRemoveSnapshots extends TableTestBase {
         .rollbackTo(firstSnapshot.snapshotId())
         .commit();
 
-    waitUntilAfter(table.currentSnapshot().timestampMillis());
+    long tAfterCommits = waitUntilAfter(secondSnapshot.timestampMillis());
 
     long snapshotId = table.currentSnapshot().snapshotId();
-
-    long tAfterCommits = waitUntilAfter(table.currentSnapshot().timestampMillis());
 
     Set<String> deletedFiles = Sets.newHashSet();
 

--- a/spark/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction.java
@@ -108,8 +108,12 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
   }
 
   private Long rightAfterSnapshot() {
+    return rightAfterSnapshot(table.currentSnapshot().snapshotId());
+  }
+
+  private Long rightAfterSnapshot(long snapshotId) {
     Long end = System.currentTimeMillis();
-    while (end <= table.currentSnapshot().timestampMillis()) {
+    while (end <= table.snapshot(snapshotId).timestampMillis()) {
       end = System.currentTimeMillis();
     }
     return end;
@@ -875,11 +879,9 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
         .rollbackTo(firstSnapshot.snapshotId())
         .commit();
 
-    rightAfterSnapshot();
+    long tAfterCommits = rightAfterSnapshot(secondSnapshot.snapshotId());
 
     long snapshotId = table.currentSnapshot().snapshotId();
-
-    long tAfterCommits = rightAfterSnapshot();
 
     Set<String> deletedFiles = Sets.newHashSet();
 
@@ -926,11 +928,9 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
         .rollbackTo(firstSnapshot.snapshotId())
         .commit();
 
-    rightAfterSnapshot();
+    long tAfterCommits = rightAfterSnapshot(secondSnapshot.snapshotId());
 
     long snapshotId = table.currentSnapshot().snapshotId();
-
-    long tAfterCommits = rightAfterSnapshot();
 
     Set<String> deletedFiles = Sets.newHashSet();
 


### PR DESCRIPTION
This fixes the new snapshot expiration with rollback tests. The tests were not waiting enough time before running expire because the wait was based on the current snapshot, not the newer snapshot that was committed and rolled back.