### PR TITLE
Add null check when calling catalog.close in SparkTestBase

### DIFF
--- a/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -71,7 +71,9 @@ public class SparkTestBase {
 
   @AfterClass
   public static void stopMetastoreAndSpark() {
-    catalog.close();
+    if (catalog != null) {
+      catalog.close();
+    }
     SparkTestBase.catalog = null;
     metastore.stop();
     SparkTestBase.metastore = null;


### PR DESCRIPTION
As pointed out by @RussellSpitzer in his PR https://github.com/apache/iceberg/pull/1525/files, there is the possibility that the catalog is null when the tests are running. This error likely come from killing tests early while debugging, but that's something that probably a good handful of us do in our workflow and this will make the output less verbose.

I've cherry picked this change from his PR, as that PR will likely take much more time to merge in due to its scope and the community can benefit from this fix now.