### PR TITLE
API: Introduce a builder in Catalog

### DIFF
--- a/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
@@ -303,4 +303,83 @@ public interface Catalog {
    * @throws NoSuchTableException if the table does not exist
    */
   Table loadTable(TableIdentifier identifier);
+
+  /**
+   * Instantiate a builder to either create a table or start a create/replace transaction.
+   *
+   * @param identifier a table identifier
+   * @param schema a schema
+   * @return the builder to create a table or start a create/replace transaction
+   */
+  default TableBuilder buildTable(TableIdentifier identifier, Schema schema) {
+    throw new UnsupportedOperationException(this.getClass().getName() + " does not implement buildTable");
+  }
+
+  /**
+   * A builder used to create valid {@link Table tables} or start create/replace {@link Transaction transactions}.
+   * <p>
+   * Call {@link #buildTable(TableIdentifier, Schema)} to create a new builder.
+   */
+  interface TableBuilder {
+    /**
+     * Sets a partition spec for the table.
+     *
+     * @param spec a partition spec
+     * @return this for method chaining
+     */
+    TableBuilder withPartitionSpec(PartitionSpec spec);
+
+    /**
+     * Sets a location for the table.
+     *
+     * @param location a location
+     * @return this for method chaining
+     */
+    TableBuilder withLocation(String location);
+
+    /**
+     * Adds key/value properties to the table.
+     *
+     * @param properties key/value properties
+     * @return this for method chaining
+     */
+    TableBuilder withProperties(Map<String, String> properties);
+
+    /**
+     * Adds a key/value property to the table.
+     *
+     * @param key   a key
+     * @param value a value
+     * @return this for method chaining
+     */
+    TableBuilder withProperty(String key, String value);
+
+    /**
+     * Creates the table.
+     *
+     * @return the created table
+     */
+    Table create();
+
+    /**
+     * Starts a transaction to create the table.
+     *
+     * @return the {@link Transaction} to create the table
+     */
+    Transaction createTransaction();
+
+    /**
+     * Starts a transaction to replace the table.
+     *
+     * @return the {@link Transaction} to replace the table
+     */
+    Transaction replaceTransaction();
+
+    /**
+     * Starts a transaction to create or replace the table.
+     *
+     * @return the {@link Transaction} to create or replace the table
+     */
+    Transaction createOrReplaceTransaction();
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -205,9 +205,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
 
     @Override
     public TableBuilder withPartitionSpec(PartitionSpec newSpec) {
-      if (spec != null) {
-        this.spec = newSpec;
-      }
+      this.spec = newSpec != null ? newSpec : PartitionSpec.unpartitioned();
       return this;
     }
 

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -31,9 +31,9 @@ import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.MapMaker;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.util.ThreadPools;
@@ -50,30 +50,12 @@ public abstract class BaseMetastoreCatalog implements Catalog {
       PartitionSpec spec,
       String location,
       Map<String, String> properties) {
-    Preconditions.checkArgument(isValidIdentifier(identifier), "Invalid table identifier: %s", identifier);
 
-    TableOperations ops = newTableOps(identifier);
-    if (ops.current() != null) {
-      throw new AlreadyExistsException("Table already exists: " + identifier);
-    }
-
-    String baseLocation;
-    if (location != null) {
-      baseLocation = location;
-    } else {
-      baseLocation = defaultWarehouseLocation(identifier);
-    }
-
-    TableMetadata metadata = TableMetadata.newTableMetadata(
-        schema, spec, baseLocation, properties == null ? Maps.newHashMap() : properties);
-
-    try {
-      ops.commit(null, metadata);
-    } catch (CommitFailedException ignored) {
-      throw new AlreadyExistsException("Table was created concurrently: " + identifier);
-    }
-
-    return new BaseTable(ops, fullTableName(name(), identifier));
+    return buildTable(identifier, schema)
+        .withPartitionSpec(spec)
+        .withLocation(location)
+        .withProperties(properties)
+        .create();
   }
 
   @Override
@@ -83,17 +65,12 @@ public abstract class BaseMetastoreCatalog implements Catalog {
       PartitionSpec spec,
       String location,
       Map<String, String> properties) {
-    Preconditions.checkArgument(isValidIdentifier(identifier), "Invalid table identifier: %s", identifier);
 
-    TableOperations ops = newTableOps(identifier);
-    if (ops.current() != null) {
-      throw new AlreadyExistsException("Table already exists: " + identifier);
-    }
-
-    String baseLocation = location != null ? location : defaultWarehouseLocation(identifier);
-    Map<String, String> tableProperties = properties != null ? properties : Maps.newHashMap();
-    TableMetadata metadata = TableMetadata.newTableMetadata(schema, spec, baseLocation, tableProperties);
-    return Transactions.createTableTransaction(identifier.toString(), ops, metadata);
+    return buildTable(identifier, schema)
+        .withPartitionSpec(spec)
+        .withLocation(location)
+        .withProperties(properties)
+        .createTransaction();
   }
 
   @Override
@@ -105,26 +82,15 @@ public abstract class BaseMetastoreCatalog implements Catalog {
       Map<String, String> properties,
       boolean orCreate) {
 
-    TableOperations ops = newTableOps(identifier);
-    if (!orCreate && ops.current() == null) {
-      throw new NoSuchTableException("No such table: " + identifier);
-    }
-
-    Map<String, String> tableProperties = properties != null ? properties : Maps.newHashMap();
-
-    TableMetadata metadata;
-    if (ops.current() != null) {
-      String baseLocation = location != null ? location : ops.current().location();
-      metadata = ops.current().buildReplacement(schema, spec, baseLocation, tableProperties);
-    } else {
-      String baseLocation = location != null ? location : defaultWarehouseLocation(identifier);
-      metadata = TableMetadata.newTableMetadata(schema, spec, baseLocation, tableProperties);
-    }
+    TableBuilder tableBuilder = buildTable(identifier, schema)
+        .withPartitionSpec(spec)
+        .withLocation(location)
+        .withProperties(properties);
 
     if (orCreate) {
-      return Transactions.createOrReplaceTableTransaction(identifier.toString(), ops, metadata);
+      return tableBuilder.createOrReplaceTransaction();
     } else {
-      return Transactions.replaceTableTransaction(identifier.toString(), ops, metadata);
+      return tableBuilder.replaceTransaction();
     }
   }
 
@@ -155,6 +121,11 @@ public abstract class BaseMetastoreCatalog implements Catalog {
 
     LOG.info("Table loaded by catalog: {}", result);
     return result;
+  }
+
+  @Override
+  public TableBuilder buildTable(TableIdentifier identifier, Schema schema) {
+    return new BaseMetastoreCatalogTableBuilder(identifier, schema);
   }
 
   private Table loadMetadataTable(TableIdentifier identifier) {
@@ -217,6 +188,114 @@ public abstract class BaseMetastoreCatalog implements Catalog {
   protected abstract TableOperations newTableOps(TableIdentifier tableIdentifier);
 
   protected abstract String defaultWarehouseLocation(TableIdentifier tableIdentifier);
+
+  protected class BaseMetastoreCatalogTableBuilder implements TableBuilder {
+    private final TableIdentifier identifier;
+    private final Schema schema;
+    private final ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.builder();
+    private PartitionSpec spec = PartitionSpec.unpartitioned();
+    private String location = null;
+
+    public BaseMetastoreCatalogTableBuilder(TableIdentifier identifier, Schema schema) {
+      Preconditions.checkArgument(isValidIdentifier(identifier), "Invalid table identifier: %s", identifier);
+
+      this.identifier = identifier;
+      this.schema = schema;
+    }
+
+    @Override
+    public TableBuilder withPartitionSpec(PartitionSpec newSpec) {
+      if (spec != null) {
+        this.spec = newSpec;
+      }
+      return this;
+    }
+
+    @Override
+    public TableBuilder withLocation(String newLocation) {
+      this.location = newLocation;
+      return this;
+    }
+
+    @Override
+    public TableBuilder withProperties(Map<String, String> properties) {
+      if (properties != null) {
+        propertiesBuilder.putAll(properties);
+      }
+      return this;
+    }
+
+    @Override
+    public TableBuilder withProperty(String key, String value) {
+      propertiesBuilder.put(key, value);
+      return this;
+    }
+
+    @Override
+    public Table create() {
+      TableOperations ops = newTableOps(identifier);
+      if (ops.current() != null) {
+        throw new AlreadyExistsException("Table already exists: " + identifier);
+      }
+
+      String baseLocation = location != null ? location : defaultWarehouseLocation(identifier);
+      Map<String, String> properties = propertiesBuilder.build();
+      TableMetadata metadata = TableMetadata.newTableMetadata(schema, spec, baseLocation, properties);
+
+      try {
+        ops.commit(null, metadata);
+      } catch (CommitFailedException ignored) {
+        throw new AlreadyExistsException("Table was created concurrently: " + identifier);
+      }
+
+      return new BaseTable(ops, fullTableName(name(), identifier));
+    }
+
+    @Override
+    public Transaction createTransaction() {
+      TableOperations ops = newTableOps(identifier);
+      if (ops.current() != null) {
+        throw new AlreadyExistsException("Table already exists: " + identifier);
+      }
+
+      String baseLocation = location != null ? location : defaultWarehouseLocation(identifier);
+      Map<String, String> properties = propertiesBuilder.build();
+      TableMetadata metadata = TableMetadata.newTableMetadata(schema, spec, baseLocation, properties);
+      return Transactions.createTableTransaction(identifier.toString(), ops, metadata);
+    }
+
+    @Override
+    public Transaction replaceTransaction() {
+      return newReplaceTableTransaction(false);
+    }
+
+    @Override
+    public Transaction createOrReplaceTransaction() {
+      return newReplaceTableTransaction(true);
+    }
+
+    private Transaction newReplaceTableTransaction(boolean orCreate) {
+      TableOperations ops = newTableOps(identifier);
+      if (!orCreate && ops.current() == null) {
+        throw new NoSuchTableException("No such table: " + identifier);
+      }
+
+      TableMetadata metadata;
+      if (ops.current() != null) {
+        String baseLocation = location != null ? location : ops.current().location();
+        metadata = ops.current().buildReplacement(schema, spec, baseLocation, propertiesBuilder.build());
+      } else {
+        String baseLocation = location != null ? location : defaultWarehouseLocation(identifier);
+        metadata = TableMetadata.newTableMetadata(schema, spec, baseLocation, propertiesBuilder.build());
+      }
+
+      if (orCreate) {
+        return Transactions.createOrReplaceTableTransaction(identifier.toString(), ops, metadata);
+      } else {
+        return Transactions.replaceTableTransaction(identifier.toString(), ops, metadata);
+      }
+    }
+  }
 
   /**
    * Drops all data and metadata files referenced by TableMetadata.

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -33,9 +33,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 import org.apache.iceberg.BaseMetastoreCatalog;
-import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.catalog.Namespace;
@@ -155,13 +153,6 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
     }
 
     return Lists.newArrayList(tblIdents);
-  }
-
-  @Override
-  public Table createTable(
-      TableIdentifier identifier, Schema schema, PartitionSpec spec, String location, Map<String, String> properties) {
-    Preconditions.checkArgument(location == null, "Cannot set a custom location for a path-based table");
-    return super.createTable(identifier, schema, spec, null, properties);
   }
 
   @Override
@@ -332,5 +323,22 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
         .add("name", catalogName)
         .add("location", warehouseLocation)
         .toString();
+  }
+
+  @Override
+  public TableBuilder buildTable(TableIdentifier identifier, Schema schema) {
+    return new HadoopCatalogTableBuilder(identifier, schema);
+  }
+
+  private class HadoopCatalogTableBuilder extends BaseMetastoreCatalogTableBuilder {
+    private HadoopCatalogTableBuilder(TableIdentifier identifier, Schema schema) {
+      super(identifier, schema);
+    }
+
+    @Override
+    public TableBuilder withLocation(String location) {
+      Preconditions.checkArgument(location == null, "Cannot set a custom location for a path-based table");
+      return this;
+    }
   }
 }


### PR DESCRIPTION
This PR introduces a builder in `Catalog` to avoid duplicating the number of methods each time we introduce a new param.