### PR TITLE
Use gitattributes file to detect archive list automatically and simplify release script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Files marked as export-ignore will be ignored from the release's
+# built via `git archive`. This simplifies the release script and 
+# uses an industry standard as opposed to possibly hard to read
+# shell scripts with many flags. Unfortunately, directories themselves
+# won't recursively ignore, so we need the top level directories
+# as well as their files.
+/build         export-ignore
+/build/**      export-ignore
+/examples      export-ignore
+/examples/**   export-ignore
+jitpack.yml    export-ignore
+/python        export-ignore
+/python/**     export-ignore
+/site          export-ignore
+/site/**       export-ignore
+

--- a/dev/source-release.sh
+++ b/dev/source-release.sh
@@ -66,7 +66,7 @@ tarball=$tag.tar.gz
 
 # be conservative and use the release hash, even though git produces the same
 # archive (identical hashes) using the scm tag
-git archive $release_hash --worktree-attributes --prefix $tag/ -o $tarball $tagrc
+git archive $release_hash --worktree-attributes --prefix $tag/ -o $tarball HEAD
 
 # sign the archive
 gpg --armor --output ${tarball}.asc --detach-sig $tarball

--- a/dev/source-release.sh
+++ b/dev/source-release.sh
@@ -21,12 +21,12 @@
 set -e
 
 if [ -z "$1" ]; then
-  echo "Usage: $0 <version> <rc-num>"
+  echo "Usage: $0 <version-num> <rc-num>"
   exit
 fi
 
 if [ -z "$2" ]; then
-  echo "Usage: $0 <version> <rc-num>"
+  echo "Usage: $0 <version-num> <rc-num>"
   exit
 fi
 
@@ -66,7 +66,7 @@ tarball=$tag.tar.gz
 
 # be conservative and use the release hash, even though git produces the same
 # archive (identical hashes) using the scm tag
-git archive $release_hash --prefix $tag/ -o $tarball .baseline api arrow bundled-guava common core data dev flink gradle gradlew hive mr orc parquet pig spark spark2 spark-runtime spark3 spark3-runtime LICENSE NOTICE README.md build.gradle baseline.gradle deploy.gradle tasks.gradle jmh.gradle gradle.properties settings.gradle versions.lock versions.props version.txt
+git archive $release_hash --worktree-attributes --prefix $tag/ -o $tarball $tagrc
 
 # sign the archive
 gpg --armor --output ${tarball}.asc --detach-sig $tarball


### PR DESCRIPTION
This PR replaces https://github.com/apache/iceberg/pull/1227, as @rdblue and I spent quite some time on it yesterday trying to get it to work and it wound up becoming one of those somewhat overly complex shell scripts (mostly due to my suggestions).

As it turns out, git already has a feature to explicitly ignore certain files, directories, and the contents of those directories from the `git archive` process. This can be achieved via the `.gitattributes` file and the `export-ignore` label.

In order to achieve the same behavior of `git ls-tree --name-only -r HEAD`, which Ryan suggested as an alternative to automatically keeping the archives "includes" up to date, I've gone ahead and used HEAD as the tag that is passed to the `git archive` script. It still uses the `release_hash`, but it then no longer requires us to explicitly include anything (or to rely on possibly non-portable shell scripts that use a combination of several commands in a row to generate the list of things to include). Especially given that the script makes a commit prior to tagging the release, it seemed to make sense to use HEAD.

I have tested this in my local fork and I can confirm that, once merging in the .gitattributes file, the resulting tarball does not hav any of the ignored files or top-level directories or their contents. Additionally, subdirectories that share the same name as top level directories we want to ignore _are not ignored_, which is the behavior we want. The examples I found were the `build` subdirectories from some of the spark modules that are needed for running tests and therefore need to be included in the release).

This PR should be merged in after https://github.com/apache/iceberg/pull/1457. This PR will close this issue https://github.com/apache/iceberg/issues/1458 and subsumes the original PR, https://github.com/apache/iceberg/pull/1227, as that PR dates back quite some time and this solution deviates pretty heavily from the original solution proposed Thanks to @waterlx for bringing this issue to our attention and working on the first patch.

However, this patch has deviated quite a lot from that one, and I think it's arguable preferable given that it uses a standard tool built into git (the .gitattributes flle) to handle what we were attempting to do ourselves with a large amount of shell based munging.