### PR TITLE
Parquet: Add type visitor with partner type

### DIFF
--- a/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
@@ -82,11 +82,7 @@ public class FlinkParquetReaders {
     @Override
     public ParquetValueReader<RowData> message(org.apache.iceberg.types.Type expected, MessageType message,
                                                List<ParquetValueReader<?>> fieldReaders) {
-      if (expected == null) {
-        return struct(null, message.asGroupType(), fieldReaders);
-      } else {
-        return struct(expected.asStructType(), message.asGroupType(), fieldReaders);
-      }
+      return struct(expected == null ? null : expected.asStructType(), message.asGroupType(), fieldReaders);
     }
 
     @Override

--- a/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
@@ -80,13 +80,17 @@ public class FlinkParquetReaders {
     }
 
     @Override
-    public ParquetValueReader<RowData> message(Types.StructType expected, MessageType message,
+    public ParquetValueReader<RowData> message(org.apache.iceberg.types.Type expected, MessageType message,
                                                List<ParquetValueReader<?>> fieldReaders) {
-      return struct(expected, message.asGroupType(), fieldReaders);
+      if (expected == null) {
+        return struct(null, message.asGroupType(), fieldReaders);
+      } else {
+        return struct(expected.asStructType(), message.asGroupType(), fieldReaders);
+      }
     }
 
     @Override
-    public ParquetValueReader<RowData> struct(Types.StructType expected, GroupType struct,
+    public ParquetValueReader<RowData> struct(org.apache.iceberg.types.Type expected, GroupType struct,
                                               List<ParquetValueReader<?>> fieldReaders) {
       // match the expected struct's order
       Map<Integer, ParquetValueReader<?>> readersById = Maps.newHashMap();
@@ -103,7 +107,7 @@ public class FlinkParquetReaders {
       }
 
       List<Types.NestedField> expectedFields = expected != null ?
-          expected.fields() : ImmutableList.of();
+          expected.asStructType().fields() : ImmutableList.of();
       List<ParquetValueReader<?>> reorderedFields = Lists.newArrayListWithExpectedSize(
           expectedFields.size());
       List<Type> types = Lists.newArrayListWithExpectedSize(expectedFields.size());
@@ -132,7 +136,7 @@ public class FlinkParquetReaders {
     }
 
     @Override
-    public ParquetValueReader<?> list(Types.ListType expectedList, GroupType array,
+    public ParquetValueReader<?> list(org.apache.iceberg.types.Type expectedList, GroupType array,
                                       ParquetValueReader<?> elementReader) {
       GroupType repeated = array.getFields().get(0).asGroupType();
       String[] repeatedPath = currentPath();
@@ -147,7 +151,7 @@ public class FlinkParquetReaders {
     }
 
     @Override
-    public ParquetValueReader<?> map(Types.MapType expectedMap, GroupType map,
+    public ParquetValueReader<?> map(org.apache.iceberg.types.Type expectedMap, GroupType map,
                                      ParquetValueReader<?> keyReader,
                                      ParquetValueReader<?> valueReader) {
       GroupType repeatedKeyValue = map.getFields().get(0).asGroupType();
@@ -168,7 +172,7 @@ public class FlinkParquetReaders {
 
     @Override
     @SuppressWarnings("CyclomaticComplexity")
-    public ParquetValueReader<?> primitive(org.apache.iceberg.types.Type.PrimitiveType expected,
+    public ParquetValueReader<?> primitive(org.apache.iceberg.types.Type expected,
                                            PrimitiveType primitive) {
       ColumnDescriptor desc = type.getColumnDescription(currentPath());
 

--- a/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetWriters.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetWriters.java
@@ -29,9 +29,7 @@ import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
-import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.LogicalType;
-import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.iceberg.parquet.ParquetValueReaders;
@@ -95,7 +93,7 @@ public class FlinkParquetWriters {
 
       return new ArrayDataWriter<>(repeatedD, repeatedR,
           newOption(repeated.getType(0), elementWriter),
-          ((ArrayType) fArray).getElementType());
+          arrayElementType(fArray));
     }
 
     @Override
@@ -110,9 +108,8 @@ public class FlinkParquetWriters {
       return new MapDataWriter<>(repeatedD, repeatedR,
           newOption(repeatedKeyValue.getType(0), keyWriter),
           newOption(repeatedKeyValue.getType(1), valueWriter),
-          ((MapType) fMap).getKeyType(), ((MapType) fMap).getValueType());
+          mapKeyType(fMap), mapValueType(fMap));
     }
-
 
     private ParquetValueWriter<?> newOption(org.apache.parquet.schema.Type fieldType, ParquetValueWriter<?> writer) {
       int maxD = type.getMaxDefinitionLevel(path(fieldType.getName()));

--- a/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetWriters.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetWriters.java
@@ -68,15 +68,15 @@ public class FlinkParquetWriters {
     }
 
     @Override
-    public ParquetValueWriter<?> message(RowType sStruct, MessageType message, List<ParquetValueWriter<?>> fields) {
+    public ParquetValueWriter<?> message(LogicalType sStruct, MessageType message, List<ParquetValueWriter<?>> fields) {
       return struct(sStruct, message.asGroupType(), fields);
     }
 
     @Override
-    public ParquetValueWriter<?> struct(RowType sStruct, GroupType struct,
+    public ParquetValueWriter<?> struct(LogicalType fStruct, GroupType struct,
                                         List<ParquetValueWriter<?>> fieldWriters) {
       List<Type> fields = struct.getFields();
-      List<RowField> flinkFields = sStruct.getFields();
+      List<RowField> flinkFields = ((RowType) fStruct).getFields();
       List<ParquetValueWriter<?>> writers = Lists.newArrayListWithExpectedSize(fieldWriters.size());
       List<LogicalType> flinkTypes = Lists.newArrayList();
       for (int i = 0; i < fields.size(); i += 1) {
@@ -88,7 +88,7 @@ public class FlinkParquetWriters {
     }
 
     @Override
-    public ParquetValueWriter<?> list(ArrayType sArray, GroupType array, ParquetValueWriter<?> elementWriter) {
+    public ParquetValueWriter<?> list(LogicalType fArray, GroupType array, ParquetValueWriter<?> elementWriter) {
       GroupType repeated = array.getFields().get(0).asGroupType();
       String[] repeatedPath = currentPath();
 
@@ -97,11 +97,11 @@ public class FlinkParquetWriters {
 
       return new ArrayDataWriter<>(repeatedD, repeatedR,
           newOption(repeated.getType(0), elementWriter),
-          sArray.getElementType());
+          ((ArrayType) fArray).getElementType());
     }
 
     @Override
-    public ParquetValueWriter<?> map(MapType sMap, GroupType map,
+    public ParquetValueWriter<?> map(LogicalType fMap, GroupType map,
                                      ParquetValueWriter<?> keyWriter, ParquetValueWriter<?> valueWriter) {
       GroupType repeatedKeyValue = map.getFields().get(0).asGroupType();
       String[] repeatedPath = currentPath();
@@ -112,7 +112,7 @@ public class FlinkParquetWriters {
       return new MapDataWriter<>(repeatedD, repeatedR,
           newOption(repeatedKeyValue.getType(0), keyWriter),
           newOption(repeatedKeyValue.getType(1), valueWriter),
-          sMap.getKeyType(), sMap.getValueType());
+          ((MapType) fMap).getKeyType(), ((MapType) fMap).getValueType());
     }
 
 

--- a/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetWriters.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetWriters.java
@@ -32,8 +32,6 @@ import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.MapType;
-import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.types.logical.RowType.RowField;
 import org.apache.flink.table.types.logical.SmallIntType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.iceberg.parquet.ParquetValueReaders;
@@ -76,12 +74,12 @@ public class FlinkParquetWriters {
     public ParquetValueWriter<?> struct(LogicalType fStruct, GroupType struct,
                                         List<ParquetValueWriter<?>> fieldWriters) {
       List<Type> fields = struct.getFields();
-      List<RowField> flinkFields = ((RowType) fStruct).getFields();
+      List<LogicalType> flinkFields = fStruct.getChildren();
       List<ParquetValueWriter<?>> writers = Lists.newArrayListWithExpectedSize(fieldWriters.size());
       List<LogicalType> flinkTypes = Lists.newArrayList();
       for (int i = 0; i < fields.size(); i += 1) {
         writers.add(newOption(struct.getType(i), fieldWriters.get(i)));
-        flinkTypes.add(flinkFields.get(i).getType());
+        flinkTypes.add(flinkFields.get(i));
       }
 
       return new RowDataWriter(writers, flinkTypes);

--- a/flink/src/main/java/org/apache/iceberg/flink/data/ParquetWithFlinkSchemaVisitor.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/data/ParquetWithFlinkSchemaVisitor.java
@@ -24,7 +24,6 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.iceberg.parquet.ParquetTypeWithPartnerVisitor;
-import org.apache.iceberg.util.Pair;
 
 public class ParquetWithFlinkSchemaVisitor<T> extends ParquetTypeWithPartnerVisitor<LogicalType, T> {
 
@@ -56,14 +55,12 @@ public class ParquetWithFlinkSchemaVisitor<T> extends ParquetTypeWithPartnerVisi
   }
 
   @Override
-  protected Pair<String, LogicalType> fieldNameAndType(LogicalType structType, int pos, Integer fieldId) {
+  protected LogicalType fieldType(LogicalType structType, int pos, Integer fieldId) {
     if (structType == null || ((RowType) structType).getFieldCount() < pos + 1) {
       return null;
     }
 
-    LogicalType type = ((RowType) structType).getTypeAt(pos);
-    String name = ((RowType) structType).getFieldNames().get(pos);
-    return Pair.of(name, type);
+    return ((RowType) structType).getTypeAt(pos);
   }
 
 }

--- a/flink/src/main/java/org/apache/iceberg/flink/data/ParquetWithFlinkSchemaVisitor.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/data/ParquetWithFlinkSchemaVisitor.java
@@ -19,181 +19,51 @@
 
 package org.apache.iceberg.flink.data;
 
-import java.util.Deque;
-import java.util.List;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.types.logical.RowType.RowField;
-import org.apache.iceberg.avro.AvroSchemaUtil;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.parquet.schema.GroupType;
-import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.OriginalType;
-import org.apache.parquet.schema.PrimitiveType;
-import org.apache.parquet.schema.Type;
+import org.apache.iceberg.parquet.ParquetTypeWithPartnerVisitor;
+import org.apache.iceberg.util.Pair;
 
-public class ParquetWithFlinkSchemaVisitor<T> {
-  private final Deque<String> fieldNames = Lists.newLinkedList();
+public class ParquetWithFlinkSchemaVisitor<T> extends ParquetTypeWithPartnerVisitor<LogicalType, T> {
 
-  public static <T> T visit(LogicalType sType, Type type, ParquetWithFlinkSchemaVisitor<T> visitor) {
-    Preconditions.checkArgument(sType != null, "Invalid DataType: null");
-    if (type instanceof MessageType) {
-      Preconditions.checkArgument(sType instanceof RowType, "Invalid struct: %s is not a struct", sType);
-      RowType struct = (RowType) sType;
-      return visitor.message(struct, (MessageType) type, visitFields(struct, type.asGroupType(), visitor));
-    } else if (type.isPrimitive()) {
-      return visitor.primitive(sType, type.asPrimitiveType());
-    } else {
-      // if not a primitive, the typeId must be a group
-      GroupType group = type.asGroupType();
-      OriginalType annotation = group.getOriginalType();
-      if (annotation != null) {
-        switch (annotation) {
-          case LIST:
-            Preconditions.checkArgument(!group.isRepetition(Type.Repetition.REPEATED),
-                "Invalid list: top-level group is repeated: %s", group);
-            Preconditions.checkArgument(group.getFieldCount() == 1,
-                "Invalid list: does not contain single repeated field: %s", group);
-
-            GroupType repeatedElement = group.getFields().get(0).asGroupType();
-            Preconditions.checkArgument(repeatedElement.isRepetition(Type.Repetition.REPEATED),
-                "Invalid list: inner group is not repeated");
-            Preconditions.checkArgument(repeatedElement.getFieldCount() <= 1,
-                "Invalid list: repeated group is not a single field: %s", group);
-
-            Preconditions.checkArgument(sType instanceof ArrayType, "Invalid list: %s is not an array", sType);
-            ArrayType array = (ArrayType) sType;
-            RowType.RowField element = new RowField(
-                "element", array.getElementType(), "element of " + array.asSummaryString());
-
-            visitor.fieldNames.push(repeatedElement.getName());
-            try {
-              T elementResult = null;
-              if (repeatedElement.getFieldCount() > 0) {
-                elementResult = visitField(element, repeatedElement.getType(0), visitor);
-              }
-
-              return visitor.list(array, group, elementResult);
-
-            } finally {
-              visitor.fieldNames.pop();
-            }
-
-          case MAP:
-            Preconditions.checkArgument(!group.isRepetition(Type.Repetition.REPEATED),
-                "Invalid map: top-level group is repeated: %s", group);
-            Preconditions.checkArgument(group.getFieldCount() == 1,
-                "Invalid map: does not contain single repeated field: %s", group);
-
-            GroupType repeatedKeyValue = group.getType(0).asGroupType();
-            Preconditions.checkArgument(repeatedKeyValue.isRepetition(Type.Repetition.REPEATED),
-                "Invalid map: inner group is not repeated");
-            Preconditions.checkArgument(repeatedKeyValue.getFieldCount() <= 2,
-                "Invalid map: repeated group does not have 2 fields");
-
-            Preconditions.checkArgument(sType instanceof MapType, "Invalid map: %s is not a map", sType);
-            MapType map = (MapType) sType;
-            RowField keyField = new RowField("key", map.getKeyType(), "key of " + map.asSummaryString());
-            RowField valueField = new RowField(
-                "value", map.getValueType(), "value of " + map.asSummaryString());
-
-            visitor.fieldNames.push(repeatedKeyValue.getName());
-            try {
-              T keyResult = null;
-              T valueResult = null;
-              switch (repeatedKeyValue.getFieldCount()) {
-                case 2:
-                  // if there are 2 fields, both key and value are projected
-                  keyResult = visitField(keyField, repeatedKeyValue.getType(0), visitor);
-                  valueResult = visitField(valueField, repeatedKeyValue.getType(1), visitor);
-                  break;
-                case 1:
-                  // if there is just one, use the name to determine what it is
-                  Type keyOrValue = repeatedKeyValue.getType(0);
-                  if (keyOrValue.getName().equalsIgnoreCase("key")) {
-                    keyResult = visitField(keyField, keyOrValue, visitor);
-                    // value result remains null
-                  } else {
-                    valueResult = visitField(valueField, keyOrValue, visitor);
-                    // key result remains null
-                  }
-                  break;
-                default:
-                  // both results will remain null
-              }
-
-              return visitor.map(map, group, keyResult, valueResult);
-
-            } finally {
-              visitor.fieldNames.pop();
-            }
-
-          default:
-        }
-      }
-      Preconditions.checkArgument(sType instanceof RowType, "Invalid struct: %s is not a struct", sType);
-      RowType struct = (RowType) sType;
-      return visitor.struct(struct, group, visitFields(struct, group, visitor));
-    }
-  }
-
-  private static <T> T visitField(RowType.RowField sField, Type field, ParquetWithFlinkSchemaVisitor<T> visitor) {
-    visitor.fieldNames.push(field.getName());
-    try {
-      return visit(sField.getType(), field, visitor);
-    } finally {
-      visitor.fieldNames.pop();
-    }
-  }
-
-  private static <T> List<T> visitFields(RowType struct, GroupType group,
-                                         ParquetWithFlinkSchemaVisitor<T> visitor) {
-    List<RowType.RowField> sFields = struct.getFields();
-    Preconditions.checkArgument(sFields.size() == group.getFieldCount(),
-        "Structs do not match: %s and %s", struct, group);
-    List<T> results = Lists.newArrayListWithExpectedSize(group.getFieldCount());
-    for (int i = 0; i < sFields.size(); i += 1) {
-      Type field = group.getFields().get(i);
-      RowType.RowField sField = sFields.get(i);
-      Preconditions.checkArgument(field.getName().equals(AvroSchemaUtil.makeCompatibleName(sField.getName())),
-          "Structs do not match: field %s != %s", field.getName(), sField.getName());
-      results.add(visitField(sField, field, visitor));
+  @Override
+  protected LogicalType arrayElementType(LogicalType arrayType) {
+    if (arrayType == null) {
+      return null;
     }
 
-    return results;
+    return ((ArrayType) arrayType).getElementType();
   }
 
-  public T message(RowType sStruct, MessageType message, List<T> fields) {
-    return null;
+  @Override
+  protected LogicalType mapKeyType(LogicalType mapType) {
+    if (mapType == null) {
+      return null;
+    }
+
+    return ((MapType) mapType).getKeyType();
   }
 
-  public T struct(RowType sStruct, GroupType struct, List<T> fields) {
-    return null;
+  @Override
+  protected LogicalType mapValueType(LogicalType mapType) {
+    if (mapType == null) {
+      return null;
+    }
+
+    return ((MapType) mapType).getValueType();
   }
 
-  public T list(ArrayType sArray, GroupType array, T element) {
-    return null;
-  }
+  @Override
+  protected Pair<String, LogicalType> fieldNameAndType(LogicalType structType, int pos, Integer fieldId) {
+    if (structType == null || ((RowType) structType).getFieldCount() < pos + 1) {
+      return null;
+    }
 
-  public T map(MapType sMap, GroupType map, T key, T value) {
-    return null;
-  }
-
-  public T primitive(LogicalType sPrimitive, PrimitiveType primitive) {
-    return null;
-  }
-
-  protected String[] currentPath() {
-    return Lists.newArrayList(fieldNames.descendingIterator()).toArray(new String[0]);
-  }
-
-  protected String[] path(String name) {
-    List<String> list = Lists.newArrayList(fieldNames.descendingIterator());
-    list.add(name);
-    return list.toArray(new String[0]);
+    LogicalType type = ((RowType) structType).getTypeAt(pos);
+    String name = ((RowType) structType).getFieldNames().get(pos);
+    return Pair.of(name, type);
   }
 
 }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetAvroValueReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetAvroValueReaders.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.parquet;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -76,13 +77,13 @@ public class ParquetAvroValueReaders {
     }
 
     @Override
-    public ParquetValueReader<?> message(Types.StructType expected, MessageType message,
+    public ParquetValueReader<?> message(org.apache.iceberg.types.Type expected, MessageType message,
                                          List<ParquetValueReader<?>> fieldReaders) {
       return struct(expected, message.asGroupType(), fieldReaders);
     }
 
     @Override
-    public ParquetValueReader<?> struct(Types.StructType expected, GroupType struct,
+    public ParquetValueReader<?> struct(org.apache.iceberg.types.Type expected, GroupType struct,
                                         List<ParquetValueReader<?>> fieldReaders) {
       Schema avroSchema = avroSchemas.get(expected);
 
@@ -99,7 +100,7 @@ public class ParquetAvroValueReaders {
       }
 
       List<Types.NestedField> expectedFields = expected != null ?
-          expected.fields() : ImmutableList.of();
+          expected.asStructType().fields() : ImmutableList.of();
       List<ParquetValueReader<?>> reorderedFields = Lists.newArrayListWithExpectedSize(
           expectedFields.size());
       List<Type> types = Lists.newArrayListWithExpectedSize(expectedFields.size());
@@ -119,7 +120,7 @@ public class ParquetAvroValueReaders {
     }
 
     @Override
-    public ParquetValueReader<?> list(Types.ListType expectedList, GroupType array,
+    public ParquetValueReader<?> list(org.apache.iceberg.types.Type expectedList, GroupType array,
                                       ParquetValueReader<?> elementReader) {
       GroupType repeated = array.getFields().get(0).asGroupType();
       String[] repeatedPath = currentPath();
@@ -134,7 +135,7 @@ public class ParquetAvroValueReaders {
     }
 
     @Override
-    public ParquetValueReader<?> map(Types.MapType expectedMap, GroupType map,
+    public ParquetValueReader<?> map(org.apache.iceberg.types.Type expectedMap, GroupType map,
                                      ParquetValueReader<?> keyReader,
                                      ParquetValueReader<?> valueReader) {
       GroupType repeatedKeyValue = map.getFields().get(0).asGroupType();
@@ -154,11 +155,11 @@ public class ParquetAvroValueReaders {
     }
 
     @Override
-    public ParquetValueReader<?> primitive(org.apache.iceberg.types.Type.PrimitiveType expected,
+    public ParquetValueReader<?> primitive(org.apache.iceberg.types.Type expected,
                                            PrimitiveType primitive) {
       ColumnDescriptor desc = type.getColumnDescription(currentPath());
 
-      boolean isMapKey = fieldNames.contains("key");
+      boolean isMapKey = Arrays.asList(currentPath()).contains("key");
 
       if (primitive.getOriginalType() != null) {
         switch (primitive.getOriginalType()) {

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetTypeWithPartnerVisitor.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetTypeWithPartnerVisitor.java
@@ -71,8 +71,8 @@ public abstract class ParquetTypeWithPartnerVisitor<P, T> {
       T elementResult = null;
       if (repeatedElement.getFieldCount() > 0) {
         Type elementField = repeatedElement.getType(0);
+        visitor.beforeElementField(elementField);
         try {
-          visitor.beforeElementField(elementField);
           elementResult = visit(visitor.arrayElementType(list), elementField, visitor);
         } finally {
           visitor.afterElementField(elementField);
@@ -155,9 +155,12 @@ public abstract class ParquetTypeWithPartnerVisitor<P, T> {
     for (int i = 0; i < group.getFieldCount(); i += 1) {
       Type field = group.getFields().get(i);
       visitor.beforeField(field);
-      Integer fieldId = field.getId() == null ? null : field.getId().intValue();
-      results.add(visit(visitor.fieldType(struct, i, fieldId), field, visitor));
-      visitor.afterField(field);
+      try {
+        Integer fieldId = field.getId() == null ? null : field.getId().intValue();
+        results.add(visit(visitor.fieldType(struct, i, fieldId), field, visitor));
+      } finally {
+        visitor.afterField(field);
+      }
     }
 
     return results;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetTypeWithPartnerVisitor.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetTypeWithPartnerVisitor.java
@@ -1,0 +1,256 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.parquet;
+
+import java.util.Deque;
+import java.util.List;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.Pair;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.OriginalType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+
+public abstract class ParquetTypeWithPartnerVisitor<P, T> {
+  private final Deque<String> fieldNames = Lists.newLinkedList();
+
+  public static <P, T> T visit(P partnerType, Type type, ParquetTypeWithPartnerVisitor<P, T> visitor) {
+    if (type instanceof MessageType) {
+      return visitor.message(partnerType, (MessageType) type, visitFields(partnerType, type.asGroupType(), visitor));
+    } else if (type.isPrimitive()) {
+      return visitor.primitive(partnerType, type.asPrimitiveType());
+    } else {
+      // if not a primitive, the typeId must be a group
+      GroupType group = type.asGroupType();
+      OriginalType annotation = group.getOriginalType();
+      if (annotation != null) {
+        switch (annotation) {
+          case LIST:
+            return visitList(partnerType, group, visitor);
+          case MAP:
+            return visitMap(partnerType, group, visitor);
+          default:
+        }
+      }
+      return visitor.struct(partnerType, group, visitFields(partnerType, group, visitor));
+    }
+  }
+
+  private static <P, T> T visitList(P list, GroupType group, ParquetTypeWithPartnerVisitor<P, T> visitor) {
+    Preconditions.checkArgument(!group.isRepetition(Type.Repetition.REPEATED),
+        "Invalid list: top-level group is repeated: %s", group);
+    Preconditions.checkArgument(group.getFieldCount() == 1,
+        "Invalid list: does not contain single repeated field: %s", group);
+
+    GroupType repeatedElement = group.getFields().get(0).asGroupType();
+    Preconditions.checkArgument(repeatedElement.isRepetition(Type.Repetition.REPEATED),
+        "Invalid list: inner group is not repeated");
+    Preconditions.checkArgument(repeatedElement.getFieldCount() <= 1,
+        "Invalid list: repeated group is not a single field: %s", group);
+
+    visitor.beforeRepeatedElement(repeatedElement);
+    try {
+      T elementResult = null;
+      if (repeatedElement.getFieldCount() > 0) {
+        Type elementField = repeatedElement.getType(0);
+        try {
+          visitor.beforeElementField(elementField);
+          elementResult = visit(visitor.arrayElementType(list), elementField, visitor);
+        } finally {
+          visitor.afterElementField(elementField);
+        }
+      }
+      return visitor.list(list, group, elementResult);
+    } finally {
+      visitor.afterRepeatedElement(repeatedElement);
+    }
+  }
+
+  private static <P, T> T visitMap(P map, GroupType group, ParquetTypeWithPartnerVisitor<P, T> visitor) {
+    Preconditions.checkArgument(!group.isRepetition(Type.Repetition.REPEATED),
+        "Invalid map: top-level group is repeated: %s", group);
+    Preconditions.checkArgument(group.getFieldCount() == 1,
+        "Invalid map: does not contain single repeated field: %s", group);
+
+    GroupType repeatedKeyValue = group.getType(0).asGroupType();
+    Preconditions.checkArgument(repeatedKeyValue.isRepetition(Type.Repetition.REPEATED),
+        "Invalid map: inner group is not repeated");
+    Preconditions.checkArgument(repeatedKeyValue.getFieldCount() <= 2,
+        "Invalid map: repeated group does not have 2 fields");
+
+    visitor.beforeRepeatedKeyValue(repeatedKeyValue);
+    try {
+      T keyResult = null;
+      T valueResult = null;
+      switch (repeatedKeyValue.getFieldCount()) {
+        case 2:
+          // if there are 2 fields, both key and value are projected
+          Type keyType = repeatedKeyValue.getType(0);
+          visitor.beforeKeyField(keyType);
+          try {
+            keyResult = visit(visitor.mapKeyType(map), keyType, visitor);
+          } finally {
+            visitor.afterKeyField(keyType);
+          }
+          Type valueType = repeatedKeyValue.getType(1);
+          visitor.beforeValueField(valueType);
+          try {
+            valueResult = visit(visitor.mapValueType(map), repeatedKeyValue.getType(1), visitor);
+          } finally {
+            visitor.afterValueField(valueType);
+          }
+          break;
+        case 1:
+          // if there is just one, use the name to determine what it is
+          Type keyOrValue = repeatedKeyValue.getType(0);
+          if (keyOrValue.getName().equalsIgnoreCase("key")) {
+            visitor.beforeKeyField(keyOrValue);
+            try {
+              keyResult = visit(visitor.mapKeyType(map), keyOrValue, visitor);
+            } finally {
+              visitor.afterKeyField(keyOrValue);
+            }
+            // value result remains null
+          } else {
+            visitor.beforeValueField(keyOrValue);
+            try {
+              valueResult = visit(visitor.mapValueType(map), keyOrValue, visitor);
+            } finally {
+              visitor.afterValueField(keyOrValue);
+            }
+            // key result remains null
+          }
+          break;
+        default:
+          // both results will remain null
+      }
+
+      return visitor.map(map, group, keyResult, valueResult);
+
+    } finally {
+      visitor.afterRepeatedKeyValue(repeatedKeyValue);
+    }
+  }
+
+  protected static <P, T> List<T> visitFields(P struct, GroupType group, ParquetTypeWithPartnerVisitor<P, T> visitor) {
+    List<T> results = Lists.newArrayListWithExpectedSize(group.getFieldCount());
+    for (int i = 0; i < group.getFieldCount(); i += 1) {
+      Type field = group.getFields().get(i);
+      visitor.beforeField(field);
+      Integer fieldId = field.getId() == null ? null : field.getId().intValue();
+      Pair<String, P> filedNameAndType = visitor.fieldNameAndType(struct, i, fieldId);
+      if (filedNameAndType != null) {
+        results.add(visit(filedNameAndType.second(), field, visitor));
+      } else {
+        results.add(visit(null, field, visitor));
+      }
+      visitor.afterField(field);
+    }
+
+    return results;
+  }
+
+  protected abstract P arrayElementType(P arrayType);
+  protected abstract P mapKeyType(P mapType);
+  protected abstract P mapValueType(P mapType);
+  protected abstract Pair<String, P> fieldNameAndType(P structType, int pos, Integer fieldId);
+
+  public T message(P struct, MessageType message, List<T> fields) {
+    return null;
+  }
+
+  public T struct(P pStruct, GroupType struct, List<T> fields) {
+    return null;
+  }
+
+  public T list(P pArray, GroupType array, T element) {
+    return null;
+  }
+
+  public T map(P pMap, GroupType map, T key, T value) {
+    return null;
+  }
+
+  public T primitive(P pType, PrimitiveType primitive) {
+    return null;
+  }
+
+
+  public void beforeField(Type type) {
+    fieldNames.push(type.getName());
+  }
+
+  public void afterField(Type type) {
+    fieldNames.pop();
+  }
+
+  public void beforeRepeatedElement(Type element) {
+    beforeField(element);
+  }
+
+  public void afterRepeatedElement(Type element) {
+    afterField(element);
+  }
+
+  public void beforeElementField(Type element) {
+    beforeField(element);
+  }
+
+  public void afterElementField(Type element) {
+    afterField(element);
+  }
+
+  public void beforeRepeatedKeyValue(Type keyValue) {
+    beforeField(keyValue);
+  }
+
+  public void afterRepeatedKeyValue(Type keyValue) {
+    afterField(keyValue);
+  }
+
+  public void beforeKeyField(Type key) {
+    beforeField(key);
+  }
+
+  public void afterKeyField(Type key) {
+    afterField(key);
+  }
+
+  public void beforeValueField(Type value) {
+    beforeField(value);
+  }
+
+  public void afterValueField(Type value) {
+    afterField(value);
+  }
+
+  protected String[] currentPath() {
+    return Lists.newArrayList(fieldNames.descendingIterator()).toArray(new String[0]);
+  }
+
+  protected String[] path(String name) {
+    List<String> list = Lists.newArrayList(fieldNames.descendingIterator());
+    list.add(name);
+    return list.toArray(new String[0]);
+  }
+
+}

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetTypeWithPartnerVisitor.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetTypeWithPartnerVisitor.java
@@ -33,7 +33,6 @@ public abstract class ParquetTypeWithPartnerVisitor<P, T> {
   private final Deque<String> fieldNames = Lists.newLinkedList();
 
   public static <P, T> T visit(P partnerType, Type type, ParquetTypeWithPartnerVisitor<P, T> visitor) {
-    Preconditions.checkNotNull(partnerType, "partner type cannot be null");
     if (type instanceof MessageType) {
       return visitor.message(partnerType, (MessageType) type, visitFields(partnerType, type.asGroupType(), visitor));
     } else if (type.isPrimitive()) {

--- a/parquet/src/main/java/org/apache/iceberg/parquet/TypeWithSchemaVisitor.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/TypeWithSchemaVisitor.java
@@ -19,187 +19,57 @@
 
 package org.apache.iceberg.parquet;
 
-import java.util.LinkedList;
-import java.util.List;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
-import org.apache.parquet.schema.GroupType;
-import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.OriginalType;
-import org.apache.parquet.schema.PrimitiveType;
-import org.apache.parquet.schema.Type;
+import org.apache.iceberg.util.Pair;
 
 /**
  * Visitor for traversing a Parquet type with a companion Iceberg type.
  *
  * @param <T> the Java class returned by the visitor
  */
-public class TypeWithSchemaVisitor<T> {
-  @SuppressWarnings({"checkstyle:VisibilityModifier", "checkstyle:IllegalType"})
-  protected LinkedList<String> fieldNames = Lists.newLinkedList();
+public class TypeWithSchemaVisitor<T> extends ParquetTypeWithPartnerVisitor<Type, T> {
 
-  @SuppressWarnings("checkstyle:CyclomaticComplexity")
-  public static <T> T visit(org.apache.iceberg.types.Type iType, Type type, TypeWithSchemaVisitor<T> visitor) {
-    if (type instanceof MessageType) {
-      Types.StructType struct = iType != null ? iType.asStructType() : null;
-      return visitor.message(struct, (MessageType) type,
-          visitFields(struct, type.asGroupType(), visitor));
-
-    } else if (type.isPrimitive()) {
-      org.apache.iceberg.types.Type.PrimitiveType iPrimitive = iType != null ?
-          iType.asPrimitiveType() : null;
-      return visitor.primitive(iPrimitive, type.asPrimitiveType());
-
-    } else {
-      // if not a primitive, the typeId must be a group
-      GroupType group = type.asGroupType();
-      OriginalType annotation = group.getOriginalType();
-      if (annotation != null) {
-        switch (annotation) {
-          case LIST:
-            Preconditions.checkArgument(!group.isRepetition(Type.Repetition.REPEATED),
-                "Invalid list: top-level group is repeated: %s", group);
-            Preconditions.checkArgument(group.getFieldCount() == 1,
-                "Invalid list: does not contain single repeated field: %s", group);
-
-            GroupType repeatedElement = group.getFields().get(0).asGroupType();
-            Preconditions.checkArgument(repeatedElement.isRepetition(Type.Repetition.REPEATED),
-                "Invalid list: inner group is not repeated");
-            Preconditions.checkArgument(repeatedElement.getFieldCount() <= 1,
-                "Invalid list: repeated group is not a single field: %s", group);
-
-            Types.ListType list = null;
-            Types.NestedField element = null;
-            if (iType != null) {
-              list = iType.asListType();
-              element = list.fields().get(0);
-            }
-
-            visitor.fieldNames.push(repeatedElement.getName());
-            try {
-              T elementResult = null;
-              if (repeatedElement.getFieldCount() > 0) {
-                elementResult = visitField(element, repeatedElement.getType(0), visitor);
-              }
-
-              return visitor.list(list, group, elementResult);
-            } finally {
-              visitor.fieldNames.pop();
-            }
-
-          case MAP:
-            Preconditions.checkArgument(!group.isRepetition(Type.Repetition.REPEATED),
-                "Invalid map: top-level group is repeated: %s", group);
-            Preconditions.checkArgument(group.getFieldCount() == 1,
-                "Invalid map: does not contain single repeated field: %s", group);
-
-            GroupType repeatedKeyValue = group.getType(0).asGroupType();
-            Preconditions.checkArgument(repeatedKeyValue.isRepetition(Type.Repetition.REPEATED),
-                "Invalid map: inner group is not repeated");
-            Preconditions.checkArgument(repeatedKeyValue.getFieldCount() <= 2,
-                "Invalid map: repeated group does not have 2 fields");
-
-            Types.MapType map = null;
-            Types.NestedField keyField = null;
-            Types.NestedField valueField = null;
-            if (iType != null) {
-              map = iType.asMapType();
-              keyField = map.fields().get(0);
-              valueField = map.fields().get(1);
-            }
-
-            visitor.fieldNames.push(repeatedKeyValue.getName());
-            try {
-              T keyResult = null;
-              T valueResult = null;
-              switch (repeatedKeyValue.getFieldCount()) {
-                case 2:
-                  // if there are 2 fields, both key and value are projected
-                  keyResult = visitField(keyField, repeatedKeyValue.getType(0), visitor);
-                  valueResult = visitField(valueField, repeatedKeyValue.getType(1), visitor);
-                  break;
-                case 1:
-                  // if there is just one, use the name to determine what it is
-                  Type keyOrValue = repeatedKeyValue.getType(0);
-                  if (keyOrValue.getName().equalsIgnoreCase("key")) {
-                    keyResult = visitField(keyField, keyOrValue, visitor);
-                    // value result remains null
-                  } else {
-                    valueResult = visitField(valueField, keyOrValue, visitor);
-                    // key result remains null
-                  }
-                  break;
-                default:
-                  // both results will remain null
-              }
-
-              return visitor.map(map, group, keyResult, valueResult);
-
-            } finally {
-              visitor.fieldNames.pop();
-            }
-
-          default:
-        }
-      }
-
-      Types.StructType struct = iType != null ? iType.asStructType() : null;
-      return visitor.struct(struct, group, visitFields(struct, group, visitor));
-    }
-  }
-
-  private static <T> T visitField(Types.NestedField iField, Type field, TypeWithSchemaVisitor<T> visitor) {
-    visitor.fieldNames.push(field.getName());
-    try {
-      return visit(iField != null ? iField.type() : null, field, visitor);
-    } finally {
-      visitor.fieldNames.pop();
-    }
-  }
-
-  private static <T> List<T> visitFields(Types.StructType struct, GroupType group, TypeWithSchemaVisitor<T> visitor) {
-    List<T> results = Lists.newArrayListWithExpectedSize(group.getFieldCount());
-    for (Type field : group.getFields()) {
-      int id = -1;
-      if (field.getId() != null) {
-        id = field.getId().intValue();
-      }
-      Types.NestedField iField = (struct != null && id >= 0) ? struct.field(id) : null;
-      results.add(visitField(iField, field, visitor));
+  @Override
+  protected Type arrayElementType(Type arrayType) {
+    if (arrayType == null) {
+      return null;
     }
 
-    return results;
+    return arrayType.asListType().elementType();
   }
 
-  public T message(Types.StructType iStruct, MessageType message, List<T> fields) {
-    return null;
+  @Override
+  protected Type mapKeyType(Type mapType) {
+    if (mapType == null) {
+      return null;
+    }
+
+    return mapType.asMapType().keyType();
   }
 
-  public T struct(Types.StructType iStruct, GroupType struct, List<T> fields) {
-    return null;
+  @Override
+  protected Type mapValueType(Type mapType) {
+    if (mapType == null) {
+      return null;
+    }
+
+    return mapType.asMapType().valueType();
   }
 
-  public T list(Types.ListType iList, GroupType array, T element) {
-    return null;
-  }
+  @Override
+  protected Pair<String, Type> fieldNameAndType(Type structType, int pos, Integer fieldId) {
+    if (structType == null || fieldId == null) {
+      return null;
+    }
 
-  public T map(Types.MapType iMap, GroupType map, T key, T value) {
-    return null;
-  }
+    Types.StructType struct = structType.asStructType();
+    if (struct.field(fieldId) == null) {
+      return null;
+    }
 
-  public T primitive(org.apache.iceberg.types.Type.PrimitiveType iPrimitive,
-                     PrimitiveType primitive) {
-    return null;
-  }
-
-  protected String[] currentPath() {
-    return Lists.newArrayList(fieldNames.descendingIterator()).toArray(new String[0]);
-  }
-
-  protected String[] path(String name) {
-    List<String> list = Lists.newArrayList(fieldNames.descendingIterator());
-    list.add(name);
-    return list.toArray(new String[0]);
+    Type type = struct.field(fieldId).type();
+    String name = struct.field(fieldId).name();
+    return Pair.of(name, type);
   }
 }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/TypeWithSchemaVisitor.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/TypeWithSchemaVisitor.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.parquet;
 
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
-import org.apache.iceberg.util.Pair;
 
 /**
  * Visitor for traversing a Parquet type with a companion Iceberg type.
@@ -58,18 +57,12 @@ public class TypeWithSchemaVisitor<T> extends ParquetTypeWithPartnerVisitor<Type
   }
 
   @Override
-  protected Pair<String, Type> fieldNameAndType(Type structType, int pos, Integer fieldId) {
+  protected Type fieldType(Type structType, int pos, Integer fieldId) {
     if (structType == null || fieldId == null) {
       return null;
     }
 
-    Types.StructType struct = structType.asStructType();
-    if (struct.field(fieldId) == null) {
-      return null;
-    }
-
-    Type type = struct.field(fieldId).type();
-    String name = struct.field(fieldId).name();
-    return Pair.of(name, type);
+    Types.NestedField field = structType.asStructType().field(fieldId);
+    return field == null ? null : field.type();
   }
 }

--- a/pig/src/main/java/org/apache/iceberg/pig/PigParquetReader.java
+++ b/pig/src/main/java/org/apache/iceberg/pig/PigParquetReader.java
@@ -87,14 +87,14 @@ public class PigParquetReader {
 
     @Override
     public ParquetValueReader<?> message(
-        Types.StructType expected, MessageType message, List<ParquetValueReader<?>> fieldReaders) {
+        org.apache.iceberg.types.Type expected, MessageType message, List<ParquetValueReader<?>> fieldReaders) {
       // the top level matches by ID, but the remaining IDs are missing
       return super.struct(expected, message, fieldReaders);
     }
 
     @Override
     public ParquetValueReader<?> struct(
-        Types.StructType ignored, GroupType struct, List<ParquetValueReader<?>> fieldReaders) {
+        org.apache.iceberg.types.Type ignored, GroupType struct, List<ParquetValueReader<?>> fieldReaders) {
       // the expected struct is ignored because nested fields are never found when the
       List<ParquetValueReader<?>> newFields = Lists.newArrayListWithExpectedSize(
           fieldReaders.size());
@@ -126,13 +126,13 @@ public class PigParquetReader {
 
     @Override
     public ParquetValueReader<?> message(
-        Types.StructType expected, MessageType message, List<ParquetValueReader<?>> fieldReaders) {
+        org.apache.iceberg.types.Type expected, MessageType message, List<ParquetValueReader<?>> fieldReaders) {
       return struct(expected, message.asGroupType(), fieldReaders);
     }
 
     @Override
     public ParquetValueReader<?> struct(
-        Types.StructType expected, GroupType struct, List<ParquetValueReader<?>> fieldReaders) {
+        org.apache.iceberg.types.Type expected, GroupType struct, List<ParquetValueReader<?>> fieldReaders) {
       // match the expected struct's order
       Map<Integer, ParquetValueReader<?>> readersById = Maps.newHashMap();
       Map<Integer, Type> typesById = Maps.newHashMap();
@@ -146,7 +146,7 @@ public class PigParquetReader {
       }
 
       List<Types.NestedField> expectedFields = expected != null ?
-          expected.fields() : ImmutableList.of();
+          expected.asStructType().fields() : ImmutableList.of();
       List<ParquetValueReader<?>> reorderedFields = Lists.newArrayListWithExpectedSize(
           expectedFields.size());
       List<Type> types = Lists.newArrayListWithExpectedSize(expectedFields.size());
@@ -173,7 +173,7 @@ public class PigParquetReader {
 
     @Override
     public ParquetValueReader<?> list(
-        Types.ListType expectedList, GroupType array, ParquetValueReader<?> elementReader) {
+        org.apache.iceberg.types.Type expectedList, GroupType array, ParquetValueReader<?> elementReader) {
       GroupType repeated = array.getFields().get(0).asGroupType();
       String[] repeatedPath = currentPath();
 
@@ -188,7 +188,8 @@ public class PigParquetReader {
 
     @Override
     public ParquetValueReader<?> map(
-        Types.MapType expectedMap, GroupType map, ParquetValueReader<?> keyReader, ParquetValueReader<?> valueReader) {
+        org.apache.iceberg.types.Type expectedMap, GroupType map, ParquetValueReader<?> keyReader,
+        ParquetValueReader<?> valueReader) {
       GroupType repeatedKeyValue = map.getFields().get(0).asGroupType();
       String[] repeatedPath = currentPath();
 
@@ -207,7 +208,7 @@ public class PigParquetReader {
 
     @Override
     public ParquetValueReader<?> primitive(
-        org.apache.iceberg.types.Type.PrimitiveType expected, PrimitiveType primitive) {
+        org.apache.iceberg.types.Type expected, PrimitiveType primitive) {
       ColumnDescriptor desc = type.getColumnDescription(currentPath());
 
       if (primitive.getOriginalType() != null) {

--- a/spark/src/main/java/org/apache/iceberg/spark/data/ParquetWithSparkSchemaVisitor.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/ParquetWithSparkSchemaVisitor.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.spark.data;
 
 import org.apache.iceberg.parquet.ParquetTypeWithPartnerVisitor;
-import org.apache.iceberg.util.Pair;
 import org.apache.spark.sql.types.ArrayType;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.MapType;
@@ -61,13 +60,11 @@ public class ParquetWithSparkSchemaVisitor<T> extends ParquetTypeWithPartnerVisi
   }
 
   @Override
-  protected Pair<String, DataType> fieldNameAndType(DataType structType, int pos, Integer fieldId) {
+  protected DataType fieldType(DataType structType, int pos, Integer fieldId) {
     if (structType == null || ((StructType) structType).size() <  pos + 1) {
       return null;
     }
 
-    DataType type = ((StructType) structType).apply(pos).dataType();
-    String name = ((StructType) structType).apply(pos).name();
-    return Pair.of(name, type);
+    return ((StructType) structType).apply(pos).dataType();
   }
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/data/ParquetWithSparkSchemaVisitor.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/ParquetWithSparkSchemaVisitor.java
@@ -19,22 +19,11 @@
 
 package org.apache.iceberg.spark.data;
 
-import java.util.Deque;
-import java.util.List;
-import org.apache.iceberg.avro.AvroSchemaUtil;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.parquet.schema.GroupType;
-import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.OriginalType;
-import org.apache.parquet.schema.PrimitiveType;
-import org.apache.parquet.schema.Type;
-import org.apache.parquet.schema.Type.Repetition;
+import org.apache.iceberg.parquet.ParquetTypeWithPartnerVisitor;
+import org.apache.iceberg.util.Pair;
 import org.apache.spark.sql.types.ArrayType;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.MapType;
-import org.apache.spark.sql.types.Metadata;
-import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
 /**
@@ -42,167 +31,43 @@ import org.apache.spark.sql.types.StructType;
  *
  * @param <T> the Java class returned by the visitor
  */
-public class ParquetWithSparkSchemaVisitor<T> {
-  private final Deque<String> fieldNames = Lists.newLinkedList();
+public class ParquetWithSparkSchemaVisitor<T> extends ParquetTypeWithPartnerVisitor<DataType, T> {
 
-  public static <T> T visit(DataType sType, Type type, ParquetWithSparkSchemaVisitor<T> visitor) {
-    Preconditions.checkArgument(sType != null, "Invalid DataType: null");
-    if (type instanceof MessageType) {
-      Preconditions.checkArgument(sType instanceof StructType, "Invalid struct: %s is not a struct", sType);
-      StructType struct = (StructType) sType;
-      return visitor.message(struct, (MessageType) type, visitFields(struct, type.asGroupType(), visitor));
-
-    } else if (type.isPrimitive()) {
-      return visitor.primitive(sType, type.asPrimitiveType());
-
-    } else {
-      // if not a primitive, the typeId must be a group
-      GroupType group = type.asGroupType();
-      OriginalType annotation = group.getOriginalType();
-      if (annotation != null) {
-        switch (annotation) {
-          case LIST:
-            Preconditions.checkArgument(!group.isRepetition(Repetition.REPEATED),
-                "Invalid list: top-level group is repeated: %s", group);
-            Preconditions.checkArgument(group.getFieldCount() == 1,
-                "Invalid list: does not contain single repeated field: %s", group);
-
-            GroupType repeatedElement = group.getFields().get(0).asGroupType();
-            Preconditions.checkArgument(repeatedElement.isRepetition(Repetition.REPEATED),
-                "Invalid list: inner group is not repeated");
-            Preconditions.checkArgument(repeatedElement.getFieldCount() <= 1,
-                "Invalid list: repeated group is not a single field: %s", group);
-
-            Preconditions.checkArgument(sType instanceof ArrayType, "Invalid list: %s is not an array", sType);
-            ArrayType array = (ArrayType) sType;
-            StructField element = new StructField(
-                "element", array.elementType(), array.containsNull(), Metadata.empty());
-
-            visitor.fieldNames.push(repeatedElement.getName());
-            try {
-              T elementResult = null;
-              if (repeatedElement.getFieldCount() > 0) {
-                elementResult = visitField(element, repeatedElement.getType(0), visitor);
-              }
-
-              return visitor.list(array, group, elementResult);
-
-            } finally {
-              visitor.fieldNames.pop();
-            }
-
-          case MAP:
-            Preconditions.checkArgument(!group.isRepetition(Repetition.REPEATED),
-                "Invalid map: top-level group is repeated: %s", group);
-            Preconditions.checkArgument(group.getFieldCount() == 1,
-                "Invalid map: does not contain single repeated field: %s", group);
-
-            GroupType repeatedKeyValue = group.getType(0).asGroupType();
-            Preconditions.checkArgument(repeatedKeyValue.isRepetition(Repetition.REPEATED),
-                "Invalid map: inner group is not repeated");
-            Preconditions.checkArgument(repeatedKeyValue.getFieldCount() <= 2,
-                "Invalid map: repeated group does not have 2 fields");
-
-            Preconditions.checkArgument(sType instanceof MapType, "Invalid map: %s is not a map", sType);
-            MapType map = (MapType) sType;
-            StructField keyField = new StructField("key", map.keyType(), false, Metadata.empty());
-            StructField valueField = new StructField(
-                "value", map.valueType(), map.valueContainsNull(), Metadata.empty());
-
-            visitor.fieldNames.push(repeatedKeyValue.getName());
-            try {
-              T keyResult = null;
-              T valueResult = null;
-              switch (repeatedKeyValue.getFieldCount()) {
-                case 2:
-                  // if there are 2 fields, both key and value are projected
-                  keyResult = visitField(keyField, repeatedKeyValue.getType(0), visitor);
-                  valueResult = visitField(valueField, repeatedKeyValue.getType(1), visitor);
-                  break;
-                case 1:
-                  // if there is just one, use the name to determine what it is
-                  Type keyOrValue = repeatedKeyValue.getType(0);
-                  if (keyOrValue.getName().equalsIgnoreCase("key")) {
-                    keyResult = visitField(keyField, keyOrValue, visitor);
-                    // value result remains null
-                  } else {
-                    valueResult = visitField(valueField, keyOrValue, visitor);
-                    // key result remains null
-                  }
-                  break;
-                default:
-                  // both results will remain null
-              }
-
-              return visitor.map(map, group, keyResult, valueResult);
-
-            } finally {
-              visitor.fieldNames.pop();
-            }
-
-          default:
-        }
-      }
-
-      Preconditions.checkArgument(sType instanceof StructType, "Invalid struct: %s is not a struct", sType);
-      StructType struct = (StructType) sType;
-      return visitor.struct(struct, group, visitFields(struct, group, visitor));
-    }
-  }
-
-  private static <T> T visitField(StructField sField, Type field, ParquetWithSparkSchemaVisitor<T> visitor) {
-    visitor.fieldNames.push(field.getName());
-    try {
-      return visit(sField.dataType(), field, visitor);
-    } finally {
-      visitor.fieldNames.pop();
-    }
-  }
-
-  private static <T> List<T> visitFields(StructType struct, GroupType group,
-                                         ParquetWithSparkSchemaVisitor<T> visitor) {
-    StructField[] sFields = struct.fields();
-    Preconditions.checkArgument(sFields.length == group.getFieldCount(),
-        "Structs do not match: %s and %s", struct, group);
-    List<T> results = Lists.newArrayListWithExpectedSize(group.getFieldCount());
-    for (int i = 0; i < sFields.length; i += 1) {
-      Type field = group.getFields().get(i);
-      StructField sField = sFields[i];
-      Preconditions.checkArgument(field.getName().equals(AvroSchemaUtil.makeCompatibleName(sField.name())),
-          "Structs do not match: field %s != %s", field.getName(), sField.name());
-      results.add(visitField(sField, field, visitor));
+  @Override
+  protected DataType arrayElementType(DataType arrayType) {
+    if (arrayType == null) {
+      return null;
     }
 
-    return results;
+    return ((ArrayType) arrayType).elementType();
   }
 
-  public T message(StructType sStruct, MessageType message, List<T> fields) {
-    return null;
+  @Override
+  protected DataType mapKeyType(DataType mapType) {
+    if (mapType == null) {
+      return null;
+    }
+
+    return ((MapType) mapType).keyType();
   }
 
-  public T struct(StructType sStruct, GroupType struct, List<T> fields) {
-    return null;
+  @Override
+  protected DataType mapValueType(DataType mapType) {
+    if (mapType == null) {
+      return null;
+    }
+
+    return ((MapType) mapType).valueType();
   }
 
-  public T list(ArrayType sArray, GroupType array, T element) {
-    return null;
-  }
+  @Override
+  protected Pair<String, DataType> fieldNameAndType(DataType structType, int pos, Integer fieldId) {
+    if (structType == null || ((StructType) structType).size() <  pos + 1) {
+      return null;
+    }
 
-  public T map(MapType sMap, GroupType map, T key, T value) {
-    return null;
-  }
-
-  public T primitive(DataType sPrimitive, PrimitiveType primitive) {
-    return null;
-  }
-
-  protected String[] currentPath() {
-    return Lists.newArrayList(fieldNames.descendingIterator()).toArray(new String[0]);
-  }
-
-  protected String[] path(String name) {
-    List<String> list = Lists.newArrayList(fieldNames.descendingIterator());
-    list.add(name);
-    return list.toArray(new String[0]);
+    DataType type = ((StructType) structType).apply(pos).dataType();
+    String name = ((StructType) structType).apply(pos).name();
+    return Pair.of(name, type);
   }
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -95,14 +95,14 @@ public class SparkParquetReaders {
     }
 
     @Override
-    public ParquetValueReader<?> message(Types.StructType expected, MessageType message,
+    public ParquetValueReader<?> message(org.apache.iceberg.types.Type expected, MessageType message,
                                          List<ParquetValueReader<?>> fieldReaders) {
       // the top level matches by ID, but the remaining IDs are missing
-      return super.struct(expected, message, fieldReaders);
+      return super.struct(expected.asStructType(), message, fieldReaders);
     }
 
     @Override
-    public ParquetValueReader<?> struct(Types.StructType ignored, GroupType struct,
+    public ParquetValueReader<?> struct(org.apache.iceberg.types.Type ignored, GroupType struct,
                                         List<ParquetValueReader<?>> fieldReaders) {
       // the expected struct is ignored because nested fields are never found when the
       List<ParquetValueReader<?>> newFields = Lists.newArrayListWithExpectedSize(
@@ -130,13 +130,13 @@ public class SparkParquetReaders {
     }
 
     @Override
-    public ParquetValueReader<?> message(Types.StructType expected, MessageType message,
+    public ParquetValueReader<?> message(org.apache.iceberg.types.Type expected, MessageType message,
                                          List<ParquetValueReader<?>> fieldReaders) {
       return struct(expected, message.asGroupType(), fieldReaders);
     }
 
     @Override
-    public ParquetValueReader<?> struct(Types.StructType expected, GroupType struct,
+    public ParquetValueReader<?> struct(org.apache.iceberg.types.Type expected, GroupType struct,
                                         List<ParquetValueReader<?>> fieldReaders) {
       // match the expected struct's order
       Map<Integer, ParquetValueReader<?>> readersById = Maps.newHashMap();
@@ -153,7 +153,7 @@ public class SparkParquetReaders {
       }
 
       List<Types.NestedField> expectedFields = expected != null ?
-          expected.fields() : ImmutableList.of();
+          expected.asStructType().fields() : ImmutableList.of();
       List<ParquetValueReader<?>> reorderedFields = Lists.newArrayListWithExpectedSize(
           expectedFields.size());
       List<Type> types = Lists.newArrayListWithExpectedSize(expectedFields.size());
@@ -182,7 +182,7 @@ public class SparkParquetReaders {
     }
 
     @Override
-    public ParquetValueReader<?> list(Types.ListType expectedList, GroupType array,
+    public ParquetValueReader<?> list(org.apache.iceberg.types.Type expectedList, GroupType array,
                                       ParquetValueReader<?> elementReader) {
       GroupType repeated = array.getFields().get(0).asGroupType();
       String[] repeatedPath = currentPath();
@@ -197,7 +197,7 @@ public class SparkParquetReaders {
     }
 
     @Override
-    public ParquetValueReader<?> map(Types.MapType expectedMap, GroupType map,
+    public ParquetValueReader<?> map(org.apache.iceberg.types.Type expectedMap, GroupType map,
                                      ParquetValueReader<?> keyReader,
                                      ParquetValueReader<?> valueReader) {
       GroupType repeatedKeyValue = map.getFields().get(0).asGroupType();
@@ -217,7 +217,7 @@ public class SparkParquetReaders {
     }
 
     @Override
-    public ParquetValueReader<?> primitive(org.apache.iceberg.types.Type.PrimitiveType expected,
+    public ParquetValueReader<?> primitive(org.apache.iceberg.types.Type expected,
                                            PrimitiveType primitive) {
       ColumnDescriptor desc = type.getColumnDescription(currentPath());
 

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetWriters.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetWriters.java
@@ -70,16 +70,16 @@ public class SparkParquetWriters {
     }
 
     @Override
-    public ParquetValueWriter<?> message(StructType sStruct, MessageType message,
+    public ParquetValueWriter<?> message(DataType sStruct, MessageType message,
                                          List<ParquetValueWriter<?>> fieldWriters) {
       return struct(sStruct, message.asGroupType(), fieldWriters);
     }
 
     @Override
-    public ParquetValueWriter<?> struct(StructType sStruct, GroupType struct,
+    public ParquetValueWriter<?> struct(DataType sStruct, GroupType struct,
                                         List<ParquetValueWriter<?>> fieldWriters) {
       List<Type> fields = struct.getFields();
-      StructField[] sparkFields = sStruct.fields();
+      StructField[] sparkFields = ((StructType) sStruct).fields();
       List<ParquetValueWriter<?>> writers = Lists.newArrayListWithExpectedSize(fieldWriters.size());
       List<DataType> sparkTypes = Lists.newArrayList();
       for (int i = 0; i < fields.size(); i += 1) {
@@ -91,7 +91,7 @@ public class SparkParquetWriters {
     }
 
     @Override
-    public ParquetValueWriter<?> list(ArrayType sArray, GroupType array, ParquetValueWriter<?> elementWriter) {
+    public ParquetValueWriter<?> list(DataType sArray, GroupType array, ParquetValueWriter<?> elementWriter) {
       GroupType repeated = array.getFields().get(0).asGroupType();
       String[] repeatedPath = currentPath();
 
@@ -100,11 +100,11 @@ public class SparkParquetWriters {
 
       return new ArrayDataWriter<>(repeatedD, repeatedR,
           newOption(repeated.getType(0), elementWriter),
-          sArray.elementType());
+          ((ArrayType) sArray).elementType());
     }
 
     @Override
-    public ParquetValueWriter<?> map(MapType sMap, GroupType map,
+    public ParquetValueWriter<?> map(DataType sMap, GroupType map,
                                      ParquetValueWriter<?> keyWriter, ParquetValueWriter<?> valueWriter) {
       GroupType repeatedKeyValue = map.getFields().get(0).asGroupType();
       String[] repeatedPath = currentPath();
@@ -115,7 +115,7 @@ public class SparkParquetWriters {
       return new MapDataWriter<>(repeatedD, repeatedR,
           newOption(repeatedKeyValue.getType(0), keyWriter),
           newOption(repeatedKeyValue.getType(1), valueWriter),
-          sMap.keyType(), sMap.valueType());
+          ((MapType) sMap).keyType(), ((MapType) sMap).valueType());
     }
 
     private ParquetValueWriter<?> newOption(org.apache.parquet.schema.Type fieldType, ParquetValueWriter<?> writer) {

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetWriters.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetWriters.java
@@ -43,11 +43,9 @@ import org.apache.parquet.schema.Type;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.MapData;
-import org.apache.spark.sql.types.ArrayType;
 import org.apache.spark.sql.types.ByteType;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.Decimal;
-import org.apache.spark.sql.types.MapType;
 import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
@@ -100,7 +98,7 @@ public class SparkParquetWriters {
 
       return new ArrayDataWriter<>(repeatedD, repeatedR,
           newOption(repeated.getType(0), elementWriter),
-          ((ArrayType) sArray).elementType());
+          arrayElementType(sArray));
     }
 
     @Override
@@ -115,7 +113,7 @@ public class SparkParquetWriters {
       return new MapDataWriter<>(repeatedD, repeatedR,
           newOption(repeatedKeyValue.getType(0), keyWriter),
           newOption(repeatedKeyValue.getType(1), valueWriter),
-          ((MapType) sMap).keyType(), ((MapType) sMap).valueType());
+          mapKeyType(sMap), mapValueType(sMap));
     }
 
     private ParquetValueWriter<?> newOption(org.apache.parquet.schema.Type fieldType, ParquetValueWriter<?> writer) {

--- a/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkParquetReaders.java
@@ -82,8 +82,8 @@ public class VectorizedSparkParquetReaders {
 
     @Override
     public VectorizedReader<?> message(
-            Types.StructType expected, MessageType message,
-            List<VectorizedReader<?>> fieldReaders) {
+        org.apache.iceberg.types.Type expected, MessageType message,
+        List<VectorizedReader<?>> fieldReaders) {
       GroupType groupType = message.asGroupType();
       Map<Integer, VectorizedReader<?>> readersById = Maps.newHashMap();
       List<Type> fields = groupType.getFields();
@@ -93,7 +93,7 @@ public class VectorizedSparkParquetReaders {
           .forEach(pos -> readersById.put(fields.get(pos).getId().intValue(), fieldReaders.get(pos)));
 
       List<Types.NestedField> icebergFields = expected != null ?
-          expected.fields() : ImmutableList.of();
+          expected.asStructType().fields() : ImmutableList.of();
 
       List<VectorizedReader<?>> reorderedFields = Lists.newArrayListWithExpectedSize(
           icebergFields.size());
@@ -114,7 +114,7 @@ public class VectorizedSparkParquetReaders {
 
     @Override
     public VectorizedReader<?> struct(
-        Types.StructType expected, GroupType groupType,
+        org.apache.iceberg.types.Type expected, GroupType groupType,
         List<VectorizedReader<?>> fieldReaders) {
       if (expected != null) {
         throw new UnsupportedOperationException("Vectorized reads are not supported yet for struct fields");
@@ -124,7 +124,7 @@ public class VectorizedSparkParquetReaders {
 
     @Override
     public VectorizedReader<?> primitive(
-        org.apache.iceberg.types.Type.PrimitiveType expected,
+        org.apache.iceberg.types.Type expected,
         PrimitiveType primitive) {
 
       // Create arrow vector for this field


### PR DESCRIPTION
This is a refactor for parquet schema visitor which accepts a partner type,  such as Iceberg `Type`, Spark `DataType`, Flink `LogicalType`. 