### PR TITLE
Flink: Support creating table and altering table in Flink SQL

### DIFF
--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.flink.table.api.TableSchema;
@@ -386,7 +387,7 @@ public class FlinkCatalog extends AbstractCatalog {
       String key = entry.getKey();
       String value = entry.getValue();
 
-      if (value.equals(oldOptions.get(key))) {
+      if (Objects.equals(value, oldOptions.get(key))) {
         continue;
       }
 
@@ -451,7 +452,7 @@ public class FlinkCatalog extends AbstractCatalog {
   }
 
   private static void commitChanges(Table table, String setLocation, String setSnapshotId,
-      String pickSnapshotId, Map<String, String> setProperties) {
+                                    String pickSnapshotId, Map<String, String> setProperties) {
     // don't allow setting the snapshot and picking a commit at the same time because order is ambiguous and choosing
     // one order leads to different results
     Preconditions.checkArgument(setSnapshotId == null || pickSnapshotId == null,

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.AbstractCatalog;

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -300,17 +300,6 @@ public class FlinkCatalog extends AbstractCatalog {
     }
   }
 
-  private CatalogTable toCatalogTable(Table table) {
-    TableSchema schema = FlinkSchemaUtil.toSchema(FlinkSchemaUtil.convert(table.schema()));
-    List<String> partitionKeys = toPartitionKeys(table.spec(), table.schema());
-
-    // NOTE: We can not create a IcebergCatalogTable, because Flink optimizer may use CatalogTableImpl to copy a new
-    // catalog table.
-    // Let's re-loading table from Iceberg catalog when creating source/sink operators.
-    // Iceberg does not have Table comment, so pass a null (Default comment value in Flink).
-    return new CatalogTableImpl(schema, partitionKeys, table.properties(), null);
-  }
-
   @Override
   public boolean tableExists(ObjectPath tablePath) throws CatalogException {
     return icebergCatalog.tableExists(toIdentifier(tablePath));
@@ -503,6 +492,17 @@ public class FlinkCatalog extends AbstractCatalog {
     }
 
     transaction.commitTransaction();
+  }
+
+  static CatalogTable toCatalogTable(Table table) {
+    TableSchema schema = FlinkSchemaUtil.toSchema(FlinkSchemaUtil.convert(table.schema()));
+    List<String> partitionKeys = toPartitionKeys(table.spec(), table.schema());
+
+    // NOTE: We can not create a IcebergCatalogTable extends CatalogTable, because Flink optimizer may use
+    // CatalogTableImpl to copy a new catalog table.
+    // Let's re-loading table from Iceberg catalog when creating source/sink operators.
+    // Iceberg does not have Table comment, so pass a null (Default comment value in Flink).
+    return new CatalogTableImpl(schema, partitionKeys, table.properties(), null);
   }
 
   // ------------------------------ Unsupported methods ---------------------------------------------

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -99,7 +99,7 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
         "Should fail if trying to get a nonexistent table",
         ValidationException.class,
         "Table `tl` was not found.",
-        () ->  tEnv.from("tl")
+        () -> tEnv.from("tl")
     );
     Assert.assertEquals(
         Collections.singletonList(TableColumn.of("id", DataTypes.BIGINT())),
@@ -211,42 +211,42 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
     Table table = table("tl");
 
     DataFile fileA = DataFiles.builder(table.spec())
-                               .withPath("/path/to/data-a.parquet")
-                               .withFileSizeInBytes(10)
-                               .withPartitionPath("c1=0") // easy way to set partition data for now
-                               .withRecordCount(1)
-                               .build();
+        .withPath("/path/to/data-a.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("c1=0") // easy way to set partition data for now
+        .withRecordCount(1)
+        .build();
     DataFile fileB = DataFiles.builder(table.spec())
-                               .withPath("/path/to/data-b.parquet")
-                               .withFileSizeInBytes(10)
-                               .withPartitionPath("c1=1") // easy way to set partition data for now
-                               .withRecordCount(1)
-                               .build();
+        .withPath("/path/to/data-b.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("c1=1") // easy way to set partition data for now
+        .withRecordCount(1)
+        .build();
     DataFile replacementFile = DataFiles.builder(table.spec())
-                                        .withPath("/path/to/data-a-replacement.parquet")
-                                        .withFileSizeInBytes(10)
-                                        .withPartitionPath("c1=0") // easy way to set partition data for now
-                                        .withRecordCount(1)
-                                        .build();
+        .withPath("/path/to/data-a-replacement.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("c1=0") // easy way to set partition data for now
+        .withRecordCount(1)
+        .build();
 
     table.newAppend()
-         .appendFile(fileA)
-         .commit();
+        .appendFile(fileA)
+        .commit();
     long snapshotId = table.currentSnapshot().snapshotId();
 
     // stage an overwrite that replaces FILE_A
     table.newReplacePartitions()
-         .addFile(replacementFile)
-         .stageOnly()
-         .commit();
+        .addFile(replacementFile)
+        .stageOnly()
+        .commit();
 
     Snapshot staged = Iterables.getLast(table.snapshots());
     Assert.assertEquals("Should find the staged overwrite snapshot", DataOperations.OVERWRITE, staged.operation());
 
     // add another append so that the original commit can't be fast-forwarded
     table.newAppend()
-         .appendFile(fileB)
-         .commit();
+        .appendFile(fileB)
+        .commit();
 
     // test cherry pick
     tEnv.executeSql(String.format("ALTER TABLE tl SET('cherry-pick-snapshot-id'='%s')", staged.snapshotId()));
@@ -261,8 +261,8 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
     tbl.refresh();
     Set<CharSequence> expectedFilePaths = Arrays.stream(expectedFiles).map(DataFile::path).collect(Collectors.toSet());
     Set<CharSequence> actualFilePaths = StreamSupport.stream(tbl.newScan().planFiles().spliterator(), false)
-                                                     .map(FileScanTask::file).map(ContentFile::path)
-                                                     .collect(Collectors.toSet());
+        .map(FileScanTask::file).map(ContentFile::path)
+        .collect(Collectors.toSet());
     Assert.assertEquals("Files should match", expectedFilePaths, actualFilePaths);
   }
 

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -172,10 +172,14 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
     tEnv.executeSql("ALTER TABLE tl SET('oldK'='oldV2')");
     properties.put("oldK", "oldV2");
     Assert.assertEquals(properties, table("tl").properties());
+  }
 
-    // location
+  @Test
+  public void testRelocateTable() {
+    Assume.assumeFalse("HadoopCatalog does not support relocate table", isHadoopCatalog);
+
+    tEnv.executeSql("CREATE TABLE tl(id BIGINT)");
     tEnv.executeSql("ALTER TABLE tl SET('location'='/tmp/location')");
-    properties.put("oldK", "oldV2");
     Assert.assertEquals("/tmp/location", table("tl").location());
   }
 

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -21,13 +21,30 @@ package org.apache.iceberg.flink;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableColumn;
+import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.ContentFile;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DataOperations;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
 import org.junit.After;
 import org.junit.Assert;
@@ -87,5 +104,148 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
     Assert.assertEquals(
         Collections.singletonList(TableColumn.of("id", DataTypes.BIGINT())),
         tEnv.from("tl2").getSchema().getTableColumns());
+  }
+
+  @Test
+  public void testCreateTable() throws TableNotExistException {
+    tEnv.executeSql("CREATE TABLE tl(id BIGINT)");
+
+    Table table = table("tl");
+    Assert.assertEquals(
+        new Schema(Types.NestedField.optional(1, "id", Types.LongType.get())).asStruct(),
+        table.schema().asStruct());
+    Assert.assertEquals(Maps.newHashMap(), table.properties());
+
+    CatalogTable catalogTable = catalogTable("tl");
+    Assert.assertEquals(TableSchema.builder().field("id", DataTypes.BIGINT()).build(), catalogTable.getSchema());
+    Assert.assertEquals(Maps.newHashMap(), catalogTable.getOptions());
+  }
+
+  @Test
+  public void testCreatePartitionTable() throws TableNotExistException {
+    tEnv.executeSql("CREATE TABLE tl(id BIGINT, dt STRING) PARTITIONED BY(dt)");
+
+    Table table = table("tl");
+    Assert.assertEquals(
+        new Schema(
+            Types.NestedField.optional(1, "id", Types.LongType.get()),
+            Types.NestedField.optional(2, "dt", Types.StringType.get())).asStruct(),
+        table.schema().asStruct());
+    Assert.assertEquals(PartitionSpec.builderFor(table.schema()).identity("dt").build(), table.spec());
+    Assert.assertEquals(Maps.newHashMap(), table.properties());
+
+    CatalogTable catalogTable = catalogTable("tl");
+    Assert.assertEquals(
+        TableSchema.builder().field("id", DataTypes.BIGINT()).field("dt", DataTypes.STRING()).build(),
+        catalogTable.getSchema());
+    Assert.assertEquals(Maps.newHashMap(), catalogTable.getOptions());
+    Assert.assertEquals(Collections.singletonList("dt"), catalogTable.getPartitionKeys());
+  }
+
+  @Test
+  public void testLoadTransformPartitionTable() throws TableNotExistException {
+    Schema schema = new Schema(Types.NestedField.optional(0, "id", Types.LongType.get()));
+    validationCatalog.createTable(
+        TableIdentifier.of(icebergNamespace, "tl"), schema,
+        PartitionSpec.builderFor(schema).bucket("id", 100).build());
+
+    CatalogTable catalogTable = catalogTable("tl");
+    Assert.assertEquals(
+        TableSchema.builder().field("id", DataTypes.BIGINT()).build(),
+        catalogTable.getSchema());
+    Assert.assertEquals(Maps.newHashMap(), catalogTable.getOptions());
+    Assert.assertEquals(Collections.emptyList(), catalogTable.getPartitionKeys());
+  }
+
+  @Test
+  public void testAlterTable() {
+    tEnv.executeSql("CREATE TABLE tl(id BIGINT) WITH ('oldK'='oldV')");
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("oldK", "oldV");
+
+    // new
+    tEnv.executeSql("ALTER TABLE tl SET('newK'='newV')");
+    properties.put("newK", "newV");
+    Assert.assertEquals(properties, table("tl").properties());
+
+    // update old
+    tEnv.executeSql("ALTER TABLE tl SET('oldK'='oldV2')");
+    properties.put("oldK", "oldV2");
+    Assert.assertEquals(properties, table("tl").properties());
+
+    // location
+    tEnv.executeSql("ALTER TABLE tl SET('location'='/tmp/location')");
+    properties.put("oldK", "oldV2");
+    Assert.assertEquals("/tmp/location", table("tl").location());
+  }
+
+  @Test
+  public void testSetCurrentAndCherryPickSnapshotId() {
+    tEnv.executeSql("CREATE TABLE tl(c1 INT, c2 STRING, c3 STRING) PARTITIONED BY (c1)");
+
+    Table table = table("tl");
+
+    DataFile fileA = DataFiles.builder(table.spec())
+                               .withPath("/path/to/data-a.parquet")
+                               .withFileSizeInBytes(10)
+                               .withPartitionPath("c1=0") // easy way to set partition data for now
+                               .withRecordCount(1)
+                               .build();
+    DataFile fileB = DataFiles.builder(table.spec())
+                               .withPath("/path/to/data-b.parquet")
+                               .withFileSizeInBytes(10)
+                               .withPartitionPath("c1=1") // easy way to set partition data for now
+                               .withRecordCount(1)
+                               .build();
+    DataFile replacementFile = DataFiles.builder(table.spec())
+                                        .withPath("/path/to/data-a-replacement.parquet")
+                                        .withFileSizeInBytes(10)
+                                        .withPartitionPath("c1=0") // easy way to set partition data for now
+                                        .withRecordCount(1)
+                                        .build();
+
+    table.newAppend()
+         .appendFile(fileA)
+         .commit();
+    long snapshotId = table.currentSnapshot().snapshotId();
+
+    // stage an overwrite that replaces FILE_A
+    table.newReplacePartitions()
+         .addFile(replacementFile)
+         .stageOnly()
+         .commit();
+
+    Snapshot staged = Iterables.getLast(table.snapshots());
+    Assert.assertEquals("Should find the staged overwrite snapshot", DataOperations.OVERWRITE, staged.operation());
+
+    // add another append so that the original commit can't be fast-forwarded
+    table.newAppend()
+         .appendFile(fileB)
+         .commit();
+
+    // test cherry pick
+    tEnv.executeSql(String.format("ALTER TABLE tl SET('cherry-pick-snapshot-id'='%s')", staged.snapshotId()));
+    validateTableFiles(table, fileB, replacementFile);
+
+    // test set current snapshot
+    tEnv.executeSql(String.format("ALTER TABLE tl SET('current-snapshot-id'='%s')", snapshotId));
+    validateTableFiles(table, fileA);
+  }
+
+  private void validateTableFiles(Table tbl, DataFile... expectedFiles) {
+    tbl.refresh();
+    Set<CharSequence> expectedFilePaths = Arrays.stream(expectedFiles).map(DataFile::path).collect(Collectors.toSet());
+    Set<CharSequence> actualFilePaths = StreamSupport.stream(tbl.newScan().planFiles().spliterator(), false)
+                                                     .map(FileScanTask::file).map(ContentFile::path)
+                                                     .collect(Collectors.toSet());
+    Assert.assertEquals("Files should match", expectedFilePaths, actualFilePaths);
+  }
+
+  private Table table(String name) {
+    return validationCatalog.loadTable(TableIdentifier.of(icebergNamespace, name));
+  }
+
+  private CatalogTable catalogTable(String name) throws TableNotExistException {
+    return (CatalogTable) tEnv.getCatalog(tEnv.getCurrentCatalog()).get().getTable(new ObjectPath(DATABASE, name));
   }
 }


### PR DESCRIPTION
Fixes #1392 
1. Create table: Only support identity partition, wait for Flink SQL support hidden partition, but can load all Iceberg tables.
2. Alter table: 
    - Currently, Flink SQL only support altering table properties, not support altering schema and partition.
    - Also support `location`, `current-snapshot-id` and `cherry-pick-snapshot-id` like Spark.