### PR TITLE
WIP - Add an api for Parallelizing Manifest Reading in ManifestGroup

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ManifestEntry.java
+++ b/api/src/main/java/org/apache/iceberg/ManifestEntry.java
@@ -1,20 +1,15 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.iceberg;
@@ -25,7 +20,7 @@ import org.apache.iceberg.types.Types.StructType;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
-interface ManifestEntry<F extends ContentFile<F>> {
+public interface ManifestEntry<F extends ContentFile<F>> {
   enum Status {
     EXISTING(0),
     ADDED(1),

--- a/api/src/main/java/org/apache/iceberg/ManifestProcessor.java
+++ b/api/src/main/java/org/apache/iceberg/ManifestProcessor.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.io.Serializable;
+import java.util.function.BiFunction;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
+
+public abstract class ManifestProcessor implements Serializable {
+    public abstract <T extends ContentFile<T>> Iterable<CloseableIterable<ManifestEntry<T>>> readManifests(final Iterable<ManifestFile> fromIterable,
+        BiFunction<ManifestFile, FileIO, CloseableIterable<ManifestEntry<T>>> reader);
+
+    /**
+     * A Helper interface for making lambdas transform into the correct type for the ManfiestProcessor
+     * @param <T> The ManifestEntry Type being read from Manifest files
+     */
+    public interface Func<T extends ContentFile<T>> extends BiFunction<ManifestFile, FileIO,
+        CloseableIterable<ManifestEntry<T>>>, Serializable {}
+
+}

--- a/api/src/main/java/org/apache/iceberg/TableScan.java
+++ b/api/src/main/java/org/apache/iceberg/TableScan.java
@@ -95,6 +95,11 @@ public interface TableScan {
   TableScan includeColumnStats();
 
   /**
+   * Doc doc doc
+   */
+  TableScan withManifestProcessor(ManifestProcessor processor);
+
+  /**
    * Create a new {@link TableScan} from this that will read the given data columns. This produces
    * an expected schema that includes all fields that are either selected or used by this scan's
    * filter expression.

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -54,6 +54,7 @@ abstract class BaseTableScan implements TableScan {
   private final Table table;
   private final Schema schema;
   private final TableScanContext context;
+  protected ManifestProcessor manifestProcessor;
 
   protected BaseTableScan(TableOperations ops, Table table, Schema schema) {
     this(ops, table, schema, new TableScanContext());
@@ -64,6 +65,7 @@ abstract class BaseTableScan implements TableScan {
     this.table = table;
     this.schema = schema;
     this.context = context;
+    this.manifestProcessor = new LocalManifestProcessor(table.io());
   }
 
   protected TableOperations tableOps() {
@@ -130,6 +132,9 @@ abstract class BaseTableScan implements TableScan {
     return newRefinedScan(
         ops, table, schema, context.useSnapshotId(scanSnapshotId));
   }
+
+
+
 
   @Override
   public TableScan asOfTime(long timestampMillis) {
@@ -273,6 +278,12 @@ abstract class BaseTableScan implements TableScan {
         .add("ignoreResiduals", context.ignoreResiduals())
         .add("caseSensitive", context.caseSensitive())
         .toString();
+  }
+
+  @Override
+  public TableScan withManifestProcessor(ManifestProcessor processor) {
+    this.manifestProcessor = processor;
+    return this;
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -86,7 +86,7 @@ public class DataTableScan extends BaseTableScan {
       manifestGroup = manifestGroup.planWith(ThreadPools.getWorkerPool());
     }
 
-    return manifestGroup.planFiles();
+    return manifestGroup.withProcessor(this.manifestProcessor).planFiles();
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
+++ b/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg;
 
+import java.io.Serializable;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.specific.SpecificData;
 import org.apache.iceberg.avro.AvroSchemaUtil;
@@ -26,7 +27,7 @@ import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.types.Types;
 
 class GenericManifestEntry<F extends ContentFile<F>>
-    implements ManifestEntry<F>, IndexedRecord, SpecificData.SchemaConstructable, StructLike {
+    implements ManifestEntry<F>, IndexedRecord, SpecificData.SchemaConstructable, StructLike, Serializable {
   private final org.apache.avro.Schema schema;
   private Status status = Status.EXISTING;
   private Long snapshotId = null;

--- a/core/src/main/java/org/apache/iceberg/LocalManifestProcessor.java
+++ b/core/src/main/java/org/apache/iceberg/LocalManifestProcessor.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.function.BiFunction;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
+
+public class LocalManifestProcessor extends ManifestProcessor {
+    private final FileIO io;
+
+    public LocalManifestProcessor(FileIO io){
+        this.io = io;
+    }
+
+    @Override
+    public <T extends ContentFile<T>> Iterable<CloseableIterable<ManifestEntry<T>>> readManifests(
+        Iterable<ManifestFile> fromIterable,
+        BiFunction<ManifestFile, FileIO, CloseableIterable<ManifestEntry<T>>> reader) {
+        return CloseableIterable.transform(
+            CloseableIterable.withNoopClose(fromIterable), manifestFile -> reader.apply(manifestFile, io));
+    }
+}

--- a/core/src/main/java/org/apache/iceberg/util/SerializablePredicate.java
+++ b/core/src/main/java/org/apache/iceberg/util/SerializablePredicate.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.function.Predicate;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+public interface SerializablePredicate<T> extends Predicate<T>, Serializable {
+
+  @Override
+  default SerializablePredicate<T> and(Predicate<? super T> other) {
+    Objects.requireNonNull(other);
+    Preconditions.checkArgument(other instanceof SerializablePredicate);
+    return (T x) -> this.test(x) && other.test(x);
+  }
+}

--- a/spark/src/main/java/org/apache/iceberg/spark/DistributedManifestProcessor.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/DistributedManifestProcessor.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.spark;
+
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+import org.apache.iceberg.ContentFile;
+import org.apache.iceberg.ManifestEntry;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestProcessor;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.broadcast.Broadcast;
+import org.apache.spark.sql.SparkSession;
+
+public class DistributedManifestProcessor extends ManifestProcessor {
+    transient private final SparkSession spark;
+    private final Broadcast<FileIO> ioBroadcast;
+
+    public DistributedManifestProcessor(SparkSession spark, FileIO io) {
+        this.spark = spark;
+        this.ioBroadcast = JavaSparkContext.fromSparkContext(spark.sparkContext()).broadcast(io);
+    }
+
+  @Override
+  public <T extends ContentFile<T>> Iterable<CloseableIterable<ManifestEntry<T>>> readManifests(
+      Iterable<ManifestFile> fromIterable,
+      BiFunction<ManifestFile, FileIO, CloseableIterable<ManifestEntry<T>>> reader) {
+      List<Iterable<ManifestEntry<T>>> results =
+          JavaSparkContext.fromSparkContext(spark.sparkContext())
+              .parallelize(Lists.newArrayList(fromIterable))
+              .map(file -> {
+                CloseableIterable<ManifestEntry<T>> closeable = reader.apply(file, ioBroadcast.getValue());
+                Iterable<ManifestEntry<T>> realizedEntries = Lists.newArrayList(CloseableIterable.transform(closeable,
+                    ManifestEntry::copy));
+                closeable.close();
+                return realizedEntries;
+              }).collect();
+    return results.stream().map(list -> CloseableIterable.withNoopClose(list)).collect(Collectors.toList());
+  }
+}


### PR DESCRIPTION
This is one of two WIP PR's to demonstrate some approaches to parallelizing the job planning phase of Spark Reads.

The other is located at https://github.com/apache/iceberg/pull/1421

To add distribtued manifest reading to table scans, we allow for a ManifestProcessor
to be used in a TableScan. This class is utilzied when ManifestGroup processes
Manifest files. The default implementation mimics the current code by just wrapping
the reading code in a CloseableIterable. A distributed Spark implementation is also
provided which reads all of the manifests remotely before returning valid entries
for further processing.