### PR TITLE
Add a null precondition check to the varargs BaseCombinedTask constructor

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseCombinedScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseCombinedScanTask.java
@@ -30,6 +30,7 @@ public class BaseCombinedScanTask implements CombinedScanTask {
   private final FileScanTask[] tasks;
 
   public BaseCombinedScanTask(FileScanTask... tasks) {
+    Preconditions.checkNotNull(tasks, "tasks cannot be null");
     this.tasks = tasks;
   }
 


### PR DESCRIPTION
I was looking at another PR and checking for nullability concerns, when I noticed that there are two constructors for BaseCombineTask. There's one constructor that takes in a List<FileScanTask> and one that uses varargs FileScanTask.... The List constructor specifically checks for null, however, the varargs one does not.

However, because arrays are objects in java, the FileScanTask... when passed in null does not give new FileScanTask[]{null} or new FileScanTask[0], it simply passes null.

Therefore, it doesn't seem overly cautious to add a precondition check for null here since we have it already.

This closes issue: https://github.com/apache/iceberg/issues/1451