### PR TITLE
Fix IntLongMath warnings

### DIFF
--- a/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcWriters.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcWriters.java
@@ -132,7 +132,7 @@ class FlinkOrcWriters {
     public void nonNullWrite(int rowId, Integer millis, ColumnVector output) {
       // The time in flink is in millisecond, while the standard time in iceberg is microsecond.
       // So we need to transform it to microsecond.
-      ((LongColumnVector) output).vector[rowId] = millis * 1000;
+      ((LongColumnVector) output).vector[rowId] = millis * 1000L;
     }
   }
 


### PR DESCRIPTION
This patch fixes the following warning for `IntLongMath`

```
/iceberg/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcWriters.java:135: warning: [IntLongMath] Expression of type int may overflow before being assigned to a long
      ((LongColumnVector) output).vector[rowId] = millis * 1000;
                                                         ^
    (see https://errorprone.info/bugpattern/IntLongMath)
  Did you mean '((LongColumnVector) output).vector[rowId] = millis * 1000L;'?
```