### PR TITLE
MR: Fix NPE when InputSplit.getLocations is called on mappers

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergSplit.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergSplit.java
@@ -74,9 +74,11 @@ public class IcebergSplit extends InputSplit implements org.apache.hadoop.mapred
 
   @Override
   public String[] getLocations() {
-    if (locations == null) {
+    if (locations == null && conf != null) {
       boolean localityPreferred = conf.getBoolean(InputFormatConfig.LOCALITY, false);
       locations = localityPreferred ? Util.blockLocations(task, conf) : ANYWHERE;
+    } else {
+      locations = ANYWHERE;
     }
 
     return locations;


### PR DESCRIPTION
`InputSplit.getLocations()` can be called on mappers in some cases. Since both `locations` and `conf` are transient, the current code produces an NPE as `conf` is null on the mappers.

The value of `locations` is not really relevant on the mappers since the tasks have already been distributed. So here we just return `ANYWHERE` when the `conf` is null. We can probably be more accurate by serializing the `locations` values if set, but I don't think its worth it.

```
java.lang.Exception: java.lang.NullPointerException
    at org.apache.hadoop.mapred.LocalJobRunner$Job.runTasks(LocalJobRunner.java:462)
    at org.apache.hadoop.mapred.LocalJobRunner$Job.run(LocalJobRunner.java:522)
Caused by: java.lang.NullPointerException
    at org.apache.iceberg.mr.mapreduce.IcebergSplit.getLocations(IcebergSplit.java:69)
    .
    .
    .
    at org.apache.pig.backend.hadoop.executionengine.mapReduceLayer.PigSplit.toString(PigSplit.java:465)
    at java.lang.String.valueOf(String.java:2994)
    at java.lang.StringBuilder.append(StringBuilder.java:131)
    at org.apache.hadoop.mapred.MapTask.runNewMapper(MapTask.java:756)
    at org.apache.hadoop.mapred.MapTask.run(MapTask.java:341)
    at org.apache.hadoop.mapred.LocalJobRunner$Job$MapTaskRunnable.run(LocalJobRunner.java:243)
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
    at java.util.concurrent.FutureTask.run(FutureTask.java:266)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
    at java.lang.Thread.run(Thread.java:748)
```

I discovered this issue while testing our internal Pig `LoadFunc` implementation which works with multiple `InputFormat`s. Iceberg's `LoadFunc` implementation in `iceberg-pig` does not have this issue as it contains its own `InputSplit` implementation which does not provide location information.