### PR TITLE
Add top level flink-runtime directory to flink autolabeler config

### DIFF
--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -73,6 +73,7 @@ SPARK:
   - "/spark2"
   - "/spark3"
 FLINK:
+  - "/flink-runtime"
   - "/flink"
 MR:
   - "/mr"


### PR DESCRIPTION
This adds the upcoming `flink-runtime` module, and associated top level directory, to be tagged under `flink` like the current `spark-runtime` and associated top level spark directories / different spark modules are all tagged as `spark`.

The pending PR which adds the `flink-runtime` module is here: https://github.com/apache/iceberg/pull/1423

This closes this issue: https://github.com/apache/iceberg/issues/1448