### PR TITLE
Add position delete validation that data files have not been deleted

### DIFF
--- a/api/src/main/java/org/apache/iceberg/OverwriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/OverwriteFiles.java
@@ -88,6 +88,36 @@ public interface OverwriteFiles extends SnapshotUpdate<OverwriteFiles> {
   OverwriteFiles validateAddedFilesMatchOverwriteFilter();
 
   /**
+   * Set the snapshot ID used in any reads for this operation.
+   * <p>
+   * Validations will check changes after this snapshot ID.
+   *
+   * @param snapshotId a snapshot ID
+   * @return this for method chaining
+   */
+  OverwriteFiles validateFromSnapshot(long snapshotId);
+
+  /**
+   * Enables validation that files added concurrently do not conflict with this commit's operation.
+   * <p>
+   * This method should be called when the table is queried to determine which files to delete/append.
+   * If a concurrent operation commits a new file after the data was read and that file might
+   * contain rows matching the specified conflict detection filter, the overwrite operation
+   * will detect this during retries and fail.
+   * <p>
+   * Calling this method with a correct conflict detection filter is required to maintain
+   * serializable isolation for eager update/delete operations. Otherwise, the isolation level
+   * will be snapshot isolation.
+   * <p>
+   * Validation applies to files added to the table since the snapshot passed to {@link #validateFromSnapshot(long)}.
+   *
+   * @param conflictDetectionFilter an expression on rows in the table
+   * @param isCaseSensitive whether conflict detection filter evaluation should be case sensitive
+   * @return this for method chaining
+   */
+  OverwriteFiles validateNoConflictingAppends(Expression conflictDetectionFilter, boolean isCaseSensitive);
+
+  /**
    * Enables validation that files added concurrently do not conflict with this commit's operation.
    * <p>
    * This method should be called when the table is queried to determine which files to delete/append.
@@ -102,6 +132,10 @@ public interface OverwriteFiles extends SnapshotUpdate<OverwriteFiles> {
    * @param readSnapshotId the snapshot id that was used to read the data or null if the table was empty
    * @param conflictDetectionFilter an expression on rows in the table
    * @return this for method chaining
+   * @deprecated this will be removed in 0.11.0;
+   *             use {@link #validateNoConflictingAppends(Expression, boolean)} and {@link #validateFromSnapshot(long)}
+   *             instead
    */
+  @Deprecated
   OverwriteFiles validateNoConflictingAppends(Long readSnapshotId, Expression conflictDetectionFilter);
 }

