### PR TITLE
Fix javadoc encoding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,10 @@ subprojects {
     options.encoding = "UTF-8"
   }
 
+  javadoc {
+    options.encoding = 'UTF-8'
+  }
+
   ext {
     jmhVersion = '1.21'
   }


### PR DESCRIPTION
The PR set the `javadoc` task encoding option since the build task fails on the system that uses ascii. For example, we can reproduce the issue when setting `javadoc` encoding to `ASCII`.

```
> Task :iceberg-orc:javadoc FAILED                                                                                                                         
/home/cjj/iceberg/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java:233: error: unmappable character for encoding ASCII                          
   * which would then use its schema evolution to map that to the writer??????s schema.                                                                       
                                                                        ^                                                                                  
/home/cjj/iceberg/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java:233: error: unmappable character for encoding ASCII                          
   * which would then use its schema evolution to map that to the writer??????s schema.                                                                       
                                                                         ^                                                                                 
/home/cjj/iceberg/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java:233: error: unmappable character for encoding ASCII                          
   * which would then use its schema evolution to map that to the writer??????s schema.  
```

I don't update the quote character here, it should be updated, though.
 