### PR TITLE
DOC: Remove unnecessary appendix in SSS doc, add missing links

### DIFF
--- a/site/docs/java-api-quickstart.md
+++ b/site/docs/java-api-quickstart.md
@@ -41,6 +41,9 @@ import org.apache.iceberg.catalog.TableIdentifier;
 
 TableIdentifier name = TableIdentifier.of("logging", "logs");
 Table table = catalog.createTable(name, schema, spec);
+
+// or to load an existing table, use the following line
+// Table table = catalog.loadTable(name);
 ```
 
 The logs [schema](#create-a-schema) and [partition spec](#create-a-partition-spec) are created below.
@@ -69,6 +72,9 @@ import org.apache.iceberg.catalog.TableIdentifier;
 
 TableIdentifier name = TableIdentifier.of("logging", "logs");
 Table table = catalog.createTable(name, schema, spec);
+
+// or to load an existing table, use the following line
+// Table table = catalog.loadTable(name);
 ```
 
 The logs [schema](#create-a-schema) and [partition spec](#create-a-partition-spec) are created below.
@@ -88,6 +94,9 @@ import org.apache.iceberg.Table;
 Configuration conf = new Configuration():
 HadoopTables tables = new HadoopTables(conf);
 Table table = tables.create(schema, spec, table_location);
+
+// or to load an existing table, use the following line
+// Table table = tables.load(table_location);
 ```
 
 !!! Warning

--- a/site/docs/maintenance.md
+++ b/site/docs/maintenance.md
@@ -17,6 +17,9 @@
 
 # Table Maintenance
 
+!!! Note
+    Maintenance operations require the `Table` instance. Please refer [Java API quickstart](/java-api-quickstart/#create-a-table) page to refer how to load an existing table.
+
 ## Recommended Maintenance
 
 ### Expire Snapshots
@@ -129,26 +132,3 @@ table.rewriteManifests()
 ```
 
 See the [`RewriteManifestsAction` Javadoc](/javadoc/master/org/apache/iceberg/actions/RewriteManifestsAction.html) to see more configuration options.
-
-## Appendix
-
-### Retrieve Table instance in Hadoop catalog
-
-```scala
-// ... assume catalogName, dbName, tableName are present ...
-import org.apache.iceberg.hadoop.HadoopTables
-val warehousePath = spark.sparkContext.getConf.get(s"spark.sql.catalog.$catalogName.warehouse")
-val hadoopTables = new HadoopTables(spark.sessionState.newHadoopConf)
-val table = hadoopTables.load(s"$warehousePath/$dbName/$tableName")
-```
-
-### Retrieve Table instance in Hive catalog
-
-```scala
-// ... assume dbName, tableName are present ...
-import org.apache.iceberg.hive.HiveCatalog;
-
-val catalog = new HiveCatalog(spark.sessionState.newHadoopConf)
-val table = catalog.loadTable(TableIdentifier.of(dbName, tableName))
-```
-

--- a/site/docs/maintenance.md
+++ b/site/docs/maintenance.md
@@ -130,3 +130,25 @@ table.rewriteManifests()
 
 See the [`RewriteManifestsAction` Javadoc](/javadoc/master/org/apache/iceberg/actions/RewriteManifestsAction.html) to see more configuration options.
 
+## Appendix
+
+### Retrieve Table instance in Hadoop catalog
+
+```scala
+// ... assume catalogName, dbName, tableName are present ...
+import org.apache.iceberg.hadoop.HadoopTables
+val warehousePath = spark.sparkContext.getConf.get(s"spark.sql.catalog.$catalogName.warehouse")
+val hadoopTables = new HadoopTables(spark.sessionState.newHadoopConf)
+val table = hadoopTables.load(s"$warehousePath/$dbName/$tableName")
+```
+
+### Retrieve Table instance in Hive catalog
+
+```scala
+// ... assume dbName, tableName are present ...
+import org.apache.iceberg.hive.HiveCatalog;
+
+val catalog = new HiveCatalog(spark.sessionState.newHadoopConf)
+val table = catalog.loadTable(TableIdentifier.of(dbName, tableName))
+```
+

--- a/site/docs/spark-structured-streaming.md
+++ b/site/docs/spark-structured-streaming.md
@@ -76,31 +76,9 @@ Each micro-batch written to a table produces a new snapshot, which are tracked i
 
 ### Compacting data files
 
-The amount of data written in a micro batch is typically small, which can cause the table metadata to track lots of small files. Compacting small files into larger files reduces the metadata needed by the table, and increases query efficiency.
+The amount of data written in a micro batch is typically small, which can cause the table metadata to track lots of small files. [Compacting small files into larger files](../maintenance#compact-data-files) reduces the metadata needed by the table, and increases query efficiency.
 
 ### Rewrite manifests
 
 To optimize write latency on streaming workload, Iceberg may write the new snapshot with a "fast" append that does not automatically compact manifests.
 This could lead lots of small manifest files. Manifests can be [rewritten to optimize queries and to compact](../maintenance#rewrite-manifests).
-
-## Appendix
-
-### Retrieve Table instance in Hadoop catalog
-
-```scala
-// ... assume catalogName, dbName, tableName are present ...
-import org.apache.iceberg.hadoop.HadoopTables
-val warehousePath = spark.sparkContext.getConf.get(s"spark.sql.catalog.$catalogName.warehouse")
-val hadoopTables = new HadoopTables(spark.sessionState.newHadoopConf)
-val table = hadoopTables.load(s"$warehousePath/$dbName/$tableName")
-```
-
-### Retrieve Table instance in Hive catalog
-
-```scala
-// ... assume dbName, tableName are present ...
-import org.apache.iceberg.hive.HiveCatalog;
-
-val catalog = new HiveCatalog(spark.sessionState.newHadoopConf)
-val table = catalog.loadTable(TableIdentifier.of(dbName, tableName))
-```


### PR DESCRIPTION
Appendix in SSS page was actually to deduplicate code in maintenance page, but it didn't move to maintenance page once we extract the content from SSS page.

I also add a link for compacting data files in SSS page.