### PR TITLE
Create a new METASTORE PR label and add it to changes made underneath /hive-metastore

### DIFF
--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -79,4 +79,6 @@ MR:
   - "/mr"
 PIG:
   - "/pig"
+METASTORE:
+  - "/hive-metastore"
 


### PR DESCRIPTION
We currently use top level names to the use our labels, with a few exceptions for build and infra related purposes.

The relatively recently added `hive-metastore` module could arguably be labeled as `HIVE` given that it is the hive metastore, but I feel that metastore related changes might be of interest to a wider audience. 

Admittedly, the audience that would be most interested in those changes would be more interested in a `CATALOG` tag, but given the current way the autolabeler is set up, we don't support that.

I'm opening this PR to add everything underneath `/hive-metastore` to a label `METASTORE`, though I'm open to changing it. I'm also opening another PR to add in the other recently added hive modules to the hive tag.

This closes this issue: https://github.com/apache/iceberg/issues/1575