### PR TITLE
Core: Lower the log level of warning message on refresh() for NoSuchIcebergTableException

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.exceptions.CommitFailedException;
-import org.apache.iceberg.exceptions.NoSuchIcebergTableException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -73,17 +73,14 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
 
   @Override
   public TableMetadata refresh() {
+    boolean currentMetadataWasAvailable = currentMetadata != null;
     try {
       doRefresh();
     } catch (NoSuchTableException e) {
-      // Adjust log level according to the type of exception, as it might be intentional to call
-      // the method without determining the type of table in prior (like SparkSessionCatalog),
-      // and in such case it may not be an error case if the table is not an Iceberg table.
-      if (e instanceof NoSuchIcebergTableException) {
-        LOG.debug("Could not find the table during refresh, setting current metadata to null", e);
-      } else {
+      if (currentMetadataWasAvailable) {
         LOG.warn("Could not find the table during refresh, setting current metadata to null", e);
       }
+
       currentMetadata = null;
       currentMetadataLocation = null;
       version = -1;


### PR DESCRIPTION
Closes #1428 

This patch adjusts the log level on NoSuchTableException in refresh() with HiveCatalog, specific to the NoSuchIcebergTableException, which can be occurred in the "normal" case, like below:

1. Use default spark catalog with type=hive
2. Read non-iceberg table