### PR TITLE
ORC: Fix predicate pushdown for Not In and Not Equals

### DIFF
--- a/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilter.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilter.java
@@ -738,12 +738,8 @@ public class TestMetricsRowGroupFilter {
     shouldRead = shouldRead(notIn("all_nulls", 1, 2));
     Assert.assertTrue("Should read: notIn on all nulls column", shouldRead);
 
-    // ORC-623: ORC seems to incorrectly skip a row group for a notIn(column, {X, ...}) predicate on a column which
-    // has only 1 non-null value X but also has nulls
-    if (format != FileFormat.ORC) {
-      shouldRead = shouldRead(notIn("some_nulls", "aaa", "some"));
-      Assert.assertTrue("Should read: notIn on some nulls column", shouldRead);
-    }
+    shouldRead = shouldRead(notIn("some_nulls", "aaa", "some"));
+    Assert.assertTrue("Should read: notIn on some nulls column", shouldRead);
 
     shouldRead = shouldRead(notIn("no_nulls", "aaa", ""));
     if (format == FileFormat.PARQUET) {
@@ -753,6 +749,12 @@ public class TestMetricsRowGroupFilter {
     } else {
       Assert.assertFalse("Should skip: notIn on no nulls column", shouldRead);
     }
+  }
+
+  @Test
+  public void testSomeNullsNotEq() {
+    boolean shouldRead = shouldRead(notEqual("some_nulls", "some"));
+    Assert.assertTrue("Should read: notEqual on some nulls column", shouldRead);
   }
 
   private boolean shouldRead(Expression expression) {

--- a/orc/src/main/java/org/apache/iceberg/orc/ExpressionToSearchArgument.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ExpressionToSearchArgument.java
@@ -168,11 +168,19 @@ class ExpressionToSearchArgument extends ExpressionVisitors.BoundVisitor<Express
 
   @Override
   public <T> Action notEq(Bound<T> expr, Literal<T> lit) {
-    return () -> this.builder.startNot()
-          .equals(idToColumnName.get(expr.ref().fieldId()),
-              type(expr.ref().type()),
-              literal(expr.ref().type(), lit.value()))
-          .end();
+    // NOTE: ORC uses SQL semantics for Search Arguments, so an expression like
+    // `col != 1` will exclude rows where col is NULL along with rows where col = 1
+    // In contrast, Iceberg's Expressions will keep rows with NULL values
+    // So the equivalent ORC Search Argument for an Iceberg Expression `col != x`
+    // is `col IS NULL OR col != x`
+    return () -> {
+      this.builder.startOr();
+      isNull(expr).invoke();
+      this.builder.startNot();
+      eq(expr, lit).invoke();
+      this.builder.end(); // end NOT
+      this.builder.end(); // end OR
+    };
   }
 
   @Override
@@ -185,10 +193,19 @@ class ExpressionToSearchArgument extends ExpressionVisitors.BoundVisitor<Express
 
   @Override
   public <T> Action notIn(Bound<T> expr, Set<T> literalSet) {
-    return () -> this.builder.startNot()
-          .in(idToColumnName.get(expr.ref().fieldId()), type(expr.ref().type()),
-              literalSet.stream().map(lit -> literal(expr.ref().type(), lit)).toArray(Object[]::new))
-          .end();
+    // NOTE: ORC uses SQL semantics for Search Arguments, so an expression like
+    // `col NOT IN {1}` will exclude rows where col is NULL along with rows where col = 1
+    // In contrast, Iceberg's Expressions will keep rows with NULL values
+    // So the equivalent ORC Search Argument for an Iceberg Expression `col NOT IN {x}`
+    // is `col IS NULL OR col NOT IN {x}`
+    return () -> {
+      this.builder.startOr();
+      isNull(expr).invoke();
+      this.builder.startNot();
+      in(expr, literalSet).invoke();
+      this.builder.end(); // end NOT
+      this.builder.end(); // end OR
+    };
   }
 
   @Override

--- a/orc/src/test/java/org/apache/iceberg/orc/TestExpressionToSearchArgument.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestExpressionToSearchArgument.java
@@ -95,9 +95,9 @@ public class TestExpressionToSearchArgument {
         .startNot().lessThanEquals("`float`", Type.FLOAT, 5.0).end()
         .startNot().lessThan("`double`", Type.FLOAT, 500.0).end()
         .equals("`boolean`", Type.BOOLEAN, true)
-        .startNot().equals("`string`", Type.STRING, "test").end()
+        .startOr().isNull("`string`", Type.STRING).startNot().equals("`string`", Type.STRING, "test").end().end()
         .in("`decimal`", Type.DECIMAL, new HiveDecimalWritable("-123.45"), new HiveDecimalWritable("123.45"))
-        .startNot().in("`time`", Type.LONG, 100L, 200L).end()
+        .startOr().isNull("`time`", Type.LONG).startNot().in("`time`", Type.LONG, 100L, 200L).end().end()
         .end()
         .build();
 
@@ -382,8 +382,9 @@ public class TestExpressionToSearchArgument {
         .equals("`newMap_r5`.`_key`", Type.STRING, "country")
         // Drops listOfStruct.long
         .equals("`listOfStruct`.`_elem`.`newLong_r10`", Type.LONG, 100L)
-        .startNot()
-        .equals("`listOfPeople`.`_elem`.`name`", Type.STRING, "Bob")
+        .startOr()
+        .isNull("`listOfPeople`.`_elem`.`name`", Type.STRING)
+        .startNot().equals("`listOfPeople`.`_elem`.`name`", Type.STRING, "Bob").end()
         .end()
         .lessThan("`listOfPeople`.`_elem`.`age_r14`", Type.LONG, 30L)
         .end()


### PR DESCRIPTION
ORC uses SQL semantics for Search Arguments, so an expression like `col != 1` will exclude rows where col is NULL along with rows where `col = 1`. In contrast, Iceberg's Expressions will keep rows with NULL values, so the equivalent ORC Search Argument for an Iceberg Expression `col != x` is `col IS NULL OR col != x`.

This PR fixes the issue of the ORC pushdown returning less rows than what Iceberg expects. https://github.com/apache/iceberg/blob/78e80d2a35c4c93e68776c31c24cc8ccb06fed4b/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilter.java#L741-L742 mentions that this might be a bug in ORC, but in fact its just a case of mismatched semantics. During conversion of Iceberg expression to ORC Search Arguments, we now take care of this semantic difference.

The wider discussion of SQL compatibility for Iceberg expressions is discussed on [the dev list](https://lists.apache.org/thread.html/r1f02485a6c007715939f9ee9aa33344b8cfc90e5f72fa68e5d989056%40%3Cdev.iceberg.apache.org%3E).