### PR TITLE
Replace calls to table.toString with table.name

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
@@ -39,7 +39,7 @@ abstract class BaseAllMetadataTableScan extends BaseTableScan {
   @Override
   public CloseableIterable<FileScanTask> planFiles() {
     LOG.info("Scanning metadata table {} with filter {}.", table(), filter());
-    Listeners.notifyAll(new ScanEvent(table().toString(), 0L, filter(), schema()));
+    Listeners.notifyAll(new ScanEvent(table().name(), 0L, filter(), schema()));
 
     return planFiles(tableOps(), snapshot(), filter(), shouldIgnoreResiduals(), isCaseSensitive(), colStats());
   }

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -206,7 +206,7 @@ abstract class BaseTableScan implements TableScan {
           context.rowFilter());
 
       Listeners.notifyAll(
-          new ScanEvent(table.toString(), snapshot.snapshotId(), context.rowFilter(), schema()));
+          new ScanEvent(table.name(), snapshot.snapshotId(), context.rowFilter(), schema()));
 
       return planFiles(ops, snapshot,
           context.rowFilter(), context.ignoreResiduals(), context.caseSensitive(), context.returnColumnStats());

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
@@ -205,7 +205,7 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
     Table table = catalog.createTable(testTable, SCHEMA, PartitionSpec.unpartitioned());
 
     Assert.assertEquals(table.schema().toString(), TABLE_SCHEMA.toString());
-    Assert.assertEquals("hadoop.tbl", table.toString());
+    Assert.assertEquals("hadoop.tbl", table.name());
     String metaLocation = catalog.defaultWarehouseLocation(testTable);
 
     FileSystem fs = Util.getFs(new Path(metaLocation), conf);

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -190,7 +190,7 @@ public class FlinkSink {
           .setMaxParallelism(1);
 
       return returnStream.addSink(new DiscardingSink())
-          .name(String.format("IcebergSink %s", table.toString()))
+          .name(String.format("IcebergSink %s", table.name()))
           .setParallelism(1);
     }
   }
@@ -220,7 +220,7 @@ public class FlinkSink {
     TaskWriterFactory<RowData> taskWriterFactory = new RowDataTaskWriterFactory(table.schema(), flinkSchema,
         table.spec(), table.locationProvider(), table.io(), table.encryption(), targetFileSize, fileFormat, props);
 
-    return new IcebergStreamWriter<>(table.toString(), taskWriterFactory);
+    return new IcebergStreamWriter<>(table.name(), taskWriterFactory);
   }
 
   private static FileFormat getFileFormat(Map<String, String> properties) {

--- a/spark/src/main/java/org/apache/iceberg/actions/BaseAction.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/BaseAction.java
@@ -46,7 +46,7 @@ abstract class BaseAction<R> implements Action<R> {
   protected abstract Table table();
 
   protected String metadataTableName(MetadataTableType type) {
-    return metadataTableName(table().toString(), type);
+    return metadataTableName(table().name(), type);
   }
 
   protected String metadataTableName(String tableName, MetadataTableType type) {
@@ -99,7 +99,7 @@ abstract class BaseAction<R> implements Action<R> {
   }
 
   protected Dataset<Row> buildValidDataFileDF(SparkSession spark) {
-    return buildValidDataFileDF(spark, table().toString());
+    return buildValidDataFileDF(spark, table().name());
   }
 
   protected Dataset<Row> buildValidDataFileDF(SparkSession spark, String tableName) {

--- a/spark/src/main/java/org/apache/iceberg/actions/BaseAction.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/BaseAction.java
@@ -128,7 +128,7 @@ abstract class BaseAction<R> implements Action<R> {
 
   protected Dataset<Row> buildManifestListDF(SparkSession spark, String metadataFileLocation) {
     StaticTableOperations ops = new StaticTableOperations(metadataFileLocation, table().io());
-    return buildManifestListDF(spark, new BaseTable(ops, table().toString()));
+    return buildManifestListDF(spark, new BaseTable(ops, table().name()));
   }
 
   protected Dataset<Row> buildOtherMetadataFileDF(SparkSession spark, TableOperations ops) {
@@ -137,7 +137,7 @@ abstract class BaseAction<R> implements Action<R> {
   }
 
   protected Dataset<Row> buildValidMetadataFileDF(SparkSession spark, Table table, TableOperations ops) {
-    Dataset<Row> manifestDF = buildManifestFileDF(spark, table.toString());
+    Dataset<Row> manifestDF = buildManifestFileDF(spark, table.name());
     Dataset<Row> manifestListDF = buildManifestListDF(spark, table);
     Dataset<Row> otherMetadataFileDF = buildOtherMetadataFileDF(spark, ops);
 

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
@@ -224,7 +224,7 @@ class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
     }
 
     SparkBatchScan that = (SparkBatchScan) o;
-    return table.toString().equals(that.table.toString()) &&
+    return table.name().equals(that.table.name()) &&
         readSchema().equals(that.readSchema()) && // compare Spark schemas to ignore field ids
         filterExpressions.toString().equals(that.filterExpressions.toString()) &&
         Objects.equals(snapshotId, that.snapshotId) &&
@@ -236,7 +236,7 @@ class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
   @Override
   public int hashCode() {
     return Objects.hash(
-        table.toString(), readSchema(), filterExpressions.toString(), snapshotId, startSnapshotId, endSnapshotId,
+        table.name(), readSchema(), filterExpressions.toString(), snapshotId, startSnapshotId, endSnapshotId,
         asOfTimestamp);
   }
 


### PR DESCRIPTION
In many places we rely on `table.toString()` when we're really looking for the table's name, which is available in another method `table.name()`. Although at the moment, at least when looking at the interface, the two are semantically equivalent, it makes it much more difficult to read the code when seeing so many calls to `table.toString()` when what we're really looking for is the table's name.

This assists with, but does not  necessarily close, issue https://github.com/apache/iceberg/issues/1544. I'm not sure if this has captured all instances where `table.toString` is used when logically `table.name` is what should be requested.

I chose not to update any calls where the table is logged as a parameter, which implicitly uses `toString`, as that's standard behavior. I only updated calls that were in the code that meaningfully were looking for `name` and not just `toString`.

I grepped for combinations of `table.toString`, `Table.toString`, `table().toString`, etc.