### PR TITLE
Add .gitattributes file for simplifying excludes/includes in release script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Files marked as export-ignore will be ignored from the release's
+# built via `git archive`. This simplifies the release script and 
+# uses an industry standard as opposed to possibly hard to read
+# shell scripts with many flags. Unfortunately, directories themselves
+# won't recursively ignore, so we need the top level directories
+# as well as their files.
+/build         export-ignore
+/build/**      export-ignore
+/examples      export-ignore
+/examples/**   export-ignore
+jitpack.yml    export-ignore
+/python        export-ignore
+/python/**     export-ignore
+/site          export-ignore
+/site/**       export-ignore
+


### PR DESCRIPTION
We are working on updating the release script to make it easier to pick up all current files, except for the few sets of directories or files that we would like to ignore from the release. The current PR (which has a large number of added shell commands) is https://github.com/apache/iceberg/issues/1453.

`.gitattributes` provides an easy, industry-standard way of doing this which will greatly simplify the release scripts.

In order to see the changes in any PR to update the release script, the `.gitattributes` file needs to be added first.

This closes https://github.com/apache/iceberg/issues/1453 and then makes way for a much simplified release script, using industry standards, beyond the work done in https://github.com/apache/iceberg/issues/1453.

I have merged this into my local repository and then run the release script and listed the contents of the tarball. None of the ignored files are there. Additionally, for ignored directories like `/build`, only the top level directory is ignored and not any subdirectories of that name (such as some `/build` directories included underneath some of the various `/spark` repo root directories that _would_ need to be included in a release to fully run tests.