### PR TITLE
Hive: Don't use catalog to initialize serde on mappers

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
@@ -27,8 +27,11 @@ import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.SerDeStats;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.io.Writable;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.mr.Catalogs;
+import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.iceberg.mr.hive.serde.objectinspector.IcebergObjectInspector;
 import org.apache.iceberg.mr.mapred.Container;
 
@@ -38,10 +41,15 @@ public class HiveIcebergSerDe extends AbstractSerDe {
 
   @Override
   public void initialize(@Nullable Configuration configuration, Properties serDeProperties) throws SerDeException {
-    Table table = Catalogs.loadTable(configuration, serDeProperties);
-
+    Schema tableSchema;
+    if (configuration.get(InputFormatConfig.TABLE_SCHEMA) != null) {
+      tableSchema = SchemaParser.fromJson(configuration.get(InputFormatConfig.TABLE_SCHEMA));
+    } else {
+      Table table = Catalogs.loadTable(configuration, serDeProperties);
+      tableSchema = table.schema();
+    }
     try {
-      this.inspector = IcebergObjectInspector.create(table.schema());
+      this.inspector = IcebergObjectInspector.create(tableSchema);
     } catch (Exception e) {
       throw new SerDeException(e);
     }


### PR DESCRIPTION
Hive when it spawns Map Reduce jobs, needs to initialize `HiveIcebergSerDe` on mappers. When HiveIcebergSerDe is initialized, [a catalog instance](https://github.com/apache/iceberg/blob/master/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java#L41)  is created and queried for table schema. This doesn't seem like a good behavior, considering that there can be 1000s of mappers, and that can overload the catalog, for example a hive metastore. 

I accidentally came across this behavior while trying to run it on a yarn cluster, the mappers didn't have access to HiveMetaStore classes ([see the error](https://gist.github.com/HotSushi/fe86bdfe576138aa53d1b6cf4b12a24b)). The reason this is not reproducible in HiveRunner unit tests, is because the classpath already contains HiveMetaStore classes.

With this PR, the jobconf will be checked first to see if serialized schema is already present, if so use that instead of querying the catalog. 

Note that we can't completely get rid of the catalog call because `HiveIcebergSerDe` is also initialized during query analysis time when jobconf is not set (see the stacktrace if we get rid of the call [here](https://gist.github.com/HotSushi/33d8c7bdd59e7dbda202c3172a0be186)). 

I didn't write any tests with this PR because i'm not sure how classpath changes can be tested in HiveRunner, but any ideas are welcome. 