### PR TITLE
reuse container when reading parquet records

### DIFF
--- a/flink/src/main/java/org/apache/iceberg/flink/source/RowDataIterator.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/source/RowDataIterator.java
@@ -112,7 +112,8 @@ class RowDataIterator extends DataIterator<RowData> {
         .project(projectedSchema)
         .createReaderFunc(fileSchema -> FlinkParquetReaders.buildReader(projectedSchema, fileSchema, idToConstant))
         .filter(task.residual())
-        .caseSensitive(caseSensitive);
+        .caseSensitive(caseSensitive)
+        .reuseContainers();
 
     if (nameMapping != null) {
       builder.withNameMapping(NameMappingParser.fromJson(nameMapping));

--- a/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -149,6 +149,7 @@ class RowDataReader extends BaseDataReader<InternalRow> {
       Schema readSchema,
       Map<Integer, ?> idToConstant) {
     Parquet.ReadBuilder builder = Parquet.read(location)
+        .reuseContainers()
         .split(task.start(), task.length())
         .project(readSchema)
         .createReaderFunc(fileSchema -> SparkParquetReaders.buildReader(readSchema, fileSchema, idToConstant))


### PR DESCRIPTION
This is for discussion [here](https://github.com/apache/iceberg/pull/1517#discussion_r495701495). I don't add the unit test here since the existing end to end unit tests should cover.