### PR TITLE
Update autolabeler config to match any file with gradle in it

### DIFF
--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -37,7 +37,7 @@ INFRA:
   - "jitpack.yml"
   - "travis.yml"
 BUILD:
-  - "**gradle**"
+  - "*gradle*"
   - "versions.props"
 DOCS:
   - "/site"


### PR DESCRIPTION
As noticed in this PR, https://github.com/apache/iceberg/pull/1423, changes to the `build.gradle` file were not properly handled by the autolabeler.

I have updated the autolabeler config to handle this case. I've also merged this into my local repo in order to test for this.

I validated the change on a top level file named `gradle.properties` (to check both top level files as well as files with only the substing gradle) in [this PR in my local repo](https://github.com/kbendick/iceberg/pull/12).

I also tested against [the build.gradle file](https://github.com/kbendick/iceberg/pull/13), as that was the original file and it differed from the previous one in that `gradle` is now the ending substring (checking padding on either side).

I also performed two checks for files in the `gradle` directory, [one that checks on a file with gradle in the name](https://github.com/kbendick/iceberg/pull/14) and [one that checks solely on a change that matches the gradle dir in the path, with no gradle in the file name](https://github.com/kbendick/iceberg/pull/15).

Suffice it to say that this has ben pretty pedantically checked 😅 .

This PR closes this issue: https://github.com/apache/iceberg/issues/1447

cc @rdblue who noticed that the file didn't match. Thank you for that!