### PR TITLE
Create the default database if it does not exist when opening the catalog

### DIFF
--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -111,6 +111,12 @@ public class FlinkCatalog extends AbstractCatalog {
 
   @Override
   public void open() throws CatalogException {
+    // Create the default database if it does not exist.
+    try {
+      createDatabase(getDefaultDatabase(), ImmutableMap.of(), true);
+    } catch (DatabaseAlreadyExistException e) {
+      throw new CatalogException(e);
+    }
   }
 
   @Override
@@ -179,14 +185,17 @@ public class FlinkCatalog extends AbstractCatalog {
   @Override
   public void createDatabase(String name, CatalogDatabase database, boolean ignoreIfExists)
       throws DatabaseAlreadyExistException, CatalogException {
+    createDatabase(name, mergeComment(database.getProperties(), database.getComment()), ignoreIfExists);
+  }
+
+  private void createDatabase(String databaseName, Map<String, String> comments, boolean ignoreIfExists)
+      throws DatabaseAlreadyExistException, CatalogException {
     if (asNamespaceCatalog != null) {
       try {
-        asNamespaceCatalog.createNamespace(
-            toNamespace(name),
-            mergeComment(database.getProperties(), database.getComment()));
+        asNamespaceCatalog.createNamespace(toNamespace(databaseName), comments);
       } catch (AlreadyExistsException e) {
         if (!ignoreIfExists) {
-          throw new DatabaseAlreadyExistException(getName(), name, e);
+          throw new DatabaseAlreadyExistException(getName(), databaseName, e);
         }
       }
     } else {

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -115,7 +115,7 @@ public class FlinkCatalog extends AbstractCatalog {
     try {
       createDatabase(getDefaultDatabase(), ImmutableMap.of(), true);
     } catch (DatabaseAlreadyExistException e) {
-      throw new CatalogException(e);
+      // Ignore the exception if it's already exist.
     }
   }
 
@@ -188,11 +188,11 @@ public class FlinkCatalog extends AbstractCatalog {
     createDatabase(name, mergeComment(database.getProperties(), database.getComment()), ignoreIfExists);
   }
 
-  private void createDatabase(String databaseName, Map<String, String> comments, boolean ignoreIfExists)
+  private void createDatabase(String databaseName, Map<String, String> metadata, boolean ignoreIfExists)
       throws DatabaseAlreadyExistException, CatalogException {
     if (asNamespaceCatalog != null) {
       try {
-        asNamespaceCatalog.createNamespace(toNamespace(databaseName), comments);
+        asNamespaceCatalog.createNamespace(toNamespace(databaseName), metadata);
       } catch (AlreadyExistsException e) {
         if (!ignoreIfExists) {
           throw new DatabaseAlreadyExistException(getName(), databaseName, e);

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogDatabase.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogDatabase.java
@@ -59,7 +59,7 @@ public class TestFlinkCatalogDatabase extends FlinkCatalogTestBase {
   @Test
   public void testDefaultDatabase() {
     sql("USE CATALOG %s", catalogName);
-    sql("show tables");
+    sql("SHOW TABLES");
 
     Assert.assertEquals("Should use the current catalog", getTableEnv().getCurrentCatalog(), catalogName);
     Assert.assertEquals("Should use the configured default namespace",
@@ -146,15 +146,17 @@ public class TestFlinkCatalogDatabase extends FlinkCatalogTestBase {
     List<Object[]> databases = sql("SHOW DATABASES");
 
     if (isHadoopCatalog) {
-      Assert.assertEquals("Should have 1 database", 1, databases.size());
-      Assert.assertEquals("Should have only db database", "db", databases.get(0)[0]);
+      Assert.assertEquals("Should have 2 database", 2, databases.size());
+      Assert.assertArrayEquals("Should have db and default database",
+          new Object[] {"default", "db"}, new Object[] {databases.get(0)[0], databases.get(1)[0]});
 
       if (baseNamespace.length > 0) {
         // test namespace not belongs to this catalog
         validationNamespaceCatalog.createNamespace(Namespace.of(baseNamespace[0], "UNKNOWN_NAMESPACE"));
         databases = sql("SHOW DATABASES");
-        Assert.assertEquals("Should have 1 database", 1, databases.size());
-        Assert.assertEquals("Should have only db database", "db", databases.get(0)[0]);
+        Assert.assertEquals("Should have 2 database", 2, databases.size());
+        Assert.assertArrayEquals("Should have db and default database",
+            new Object[] {"default", "db"}, new Object[] {databases.get(0)[0], databases.get(1)[0]});
       }
     } else {
       // If there are multiple classes extends FlinkTestBase, TestHiveMetastore may loose the creation for default

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogDatabase.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogDatabase.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
 import org.junit.After;
 import org.junit.Assert;
@@ -147,16 +148,16 @@ public class TestFlinkCatalogDatabase extends FlinkCatalogTestBase {
 
     if (isHadoopCatalog) {
       Assert.assertEquals("Should have 2 database", 2, databases.size());
-      Assert.assertArrayEquals("Should have db and default database",
-          new Object[] {"default", "db"}, new Object[] {databases.get(0)[0], databases.get(1)[0]});
+      Assert.assertEquals("Should have db and default database",
+          Sets.newHashSet("default", "db"), Sets.newHashSet(databases.get(0)[0], databases.get(1)[0]));
 
       if (baseNamespace.length > 0) {
         // test namespace not belongs to this catalog
         validationNamespaceCatalog.createNamespace(Namespace.of(baseNamespace[0], "UNKNOWN_NAMESPACE"));
         databases = sql("SHOW DATABASES");
         Assert.assertEquals("Should have 2 database", 2, databases.size());
-        Assert.assertArrayEquals("Should have db and default database",
-            new Object[] {"default", "db"}, new Object[] {databases.get(0)[0], databases.get(1)[0]});
+        Assert.assertEquals("Should have db and default database",
+            Sets.newHashSet("default", "db"), Sets.newHashSet(databases.get(0)[0], databases.get(1)[0]));
       }
     } else {
       // If there are multiple classes extends FlinkTestBase, TestHiveMetastore may loose the creation for default

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogDatabase.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogDatabase.java
@@ -59,6 +59,7 @@ public class TestFlinkCatalogDatabase extends FlinkCatalogTestBase {
   @Test
   public void testDefaultDatabase() {
     sql("USE CATALOG %s", catalogName);
+    sql("show tables");
 
     Assert.assertEquals("Should use the current catalog", getTableEnv().getCurrentCatalog(), catalogName);
     Assert.assertEquals("Should use the configured default namespace",


### PR DESCRIPTION
This fix the issue https://github.com/apache/iceberg/issues/1434. 

It's necessary to create the default database if it does not exist in the newly created catalog.