### PR TITLE
Spark3: Make views that reference Iceberg tables show current data

### DIFF
--- a/spark3/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/IcebergSource.java
@@ -62,7 +62,8 @@ public class IcebergSource implements DataSourceRegister, TableProvider {
     Table icebergTable = getTableAndResolveHadoopConfiguration(options, conf);
 
     // Build Spark table based on Iceberg table, and return it
-    return new SparkTable(icebergTable, schema);
+    // Eagerly refresh the table before reading to ensure views containing this table show up-to-date data
+    return new SparkTable(icebergTable, schema, true);
   }
 
   protected Table findTable(Map<String, String> options, Configuration conf) {

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/StagedSparkTable.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/StagedSparkTable.java
@@ -26,7 +26,7 @@ public class StagedSparkTable extends SparkTable implements StagedTable {
   private final Transaction transaction;
 
   public StagedSparkTable(Transaction transaction) {
-    super(transaction.table());
+    super(transaction.table(), false);
     this.transaction = transaction;
   }
 


### PR DESCRIPTION
This PR makes views that reference Iceberg tables show up-to-date data with and without catalog cache.

See #1485 for more info.