### PR TITLE
Hive: HiveIcebergOutputFormat first implementation for handling Hive inserts into unpartitioned Iceberg tables

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,6 +133,7 @@ subprojects {
     testLogging {
       if ("true".equalsIgnoreCase(System.getenv('CI'))) {
         events "failed", "passed"
+        testLogging.showStandardStreams = true
       } else {
         events "failed"
       }
@@ -533,6 +534,7 @@ if (jdkVersion == '8') {
     test {
       exclude '**/TestIcebergDateObjectInspector.class'
       exclude '**/TestIcebergTimestampObjectInspector.class'
+      exclude '**/TestHiveIcebergSerDe.class'
     }
 
     dependencies {

--- a/hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergDateObjectInspectorHive3.java
+++ b/hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergDateObjectInspectorHive3.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.iceberg.util.DateTimeUtil;
 
 public final class IcebergDateObjectInspectorHive3 extends AbstractPrimitiveJavaObjectInspector
-    implements DateObjectInspector {
+    implements DateObjectInspector, IcebergReadObjectInspector {
 
   private static final IcebergDateObjectInspectorHive3 INSTANCE = new IcebergDateObjectInspectorHive3();
 
@@ -69,4 +69,8 @@ public final class IcebergDateObjectInspectorHive3 extends AbstractPrimitiveJava
     }
   }
 
+  @Override
+  public Object getIcebergObject(Object o) {
+    return o == null ? null : LocalDate.ofEpochDay(((DateWritableV2) o).get().toEpochDay());
+  }
 }

--- a/hive3/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSerDeHive3.java
+++ b/hive3/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSerDeHive3.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.mr.hive;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.apache.hadoop.hive.common.type.HiveDecimal;
+import org.apache.hadoop.hive.common.type.Timestamp;
+import org.apache.hadoop.hive.serde2.io.DateWritableV2;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+import org.apache.hadoop.hive.serde2.io.TimestampWritableV2;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.io.BooleanWritable;
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.io.DoubleWritable;
+import org.apache.hadoop.io.FloatWritable;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.iceberg.data.Record;
+
+public class TestHiveIcebergSerDeHive3 extends TestHiveIcebergSerDe {
+
+  protected List<ObjectInspector> objectInspectors() {
+    return Arrays.asList(
+        PrimitiveObjectInspectorFactory.writableBooleanObjectInspector,
+        PrimitiveObjectInspectorFactory.writableIntObjectInspector,
+        PrimitiveObjectInspectorFactory.writableLongObjectInspector,
+        PrimitiveObjectInspectorFactory.writableFloatObjectInspector,
+        PrimitiveObjectInspectorFactory.writableDoubleObjectInspector,
+        PrimitiveObjectInspectorFactory.writableDateObjectInspector,
+        PrimitiveObjectInspectorFactory.writableTimestampObjectInspector,
+        PrimitiveObjectInspectorFactory.writableTimestampObjectInspector,
+        PrimitiveObjectInspectorFactory.writableStringObjectInspector,
+        PrimitiveObjectInspectorFactory.writableStringObjectInspector,
+        PrimitiveObjectInspectorFactory.writableBinaryObjectInspector,
+        PrimitiveObjectInspectorFactory.writableBinaryObjectInspector,
+        PrimitiveObjectInspectorFactory.writableHiveDecimalObjectInspector
+    );
+  }
+
+  protected List<Object> values(Record record) {
+    OffsetDateTime offsetDateTime = record.get(6, OffsetDateTime.class);
+    Timestamp timestampForOffsetDateTime = Timestamp.ofEpochMilli(offsetDateTime.toInstant().toEpochMilli());
+
+    LocalDateTime localDateTime = record.get(7, LocalDateTime.class);
+    Timestamp timestampForLocalDateTime =
+        Timestamp.ofEpochMilli(localDateTime.toInstant(ZoneOffset.UTC).toEpochMilli());
+
+    ByteBuffer byteBuffer = record.get(11, ByteBuffer.class);
+    byte[] bytes = new byte[byteBuffer.remaining()];
+    byteBuffer.mark();
+    byteBuffer.get(bytes);
+    byteBuffer.reset();
+
+    return Arrays.asList(
+        new BooleanWritable(Boolean.TRUE),
+        new IntWritable(record.get(1, Integer.class)),
+        new LongWritable(record.get(2, Long.class)),
+        new FloatWritable(record.get(3, Float.class)),
+        new DoubleWritable(record.get(4, Double.class)),
+        new DateWritableV2((int) record.get(5, LocalDate.class).toEpochDay()),
+        // TimeType is not supported
+        // new Timestamp()
+        new TimestampWritableV2(timestampForOffsetDateTime),
+        new TimestampWritableV2(timestampForLocalDateTime),
+        new Text(record.get(8, String.class)),
+        new Text(record.get(9, UUID.class).toString()),
+        new BytesWritable(record.get(10, byte[].class)),
+        new BytesWritable(bytes),
+        new HiveDecimalWritable(HiveDecimal.create(record.get(12, BigDecimal.class)))
+    );
+  }
+}

--- a/hive3/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergDateObjectInspectorHive3.java
+++ b/hive3/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergDateObjectInspectorHive3.java
@@ -63,4 +63,14 @@ public class TestIcebergDateObjectInspectorHive3 {
     Assert.assertFalse(oi.preferWritable());
   }
 
+  @Test
+  public void testGetIcebergObject() {
+    IcebergDateObjectInspectorHive3 oi = IcebergDateObjectInspectorHive3.get();
+
+    int epochDays = 5005;
+    LocalDate local = LocalDate.ofEpochDay(epochDays);
+    LocalDate copy = (LocalDate) oi.getIcebergObject(oi.getPrimitiveWritableObject(local));
+    Assert.assertEquals(local, copy);
+    Assert.assertEquals(local, copy);
+  }
 }

--- a/hive3/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampObjectInspectorHive3.java
+++ b/hive3/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampObjectInspectorHive3.java
@@ -85,8 +85,7 @@ public class TestIcebergTimestampObjectInspectorHive3 {
     Assert.assertNull(oi.getPrimitiveWritableObject(null));
 
     long epochMilli = 1601471970000L;
-    LocalDateTime local = LocalDateTime.ofInstant(Instant.ofEpochMilli(epochMilli), ZoneId.of("UTC"));
-    OffsetDateTime offsetDateTime = OffsetDateTime.of(local, ZoneOffset.ofHours(4));
+    OffsetDateTime offsetDateTime = OffsetDateTime.ofInstant(Instant.ofEpochMilli(epochMilli), ZoneOffset.ofHours(4));
     Timestamp ts = Timestamp.ofEpochMilli(epochMilli);
 
     Assert.assertEquals(ts, oi.getPrimitiveJavaObject(offsetDateTime));
@@ -100,4 +99,34 @@ public class TestIcebergTimestampObjectInspectorHive3 {
     Assert.assertFalse(oi.preferWritable());
   }
 
+  @Test
+  public void testGetLocalDateTime() {
+    IcebergTimestampObjectInspectorHive3 oi = IcebergTimestampObjectInspectorHive3.get(false);
+
+    long instantSecond = 1601471970L;
+    int instantNano = 1235;
+    LocalDateTime localDateTime =
+        LocalDateTime.ofInstant(Instant.ofEpochSecond(instantSecond, instantNano), ZoneId.of("UTC"));
+
+    LocalDateTime copyLocalDateTime =
+        (LocalDateTime) oi.getIcebergObject(oi.getPrimitiveWritableObject(localDateTime));
+    Assert.assertEquals(localDateTime, copyLocalDateTime);
+    Assert.assertNotSame(localDateTime, copyLocalDateTime);
+  }
+
+  @Test
+  public void testGetOffsetDateTime() {
+    IcebergTimestampObjectInspectorHive3 oi = IcebergTimestampObjectInspectorHive3.get(true);
+
+    long instantSecond = 1601471970L;
+    int instantNano = 1235;
+    LocalDateTime localDateTime =
+        LocalDateTime.ofInstant(Instant.ofEpochSecond(instantSecond, instantNano), ZoneId.of("UTC"));
+    OffsetDateTime offsetDateTime = OffsetDateTime.of(localDateTime, ZoneOffset.ofHours(4));
+
+    OffsetDateTime copyOffsetDateTime =
+        (OffsetDateTime) oi.getIcebergObject(oi.getPrimitiveWritableObject(offsetDateTime));
+    Assert.assertEquals(offsetDateTime.toInstant(), copyOffsetDateTime.toInstant());
+    Assert.assertNotSame(offsetDateTime, copyOffsetDateTime);
+  }
 }

--- a/mr/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.mr;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -49,6 +50,12 @@ public class InputFormatConfig {
   public static final String HADOOP_CATALOG_WAREHOUSE_LOCATION = "iceberg.mr.catalog.hadoop.warehouse.location";
   public static final String CATALOG_LOADER_CLASS = "iceberg.mr.catalog.loader.class";
   public static final String EXTERNAL_TABLE_PURGE = "external.table.purge";
+
+  // TODO: Find a better place for the OutputFormat configuration, or rename the class
+  public static final String WRITE_FILE_FORMAT = "iceberg.mr.write.file.format";
+  public static final FileFormat WRITE_FILE_FORMAT_DEFAULT = FileFormat.PARQUET;
+  public static final String COMMIT_THREAD_POOL_SIZE = "iceberg.mr.commit.thread.pool.size";
+  public static final int COMMIT_THREAD_POOL_SIZE_DEFAULT = 10;
 
   public static final String CATALOG_NAME = "iceberg.catalog";
   public static final String HADOOP_CATALOG = "hadoop.catalog";

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/ClosedFileData.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/ClosedFileData.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.mr.hive;
+
+import java.io.Serializable;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.PartitionKey;
+
+/**
+ * Class for storing the data file properties which are needed for an Icebreg commit.
+ * <ul>
+ *   <li>Partition key
+ *   <li>File name
+ *   <li>File format
+ *   <li>File size
+ *   <li>Metrics
+ * </ul>
+ */
+final class ClosedFileData implements Serializable {
+  private final PartitionKey partitionKey;
+  private final String fileName;
+  private final FileFormat fileFormat;
+  private final Long length;
+  private final Metrics metrics;
+
+  ClosedFileData(PartitionKey partitionKey, String fileName, FileFormat fileFormat, Long length, Metrics metrics) {
+    this.partitionKey = partitionKey;
+    this.fileName = fileName;
+    this.fileFormat = fileFormat;
+    this.length = length;
+    this.metrics = metrics;
+  }
+
+  PartitionKey partitionKey() {
+    return partitionKey;
+  }
+
+  String fileName() {
+    return fileName;
+  }
+
+  FileFormat fileFormat() {
+    return fileFormat;
+  }
+
+  Long length() {
+    return length;
+  }
+
+  Metrics metrics() {
+    return metrics;
+  }
+}

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/DeserializerHelper.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/DeserializerHelper.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.mr.hive;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.UUID;
+import org.apache.hadoop.hive.serde2.SerDeException;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StructField;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.BinaryObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.BooleanObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.DoubleObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.FloatObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.HiveDecimalObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.IntObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.LongObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.StringObjectInspector;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.mr.hive.serde.objectinspector.IcebergObjectInspector;
+import org.apache.iceberg.mr.hive.serde.objectinspector.IcebergReadObjectInspector;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+
+class DeserializerHelper {
+
+  private DeserializerHelper() {
+  }
+
+  static Record deserialize(Object data, Schema tableSchema, ObjectInspector objectInspector) throws SerDeException {
+    Preconditions.checkArgument(objectInspector.getCategory() == ObjectInspector.Category.STRUCT);
+
+    StructObjectInspector soi = (StructObjectInspector) objectInspector;
+    List<Object> writableObj = soi.getStructFieldsDataAsList(data);
+    List<? extends StructField> fields = soi.getAllStructFieldRefs();
+
+    Record record = GenericRecord.create(tableSchema);
+    for (int i = 0; i < tableSchema.columns().size(); i++) {
+      StructField field = fields.get(i);
+      Object value = writableObj.get(i);
+
+      if (value == null) {
+        record.setField(tableSchema.findColumnName(i), null);
+      } else {
+        Type type = tableSchema.columns().get(i).type();
+        ObjectInspector fieldInspector = field.getFieldObjectInspector();
+        switch (type.typeId()) {
+          case BOOLEAN:
+            boolean boolVal = ((BooleanObjectInspector) fieldInspector).get(value);
+            record.set(i, boolVal);
+            break;
+          case INTEGER:
+            int intVal = ((IntObjectInspector) fieldInspector).get(value);
+            record.set(i, intVal);
+            break;
+          case LONG:
+            long longVal = ((LongObjectInspector) fieldInspector).get(value);
+            record.set(i, longVal);
+            break;
+          case FLOAT:
+            float floatVal = ((FloatObjectInspector) fieldInspector).get(value);
+            record.set(i, floatVal);
+            break;
+          case DOUBLE:
+            double doubleVal = ((DoubleObjectInspector) fieldInspector).get(value);
+            record.set(i, doubleVal);
+            break;
+          case DATE:
+            record.set(i, ((IcebergReadObjectInspector) IcebergObjectInspector.DATE_INSPECTOR).getIcebergObject(value));
+            break;
+          case TIMESTAMP:
+            // TODO: handle timezone in Hive 3.x where Hive type also has TZ
+            Types.TimestampType timestampType = (Types.TimestampType) tableSchema.columns().get(i).type();
+            ObjectInspector readObjectInspector = timestampType.shouldAdjustToUTC() ?
+                IcebergObjectInspector.TIMESTAMP_INSPECTOR_WITH_TZ : IcebergObjectInspector.TIMESTAMP_INSPECTOR;
+            record.set(i, ((IcebergReadObjectInspector) readObjectInspector).getIcebergObject(value));
+            break;
+          case STRING:
+            String stringVal = ((StringObjectInspector) fieldInspector).getPrimitiveJavaObject(value);
+            record.set(i, stringVal);
+            break;
+          case UUID:
+            String stringUuidVal = ((StringObjectInspector) fieldInspector).getPrimitiveJavaObject(value);
+            // TODO: This will not work with Parquet. Parquet UUID expect byte[], others are expecting UUID
+            record.set(i, UUID.fromString(stringUuidVal));
+            break;
+          case FIXED:
+            byte[] bytesVal = ((BinaryObjectInspector) fieldInspector).getPrimitiveJavaObject(value);
+            record.set(i, bytesVal);
+            break;
+          case BINARY:
+            byte[] binaryBytesVal = ((BinaryObjectInspector) fieldInspector).getPrimitiveJavaObject(value);
+            record.set(i, ByteBuffer.wrap(binaryBytesVal));
+            break;
+          case DECIMAL:
+            BigDecimal decimalVal =
+                ((HiveDecimalObjectInspector) fieldInspector).getPrimitiveJavaObject(value).bigDecimalValue();
+            record.set(i, decimalVal);
+            break;
+          case STRUCT:
+          case LIST:
+          case MAP:
+          case TIME:
+          default:
+            throw new SerDeException("Unsupported column type: " + type);
+        }
+      }
+    }
+    return record;
+  }
+}

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.mr.hive;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.JobContext;
+import org.apache.hadoop.mapred.OutputCommitter;
+import org.apache.hadoop.mapred.TaskAttemptContext;
+import org.apache.hadoop.mapred.TaskAttemptID;
+import org.apache.hadoop.mapreduce.TaskType;
+import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.exceptions.NotFoundException;
+import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.hadoop.HadoopFileIO;
+import org.apache.iceberg.hadoop.Util;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.mr.Catalogs;
+import org.apache.iceberg.mr.InputFormatConfig;
+import org.apache.iceberg.relocated.com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.iceberg.util.Tasks;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An Iceberg table committer for adding data files to the Iceberg tables.
+ * Currently independent of the Hive ACID transactions.
+ */
+public final class HiveIcebergOutputCommitter extends OutputCommitter {
+  private static final Logger LOG = LoggerFactory.getLogger(HiveIcebergOutputCommitter.class);
+
+  @Override
+  public void setupJob(JobContext jobContext) {
+    // do nothing.
+  }
+
+  @Override
+  public void setupTask(TaskAttemptContext taskAttemptContext) {
+    // do nothing.
+  }
+
+  @Override
+  public boolean needsTaskCommit(TaskAttemptContext context) {
+    // We need to commit if this is the last phase of a MapReduce process
+    return TaskType.REDUCE.equals(context.getTaskAttemptID().getTaskID().getTaskType()) ||
+        context.getJobConf().getNumReduceTasks() == 0;
+  }
+
+  @Override
+  public void commitTask(TaskAttemptContext context) throws IOException {
+    TaskAttemptID attemptID = context.getTaskAttemptID();
+    String commitFileLocation = LocationHelper.generateToCommitFileLocation(context.getJobConf(), attemptID);
+    HiveIcebergRecordWriter writer = HiveIcebergOutputFormat.writers.remove(attemptID);
+
+    Set<ClosedFileData> closedFiles = Collections.emptySet();
+    if (writer != null) {
+      closedFiles = writer.closedFileData();
+    }
+
+    // Create the committed file for the task
+    createToCommitFile(closedFiles, commitFileLocation, new HadoopFileIO(context.getJobConf()));
+  }
+
+  @Override
+  public void abortTask(TaskAttemptContext context) throws IOException {
+    // Clean up writer data from the local store
+    HiveIcebergRecordWriter writer = HiveIcebergOutputFormat.writers.remove(context.getTaskAttemptID());
+
+    // Remove files if it was not done already
+    writer.close(true);
+  }
+
+  @Override
+  public void commitJob(JobContext jobContext) throws IOException {
+    JobConf conf = jobContext.getJobConf();
+    // If there are reducers, then every reducer will generate a result file.
+    // If this is a map only task, then every mapper will generate a result file.
+    int expectedFiles = conf.getNumReduceTasks() != 0 ? conf.getNumReduceTasks() : conf.getNumMapTasks();
+    Table table = Catalogs.loadTable(conf);
+
+    ExecutorService executor = null;
+    try {
+      // Creating executor service for parallel handling of file reads
+      executor = Executors.newFixedThreadPool(
+          conf.getInt(InputFormatConfig.COMMIT_THREAD_POOL_SIZE, InputFormatConfig.COMMIT_THREAD_POOL_SIZE_DEFAULT),
+          new ThreadFactoryBuilder()
+              .setDaemon(false)
+              .setPriority(Thread.NORM_PRIORITY)
+              .setNameFormat("iceberg-commit-pool-%d")
+              .build());
+
+      Set<DataFile> dataFiles = new ConcurrentHashMap<>().newKeySet();
+
+      // Reading the committed files. The assumption here is that the taskIds are generated in sequential order
+      // starting from 0.
+      Tasks.range(expectedFiles)
+          .executeWith(executor)
+          .retry(3)
+          .run(taskId -> {
+            String taskFileName = LocationHelper.generateToCommitFileLocation(conf, jobContext.getJobID(), taskId);
+            Set<ClosedFileData> closedFiles = readToCommitFile(taskFileName, table.io());
+
+            // If the data is not empty add to the table
+            if (!closedFiles.isEmpty()) {
+              closedFiles.forEach(file -> {
+                DataFiles.Builder builder = DataFiles.builder(table.spec())
+                    .withPath(file.fileName())
+                    .withFormat(file.fileFormat())
+                    .withFileSizeInBytes(file.length())
+                    .withPartition(file.partitionKey())
+                    .withMetrics(file.metrics());
+                dataFiles.add(builder.build());
+              });
+            }
+          });
+
+      if (dataFiles.size() > 0) {
+        // Appending data files to the table
+        AppendFiles append = table.newAppend();
+        Set<String> addedFiles = new HashSet<>(dataFiles.size());
+        dataFiles.forEach(dataFile -> {
+          append.appendFile(dataFile);
+          addedFiles.add(dataFile.path().toString());
+        });
+        append.commit();
+        LOG.info("Iceberg write is committed for {} with files {}", table, addedFiles);
+      } else {
+        LOG.info("Iceberg write is committed for {} with no new files", table);
+      }
+
+      // Calling super to cleanupJob if something more is needed
+      cleanupJob(jobContext);
+
+    } finally {
+      if (executor != null) {
+        executor.shutdown();
+      }
+    }
+  }
+
+  @Override
+  public void abortJob(JobContext context, int status) throws IOException {
+    // Remove the result directory for the failed job
+    Tasks.foreach(LocationHelper.generateJobLocation(context.getJobConf(), context.getJobID()))
+        .retry(3)
+        .suppressFailureWhenFinished()
+        .onFailure((file, exc) -> LOG.debug("Failed on to remove directory {} on abort job", file, exc))
+        .run(file -> {
+          Path toDelete = new Path(file);
+          FileSystem fs = Util.getFs(toDelete, context.getJobConf());
+          try {
+            fs.delete(toDelete, true /* recursive */);
+          } catch (IOException e) {
+            throw new RuntimeIOException(e, "Failed to delete job directory: %s", file);
+          }
+        });
+    cleanupJob(context);
+  }
+
+  private static void createToCommitFile(Set<ClosedFileData> closedFiles, String location, FileIO io)
+      throws IOException {
+
+    OutputFile commitFile = io.newOutputFile(location);
+    ObjectOutputStream oos = new ObjectOutputStream(commitFile.createOrOverwrite());
+    oos.writeObject(closedFiles);
+    oos.close();
+    LOG.debug("Iceberg committed file is created {}", commitFile);
+  }
+
+  private static Set<ClosedFileData> readToCommitFile(String toCommitFileLocation, FileIO io) {
+    try (ObjectInputStream ois = new ObjectInputStream(io.newInputFile(toCommitFileLocation).newStream())) {
+      return (Set<ClosedFileData>) ois.readObject();
+    } catch (ClassNotFoundException | IOException e) {
+      throw new NotFoundException("Can not read or parse committed file: %s", toCommitFileLocation);
+    }
+  }
+}

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputFormat.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputFormat.java
@@ -19,21 +19,83 @@
 
 package org.apache.iceberg.mr.hive;
 
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
+import org.apache.hadoop.hive.ql.io.HiveOutputFormat;
+import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.OutputFormat;
-import org.apache.hadoop.mapred.RecordWriter;
+import org.apache.hadoop.mapred.TaskAttemptID;
 import org.apache.hadoop.util.Progressable;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.PartitionSpecParser;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.mr.InputFormatConfig;
+import org.apache.iceberg.mr.mapreduce.IcebergWritable;
 
-public class HiveIcebergOutputFormat<T> implements OutputFormat<Void, T> {
+public class HiveIcebergOutputFormat implements OutputFormat<NullWritable, IcebergWritable>,
+    HiveOutputFormat<NullWritable, IcebergWritable> {
+
+  private static final String TASK_ATTEMPT_ID_KEY = "mapred.task.id";
+
+  // <TaskAttemptId, HiveIcebergRecordWriter> map to store the active writers
+  // Stored in concurrent map, since some executor engines can share containers
+  static final Map<TaskAttemptID, HiveIcebergRecordWriter> writers = new ConcurrentHashMap<>();
+
+  private Configuration overlayedConf = null;
+  private TaskAttemptID taskAttemptId = null;
+  private Schema schema = null;
+  private PartitionSpec spec = null;
+  private FileFormat fileFormat = null;
 
   @Override
-  public RecordWriter<Void, T> getRecordWriter(FileSystem ignored, JobConf job, String name, Progressable progress) {
-    throw new UnsupportedOperationException("Writing to an Iceberg table with Hive is not supported");
+  @SuppressWarnings("rawtypes")
+  public FileSinkOperator.RecordWriter getHiveRecordWriter(JobConf jc, Path finalOutPath, Class valueClass,
+      boolean isCompressed, Properties tableAndSerDeProperties, Progressable progress) {
+
+    this.overlayedConf = createOverlayedConf(jc, tableAndSerDeProperties);
+    this.taskAttemptId = TaskAttemptID.forName(overlayedConf.get(TASK_ATTEMPT_ID_KEY));
+    this.schema = SchemaParser.fromJson(overlayedConf.get(InputFormatConfig.TABLE_SCHEMA));
+    this.spec = PartitionSpecParser.fromJson(schema, overlayedConf.get(InputFormatConfig.PARTITION_SPEC));
+    String fileFormatString =
+        overlayedConf.get(InputFormatConfig.WRITE_FILE_FORMAT, InputFormatConfig.WRITE_FILE_FORMAT_DEFAULT.name());
+    this.fileFormat = FileFormat.valueOf(fileFormatString);
+
+    String location = LocationHelper.generateDataFileLocation(overlayedConf, taskAttemptId);
+    HiveIcebergRecordWriter writer = new HiveIcebergRecordWriter(overlayedConf, location, fileFormat, schema, spec);
+    writers.put(this.taskAttemptId, writer);
+
+    return writer;
+  }
+
+  /**
+   * Returns the union of the configuration and table properties with the
+   * table properties taking precedence.
+   */
+  private static Configuration createOverlayedConf(Configuration conf, Properties tblProps) {
+    Configuration newConf = new Configuration(conf);
+    for (Map.Entry<Object, Object> prop : tblProps.entrySet()) {
+      newConf.set((String) prop.getKey(), (String) prop.getValue());
+    }
+    return newConf;
+  }
+
+  @Override
+  public org.apache.hadoop.mapred.RecordWriter<NullWritable, IcebergWritable> getRecordWriter(FileSystem ignored,
+      JobConf job, String name, Progressable progress) {
+
+    throw new UnsupportedOperationException("Please implement if needed");
   }
 
   @Override
   public void checkOutputSpecs(FileSystem ignored, JobConf job) {
-    throw new UnsupportedOperationException("Writing to an Iceberg table with Hive is not supported");
+    // Not doing any check.
   }
 }

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergRecordWriter.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergRecordWriter.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.mr.hive;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapred.Reporter;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.PartitionKey;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericAppenderFactory;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.hadoop.HadoopFileIO;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.mr.mapreduce.IcebergWritable;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.Tasks;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class HiveIcebergRecordWriter extends org.apache.hadoop.mapreduce.RecordWriter<NullWritable, IcebergWritable>
+    implements FileSinkOperator.RecordWriter, org.apache.hadoop.mapred.RecordWriter<NullWritable, IcebergWritable> {
+  private static final Logger LOG = LoggerFactory.getLogger(HiveIcebergRecordWriter.class);
+
+  private final FileIO io;
+  private final String location;
+  private final FileFormat fileFormat;
+  private final GenericAppenderFactory appenderFactory;
+  // The current key is reused at every write to avoid unnecessary object creation
+  private final PartitionKey currentKey;
+  // Data for every partition is written to a different appender
+  // This map stores the open appenders for the given partition key
+  private final Map<PartitionKey, AppenderWrapper> openAppenders = new HashMap<>();
+  // When the appenders are closed the file data needed for the Iceberg commit is stored and accessible through
+  // this map
+  private final Map<PartitionKey, ClosedFileData> closedFileData = new HashMap<>();
+
+  HiveIcebergRecordWriter(Configuration conf, String location, FileFormat fileFormat, Schema schema,
+      PartitionSpec spec) {
+    this.io = new HadoopFileIO(conf);
+    this.location = location;
+    this.fileFormat = fileFormat;
+    this.appenderFactory = new GenericAppenderFactory(schema);
+    this.currentKey = new PartitionKey(spec, schema);
+    LOG.info("IcebergRecordWriter is created in {} with {}", location, fileFormat);
+  }
+
+  @Override
+  public void write(Writable row) {
+    Preconditions.checkArgument(row instanceof IcebergWritable);
+
+    Record record = ((IcebergWritable) row).record();
+
+    currentKey.partition(record);
+
+    AppenderWrapper currentAppender = openAppenders.get(currentKey);
+    if (currentAppender == null) {
+      currentAppender = getAppender();
+      openAppenders.put(currentKey.copy(), currentAppender);
+    }
+
+    currentAppender.appender.add(record);
+  }
+
+  @Override
+  public void write(NullWritable key, IcebergWritable value) {
+    write(value);
+  }
+
+  @Override
+  public void close(boolean abort) throws IOException {
+    // Close the open appenders and store the closed file data
+    for (PartitionKey key : openAppenders.keySet()) {
+      AppenderWrapper wrapper = openAppenders.get(key);
+      wrapper.close();
+      closedFileData.put(key,
+          new ClosedFileData(key, wrapper.location, fileFormat, wrapper.length(), wrapper.metrics()));
+    }
+
+    openAppenders.clear();
+
+    // If abort then remove the unnecessary files
+    if (abort) {
+      Tasks.foreach(closedFileData.values().stream().map(ClosedFileData::fileName).iterator())
+          .retry(3)
+          .suppressFailureWhenFinished()
+          .onFailure((file, exception) -> LOG.debug("Failed on to remove file {} on abort", file, exception))
+          .run(io::deleteFile);
+    }
+  }
+
+  @Override
+  public void close(org.apache.hadoop.mapreduce.TaskAttemptContext context) throws IOException {
+    close(false);
+  }
+
+  @Override
+  public void close(Reporter reporter) throws IOException {
+    close(false);
+  }
+
+  FileIO io() {
+    return io;
+  }
+
+  FileFormat fileFormat() {
+    return fileFormat;
+  }
+
+  Set<ClosedFileData> closedFileData() {
+    return new HashSet<>(closedFileData.values());
+  }
+
+  private AppenderWrapper getAppender() {
+    String dataFileLocation = location + UUID.randomUUID();
+    OutputFile dataFile = io.newOutputFile(dataFileLocation);
+
+    FileAppender<Record> appender = appenderFactory.newAppender(dataFile, fileFormat);
+
+    return new AppenderWrapper(appender, dataFileLocation);
+  }
+
+  private static final class AppenderWrapper {
+    private final FileAppender<Record> appender;
+    private final String location;
+
+    AppenderWrapper(FileAppender<Record> appender, String location) {
+      this.appender = appender;
+      this.location = location;
+    }
+
+    public long length() {
+      return appender.length();
+    }
+
+    public Metrics metrics() {
+      return appender.metrics();
+    }
+
+    public void close() throws IOException {
+      appender.close();
+    }
+  }
+}

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.mr.hive;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import org.apache.hadoop.conf.Configuration;
@@ -35,12 +36,17 @@ import org.apache.hadoop.hive.serde2.Deserializer;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.OutputFormat;
+import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.mr.Catalogs;
 import org.apache.iceberg.mr.InputFormatConfig;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, HiveStorageHandler {
+
+  private static final String NAME = "name";
+  private static final String WRITE_KEY = "HiveIcebergStorageHandler_write";
 
   private Configuration conf;
 
@@ -77,11 +83,13 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
     map.put(InputFormatConfig.TABLE_IDENTIFIER, props.getProperty(Catalogs.NAME));
     map.put(InputFormatConfig.TABLE_LOCATION, table.location());
     map.put(InputFormatConfig.TABLE_SCHEMA, SchemaParser.toJson(table.schema()));
+    overlayTableProperties(tableDesc, map);
   }
 
   @Override
   public void configureOutputJobProperties(TableDesc tableDesc, Map<String, String> map) {
-
+    overlayTableProperties(tableDesc, map);
+    map.put(WRITE_KEY, "true");
   }
 
   @Override
@@ -97,7 +105,10 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
 
   @Override
   public void configureJobConf(TableDesc tableDesc, JobConf jobConf) {
-
+    if (tableDesc != null && tableDesc.getJobProperties() != null &&
+        tableDesc.getJobProperties().get(WRITE_KEY) != null) {
+      jobConf.set("mapred.output.committer.class", HiveIcebergOutputCommitter.class.getName());
+    }
   }
 
   @Override
@@ -122,10 +133,29 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
    * @return Entire filter to take advantage of Hive's pruning as well as Iceberg's pruning.
    */
   @Override
-  public DecomposedPredicate decomposePredicate(JobConf jobConf, Deserializer deserializer, ExprNodeDesc exprNodeDesc) {
+  public DecomposedPredicate decomposePredicate(JobConf jobConf, Deserializer deserializer,
+      ExprNodeDesc exprNodeDesc) {
     DecomposedPredicate predicate = new DecomposedPredicate();
     predicate.residualPredicate = (ExprNodeGenericFuncDesc) exprNodeDesc;
     predicate.pushedPredicate = (ExprNodeGenericFuncDesc) exprNodeDesc;
     return predicate;
+  }
+
+  private void overlayTableProperties(TableDesc tableDesc, Map<String, String> map) {
+    Properties props = tableDesc.getProperties();
+    Table table = Catalogs.loadTable(conf, props);
+
+    Map<String, String> original = new HashMap<>(map);
+    map.clear();
+
+    map.putAll(Maps.fromProperties(props));
+    map.putAll(original);
+
+    map.put(InputFormatConfig.TABLE_IDENTIFIER, props.getProperty(NAME));
+    map.put(InputFormatConfig.TABLE_LOCATION, table.location());
+    map.put(InputFormatConfig.TABLE_SCHEMA, SchemaParser.toJson(table.schema()));
+    map.put(InputFormatConfig.PARTITION_SPEC, PartitionSpecParser.toJson(table.spec()));
+    // We need to remove this otherwise the job.xml will be invalid
+    map.remove("columns.comments");
   }
 }

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/LocationHelper.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/LocationHelper.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.mr.hive;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.mapred.TaskAttemptID;
+import org.apache.hadoop.mapreduce.JobID;
+import org.apache.iceberg.mr.InputFormatConfig;
+
+class LocationHelper {
+  private static final String TO_COMMIT_EXTENSION = ".toCommit";
+
+  private LocationHelper() {
+  }
+
+  /**
+   * Generates query directory location based on the configuration.
+   * Currently it uses tableLocation/queryId
+   * @param conf The job's configuration
+   * @return The directory to store the query result files
+   */
+  static String generateQueryLocation(Configuration conf) {
+    String tableLocation = conf.get(InputFormatConfig.TABLE_LOCATION);
+    String queryId = conf.get(HiveConf.ConfVars.HIVEQUERYID.varname);
+    return tableLocation + "/" + queryId;
+  }
+
+  /**
+   * Generates the job temp location based on the job configuration.
+   * Currently it uses QUERY_LOCATION/jobId.
+   * @param conf The job's configuration
+   * @param jobId The JobID for the task
+   * @return The file to store the results
+   */
+  static String generateJobLocation(Configuration conf, JobID jobId) {
+    return generateQueryLocation(conf) + "/" + jobId;
+  }
+
+  /**
+   * Generates datafile location based on the task configuration.
+   * Currently it uses QUERY_LOCATION/jobId/taskAttemptId.
+   * @param conf The job's configuration
+   * @param taskAttemptId The TaskAttemptID for the task
+   * @return The file to store the results
+   */
+  static String generateDataFileLocation(Configuration conf, TaskAttemptID taskAttemptId) {
+    return generateJobLocation(conf, taskAttemptId.getJobID()) + "/" + taskAttemptId.toString();
+  }
+
+  /**
+   * Generates file location based on the task configuration and a specific task id.
+   * This file will be used to store the data required to generate the Iceberg commit.
+   * Currently it uses QUERY_LOCATION/jobId/task-[0..numTasks].toCommit.
+   * @param conf The job's configuration
+   * @param jobId The jobId for the task
+   * @param taskId The taskId for the commit file
+   * @return The file to store the results
+   */
+  static String generateToCommitFileLocation(Configuration conf, JobID jobId, int taskId) {
+    return generateJobLocation(conf, jobId) + "/task-" + taskId + TO_COMMIT_EXTENSION;
+  }
+
+  /**
+   * Generates file location location based on the task configuration.
+   * This file will be used to store the data required to generate the Iceberg commit.
+   * Currently it uses QUERY_LOCATION/jobId/task-[0..numTasks].committed.
+   * @param conf The job's configuration
+   * @param taskAttemptId The TaskAttemptID for the task
+   * @return The file to store the results
+   */
+  static String generateToCommitFileLocation(Configuration conf, TaskAttemptID taskAttemptId) {
+    return generateToCommitFileLocation(conf, taskAttemptId.getJobID(), taskAttemptId.getTaskID().getId());
+  }
+}

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergDateObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergDateObjectInspector.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.iceberg.util.DateTimeUtil;
 
 public final class IcebergDateObjectInspector extends AbstractPrimitiveJavaObjectInspector
-                                              implements DateObjectInspector {
+                                              implements DateObjectInspector, IcebergReadObjectInspector {
 
   private static final IcebergDateObjectInspector INSTANCE = new IcebergDateObjectInspector();
 
@@ -65,4 +65,8 @@ public final class IcebergDateObjectInspector extends AbstractPrimitiveJavaObjec
     }
   }
 
+  @Override
+  public LocalDate getIcebergObject(Object o) {
+    return o == null ? null : ((DateWritable) o).get().toLocalDate();
+  }
 }

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergObjectInspector.java
@@ -41,7 +41,7 @@ public final class IcebergObjectInspector extends TypeUtil.SchemaVisitor<ObjectI
           "org.apache.iceberg.mr.hive.serde.objectinspector.IcebergDateObjectInspectorHive3" :
           "org.apache.iceberg.mr.hive.serde.objectinspector.IcebergDateObjectInspector";
 
-  private static final ObjectInspector DATE_INSPECTOR = DynMethods.builder("get")
+  public static final ObjectInspector DATE_INSPECTOR = DynMethods.builder("get")
           .impl(DATE_INSPECTOR_CLASS)
           .buildStatic()
           .invoke();
@@ -50,12 +50,12 @@ public final class IcebergObjectInspector extends TypeUtil.SchemaVisitor<ObjectI
           "org.apache.iceberg.mr.hive.serde.objectinspector.IcebergTimestampObjectInspectorHive3" :
           "org.apache.iceberg.mr.hive.serde.objectinspector.IcebergTimestampObjectInspector";
 
-  private static final ObjectInspector TIMESTAMP_INSPECTOR = DynMethods.builder("get")
+  public static final ObjectInspector TIMESTAMP_INSPECTOR = DynMethods.builder("get")
           .impl(TIMESTAMP_INSPECTOR_CLASS, boolean.class)
           .buildStatic()
           .invoke(false);
 
-  private static final ObjectInspector TIMESTAMP_INSPECTOR_WITH_TZ = DynMethods.builder("get")
+  public static final ObjectInspector TIMESTAMP_INSPECTOR_WITH_TZ = DynMethods.builder("get")
           .impl(TIMESTAMP_INSPECTOR_CLASS, boolean.class)
           .buildStatic()
           .invoke(true);

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergReadObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergReadObjectInspector.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.mr.hive.serde.objectinspector;
+
+public interface IcebergReadObjectInspector {
+  Object getIcebergObject(Object value);
+}

--- a/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -71,8 +71,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.PartitionUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Generic Mrv2 InputFormat API for Iceberg.
@@ -80,7 +78,6 @@ import org.slf4j.LoggerFactory;
  * @param <T> T is the in memory data model which can either be Pig tuples, Hive rows. Default is Iceberg records
  */
 public class IcebergInputFormat<T> extends InputFormat<Void, T> {
-  private static final Logger LOG = LoggerFactory.getLogger(IcebergInputFormat.class);
 
   /**
    * Configures the {@code Job} to use the {@code IcebergInputFormat} and

--- a/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergWritable.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergWritable.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.mr.mapreduce;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import org.apache.hadoop.io.Writable;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+public class IcebergWritable implements Writable {
+  private Record record;
+
+  public IcebergWritable(Record record) {
+    this.record = record;
+  }
+
+  public Record record() {
+    Preconditions.checkNotNull(record, "Should not return null record");
+    return record;
+  }
+
+  public Object getValueObject(int colIndex) {
+    if (record != null) {
+      return record.get(colIndex);
+    } else {
+      return null;
+    }
+  }
+
+  public Object getValueObject(String colName) {
+    if (record != null) {
+      return record.getField(colName);
+    } else {
+      return null;
+    }
+  }
+
+  public boolean isSet(int colIndex) {
+    if (record != null) {
+      return record.get(colIndex) != null;
+    } else {
+      return false;
+    }
+  }
+
+  public boolean isSet(String colName) {
+    if (record != null) {
+      return record.getField(colName) != null;
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public void readFields(DataInput in) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void write(DataOutput out) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergSerDeTestUtils.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergSerDeTestUtils.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.mr.hive;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.IcebergGenerics;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.UUIDUtil;
+import org.junit.Assert;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+
+public class HiveIcebergSerDeTestUtils {
+  // TODO: Can this be a constant all around the Iceberg tests?
+  public static final Schema FULL_SCHEMA = new Schema(
+      optional(1, "boolean_type", Types.BooleanType.get()),
+      optional(2, "integer_type", Types.IntegerType.get()),
+      optional(3, "long_type", Types.LongType.get()),
+      optional(4, "float_type", Types.FloatType.get()),
+      optional(5, "double_type", Types.DoubleType.get()),
+      optional(6, "date_type", Types.DateType.get()),
+      // TimeType is not supported
+      // required(7, "time_type", Types.TimeType.get()),
+      optional(7, "tsTz", Types.TimestampType.withZone()),
+      optional(8, "ts", Types.TimestampType.withoutZone()),
+      optional(9, "string_type", Types.StringType.get()),
+      optional(10, "uuid_type", Types.UUIDType.get()),
+      optional(11, "fixed_type", Types.FixedType.ofLength(3)),
+      optional(12, "binary_type", Types.BinaryType.get()),
+      optional(13, "decimal_type", Types.DecimalType.of(38, 10)));
+
+  private HiveIcebergSerDeTestUtils() {
+    // Empty constructor for the utility class
+  }
+
+  public static Record getTestRecord(boolean uuidAsByte) {
+    Record record = GenericRecord.create(HiveIcebergSerDeTestUtils.FULL_SCHEMA);
+    record.set(0, true);
+    record.set(1, 1);
+    record.set(2, 2L);
+    record.set(3, 3.1f);
+    record.set(4, 4.2d);
+    record.set(5, LocalDate.of(2020, 1, 21));
+    // TimeType is not supported
+    // record.set(6, LocalTime.of(11, 33));
+    // Nano is not supported
+    record.set(6, OffsetDateTime.of(2017, 11, 22, 11, 30, 7, 0, ZoneOffset.ofHours(2)));
+    record.set(7, LocalDateTime.of(2019, 2, 22, 9, 44, 54));
+    record.set(8, "kilenc");
+    if (uuidAsByte) {
+      // TODO: Parquet UUID expect byte[], others are expecting UUID
+      record.set(9, UUIDUtil.convert(UUID.fromString("1-2-3-4-5")));
+    } else {
+      record.set(9, UUID.fromString("1-2-3-4-5"));
+    }
+    record.set(10, new byte[] {0, 1, 2});
+    record.set(11, ByteBuffer.wrap(new byte[] {0, 1, 2, 3}));
+    record.set(12, new BigDecimal("0.0000000013"));
+
+    return record;
+  }
+
+  public static Record getNullTestRecord() {
+    Record record = GenericRecord.create(HiveIcebergSerDeTestUtils.FULL_SCHEMA);
+
+    for (int i = 0; i < HiveIcebergSerDeTestUtils.FULL_SCHEMA.columns().size(); i++) {
+      record.set(i, null);
+    }
+
+    return record;
+  }
+
+  public static void assertEquals(Record expected, Record actual) {
+    for (int i = 0; i < expected.size(); ++i) {
+      if (expected.get(i) instanceof OffsetDateTime) {
+        // For OffsetDateTime we just compare the actual instant
+        Assert.assertEquals(((OffsetDateTime) expected.get(i)).toInstant(),
+            ((OffsetDateTime) actual.get(i)).toInstant());
+      } else {
+        if (expected.get(i) instanceof byte[]) {
+          Assert.assertArrayEquals((byte[]) expected.get(i), (byte[]) actual.get(i));
+        } else {
+          Assert.assertEquals(expected.get(i), actual.get(i));
+        }
+      }
+    }
+  }
+
+  public static void validate(Table table, List<Record> expected, Integer sortBy) throws IOException {
+    // Refresh the table, so we get the new data as well
+    table.refresh();
+    List<Record> records = new ArrayList<>();
+    try (CloseableIterable<Record> iterable = IcebergGenerics.read(table).build()) {
+      iterable.forEach(records::add);
+    }
+
+    // Sort if needed
+    if (sortBy != null) {
+      expected.sort(Comparator.comparingLong(record -> ((Long) record.get(sortBy.intValue())).longValue()));
+      records.sort(Comparator.comparingLong(record -> ((Long) record.get(sortBy.intValue())).longValue()));
+    }
+    Assert.assertEquals(expected.size(), records.size());
+    for (int i = 0; i < expected.size(); ++i) {
+      HiveIcebergSerDeTestUtils.assertEquals(expected.get(i), records.get(i));
+    }
+  }
+}

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergOutputFormat.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergOutputFormat.java
@@ -1,0 +1,289 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.mr.hive;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.Set;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.JobContext;
+import org.apache.hadoop.mapred.JobContextImpl;
+import org.apache.hadoop.mapred.JobID;
+import org.apache.hadoop.mapred.OutputCommitter;
+import org.apache.hadoop.mapred.TaskAttemptContext;
+import org.apache.hadoop.mapred.TaskAttemptContextImpl;
+import org.apache.hadoop.mapred.TaskAttemptID;
+import org.apache.hadoop.mapreduce.JobStatus;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpecParser;
+import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.mr.Catalogs;
+import org.apache.iceberg.mr.InputFormatConfig;
+import org.apache.iceberg.mr.TestHelper;
+import org.apache.iceberg.mr.mapreduce.IcebergWritable;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestHiveIcebergOutputFormat {
+
+  private static final Object[] TESTED_FILE_FORMATS = new Object[] {"avro", "orc", "parquet"};
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Object[] parameters() {
+    return TESTED_FILE_FORMATS;
+  }
+
+  // parametrized variables
+  private final FileFormat fileFormat;
+
+  private static final Configuration conf = new Configuration();
+  private TestHelper helper;
+  private Table table;
+  private TestOutputFormat testOutputFormat;
+
+  public TestHiveIcebergOutputFormat(String fileFormat) {
+    this.fileFormat = FileFormat.valueOf(fileFormat.toUpperCase(Locale.ENGLISH));
+  }
+
+  @Before
+  public void before() throws Exception {
+    helper = new TestHelper(conf,
+        new HadoopTables(conf),
+        temp.newFolder(this.fileFormat.name()).toString(),
+        HiveIcebergSerDeTestUtils.FULL_SCHEMA,
+        null,
+        fileFormat,
+        temp);
+
+    table = helper.createUnpartitionedTable();
+    testOutputFormat = new TestOutputFormat(table, fileFormat);
+  }
+
+  @Test
+  public void testWriteRow() throws IOException {
+    // Write a row.
+    List<Record> records =
+        Arrays.asList(new Record[] { HiveIcebergSerDeTestUtils.getTestRecord(FileFormat.PARQUET.equals(fileFormat)) });
+
+    testOutputFormat.write(records, false, false);
+    testOutputFormat.validate(records);
+  }
+
+  @Test
+  public void testNullRow() throws IOException {
+    // FIXME: ORC file does not read back the row consisting only of nulls. The data in the files seems ok.
+    if (FileFormat.ORC.equals(fileFormat)) {
+      return;
+    }
+    // Write a row.
+    List<Record> records = Arrays.asList(new Record[] { HiveIcebergSerDeTestUtils.getNullTestRecord() });
+
+    testOutputFormat.write(records, false, false);
+    testOutputFormat.validate(records);
+  }
+
+  @Test
+  public void testMultipleRows() throws IOException {
+    // Write 2 rows. One with nulls too.
+    List<Record> records = Arrays.asList(new Record[] {
+        HiveIcebergSerDeTestUtils.getTestRecord(FileFormat.PARQUET.equals(fileFormat)),
+        HiveIcebergSerDeTestUtils.getNullTestRecord()
+    });
+
+    testOutputFormat.write(records, false, false);
+    testOutputFormat.validate(records);
+  }
+
+  @Test
+  public void testRandomRecords() throws IOException {
+    // Write 30 random rows
+    // FIXME: Parquet appender expect byte[] instead of UUID when writing values.
+    if (FileFormat.PARQUET.equals(fileFormat)) {
+      return;
+    }
+
+    List<Record> records = helper.generateRandomRecords(30, 0L);
+
+    testOutputFormat.write(records, false, false);
+    testOutputFormat.validate(records);
+  }
+
+  @Test
+  public void testWithAbortedTask() throws IOException {
+    // Write a row.
+    List<Record> records =
+        Arrays.asList(new Record[] { HiveIcebergSerDeTestUtils.getTestRecord(FileFormat.PARQUET.equals(fileFormat)) });
+
+    testOutputFormat.write(records, true, false);
+    testOutputFormat.validate(records);
+  }
+
+  @Test
+  public void testEmptyWrite() throws IOException {
+    testOutputFormat.writeEmpty();
+    testOutputFormat.validate(Collections.emptyList());
+  }
+
+  @Test
+  public void testAbortJob() throws IOException {
+    // Write a row.
+    List<Record> records =
+        Arrays.asList(new Record[] { HiveIcebergSerDeTestUtils.getTestRecord(FileFormat.PARQUET.equals(fileFormat)) });
+
+    testOutputFormat.write(records, true, true);
+    testOutputFormat.validate(Collections.emptyList());
+  }
+
+  private static class TestOutputFormat {
+    private Configuration configuration;
+    private Properties serDeProperties;
+    private JobConf jobConf;
+    private JobContext jobContext;
+    private TaskAttemptContext taskAttemptContext;
+    private boolean jobAborted;
+
+    private TestOutputFormat(Table table, FileFormat fileFormat) {
+      configuration = new Configuration();
+
+      // Create the SerDeProperties
+      serDeProperties = new Properties();
+      serDeProperties.put(InputFormatConfig.WRITE_FILE_FORMAT, fileFormat.name());
+      serDeProperties.put(InputFormatConfig.TABLE_LOCATION, table.location());
+      serDeProperties.put(InputFormatConfig.TABLE_SCHEMA, SchemaParser.toJson(table.schema()));
+      serDeProperties.put(InputFormatConfig.PARTITION_SPEC, PartitionSpecParser.toJson(table.spec()));
+      serDeProperties.put("location", table.location());
+      serDeProperties.put(HiveConf.ConfVars.HIVEQUERYID.varname, "TestQuery_" + fileFormat);
+
+      // Create a dummy jobContext and taskAttemptContext
+      jobConf = new JobConf(configuration);
+      TaskAttemptID taskAttemptID = new TaskAttemptID();
+      jobConf.set(InputFormatConfig.TABLE_LOCATION, table.location());
+      jobConf.set("mapred.task.id", taskAttemptID.toString());
+      jobConf.set(HiveConf.ConfVars.HIVEQUERYID.varname, "TestQuery_" + fileFormat);
+      jobContext = new JobContextImpl(jobConf, new JobID());
+      taskAttemptContext = new TaskAttemptContextImpl(jobConf, taskAttemptID);
+    }
+
+    private void writeEmpty() throws IOException {
+      OutputCommitter outputCommitter = new HiveIcebergOutputCommitter();
+
+      outputCommitter.commitTask(taskAttemptContext);
+      outputCommitter.commitJob(jobContext);
+    }
+
+    private void write(List<Record> records, boolean withAbortedTask, boolean withAbortJob) throws IOException {
+      HiveIcebergOutputFormat outputFormat = new HiveIcebergOutputFormat();
+      OutputCommitter outputCommitter = new HiveIcebergOutputCommitter();
+
+      if (withAbortedTask) {
+        HiveIcebergRecordWriter writer =
+            (HiveIcebergRecordWriter) outputFormat.getHiveRecordWriter(jobConf,
+                null, null, false, serDeProperties, null);
+
+        records.forEach(record -> writer.write(new IcebergWritable(record)));
+
+        writer.close(false);
+
+        // Abort the previous task
+        outputCommitter.abortTask(taskAttemptContext);
+
+        // Create and set the new task attempt id
+        TaskAttemptID newId = new TaskAttemptID(taskAttemptContext.getTaskAttemptID().getTaskID(), 1);
+        jobConf.set("mapred.task.id", newId.toString());
+        taskAttemptContext = new TaskAttemptContextImpl(jobConf, newId);
+      }
+
+      HiveIcebergRecordWriter writer =
+          (HiveIcebergRecordWriter) outputFormat.getHiveRecordWriter(jobConf,
+              null, null, false, serDeProperties, null);
+
+      records.forEach(record -> writer.write(new IcebergWritable(record)));
+
+      writer.close(false);
+
+      outputCommitter.commitTask(taskAttemptContext);
+      if (withAbortJob) {
+        outputCommitter.abortJob(jobContext, JobStatus.State.KILLED);
+        jobAborted = true;
+      } else {
+        outputCommitter.commitJob(jobContext);
+        jobAborted = false;
+      }
+    }
+
+    private void validate(List<Record> expected) throws IOException {
+      Table table = Catalogs.loadTable(configuration, serDeProperties);
+      HiveIcebergSerDeTestUtils.validate(table, expected, null);
+
+      // Check the number of the files, and the content of the directory
+      // We expect the following dir structure
+      // table - queryId - jobId + attemptFile
+      //                         \ task-0.toCommit
+      // We definitely do not want more files in the directory
+
+      String expectedBaseLocation = table.location() + "/" + jobConf.get(HiveConf.ConfVars.HIVEQUERYID.varname) +
+          "/" + taskAttemptContext.getTaskAttemptID().getJobID();
+
+      if (!jobAborted) {
+        Set<String> fileList = Sets.newHashSet();
+        for (String fileName : new File(expectedBaseLocation).list((dir, name) -> !name.startsWith("."))) {
+          fileList.add(fileName.replaceAll("(.*)_([^_]*)", "$1"));
+        }
+
+        if (expected.size() > 0) {
+          TableScan scan = table.newScan();
+          String dataFilePath = scan.planFiles().iterator().next().file().path().toString();
+          File parentDir = new File(dataFilePath).getParentFile();
+          String expectedFileName = taskAttemptContext.getTaskAttemptID().toString();
+          expectedFileName = expectedFileName.substring(0, expectedFileName.length() - 2);
+
+          Assert.assertEquals(expectedBaseLocation, parentDir.getPath());
+          Assert.assertEquals(fileList, Sets.newHashSet(new String[]{"task-0.toCommit", expectedFileName}));
+        } else {
+          Assert.assertEquals(fileList, Sets.newHashSet(new String[]{"task-0.toCommit"}));
+        }
+      } else {
+        // If the job is aborted, we expect that the job directory is removed
+        Assert.assertFalse(new File(expectedBaseLocation).exists());
+      }
+    }
+  }
+}

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSerDe.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSerDe.java
@@ -19,60 +19,166 @@
 
 package org.apache.iceberg.mr.hive;
 
-import java.io.File;
-import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
+import java.util.UUID;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.common.type.HiveDecimal;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.serde2.SerDeException;
-import org.apache.iceberg.Schema;
+import org.apache.hadoop.hive.serde2.io.DateWritable;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+import org.apache.hadoop.hive.serde2.io.TimestampWritable;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.StandardStructObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.io.BooleanWritable;
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.io.DoubleWritable;
+import org.apache.hadoop.io.FloatWritable;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.mr.InputFormatConfig;
+import org.apache.iceberg.mr.TestHelper;
 import org.apache.iceberg.mr.hive.serde.objectinspector.IcebergObjectInspector;
 import org.apache.iceberg.mr.mapred.Container;
-import org.apache.iceberg.types.Types;
+import org.apache.iceberg.mr.mapreduce.IcebergWritable;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static org.apache.iceberg.types.Types.NestedField.required;
-
 public class TestHiveIcebergSerDe {
 
-  private static final Schema schema = new Schema(required(1, "string_field", Types.StringType.get()));
-
   @Rule
-  public TemporaryFolder tmp = new TemporaryFolder();
+  public TemporaryFolder temp = new TemporaryFolder();
+  private static final Configuration conf = new Configuration();
+
+  private TestHelper helper;
+
+  @Before
+  public void before() throws Exception {
+    helper = new TestHelper(conf,
+        new HadoopTables(conf),
+        temp.newFolder("ORC").toString(),
+        HiveIcebergSerDeTestUtils.FULL_SCHEMA,
+        null,
+        FileFormat.ORC,
+        temp);
+  }
 
   @Test
-  public void testInitialize() throws IOException, SerDeException {
-    File location = tmp.newFolder();
-    Assert.assertTrue(location.delete());
-
-    Configuration conf = new Configuration();
-
-    Properties properties = new Properties();
-    properties.setProperty("location", location.toString());
-
-    HadoopTables tables = new HadoopTables(conf);
-    tables.create(schema, location.toString());
+  public void testInitialize() throws SerDeException {
+    Properties properties = createUnpartitionedTable();
 
     HiveIcebergSerDe serDe = new HiveIcebergSerDe();
     serDe.initialize(conf, properties);
 
-    Assert.assertEquals(IcebergObjectInspector.create(schema), serDe.getObjectInspector());
+    Assert.assertEquals(IcebergObjectInspector.create(HiveIcebergSerDeTestUtils.FULL_SCHEMA),
+        serDe.getObjectInspector());
   }
 
   @Test
   public void testDeserialize() {
     HiveIcebergSerDe serDe = new HiveIcebergSerDe();
 
-    Record record = RandomGenericData.generate(schema, 1, 0).get(0);
+    Record record = RandomGenericData.generate(HiveIcebergSerDeTestUtils.FULL_SCHEMA, 1, 0).get(0);
     Container<Record> container = new Container<>();
     container.set(record);
 
     Assert.assertEquals(record, serDe.deserialize(container));
   }
 
+  @Test
+  public void testFromWritables() throws Exception {
+    Properties properties = createUnpartitionedTable();
+
+    HiveIcebergSerDe serDe = new HiveIcebergSerDe();
+    serDe.initialize(conf, properties);
+
+    Record record = HiveIcebergSerDeTestUtils.getTestRecord(false);
+
+    // Capitalized `boolean_type` field to check for field case insensitivity.
+    List<String> fieldNames = Arrays.asList("Boolean_Type", "integer_type", "long_type", "float_type", "double_type",
+        "date_type", "tsTz", "ts", "string_type", "uuid_type", "fixed_type", "binary_type", "decimal_type");
+
+    List<ObjectInspector> ois = objectInspectors();
+
+    List<Object> values = values(record);
+
+    StandardStructObjectInspector objectInspector =
+        ObjectInspectorFactory.getStandardStructObjectInspector(fieldNames, ois);
+    IcebergWritable afterWritable = serDe.serialize(values, objectInspector);
+
+    HiveIcebergSerDeTestUtils.assertEquals(record, afterWritable.record());
+  }
+
+  private Properties createUnpartitionedTable() {
+    Table table = helper.createUnpartitionedTable();
+    Properties props = new Properties();
+    props.put(InputFormatConfig.WRITE_FILE_FORMAT, FileFormat.ORC);
+    props.put(InputFormatConfig.TABLE_LOCATION, table.location());
+    props.put("location", table.location());
+    props.put(HiveConf.ConfVars.HIVEQUERYID.varname, "TestQuery_ORC");
+    return props;
+  }
+
+  protected List<ObjectInspector> objectInspectors() {
+    return Arrays.asList(
+        PrimitiveObjectInspectorFactory.writableBooleanObjectInspector,
+        PrimitiveObjectInspectorFactory.writableIntObjectInspector,
+        PrimitiveObjectInspectorFactory.writableLongObjectInspector,
+        PrimitiveObjectInspectorFactory.writableFloatObjectInspector,
+        PrimitiveObjectInspectorFactory.writableDoubleObjectInspector,
+        PrimitiveObjectInspectorFactory.writableDateObjectInspector,
+        PrimitiveObjectInspectorFactory.writableTimestampObjectInspector,
+        PrimitiveObjectInspectorFactory.writableTimestampObjectInspector,
+        PrimitiveObjectInspectorFactory.writableStringObjectInspector,
+        PrimitiveObjectInspectorFactory.writableStringObjectInspector,
+        PrimitiveObjectInspectorFactory.writableBinaryObjectInspector,
+        PrimitiveObjectInspectorFactory.writableBinaryObjectInspector,
+        PrimitiveObjectInspectorFactory.writableHiveDecimalObjectInspector
+    );
+  }
+
+  protected List<Object> values(Record record) {
+    ByteBuffer byteBuffer = record.get(11, ByteBuffer.class);
+    byte[] bytes = new byte[byteBuffer.remaining()];
+    byteBuffer.mark();
+    byteBuffer.get(bytes);
+    byteBuffer.reset();
+
+    return Arrays.asList(
+        new BooleanWritable(Boolean.TRUE),
+        new IntWritable(record.get(1, Integer.class)),
+        new LongWritable(record.get(2, Long.class)),
+        new FloatWritable(record.get(3, Float.class)),
+        new DoubleWritable(record.get(4, Double.class)),
+        new DateWritable((int) record.get(5, LocalDate.class).toEpochDay()),
+        // TimeType is not supported
+        // new Timestamp()
+        new TimestampWritable(Timestamp.from(record.get(6, OffsetDateTime.class).toInstant())),
+        new TimestampWritable(Timestamp.valueOf(record.get(7, LocalDateTime.class))),
+        new Text(record.get(8, String.class)),
+        new Text(record.get(9, UUID.class).toString()),
+        new BytesWritable(record.get(10, byte[].class)),
+        new BytesWritable(bytes),
+        new HiveDecimalWritable(HiveDecimal.create(record.get(12, BigDecimal.class)))
+    );
+  }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Properties;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -35,6 +36,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.hadoop.HadoopCatalog;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.hive.HiveCatalogs;
+import org.apache.iceberg.mr.Catalogs;
 import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.iceberg.mr.TestCatalogs;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -68,6 +70,16 @@ abstract class TestTables {
 
   public Tables tables() {
     return tables;
+  }
+
+  public Table load(Configuration configuration, String tableName, String location) {
+    Properties properties = new Properties();
+    properties.put(Catalogs.NAME, TableIdentifier.of("default", tableName).toString());
+    if (location != null) {
+      properties.put(Catalogs.LOCATION, location);
+    }
+
+    return Catalogs.loadTable(configuration, properties);
   }
 
 


### PR DESCRIPTION
The goal of the patch is to have a PoC implementation of Hive writes to Iceberg tables.

The patch changes:
- _HiveIcebergOutputFormat / RecordWriter_ to write out data to Iceberg tables
- _HiveIcebergSerDe.serialize_ so the data in the Writables are converted to the correct Iceberg values
- Tests for the happy path of the things above

The tests were run successfully. Also after adding the change after the uber jar patch I was able to create a Hive table above an unpartitioned Iceberg table and write and read back data from it. The table was created with the following command:
```
CREATE EXTERNAL TABLE purchases STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler'
LOCATION '/tmp/hive/iceberg/test-run-3885506338417686444/purchases'
TBLPROPERTIES ('iceberg.mr.write.file.format'='orc') ;
```

Findings:
- When writing UUID type fields Parquet writer requires byte[], on the other hand ORC and Avro requires UUID object. I think this should be generic throughout the FileFormats.
- The Hive interface does not provide the possibility to "commit" all the writes in the query at once. Will do more investigation but I have not found a way to do it it one run. The current implementation immediately commits the changes upon closing the writer. This is _suboptimal and not correct_ when we write data which ends up on multiple FileSinks.

Missing stuff:
- Hive commit as described above
- Way to handle partitioned tables. Do I have to write multiple DataFiles for it, and add them manually to the commit, or there is some API helping me out? What about multicolumn partitioning - is it possible?
- More tests
- Error handling
- Logging
- Did I mention more tests? :)

Any suggestions / ideas / thoughts are welcome.

Thanks,
Peter

