### PR TITLE
Hive3/Hadoop3 upgrade for iceberg-mr and iceberg-flink - [Draft]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ derby.log
 
 # Python stuff
 python/.mypy_cache/
+
+hive2-metastore/src

--- a/build.gradle
+++ b/build.gradle
@@ -630,7 +630,7 @@ project(':iceberg-spark') {
     compile project(':iceberg-orc')
     compile project(':iceberg-parquet')
     compile project(':iceberg-arrow')
-    compile project(':iceberg-hive-metastore')
+    compile project(':iceberg-hive2-metastore')
     compile project(':iceberg-arrow')
 
     compileOnly "org.apache.avro:avro"
@@ -643,7 +643,7 @@ project(':iceberg-spark') {
     testCompile("org.apache.hadoop:hadoop-minicluster") {
       exclude group: 'org.apache.avro', module: 'avro'
     }
-    testCompile project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
+    testCompile project(path: ':iceberg-hive2-metastore', configuration: 'testArtifacts')
     testCompile project(path: ':iceberg-api', configuration: 'testArtifacts')
     testCompile project(path: ':iceberg-data', configuration: 'testArtifacts')
   }

--- a/build.gradle
+++ b/build.gradle
@@ -685,9 +685,7 @@ if (jdkVersion == '8') {
       compile project(':iceberg-parquet')
       compile project(':iceberg-arrow')
       compile project(':iceberg-hive2-metastore')
-      compile(project(":iceberg-spark")) {
-        exclude module: "iceberg-hive-metastore"
-      }
+      compile project(":iceberg-spark")
 
       compileOnly "org.apache.avro:avro"
       compileOnly("org.apache.spark:spark-hive_2.11") {

--- a/build.gradle
+++ b/build.gradle
@@ -362,6 +362,87 @@ project(':iceberg-hive-metastore') {
   }
 }
 
+
+project(':iceberg-hive2-metastore') {
+
+  task copyFilesFromHive3(type: Copy) {
+    copy {
+      from('../hive-metastore/src/main/java/')
+      into 'src/main/java/'
+    }
+    copy {
+      from('../hive-metastore/src/main/resources/')
+      into 'src/main/resources/'
+    }
+    copy {
+      from('../hive-metastore/src/test/java/')
+      into 'src/test/java/'
+    }
+    copy {
+      from('../hive-metastore/src/test/resources/')
+      into 'src/test/resources/'
+    }
+  }
+
+  dependencies {
+
+    compile project(':iceberg-core')
+
+    compileOnly "org.apache.avro:avro"
+
+    compileOnly("org.apache.hive:hive-metastore:2.3.7") {
+      exclude group: 'org.apache.avro', module: 'avro'
+      exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+      exclude group: 'org.pentaho' // missing dependency
+      exclude group: 'org.apache.hbase'
+      exclude group: 'org.apache.logging.log4j'
+      exclude group: 'co.cask.tephra'
+      exclude group: 'com.google.code.findbugs', module: 'jsr305'
+      exclude group: 'org.eclipse.jetty.aggregate', module: 'jetty-all'
+      exclude group: 'org.eclipse.jetty.orbit', module: 'javax.servlet'
+      exclude group: 'org.apache.parquet', module: 'parquet-hadoop-bundle'
+      exclude group: 'com.tdunning', module: 'json'
+      exclude group: 'javax.transaction', module: 'transaction-api'
+      exclude group: 'com.zaxxer', module: 'HikariCP'
+    }
+
+    testCompile("org.apache.hive:hive-exec:2.3.7") {
+      exclude group: 'org.apache.avro', module: 'avro'
+      exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+      exclude group: 'org.pentaho' // missing dependency
+      exclude group: 'org.apache.hive', module: 'hive-llap-tez'
+      exclude group: 'org.apache.logging.log4j'
+      exclude group: 'com.google.protobuf', module: 'protobuf-java'
+      exclude group: 'org.apache.calcite'
+      exclude group: 'org.apache.calcite.avatica'
+      exclude group: 'com.google.code.findbugs', module: 'jsr305'
+    }
+
+    testCompile("org.apache.hive:hive-metastore:2.3.7") {
+      exclude group: 'org.apache.avro', module: 'avro'
+      exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+      exclude group: 'org.pentaho' // missing dependency
+      exclude group: 'org.apache.hbase'
+      exclude group: 'org.apache.logging.log4j'
+      exclude group: 'co.cask.tephra'
+      exclude group: 'com.google.code.findbugs', module: 'jsr305'
+      exclude group: 'org.eclipse.jetty.aggregate', module: 'jetty-all'
+      exclude group: 'org.eclipse.jetty.orbit', module: 'javax.servlet'
+      exclude group: 'org.apache.parquet', module: 'parquet-hadoop-bundle'
+      exclude group: 'com.tdunning', module: 'json'
+      exclude group: 'javax.transaction', module: 'transaction-api'
+      exclude group: 'com.zaxxer', module: 'HikariCP'
+    }
+
+    compileOnly("org.apache.hadoop:hadoop-client:2.7.3") {
+      exclude group: 'org.apache.avro', module: 'avro'
+      exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+    }
+
+    testCompile project(path: ':iceberg-api', configuration: 'testArtifacts')
+  }
+}
+
 project(':iceberg-mr') {
   configurations {
     testCompile {
@@ -404,7 +485,7 @@ project(':iceberg-mr') {
     testCompile("org.apache.calcite:calcite-core")
     testCompile("com.esotericsoftware:kryo-shaded:4.0.2")
     testCompile("com.fasterxml.jackson.core:jackson-annotations:2.6.5")
-    testCompile("com.klarna:hiverunner:5.2.1") {
+    testCompile("com.klarna:hiverunner:6.0.1") {
       exclude group: 'javax.jms', module: 'jms'
       exclude group: 'org.apache.hive', module: 'hive-exec'
       exclude group: 'org.codehaus.jettison', module: 'jettison'
@@ -603,8 +684,10 @@ if (jdkVersion == '8') {
       compile project(':iceberg-orc')
       compile project(':iceberg-parquet')
       compile project(':iceberg-arrow')
-      compile project(':iceberg-hive-metastore')
-      compile project(':iceberg-spark')
+      compile project(':iceberg-hive2-metastore')
+      compile(project(":iceberg-spark")) {
+        exclude module: "iceberg-hive-metastore"
+      }
 
       compileOnly "org.apache.avro:avro"
       compileOnly("org.apache.spark:spark-hive_2.11") {
@@ -613,12 +696,13 @@ if (jdkVersion == '8') {
 
       testCompile project(path: ':iceberg-spark', configuration: 'testArtifacts')
 
-      testCompile "org.apache.hadoop:hadoop-hdfs::tests"
-      testCompile "org.apache.hadoop:hadoop-common::tests"
-      testCompile("org.apache.hadoop:hadoop-minicluster") {
+      testCompile "org.apache.hadoop:hadoop-hdfs:2.7.3"
+      testCompile "org.apache.hadoop:hadoop-common:2.7.3"
+      testCompile("org.apache.hadoop:hadoop-minicluster:2.7.3") {
         exclude group: 'org.apache.avro', module: 'avro'
       }
-      testCompile project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
+
+      testCompile project(path: ':iceberg-hive2-metastore', configuration: 'testArtifacts')
       testCompile project(path: ':iceberg-api', configuration: 'testArtifacts')
     }
 
@@ -709,7 +793,7 @@ project(':iceberg-spark3') {
     compile project(':iceberg-orc')
     compile project(':iceberg-parquet')
     compile project(':iceberg-arrow')
-    compile project(':iceberg-hive-metastore')
+    compile project(':iceberg-hive2-metastore')
     compile project(':iceberg-spark')
 
     compileOnly "org.apache.avro:avro"
@@ -725,7 +809,7 @@ project(':iceberg-spark3') {
     testCompile("org.apache.hadoop:hadoop-minicluster") {
       exclude group: 'org.apache.avro', module: 'avro'
     }
-    testCompile project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
+    testCompile project(path: ':iceberg-hive2-metastore', configuration: 'testArtifacts')
     testCompile project(path: ':iceberg-api', configuration: 'testArtifacts')
   }
 

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -79,6 +80,15 @@ public class TestHiveMetastore {
     }
     if (hiveLocalDir != null) {
       hiveLocalDir.delete();
+    }
+
+    // remove raw store if exists
+    try {
+      Method cleanupRawStore = HiveMetaStore.class.getDeclaredMethod("cleanupRawStore");
+      cleanupRawStore.setAccessible(true);
+      cleanupRawStore.invoke(null);
+    } catch (Exception e) {
+      // no op
     }
   }
 

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergFilterFactory.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergFilterFactory.java
@@ -127,7 +127,7 @@ public class HiveIcebergFilterFactory {
       case FLOAT:
         return leaf.getLiteral();
       case DATE:
-        return daysFromTimestamp((Timestamp) leaf.getLiteral());
+        return daysFromDate((Date) leaf.getLiteral());
       case TIMESTAMP:
         return microsFromTimestamp((Timestamp) LITERAL_FIELD.get(leaf));
       case DECIMAL:

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -82,6 +82,11 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
   }
 
   @Override
+  public void configureInputJobCredentials(TableDesc tableDesc, Map<String, String> secrets) {
+
+  }
+
+  @Override
   public void configureOutputJobProperties(TableDesc tableDesc, Map<String, String> map) {
 
   }

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergDateObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergDateObjectInspector.java
@@ -19,9 +19,9 @@
 
 package org.apache.iceberg.mr.hive.serde.objectinspector;
 
-import java.sql.Date;
 import java.time.LocalDate;
-import org.apache.hadoop.hive.serde2.io.DateWritable;
+import org.apache.hadoop.hive.common.type.Date;
+import org.apache.hadoop.hive.serde2.io.DateWritableV2;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.AbstractPrimitiveJavaObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.DateObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
@@ -42,17 +42,17 @@ public final class IcebergDateObjectInspector extends AbstractPrimitiveJavaObjec
 
   @Override
   public Date getPrimitiveJavaObject(Object o) {
-    return o == null ? null : Date.valueOf((LocalDate) o);
+    return o == null ? null : Date.valueOf(o.toString());
   }
 
   @Override
-  public DateWritable getPrimitiveWritableObject(Object o) {
-    return o == null ? null : new DateWritable(DateTimeUtil.daysFromDate((LocalDate) o));
+  public DateWritableV2 getPrimitiveWritableObject(Object o) {
+    return o == null ? null : new DateWritableV2(DateTimeUtil.daysFromDate((LocalDate) o));
   }
 
   @Override
   public Object copyObject(Object o) {
-    return o == null ? null : new Date(((Date) o).getTime());
+    return o == null ? null : Date.valueOf(o.toString());
   }
 
 }

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampObjectInspector.java
@@ -19,10 +19,10 @@
 
 package org.apache.iceberg.mr.hive.serde.objectinspector;
 
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
-import org.apache.hadoop.hive.serde2.io.TimestampWritable;
+import org.apache.hadoop.hive.common.type.Timestamp;
+import org.apache.hadoop.hive.serde2.io.TimestampWritableV2;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.AbstractPrimitiveJavaObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
@@ -57,13 +57,13 @@ public abstract class IcebergTimestampObjectInspector extends AbstractPrimitiveJ
 
   @Override
   public Timestamp getPrimitiveJavaObject(Object o) {
-    return o == null ? null : Timestamp.valueOf(toLocalDateTime(o));
+    return o == null ? null : Timestamp.valueOf(o.toString());
   }
 
   @Override
-  public TimestampWritable getPrimitiveWritableObject(Object o) {
+  public TimestampWritableV2 getPrimitiveWritableObject(Object o) {
     Timestamp ts = getPrimitiveJavaObject(o);
-    return ts == null ? null : new TimestampWritable(ts);
+    return ts == null ? null : new TimestampWritableV2(ts);
   }
 
   @Override
@@ -73,7 +73,7 @@ public abstract class IcebergTimestampObjectInspector extends AbstractPrimitiveJ
     }
 
     Timestamp ts = (Timestamp) o;
-    Timestamp copy = new Timestamp(ts.getTime());
+    Timestamp copy = new Timestamp(ts);
     copy.setNanos(ts.getNanos());
     return copy;
   }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergDateObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergDateObjectInspector.java
@@ -19,9 +19,9 @@
 
 package org.apache.iceberg.mr.hive.serde.objectinspector;
 
-import java.sql.Date;
 import java.time.LocalDate;
-import org.apache.hadoop.hive.serde2.io.DateWritable;
+import org.apache.hadoop.hive.common.type.Date;
+import org.apache.hadoop.hive.serde2.io.DateWritableV2;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.DateObjectInspector;
@@ -42,7 +42,7 @@ public class TestIcebergDateObjectInspector {
     Assert.assertEquals(TypeInfoFactory.dateTypeInfo.getTypeName(), oi.getTypeName());
 
     Assert.assertEquals(Date.class, oi.getJavaPrimitiveClass());
-    Assert.assertEquals(DateWritable.class, oi.getPrimitiveWritableClass());
+    Assert.assertEquals(DateWritableV2.class, oi.getPrimitiveWritableClass());
 
     Assert.assertNull(oi.copyObject(null));
     Assert.assertNull(oi.getPrimitiveJavaObject(null));
@@ -52,7 +52,7 @@ public class TestIcebergDateObjectInspector {
     Date date = Date.valueOf("2020-01-01");
 
     Assert.assertEquals(date, oi.getPrimitiveJavaObject(local));
-    Assert.assertEquals(new DateWritable(date), oi.getPrimitiveWritableObject(local));
+    Assert.assertEquals(new DateWritableV2(date), oi.getPrimitiveWritableObject(local));
 
     Date copy = (Date) oi.copyObject(date);
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampObjectInspector.java
@@ -19,9 +19,9 @@
 
 package org.apache.iceberg.mr.hive.serde.objectinspector;
 
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
-import org.apache.hadoop.hive.serde2.io.TimestampWritable;
+import org.apache.hadoop.hive.common.type.Timestamp;
+import org.apache.hadoop.hive.serde2.io.TimestampWritableV2;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectInspector;
@@ -42,7 +42,7 @@ public class TestIcebergTimestampObjectInspector {
     Assert.assertEquals(TypeInfoFactory.timestampTypeInfo.getTypeName(), oi.getTypeName());
 
     Assert.assertEquals(Timestamp.class, oi.getJavaPrimitiveClass());
-    Assert.assertEquals(TimestampWritable.class, oi.getPrimitiveWritableClass());
+    Assert.assertEquals(TimestampWritableV2.class, oi.getPrimitiveWritableClass());
 
     Assert.assertNull(oi.copyObject(null));
     Assert.assertNull(oi.getPrimitiveJavaObject(null));
@@ -52,7 +52,7 @@ public class TestIcebergTimestampObjectInspector {
     Timestamp ts = Timestamp.valueOf("2020-01-01 00:00:00");
 
     Assert.assertEquals(ts, oi.getPrimitiveJavaObject(local));
-    Assert.assertEquals(new TimestampWritable(ts), oi.getPrimitiveWritableObject(local));
+    Assert.assertEquals(new TimestampWritableV2(ts), oi.getPrimitiveWritableObject(local));
 
     Timestamp copy = (Timestamp) oi.copyObject(ts);
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -34,6 +34,7 @@ include 'spark3'
 include 'spark3-runtime'
 include 'pig'
 include 'hive-metastore'
+include 'hive2-metastore'
 
 project(':api').name = 'iceberg-api'
 project(':common').name = 'iceberg-common'
@@ -51,6 +52,7 @@ project(':spark3').name = 'iceberg-spark3'
 project(':spark3-runtime').name = 'iceberg-spark3-runtime'
 project(':pig').name = 'iceberg-pig'
 project(':hive-metastore').name = 'iceberg-hive-metastore'
+project(':hive2-metastore').name = 'iceberg-hive2-metastore'
 
 if (JavaVersion.current() == JavaVersion.VERSION_1_8) {
   include 'spark2'

--- a/versions.props
+++ b/versions.props
@@ -1,9 +1,9 @@
 org.slf4j:* = 1.7.25
 org.apache.avro:avro = 1.9.2
 org.apache.flink:* = 1.11.0
-org.apache.hadoop:* = 2.7.3
-org.apache.hive:hive-metastore = 2.3.7
-org.apache.hive:hive-serde = 2.3.7
+org.apache.hadoop:* = 3.1.0
+org.apache.hive:hive-metastore = 3.1.2
+org.apache.hive:hive-serde = 3.1.2
 org.apache.orc:* = 1.6.3
 org.apache.parquet:* = 1.11.0
 org.apache.spark:spark-hive_2.11 = 2.4.6
@@ -21,4 +21,4 @@ com.github.stephenc.findbugs:findbugs-annotations = 1.3.9-1
 # test deps
 junit:junit = 4.12
 org.mockito:mockito-core = 1.10.19
-org.apache.hive:hive-exec = 2.3.7
+org.apache.hive:hive-exec = 3.1.2


### PR DESCRIPTION
The goal of this patch is to upgrade certain components to Hive3/Hadoop3 (Hive and Flink), while keeping the option open for other components to stay at Hive2/Hadoop2 (Spark 2/3). 

For these latter components, I've created a separate iceberg-hive2-metastore module which they can continue using. I'm not that familiar with gradle, so this part is very much draft-like, with a copy task copying over the source files from the iceberg-hive-metastore module, just using different versions for its dependencies. Any ideas on how to solve this better is greatly appreciated.

(note: only been tested with java8, so will need to look into any test failures on java 11)