### PR TITLE
Spark: Apply row-level delete files when reading

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Accessors.java
+++ b/api/src/main/java/org/apache/iceberg/Accessors.java
@@ -212,10 +212,6 @@ public class Accessors {
         }
       }
 
-      if (accessors.isEmpty()) {
-        return null;
-      }
-
       return accessors;
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -620,6 +620,7 @@ if (jdkVersion == '8') {
       }
       testCompile project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
       testCompile project(path: ':iceberg-api', configuration: 'testArtifacts')
+      testCompile project(path: ':iceberg-data', configuration: 'testArtifacts')
     }
 
     test {
@@ -727,6 +728,7 @@ project(':iceberg-spark3') {
     }
     testCompile project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
     testCompile project(path: ':iceberg-api', configuration: 'testArtifacts')
+    testCompile project(path: ':iceberg-data', configuration: 'testArtifacts')
   }
 
   test {

--- a/core/src/main/java/org/apache/iceberg/util/TableScanUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/TableScanUtil.java
@@ -31,6 +31,20 @@ public class TableScanUtil {
   private TableScanUtil() {
   }
 
+  public static boolean hasDeletes(CombinedScanTask task) {
+    for (FileScanTask fileTask : task.files()) {
+      if (hasDeletes(fileTask)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  public static boolean hasDeletes(FileScanTask task) {
+    return !task.deletes().isEmpty();
+  }
+
   public static CloseableIterable<FileScanTask> splitFiles(CloseableIterable<FileScanTask> tasks, long splitSize) {
     Iterable<FileScanTask> splitTasks = FluentIterable
         .from(tasks)

--- a/core/src/main/java/org/apache/iceberg/util/TableScanUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/TableScanUtil.java
@@ -32,13 +32,7 @@ public class TableScanUtil {
   }
 
   public static boolean hasDeletes(CombinedScanTask task) {
-    for (FileScanTask fileTask : task.files()) {
-      if (hasDeletes(fileTask)) {
-        return true;
-      }
-    }
-
-    return false;
+    return task.files().stream().anyMatch(TableScanUtil::hasDeletes);
   }
 
   public static boolean hasDeletes(FileScanTask task) {

--- a/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.data;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.iceberg.Accessor;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.avro.Avro;
+import org.apache.iceberg.data.avro.DataReader;
+import org.apache.iceberg.data.parquet.GenericParquetReaders;
+import org.apache.iceberg.deletes.Deletes;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Multimap;
+import org.apache.iceberg.relocated.com.google.common.collect.Multimaps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.StructLikeSet;
+import org.apache.iceberg.util.StructProjection;
+import org.apache.parquet.Preconditions;
+
+public abstract class DeleteFilter<T> {
+  private static final long DEFAULT_SET_FILTER_THRESHOLD = 100_000L;
+  private static final Schema POS_DELETE_SCHEMA = new Schema(
+      MetadataColumns.DELETE_FILE_PATH,
+      MetadataColumns.DELETE_FILE_POS);
+
+  private final long setFilterThreshold;
+  private final FileIO io;
+  private final DataFile dataFile;
+  private final List<DeleteFile> posDeletes;
+  private final List<DeleteFile> eqDeletes;
+  private final Schema requiredSchema;
+  private final Accessor<StructLike> posAccessor;
+
+  public DeleteFilter(FileIO io, FileScanTask task, Schema tableSchema, Schema requestedSchema) {
+    this.setFilterThreshold = DEFAULT_SET_FILTER_THRESHOLD;
+    this.io = io;
+    this.dataFile = task.file();
+
+    ImmutableList.Builder<DeleteFile> posDeleteBuilder = ImmutableList.builder();
+    ImmutableList.Builder<DeleteFile> eqDeleteBuilder = ImmutableList.builder();
+    for (DeleteFile delete : task.deletes()) {
+      switch (delete.content()) {
+        case POSITION_DELETES:
+          posDeleteBuilder.add(delete);
+          break;
+        case EQUALITY_DELETES:
+          eqDeleteBuilder.add(delete);
+          break;
+        default:
+          throw new UnsupportedOperationException("Unknown delete file content: " + delete.content());
+      }
+    }
+
+    this.posDeletes = posDeleteBuilder.build();
+    this.eqDeletes = eqDeleteBuilder.build();
+    this.requiredSchema = fileProjection(tableSchema, requestedSchema, posDeletes, eqDeletes);
+    this.posAccessor = requiredSchema.accessorForField(MetadataColumns.ROW_POSITION.fieldId());
+  }
+
+  public Schema requiredSchema() {
+    return requiredSchema;
+  }
+
+  Accessor<StructLike> posAccessor() {
+    return posAccessor;
+  }
+
+  protected abstract StructLike asStructLike(T record);
+
+  protected long pos(T record) {
+    return (Long) posAccessor.get(asStructLike(record));
+  }
+
+  public CloseableIterable<T> filter(CloseableIterable<T> records) {
+    return applyEqDeletes(applyPosDeletes(records));
+  }
+
+  private CloseableIterable<T> applyEqDeletes(CloseableIterable<T> records) {
+    if (eqDeletes.isEmpty()) {
+      return records;
+    }
+
+    Multimap<Set<Integer>, DeleteFile> filesByDeleteIds = Multimaps.newMultimap(Maps.newHashMap(), Lists::newArrayList);
+    for (DeleteFile delete : eqDeletes) {
+      filesByDeleteIds.put(Sets.newHashSet(delete.equalityFieldIds()), delete);
+    }
+
+    CloseableIterable<T> filteredRecords = records;
+    for (Map.Entry<Set<Integer>, Collection<DeleteFile>> entry : filesByDeleteIds.asMap().entrySet()) {
+      Set<Integer> ids = entry.getKey();
+      Iterable<DeleteFile> deletes = entry.getValue();
+
+      Schema deleteSchema = TypeUtil.select(requiredSchema, ids);
+
+      // a projection to select and reorder fields of the file schema to match the delete rows
+      StructProjection projectRow = StructProjection.create(requiredSchema, deleteSchema);
+
+      Iterable<CloseableIterable<Record>> deleteRecords = Iterables.transform(deletes,
+          delete -> openDeletes(delete, dataFile, deleteSchema));
+      StructLikeSet deleteSet = Deletes.toEqualitySet(
+          // copy the delete records because they will be held in a set
+          CloseableIterable.transform(CloseableIterable.concat(deleteRecords), Record::copy),
+          deleteSchema.asStruct());
+
+      filteredRecords = Deletes.filter(filteredRecords,
+          record -> projectRow.wrap(asStructLike(record)), deleteSet);
+    }
+
+    return filteredRecords;
+  }
+
+  private CloseableIterable<T> applyPosDeletes(CloseableIterable<T> records) {
+    if (posDeletes.isEmpty()) {
+      return records;
+    }
+
+    List<CloseableIterable<Record>> deletes = Lists.transform(posDeletes,
+        delete -> openPosDeletes(delete, dataFile));
+
+    // if there are fewer deletes than a reasonable number to keep in memory, use a set
+    if (posDeletes.stream().mapToLong(DeleteFile::recordCount).sum() < setFilterThreshold) {
+      return Deletes.filter(
+          records, this::pos,
+          Deletes.toPositionSet(dataFile.path(), CloseableIterable.concat(deletes)));
+    }
+
+    return Deletes.streamingFilter(records, this::pos, Deletes.deletePositions(dataFile.path(), deletes));
+  }
+
+  private CloseableIterable<Record> openPosDeletes(DeleteFile file, DataFile dataFile) {
+    return openDeletes(file, dataFile, POS_DELETE_SCHEMA);
+  }
+
+  private CloseableIterable<Record> openDeletes(DeleteFile deleteFile, DataFile dataFile, Schema deleteSchema) {
+    InputFile input = io.newInputFile(deleteFile.path().toString());
+    switch (deleteFile.format()) {
+      case AVRO:
+        return Avro.read(input)
+            .project(deleteSchema)
+            .reuseContainers()
+            .createReaderFunc(DataReader::create)
+            .build();
+
+      case PARQUET:
+        Parquet.ReadBuilder builder = Parquet.read(input)
+            .project(deleteSchema)
+            .reuseContainers()
+            .createReaderFunc(fileSchema -> GenericParquetReaders.buildReader(deleteSchema, fileSchema));
+
+        if (deleteFile.content() == FileContent.POSITION_DELETES) {
+          builder.filter(Expressions.equal(MetadataColumns.DELETE_FILE_PATH.name(), dataFile.path()));
+        }
+
+        return builder.build();
+
+      case ORC:
+      default:
+        throw new UnsupportedOperationException(String.format(
+            "Cannot read %s file: %s", deleteFile.format().name(), deleteFile.path()));
+    }
+  }
+
+  private static Schema fileProjection(Schema tableSchema, Schema requestedSchema,
+                                       List<DeleteFile> posDeletes, List<DeleteFile> eqDeletes) {
+    Set<Integer> requiredIds = Sets.newLinkedHashSet();
+    if (!posDeletes.isEmpty()) {
+      requiredIds.add(MetadataColumns.ROW_POSITION.fieldId());
+    }
+
+    for (DeleteFile eqDelete : eqDeletes) {
+      requiredIds.addAll(eqDelete.equalityFieldIds());
+    }
+
+    Set<Integer> missingIds = Sets.newLinkedHashSet(
+        Sets.difference(requiredIds, TypeUtil.getProjectedIds(requestedSchema)));
+
+    if (missingIds.isEmpty()) {
+      return requestedSchema;
+    }
+
+    // TODO: support adding nested columns. this will currently fail when finding nested columns to add
+    List<Types.NestedField> columns = Lists.newArrayList(requestedSchema.columns());
+    for (int fieldId : missingIds) {
+      if (fieldId == MetadataColumns.ROW_POSITION.fieldId()) {
+        continue; // add _pos at the end
+      }
+
+      Types.NestedField field = tableSchema.asStruct().field(fieldId);
+      Preconditions.checkArgument(field != null, "Cannot find required field for ID %s", fieldId);
+
+      columns.add(field);
+    }
+
+    if (requiredIds.contains(MetadataColumns.ROW_POSITION.fieldId())) {
+      columns.add(MetadataColumns.ROW_POSITION);
+    }
+
+    return new Schema(columns);
+  }
+}

--- a/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
@@ -1,15 +1,20 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.iceberg.data;

--- a/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
@@ -190,7 +190,7 @@ public abstract class DeleteFilter<T> {
       case ORC:
       default:
         throw new UnsupportedOperationException(String.format(
-            "Cannot read %s file: %s", deleteFile.format().name(), deleteFile.path()));
+            "Cannot read deletes, %s is not a supported format: %s", deleteFile.format().name(), deleteFile.path()));
     }
   }
 

--- a/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
@@ -192,6 +192,10 @@ public abstract class DeleteFilter<T> {
 
   private static Schema fileProjection(Schema tableSchema, Schema requestedSchema,
                                        List<DeleteFile> posDeletes, List<DeleteFile> eqDeletes) {
+    if (posDeletes.isEmpty() && eqDeletes.isEmpty()) {
+      return requestedSchema;
+    }
+
     Set<Integer> requiredIds = Sets.newLinkedHashSet();
     if (!posDeletes.isEmpty()) {
       requiredIds.add(MetadataColumns.ROW_POSITION.fieldId());

--- a/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
@@ -229,7 +229,7 @@ public abstract class DeleteFilter<T> {
       columns.add(field);
     }
 
-    if (requiredIds.contains(MetadataColumns.ROW_POSITION.fieldId())) {
+    if (missingIds.contains(MetadataColumns.ROW_POSITION.fieldId())) {
       columns.add(MetadataColumns.ROW_POSITION);
     }
 

--- a/data/src/main/java/org/apache/iceberg/data/GenericDeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/GenericDeleteFilter.java
@@ -1,15 +1,20 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.iceberg.data;

--- a/data/src/main/java/org/apache/iceberg/data/GenericDeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/GenericDeleteFilter.java
@@ -18,12 +18,15 @@ import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
 
 public class GenericDeleteFilter extends DeleteFilter<Record> {
+  private final FileIO io;
   private final InternalRecordWrapper asStructLike;
 
   public GenericDeleteFilter(FileIO io, FileScanTask task, Schema tableSchema, Schema requestedSchema) {
-    super(io, task, tableSchema, requestedSchema);
+    super(task, tableSchema, requestedSchema);
+    this.io = io;
     this.asStructLike = new InternalRecordWrapper(requiredSchema().asStruct());
   }
 
@@ -35,5 +38,10 @@ public class GenericDeleteFilter extends DeleteFilter<Record> {
   @Override
   protected StructLike asStructLike(Record record) {
     return asStructLike.wrap(record);
+  }
+
+  @Override
+  protected InputFile getInputFile(String location) {
+    return io.newInputFile(location);
   }
 }

--- a/data/src/main/java/org/apache/iceberg/data/GenericDeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/GenericDeleteFilter.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.data;
+
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.io.FileIO;
+
+public class GenericDeleteFilter extends DeleteFilter<Record> {
+  private final InternalRecordWrapper asStructLike;
+
+  public GenericDeleteFilter(FileIO io, FileScanTask task, Schema tableSchema, Schema requestedSchema) {
+    super(io, task, tableSchema, requestedSchema);
+    this.asStructLike = new InternalRecordWrapper(requiredSchema().asStruct());
+  }
+
+  @Override
+  protected long pos(Record record) {
+    return (Long) posAccessor().get(record);
+  }
+
+  @Override
+  protected StructLike asStructLike(Record record) {
+    return asStructLike.wrap(record);
+  }
+}

--- a/spark/src/main/java/org/apache/iceberg/spark/source/BaseDataReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/BaseDataReader.java
@@ -25,18 +25,19 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.util.Utf8;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.encryption.EncryptedFiles;
+import org.apache.iceberg.encryption.EncryptedInputFile;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.ByteBuffers;
 import org.apache.spark.rdd.InputFileBlockHolder;
@@ -50,21 +51,20 @@ import org.apache.spark.unsafe.types.UTF8String;
  */
 abstract class BaseDataReader<T> implements Closeable {
   private final Iterator<FileScanTask> tasks;
-  private final FileIO fileIo;
   private final Map<String, InputFile> inputFiles;
 
   private CloseableIterator<T> currentIterator;
   private T current = null;
 
-  BaseDataReader(CombinedScanTask task, FileIO fileIo, EncryptionManager encryptionManager) {
-    this.fileIo = fileIo;
+  BaseDataReader(CombinedScanTask task, FileIO io, EncryptionManager encryptionManager) {
     this.tasks = task.files().iterator();
-    Iterable<InputFile> decryptedFiles = encryptionManager.decrypt(Iterables.transform(
-        task.files(),
-        fileScanTask ->
-            EncryptedFiles.encryptedInput(
-                this.fileIo.newInputFile(fileScanTask.file().path().toString()),
-                fileScanTask.file().keyMetadata())));
+    Stream<EncryptedInputFile> encrypted = task.files().stream()
+        .flatMap(fileScanTask -> Stream.concat(Stream.of(fileScanTask.file()), fileScanTask.deletes().stream()))
+        .map(file -> EncryptedFiles.encryptedInput(io.newInputFile(file.path().toString()), file.keyMetadata()));
+
+    // decrypt with the batch call to avoid multiple RPCs to a key server, if possible
+    Iterable<InputFile> decryptedFiles = encryptionManager.decrypt(encrypted::iterator);
+
     ImmutableMap.Builder<String, InputFile> inputFileBuilder = ImmutableMap.builder();
     decryptedFiles.forEach(decrypted -> inputFileBuilder.put(decrypted.location(), decrypted));
     this.inputFiles = inputFileBuilder.build();
@@ -104,9 +104,13 @@ abstract class BaseDataReader<T> implements Closeable {
     }
   }
 
-  InputFile getInputFile(FileScanTask task) {
+  protected InputFile getInputFile(FileScanTask task) {
     Preconditions.checkArgument(!task.isDataTask(), "Invalid task type");
     return inputFiles.get(task.file().path().toString());
+  }
+
+  protected InputFile getInputFile(String location) {
+    return inputFiles.get(location);
   }
 
   protected static Object convertConstant(Type type, Object value) {

--- a/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -21,16 +21,16 @@ package org.apache.iceberg.spark.source;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataTask;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetadataColumns;
-import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.common.DynMethods;
+import org.apache.iceberg.data.DeleteFilter;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
@@ -40,7 +40,6 @@ import org.apache.iceberg.mapping.NameMappingParser;
 import org.apache.iceberg.orc.ORC;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.spark.SparkSchemaUtil;
@@ -64,15 +63,17 @@ class RowDataReader extends BaseDataReader<InternalRow> {
       .impl(UnsafeProjection.class, InternalRow.class)
       .build();
 
+  private final FileIO io;
   private final Schema tableSchema;
   private final Schema expectedSchema;
   private final String nameMapping;
   private final boolean caseSensitive;
 
   RowDataReader(
-      CombinedScanTask task, Schema tableSchema, Schema expectedSchema, String nameMapping, FileIO fileIo,
+      CombinedScanTask task, Schema tableSchema, Schema expectedSchema, String nameMapping, FileIO io,
       EncryptionManager encryptionManager, boolean caseSensitive) {
-    super(task, fileIo, encryptionManager);
+    super(task, io, encryptionManager);
+    this.io = io;
     this.tableSchema = tableSchema;
     this.expectedSchema = expectedSchema;
     this.nameMapping = nameMapping;
@@ -81,23 +82,17 @@ class RowDataReader extends BaseDataReader<InternalRow> {
 
   @Override
   CloseableIterator<InternalRow> open(FileScanTask task) {
+    SparkDeleteFilter deletes = new SparkDeleteFilter(io, task, tableSchema, expectedSchema);
+
+    // schema or rows returned by readers
+    Schema requiredSchema = deletes.requiredSchema();
+    Map<Integer, ?> idToConstant = PartitionUtil.constantsMap(task, RowDataReader::convertConstant);
     DataFile file = task.file();
 
     // update the current file for Spark's filename() function
     InputFileBlockHolder.set(file.path().toString(), task.start(), task.length());
 
-    // schema or rows returned by readers
-    PartitionSpec spec = task.spec();
-    Set<Integer> idColumns = spec.identitySourceIds();
-    Schema partitionSchema = TypeUtil.select(expectedSchema, idColumns);
-    boolean projectsIdentityPartitionColumns = !partitionSchema.columns().isEmpty();
-
-    if (projectsIdentityPartitionColumns) {
-      return open(task, expectedSchema, PartitionUtil.constantsMap(task, RowDataReader::convertConstant))
-          .iterator();
-    }
-    // return the base iterator
-    return open(task, expectedSchema, ImmutableMap.of()).iterator();
+    return deletes.filter(open(task, requiredSchema, idToConstant)).iterator();
   }
 
   private CloseableIterable<InternalRow> open(FileScanTask task, Schema readSchema, Map<Integer, ?> idToConstant) {
@@ -217,5 +212,19 @@ class RowDataReader extends BaseDataReader<InternalRow> {
     return UnsafeProjection.create(
         JavaConverters.asScalaBufferConverter(exprs).asScala().toSeq(),
         JavaConverters.asScalaBufferConverter(attrs).asScala().toSeq());
+  }
+
+  private static class SparkDeleteFilter extends DeleteFilter<InternalRow> {
+    private final InternalRowWrapper asStructLike;
+
+    public SparkDeleteFilter(FileIO io, FileScanTask task, Schema tableSchema, Schema requestedSchema) {
+      super(io, task, tableSchema, requestedSchema);
+      this.asStructLike = new InternalRowWrapper(SparkSchemaUtil.convert(requiredSchema()));
+    }
+
+    @Override
+    protected StructLike asStructLike(InternalRow row) {
+      return asStructLike.wrap(row);
+    }
   }
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -217,7 +217,7 @@ class RowDataReader extends BaseDataReader<InternalRow> {
   private class SparkDeleteFilter extends DeleteFilter<InternalRow> {
     private final InternalRowWrapper asStructLike;
 
-    public SparkDeleteFilter(FileScanTask task, Schema tableSchema, Schema requestedSchema) {
+    SparkDeleteFilter(FileScanTask task, Schema tableSchema, Schema requestedSchema) {
       super(task, tableSchema, requestedSchema);
       this.asStructLike = new InternalRowWrapper(SparkSchemaUtil.convert(requiredSchema()));
     }

--- a/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -65,6 +65,7 @@ public class SparkTestBase {
     try {
       catalog.createNamespace(Namespace.of("default"));
     } catch (AlreadyExistsException ignored) {
+      // the default namespace already exists. ignore the create error
     }
   }
 

--- a/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.TestHiveMetastore;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -61,7 +62,10 @@ public class SparkTestBase {
 
     SparkTestBase.catalog = new HiveCatalog(spark.sessionState().newHadoopConf());
 
-    catalog.createNamespace(Namespace.of("default"));
+    try {
+      catalog.createNamespace(Namespace.of("default"));
+    } catch (AlreadyExistsException ignored) {
+    }
   }
 
   @AfterClass

--- a/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.TestHiveMetastore;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -59,6 +60,8 @@ public class SparkTestBase {
         .getOrCreate();
 
     SparkTestBase.catalog = new HiveCatalog(spark.sessionState().newHadoopConf());
+
+    catalog.createNamespace(Namespace.of("default"));
   }
 
   @AfterClass

--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
@@ -207,6 +207,9 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
     String expectedSchemaString = SchemaParser.toJson(lazySchema());
     String nameMappingString = table.properties().get(DEFAULT_NAME_MAPPING);
 
+    ValidationException.check(tasks().stream().noneMatch(TableScanUtil::hasDeletes),
+        "Cannot scan table %s: cannot apply required delete files", table);
+
     List<InputPartition<ColumnarBatch>> readTasks = Lists.newArrayList();
     for (CombinedScanTask task : tasks()) {
       readTasks.add(new ReadTask<>(
@@ -388,9 +391,6 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
         throw new RuntimeIOException(e, "Failed to close table scan: %s", scan);
       }
     }
-
-    ValidationException.check(tasks.stream().noneMatch(TableScanUtil::hasDeletes),
-        "Cannot scan table %s: cannot apply required delete files", table);
 
     return tasks;
   }

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes24.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes24.java
@@ -1,0 +1,18 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+public class TestSparkReaderDeletes24 extends TestSparkReaderDeletes {
+}

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes24.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes24.java
@@ -1,15 +1,20 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.iceberg.spark.source;

--- a/spark3/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes3.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes3.java
@@ -1,0 +1,18 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+public class TestSparkReaderDeletes3 extends TestSparkReaderDeletes {
+}

--- a/spark3/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes3.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes3.java
@@ -1,15 +1,20 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.iceberg.spark.source;


### PR DESCRIPTION
This applies row-level delete files while reading in Spark, and refactors the generic read code to share the filter code between Spark and generics.

* Moves filter methods from `GenericReader` to `DeleteFilter`
* Adds `SparkDeleteFilter` to adapt `InternalRow` to `StructLike` for deletes
* Adds `GenericDeleteFilter` for generic rows, which can be reused for `IcebergInputFormat`
* Updates Spark to also decrypt delete files
* Adds tests for deletes in Spark based on generics tests