### PR TITLE
Core: Fix table load error on corrupted version-hint.text file

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -282,13 +282,11 @@ public class HadoopTableOperations implements TableOperations {
   @VisibleForTesting
   int readVersionHint() {
     Path versionHintFile = versionHintFile();
-    try {
-      FileSystem fs = Util.getFs(versionHintFile, conf);
+    FileSystem fs = Util.getFs(versionHintFile, conf);
 
-      try (InputStreamReader fsr = new InputStreamReader(fs.open(versionHintFile), StandardCharsets.UTF_8);
-           BufferedReader in = new BufferedReader(fsr)) {
-        return Integer.parseInt(in.readLine().replace("\n", ""));
-      }
+    try (InputStreamReader fsr = new InputStreamReader(fs.open(versionHintFile), StandardCharsets.UTF_8);
+         BufferedReader in = new BufferedReader(fsr)) {
+      return Integer.parseInt(in.readLine().replace("\n", ""));
 
     } catch (Exception e) {
       LOG.warn("Error reading version hint file {}", versionHintFile, e);
@@ -296,6 +294,7 @@ public class HadoopTableOperations implements TableOperations {
         if (getMetadataFile(1) != null) {
           // We just assume corrupted metadata and start to read from the first version file
           return 1;
+
         }
       } catch (IOException io) {
         // We log this error only on debug level since this is just a problem in recovery path
@@ -303,6 +302,7 @@ public class HadoopTableOperations implements TableOperations {
       }
       // We just return 0 as not able to recover easily
       return 0;
+
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -294,7 +294,6 @@ public class HadoopTableOperations implements TableOperations {
         if (getMetadataFile(1) != null) {
           // We just assume corrupted metadata and start to read from the first version file
           return 1;
-
         }
       } catch (IOException io) {
         // We log this error only on debug level since this is just a problem in recovery path

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
@@ -20,12 +20,15 @@
 package org.apache.iceberg.hadoop;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
@@ -34,6 +37,9 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
+import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.PositionOutputStream;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -440,5 +446,71 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
     String metaLocation = warehousePath + "/" + "db";
     FileSystem fs = Util.getFs(new Path(metaLocation), conf);
     Assert.assertFalse(fs.isDirectory(new Path(metaLocation)));
+  }
+
+  @Test
+  public void testVersionHintFile() throws Exception {
+    Configuration conf = new Configuration();
+    String warehousePath = temp.newFolder().getAbsolutePath();
+    HadoopCatalog catalog = new HadoopCatalog(conf, warehousePath);
+
+    // Create a test table with multiple versions
+    TableIdentifier tableId = TableIdentifier.of("tbl");
+    Table table = catalog.createTable(tableId, SCHEMA, PartitionSpec.unpartitioned());
+
+    DataFile dataFile1 = DataFiles.builder(SPEC)
+        .withPath("/a.parquet")
+        .withFileSizeInBytes(10)
+        .withRecordCount(1)
+        .build();
+
+    DataFile dataFile2 = DataFiles.builder(SPEC)
+        .withPath("/b.parquet")
+        .withFileSizeInBytes(10)
+        .withRecordCount(1)
+        .build();
+
+    table.newAppend().appendFile(dataFile1).commit();
+    table.newAppend().appendFile(dataFile2).commit();
+    long secondSnapshotId = table.currentSnapshot().snapshotId();
+
+    // Get the version-hint.text file location
+    String versionHintLocation = ((HadoopTableOperations) catalog.newTableOps(tableId)).versionHintFile().toString();
+
+    // Write old data to confirm that we are writing the correct file
+    FileIO io = new HadoopFileIO(conf);
+    io.deleteFile(versionHintLocation);
+    try (PositionOutputStream stream = io.newOutputFile(versionHintLocation).create()) {
+      stream.write("1".getBytes(StandardCharsets.UTF_8));
+    }
+
+    // Load the table and check the current snapshotId
+    Assert.assertEquals(secondSnapshotId, catalog.loadTable(tableId).currentSnapshot().snapshotId());
+
+    // Write newer data to confirm that we are writing the correct file
+    io.deleteFile(versionHintLocation);
+    try (PositionOutputStream stream = io.newOutputFile(versionHintLocation).create()) {
+      stream.write("3".getBytes(StandardCharsets.UTF_8));
+    }
+
+    // Load the table and check the current snapshotId
+    Assert.assertEquals(secondSnapshotId, catalog.loadTable(tableId).currentSnapshot().snapshotId());
+
+    // Write an empty version hint file
+    io.deleteFile(versionHintLocation);
+    io.newOutputFile(versionHintLocation).create().close();
+
+    // Load the table and check the current snapshotId
+    Assert.assertEquals(secondSnapshotId, catalog.loadTable(tableId).currentSnapshot().snapshotId());
+
+    // Just delete the file - double check that we have manipulated the correct file
+    io.deleteFile(versionHintLocation);
+
+    // Check that exception is thrown
+    AssertHelpers.assertThrows(
+        "Should not be able to find the table",
+        NoSuchTableException.class,
+        "Table does not exist: tbl",
+        () -> catalog.loadTable(tableId));
   }
 }


### PR DESCRIPTION
During my testing I have noticed that if the version-hint.text file content is empty then we can not read the table anymore.
Based on @rdblue's comment on the mail list this is not the expected behavior. We should try to recover from it.

This patch starts to read the metadata files from version 1 if the version-hint.text content can not be parsed, or there is an error reading the file. The only remaining failure situation is if the file itself does not exists - I use this case to double-check that we have really manipulated the correct file, and not just reading the old file again and again 😄 