### PR TITLE
Fix REPLACE TABLE by preserving existing field IDs

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/AssignFreshIds.java
+++ b/api/src/main/java/org/apache/iceberg/types/AssignFreshIds.java
@@ -26,12 +26,12 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
 class AssignFreshIds extends TypeUtil.CustomOrderSchemaVisitor<Type> {
-  private final Schema schema;
+  private final Schema visitingSchema;
   private final Schema baseSchema;
   private final TypeUtil.NextID nextId;
 
   AssignFreshIds(TypeUtil.NextID nextId) {
-    this.schema = null;
+    this.visitingSchema = null;
     this.baseSchema = null;
     this.nextId = nextId;
   }
@@ -39,12 +39,12 @@ class AssignFreshIds extends TypeUtil.CustomOrderSchemaVisitor<Type> {
   /**
    * Replaces the ids in a schema with ids from a base schema, or uses nextId to assign a fresh ids.
    *
-   * @param schema current schema that will have ids replaced (for id to name lookup)
+   * @param visitingSchema current schema that will have ids replaced (for id to name lookup)
    * @param baseSchema base schema to assign existing ids from
    * @param nextId new id assigner
    */
-  AssignFreshIds(Schema schema, Schema baseSchema, TypeUtil.NextID nextId) {
-    this.schema = schema;
+  AssignFreshIds(Schema visitingSchema, Schema baseSchema, TypeUtil.NextID nextId) {
+    this.visitingSchema = visitingSchema;
     this.baseSchema = baseSchema;
     this.nextId = nextId;
   }
@@ -61,8 +61,8 @@ class AssignFreshIds extends TypeUtil.CustomOrderSchemaVisitor<Type> {
   }
 
   private String name(int id) {
-    if (schema != null) {
-      return schema.findColumnName(id);
+    if (visitingSchema != null) {
+      return visitingSchema.findColumnName(id);
     }
 
     return null;

--- a/api/src/main/java/org/apache/iceberg/types/AssignFreshIds.java
+++ b/api/src/main/java/org/apache/iceberg/types/AssignFreshIds.java
@@ -26,10 +26,46 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
 class AssignFreshIds extends TypeUtil.CustomOrderSchemaVisitor<Type> {
+  private final Schema schema;
+  private final Schema baseSchema;
   private final TypeUtil.NextID nextId;
 
   AssignFreshIds(TypeUtil.NextID nextId) {
+    this.schema = null;
+    this.baseSchema = null;
     this.nextId = nextId;
+  }
+
+  /**
+   * Replaces the ids in a schema with ids from a base schema, or uses nextId to assign a fresh ids.
+   *
+   * @param schema current schema that will have ids replaced (for id to name lookup)
+   * @param baseSchema base schema to assign existing ids from
+   * @param nextId new id assigner
+   */
+  AssignFreshIds(Schema schema, Schema baseSchema, TypeUtil.NextID nextId) {
+    this.schema = schema;
+    this.baseSchema = baseSchema;
+    this.nextId = nextId;
+  }
+
+  private int idFor(String fullName) {
+    if (baseSchema != null && fullName != null) {
+      Types.NestedField field = baseSchema.findField(fullName);
+      if (field != null) {
+        return field.fieldId();
+      }
+    }
+
+    return nextId.get();
+  }
+
+  private String name(int id) {
+    if (schema != null) {
+      return schema.findColumnName(id);
+    }
+
+    return null;
   }
 
   @Override
@@ -42,9 +78,10 @@ class AssignFreshIds extends TypeUtil.CustomOrderSchemaVisitor<Type> {
     List<Types.NestedField> fields = struct.fields();
     int length = struct.fields().size();
 
+    // assign IDs for this struct's fields first
     List<Integer> newIds = Lists.newArrayListWithExpectedSize(length);
     for (int i = 0; i < length; i += 1) {
-      newIds.add(nextId.get()); // assign IDs for this struct's fields first
+      newIds.add(idFor(name(fields.get(i).fieldId())));
     }
 
     List<Types.NestedField> newFields = Lists.newArrayListWithExpectedSize(length);
@@ -69,7 +106,7 @@ class AssignFreshIds extends TypeUtil.CustomOrderSchemaVisitor<Type> {
 
   @Override
   public Type list(Types.ListType list, Supplier<Type> future) {
-    int newId = nextId.get();
+    int newId = idFor(name(list.elementId()));
     if (list.isElementOptional()) {
       return Types.ListType.ofOptional(newId, future.get());
     } else {
@@ -78,13 +115,13 @@ class AssignFreshIds extends TypeUtil.CustomOrderSchemaVisitor<Type> {
   }
 
   @Override
-  public Type map(Types.MapType map, Supplier<Type> keyFuture, Supplier<Type> valuefuture) {
-    int newKeyId = nextId.get();
-    int newValueId = nextId.get();
+  public Type map(Types.MapType map, Supplier<Type> keyFuture, Supplier<Type> valueFuture) {
+    int newKeyId = idFor(name(map.keyId()));
+    int newValueId = idFor(name(map.valueId()));
     if (map.isValueOptional()) {
-      return Types.MapType.ofOptional(newKeyId, newValueId, keyFuture.get(), valuefuture.get());
+      return Types.MapType.ofOptional(newKeyId, newValueId, keyFuture.get(), valueFuture.get());
     } else {
-      return Types.MapType.ofRequired(newKeyId, newValueId, keyFuture.get(), valuefuture.get());
+      return Types.MapType.ofRequired(newKeyId, newValueId, keyFuture.get(), valueFuture.get());
     }
   }
 

--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -158,6 +158,21 @@ public class TypeUtil {
   }
 
   /**
+   * Assigns ids to match a given schema, and fresh ids from the {@link NextID nextId function} for all other fields.
+   *
+   * @param schema a schema
+   * @param baseSchema a schema with existing IDs to copy by name
+   * @param nextId an id assignment function
+   * @return a structurally identical schema with new ids assigned by the nextId function
+   */
+  public static Schema assignFreshIds(Schema schema, Schema baseSchema, NextID nextId) {
+    return new Schema(TypeUtil
+        .visit(schema.asStruct(), new AssignFreshIds(schema, baseSchema, nextId))
+        .asNestedType()
+        .fields());
+  }
+
+  /**
    * Assigns strictly increasing fresh ids for all fields in a schema, starting from 1.
    *
    * @param schema a schema

--- a/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
@@ -150,7 +150,7 @@ public class TestReplaceTransaction extends TableTestBase {
     Assert.assertEquals("Version should be 2", 2L, (long) version());
     Assert.assertNull("Table should not have a current snapshot", table.currentSnapshot());
     Assert.assertEquals("Schema should use new schema, not compatible with previous",
-        new Schema(required(1, "obj_id", Types.IntegerType.get())).asStruct(),
+        new Schema(required(3, "obj_id", Types.IntegerType.get())).asStruct(),
         table.schema().asStruct());
   }
 


### PR DESCRIPTION
`REPLACE TABLE` replaces the table schema and partition spec in addition to the table data. When the new schema is passed to Iceberg, its field IDs are reassigned to ensure they are consistent (for example, no duplicate IDs), just like when a table is created. This updates how the IDs are reassigned to fix time travel and partition specs.

Iceberg doesn't currently track what the table schema was at the time a snapshot was written. The current table schema is always used to read older snapshots. When a table is replaced and the ids are reassigned, this can lead to incompatible ID conflicts between an older schema and the current schema.

To fix incompatible IDs, this updates reassignment to use the current table schema's ids if possible. If the current schema is `1: id bigint, 2: data string` and the new schema is `data string, id int`, then ids are reused by name: `2: data string, 1: id int`. Any field that is not in the current table schema is assigned a new unique ID using `lastColumnId`.

This also fixes a bug where incompatible ID reassignment breaks old partition specs, resulting in errors like "Cannot create identity partition sourced from different field in schema: partititon_col".