### PR TITLE
Suppress the last remaining invalid DangerousStringInternUsage warning

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -85,6 +85,7 @@ public class CatalogUtil {
         .run(io::deleteFile);
   }
 
+  @SuppressWarnings("DangerousStringInternUsage")
   private static void deleteFiles(FileIO io, Set<ManifestFile> allManifests) {
     // keep track of deleted files in a map that can be cleaned up when memory runs low
     Map<String, Boolean> deletedFiles = new MapMaker()


### PR DESCRIPTION
When cleaning up valid uses of java.lang.String.intern (on weak-keyed maps which use identity comparison instead of equality comparison), I missed one instance. Here's a previous PR: https://github.com/apache/iceberg/pull/1489

This suppresses that final warning as well.

I tried to enforce this type of warning as a bug, but I was unable to do so in a way that emitted a readable error (admittedly I didn't spend too much time on it). 

I can open an issue if this is something we'd like to enforce as either suppressed or not done. Depends on your thoughts @rdblue @RussellSpitzer.