### PR TITLE
Add a Parallelized Spark Job Planning Path

### DIFF
--- a/api/src/main/java/org/apache/iceberg/DataFile.java
+++ b/api/src/main/java/org/apache/iceberg/DataFile.java
@@ -80,7 +80,8 @@ public interface DataFile extends ContentFile<DataFile> {
         UPPER_BOUNDS,
         KEY_METADATA,
         SPLIT_OFFSETS,
-        EQUALITY_IDS
+        EQUALITY_IDS,
+        ManifestFile.SPEC_ID.asOptional()
     );
   }
 

--- a/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.expressions;
 
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.Comparator;
@@ -45,7 +46,7 @@ import static org.apache.iceberg.expressions.Expressions.rewriteNot;
  * rows and false if the file cannot contain matching rows. Files may be skipped if and only if the
  * return value of {@code eval} is false.
  */
-public class InclusiveMetricsEvaluator {
+public class InclusiveMetricsEvaluator implements Serializable {
   private final Expression expr;
 
   public InclusiveMetricsEvaluator(Schema schema, Expression unbound) {

--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -100,6 +100,10 @@ abstract class BaseFile<F>
           found = true;
           fromProjectionPos[i] = j;
         }
+        if (fields.get(i).fieldId() == ManifestFile.SPEC_ID.fieldId()) {
+          found = true;
+          fromProjectionPos[i] = 14;
+        }
       }
 
       if (!found) {
@@ -255,6 +259,9 @@ abstract class BaseFile<F>
       case 13:
         this.equalityIds = ArrayUtil.toIntArray((List<Integer>) value);
         return;
+      case 14:
+        this.partitionSpecId = (value != null) ? (Integer) value : -1;
+        return;
       default:
         // ignore the object, it must be from a newer version of the format
     }
@@ -301,6 +308,8 @@ abstract class BaseFile<F>
         return splitOffsets();
       case 13:
         return equalityFieldIds();
+      case 14:
+        return partitionSpecId;
       default:
         throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
     }

--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -94,4 +94,9 @@ public class DataTableScan extends BaseTableScan {
     return ops.current().propertyAsLong(
         TableProperties.SPLIT_SIZE, TableProperties.SPLIT_SIZE_DEFAULT);
   }
