### PR TITLE
API: Add name to Table and Catalog APIs

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Table.java
+++ b/api/src/main/java/org/apache/iceberg/Table.java
@@ -31,6 +31,15 @@ import org.apache.iceberg.io.LocationProvider;
 public interface Table {
 
   /**
+   * Return the full name for this table.
+   *
+   * @return this table's name
+   */
+  default String name() {
+    return toString();
+  }
+
+  /**
    * Refresh the current table metadata.
    */
   void refresh();

--- a/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
@@ -36,6 +36,15 @@ import org.apache.iceberg.exceptions.NotFoundException;
 public interface Catalog {
 
   /**
+   * Return the name for this catalog.
+   *
+   * @return this catalog's name
+   */
+  default String name() {
+    return toString();
+  }
+
+  /**
    * Return all the identifiers under this namespace.
    *
    * @param namespace a namespace

--- a/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
@@ -44,11 +44,11 @@ public class AllDataFilesTable extends BaseMetadataTable {
   private final Table table;
   private final String name;
 
-  public AllDataFilesTable(TableOperations ops, Table table) {
+  AllDataFilesTable(TableOperations ops, Table table) {
     this(ops, table, table.name() + ".all_data_files");
   }
 
-  public AllDataFilesTable(TableOperations ops, Table table, String name) {
+  AllDataFilesTable(TableOperations ops, Table table, String name) {
     this.ops = ops;
     this.table = table;
     this.name = name;

--- a/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
@@ -42,10 +42,16 @@ import org.apache.iceberg.util.ThreadPools;
 public class AllDataFilesTable extends BaseMetadataTable {
   private final TableOperations ops;
   private final Table table;
+  private final String name;
 
   public AllDataFilesTable(TableOperations ops, Table table) {
+    this(ops, table, table.name() + ".all_data_files");
+  }
+
+  public AllDataFilesTable(TableOperations ops, Table table, String name) {
     this.ops = ops;
     this.table = table;
+    this.name = name;
   }
 
   @Override
@@ -54,8 +60,8 @@ public class AllDataFilesTable extends BaseMetadataTable {
   }
 
   @Override
-  String metadataTableName() {
-    return "all_data_files";
+  public String name() {
+    return name;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
@@ -44,11 +44,11 @@ public class AllEntriesTable extends BaseMetadataTable {
   private final Table table;
   private final String name;
 
-  public AllEntriesTable(TableOperations ops, Table table) {
+  AllEntriesTable(TableOperations ops, Table table) {
     this(ops, table, table.name() + ".all_entries");
   }
 
-  public AllEntriesTable(TableOperations ops, Table table, String name) {
+  AllEntriesTable(TableOperations ops, Table table, String name) {
     this.ops = ops;
     this.table = table;
     this.name = name;

--- a/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
@@ -42,10 +42,16 @@ import org.apache.iceberg.util.ThreadPools;
 public class AllEntriesTable extends BaseMetadataTable {
   private final TableOperations ops;
   private final Table table;
+  private final String name;
 
   public AllEntriesTable(TableOperations ops, Table table) {
+    this(ops, table, table.name() + ".all_entries");
+  }
+
+  public AllEntriesTable(TableOperations ops, Table table, String name) {
     this.ops = ops;
     this.table = table;
+    this.name = name;
   }
 
   @Override
@@ -54,8 +60,8 @@ public class AllEntriesTable extends BaseMetadataTable {
   }
 
   @Override
-  String metadataTableName() {
-    return "all_entries";
+  public String name() {
+    return name;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -57,10 +57,16 @@ public class AllManifestsTable extends BaseMetadataTable {
 
   private final TableOperations ops;
   private final Table table;
+  private final String name;
 
   public AllManifestsTable(TableOperations ops, Table table) {
+    this(ops, table, table.name() + ".all_manifests");
+  }
+
+  public AllManifestsTable(TableOperations ops, Table table, String name) {
     this.ops = ops;
     this.table = table;
+    this.name = name;
   }
 
   @Override
@@ -69,8 +75,8 @@ public class AllManifestsTable extends BaseMetadataTable {
   }
 
   @Override
-  String metadataTableName() {
-    return "all_manifests";
+  public String name() {
+    return name;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -59,11 +59,11 @@ public class AllManifestsTable extends BaseMetadataTable {
   private final Table table;
   private final String name;
 
-  public AllManifestsTable(TableOperations ops, Table table) {
+  AllManifestsTable(TableOperations ops, Table table) {
     this(ops, table, table.name() + ".all_manifests");
   }
 
-  public AllManifestsTable(TableOperations ops, Table table, String name) {
+  AllManifestsTable(TableOperations ops, Table table, String name) {
     this.ops = ops;
     this.table = table;
     this.name = name;

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -34,6 +34,11 @@ abstract class BaseMetadataTable implements Table {
   abstract String metadataTableName();
 
   @Override
+  public String name() {
+    return table().name() + "." + metadataTableName();
+  }
+
+  @Override
   public FileIO io() {
     return table().io();
   }
@@ -175,6 +180,6 @@ abstract class BaseMetadataTable implements Table {
 
   @Override
   public String toString() {
-    return table().toString() + "." + metadataTableName();
+    return name();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -31,12 +31,6 @@ abstract class BaseMetadataTable implements Table {
   private final SortOrder sortOrder = SortOrder.unsorted();
 
   abstract Table table();
-  abstract String metadataTableName();
-
-  @Override
-  public String name() {
-    return table().name() + "." + metadataTableName();
-  }
 
   @Override
   public FileIO io() {

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -129,8 +129,8 @@ public abstract class BaseMetastoreCatalog implements Catalog {
   }
 
   private Table loadMetadataTable(TableIdentifier identifier) {
-    String name = identifier.name();
-    MetadataTableType type = MetadataTableType.from(name);
+    String tableName = identifier.name();
+    MetadataTableType type = MetadataTableType.from(tableName);
     if (type != null) {
       TableIdentifier baseTableIdentifier = TableIdentifier.of(identifier.namespace().levels());
       TableOperations ops = newTableOps(baseTableIdentifier);
@@ -138,7 +138,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
         throw new NoSuchTableException("Table does not exist: %s", baseTableIdentifier);
       }
 
-      return MetadataTableUtils.createMetadataTableInstance(ops, baseTableIdentifier, type);
+      return MetadataTableUtils.createMetadataTableInstance(ops, name(), baseTableIdentifier, type);
     } else {
       throw new NoSuchTableException("Table does not exist: %s", identifier);
     }
@@ -158,8 +158,6 @@ public abstract class BaseMetastoreCatalog implements Catalog {
   public String toString() {
     return getClass().getSimpleName() + "(" + name() + ")";
   }
-
-  protected abstract String name();
 
   protected abstract TableOperations newTableOps(TableIdentifier tableIdentifier);
 

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -138,7 +138,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
         throw new NoSuchTableException("Table does not exist: %s", baseTableIdentifier);
       }
 
-      return MetadataTableUtils.createMetadataTableInstance(ops, name(), baseTableIdentifier, type);
+      return MetadataTableUtils.createMetadataTableInstance(ops, name(), baseTableIdentifier, identifier, type);
     } else {
       throw new NoSuchTableException("Table does not exist: %s", identifier);
     }

--- a/core/src/main/java/org/apache/iceberg/BaseTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTable.java
@@ -45,6 +45,11 @@ public class BaseTable implements Table, HasTableOperations {
   }
 
   @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
   public void refresh() {
     ops.refresh();
   }
@@ -201,6 +206,6 @@ public class BaseTable implements Table, HasTableOperations {
 
   @Override
   public String toString() {
-    return name;
+    return name();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -484,6 +484,12 @@ class BaseTransaction implements Transaction {
   }
 
   public class TransactionTable implements Table {
+
+    @Override
+    public String name() {
+      return tableName;
+    }
+
     @Override
     public void refresh() {
     }
@@ -636,6 +642,11 @@ class BaseTransaction implements Transaction {
     @Override
     public LocationProvider locationProvider() {
       return transactionOps.locationProvider();
+    }
+
+    @Override
+    public String toString() {
+      return name();
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -56,6 +56,11 @@ public class CachingCatalog implements Catalog {
   }
 
   @Override
+  public String name() {
+    return catalog.name();
+  }
+
+  @Override
   public List<TableIdentifier> listTables(Namespace namespace) {
     return catalog.listTables(namespace);
   }
@@ -78,7 +83,7 @@ public class CachingCatalog implements Catalog {
         TableOperations ops = ((HasTableOperations) originTable).operations();
         MetadataTableType type = MetadataTableType.from(canonicalized.name());
 
-        Table metadataTable = MetadataTableUtils.createMetadataTableInstance(ops, originTableIdentifier, type);
+        Table metadataTable = MetadataTableUtils.createMetadataTableInstance(ops, name(), originTableIdentifier, type);
         tableCache.put(canonicalized, metadataTable);
         return metadataTable;
       }

--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -83,7 +83,9 @@ public class CachingCatalog implements Catalog {
         TableOperations ops = ((HasTableOperations) originTable).operations();
         MetadataTableType type = MetadataTableType.from(canonicalized.name());
 
-        Table metadataTable = MetadataTableUtils.createMetadataTableInstance(ops, name(), originTableIdentifier, type);
+        Table metadataTable = MetadataTableUtils.createMetadataTableInstance(
+            ops, name(), originTableIdentifier,
+            canonicalized, type);
         tableCache.put(canonicalized, metadataTable);
         return metadataTable;
       }

--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -84,7 +84,7 @@ public class CachingCatalog implements Catalog {
         MetadataTableType type = MetadataTableType.from(canonicalized.name());
 
         Table metadataTable = MetadataTableUtils.createMetadataTableInstance(
-            ops, name(), originTableIdentifier,
+            ops, catalog.name(), originTableIdentifier,
             canonicalized, type);
         tableCache.put(canonicalized, metadataTable);
         return metadataTable;

--- a/core/src/main/java/org/apache/iceberg/DataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DataFilesTable.java
@@ -34,10 +34,16 @@ import org.apache.iceberg.types.TypeUtil;
 public class DataFilesTable extends BaseMetadataTable {
   private final TableOperations ops;
   private final Table table;
+  private final String name;
 
   public DataFilesTable(TableOperations ops, Table table) {
+    this(ops, table, table.name() + ".files");
+  }
+
+  public DataFilesTable(TableOperations ops, Table table, String name) {
     this.ops = ops;
     this.table = table;
+    this.name = name;
   }
 
   @Override
@@ -46,8 +52,8 @@ public class DataFilesTable extends BaseMetadataTable {
   }
 
   @Override
-  String metadataTableName() {
-    return "files";
+  public String name() {
+    return name;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/DataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DataFilesTable.java
@@ -36,11 +36,11 @@ public class DataFilesTable extends BaseMetadataTable {
   private final Table table;
   private final String name;
 
-  public DataFilesTable(TableOperations ops, Table table) {
+  DataFilesTable(TableOperations ops, Table table) {
     this(ops, table, table.name() + ".files");
   }
 
-  public DataFilesTable(TableOperations ops, Table table, String name) {
+  DataFilesTable(TableOperations ops, Table table, String name) {
     this.ops = ops;
     this.table = table;
     this.name = name;

--- a/core/src/main/java/org/apache/iceberg/HistoryTable.java
+++ b/core/src/main/java/org/apache/iceberg/HistoryTable.java
@@ -45,11 +45,11 @@ public class HistoryTable extends BaseMetadataTable {
   private final Table table;
   private final String name;
 
-  public HistoryTable(TableOperations ops, Table table) {
+  HistoryTable(TableOperations ops, Table table) {
     this(ops, table, table.name() + ".history");
   }
 
-  public HistoryTable(TableOperations ops, Table table, String name) {
+  HistoryTable(TableOperations ops, Table table, String name) {
     this.ops = ops;
     this.table = table;
     this.name = name;

--- a/core/src/main/java/org/apache/iceberg/HistoryTable.java
+++ b/core/src/main/java/org/apache/iceberg/HistoryTable.java
@@ -43,10 +43,16 @@ public class HistoryTable extends BaseMetadataTable {
 
   private final TableOperations ops;
   private final Table table;
+  private final String name;
 
   public HistoryTable(TableOperations ops, Table table) {
+    this(ops, table, table.name() + ".history");
+  }
+
+  public HistoryTable(TableOperations ops, Table table, String name) {
     this.ops = ops;
     this.table = table;
+    this.name = name;
   }
 
   @Override
@@ -55,8 +61,8 @@ public class HistoryTable extends BaseMetadataTable {
   }
 
   @Override
-  String metadataTableName() {
-    return "history";
+  public String name() {
+    return name;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
@@ -38,10 +38,16 @@ import org.apache.iceberg.types.TypeUtil;
 public class ManifestEntriesTable extends BaseMetadataTable {
   private final TableOperations ops;
   private final Table table;
+  private final String name;
 
   public ManifestEntriesTable(TableOperations ops, Table table) {
+    this(ops, table, table.name() + ".entries");
+  }
+
+  public ManifestEntriesTable(TableOperations ops, Table table, String name) {
     this.ops = ops;
     this.table = table;
+    this.name = name;
   }
 
   @Override
@@ -50,8 +56,8 @@ public class ManifestEntriesTable extends BaseMetadataTable {
   }
 
   @Override
-  String metadataTableName() {
-    return "entries";
+  public String name() {
+    return name;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
@@ -40,11 +40,11 @@ public class ManifestEntriesTable extends BaseMetadataTable {
   private final Table table;
   private final String name;
 
-  public ManifestEntriesTable(TableOperations ops, Table table) {
+  ManifestEntriesTable(TableOperations ops, Table table) {
     this(ops, table, table.name() + ".entries");
   }
 
-  public ManifestEntriesTable(TableOperations ops, Table table, String name) {
+  ManifestEntriesTable(TableOperations ops, Table table, String name) {
     this.ops = ops;
     this.table = table;
     this.name = name;

--- a/core/src/main/java/org/apache/iceberg/ManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestsTable.java
@@ -46,11 +46,17 @@ public class ManifestsTable extends BaseMetadataTable {
   private final TableOperations ops;
   private final Table table;
   private final PartitionSpec spec;
+  private final String name;
 
   public ManifestsTable(TableOperations ops, Table table) {
+    this(ops, table, table.name() + ".manifests");
+  }
+
+  public ManifestsTable(TableOperations ops, Table table, String name) {
     this.ops = ops;
     this.table = table;
     this.spec = table.spec();
+    this.name = name;
   }
 
   @Override
@@ -59,8 +65,8 @@ public class ManifestsTable extends BaseMetadataTable {
   }
 
   @Override
-  String metadataTableName() {
-    return "manifests";
+  public String name() {
+    return name;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/ManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestsTable.java
@@ -48,11 +48,11 @@ public class ManifestsTable extends BaseMetadataTable {
   private final PartitionSpec spec;
   private final String name;
 
-  public ManifestsTable(TableOperations ops, Table table) {
+  ManifestsTable(TableOperations ops, Table table) {
     this(ops, table, table.name() + ".manifests");
   }
 
-  public ManifestsTable(TableOperations ops, Table table, String name) {
+  ManifestsTable(TableOperations ops, Table table, String name) {
     this.ops = ops;
     this.table = table;
     this.spec = table.spec();

--- a/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
@@ -59,10 +59,10 @@ public class MetadataTableUtils {
   }
 
   public static Table createMetadataTableInstance(TableOperations originTableOps,
+                                                  String catalogName,
                                                   TableIdentifier originTableIdentifier,
                                                   MetadataTableType type) {
-    return createMetadataTableInstance(originTableOps,
-        BaseMetastoreCatalog.fullTableName(type.name(), originTableIdentifier),
-        type);
+    String fullTableName = BaseMetastoreCatalog.fullTableName(catalogName, originTableIdentifier);
+    return createMetadataTableInstance(originTableOps, fullTableName, type);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
@@ -30,39 +30,42 @@ public class MetadataTableUtils {
     return MetadataTableType.from(identifier.name()) != null;
   }
 
-  public static Table createMetadataTableInstance(TableOperations originTableOps,
-                                                  String fullTableName,
+  public static Table createMetadataTableInstance(TableOperations ops,
+                                                  String baseTableName,
+                                                  String metadataTableName,
                                                   MetadataTableType type) {
-    Table baseTableForMetadata = new BaseTable(originTableOps, fullTableName);
+    Table baseTable = new BaseTable(ops, baseTableName);
     switch (type) {
       case ENTRIES:
-        return new ManifestEntriesTable(originTableOps, baseTableForMetadata);
+        return new ManifestEntriesTable(ops, baseTable, metadataTableName);
       case FILES:
-        return new DataFilesTable(originTableOps, baseTableForMetadata);
+        return new DataFilesTable(ops, baseTable, metadataTableName);
       case HISTORY:
-        return new HistoryTable(originTableOps, baseTableForMetadata);
+        return new HistoryTable(ops, baseTable, metadataTableName);
       case SNAPSHOTS:
-        return new SnapshotsTable(originTableOps, baseTableForMetadata);
+        return new SnapshotsTable(ops, baseTable, metadataTableName);
       case MANIFESTS:
-        return new ManifestsTable(originTableOps, baseTableForMetadata);
+        return new ManifestsTable(ops, baseTable, metadataTableName);
       case PARTITIONS:
-        return new PartitionsTable(originTableOps, baseTableForMetadata);
+        return new PartitionsTable(ops, baseTable, metadataTableName);
       case ALL_DATA_FILES:
-        return new AllDataFilesTable(originTableOps, baseTableForMetadata);
+        return new AllDataFilesTable(ops, baseTable, metadataTableName);
       case ALL_MANIFESTS:
-        return new AllManifestsTable(originTableOps, baseTableForMetadata);
+        return new AllManifestsTable(ops, baseTable, metadataTableName);
       case ALL_ENTRIES:
-        return new AllEntriesTable(originTableOps, baseTableForMetadata);
+        return new AllEntriesTable(ops, baseTable, metadataTableName);
       default:
-        throw new NoSuchTableException("Unknown metadata table type: %s for %s", type, fullTableName);
+        throw new NoSuchTableException("Unknown metadata table type: %s for %s", type, metadataTableName);
     }
   }
 
-  public static Table createMetadataTableInstance(TableOperations originTableOps,
+  public static Table createMetadataTableInstance(TableOperations ops,
                                                   String catalogName,
-                                                  TableIdentifier originTableIdentifier,
+                                                  TableIdentifier baseTableIdentifier,
+                                                  TableIdentifier metadataTableIdentifier,
                                                   MetadataTableType type) {
-    String fullTableName = BaseMetastoreCatalog.fullTableName(catalogName, originTableIdentifier);
-    return createMetadataTableInstance(originTableOps, fullTableName, type);
+    String baseTableName = BaseMetastoreCatalog.fullTableName(catalogName, baseTableIdentifier);
+    String metadataTableName = BaseMetastoreCatalog.fullTableName(catalogName, metadataTableIdentifier);
+    return createMetadataTableInstance(ops, baseTableName, metadataTableName, type);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -34,11 +34,11 @@ public class PartitionsTable extends BaseMetadataTable {
   private final Schema schema;
   private final String name;
 
-  public PartitionsTable(TableOperations ops, Table table) {
+  PartitionsTable(TableOperations ops, Table table) {
     this(ops, table, table.name() + ".partitions");
   }
 
-  public PartitionsTable(TableOperations ops, Table table, String name) {
+  PartitionsTable(TableOperations ops, Table table, String name) {
     this.ops = ops;
     this.table = table;
     this.schema = new Schema(

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -32,8 +32,13 @@ public class PartitionsTable extends BaseMetadataTable {
   private final TableOperations ops;
   private final Table table;
   private final Schema schema;
+  private final String name;
 
   public PartitionsTable(TableOperations ops, Table table) {
+    this(ops, table, table.name() + ".partitions");
+  }
+
+  public PartitionsTable(TableOperations ops, Table table, String name) {
     this.ops = ops;
     this.table = table;
     this.schema = new Schema(
@@ -41,6 +46,7 @@ public class PartitionsTable extends BaseMetadataTable {
         Types.NestedField.required(2, "record_count", Types.LongType.get()),
         Types.NestedField.required(3, "file_count", Types.IntegerType.get())
     );
+    this.name = name;
   }
 
   @Override
@@ -49,8 +55,8 @@ public class PartitionsTable extends BaseMetadataTable {
   }
 
   @Override
-  String metadataTableName() {
-    return "partitions";
+  public String name() {
+    return name;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
@@ -42,11 +42,11 @@ public class SnapshotsTable extends BaseMetadataTable {
   private final Table table;
   private final String name;
 
-  public SnapshotsTable(TableOperations ops, Table table) {
+  SnapshotsTable(TableOperations ops, Table table) {
     this(ops, table, table.name() + ".snapshots");
   }
 
-  public SnapshotsTable(TableOperations ops, Table table, String name) {
+  SnapshotsTable(TableOperations ops, Table table, String name) {
     this.ops = ops;
     this.table = table;
     this.name = name;

--- a/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
@@ -40,10 +40,16 @@ public class SnapshotsTable extends BaseMetadataTable {
 
   private final TableOperations ops;
   private final Table table;
+  private final String name;
 
   public SnapshotsTable(TableOperations ops, Table table) {
+    this(ops, table, table.name() + ".snapshots");
+  }
+
+  public SnapshotsTable(TableOperations ops, Table table, String name) {
     this.ops = ops;
     this.table = table;
+    this.name = name;
   }
 
   @Override
@@ -52,8 +58,8 @@ public class SnapshotsTable extends BaseMetadataTable {
   }
 
   @Override
-  String metadataTableName() {
-    return "snapshots";
+  public String name() {
+    return name;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -116,7 +116,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
   }
 
   @Override
-  protected String name() {
+  public String name() {
     return catalogName;
   }
 

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTables.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTables.java
@@ -76,7 +76,7 @@ public class HadoopTables implements Tables, Configurable {
 
     if (parsedMetadataType != null) {
       // Load a metadata table
-      result = loadMetadataTable(parsedMetadataType.first(), parsedMetadataType.second());
+      result = loadMetadataTable(parsedMetadataType.first(), location, parsedMetadataType.second());
     } else {
       // Load a normal table
       TableOperations ops = newTableOps(location);
@@ -109,13 +109,13 @@ public class HadoopTables implements Tables, Configurable {
     }
   }
 
-  private Table loadMetadataTable(String location, MetadataTableType type) {
+  private Table loadMetadataTable(String location, String metadataTableName, MetadataTableType type) {
     TableOperations ops = newTableOps(location);
     if (ops.current() == null) {
       throw new NoSuchTableException("Table does not exist at location: %s", location);
     }
 
-    return MetadataTableUtils.createMetadataTableInstance(ops, location, type);
+    return MetadataTableUtils.createMetadataTableInstance(ops, location, metadataTableName, type);
   }
 
   /**

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestCachingCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestCachingCatalog.java
@@ -67,4 +67,22 @@ public class TestCachingCatalog extends HadoopTableTestBase {
     Assert.assertEquals(filesMetaTable2.currentSnapshot(), table.currentSnapshot());
     Assert.assertEquals(manifestsMetaTable2.currentSnapshot(), table.currentSnapshot());
   }
+
+  @Test
+  public void testTableName() throws Exception {
+    Configuration conf = new Configuration();
+    String warehousePath = temp.newFolder().getAbsolutePath();
+
+    HadoopCatalog hadoopCatalog = new HadoopCatalog(conf, warehousePath);
+    Catalog catalog = CachingCatalog.wrap(hadoopCatalog);
+    TableIdentifier tableIdent = TableIdentifier.of("db", "ns1", "ns2", "tbl");
+    catalog.createTable(tableIdent, SCHEMA, SPEC, ImmutableMap.of("key2", "value2"));
+
+    Table table = catalog.loadTable(tableIdent);
+    Assert.assertEquals("Name must match", "hadoop.db.ns1.ns2.tbl", table.name());
+
+    TableIdentifier snapshotsTableIdent = TableIdentifier.of("db", "ns1", "ns2", "tbl", "snapshots");
+    Table snapshotsTable = catalog.loadTable(snapshotsTableIdent);
+    Assert.assertEquals("Name must match", "hadoop.db.ns1.ns2.tbl.snapshots", snapshotsTable.name());
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
@@ -525,6 +525,24 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
         () -> TABLES.load(tableLocation));
   }
 
+  @Test
+  public void testTableName() throws Exception {
+    Configuration conf = new Configuration();
+    String warehousePath = temp.newFolder().getAbsolutePath();
+    HadoopCatalog catalog = new HadoopCatalog(conf, warehousePath);
+    TableIdentifier tableIdent = TableIdentifier.of("db", "ns1", "ns2", "tbl");
+    catalog.buildTable(tableIdent, SCHEMA)
+        .withPartitionSpec(SPEC)
+        .create();
+
+    Table table = catalog.loadTable(tableIdent);
+    Assert.assertEquals("Name must match", "hadoop.db.ns1.ns2.tbl", table.name());
+
+    TableIdentifier snapshotsTableIdent = TableIdentifier.of("db", "ns1", "ns2", "tbl", "snapshots");
+    Table snapshotsTable = catalog.loadTable(snapshotsTableIdent);
+    Assert.assertEquals("Name must match", "hadoop.db.ns1.ns2.tbl.snapshots", snapshotsTable.name());
+  }
+
   private static void addVersionsToTable(Table table) {
     DataFile dataFile1 = DataFiles.builder(SPEC)
         .withPath("/a.parquet")

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopTables.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopTables.java
@@ -139,6 +139,18 @@ public class TestHadoopTables {
     Assert.assertEquals("Transform must match", transform, sortOrder.fields().get(0).transform());
   }
 
+  @Test
+  public void testTableName() {
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA)
+        .bucket("data", 16)
+        .build();
+    String location = tableDir.toURI().toString();
+    TABLES.create(SCHEMA, spec, location);
+
+    Table table = TABLES.load(location);
+    Assert.assertEquals("Table name must match", location, table.name());
+  }
+
   private static void createDummyTable(File tableDir, File dataDir) throws IOException {
     Table table = TABLES.create(SCHEMA, tableDir.toURI().toString());
     AppendFiles append = table.newAppend();

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopTables.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopTables.java
@@ -148,7 +148,10 @@ public class TestHadoopTables {
     TABLES.create(SCHEMA, spec, location);
 
     Table table = TABLES.load(location);
-    Assert.assertEquals("Table name must match", location, table.name());
+    Assert.assertEquals("Name must match", location, table.name());
+
+    Table snapshotsTable = TABLES.load(location + "#snapshots");
+    Assert.assertEquals("Name must match", location + "#snapshots", snapshotsTable.name());
   }
 
   private static void createDummyTable(File tableDir, File dataDir) throws IOException {

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -112,7 +112,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable, Supp
   }
 
   @Override
-  protected String name() {
+  public String name() {
     return name;
   }
 


### PR DESCRIPTION
This PR adds `name` methods to the `Table` and `Catalog` APIs.

Resolves #658.