### PR TITLE
BaseMetastoreTableOperations shouldn't disable refresh upon NoSuchTab…

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -87,12 +87,12 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
     } catch (NoSuchTableException e) {
       if (currentMetadataWasAvailable) {
         LOG.warn("Could not find the table during refresh, setting current metadata to null", e);
+        shouldRefresh = true;
       }
 
       currentMetadata = null;
       currentMetadataLocation = null;
       version = -1;
-      shouldRefresh = false;
       throw e;
     }
     return current();


### PR DESCRIPTION
…leException. Otherwise it might cause unfriendly NPE for callers that don't check null return value from current() method.