### PR TITLE
Changes default collect behavior of ExpireSnapshotActions

### DIFF
--- a/spark/src/main/java/org/apache/iceberg/actions/ExpireSnapshotsAction.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/ExpireSnapshotsAction.java
@@ -92,11 +92,10 @@ public class ExpireSnapshotsAction extends BaseAction<ExpireSnapshotsActionResul
   }
 
   /**
-   * Whether or not to use stream the expired file list to the driver. The default (false) will use
-   * collect to bring back all results to the driver at once which may be an issue with very long file lists.
-   * Set this to true to use toLocalIterator if you are running into memory issues when collecting the list of files
-   * to be deleted.
-   * @param stream whether to use toLocalIterator to stream results instead of collect.
+   * By default, all files to delete are brought to the driver at once which may be an issue with very long file lists.
+   * Set this to true to use {@link Dataset#toLocalIterator()} if you are running into memory issues when collecting
+   * the list of files to be deleted.
+   * @param stream whether to use {@link Dataset#toLocalIterator} to stream results instead of {@link Dataset#collect}.
    * @return this for method chaining
    */
   public ExpireSnapshotsAction streamDeleteResults(boolean stream) {

--- a/spark/src/main/java/org/apache/iceberg/actions/ExpireSnapshotsAction.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/ExpireSnapshotsAction.java
@@ -93,9 +93,9 @@ public class ExpireSnapshotsAction extends BaseAction<ExpireSnapshotsActionResul
 
   /**
    * By default, all files to delete are brought to the driver at once which may be an issue with very long file lists.
-   * Set this to true to use {@link Dataset#toLocalIterator()} if you are running into memory issues when collecting
+   * Set this to true to use toLocalIterator if you are running into memory issues when collecting
    * the list of files to be deleted.
-   * @param stream whether to use {@link Dataset#toLocalIterator} to stream results instead of {@link Dataset#collect}.
+   * @param stream whether to use toLocalIterator to stream results instead of collect.
    * @return this for method chaining
    */
   public ExpireSnapshotsAction streamDeleteResults(boolean stream) {

--- a/spark/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction.java
@@ -59,13 +59,13 @@ import org.junit.rules.TemporaryFolder;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 
 public abstract class TestExpireSnapshotsAction extends SparkTestBase {
-
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());
   private static final Schema SCHEMA = new Schema(
       optional(1, "c1", Types.IntegerType.get()),
       optional(2, "c2", Types.StringType.get()),
       optional(3, "c3", Types.StringType.get())
   );
+  private static final int SHUFFLE_PARTITIONS = 2;
 
   private static final PartitionSpec SPEC = PartitionSpec.builderFor(SCHEMA).identity("c1").build();
 
@@ -106,7 +106,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
     this.tableDir = temp.newFolder();
     this.tableLocation = tableDir.toURI().toString();
     this.table = TABLES.create(SCHEMA, SPEC, Maps.newHashMap(), tableLocation);
-    spark.conf().set("spark.sql.shuffle.partitions", 1);
+    spark.conf().set("spark.sql.shuffle.partitions", SHUFFLE_PARTITIONS);
   }
 
   private Long rightAfterSnapshot() {
@@ -1007,5 +1007,38 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
 
     Assert.assertSame("Multiple calls to expire should return the same deleted files",
         pendingDeletes, action.expire());
+  }
+
+  @Test
+  public void testUseLocalIterator() {
+    table.newFastAppend()
+            .appendFile(FILE_A)
+            .commit();
+
+    table.newOverwrite()
+            .deleteFile(FILE_A)
+            .addFile(FILE_B)
+            .commit();
+
+    table.newFastAppend()
+            .appendFile(FILE_C)
+            .commit();
+
+    long end = rightAfterSnapshot();
+
+    int jobsBefore = spark.sparkContext().dagScheduler().nextJobId().get();
+
+    ExpireSnapshotsActionResult results =
+            Actions.forTable(table).expireSnapshots().expireOlderThan(end).streamDeleteResults(true).execute();
+
+    Assert.assertEquals("Table does not have 1 snapshot after expiration", 1, Iterables.size(table.snapshots()));
+
+    int jobsAfter = spark.sparkContext().dagScheduler().nextJobId().get();
+
+    checkExpirationResults(1L, 1L, 2L, results);
+
+    int expectedBroadcastJobs = 3;
+    Assert.assertEquals("Expected to run spark.sql.shuffle.partitions jobs when using local iterator",
+            SHUFFLE_PARTITIONS + expectedBroadcastJobs, jobsAfter - jobsBefore);
   }
 }

--- a/spark/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction.java
@@ -1034,11 +1034,12 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
     Assert.assertEquals("Table does not have 1 snapshot after expiration", 1, Iterables.size(table.snapshots()));
 
     int jobsAfter = spark.sparkContext().dagScheduler().nextJobId().get();
+    int totalJobsRun = jobsAfter - jobsBefore;
 
     checkExpirationResults(1L, 1L, 2L, results);
 
-    int expectedBroadcastJobs = 3;
-    Assert.assertEquals("Expected to run spark.sql.shuffle.partitions jobs when using local iterator",
-        SHUFFLE_PARTITIONS + expectedBroadcastJobs, jobsAfter - jobsBefore);
+    Assert.assertTrue(
+        String.format("Expected more than %d jobs when using local iterator, ran %d", SHUFFLE_PARTITIONS, totalJobsRun),
+        totalJobsRun > SHUFFLE_PARTITIONS);
   }
 }

--- a/spark/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction.java
@@ -1012,24 +1012,24 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
   @Test
   public void testUseLocalIterator() {
     table.newFastAppend()
-            .appendFile(FILE_A)
-            .commit();
+        .appendFile(FILE_A)
+        .commit();
 
     table.newOverwrite()
-            .deleteFile(FILE_A)
-            .addFile(FILE_B)
-            .commit();
+        .deleteFile(FILE_A)
+        .addFile(FILE_B)
+        .commit();
 
     table.newFastAppend()
-            .appendFile(FILE_C)
-            .commit();
+        .appendFile(FILE_C)
+        .commit();
 
     long end = rightAfterSnapshot();
 
     int jobsBefore = spark.sparkContext().dagScheduler().nextJobId().get();
 
     ExpireSnapshotsActionResult results =
-            Actions.forTable(table).expireSnapshots().expireOlderThan(end).streamDeleteResults(true).execute();
+        Actions.forTable(table).expireSnapshots().expireOlderThan(end).streamDeleteResults(true).execute();
 
     Assert.assertEquals("Table does not have 1 snapshot after expiration", 1, Iterables.size(table.snapshots()));
 
@@ -1039,6 +1039,6 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
 
     int expectedBroadcastJobs = 3;
     Assert.assertEquals("Expected to run spark.sql.shuffle.partitions jobs when using local iterator",
-            SHUFFLE_PARTITIONS + expectedBroadcastJobs, jobsAfter - jobsBefore);
+        SHUFFLE_PARTITIONS + expectedBroadcastJobs, jobsAfter - jobsBefore);
   }
 }


### PR DESCRIPTION
Previously ExpireSnapshotAction would always use toLocalIterator which
ends up costing significantly more time on smaller data sets. Since even
the largest lists of files are expected to fit in memory we are changing
the default to Collect. Collect will bring back the results more quickly
at the cost of additional memory. An option to streamDeleteResults will still
be available for extremely large expire operations.