### PR TITLE
Fix the bug that clientPool#close will block forever when newClient encountered an exception.

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/ClientPool.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/ClientPool.java
@@ -114,8 +114,9 @@ public abstract class ClientPool<C, E extends Exception> implements Closeable {
           if (!clients.isEmpty()) {
             return clients.removeFirst();
           } else if (currentSize < poolSize) {
+            C client = newClient();
             currentSize += 1;
-            return newClient();
+            return client;
           }
         }
       }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestClientPool.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestClientPool.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.hive;
+
+import org.junit.Test;
+
+public class TestClientPool {
+
+  @Test(expected = RuntimeException.class)
+  public void testNewClientFailure() throws Exception {
+    try (MockClientPool pool = new MockClientPool(2, Exception.class)) {
+      pool.run(Object::toString);
+    }
+  }
+
+  private static class MockClientPool extends ClientPool<Object, Exception> {
+
+    MockClientPool(int poolSize, Class<? extends Exception> reconnectExc) {
+      super(poolSize, reconnectExc);
+    }
+
+    @Override
+    protected Object newClient() {
+      throw new RuntimeException();
+    }
+
+    @Override
+    protected Object reconnect(Object client) {
+      return null;
+    }
+
+    @Override
+    protected void close(Object client) {
+
+    }
+  }
+}


### PR DESCRIPTION
When preparing demo for flink + hive metastore,   I created a hive catalog with a random port for metastore, for example: 

```sql
create catalog hive_catalog with(
  'type'='iceberg',
  'catalog-type'='hive',
  'uri'='thrift://localhost:3234',
  'clients'='1',
  'property-version'='1'
);
```

Then I switch to use the `hive_catalog` and execute sql command `show databases` to show all the databases,  I found that the sql command was blocked. 

After digging into the code, I find that it's a bug in `ClientPool`, saying if encountering an exception when `newClient`,  the upper layer (Flink SQL client) will try to close all the resources from `ClientPool` by calling `ClientPool#close`, finally it will be blocked in close method like following: 

```
"main" #1 prio=5 os_prio=31 tid=0x00007fc853802800 nid=0x1d03 in Object.wait() [0x000070000ad92000]
   java.lang.Thread.State: TIMED_WAITING (on object monitor)
        at java.lang.Object.wait(Native Method)
        at org.apache.iceberg.hive.ClientPool.close(ClientPool.java:110)
        - locked <0x0000000771b203c8> (a java.lang.Object)
        at org.apache.iceberg.hive.HiveCatalog.close(HiveCatalog.java:480)
        at org.apache.iceberg.flink.FlinkCatalog.close(FlinkCatalog.java:120)
        at org.apache.flink.table.client.gateway.local.ExecutionContext$$Lambda$503/1760443245.accept(Unknown Source)
        at java.util.HashMap$Values.forEach(HashMap.java:981)
        at org.apache.flink.table.client.gateway.local.ExecutionContext.lambda$close$2(ExecutionContext.java:307)
        at org.apache.flink.table.client.gateway.local.ExecutionContext$$Lambda$500/1972628089.run(Unknown Source)
        at org.apache.flink.table.client.gateway.local.ExecutionContext.wrapClassLoader(ExecutionContext.java:264)
        at org.apache.flink.table.client.gateway.local.ExecutionContext.close(ExecutionContext.java:307)
        at org.apache.flink.table.client.gateway.local.LocalExecutor.closeSession(LocalExecutor.java:244)
        at org.apache.flink.table.client.SqlClient.start(SqlClient.java:116)
        at org.apache.flink.table.client.SqlClient.main(SqlClient.java:201)
```

The patch fixed this bug and attached an unit test to reproduce the case. 
