### PR TITLE
Small fixes to LICENSE and NOTICE files

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 
-Apache Iceberg (incubating)
+Apache Iceberg
 Copyright 2017-2020 The Apache Software Foundation
 
 This product includes software developed at

--- a/bundled-guava/NOTICE
+++ b/bundled-guava/NOTICE
@@ -1,5 +1,5 @@
 
-Apache Iceberg (incubating)
+Apache Iceberg
 Copyright 2017-2020 The Apache Software Foundation
 
 This product includes software developed at

--- a/spark-runtime/LICENSE
+++ b/spark-runtime/LICENSE
@@ -283,7 +283,7 @@ License: Apache License Version 2.0 http://www.apache.org/licenses/LICENSE-2.0
 This binary artifact contains fastutil.
 
 Copyright: 2002-2014 Sebastiano Vigna
-Home page: http://fasutil.di.unimi.it/
+Home page: http://fastutil.di.unimi.it/
 License: http://www.apache.org/licenses/LICENSE-2.0.html
 
 --------------------------------------------------------------------------------

--- a/spark-runtime/NOTICE
+++ b/spark-runtime/NOTICE
@@ -1,5 +1,5 @@
 
-Apache Iceberg (incubating)
+Apache Iceberg
 Copyright 2017-2020 The Apache Software Foundation
 
 This product includes software developed at
@@ -152,6 +152,8 @@ notice:
 | of the input file used when generating it.  This code is not
 | standalone and requires a support library to be linked with it.  This
 | support library is itself covered by the above license.
+
+--------------------------------------------------------------------------------
 
 This binary artifact includes Apache Arrow with the following in its NOTICE file:
 

--- a/spark3-runtime/LICENSE
+++ b/spark3-runtime/LICENSE
@@ -283,7 +283,7 @@ License: Apache License Version 2.0 http://www.apache.org/licenses/LICENSE-2.0
 This binary artifact contains fastutil.
 
 Copyright: 2002-2014 Sebastiano Vigna
-Home page: http://fasutil.di.unimi.it/
+Home page: http://fastutil.di.unimi.it/
 License: http://www.apache.org/licenses/LICENSE-2.0.html
 
 --------------------------------------------------------------------------------

--- a/spark3-runtime/NOTICE
+++ b/spark3-runtime/NOTICE
@@ -1,5 +1,5 @@
 
-Apache Iceberg (incubating)
+Apache Iceberg
 Copyright 2017-2020 The Apache Software Foundation
 
 This product includes software developed at
@@ -152,6 +152,8 @@ notice:
 | of the input file used when generating it.  This code is not
 | standalone and requires a support library to be linked with it.  This
 | support library is itself covered by the above license.
+
+--------------------------------------------------------------------------------
 
 This binary artifact includes Apache Arrow with the following in its NOTICE file:
 


### PR DESCRIPTION
While working on https://github.com/apache/iceberg/pull/1267 I noticed a few small things in the `NOTICE` and `LICENSE` files that I thought were worth fixing.