### PR TITLE
Replace Literal Integer with Constant Reference

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DataFilesTable.java
@@ -59,8 +59,8 @@ public class DataFilesTable extends BaseMetadataTable {
   public Schema schema() {
     Schema schema = new Schema(DataFile.getType(table.spec().partitionType()).fields());
     if (table.spec().fields().size() < 1) {
-      // avoid returning an empty struct, which is not always supported. instead, drop the partition field (id 102)
-      return TypeUtil.selectNot(schema, Sets.newHashSet(102));
+      // avoid returning an empty struct, which is not always supported. instead, drop the partition field
+      return TypeUtil.selectNot(schema, Sets.newHashSet(DataFile.PARTITION_ID));
     } else {
       return schema;
     }


### PR DESCRIPTION
We refer to the field value by literal integer rather than the field's constant ID

@rdblue Quick fix extracted to it's own PR