### PR TITLE
Suppress warning for DangerousStringInternUsage in BaseMetastoreCatalog

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -324,6 +324,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
         .run(io::deleteFile);
   }
 
+  @SuppressWarnings("DangerousStringInternUsage")
   private static void deleteFiles(FileIO io, Set<ManifestFile> allManifests) {
     // keep track of deleted files in a map that can be cleaned up when memory runs low
     Map<String, Boolean> deletedFiles = new MapMaker()


### PR DESCRIPTION
The method BaseMetastoreCatalog#deleteFiles keeps track of deleted files in a Map<String, Boolean> using a Guava MapMaker with weak keys.

We intern the file path represented as a string that is going to be placed into this weak key map, as the Guava MapMaker weak key map uses identity (==) instead of equals. Thus, interning the strings is the only way to ensure that when two possible keys p1 and p2 are placed into the map, where p1.equals(p2), it will be correctly overwritten (i.e. the intern is necessary to force the strings to share the same memory address and thus have identity comparison work as that's what is used).