### PR TITLE
[API][Core - Types/Avro][Parquet] Add a precondition null check for the constructor arg of PruneColumns

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/PruneColumns.java
+++ b/api/src/main/java/org/apache/iceberg/types/PruneColumns.java
@@ -29,7 +29,7 @@ class PruneColumns extends TypeUtil.SchemaVisitor<Type> {
   private final Set<Integer> selected;
 
   PruneColumns(Set<Integer> selected) {
-    Preconditions.checkNotNull(selected, "Selected cannot be null");
+    Preconditions.checkNotNull(selected, "Selected field ids cannot be null");
     this.selected = selected;
   }
 

--- a/api/src/main/java/org/apache/iceberg/types/PruneColumns.java
+++ b/api/src/main/java/org/apache/iceberg/types/PruneColumns.java
@@ -22,12 +22,14 @@ package org.apache.iceberg.types;
 import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
 class PruneColumns extends TypeUtil.SchemaVisitor<Type> {
   private final Set<Integer> selected;
 
   PruneColumns(Set<Integer> selected) {
+    Preconditions.checkNotNull(selected, "Selected cannot be null");
     this.selected = selected;
   }
 

--- a/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
+++ b/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
@@ -39,6 +39,7 @@ class PruneColumns extends AvroSchemaVisitor<Schema> {
   private final NameMapping nameMapping;
 
   PruneColumns(Set<Integer> selectedIds, NameMapping nameMapping) {
+    Preconditions.checkNotNull(selectedIds, "Selected field ids cannot be null");
     this.selectedIds = selectedIds;
     this.nameMapping = nameMapping;
   }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
@@ -32,6 +32,7 @@ class PruneColumns extends ParquetTypeVisitor<Type> {
   private final Set<Integer> selectedIds;
 
   PruneColumns(Set<Integer> selectedIds) {
+    Preconditions.checkNotNull(selectedIds, "Selected field ids cannot be null");
     this.selectedIds = selectedIds;
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.parquet;
 
 import java.util.List;
 import java.util.Set;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;


### PR DESCRIPTION
The class PruneColumns has a single constructor, which takes in a Set<Integer>, `PruneColumns(Set<Integer> selected)`.

Later on in this class, there are no null checks before calling methods on the value `selected` such as `contains`, etc.

Admittedly, the only place that PruneColumns is _currently_ used, `org.apache.iceberg.types.TypeUtils#select(Types.StructType struct, Set<Integer> fieldIds)`, has a precondition check for null on `fieldIds` - which is passed into PruneColumns. Thus, it is arguably not necessary to add this additional check with the code as is.

However, because the class `PruneColumns` is part of `api` and might get used elsewhere, it seems sane to add this precondition check given that we do no null checking before accessing it and so it would be up to the caller to add the preconditions check if they were to reuse it.

Lastly, it's important to note that `PruneColumns`,  while part of `api`, is not declared as public and so one could argue that this is not needed given that it's internal to iceberg and anybody using it should just know that its constructor argument must be non-null. I'm not a personal believer in tribal knowledge like that, and so I'm opening this PR.

If we don't think this PR is necessary, given the precondition check in the one and only place that it is currently used, then we can go ahead and close this PR.