--- a/api/src/main/java/org/apache/iceberg/OverwriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/OverwriteFiles.java
@@ -90,12 +90,21 @@ public interface OverwriteFiles extends SnapshotUpdate<OverwriteFiles> {
   /**
    * Set the snapshot ID used in any reads for this operation.
    * <p>
-   * Validations will check changes after this snapshot ID.
+   * Validations will check changes after this snapshot ID. If the from snapshot is not set, all ancestor snapshots
+   * through the table's initial snapshot are validated.
    *
    * @param snapshotId a snapshot ID
    * @return this for method chaining
    */
   OverwriteFiles validateFromSnapshot(long snapshotId);
+
+  /**
+   * Enables or disables case sensitive expression binding for validations that accept expressions.
+   *
+   * @param caseSensitive whether expression binding should be case sensitive
+   * @return this for method chaining
+   */
+  OverwriteFiles caseSensitive(boolean caseSensitive);
 
   /**
    * Enables validation that files added concurrently do not conflict with this commit's operation.
@@ -112,10 +121,9 @@ public interface OverwriteFiles extends SnapshotUpdate<OverwriteFiles> {
    * Validation applies to files added to the table since the snapshot passed to {@link #validateFromSnapshot(long)}.
    *
    * @param conflictDetectionFilter an expression on rows in the table
-   * @param isCaseSensitive whether conflict detection filter evaluation should be case sensitive
    * @return this for method chaining
    */
-  OverwriteFiles validateNoConflictingAppends(Expression conflictDetectionFilter, boolean isCaseSensitive);
+  OverwriteFiles validateNoConflictingAppends(Expression conflictDetectionFilter);
 
   /**
    * Enables validation that files added concurrently do not conflict with this commit's operation.
@@ -133,8 +141,7 @@ public interface OverwriteFiles extends SnapshotUpdate<OverwriteFiles> {
    * @param conflictDetectionFilter an expression on rows in the table
    * @return this for method chaining
    * @deprecated this will be removed in 0.11.0;
-   *             use {@link #validateNoConflictingAppends(Expression, boolean)} and {@link #validateFromSnapshot(long)}
-   *             instead
+   *             use {@link #validateNoConflictingAppends(Expression)} and {@link #validateFromSnapshot(long)} instead
    */
   @Deprecated
   OverwriteFiles validateNoConflictingAppends(Long readSnapshotId, Expression conflictDetectionFilter);

--- a/api/src/main/java/org/apache/iceberg/RowDelta.java
+++ b/api/src/main/java/org/apache/iceberg/RowDelta.java
@@ -65,4 +65,12 @@ public interface RowDelta extends SnapshotUpdate<RowDelta> {
    * @return this for method chaining
    */
   RowDelta validateDataFilesExist(Iterable<? extends CharSequence> referencedFiles);
+
+  /**
+   * Enable validation that referenced data files passed to {@link #validateDataFilesExist(Iterable)} have not been
+   * removed by a delete operation.
+   *
+   * @return this for method chaining
+   */
+  RowDelta validateDeletedFiles();
 }

--- a/api/src/main/java/org/apache/iceberg/RowDelta.java
+++ b/api/src/main/java/org/apache/iceberg/RowDelta.java
@@ -50,12 +50,21 @@ public interface RowDelta extends SnapshotUpdate<RowDelta> {
   /**
    * Set the snapshot ID used in any reads for this operation.
    * <p>
-   * Validations will check changes after this snapshot ID.
+   * Validations will check changes after this snapshot ID. If the from snapshot is not set, all ancestor snapshots
+   * through the table's initial snapshot are validated.
    *
    * @param snapshotId a snapshot ID
    * @return this for method chaining
    */
   RowDelta validateFromSnapshot(long snapshotId);
+
+  /**
+   * Enables or disables case sensitive expression binding for validations that accept expressions.
+   *
+   * @param caseSensitive whether expression binding should be case sensitive
+   * @return this for method chaining
+   */
+  RowDelta caseSensitive(boolean caseSensitive);
 
   /**
    * Add data file paths that must not be removed by conflicting commits for this RowDelta to succeed.
@@ -93,14 +102,13 @@ public interface RowDelta extends SnapshotUpdate<RowDelta> {
    * will detect this during retries and fail.
    * <p>
    * Calling this method with a correct conflict detection filter is required to maintain
-   * serializable isolation for eager update/delete operations. Otherwise, the isolation level
+   * serializable isolation for update/delete operations. Otherwise, the isolation level
    * will be snapshot isolation.
    * <p>
    * Validation applies to files added to the table since the snapshot passed to {@link #validateFromSnapshot(long)}.
    *
    * @param conflictDetectionFilter an expression on rows in the table
-   * @param isCaseSensitive whether conflict detection filter evaluation should be case sensitive
    * @return this for method chaining
    */
-  RowDelta validateNoConflictingAppends(Expression conflictDetectionFilter, boolean isCaseSensitive);
+  RowDelta validateNoConflictingAppends(Expression conflictDetectionFilter);
 }

--- a/api/src/main/java/org/apache/iceberg/RowDelta.java
+++ b/api/src/main/java/org/apache/iceberg/RowDelta.java
@@ -44,4 +44,25 @@ public interface RowDelta extends SnapshotUpdate<RowDelta> {
    * @return this for method chaining
    */
   RowDelta addDeletes(DeleteFile deletes);
+
+  /**
+   * Set the snapshot ID used to produce delete files.
+   * <p>
+   * Validations will check changes after this snapshot ID.
+   *
+   * @param snapshotId a snapshot ID
+   * @return this for method chaining
+   */
+  RowDelta validateFromSnapshot(long snapshotId);
+
+  /**
+   * Add data file paths that must not be deleted for this RowDelta to succeed.
+   * <p>
+   * If any path has been removed from the table since the snapshot passed to {@link #validateFromSnapshot(long)}, the
+   * operation will fail with a {@link org.apache.iceberg.exceptions.ValidationException}.
+   *
+   * @param referencedFiles file paths that are referenced by a position delete file
+   * @return this for method chaining
+   */
+  RowDelta validateDataFilesExist(Iterable<? extends CharSequence> referencedFiles);
 }

--- a/core/src/main/java/org/apache/iceberg/BaseOverwriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseOverwriteFiles.java
@@ -82,7 +82,7 @@ public class BaseOverwriteFiles extends MergingSnapshotProducer<OverwriteFiles> 
   }
 
   @Override
-  public List<ManifestFile> apply(TableMetadata base) {
+  protected void validate(TableMetadata base) {
     if (validateAddedFilesMatchOverwriteFilter) {
       PartitionSpec spec = writeSpec();
       Expression rowFilter = rowFilter();
@@ -124,7 +124,5 @@ public class BaseOverwriteFiles extends MergingSnapshotProducer<OverwriteFiles> 
             conflictDetectionFilter, newFile.path());
       }
     }
-
-    return super.apply(base);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseOverwriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseOverwriteFiles.java
@@ -19,20 +19,18 @@
 
 package org.apache.iceberg;
 
-import java.util.List;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Evaluator;
 import org.apache.iceberg.expressions.Expression;
