### PR TITLE
Actions: Speed up expire snapshots action

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/ClosingIterator.java
+++ b/api/src/main/java/org/apache/iceberg/io/ClosingIterator.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Iterator;
+
+public class ClosingIterator<T> implements Iterator<T> {
+  private final CloseableIterator<T> iterator;
+  private boolean shouldClose = false;
+
+  public ClosingIterator(CloseableIterator<T> iterator) {
+    this.iterator = iterator;
+
+  }
+
+  @Override
+  public boolean hasNext() {
+    boolean hasNext = iterator.hasNext();
+    this.shouldClose = !hasNext;
+    return hasNext;
+  }
+
+  @Override
+  public T next() {
+    T next = iterator.next();
+
+    if (shouldClose) {
+      // this will only be called once because iterator.next would throw NoSuchElementException
+      try {
+        iterator.close();
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+
+    return next;
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -23,13 +23,28 @@ import java.io.IOException;
 import java.util.Map;
 import org.apache.iceberg.ManifestReader.FileType;
 import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 
 public class ManifestFiles {
   private ManifestFiles() {
+  }
+
+  /**
+   * Returns a {@link CloseableIterable} of file paths in the {@link ManifestFile}.
+   *
+   * @param manifest a ManifestFile
+   * @param io a FileIO
+   * @return a manifest reader
+   */
+  public static CloseableIterable<String> readPaths(ManifestFile manifest, FileIO io) {
+    return CloseableIterable.transform(
+        read(manifest, io, null).select(ImmutableList.of("file_path")).liveEntries(),
+        entry -> entry.file().path().toString());
   }
 
   /**

--- a/spark/src/main/java/org/apache/iceberg/actions/ExpireSnapshotsAction.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/ExpireSnapshotsAction.java
@@ -196,7 +196,7 @@ public class ExpireSnapshotsAction extends BaseAction<ExpireSnapshotsActionResul
   }
 
   private Dataset<Row> buildValidFileDF(TableMetadata metadata) {
-    return appendTypeString(buildValidDataFileDF(spark, metadata.metadataFileLocation()), DATA_FILE)
+    return appendTypeString(buildParallelValidDataFileDF(spark, table.io(), metadata.metadataFileLocation()), DATA_FILE)
         .union(appendTypeString(buildManifestFileDF(spark, metadata.metadataFileLocation()), MANIFEST))
         .union(appendTypeString(buildManifestListDF(spark, metadata.metadataFileLocation()), MANIFEST_LIST));
   }

--- a/spark/src/main/java/org/apache/iceberg/actions/ExpireSnapshotsAction.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/ExpireSnapshotsAction.java
@@ -196,7 +196,7 @@ public class ExpireSnapshotsAction extends BaseAction<ExpireSnapshotsActionResul
   }
 
   private Dataset<Row> buildValidFileDF(TableMetadata metadata) {
-    return appendTypeString(buildParallelValidDataFileDF(spark, table.io(), metadata.metadataFileLocation()), DATA_FILE)
+    return appendTypeString(buildValidDataFileDF(spark, metadata.metadataFileLocation()), DATA_FILE)
         .union(appendTypeString(buildManifestFileDF(spark, metadata.metadataFileLocation()), MANIFEST))
         .union(appendTypeString(buildManifestListDF(spark, metadata.metadataFileLocation()), MANIFEST_LIST));
   }

--- a/spark/src/main/java/org/apache/iceberg/actions/ManifestFileBean.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/ManifestFileBean.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.actions;
+
+import java.util.List;
+import org.apache.iceberg.ManifestContent;
+import org.apache.iceberg.ManifestFile;
+
+public class ManifestFileBean implements ManifestFile {
+  private String path = null;
+  private Long length = null;
+  private Integer partitionSpecId = null;
+  private Long addedSnapshotId = null;
+
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath(String path) {
+    this.path = path;
+  }
+
+  public Long getLength() {
+    return length;
+  }
+
+  public void setLength(Long length) {
+    this.length = length;
+  }
+
+  public Integer getPartitionSpecId() {
+    return partitionSpecId;
+  }
+
+  public void setPartitionSpecId(Integer partitionSpecId) {
+    this.partitionSpecId = partitionSpecId;
+  }
+
+  public Long getAddedSnapshotId() {
+    return addedSnapshotId;
+  }
+
+  public void setAddedSnapshotId(Long addedSnapshotId) {
+    this.addedSnapshotId = addedSnapshotId;
+  }
+
+  @Override
+  public String path() {
+    return path;
+  }
+
+  @Override
+  public long length() {
+    return length;
+  }
+
+  @Override
+  public int partitionSpecId() {
+    return partitionSpecId;
+  }
+
+  @Override
+  public ManifestContent content() {
+    return ManifestContent.DATA;
+  }
+
+  @Override
+  public long sequenceNumber() {
+    return 0;
+  }
+
+  @Override
+  public long minSequenceNumber() {
+    return 0;
+  }
+
+  @Override
+  public Long snapshotId() {
+    return addedSnapshotId;
+  }
+
+  @Override
+  public Integer addedFilesCount() {
+    return null;
+  }
+
+  @Override
+  public Long addedRowsCount() {
+    return null;
+  }
+
+  @Override
+  public Integer existingFilesCount() {
+    return null;
+  }
+
+  @Override
+  public Long existingRowsCount() {
+    return null;
+  }
+
+  @Override
+  public Integer deletedFilesCount() {
+    return null;
+  }
+
+  @Override
+  public Long deletedRowsCount() {
+    return null;
+  }
+
+  @Override
+  public List<PartitionFieldSummary> partitions() {
+    return null;
+  }
+
+  @Override
+  public ManifestFile copy() {
+    throw new UnsupportedOperationException("Cannot copy");
+  }
+}


### PR DESCRIPTION
This replaces use of the `all_data_files` metadata table in RemoveOrphanFilesAction and ExpireSnapshotsAction with a call to read data file paths from manifest files in parallel. This avoids reading all of the manifest lists in the Spark driver to plan the `all_data_files` scan.

On large tables, this runs much faster with adaptive execution and broadcast joins disabled. Both optimizations use size estimates that are incorrect because the number of data files is much larger than the number of manifests in a table, and Spark does not account for a single row (manifest file) producing thousands or millions of result rows (data files) in a stage.