### PR TITLE
Rearranging some starter documentation in Spark Catalogs

### DIFF
--- a/site/docs/spark.md
+++ b/site/docs/spark.md
@@ -45,6 +45,7 @@ This creates an Iceberg catalog named `hive_prod` that loads tables from a Hive 
 spark.sql.catalog.hive_prod = org.apache.iceberg.spark.SparkCatalog
 spark.sql.catalog.hive_prod.type = hive
 spark.sql.catalog.hive_prod.uri = thrift://metastore-host:port
+# omit uri to use the same URI as Spark: hive.metastore.uris in hive-site.xml
 ```
 
 Iceberg also supports a directory-based catalog in HDFS that can be configured using `type=hadoop`:
@@ -82,7 +83,6 @@ To add Iceberg table support to Spark's built-in catalog, configure `spark_catal
 ```plain
 spark.sql.catalog.spark_catalog = org.apache.iceberg.spark.SparkSessionCatalog
 spark.sql.catalog.spark_catalog.type = hive
-# omit uri to use the same URI as Spark: hive.metastore.uris in hive-site.xml
 ```
 
 Spark's built-in catalog supports existing v1 and v2 tables tracked in a Hive Metastore. This configures Spark to use Iceberg's `SparkSessionCatalog` as a wrapper around that session catalog. When a table is not an Iceberg table, the built-in catalog will be used to load it instead.


### PR DESCRIPTION
As a new user going through the documentation and testing features, I got stuck at this third line of config to load tables from a Hive metastore. After some help from Russell and scrolling down further, I found out that URI can be ignored for hive to follow the default. 

Very simply, if this line for omitting the uri was in this first section for 'Configuring catalogs" as opposed to later in the documentation, I wouldn't have been stuck here and understood this. This note could either be placed up in the 'Configuring catalogs' section as I did here, or repeated in both places, but I think this would help.