### PR TITLE
ORC: Remove workarounds after 1.6.5 upgrade

### DIFF
--- a/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilter.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilter.java
@@ -246,12 +246,8 @@ public class TestMetricsRowGroupFilter {
   public void testAllNulls() {
     boolean shouldRead;
 
-    // ORC-623: ORC does not skip a row group for a notNull predicate on a column with all nulls
-    // boolean shouldRead = shouldRead(notNull("all_nulls"));
-    if (format != FileFormat.ORC) {
-      shouldRead = shouldRead(notNull("all_nulls"));
-      Assert.assertFalse("Should skip: no non-null value in all null column", shouldRead);
-    }
+    shouldRead = shouldRead(notNull("all_nulls"));
+    Assert.assertFalse("Should skip: no non-null value in all null column", shouldRead);
 
     shouldRead = shouldRead(notNull("some_nulls"));
     Assert.assertTrue("Should read: column with some nulls contains a non-null value", shouldRead);


### PR DESCRIPTION
A couple of fixes went into ORC 1.6.4 which allows us to remove workarounds and ignored tests

[ORC-623](https://issues.apache.org/jira/browse/ORC-623): ORC will now correctly skip row groups for notNull predicates
[ORC-661](https://issues.apache.org/jira/browse/ORC-661): ORC now provides timezone agnostic daysFromEpoch, so we no longer need to use reflection

PS: We also have a workaround for [ORC-611](https://issues.apache.org/jira/browse/ORC-611), but I will raise a separate PR for that