-import org.apache.iceberg.expressions.InclusiveMetricsEvaluator;
 import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.expressions.StrictMetricsEvaluator;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.util.SnapshotUtil;
 
 public class BaseOverwriteFiles extends MergingSnapshotProducer<OverwriteFiles> implements OverwriteFiles {
   private boolean validateAddedFilesMatchOverwriteFilter = false;
-  private Long readSnapshotId = null;
+  private Long startingSnapshotId = null;
   private Expression conflictDetectionFilter = null;
+  private boolean caseSensitive = true;
 
   protected BaseOverwriteFiles(String tableName, TableOperations ops) {
     super(tableName, ops);
@@ -73,10 +71,25 @@ public class BaseOverwriteFiles extends MergingSnapshotProducer<OverwriteFiles> 
   }
 
   @Override
+  @Deprecated
   public OverwriteFiles validateNoConflictingAppends(Long newReadSnapshotId, Expression newConflictDetectionFilter) {
+    if (newReadSnapshotId != null) {
+      validateFromSnapshot(newReadSnapshotId);
+    }
+    validateNoConflictingAppends(newConflictDetectionFilter, true);
+    return this;
+  }
+
+  @Override
+  public OverwriteFiles validateFromSnapshot(long snapshotId) {
+    this.startingSnapshotId = snapshotId;
+    return this;
+  }
+
+  public OverwriteFiles validateNoConflictingAppends(Expression newConflictDetectionFilter, boolean isCaseSensitive) {
     Preconditions.checkArgument(newConflictDetectionFilter != null, "Conflict detection filter cannot be null");
-    this.readSnapshotId = newReadSnapshotId;
     this.conflictDetectionFilter = newConflictDetectionFilter;
+    this.caseSensitive = isCaseSensitive;
     failMissingDeletePaths();
     return this;
   }
@@ -109,20 +122,7 @@ public class BaseOverwriteFiles extends MergingSnapshotProducer<OverwriteFiles> 
     }
 
     if (conflictDetectionFilter != null && base.currentSnapshot() != null) {
-      PartitionSpec spec = writeSpec();
-      Expression inclusiveExpr = Projections.inclusive(spec).project(conflictDetectionFilter);
-      Evaluator inclusive = new Evaluator(spec.partitionType(), inclusiveExpr);
-
-      InclusiveMetricsEvaluator metrics = new InclusiveMetricsEvaluator(base.schema(), conflictDetectionFilter);
-
-      List<DataFile> newFiles = SnapshotUtil.newFiles(
-          readSnapshotId, base.currentSnapshot().snapshotId(), base::snapshot);
-      for (DataFile newFile : newFiles) {
-        ValidationException.check(
-            !inclusive.eval(newFile.partition()) || !metrics.eval(newFile),
-            "A file was appended that might contain data matching filter '%s': %s",
-            conflictDetectionFilter, newFile.path());
-      }
+      validateAddedDataFiles(base, startingSnapshotId, conflictDetectionFilter, caseSensitive);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseOverwriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseOverwriteFiles.java
@@ -76,7 +76,7 @@ public class BaseOverwriteFiles extends MergingSnapshotProducer<OverwriteFiles> 
     if (newReadSnapshotId != null) {
       validateFromSnapshot(newReadSnapshotId);
     }
-    validateNoConflictingAppends(newConflictDetectionFilter, true);
+    validateNoConflictingAppends(newConflictDetectionFilter);
     return this;
   }
 
@@ -86,10 +86,15 @@ public class BaseOverwriteFiles extends MergingSnapshotProducer<OverwriteFiles> 
     return this;
   }
 
