### PR TITLE
Core: Update version-hint.txt atomically

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -305,7 +305,7 @@ public class HadoopTableOperations implements TableOperations {
   }
 
   private void writeVersionToPath(FileSystem fs, Path path, int versionToWrite) throws IOException {
-    try (FSDataOutputStream out = fs.create(path, false)) {
+    try (FSDataOutputStream out = fs.create(path, false /* overwrite */)) {
       out.write(String.valueOf(versionToWrite).getBytes(StandardCharsets.UTF_8));
     }
   }

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -297,7 +297,7 @@ public class HadoopTableOperations implements TableOperations {
     try {
       Path tempVersionHintFile = metadataPath(UUID.randomUUID().toString() + "-version-hint.temp");
       writeVersionToPath(fs, tempVersionHintFile, versionToWrite);
-      fs.delete(versionHintFile, false);
+      fs.delete(versionHintFile, false /* recursive delete */);
       fs.rename(tempVersionHintFile, versionHintFile);
     } catch (IOException e) {
       LOG.warn("Failed to update version hint", e);

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -295,22 +295,19 @@ public class HadoopTableOperations implements TableOperations {
     FileSystem fs = getFileSystem(versionHintFile, conf);
 
     try {
-      if (fs.exists(versionHintFile)) {
-        Path tempVersionHintFile = metadataPath("version-hint.temp" );
-        writeFileToPath(fs, tempVersionHintFile);
-        fs.delete(versionHintFile, false);
-        fs.rename(tempVersionHintFile, versionHintFile);
-      } else {
-        writeFileToPath(fs, versionHintFile);
-      }
+      Path tempVersionHintFile = metadataPath(UUID.randomUUID().toString() + "-version-hint.temp");
+      writeVersionToPath(fs, tempVersionHintFile, versionToWrite);
+      fs.delete(versionHintFile, false);
+      fs.rename(tempVersionHintFile, versionHintFile);
     } catch (IOException e) {
       LOG.warn("Failed to update version hint", e);
     }
   }
 
-  private void writeFileToPath(FileSystem fs, Path path) throws IOException{
-    FSDataOutputStream out = fs.create(path, true /* overwrite */);
-    out.write(String.valueOf(path).getBytes(StandardCharsets.UTF_8));
+  private void writeVersionToPath(FileSystem fs, Path path, int versionToWrite) throws IOException {
+    try (FSDataOutputStream out = fs.create(path, true /* overwrite */)) {
+      out.write(String.valueOf(versionToWrite).getBytes(StandardCharsets.UTF_8));
+    }
   }
 
   @VisibleForTesting

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -294,11 +294,23 @@ public class HadoopTableOperations implements TableOperations {
     Path versionHintFile = versionHintFile();
     FileSystem fs = getFileSystem(versionHintFile, conf);
 
-    try (FSDataOutputStream out = fs.create(versionHintFile, true /* overwrite */)) {
-      out.write(String.valueOf(versionToWrite).getBytes(StandardCharsets.UTF_8));
+    try {
+      if (fs.exists(versionHintFile)) {
+        Path tempVersionHintFile = metadataPath("version-hint.temp" );
+        writeFileToPath(fs, tempVersionHintFile);
+        fs.delete(versionHintFile, false);
+        fs.rename(tempVersionHintFile, versionHintFile);
+      } else {
+        writeFileToPath(fs, versionHintFile);
+      }
     } catch (IOException e) {
       LOG.warn("Failed to update version hint", e);
     }
+  }
+
+  private void writeFileToPath(FileSystem fs, Path path) throws IOException{
+    FSDataOutputStream out = fs.create(path, true /* overwrite */);
+    out.write(String.valueOf(path).getBytes(StandardCharsets.UTF_8));
   }
 
   @VisibleForTesting

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -305,7 +305,7 @@ public class HadoopTableOperations implements TableOperations {
   }
 
   private void writeVersionToPath(FileSystem fs, Path path, int versionToWrite) throws IOException {
-    try (FSDataOutputStream out = fs.create(path, true /* overwrite */)) {
+    try (FSDataOutputStream out = fs.create(path, false)) {
       out.write(String.valueOf(versionToWrite).getBytes(StandardCharsets.UTF_8));
     }
   }


### PR DESCRIPTION
Under issue #1496 it was already discussed that we should find a way to update version-hint.txt atomically. At the moment, there is no know operation that would support atomic updates. Based on this I think our best solution would be:
1. Create a new file
2. Delete old version-hint.txt
3. Move the new file to version-hint.txt