### PR TITLE
Fix ConcurrentModificationException in DeleteFileIndex

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -76,7 +76,7 @@ class DeleteFileIndex {
     ImmutableMap.Builder<Integer, Types.StructType> builder = ImmutableMap.builder();
     specsById.forEach((specId, spec) -> builder.put(specId, spec.partitionType()));
     this.partitionTypeById = builder.build();
-    this.wrapperById = Maps.newHashMap();
+    this.wrapperById = Maps.newConcurrentMap();
     this.globalSeqs = globalSeqs;
     this.globalDeletes = globalDeletes;
     this.sortedDeletesByPartition = sortedDeletesByPartition;


### PR DESCRIPTION
This fixes the tests that have been flaky in Java 11.

The problem was that the `DeleteFileIndex` uses a map from partition spec ID to thread-local `StructLikeWrapper` for working with partition tuples. The map was being updated with concurrent calls to `computeIfAbsent`, resulting in a `ConcurrentModificationException`.

That exception was causing a planning task to fail inside of `ParallelIterator`, which was not correctly checking for failed tasks. When a task failed, the files from the task were not added to the iterator's queue, which caused the flaky behavior. This PR also updates `ParallelIterator` to check for exceptions held by task futures when it checks task status to ensure that future issues will result in failures.

The bug does not affect any released version of Iceberg because the underlying problem was in `DeleteFileIndex` that has not been included in a release.