### PR TITLE
Gitignore - ignore all directories named spark-warehouse or tmp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.swp
 .DS_Store
 .cache
+tmp/
 
 # intellij files
 .idea
@@ -35,10 +36,6 @@ sdist/
 .coverage
 coverage.xml
 .pytest_cache/
-spark/tmp/
-spark/spark-warehouse/
-spark2/spark-warehouse/
-spark3/spark-warehouse/
 
 # vscode/eclipse files
 .classpath
@@ -48,6 +45,10 @@ bin/
 
 # Hive/metastore files
 metastore_db/
+
+# Spark/metastore files
+spark-warehouse/
+derby.log
 
 # Python stuff
 python/.mypy_cache/


### PR DESCRIPTION
Currently, we ignore directories named `spark-warehouse` only if they're underneath one of the various `spark*` repo root directories.

As a messy developer, I tend to start things like `spark-shell` etc from almost anywhere. I imagine I'm not the only one. 

This updates the .gitignore to ignore any folder named `spark-warehouse` or `tmp` (which was also underneath spark, but I can't for the life of me see why we'd check in a directory named tmp - the rule can be updated if such a use case exists).