-  public OverwriteFiles validateNoConflictingAppends(Expression newConflictDetectionFilter, boolean isCaseSensitive) {
+  @Override
+  public OverwriteFiles caseSensitive(boolean isCaseSensitive) {
+    this.caseSensitive = isCaseSensitive;
+    return this;
+  }
+
+  public OverwriteFiles validateNoConflictingAppends(Expression newConflictDetectionFilter) {
     Preconditions.checkArgument(newConflictDetectionFilter != null, "Conflict detection filter cannot be null");
     this.conflictDetectionFilter = newConflictDetectionFilter;
-    this.caseSensitive = isCaseSensitive;
     failMissingDeletePaths();
     return this;
   }

--- a/core/src/main/java/org/apache/iceberg/BaseRowDelta.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRowDelta.java
@@ -27,7 +27,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.CharSequenceSet;
-import org.apache.iceberg.util.SnapshotUtil;
 
 class BaseRowDelta extends MergingSnapshotProducer<RowDelta> implements RowDelta {
   private final Set<CharSequence> referencedDataFiles = CharSequenceSet.empty();

--- a/core/src/main/java/org/apache/iceberg/BaseRowDelta.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRowDelta.java
@@ -19,8 +19,12 @@
 
 package org.apache.iceberg;
 
+import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.CharSequenceSet;
 import org.apache.iceberg.util.SnapshotUtil;
@@ -74,12 +78,36 @@ class BaseRowDelta extends MergingSnapshotProducer<RowDelta> implements RowDelta
     }
 
     Set<CharSequence> removedDataFiles = CharSequenceSet.empty();
-    SnapshotUtil.removedDataFiles(validationSnapshotId, base.currentSnapshot().snapshotId(), base::snapshot).stream()
+    removedDataFiles(validationSnapshotId, base.currentSnapshot().snapshotId(), base::snapshot).stream()
         .map(DataFile::path)
         .forEach(removedDataFiles::add);
     Set<CharSequence> missingDataFiles = Sets.intersection(referencedDataFiles, removedDataFiles);
 
     ValidationException.check(missingDataFiles.isEmpty(),
         "Cannot commit deletes for missing data files: %s", removedDataFiles);
+  }
+
+  private static List<DataFile> removedDataFiles(Long baseSnapshotId, long latestSnapshotId,
+                                                Function<Long, Snapshot> lookup) {
+    List<DataFile> deletedFiles = Lists.newArrayList();
+
+    Long currentSnapshotId = latestSnapshotId;
+    while (currentSnapshotId != null && !currentSnapshotId.equals(baseSnapshotId)) {
+      Snapshot currentSnapshot = lookup.apply(currentSnapshotId);
+
+      if (currentSnapshot == null) {
+        throw new ValidationException(
+            "Cannot determine history between read snapshot %s and current %s",
+            baseSnapshotId, currentSnapshotId);
+      }
+
+      if (!currentSnapshot.operation().equals(DataOperations.DELETE)) {
+        Iterables.addAll(deletedFiles, currentSnapshot.deletedFiles());
+      }
+
+      currentSnapshotId = currentSnapshot.parentId();
+    }
+
+    return deletedFiles;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseRowDelta.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRowDelta.java
@@ -70,12 +70,14 @@ class BaseRowDelta extends MergingSnapshotProducer<RowDelta> implements RowDelta
   }
 
   @Override