+
+  @Override
+  public TableScanContext tableScanContext() {
+    return super.tableScanContext();
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -63,7 +63,7 @@ import org.apache.iceberg.util.Tasks;
  * {@link #forEntry(ManifestEntry)} to get the the delete files to apply to a given data file.
  */
 public class DeleteFileIndex {
-  private final static DeleteFile[] EMPTY_DELETES = new DeleteFile[0];
+  private static final DeleteFile[] EMPTY_DELETES = new DeleteFile[0];
   private final Map<Integer, PartitionSpec> specsById;
   private final Map<Integer, Types.StructType> partitionTypeById;
   private final Map<Integer, ThreadLocal<StructLikeWrapper>> wrapperById;

--- a/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
@@ -102,8 +102,8 @@ public class ManifestEntriesTable extends BaseMetadataTable {
     protected CloseableIterable<FileScanTask> planFiles(
         TableOperations ops, Snapshot snapshot, Expression rowFilter,
         boolean ignoreResiduals, boolean caseSensitive, boolean colStats) {
-      // return entries from both data and delete manifests
-      CloseableIterable<ManifestFile> manifests = CloseableIterable.withNoopClose(snapshot.allManifests());
+      // Only return Data Manifests, TODO Handle Delete Manifests
+      CloseableIterable<ManifestFile> manifests = CloseableIterable.withNoopClose(snapshot.dataManifests());
       Type fileProjection = schema().findType("data_file");
       Schema fileSchema = fileProjection != null ? new Schema(fileProjection.asStructType().fields()) : new Schema();
       String schemaString = SchemaParser.toJson(schema());

--- a/core/src/main/java/org/apache/iceberg/ScanTasks.java
+++ b/core/src/main/java/org/apache/iceberg/ScanTasks.java
@@ -17,12 +17,20 @@
  * under the License.
  */
 
-package org.apache.iceberg.spark.source;
+package org.apache.iceberg;
 
-import org.apache.iceberg.actions.PlanScanAction;
+import org.apache.iceberg.expressions.ResidualEvaluator;
 
-public class TestSnapshotSelection24 extends TestSnapshotSelection {
-  public TestSnapshotSelection24(PlanScanAction.PlanMode distributedPlanning) {
-    super(distributedPlanning);
+public class ScanTasks {
+
+  /**
+   * Utilty class no public constructor
+   */
+  private ScanTasks() {
+  }
+
+  public static BaseFileScanTask createBaseFileScanTask(DataFile file, DeleteFile[] deletes, String schemaString,
+                                                        String specString, ResidualEvaluator residuals) {
+    return new BaseFileScanTask(file, deletes, schemaString, specString, residuals);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/TableScanContext.java
+++ b/core/src/main/java/org/apache/iceberg/TableScanContext.java
@@ -29,7 +29,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 /**
  * Context object with optional arguments for a TableScan.
  */
-final class TableScanContext {
+public final class TableScanContext {
   private final Long snapshotId;
   private final Expression rowFilter;
   private final boolean ignoreResiduals;
@@ -41,7 +41,7 @@ final class TableScanContext {
   private final Long fromSnapshotId;
   private final Long toSnapshotId;
 
-  TableScanContext() {
+  public TableScanContext() {
     this.snapshotId = null;
     this.rowFilter = Expressions.alwaysTrue();
     this.ignoreResiduals = false;
@@ -70,7 +70,7 @@ final class TableScanContext {
     this.toSnapshotId = toSnapshotId;
   }
 
-  Long snapshotId() {
+  public Long snapshotId() {
     return snapshotId;
   }
 
@@ -79,7 +79,7 @@ final class TableScanContext {
         caseSensitive, colStats, projectedSchema, selectedColumns, options, fromSnapshotId, toSnapshotId);
   }
 
-  Expression rowFilter() {
+  public Expression rowFilter() {
     return rowFilter;
   }
 
@@ -88,7 +88,7 @@ final class TableScanContext {
         caseSensitive, colStats, projectedSchema, selectedColumns, options, fromSnapshotId, toSnapshotId);
   }
 
-  boolean ignoreResiduals() {
+  public boolean ignoreResiduals() {
     return ignoreResiduals;
   }
 
@@ -97,7 +97,7 @@ final class TableScanContext {
         caseSensitive, colStats, projectedSchema, selectedColumns, options, fromSnapshotId, toSnapshotId);
   }
 
-  boolean caseSensitive() {
+  public boolean caseSensitive() {
     return caseSensitive;
   }
 
@@ -106,7 +106,7 @@ final class TableScanContext {
         isCaseSensitive, colStats, projectedSchema, selectedColumns, options, fromSnapshotId, toSnapshotId);
   }
 
-  boolean returnColumnStats() {
+  public boolean returnColumnStats() {
     return colStats;
   }
 
@@ -115,7 +115,7 @@ final class TableScanContext {
         caseSensitive, returnColumnStats, projectedSchema, selectedColumns, options, fromSnapshotId, toSnapshotId);
   }
 
-  Collection<String> selectedColumns() {
+  public Collection<String> selectedColumns() {
     return selectedColumns;
   }
 
@@ -125,7 +125,7 @@ final class TableScanContext {
         caseSensitive, colStats, null, columns, options, fromSnapshotId, toSnapshotId);
   }
 
-  Schema projectedSchema() {
+  public Schema projectedSchema() {
     return projectedSchema;
   }
 
@@ -135,7 +135,7 @@ final class TableScanContext {
         caseSensitive, colStats, schema, null, options, fromSnapshotId, toSnapshotId);
   }
 
-  Map<String, String> options() {
+  public Map<String, String> options() {
     return options;
   }
 
@@ -147,7 +147,7 @@ final class TableScanContext {
         caseSensitive, colStats, projectedSchema, selectedColumns, builder.build(), fromSnapshotId, toSnapshotId);
   }
 
-  Long fromSnapshotId() {
+  public Long fromSnapshotId() {
     return fromSnapshotId;
   }
 
@@ -156,7 +156,7 @@ final class TableScanContext {
         caseSensitive, colStats, projectedSchema, selectedColumns, options, id, toSnapshotId);
   }
 
-  Long toSnapshotId() {
+  public Long toSnapshotId() {
     return toSnapshotId;
   }
 

--- a/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
@@ -20,13 +20,18 @@
 package org.apache.iceberg.util;
 
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataOperations;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableScanContext;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 
 public class SnapshotUtil {
   private SnapshotUtil() {
@@ -106,5 +111,71 @@ public class SnapshotUtil {
     }
 
     return newFiles;
+  }
+
+  public static List<Snapshot> snapshotsWithin(Table table, long fromSnapshotId, long toSnapshotId) {
+    List<Long> snapshotIds = SnapshotUtil.snapshotIdsBetween(table, fromSnapshotId, toSnapshotId);
+    List<Snapshot> snapshots = Lists.newArrayList();
+    for (Long snapshotId : snapshotIds) {
+      Snapshot snapshot = table.snapshot(snapshotId);
+      // for now, incremental scan supports only appends
+      if (snapshot.operation().equals(DataOperations.APPEND)) {
+        snapshots.add(snapshot);
+      } else if (snapshot.operation().equals(DataOperations.OVERWRITE)) {
+        throw new UnsupportedOperationException(
+            String.format("Found %s operation, cannot support incremental data in snapshots (%s, %s]",
+                DataOperations.OVERWRITE, fromSnapshotId, toSnapshotId));
+      }
+    }
+    return snapshots;
+  }
+
+  /**
+   * Checks whether or not the bounds presented in the form of snapshotIds both reside within the table in question
+   * and that there exists a valid set of snapshots between them. Uses the passed in scan context to verify that this
+   * range also resides within any previously defined snapshot range in the scan. Throws exceptions if the arguments
+   * passed cannot be used to generate a legitimate snapshot range within the previously defined range.
+   * ＜p>
+   * Used for validating incremental scan parameters
+   *
+   * @param newFromSnapshotId beginning of snapshot range
+   * @param newToSnapshotId   end of snapshot range
+   * @param table             containing the snapshots we are building a range for
+   * @param context           containing current scan restrictions
+   */
+  public static void validateSnapshotIdsRefinement(long newFromSnapshotId, long newToSnapshotId, Table table,
+                                                   TableScanContext context) {
+    Set<Long> snapshotIdsRange = Sets.newHashSet(
+        SnapshotUtil.snapshotIdsBetween(table, context.fromSnapshotId(), context.toSnapshotId()));
+    // since snapshotIdsBetween return ids in range (fromSnapshotId, toSnapshotId]
+    snapshotIdsRange.add(context.fromSnapshotId());
+    Preconditions.checkArgument(
+        snapshotIdsRange.contains(newFromSnapshotId),
+        "from snapshot id %s not in existing snapshot ids range (%s, %s]",
+        newFromSnapshotId, context.fromSnapshotId(), newToSnapshotId);
+    Preconditions.checkArgument(
+        snapshotIdsRange.contains(newToSnapshotId),
+        "to snapshot id %s not in existing snapshot ids range (%s, %s]",
+        newToSnapshotId, context.fromSnapshotId(), context.toSnapshotId());
+  }
+
+  /**
+   * Validates whether two snapshots represent the beginning and end of a continuous range of snapshots in a given
+   * table. Throws exceptions if this is not the case.
+   * ＜p>
+   * Used for validating incremental scan parameters
+   *
+   * @param table          containing snapshots
+   * @param fromSnapshotId beginning of snapshot range
+   * @param toSnapshotId   end of snapshot range
+   */
+  public static void validateSnapshotIds(Table table, long fromSnapshotId, long toSnapshotId) {
+    Preconditions.checkArgument(fromSnapshotId != toSnapshotId, "from and to snapshot ids cannot be the same");
+    Preconditions.checkArgument(
+        table.snapshot(fromSnapshotId) != null, "from snapshot %s does not exist", fromSnapshotId);
+    Preconditions.checkArgument(
+        table.snapshot(toSnapshotId) != null, "to snapshot %s does not exist", toSnapshotId);
+    Preconditions.checkArgument(SnapshotUtil.ancestorOf(table, toSnapshotId, fromSnapshotId),
+        "from snapshot %s is not an ancestor of to snapshot  %s", fromSnapshotId, toSnapshotId);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/util/TableScanUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/TableScanUtil.java
@@ -19,6 +19,10 @@
 
 package org.apache.iceberg.util;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.function.Function;
 import org.apache.iceberg.BaseCombinedScanTask;
 import org.apache.iceberg.CombinedScanTask;
@@ -56,5 +60,11 @@ public class TableScanUtil {
             new BinPacking.PackingIterable<>(splitFiles, splitSize, lookback, weightFunc, true),
             splitFiles),
         BaseCombinedScanTask::new);
+  }
+
+  private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
+
+  public static String formatTimestampMillis(long millis) {
+    return DATE_FORMAT.format(LocalDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneId.systemDefault()));
   }
 }

--- a/spark/src/main/java/org/apache/iceberg/actions/Actions.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/Actions.java
@@ -77,6 +77,10 @@ public class Actions {
     return new ExpireSnapshotsAction(spark, table);
   }
 
+  public PlanScanAction planScan() {
+    return new PlanScanAction(spark, table);
+  }
+
   protected SparkSession spark() {
     return spark;
   }

--- a/spark/src/main/java/org/apache/iceberg/actions/PlanScanAction.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/PlanScanAction.java
@@ -1,0 +1,288 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.actions;
+
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.DeleteFileIndex;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.PartitionSpecParser;
+import org.apache.iceberg.ScanTasks;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.TableScanContext;
+import org.apache.iceberg.expressions.Evaluator;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.InclusiveMetricsEvaluator;
+import org.apache.iceberg.expressions.Projections;
+import org.apache.iceberg.expressions.ResidualEvaluator;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Streams;
+import org.apache.iceberg.spark.SparkDataFile;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.SnapshotUtil;
+import org.apache.iceberg.util.TableScanUtil;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.MapPartitionsFunction;
+import org.apache.spark.broadcast.Broadcast;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.encoders.RowEncoder;
+import org.apache.spark.sql.types.StructType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PlanScanAction extends BaseAction<CloseableIterable<CombinedScanTask>> {
+  private static final Logger LOG = LoggerFactory.getLogger(PlanScanAction.class);
+
+
+  public enum PlanMode {
+    LOCAL,
+    DISTRIBUTED
+  }
+
+  public static final String ICEBERG_PLAN_MODE = "iceberg.plan_mode";
+
+  public static final PlanMode parsePlanMode(String mode) {
+    try {
+      return PlanMode.valueOf(mode.toUpperCase(Locale.ROOT));
+    } catch (IllegalArgumentException ex) {
+      throw new IllegalArgumentException(String.format("Cannot use planning mode %s, Available modes are: %s", mode,
+          Arrays.toString(PlanMode.values())));
+    }
+  }
+
+  private final Table table;
+  private final SparkSession spark;
+  private final JavaSparkContext sparkContext;
+  private final TableOperations ops;
+  private final Schema schema;
+
+  private TableScanContext context;
+
+  public PlanScanAction(SparkSession spark, Table table) {
+    this.table = table;
+    this.spark = spark;
+    this.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
+    this.schema = table.schema();
+    this.ops = ((HasTableOperations) table).operations();
+    this.context = new TableScanContext();
+  }
+
+  public PlanScanAction withContext(TableScanContext newContext) {
+    this.context = newContext;
+    return this;
+  }
+
+  @Override
+  protected Table table() {
+    return table;
+  }
+
+  @Override
+  public CloseableIterable<CombinedScanTask> execute() {
+    LOG.info("Preparing distributed planning of scan for {} snapshot {} created at {} with filter {}",
+        table, snapshot().snapshotId(), TableScanUtil.formatTimestampMillis(snapshot().timestampMillis()),
+        context.rowFilter());
+    long start = System.currentTimeMillis();
+    CloseableIterable<CombinedScanTask> result = planTasks();
+    long elapsed = System.currentTimeMillis() - start;
+    LOG.info("Planning complete. Took {} ms", elapsed);
+    return result;
+  }
+
+  protected CloseableIterable<CombinedScanTask> planTasks() {
+    Map<String, String> options = context.options();
+    long splitSize;
+    if (options.containsKey(TableProperties.SPLIT_SIZE)) {
+      splitSize = Long.parseLong(options.get(TableProperties.SPLIT_SIZE));
+    } else {
+      splitSize = ops.current().propertyAsLong(TableProperties.SPLIT_SIZE, TableProperties.SPLIT_SIZE_DEFAULT);
+    }
+    int lookback;
+    if (options.containsKey(TableProperties.SPLIT_LOOKBACK)) {
+      lookback = Integer.parseInt(options.get(TableProperties.SPLIT_LOOKBACK));
+    } else {
+      lookback = ops.current().propertyAsInt(
+          TableProperties.SPLIT_LOOKBACK, TableProperties.SPLIT_LOOKBACK_DEFAULT);
+    }
+    long openFileCost;
+    if (options.containsKey(TableProperties.SPLIT_OPEN_FILE_COST)) {
+      openFileCost = Long.parseLong(options.get(TableProperties.SPLIT_OPEN_FILE_COST));
+    } else {
+      openFileCost = ops.current().propertyAsLong(
+          TableProperties.SPLIT_OPEN_FILE_COST, TableProperties.SPLIT_OPEN_FILE_COST_DEFAULT);
+    }
+
+    CloseableIterable<FileScanTask> fileScanTasks = planFiles();
+    CloseableIterable<FileScanTask> splitFiles = TableScanUtil.splitFiles(fileScanTasks, splitSize);
+    return TableScanUtil.planTasks(splitFiles, splitSize, lookback, openFileCost);
+  }
+
+  private Snapshot snapshot() {
+    return context.snapshotId() != null ?
+        ops.current().snapshot(context.snapshotId()) :
+        ops.current().currentSnapshot();
+  }
+
+  public CloseableIterable<FileScanTask> planFiles() {
+    // Create a dataframe of all DataFile entries
+    String dataFilesMetadataTable = metadataTableName(MetadataTableType.ENTRIES);
+    Dataset<Row> manifestEntries =
+        spark.read()
+            .format("iceberg")
+            .option("snapshot-id", snapshot().snapshotId())
+            .load(dataFilesMetadataTable);
+
+    // Todo pushdown filters to ManifestEntriesTable
+    // Read entries which are not deleted and are datafiles and not delete files
+    Dataset<Row> dataFileEntries = manifestEntries
+        .filter(manifestEntries.col("data_file").getField(DataFile.CONTENT.name()).equalTo(0)) // Only DataFiles
+        .filter(manifestEntries.col("status").notEqual(2)); // No Deleted Files
+
+    dataFileEntries = handleIncrementalScan(dataFileEntries);
+
+    // Build up evaluators and filters for Metrics and Partition values
+    Expression scanFilter = context.rowFilter();
+    boolean isCaseSensitive = context.caseSensitive();
+
+    // Build cache of partition evaluators
+    Broadcast<Map<Integer, Evaluator>> broadcastPartitionEvaluators = buildPartitionEvaluators();
+
+    // Build metric evaluators
+    Broadcast<InclusiveMetricsEvaluator> broadcastMetricsEvaluator = sparkContext.broadcast(
+        new InclusiveMetricsEvaluator(schema, scanFilter, isCaseSensitive));
+
+    // Cache residual information and Partition spec information
+    Types.StructType partitionStruct = DataFile.getType(table().spec().partitionType());
+    StructType dataFileSchema = (StructType) dataFileEntries.schema().apply("data_file").dataType();
+
+    // Evaluate all files based on their partition info and collect the rows back locally
+    Dataset<Row> scanTaskDataset = dataFileEntries
+        .select(dataFileEntries.col("data_file.*"))
+        .mapPartitions(
+            (MapPartitionsFunction<Row, Row>) it -> {
+              SparkDataFile container = new SparkDataFile(partitionStruct, dataFileSchema);
+              return Streams.stream(it)
+                  .filter(row -> {
+                    SparkDataFile file = container.wrap(row);
+                    return broadcastPartitionEvaluators.getValue().get(file.specId()).eval(file.partition()) &&
+                        broadcastMetricsEvaluator.getValue().eval(file);
+                  }).iterator();
+            }, RowEncoder.apply(dataFileEntries.schema()));
+
+    LoadingCache<Integer, SpecCacheEntry> specCache = buildSpecCache();
+
+    // Build delete index locally
+    DeleteFileIndex deleteFileIndex = buildDeleteFileIndex();
+
+    SparkDataFile container = new SparkDataFile(partitionStruct, dataFileSchema);
+    List<FileScanTask> tasks = scanTaskDataset.collectAsList().stream().map(row -> {
+      Row dataFile = row.getAs("data_file");
+      SparkDataFile file = container.wrap(dataFile);
+      DeleteFile[] deletes =
+          deleteFileIndex.forDataFile(row.getAs("sequence_number"), file);
+      SpecCacheEntry cached = specCache.get(file.specId());
+      return (FileScanTask) ScanTasks
+          .createBaseFileScanTask(file.copy(), deletes, cached.schemaString, cached.specString, cached.residuals);
+    }).collect(Collectors.toList());
+
+    return CloseableIterable.withNoopClose(tasks);
+  }
+
+  private Dataset<Row> handleIncrementalScan(Dataset<Row> dataFileEntries) {
+    if (context.fromSnapshotId() != null) {
+      LOG.debug("Planning incremental scan from {} to {}", context.fromSnapshotId(), context.toSnapshotId());
+      List<Snapshot> snapshots = SnapshotUtil.snapshotsWithin(table, context.fromSnapshotId(), context.toSnapshotId());
+      List<Long> validSnapshotIds = snapshots.stream().map(Snapshot::snapshotId).collect(Collectors.toList());
+      return dataFileEntries
+          .filter(dataFileEntries.col("snapshot_id").isin(validSnapshotIds.toArray()))
+          .filter(dataFileEntries.col("status").equalTo(1)); // Added files only
+    } else {
+      return dataFileEntries;
+    }
+  }
+
+  private LoadingCache<Integer, SpecCacheEntry> buildSpecCache() {
+    return Caffeine.newBuilder().build((CacheLoader<Integer, SpecCacheEntry> & Serializable) specId -> {
+      PartitionSpec spec = table().specs().get(specId);
+      Expression filter = context.ignoreResiduals() ? Expressions.alwaysTrue() : context.rowFilter();
+      return new SpecCacheEntry(SchemaParser.toJson(spec.schema()), PartitionSpecParser.toJson(spec),
+          ResidualEvaluator.of(spec, filter, context.caseSensitive()));
+    });
+  }
+
+  private Broadcast<Map<Integer, Evaluator>> buildPartitionEvaluators() {
+    ImmutableMap.Builder<Integer, Evaluator> evalMapBuilder = ImmutableMap.builder();
+    boolean caseSensitive = context.caseSensitive();
+    Expression filter = context.rowFilter();
+    table.specs().entrySet().forEach(entry ->
+        evalMapBuilder.put(entry.getKey(),
+            new Evaluator(entry.getValue().partitionType(),
+                Projections.inclusive(entry.getValue(), caseSensitive).project(filter))));
+
+    Map<Integer, Evaluator> partitionEvaluatorsById = evalMapBuilder.build();
+    return  sparkContext.broadcast(partitionEvaluatorsById);
+  }
+
+
+  private DeleteFileIndex buildDeleteFileIndex() {
+    // Build delete index locally
+    List<ManifestFile> deleteManifests = snapshot().deleteManifests();
+    DeleteFileIndex.Builder deleteFileIndexBuilder = DeleteFileIndex.builderFor(table.io(), deleteManifests);
+    deleteFileIndexBuilder.caseSensitive(context.caseSensitive());
+    deleteFileIndexBuilder.specsById(table.specs());
+    deleteFileIndexBuilder.filterData(context.rowFilter());
+    return deleteFileIndexBuilder.build();
+  }
+
+  private static class SpecCacheEntry implements Serializable {
+    private final String schemaString;
+    private final String specString;
+    private final ResidualEvaluator residuals;
+
+    SpecCacheEntry(String schemaString, String specString, ResidualEvaluator residuals) {
+      this.schemaString = schemaString;
+      this.specString = specString;
+      this.residuals = residuals;
+    }
+  }
+}

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkStructLike.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkStructLike.java
@@ -19,11 +19,12 @@
 
 package org.apache.iceberg.spark;
 
+import java.io.Serializable;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Row;
 
-public class SparkStructLike implements StructLike {
+public class SparkStructLike implements StructLike, Serializable {
 
   private final Types.StructType type;
   private Row wrapped;

--- a/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.iceberg.actions.PlanScanAction;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.hive.HiveCatalog;
@@ -57,6 +58,7 @@ public class SparkTestBase {
         .master("local[2]")
         .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
         .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
+        .config(PlanScanAction.ICEBERG_TEST_PLAN_MODE, "true")
         .enableHiveSupport()
         .getOrCreate();
 

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -79,7 +79,10 @@ public abstract class TestDataSourceOptions {
 
   @BeforeClass
   public static void startSpark() {
-    TestDataSourceOptions.spark = SparkSession.builder().master("local[2]").getOrCreate();
+    TestDataSourceOptions.spark = SparkSession
+        .builder()
+        .config(PlanScanAction.ICEBERG_TEST_PLAN_MODE, "true")
+        .master("local[2]").getOrCreate();
   }
 
   @AfterClass

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHadoopTables.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHadoopTables.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.actions.PlanScanAction;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.junit.Before;
@@ -34,6 +35,10 @@ public abstract class TestIcebergSourceHadoopTables extends TestIcebergSourceTab
 
   File tableDir = null;
   String tableLocation = null;
+
+  public TestIcebergSourceHadoopTables(PlanScanAction.PlanMode planMode) {
+    super(planMode);
+  }
 
   @Before
   public void setupTable() throws Exception {

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.actions.PlanScanAction;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.junit.After;
@@ -33,6 +34,10 @@ import org.junit.BeforeClass;
 public abstract class TestIcebergSourceHiveTables extends TestIcebergSourceTablesBase {
 
   private static TableIdentifier currentIdentifier;
+
+  public TestIcebergSourceHiveTables(PlanScanAction.PlanMode planMode) {
+    super(planMode);
+  }
 
   @BeforeClass
   public static void start() {

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
@@ -114,6 +114,7 @@ public abstract class TestPartitionPruning {
     String optionKey = String.format("fs.%s.impl", CountOpenLocalFileSystem.scheme);
     CONF.set(optionKey, CountOpenLocalFileSystem.class.getName());
     spark.conf().set(optionKey, CountOpenLocalFileSystem.class.getName());
+    spark.conf().set(PlanScanAction.ICEBERG_TEST_PLAN_MODE, "true");
     spark.conf().set("spark.sql.session.timeZone", "UTC");
     spark.udf().register("bucket3", (Integer num) -> bucketTransform.apply(num), DataTypes.IntegerType);
     spark.udf().register("truncate5", (String str) -> truncateTransform.apply(str), DataTypes.StringType);

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection.java
@@ -76,7 +76,10 @@ public abstract class TestSnapshotSelection {
 
   @BeforeClass
   public static void startSpark() {
-    TestSnapshotSelection.spark = SparkSession.builder().master("local[2]").getOrCreate();
+    TestSnapshotSelection.spark = SparkSession
+        .builder()
+        .config(PlanScanAction.ICEBERG_TEST_PLAN_MODE, "true")
+        .master("local[2]").getOrCreate();
   }
 
   @AfterClass

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -76,6 +76,7 @@ public abstract class TestSparkReaderDeletes extends DeleteReadTests {
 
     spark = SparkSession.builder()
         .master("local[2]")
+        .config(PlanScanAction.ICEBERG_TEST_PLAN_MODE, "true")
         .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
         .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
         .enableHiveSupport()

--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
@@ -411,6 +411,9 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
     try {
       result = Lists.newArrayList(Actions.forTable(table).planScan().withContext(scan.tableScanContext()).execute());
     } catch (Exception e) {
+      if (SparkSession.active().conf().get(PlanScanAction.ICEBERG_TEST_PLAN_MODE).equals("true")) {
+        throw e;
+      }
       LOG.error("Cannot run distributed job planning, falling back to local planning.", e);
       result = planLocalScan(scan);
     }

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions24.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions24.java
@@ -19,5 +19,10 @@
 
 package org.apache.iceberg.spark.source;
 
+import org.apache.iceberg.actions.PlanScanAction;
+
 public class TestDataSourceOptions24 extends TestDataSourceOptions {
+  public TestDataSourceOptions24(PlanScanAction.PlanMode distributedPlanning) {
+    super(distributedPlanning);
+  }
 }

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHadoopTables24.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHadoopTables24.java
@@ -19,5 +19,10 @@
 
 package org.apache.iceberg.spark.source;
 
+import org.apache.iceberg.actions.PlanScanAction;
+
 public class TestIcebergSourceHadoopTables24 extends TestIcebergSourceHadoopTables {
+  public TestIcebergSourceHadoopTables24(PlanScanAction.PlanMode distributedPlanning) {
+    super(distributedPlanning);
+  }
 }

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables24.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables24.java
@@ -19,5 +19,10 @@
 
 package org.apache.iceberg.spark.source;
 
+import org.apache.iceberg.actions.PlanScanAction;
+
 public class TestIcebergSourceHiveTables24 extends TestIcebergSourceHiveTables {
+  public TestIcebergSourceHiveTables24(PlanScanAction.PlanMode distributedPlanning) {
+    super(distributedPlanning);
+  }
 }

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning24.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning24.java
@@ -19,8 +19,10 @@
 
 package org.apache.iceberg.spark.source;
 
+import org.apache.iceberg.actions.PlanScanAction;
+
 public class TestPartitionPruning24 extends TestPartitionPruning {
-  public TestPartitionPruning24(String format, boolean vectorized) {
-    super(format, vectorized);
+  public TestPartitionPruning24(String format, boolean vectorized, PlanScanAction.PlanMode distributedPlanning) {
+    super(format, vectorized, distributedPlanning);
   }
 }

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes24.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes24.java
@@ -19,5 +19,10 @@
 
 package org.apache.iceberg.spark.source;
 
+import org.apache.iceberg.actions.PlanScanAction;
+
 public class TestSparkReaderDeletes24 extends TestSparkReaderDeletes {
+  public TestSparkReaderDeletes24(PlanScanAction.PlanMode distributedPlanning) {
+    super(distributedPlanning);
+  }
 }

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
@@ -53,6 +53,7 @@ import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.TableScanUtil;
 import org.apache.spark.broadcast.Broadcast;
+import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.read.Batch;
 import org.apache.spark.sql.connector.read.InputPartition;
@@ -307,6 +308,9 @@ class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
     try {
       result = Lists.newArrayList(Actions.forTable(table).planScan().withContext(scan.tableScanContext()).execute());
     } catch (Exception e) {
+      if (SparkSession.active().conf().get(PlanScanAction.ICEBERG_TEST_PLAN_MODE).equals("true")) {
+        throw e;
+      }
       LOG.error("Cannot run distributed job planning, falling back to local planning.", e);
       result = planLocalScan(scan);
     }

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.DataTableScan;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Schema;
@@ -34,6 +35,9 @@ import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableScan;
+import org.apache.iceberg.actions.Actions;
+import org.apache.iceberg.actions.PlanScanAction;
+import org.apache.iceberg.actions.PlanScanAction.PlanMode;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Expression;
@@ -82,6 +86,7 @@ class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
   private final Broadcast<EncryptionManager> encryptionManager;
   private final boolean batchReadsEnabled;
   private final int batchSize;
+  private final PlanMode planMode;
 
   // lazy variables
   private StructType readSchema = null;
@@ -97,6 +102,8 @@ class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
     this.filterExpressions = filters;
     this.snapshotId = Spark3Util.propertyAsLong(options, "snapshot-id", null);
     this.asOfTimestamp = Spark3Util.propertyAsLong(options, "as-of-timestamp", null);
+    this.planMode = PlanScanAction.parsePlanMode(
+        options.getOrDefault(PlanScanAction.ICEBERG_PLAN_MODE, PlanMode.LOCAL.name()));
 
     if (snapshotId != null && asOfTimestamp != null) {
       throw new IllegalArgumentException(
@@ -280,15 +287,38 @@ class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
           scan = scan.filter(filter);
         }
       }
-
-      try (CloseableIterable<CombinedScanTask> tasksIterable = scan.planTasks()) {
-        this.tasks = Lists.newArrayList(tasksIterable);
-      }  catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to close table scan: %s", scan);
-      }
+      this.tasks = planScan(scan);
     }
-
     return tasks;
+  }
+
+  private List<CombinedScanTask> planScan(TableScan scan) {
+    // TODO Need to only use distributed planner for supported implementations and add some heuristics about when
+    //  to use
+    if (planMode == PlanMode.DISTRIBUTED && scan instanceof DataTableScan) {
+      return planDistributedScan((DataTableScan) scan);
+    } else {
+      return planLocalScan(scan);
+    }
+  }
+
+  private List<CombinedScanTask> planDistributedScan(DataTableScan scan) {
+    List<CombinedScanTask> result;
+    try {
+      result = Lists.newArrayList(Actions.forTable(table).planScan().withContext(scan.tableScanContext()).execute());
+    } catch (Exception e) {
+      LOG.error("Cannot run distributed job planning, falling back to local planning.", e);
+      result = planLocalScan(scan);
+    }
+    return  result;
+  }
+
+  private List<CombinedScanTask> planLocalScan(TableScan scan) {
+    try (CloseableIterable<CombinedScanTask> tasksIterable = scan.planTasks()) {
+      return Lists.newArrayList(tasksIterable);
+    } catch (IOException e) {
+      throw new RuntimeIOException(e, "Failed to close table scan: %s", scan);
+    }
   }
 
   @Override

--- a/spark3/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions3.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions3.java
@@ -19,5 +19,10 @@
 
 package org.apache.iceberg.spark.source;
 
+import org.apache.iceberg.actions.PlanScanAction;
+
 public class TestDataSourceOptions3 extends TestDataSourceOptions {
+  public TestDataSourceOptions3(PlanScanAction.PlanMode distributedPlanning) {
+    super(distributedPlanning);
+  }
 }

--- a/spark3/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHadoopTables3.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHadoopTables3.java
@@ -19,5 +19,10 @@
 
 package org.apache.iceberg.spark.source;
 
+import org.apache.iceberg.actions.PlanScanAction;
+
 public class TestIcebergSourceHadoopTables3 extends TestIcebergSourceHadoopTables {
+  public TestIcebergSourceHadoopTables3(PlanScanAction.PlanMode distributedPlanning) {
+    super(distributedPlanning);
+  }
 }

--- a/spark3/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables3.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables3.java
@@ -19,5 +19,10 @@
 
 package org.apache.iceberg.spark.source;
 
+import org.apache.iceberg.actions.PlanScanAction;
+
 public class TestIcebergSourceHiveTables3 extends TestIcebergSourceHiveTables {
+  public TestIcebergSourceHiveTables3(PlanScanAction.PlanMode distributedPlanning) {
+    super(distributedPlanning);
+  }
 }

--- a/spark3/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning3.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning3.java
@@ -19,8 +19,10 @@
 
 package org.apache.iceberg.spark.source;
 
+import org.apache.iceberg.actions.PlanScanAction;
+
 public class TestPartitionPruning3 extends TestPartitionPruning {
-  public TestPartitionPruning3(String format, boolean vectorized) {
-    super(format, vectorized);
+  public TestPartitionPruning3(String format, boolean vectorized, PlanScanAction.PlanMode distributedPlanning) {
+    super(format, vectorized, distributedPlanning);
   }
 }

--- a/spark3/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection3.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/source/TestSnapshotSelection3.java
@@ -19,5 +19,10 @@
 
 package org.apache.iceberg.spark.source;
 
+import org.apache.iceberg.actions.PlanScanAction;
+
 public class TestSnapshotSelection3 extends TestSnapshotSelection {
+  public TestSnapshotSelection3(PlanScanAction.PlanMode distributedPlanning) {
+    super(distributedPlanning);
+  }
 }

--- a/spark3/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes3.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes3.java
@@ -19,5 +19,10 @@
 
 package org.apache.iceberg.spark.source;
 
+import org.apache.iceberg.actions.PlanScanAction;
+
 public class TestSparkReaderDeletes3 extends TestSparkReaderDeletes {
+  public TestSparkReaderDeletes3(PlanScanAction.PlanMode distributedPlanning) {
+    super(distributedPlanning);
+  }
 }


### PR DESCRIPTION
This is the second of two WIPs for parallelizing Spark Read Job Planning

The other is located at https://github.com/apache/iceberg/pull/1420

To parallelize the creation of TableScanTasks, we use the
metadata tables to get a listing of DataFiles and do filtering in
spark before starting the scan job. Once the correct datafiles are
identified, scan tasks are created and returned.