### PR TITLE
Add split up hive modules to the autolabeler configuration

### DIFF
--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -64,6 +64,7 @@ ORC:
   - "/orc"
 HIVE:
   - "/hive3"
+  - "/hive-metastore"
   - "/hive-runtime"
 DATA:
   - "/data"

--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -63,7 +63,8 @@ ARROW:
 ORC:
   - "/orc"
 HIVE:
-  - "/hive"
+  - "/hive3"
+  - "/hive-runtime"
 DATA:
   - "/data"
 SPARK:


### PR DESCRIPTION
The autolabeler is currently configured mostly off of top level names, either directories or files, with an exception for some infra and build related things.

The iceberg-hive module was split into multiple modules. This updates the `/hive3` and `/hive-runtime` to be labeled as hive. It also closes https://github.com/apache/iceberg/issues/1574

I've chosen to add a new label, METASTORE, for the newer `hive-metastore` because it is of importance to several other projects. That's handled in this PR: https://github.com/apache/iceberg/pull/1576