### PR TITLE
load hive-site.xml for flink catalog

### DIFF
--- a/flink/src/main/java/org/apache/iceberg/flink/CatalogLoader.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/CatalogLoader.java
@@ -38,8 +38,8 @@ public interface CatalogLoader extends Serializable {
     return new HadoopCatalogLoader(name, hadoopConf, warehouseLocation);
   }
 
-  static CatalogLoader hive(String name, Configuration hadoopConf, String uri, int clientPoolSize) {
-    return new HiveCatalogLoader(name, hadoopConf, uri, clientPoolSize);
+  static CatalogLoader hive(String name, Configuration hadoopConf, String uri, String warehouse, int clientPoolSize) {
+    return new HiveCatalogLoader(name, hadoopConf, uri, warehouse, clientPoolSize);
   }
 
   class HadoopCatalogLoader implements CatalogLoader {
@@ -71,18 +71,21 @@ public interface CatalogLoader extends Serializable {
     private final String catalogName;
     private final SerializableConfiguration hadoopConf;
     private final String uri;
+    private final String warehouse;
     private final int clientPoolSize;
 
-    private HiveCatalogLoader(String catalogName, Configuration conf, String uri, int clientPoolSize) {
+    private HiveCatalogLoader(String catalogName, Configuration conf, String uri, String warehouse,
+                              int clientPoolSize) {
       this.catalogName = catalogName;
       this.hadoopConf = new SerializableConfiguration(conf);
       this.uri = uri;
+      this.warehouse = warehouse;
       this.clientPoolSize = clientPoolSize;
     }
 
     @Override
     public Catalog loadCatalog() {
-      return new HiveCatalog(catalogName, uri, clientPoolSize, hadoopConf.get());
+      return new HiveCatalog(catalogName, uri, warehouse, clientPoolSize, hadoopConf.get());
     }
 
     @Override
@@ -90,6 +93,7 @@ public interface CatalogLoader extends Serializable {
       return MoreObjects.toStringHelper(this)
           .add("catalogName", catalogName)
           .add("uri", uri)
+          .add("warehouse", warehouse)
           .add("clientPoolSize", clientPoolSize)
           .toString();
     }

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -62,7 +62,7 @@ public class FlinkCatalogFactory implements CatalogFactory {
   public static final String HIVE_CLIENT_POOL_SIZE = "clients";
   public static final String HADOOP_WAREHOUSE_LOCATION = "warehouse";
 
-  public static final String HIVE_SITE_PATH = "hive-site-path";
+  public static final String HIVE_CONF_DIR = "hive-conf-dir";
   public static final String HIVE_SITE_SCHEME_FILE = "file";
   public static final String HIVE_SITE_SCHEME_HDFS = "hdfs";
 
@@ -113,7 +113,7 @@ public class FlinkCatalogFactory implements CatalogFactory {
     properties.add(HADOOP_WAREHOUSE_LOCATION);
     properties.add(DEFAULT_DATABASE);
     properties.add(BASE_NAMESPACE);
-    properties.add(HIVE_SITE_PATH);
+    properties.add(HIVE_CONF_DIR);
     return properties;
   }
 
@@ -142,9 +142,9 @@ public class FlinkCatalogFactory implements CatalogFactory {
   }
 
   private void loadHiveConf(Configuration configuration, Map<String, String> properties) {
-    String hiveConfPath = properties.get(HIVE_SITE_PATH);
-    if (hiveConfPath != null) {
-      Path path = new Path(hiveConfPath);
+    String hiveConfDir = properties.get(HIVE_CONF_DIR);
+    if (hiveConfDir != null) {
+      Path path = new Path(hiveConfDir + File.separator + "hive-site.xml");
       String scheme = getScheme(path);
       // We can add more storage support later，like s3
       switch (scheme) {
@@ -168,7 +168,7 @@ public class FlinkCatalogFactory implements CatalogFactory {
     String scheme = path.toUri().getScheme();
     if (scheme == null) {
       throw new UnsupportedOperationException(
-          "the scheme of HIVE_SITE_PATH can not be null");
+          "the scheme of HIVE_CONF_DIR can not be null");
     } else {
       return scheme;
     }

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -84,7 +84,8 @@ public class FlinkCatalogFactory implements CatalogFactory {
       case "hive":
         int clientPoolSize = Integer.parseInt(properties.getOrDefault(HIVE_CLIENT_POOL_SIZE, "2"));
         String uri = properties.get(HIVE_URI);
-        return CatalogLoader.hive(name, hadoopConf, uri, clientPoolSize);
+        String warehouse = properties.get(HADOOP_WAREHOUSE_LOCATION);
+        return CatalogLoader.hive(name, hadoopConf, uri, warehouse, clientPoolSize);
 
       case "hadoop":
         String warehouseLocation = properties.get(HADOOP_WAREHOUSE_LOCATION);
@@ -167,7 +168,7 @@ public class FlinkCatalogFactory implements CatalogFactory {
     String scheme = path.toUri().getScheme();
     if (scheme == null) {
       throw new UnsupportedOperationException(
-          "the scheme can not be null");
+          "the scheme of HIVE_SITE_PATH can not be null");
     } else {
       return scheme;
     }

--- a/flink/src/test/java/org/apache/iceberg/flink/FlinkCatalogTestBase.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/FlinkCatalogTestBase.java
@@ -71,8 +71,8 @@ public abstract class FlinkCatalogTestBase extends FlinkTestBase {
   // use Namespace instead: https://github.com/apache/iceberg/issues/1541
   public static Iterable<Object[]> parameters() {
     return Lists.newArrayList(
-        new Object[] {"testhive", new String[0]},
         new Object[] {"testhadoop", new String[0]},
+        new Object[] {"testhive", new String[0]},
         new Object[] {"testhadoop_basenamespace", new String[] {"l0", "l1"}}
     );
   }
@@ -101,8 +101,11 @@ public abstract class FlinkCatalogTestBase extends FlinkTestBase {
     config.put("type", "iceberg");
     config.put(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE, isHadoopCatalog ? "hadoop" : "hive");
     config.put(FlinkCatalogFactory.HADOOP_WAREHOUSE_LOCATION, "file:" + warehouse);
-    URL url = this.getClass().getClassLoader().getResource("hive-site.xml");
-    config.put(FlinkCatalogFactory.HIVE_SITE_PATH, url.toString());
+    if (!isHadoopCatalog) {
+      URL url = this.getClass().getClassLoader().getResource("hive-site.xml");
+      config.put(FlinkCatalogFactory.HIVE_SITE_PATH, url.toString());
+    }
+
     if (baseNamespace.length > 0) {
       config.put(FlinkCatalogFactory.BASE_NAMESPACE, Joiner.on(".").join(baseNamespace));
     }
@@ -119,7 +122,7 @@ public abstract class FlinkCatalogTestBase extends FlinkTestBase {
         flinkCatalogs.computeIfAbsent(catalogName, k -> factory.createCatalog(k, config)));
 
     this.flinkDatabase = catalogName + "." + DATABASE;
-    this.icebergNamespace = Namespace.of(ArrayUtils.concat(baseNamespace, new String[] { DATABASE }));
+    this.icebergNamespace = Namespace.of(ArrayUtils.concat(baseNamespace, new String[] {DATABASE}));
   }
 
   protected TableEnvironment getTableEnv() {

--- a/flink/src/test/java/org/apache/iceberg/flink/FlinkCatalogTestBase.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/FlinkCatalogTestBase.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.flink;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -100,6 +101,8 @@ public abstract class FlinkCatalogTestBase extends FlinkTestBase {
     config.put("type", "iceberg");
     config.put(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE, isHadoopCatalog ? "hadoop" : "hive");
     config.put(FlinkCatalogFactory.HADOOP_WAREHOUSE_LOCATION, "file:" + warehouse);
+    URL url = this.getClass().getClassLoader().getResource("hive-site.xml");
+    config.put(FlinkCatalogFactory.HIVE_SITE_PATH, url.toString());
     if (baseNamespace.length > 0) {
       config.put(FlinkCatalogFactory.BASE_NAMESPACE, Joiner.on(".").join(baseNamespace));
     }

--- a/flink/src/test/java/org/apache/iceberg/flink/FlinkCatalogTestBase.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/FlinkCatalogTestBase.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.flink;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -101,11 +100,6 @@ public abstract class FlinkCatalogTestBase extends FlinkTestBase {
     config.put("type", "iceberg");
     config.put(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE, isHadoopCatalog ? "hadoop" : "hive");
     config.put(FlinkCatalogFactory.HADOOP_WAREHOUSE_LOCATION, "file:" + warehouse);
-    if (!isHadoopCatalog) {
-      URL url = this.getClass().getClassLoader().getResource("hive-site.xml");
-      config.put(FlinkCatalogFactory.HIVE_SITE_PATH, url.toString());
-    }
-
     if (baseNamespace.length > 0) {
       config.put(FlinkCatalogFactory.BASE_NAMESPACE, Joiner.on(".").join(baseNamespace));
     }

--- a/flink/src/test/java/org/apache/iceberg/flink/TestCatalogTableLoader.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestCatalogTableLoader.java
@@ -68,7 +68,7 @@ public class TestCatalogTableLoader extends FlinkTestBase {
 
   @Test
   public void testHiveCatalogLoader() throws IOException, ClassNotFoundException {
-    CatalogLoader loader = CatalogLoader.hive("my_catalog", hiveConf, null, 2);
+    CatalogLoader loader = CatalogLoader.hive("my_catalog", hiveConf, null, null, 2);
     validateCatalogLoader(loader);
   }
 
@@ -81,7 +81,7 @@ public class TestCatalogTableLoader extends FlinkTestBase {
 
   @Test
   public void testHiveCatalogTableLoader() throws IOException, ClassNotFoundException {
-    CatalogLoader catalogLoader = CatalogLoader.hive("my_catalog", hiveConf, null, 2);
+    CatalogLoader catalogLoader = CatalogLoader.hive("my_catalog", hiveConf, null, null, 2);
     validateTableLoader(TableLoader.fromCatalog(catalogLoader, IDENTIFIER));
   }
 

--- a/flink/src/test/resources/hive-site.xml
+++ b/flink/src/test/resources/hive-site.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!--
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+
+</configuration>

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -71,12 +71,16 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable, Supp
     this.closed = false;
   }
 
-  public HiveCatalog(String name, String uri, int clientPoolSize, Configuration conf) {
+  public HiveCatalog(String name, String uri, String warehouse, int clientPoolSize, Configuration conf) {
     this.name = name;
     this.conf = new Configuration(conf);
     // before building the client pool, overwrite the configuration's URIs if the argument is non-null
     if (uri != null) {
       this.conf.set(HiveConf.ConfVars.METASTOREURIS.varname, uri);
+    }
+
+    if (warehouse != null) {
+      this.conf.set(HiveConf.ConfVars.METASTOREWAREHOUSE.varname, warehouse);
     }
 
     this.clients = new HiveClientPool(clientPoolSize, this.conf);
@@ -220,7 +224,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable, Supp
 
     } catch (AlreadyExistsException e) {
       throw new org.apache.iceberg.exceptions.AlreadyExistsException(e, "Namespace '%s' already exists!",
-            namespace);
+          namespace);
 
     } catch (TException e) {
       throw new RuntimeException("Failed to create namespace " + namespace + " in Hive MataStore", e);
@@ -250,7 +254,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable, Supp
       return namespaces;
 
     } catch (TException e) {
-      throw new RuntimeException("Failed to list all namespace: " + namespace + " in Hive MataStore",  e);
+      throw new RuntimeException("Failed to list all namespace: " + namespace + " in Hive MataStore", e);
 
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
@@ -294,7 +298,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable, Supp
   }
 
   @Override
-  public boolean setProperties(Namespace namespace,  Map<String, String> properties) {
+  public boolean setProperties(Namespace namespace, Map<String, String> properties) {
     Map<String, String> parameter = Maps.newHashMap();
 
     parameter.putAll(loadNamespaceMetadata(namespace));
@@ -309,7 +313,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable, Supp
   }
 
   @Override
-  public boolean removeProperties(Namespace namespace,  Set<String> properties) {
+  public boolean removeProperties(Namespace namespace, Set<String> properties) {
     Map<String, String> parameter = Maps.newHashMap();
 
     parameter.putAll(loadNamespaceMetadata(namespace));
@@ -323,7 +327,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable, Supp
     return true;
   }
 
-  private void alterHiveDataBase(Namespace namespace,  Database database) {
+  private void alterHiveDataBase(Namespace namespace, Database database) {
     try {
       clients.run(client -> {
         client.alterDatabase(namespace.level(0), database);
@@ -453,7 +457,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable, Supp
       throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);
     }
 
-    Database database  = new Database();
+    Database database = new Database();
     Map<String, String> parameter = Maps.newHashMap();
 
     database.setName(namespace.level(0));

--- a/spark3/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -87,7 +87,7 @@ public class SparkCatalog implements StagingTableCatalog, org.apache.spark.sql.c
   /**
    * Build an Iceberg {@link Catalog} to be used by this Spark catalog adapter.
    *
-   * @param name Spark's catalog name
+   * @param name    Spark's catalog name
    * @param options Spark's catalog options
    * @return an Iceberg catalog
    */
@@ -98,7 +98,8 @@ public class SparkCatalog implements StagingTableCatalog, org.apache.spark.sql.c
       case "hive":
         int clientPoolSize = options.getInt("clients", 2);
         String uri = options.get("uri");
-        return new HiveCatalog(name, uri, clientPoolSize, conf);
+        String warehouse = options.get("warehouse");
+        return new HiveCatalog(name, uri, warehouse, clientPoolSize, conf);
 
       case "hadoop":
         String warehouseLocation = options.get("warehouse");


### PR DESCRIPTION
In order to be compatible with various flink submission modes, FlinkCatalogFactory provides a variable hive-site-path to specify the path of hive-site.xml, which can be a local path or other no local storage

this is for issue #1437

I submitted a pr (https://github.com/apache/iceberg/pull/1527) before, but it contained some conflicts and included other PRs. I did not handle it well, so I close it and open a new PR.

@rdblue could you help review it and give me some suggestions ? thank you 

@kbendick Thanks for your suggestions,I have update the code according to your suggestion


