### PR TITLE
Suppress UnnecessaryAnonymousClass warnings for classes with defaultDelete as a Consumer

### DIFF
--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -52,6 +52,7 @@ import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES_DEFAULT;
 import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS;
 import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT;
 
+@SuppressWarnings("UnnecessaryAnonymousClass")
 class RemoveSnapshots implements ExpireSnapshots {
   private static final Logger LOG = LoggerFactory.getLogger(RemoveSnapshots.class);
 

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -55,6 +55,7 @@ import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFA
 import static org.apache.iceberg.TableProperties.MANIFEST_LISTS_ENABLED;
 import static org.apache.iceberg.TableProperties.MANIFEST_LISTS_ENABLED_DEFAULT;
 
+@SuppressWarnings("UnnecessaryAnonymousClass")
 abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
   private static final Logger LOG = LoggerFactory.getLogger(SnapshotProducer.class);
   static final Set<ManifestFile> EMPTY_SET = Sets.newHashSet();

--- a/spark/src/main/java/org/apache/iceberg/actions/ExpireSnapshotsAction.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/ExpireSnapshotsAction.java
@@ -52,6 +52,7 @@ import org.slf4j.LoggerFactory;
  * locally using a direct call to RemoveSnapshots. The snapshot expiration will be fully committed before any deletes
  * are issued. Deletes are still performed locally after retrieving the results from the Spark executors.
  */
+@SuppressWarnings("UnnecessaryAnonymousClass")
 public class ExpireSnapshotsAction extends BaseAction<ExpireSnapshotsActionResult> {
   private static final Logger LOG = LoggerFactory.getLogger(ExpireSnapshotsAction.class);
 


### PR DESCRIPTION
Several classes have a private named field `defaultDelete`, which is a `Consumer<String>` and is used as a functional interface for removing files etc.

We use a functional interface so that users may pass in their own implementation of the functional interface. It is a common pattern in the code base.

I tried out the method suggested as a fix, by defining the function as a method `void defaultDelete(String file)` and it got really messy. I suggest we suppress these warnings and move on with it so as to clean up the clutter in the build phase.