### PR TITLE
API: add some validation when create bucket/truncate partition

### DIFF
--- a/api/src/main/java/org/apache/iceberg/transforms/Bucket.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Bucket.java
@@ -46,7 +46,7 @@ abstract class Bucket<T> implements Transform<T, Integer> {
   @SuppressWarnings("unchecked")
   static <T> Bucket<T> get(Type type, int numBuckets) {
     Preconditions.checkArgument(numBuckets > 0,
-        "The number of bucket must larger than zero,but is %s", numBuckets);
+        "The number of bucket(s) must be larger than zero, but is %s", numBuckets);
 
     switch (type.typeId()) {
       case DATE:

--- a/api/src/main/java/org/apache/iceberg/transforms/Bucket.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Bucket.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.hash.HashFunction;
 import org.apache.iceberg.relocated.com.google.common.hash.Hashing;
@@ -44,6 +45,9 @@ abstract class Bucket<T> implements Transform<T, Integer> {
 
   @SuppressWarnings("unchecked")
   static <T> Bucket<T> get(Type type, int numBuckets) {
+    Preconditions.checkArgument(numBuckets > 0,
+        "The number of bucket must larger than zero,but is %s", numBuckets);
+
     switch (type.typeId()) {
       case DATE:
       case INTEGER:

--- a/api/src/main/java/org/apache/iceberg/transforms/Bucket.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Bucket.java
@@ -46,7 +46,7 @@ abstract class Bucket<T> implements Transform<T, Integer> {
   @SuppressWarnings("unchecked")
   static <T> Bucket<T> get(Type type, int numBuckets) {
     Preconditions.checkArgument(numBuckets > 0,
-        "The number of bucket(s) must be larger than zero, but is %s", numBuckets);
+        "Invalid number of buckets: %s (must be > 0)", numBuckets);
 
     switch (type.typeId()) {
       case DATE:

--- a/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
@@ -30,12 +30,16 @@ import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.UnicodeUtil;
 
 abstract class Truncate<T> implements Transform<T, T> {
   @SuppressWarnings("unchecked")
   static <T> Truncate<T> get(Type type, int width) {
+    Preconditions.checkArgument(width > 0,
+        "The width of truncate must larger than zero,but is %s", width);
+
     switch (type.typeId()) {
       case INTEGER:
         return (Truncate<T>) new TruncateInteger(width);

--- a/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
@@ -38,7 +38,7 @@ abstract class Truncate<T> implements Transform<T, T> {
   @SuppressWarnings("unchecked")
   static <T> Truncate<T> get(Type type, int width) {
     Preconditions.checkArgument(width > 0,
-        "The width of truncate must larger than zero,but is %s", width);
+        "The width of truncate must be larger than zero, but is %s", width);
 
     switch (type.typeId()) {
       case INTEGER:

--- a/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
@@ -38,7 +38,7 @@ abstract class Truncate<T> implements Transform<T, T> {
   @SuppressWarnings("unchecked")
   static <T> Truncate<T> get(Type type, int width) {
     Preconditions.checkArgument(width > 0,
-        "The width of truncate must be larger than zero, but is %s", width);
+        "Invalid truncate width: %s (must be > 0)", width);
 
     switch (type.typeId()) {
       case INTEGER:

--- a/api/src/test/java/org/apache/iceberg/transforms/TestBucketing.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestBucketing.java
@@ -28,6 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import java.util.UUID;
 import org.apache.avro.util.Utf8;
+import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.hash.HashFunction;
 import org.apache.iceberg.relocated.com.google.common.hash.Hashing;
@@ -273,6 +274,14 @@ public class TestBucketing {
 
     Assert.assertEquals("UUID hash should match hash of backing bytes",
         hashBytes(uuidBytes), bucketFunc.hash(uuid));
+  }
+
+  @Test
+  public void testVerifiedIllegalNumBucket() {
+    AssertHelpers.assertThrows("Should fail if numBucket is less than or equal to zero",
+        IllegalArgumentException.class,
+        "The number of bucket must larger than zero",
+        () -> Bucket.get(Types.IntegerType.get(), 0));
   }
 
   private byte[] randomBytes(int length) {

--- a/api/src/test/java/org/apache/iceberg/transforms/TestBucketing.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestBucketing.java
@@ -277,10 +277,10 @@ public class TestBucketing {
   }
 
   @Test
-  public void testVerifiedIllegalNumBucket() {
+  public void testVerifiedIllegalNumBuckets() {
     AssertHelpers.assertThrows("Should fail if numBucket is less than or equal to zero",
         IllegalArgumentException.class,
-        "The number of bucket must larger than zero",
+        "The number of bucket(s) must be larger than zero",
         () -> Bucket.get(Types.IntegerType.get(), 0));
   }
 

--- a/api/src/test/java/org/apache/iceberg/transforms/TestBucketing.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestBucketing.java
@@ -280,7 +280,7 @@ public class TestBucketing {
   public void testVerifiedIllegalNumBuckets() {
     AssertHelpers.assertThrows("Should fail if numBucket is less than or equal to zero",
         IllegalArgumentException.class,
-        "The number of bucket(s) must be larger than zero",
+        "Invalid number of buckets: 0 (must be > 0)",
         () -> Bucket.get(Types.IntegerType.get(), 0));
   }
 

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTruncate.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTruncate.java
@@ -92,7 +92,7 @@ public class TestTruncate {
   public void testVerifiedIllegalWidth() {
     AssertHelpers.assertThrows("Should fail if width is less than or equal to zero",
         IllegalArgumentException.class,
-        "The width of truncate must larger than zero",
+        "The width of truncate must be larger than zero",
         () -> Truncate.get(Types.IntegerType.get(), 0));
   }
 }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTruncate.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTruncate.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.transforms;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.Test;
@@ -85,5 +86,13 @@ public class TestTruncate {
     Assert.assertEquals("Should not pad binary shorter than length",
         ByteBuffer.wrap("abc".getBytes("UTF-8")),
         trunc.apply(ByteBuffer.wrap("abc".getBytes("UTF-8"))));
+  }
+
+  @Test
+  public void testVerifiedIllegalWidth() {
+    AssertHelpers.assertThrows("Should fail if width is less than or equal to zero",
+        IllegalArgumentException.class,
+        "The width of truncate must larger than zero",
+        () -> Truncate.get(Types.IntegerType.get(), 0));
   }
 }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTruncate.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTruncate.java
@@ -92,7 +92,7 @@ public class TestTruncate {
   public void testVerifiedIllegalWidth() {
     AssertHelpers.assertThrows("Should fail if width is less than or equal to zero",
         IllegalArgumentException.class,
-        "The width of truncate must be larger than zero",
+        "Invalid truncate width: 0 (must be > 0)",
         () -> Truncate.get(Types.IntegerType.get(), 0));
   }
 }


### PR DESCRIPTION
There was no exception output,when create a partition table with `bucket(colName, 0)` or `bucket(colName, -1)`.
However, when writing data, the following two exceptions occur.

1) Exception in thread "main" java.lang.UnsupportedOperationException: Cannot write using unsupported transforms: bucket[-1]
2) java.lang.ArithmeticException: / by zero

Link: #1543 