### PR TITLE
Spark: add E2E test on partition pruning for filter pushdown

### DIFF
--- a/spark/src/test/java/org/apache/iceberg/spark/source/LogMessage.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/LogMessage.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.spark.source;
 
+import java.sql.Timestamp;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class LogMessage {
@@ -28,28 +29,53 @@ public class LogMessage {
     return new LogMessage(idCounter.getAndIncrement(), date, "DEBUG", message);
   }
 
+  static LogMessage debug(String date, String message, Timestamp timestamp) {
+    return new LogMessage(idCounter.getAndIncrement(), date, "DEBUG", message, timestamp);
+  }
+
   static LogMessage info(String date, String message) {
     return new LogMessage(idCounter.getAndIncrement(), date, "INFO", message);
+  }
+
+  static LogMessage info(String date, String message, Timestamp timestamp) {
+    return new LogMessage(idCounter.getAndIncrement(), date, "INFO", message, timestamp);
   }
 
   static LogMessage error(String date, String message) {
     return new LogMessage(idCounter.getAndIncrement(), date, "ERROR", message);
   }
 
+  static LogMessage error(String date, String message, Timestamp timestamp) {
+    return new LogMessage(idCounter.getAndIncrement(), date, "ERROR", message, timestamp);
+  }
+
   static LogMessage warn(String date, String message) {
     return new LogMessage(idCounter.getAndIncrement(), date, "WARN", message);
+  }
+
+  static LogMessage warn(String date, String message, Timestamp timestamp) {
+    return new LogMessage(idCounter.getAndIncrement(), date, "WARN", message, timestamp);
   }
 
   private int id;
   private String date;
   private String level;
   private String message;
+  private Timestamp timestamp;
 
   private LogMessage(int id, String date, String level, String message) {
     this.id = id;
     this.date = date;
     this.level = level;
     this.message = message;
+  }
+
+  private LogMessage(int id, String date, String level, String message, Timestamp timestamp) {
+    this.id = id;
+    this.date = date;
+    this.level = level;
+    this.message = message;
+    this.timestamp = timestamp;
   }
 
   public int getId() {
@@ -82,5 +108,13 @@ public class LogMessage {
 
   public void setMessage(String message) {
     this.message = message;
+  }
+
+  public Timestamp getTimestamp() {
+    return timestamp;
+  }
+
+  public void setTimestamp(Timestamp timestamp) {
+    this.timestamp = timestamp;
   }
 }

--- a/spark/src/test/java/org/apache/iceberg/spark/source/LogMessage.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/LogMessage.java
@@ -19,7 +19,7 @@
 
 package org.apache.iceberg.spark.source;
 
-import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class LogMessage {
@@ -29,7 +29,7 @@ public class LogMessage {
     return new LogMessage(idCounter.getAndIncrement(), date, "DEBUG", message);
   }
 
-  static LogMessage debug(String date, String message, Timestamp timestamp) {
+  static LogMessage debug(String date, String message, Instant timestamp) {
     return new LogMessage(idCounter.getAndIncrement(), date, "DEBUG", message, timestamp);
   }
 
@@ -37,7 +37,7 @@ public class LogMessage {
     return new LogMessage(idCounter.getAndIncrement(), date, "INFO", message);
   }
 
-  static LogMessage info(String date, String message, Timestamp timestamp) {
+  static LogMessage info(String date, String message, Instant timestamp) {
     return new LogMessage(idCounter.getAndIncrement(), date, "INFO", message, timestamp);
   }
 
@@ -45,7 +45,7 @@ public class LogMessage {
     return new LogMessage(idCounter.getAndIncrement(), date, "ERROR", message);
   }
 
-  static LogMessage error(String date, String message, Timestamp timestamp) {
+  static LogMessage error(String date, String message, Instant timestamp) {
     return new LogMessage(idCounter.getAndIncrement(), date, "ERROR", message, timestamp);
   }
 
@@ -53,7 +53,7 @@ public class LogMessage {
     return new LogMessage(idCounter.getAndIncrement(), date, "WARN", message);
   }
 
-  static LogMessage warn(String date, String message, Timestamp timestamp) {
+  static LogMessage warn(String date, String message, Instant timestamp) {
     return new LogMessage(idCounter.getAndIncrement(), date, "WARN", message, timestamp);
   }
 
@@ -61,7 +61,7 @@ public class LogMessage {
   private String date;
   private String level;
   private String message;
-  private Timestamp timestamp;
+  private Instant timestamp;
 
   private LogMessage(int id, String date, String level, String message) {
     this.id = id;
@@ -70,7 +70,7 @@ public class LogMessage {
     this.message = message;
   }
 
-  private LogMessage(int id, String date, String level, String message, Timestamp timestamp) {
+  private LogMessage(int id, String date, String level, String message, Instant timestamp) {
     this.id = id;
     this.date = date;
     this.level = level;
@@ -110,11 +110,11 @@ public class LogMessage {
     this.message = message;
   }
 
-  public Timestamp getTimestamp() {
+  public Instant getTimestamp() {
     return timestamp;
   }
 
-  public void setTimestamp(Timestamp timestamp) {
+  public void setTimestamp(Instant timestamp) {
     this.timestamp = timestamp;
   }
 }

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
@@ -1,0 +1,348 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RawLocalFileSystem;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.transforms.Transform;
+import org.apache.iceberg.transforms.Transforms;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.DataTypes;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+@RunWith(Parameterized.class)
+public abstract class TestPartitionPruning {
+
+  private static final Configuration CONF = new Configuration();
+  private static final HadoopTables TABLES = new HadoopTables(CONF);
+
+  @Parameterized.Parameters
+  public static Object[][] parameters() {
+    return new Object[][] {
+        new Object[] { "parquet", false },
+        new Object[] { "parquet", true },
+        new Object[] { "avro", false },
+        new Object[] { "orc", false },
+        new Object[] { "orc", true },
+    };
+  }
+
+  private final String format;
+  private final boolean vectorized;
+
+  public TestPartitionPruning(String format, boolean vectorized) {
+    this.format = format;
+    this.vectorized = vectorized;
+  }
+
+  private static SparkSession spark = null;
+
+  private static Transform<Object, Integer> bucketTransform = Transforms.bucket(Types.IntegerType.get(), 3);
+  private static Transform<Object, Object> truncateTransform = Transforms.truncate(Types.StringType.get(), 5);
+  private static Transform<Object, Integer> hourTransform = Transforms.hour(Types.TimestampType.withZone());
+
+  @BeforeClass
+  public static void startSpark() {
+    TestPartitionPruning.spark = SparkSession.builder().master("local[2]").getOrCreate();
+    String optionKey = String.format("fs.%s.impl", CountOpenLocalFileSystem.scheme);
+
+    CONF.set(optionKey, CountOpenLocalFileSystem.class.getName());
+    spark.conf().set(optionKey, CountOpenLocalFileSystem.class.getName());
+    spark.udf().register("bucket3", (Integer num) -> bucketTransform.apply(num), DataTypes.IntegerType);
+    spark.udf().register("truncate5", (String str) -> truncateTransform.apply(str), DataTypes.StringType);
+    // NOTE: date transforms take the type long, not Timestamp
+    spark.udf().register("hour", (Timestamp ts) -> hourTransform.apply(
+        (Long) org.apache.spark.sql.catalyst.util.DateTimeUtils.fromJavaTimestamp(ts)),
+        DataTypes.IntegerType);
+  }
+
+  @AfterClass
+  public static void stopSpark() {
+    SparkSession currentSpark = TestPartitionPruning.spark;
+    TestPartitionPruning.spark = null;
+    currentSpark.stop();
+  }
+
+  private static final Schema LOG_SCHEMA = new Schema(
+      Types.NestedField.optional(1, "id", Types.IntegerType.get()),
+      Types.NestedField.optional(2, "date", Types.StringType.get()),
+      Types.NestedField.optional(3, "level", Types.StringType.get()),
+      Types.NestedField.optional(4, "message", Types.StringType.get()),
+      Types.NestedField.optional(5, "timestamp", Types.TimestampType.withZone())
+  );
+
+  private static final List<LogMessage> LOGS = ImmutableList.of(
+      LogMessage.debug("2020-02-02", "debug event 1", Timestamp.valueOf("2020-02-02 00:00:00")),
+      LogMessage.info("2020-02-02", "info event 1", Timestamp.valueOf("2020-02-02 01:00:00")),
+      LogMessage.debug("2020-02-02", "debug event 2", Timestamp.valueOf("2020-02-02 02:00:00")),
+      LogMessage.info("2020-02-03", "info event 2", Timestamp.valueOf("2020-02-03 00:00:00")),
+      LogMessage.debug("2020-02-03", "debug event 3", Timestamp.valueOf("2020-02-03 01:00:00")),
+      LogMessage.info("2020-02-03", "info event 3", Timestamp.valueOf("2020-02-03 02:00:00")),
+      LogMessage.error("2020-02-03", "error event 1", Timestamp.valueOf("2020-02-03 03:00:00")),
+      LogMessage.debug("2020-02-04", "debug event 4", Timestamp.valueOf("2020-02-04 01:00:00")),
+      LogMessage.warn("2020-02-04", "warn event 1", Timestamp.valueOf("2020-02-04 02:00:00")),
+      LogMessage.debug("2020-02-04", "debug event 5", Timestamp.valueOf("2020-02-04 03:00:00"))
+  );
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  private PartitionSpec spec = PartitionSpec.builderFor(LOG_SCHEMA)
+      .identity("date")
+      .identity("level")
+      .bucket("id", 3)
+      .truncate("message", 5)
+      .hour("timestamp")
+      .build();
+  private Table table = null;
+  private Dataset<Row> logs = null;
+
+  @Before
+  public void setupTable() throws Exception {
+    File location = temp.newFolder("logs");
+    Assert.assertTrue("Temp folder should exist", location.exists());
+
+    String trackedLocation = CountOpenLocalFileSystem.convertPath(location);
+
+    Map<String, String> properties = ImmutableMap.of(TableProperties.DEFAULT_FILE_FORMAT, format);
+    this.table = TABLES.create(LOG_SCHEMA, spec, properties, trackedLocation);
+    this.logs = spark.createDataFrame(LOGS, LogMessage.class)
+        .selectExpr("id", "date", "level", "message", "timestamp", "bucket3(id) AS bucket_id",
+            "truncate5(message) AS truncated_message", "hour(timestamp) AS ts_hour");
+
+    logs.orderBy("date", "level", "bucket_id", "truncated_message", "ts_hour")
+        .select("id", "date", "level", "message", "timestamp")
+        .write().format("iceberg").mode("append").save(trackedLocation);
+  }
+
+  @Test
+  public void testPartitionPruningIdentityString() {
+    String filterCond = "date >= '2020-02-03' AND level = 'DEBUG'";
+    Predicate<Row> partCondition = (Row r) -> {
+      String date = r.getString(0);
+      String level = r.getString(1);
+      return date.compareTo("2020-02-03") >= 0 && level.equals("DEBUG");
+    };
+
+    runTest(filterCond, partCondition);
+  }
+
+  @Test
+  public void testPartitionPruningBucketingInteger() {
+    String filterCond = "id in (3, 7)";
+    Predicate<Row> partCondition = (Row r) -> {
+      int bucketId = r.getInt(2);
+      int[] expectedIds = new int[]{ 3, 7 };
+      Set<Integer> buckets = Arrays.stream(expectedIds).map(bucketTransform::apply)
+          .boxed().collect(Collectors.toSet());
+      return buckets.contains(bucketId);
+    };
+
+    runTest(filterCond, partCondition);
+  }
+
+  @Test
+  public void testPartitionPruningTruncatedString() {
+    String filterCond = "message like 'info event%'";
+    Predicate<Row> partCondition = (Row r) -> {
+      String truncatedMessage = r.getString(3);
+      return truncatedMessage.equals("info ");
+    };
+
+    runTest(filterCond, partCondition);
+  }
+
+  @Test
+  public void testPartitionPruningTruncatedStringComparingValueShorterThanPartitionValue() {
+    String filterCond = "message like 'inf%'";
+    Predicate<Row> partCondition = (Row r) -> {
+      String truncatedMessage = r.getString(3);
+      return truncatedMessage.startsWith("inf");
+    };
+
+    runTest(filterCond, partCondition);
+  }
+
+  @Test
+  public void testPartitionPruningHourlyPartition() {
+    String filterCond;
+    if (spark.version().startsWith("2")) {
+      // Looks like from Spark 2 we need to compare timestamp with timestamp to push down the filter.
+      filterCond = "timestamp >= to_timestamp('2020-02-03 01:00:00')";
+    } else {
+      filterCond = "timestamp >= '2020-02-03 01:00:00'";
+    }
+    Predicate<Row> partCondition = (Row r) -> {
+      int hourValue = r.getInt(4);
+      Timestamp ts = Timestamp.valueOf("2020-02-03 01:00:00");
+      Integer hourValueToFilter = hourTransform.apply(
+              (Long) org.apache.spark.sql.catalyst.util.DateTimeUtils.fromJavaTimestamp(ts));
+      return hourValue >= hourValueToFilter;
+    };
+
+    runTest(filterCond, partCondition);
+  }
+
+  private void runTest(String filterCond, Predicate<Row> partCondition) {
+    List<Row> expected = logs
+        .select("id", "date", "level", "message", "timestamp")
+        .filter(filterCond)
+        .orderBy("id")
+        .collectAsList();
+
+    CountOpenLocalFileSystem.resetCount();
+
+    List<Row> actual = spark.read()
+        .format("iceberg")
+        .option("vectorization-enabled", String.valueOf(vectorized))
+        .load(table.location())
+        .select("id", "date", "level", "message", "timestamp")
+        .filter(filterCond)
+        .orderBy("id")
+        .collectAsList();
+    Assert.assertEquals("Rows should match", expected, actual);
+
+    assertAccessOnDataFiles(partCondition);
+  }
+
+  private void assertAccessOnDataFiles(Predicate<Row> partCondition) {
+    Set<String> readFilesInQuery = new HashSet<>(CountOpenLocalFileSystem.pathToNumOpenCalled.keySet());
+
+    List<Row> files = spark.read().format("iceberg").load(table.location() + "#files").collectAsList();
+
+    Set<String> filesToRead = extractFilePathsMatchingConditionOnPartition(files, partCondition);
+    Set<String> filesToNotRead = extractFilePathsNotIn(files, filesToRead);
+
+    // Just to be sure, they should be mutually exclusive.
+    Assert.assertTrue(Sets.intersection(filesToRead, filesToNotRead).isEmpty());
+
+    Assert.assertFalse("The query should prune some data files.", filesToNotRead.isEmpty());
+
+    // We don't check "all" data files bound to the condition are being read, as data files can be pruned on
+    // other conditions like lower/upper bound of columns.
+    Assert.assertFalse("Some of data files in partition range should be read.",
+        Sets.intersection(filesToRead, readFilesInQuery).isEmpty());
+
+    // Data files which aren't bound to the condition shouldn't be read.
+    Assert.assertTrue("Data files outside of partition range should not be read.",
+        Sets.intersection(filesToNotRead, readFilesInQuery).isEmpty());
+  }
+
+  private Set<String> extractFilePathsMatchingConditionOnPartition(List<Row> files, Predicate<Row> condition) {
+    // idx 1: file_path, idx 3: partition
+    return files.stream()
+        .filter(r -> {
+          Row partition = r.getStruct(3);
+          return condition.test(partition);
+        }).map(r -> CountOpenLocalFileSystem.stripScheme(r.getString(1)))
+        .collect(Collectors.toSet());
+  }
+
+  private Set<String> extractFilePathsNotIn(List<Row> files, Set<String> filePaths) {
+    Set<String> allFilePaths = files.stream().map(r -> CountOpenLocalFileSystem.stripScheme(r.getString(1)))
+        .collect(Collectors.toSet());
+    return new HashSet<>(Sets.symmetricDifference(allFilePaths, filePaths));
+  }
+}
+
+class CountOpenLocalFileSystem extends RawLocalFileSystem {
+  public static String scheme = String.format("TestIdentityPartitionData%dfs",
+      new Random().nextInt());
+  public static ConcurrentHashMap<String, Long> pathToNumOpenCalled = new ConcurrentHashMap<>();
+
+  public static void resetCount() {
+    pathToNumOpenCalled.clear();
+  }
+
+  public static String convertPath(String absPath) {
+    return scheme + "://" + absPath;
+  }
+
+  public static String convertPath(File file) {
+    return convertPath(file.getAbsolutePath());
+  }
+
+  public static String stripScheme(String pathWithScheme) {
+    if (!pathWithScheme.startsWith(scheme + ":")) {
+      throw new IllegalArgumentException("Received unexpected path: " + pathWithScheme);
+    }
+
+    int idxToCut = scheme.length() + 1;
+    while (pathWithScheme.charAt(idxToCut) == '/') {
+      idxToCut++;
+    }
+
+    // leave the last '/'
+    idxToCut--;
+
+    return pathWithScheme.substring(idxToCut);
+  }
+
+  @Override
+  public URI getUri() {
+    return URI.create(scheme + ":///");
+  }
+
+  @Override
+  public String getScheme() {
+    return scheme;
+  }
+
+  @Override
+  public FSDataInputStream open(Path f, int bufferSize) throws IOException {
+    String path = f.toUri().getPath();
+    pathToNumOpenCalled.compute(path, (ignored, v) -> {
+      if (v == null)
+        return 1L;
+      else
+        return v + 1;
+    });
+    return super.open(f, bufferSize);
+  }
+}

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
@@ -162,8 +162,6 @@ public abstract class TestPartitionPruning {
       .hour("timestamp")
       .build();
 
-  private Random random = new Random();
-
   @Test
   public void testPartitionPruningIdentityString() {
     String filterCond = "date >= '2020-02-03' AND level = 'DEBUG'";
@@ -271,8 +269,7 @@ public abstract class TestPartitionPruning {
 
   private File createTempDir() {
     try {
-      int rand = random.nextInt(1000000);
-      return temp.newFolder(String.format("logs-%d", rand));
+      return temp.newFolder();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
@@ -290,11 +290,13 @@ public abstract class TestPartitionPruning {
 
     // We don't check "all" data files bound to the condition are being read, as data files can be pruned on
     // other conditions like lower/upper bound of columns.
-    Assert.assertFalse("Some of data files in partition range should be read.",
+    Assert.assertFalse("Some of data files in partition range should be read. " +
+        "Read files in query: " + readFilesInQuery + " / data files in partition range: " + filesToRead,
         Sets.intersection(filesToRead, readFilesInQuery).isEmpty());
 
     // Data files which aren't bound to the condition shouldn't be read.
-    Assert.assertTrue("Data files outside of partition range should not be read.",
+    Assert.assertTrue("Data files outside of partition range should not be read. " +
+        "Read files in query: " + readFilesInQuery + " / data files outside of partition range: " + filesToNotRead,
         Sets.intersection(filesToNotRead, readFilesInQuery).isEmpty());
   }
 

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning24.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning24.java
@@ -1,15 +1,20 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.iceberg.spark.source;

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning24.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning24.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+public class TestPartitionPruning24 extends TestPartitionPruning {
+  public TestPartitionPruning24(String format, boolean vectorized) {
+    super(format, vectorized);
+  }
+}

--- a/spark3/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning3.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning3.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+public class TestPartitionPruning3 extends TestPartitionPruning {
+  public TestPartitionPruning3(String format, boolean vectorized) {
+    super(format, vectorized);
+  }
+}

--- a/spark3/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning3.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning3.java
@@ -1,15 +1,20 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.iceberg.spark.source;


### PR DESCRIPTION
This PR proposes to add E2E tests on partition pruning for both Spark 2.4 and Spark 3. 

This PR tests below queries:

* identity with String type
* bucket with Integer type
* truncate with String type
* hour with Timestamp type

which the table has all of them in partition spec.