-  public RowDelta validateDeletedFiles() {
-    return validateDeletedFiles(true);
+  public RowDelta caseSensitive(boolean isCaseSensitive) {
+    this.caseSensitive = isCaseSensitive;
+    return this;
   }
 
-  public RowDelta validateDeletedFiles(boolean shouldValidate) {
-    this.validateDeletes = shouldValidate;
+  @Override
+  public RowDelta validateDeletedFiles() {
+    this.validateDeletes = true;
     return this;
   }
 
@@ -86,10 +88,9 @@ class BaseRowDelta extends MergingSnapshotProducer<RowDelta> implements RowDelta
   }
 
   @Override
-  public RowDelta validateNoConflictingAppends(Expression newConflictDetectionFilter, boolean isCaseSensitive) {
+  public RowDelta validateNoConflictingAppends(Expression newConflictDetectionFilter) {
     Preconditions.checkArgument(newConflictDetectionFilter != null, "Conflict detection filter cannot be null");
     this.conflictDetectionFilter = newConflictDetectionFilter;
-    this.caseSensitive = isCaseSensitive;
     return this;
   }
 

--- a/core/src/main/java/org/apache/iceberg/BaseRowDelta.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRowDelta.java
@@ -19,15 +19,9 @@
 
 package org.apache.iceberg;
 
-import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
-import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.CharSequenceSet;
 
 class BaseRowDelta extends MergingSnapshotProducer<RowDelta> implements RowDelta {

--- a/core/src/main/java/org/apache/iceberg/BaseRowDelta.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRowDelta.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import java.util.function.Function;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expression;
-import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -32,7 +31,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.CharSequenceSet;
 
 class BaseRowDelta extends MergingSnapshotProducer<RowDelta> implements RowDelta {
-  private final FileIO io;
   private Long startingSnapshotId = null; // check all versions by default
   private final Set<CharSequence> referencedDataFiles = CharSequenceSet.empty();
   private boolean validateDeletes = false;
@@ -41,7 +39,6 @@ class BaseRowDelta extends MergingSnapshotProducer<RowDelta> implements RowDelta
 
   BaseRowDelta(String tableName, TableOperations ops) {
     super(tableName, ops);
-    this.io = ops.io();
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -40,8 +40,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.apache.iceberg.relocated.com.google.common.collect.Streams;
-import org.apache.iceberg.util.CharSequenceSet;
 
 import static org.apache.iceberg.TableProperties.MANIFEST_MIN_MERGE_COUNT;
 import static org.apache.iceberg.TableProperties.MANIFEST_MIN_MERGE_COUNT_DEFAULT;

--- a/core/src/main/java/org/apache/iceberg/SnapshotManager.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotManager.java
@@ -197,19 +197,12 @@ public class SnapshotManager extends MergingSnapshotProducer<ManageSnapshots> im
     }
   }
 
-  private void validate(TableMetadata base) {
+  @Override
+  protected void validate(TableMetadata base) {
     validateCurrentSnapshot(base, requiredCurrentSnapshotId);
     validateNonAncestor(base, targetSnapshotId);
     validateReplacedPartitions(base, overwriteParentId, replacedPartitions);
     WapUtil.validateWapPublish(base, targetSnapshotId);
-  }
-
-  @Override
-  public List<ManifestFile> apply(TableMetadata base) {
-    // this apply method is called by SnapshotProducer, which refreshes the current table state
-    // because the state may have changed in that refresh, the validations must be done here
-    validate(base);
-    return super.apply(base);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -140,12 +140,25 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
    */
   protected abstract List<ManifestFile> apply(TableMetadata metadataToUpdate);
 
+  /**
+   * Validate the current metadata.
+   * <p>
+   * Child operations can override this to add custom validation.
+   *
+   * @param currentMetadata current table metadata to validate
+   */
+  protected void validate(TableMetadata currentMetadata) {
+  }
+
   @Override
   public Snapshot apply() {
     this.base = refresh();
     Long parentSnapshotId = base.currentSnapshot() != null ?
         base.currentSnapshot().snapshotId() : null;
     long sequenceNumber = base.nextSequenceNumber();
+
+    // run validations from the child operation
+    validate(base);
 
     List<ManifestFile> manifests = apply(base);
 

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -133,14 +133,6 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
   protected abstract String operation();
 
   /**
-   * Apply the update's changes to the base table metadata and return the new manifest list.
-   *
-   * @param metadataToUpdate the base table metadata to apply changes to
-   * @return a manifest list for the new snapshot.
-   */
-  protected abstract List<ManifestFile> apply(TableMetadata metadataToUpdate);
-
-  /**
    * Validate the current metadata.
    * <p>
    * Child operations can override this to add custom validation.
@@ -149,6 +141,14 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
    */
   protected void validate(TableMetadata currentMetadata) {
   }
+
+  /**
+   * Apply the update's changes to the base table metadata and return the new manifest list.
+   *
+   * @param metadataToUpdate the base table metadata to apply changes to
+   * @return a manifest list for the new snapshot.
+   */
+  protected abstract List<ManifestFile> apply(TableMetadata metadataToUpdate);
 
   @Override
   public Snapshot apply() {

--- a/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
@@ -88,27 +88,6 @@ public class SnapshotUtil {
     return ancestorIds;
   }
 
-  public static List<DataFile> removedDataFiles(Long baseSnapshotId, long latestSnapshotId,
-                                                Function<Long, Snapshot> lookup) {
-    List<DataFile> deletedFiles = Lists.newArrayList();
-
-    Long currentSnapshotId = latestSnapshotId;
-    while (currentSnapshotId != null && !currentSnapshotId.equals(baseSnapshotId)) {
-      Snapshot currentSnapshot = lookup.apply(currentSnapshotId);
-
-      if (currentSnapshot == null) {
-        throw new ValidationException(
-            "Cannot determine history between read snapshot %s and current %s",
-            baseSnapshotId, currentSnapshotId);
-      }
-
-      Iterables.addAll(deletedFiles, currentSnapshot.deletedFiles());
-      currentSnapshotId = currentSnapshot.parentId();
-    }
-
-    return deletedFiles;
-  }
-
   public static List<DataFile> newFiles(Long baseSnapshotId, long latestSnapshotId, Function<Long, Snapshot> lookup) {
     List<DataFile> newFiles = Lists.newArrayList();
 

--- a/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
@@ -88,6 +88,27 @@ public class SnapshotUtil {
     return ancestorIds;
   }
 
+  public static List<DataFile> removedDataFiles(Long baseSnapshotId, long latestSnapshotId,
+                                                Function<Long, Snapshot> lookup) {
+    List<DataFile> deletedFiles = Lists.newArrayList();
+
+    Long currentSnapshotId = latestSnapshotId;
+    while (currentSnapshotId != null && !currentSnapshotId.equals(baseSnapshotId)) {
+      Snapshot currentSnapshot = lookup.apply(currentSnapshotId);
+
+      if (currentSnapshot == null) {
+        throw new ValidationException(
+            "Cannot determine history between read snapshot %s and current %s",
+            baseSnapshotId, currentSnapshotId);
+      }
+
+      Iterables.addAll(deletedFiles, currentSnapshot.deletedFiles());
+      currentSnapshotId = currentSnapshot.parentId();
+    }
+
+    return deletedFiles;
+  }
+
   public static List<DataFile> newFiles(Long baseSnapshotId, long latestSnapshotId, Function<Long, Snapshot> lookup) {
     List<DataFile> newFiles = Lists.newArrayList();
 

--- a/core/src/test/java/org/apache/iceberg/TestOverwriteWithValidation.java
+++ b/core/src/test/java/org/apache/iceberg/TestOverwriteWithValidation.java
@@ -273,7 +273,7 @@ public class TestOverwriteWithValidation extends TableTestBase {
     long committedSnapshotId = table.currentSnapshot().snapshotId();
 
     AssertHelpers.assertThrows("Should reject commit",
-        ValidationException.class, "A file was appended",
+        ValidationException.class, "Found conflicting files",
         overwrite::commit);
 
     Assert.assertEquals("Should not create a new snapshot",
@@ -346,7 +346,7 @@ public class TestOverwriteWithValidation extends TableTestBase {
     long committedSnapshotId = table.currentSnapshot().snapshotId();
 
     AssertHelpers.assertThrows("Should reject commit",
-        ValidationException.class, "A file was appended",
+        ValidationException.class, "Found conflicting files",
         overwrite::commit);
 
     Assert.assertEquals("Should not create a new snapshot",
@@ -402,7 +402,7 @@ public class TestOverwriteWithValidation extends TableTestBase {
     long committedSnapshotId = table.currentSnapshot().snapshotId();
 
     AssertHelpers.assertThrows("Should reject commit",
-        ValidationException.class, "A file was appended",
+        ValidationException.class, "Found conflicting files",
         overwrite::commit);
 
     Assert.assertEquals("Should not create a new snapshot",
@@ -608,7 +608,7 @@ public class TestOverwriteWithValidation extends TableTestBase {
     overwrite.commit();
 
     AssertHelpers.assertThrows("Should reject commit",
-        ValidationException.class, "A file was appended",
+        ValidationException.class, "Found conflicting files",
         txn::commitTransaction);
 
     Assert.assertEquals("Should not create a new snapshot",

--- a/core/src/test/java/org/apache/iceberg/TestOverwriteWithValidation.java
+++ b/core/src/test/java/org/apache/iceberg/TestOverwriteWithValidation.java
@@ -382,7 +382,7 @@ public class TestOverwriteWithValidation extends TableTestBase {
   }
 
   @Test
-  public void testOverwriteIncompatibleRewriteValidated() {
+  public void testOverwriteCompatibleRewriteAllowed() {
     table.newAppend()
         .appendFile(FILE_DAY_1)
         .appendFile(FILE_DAY_2)
@@ -401,12 +401,9 @@ public class TestOverwriteWithValidation extends TableTestBase {
         .commit();
     long committedSnapshotId = table.currentSnapshot().snapshotId();
 
-    AssertHelpers.assertThrows("Should reject commit",
-        ValidationException.class, "Found conflicting files",
-        overwrite::commit);
+    overwrite.commit();
 
-    Assert.assertEquals("Should not create a new snapshot",
-        committedSnapshotId, table.currentSnapshot().snapshotId());
+    Assert.assertNotEquals("Should successfully commit", committedSnapshotId, table.currentSnapshot().snapshotId());
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestRowDelta.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowDelta.java
@@ -317,9 +317,7 @@ public class TestRowDelta extends V2TableTestBase {
         () -> table.newRowDelta()
             .addDeletes(FILE_A_DELETES)
             .validateFromSnapshot(validateFromSnapshotId)
-            .validateNoConflictingAppends(
-                Expressions.equal("data", "u"), // bucket16("u") -> 0
-                true)
+            .validateNoConflictingAppends(Expressions.equal("data", "u")) // bucket16("u") -> 0
             .commit());
 
     Assert.assertEquals("Table state should not be modified by failed RowDelta operation",
@@ -350,9 +348,7 @@ public class TestRowDelta extends V2TableTestBase {
         .validateDeletedFiles()
         .validateFromSnapshot(validateFromSnapshotId)
         .validateDataFilesExist(ImmutableList.of(FILE_A.path()))
-        .validateNoConflictingAppends(
-            Expressions.equal("data", "u"), // bucket16("u") -> 0
-            true)
+        .validateNoConflictingAppends(Expressions.equal("data", "u")) // bucket16("u") -> 0
         .commit();
 
     Snapshot snap = table.currentSnapshot();

--- a/core/src/test/java/org/apache/iceberg/TestRowDelta.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowDelta.java
@@ -82,7 +82,7 @@ public class TestRowDelta extends V2TableTestBase {
     long deleteSnapshotId = table.currentSnapshot().snapshotId();
 
     AssertHelpers.assertThrows("Should fail to add FILE_A_DELETES because FILE_A is missing",
-        ValidationException.class, "Cannot commit deletes for missing data files",
+        ValidationException.class, "Cannot commit, missing data files",
         () -> table.newRowDelta()
             .addDeletes(FILE_A_DELETES)
             .validateFromSnapshot(validateFromSnapshotId)
@@ -130,7 +130,7 @@ public class TestRowDelta extends V2TableTestBase {
     long deleteSnapshotId = table.currentSnapshot().snapshotId();
 
     AssertHelpers.assertThrows("Should fail to add FILE_A_DELETES because FILE_A is missing",
-        ValidationException.class, "Cannot commit deletes for missing data files",
+        ValidationException.class, "Cannot commit, missing data files",
         () -> table.newRowDelta()
             .addDeletes(FILE_A_DELETES)
             .validateFromSnapshot(validateFromSnapshotId)
@@ -162,7 +162,7 @@ public class TestRowDelta extends V2TableTestBase {
     long deleteSnapshotId = table.currentSnapshot().snapshotId();
 
     AssertHelpers.assertThrows("Should fail to add FILE_A_DELETES because FILE_A is missing",
-        ValidationException.class, "Cannot commit deletes for missing data files",
+        ValidationException.class, "Cannot commit, missing data files",
         () -> table.newRowDelta()
             .addDeletes(FILE_A_DELETES)
             .validateFromSnapshot(validateFromSnapshotId)
@@ -249,7 +249,7 @@ public class TestRowDelta extends V2TableTestBase {
     long deleteSnapshotId = table.currentSnapshot().snapshotId();
 
     AssertHelpers.assertThrows("Should fail to add FILE_A_DELETES because FILE_A is missing",
-        ValidationException.class, "Cannot commit deletes for missing data files",
+        ValidationException.class, "Cannot commit, missing data files",
         () -> table.newRowDelta()
             .addDeletes(FILE_A_DELETES)
             .validateFromSnapshot(validateFromSnapshotId)
@@ -281,7 +281,7 @@ public class TestRowDelta extends V2TableTestBase {
     long deleteSnapshotId = table.currentSnapshot().snapshotId();
 
     AssertHelpers.assertThrows("Should fail to add FILE_A_DELETES because FILE_A is missing",
-        ValidationException.class, "Cannot commit deletes for missing data files",
+        ValidationException.class, "Cannot commit, missing data files",
         () -> table.newRowDelta()
             .addDeletes(FILE_A_DELETES)
             .validateDeletedFiles()

--- a/core/src/test/java/org/apache/iceberg/TestRowDelta.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowDelta.java
@@ -67,8 +67,13 @@ public class TestRowDelta extends V2TableTestBase {
     // test changes to the table back to the snapshot where FILE_A and FILE_B existed
     long validateFromSnapshotId = table.currentSnapshot().snapshotId();
 
-    table.newDelete()
+    table.newOverwrite()
         .deleteFile(FILE_A)
+        .addFile(FILE_A2)
+        .commit();
+
+    table.newDelete()
+        .deleteFile(FILE_B)
         .commit();
 
     long deleteSnapshotId = table.currentSnapshot().snapshotId();

--- a/core/src/test/java/org/apache/iceberg/TestRowDelta.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowDelta.java
@@ -19,10 +19,10 @@
 
 package org.apache.iceberg;
 
-import com.google.common.collect.ImmutableList;
 import org.apache.iceberg.ManifestEntry.Status;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.junit.Assert;
 import org.junit.Test;

--- a/data/src/test/java/org/apache/iceberg/data/DeleteReadTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/DeleteReadTests.java
@@ -160,11 +160,12 @@ public abstract class DeleteReadTests {
         Pair.of(dataFile.path(), 6L) // id = 122
     );
 
-    DeleteFile posDeletes = FileHelpers.writeDeleteFile(
+    Pair<DeleteFile, Set<CharSequence>> posDeletes = FileHelpers.writeDeleteFile(
         table, Files.localOutput(temp.newFile()), Row.of(0), deletes);
 
     table.newRowDelta()
-        .addDeletes(posDeletes)
+        .addDeletes(posDeletes.first())
+        .validateDataFilesExist(posDeletes.second())
         .commit();
 
     StructLikeSet expected = rowSetWithoutIds(29, 89, 122);
@@ -191,12 +192,13 @@ public abstract class DeleteReadTests {
         Pair.of(dataFile.path(), 5L) // id = 121
     );
 
-    DeleteFile posDeletes = FileHelpers.writeDeleteFile(
+    Pair<DeleteFile, Set<CharSequence>> posDeletes = FileHelpers.writeDeleteFile(
         table, Files.localOutput(temp.newFile()), Row.of(0), deletes);
 
     table.newRowDelta()
         .addDeletes(eqDeletes)
-        .addDeletes(posDeletes)
+        .addDeletes(posDeletes.first())
+        .validateDataFilesExist(posDeletes.second())
         .commit();
 
     StructLikeSet expected = rowSetWithoutIds(29, 89, 121, 122);

--- a/data/src/test/java/org/apache/iceberg/data/FileHelpers.java
+++ b/data/src/test/java/org/apache/iceberg/data/FileHelpers.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.data;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DeleteFile;
@@ -42,13 +43,15 @@ public class FileHelpers {
   private FileHelpers() {
   }
 
-  public static DeleteFile writeDeleteFile(Table table, OutputFile out, List<Pair<CharSequence, Long>> deletes)
+  public static Pair<DeleteFile, Set<CharSequence>> writeDeleteFile(Table table, OutputFile out,
+                                                                    List<Pair<CharSequence, Long>> deletes)
       throws IOException {
     return writeDeleteFile(table, out, null, deletes);
   }
 
-  public static DeleteFile writeDeleteFile(Table table, OutputFile out, StructLike partition,
-                                           List<Pair<CharSequence, Long>> deletes) throws IOException {
+  public static Pair<DeleteFile, Set<CharSequence>> writeDeleteFile(Table table, OutputFile out, StructLike partition,
+                                                                   List<Pair<CharSequence, Long>> deletes)
+      throws IOException {
     PositionDeleteWriter<?> writer = Parquet.writeDeletes(out)
         .forTable(table)
         .withPartition(partition)
@@ -61,7 +64,7 @@ public class FileHelpers {
       }
     }
 
-    return writer.toDeleteFile();
+    return Pair.of(writer.toDeleteFile(), writer.referencedDataFiles());
   }
 
   public static DeleteFile writeDeleteFile(Table table, OutputFile out, List<Record> deletes, Schema deleteRowSchema)

--- a/data/src/test/java/org/apache/iceberg/data/FileHelpers.java
+++ b/data/src/test/java/org/apache/iceberg/data/FileHelpers.java
@@ -50,7 +50,7 @@ public class FileHelpers {
   }
 
   public static Pair<DeleteFile, Set<CharSequence>> writeDeleteFile(Table table, OutputFile out, StructLike partition,
-                                                                   List<Pair<CharSequence, Long>> deletes)
+                                                                    List<Pair<CharSequence, Long>> deletes)
       throws IOException {
     PositionDeleteWriter<?> writer = Parquet.writeDeletes(out)
         .forTable(table)

--- a/data/src/test/java/org/apache/iceberg/data/TestDataFileIndexStatsFilters.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestDataFileIndexStatsFilters.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.data;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
@@ -96,9 +97,11 @@ public class TestDataFileIndexStatsFilters {
     deletes.add(Pair.of(dataFile.path(), 0L));
     deletes.add(Pair.of(dataFile.path(), 1L));
 
-    DeleteFile posDeletes = FileHelpers.writeDeleteFile(table, Files.localOutput(temp.newFile()), deletes);
+    Pair<DeleteFile, Set<CharSequence>> posDeletes = FileHelpers.writeDeleteFile(
+        table, Files.localOutput(temp.newFile()), deletes);
     table.newRowDelta()
-        .addDeletes(posDeletes)
+        .addDeletes(posDeletes.first())
+        .validateDataFilesExist(posDeletes.second())
         .commit();
 
     List<FileScanTask> tasks;
@@ -121,9 +124,11 @@ public class TestDataFileIndexStatsFilters {
     deletes.add(Pair.of("some-other-file.parquet", 0L));
     deletes.add(Pair.of("some-other-file.parquet", 1L));
 
-    DeleteFile posDeletes = FileHelpers.writeDeleteFile(table, Files.localOutput(temp.newFile()), deletes);
+    Pair<DeleteFile, Set<CharSequence>> posDeletes = FileHelpers.writeDeleteFile(
+        table, Files.localOutput(temp.newFile()), deletes);
     table.newRowDelta()
-        .addDeletes(posDeletes)
+        .addDeletes(posDeletes.first())
+        .validateDataFilesExist(posDeletes.second())
         .commit();
 
     List<FileScanTask> tasks;


### PR DESCRIPTION
This adds a new validations to the `RowDelta` operation.

This includes some small cleanup by adding a `validate` method to `SnapshotProducer` to run validations and updating existing operations to use it.

One new validation for `RowDelta` finds data files that have been deleted since a starting "from" snapshot and validates that the set of referenced data files does not intersect the deleted data file set. Configuration uses 3 methods:

* `RowDelta.validateFromSnapshot(id)` to set the starting snapshot ID for accumulating deleted files
* `RowDelta.validateDataFilesExist(Iterable)` to add required data files to the validation
* `RowDelta.validateDeletedFiles()` to validate data files were not deleted by concurrent deletes (rewrite/overwrite is the default)

The second new validation tests that no new files have been added since a starting "from" snapshot that match a data filter. This is the same validation that is already in `BaseOverwriteFiles`. Configuration uses 2 methods:

* `RowDelta.validateFromSnapshot(id)` to set the starting snapshot ID for accumulating deleted files
* `RowDelta.validateNoConflictingAppends(Expression, boolean caseSensitive)` to set a conflict detection filter

`BaseOverwriteFiles` has been updated to match the configuration used here: the `caseSensitive` flag has been added and the "from" snapshot setting has been moved to use `validateFromSnapshot(id)`. The older version of `validateNoConflictingAppends` shows how to use the new configuration and is now deprecated.

This also adds `PositionDeleteWriter.referencedDataFiles` to return data files that should be validated.