### PR TITLE
Move Spark3 Action tests to the Correct Package

### DIFF
--- a/spark3/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction3.java
+++ b/spark3/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction3.java
@@ -17,9 +17,7 @@
  * under the License.
  */
 
-package org.apache.iceberg.spark.actions;
-
-import org.apache.iceberg.actions.TestExpireSnapshotsAction;
+package org.apache.iceberg.actions;
 
 public class TestExpireSnapshotsAction3 extends TestExpireSnapshotsAction {
 }

--- a/spark3/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction3.java
+++ b/spark3/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction3.java
@@ -17,12 +17,7 @@
  * under the License.
  */
 
-package org.apache.iceberg.spark.actions;
+package org.apache.iceberg.actions;
 
-import org.apache.iceberg.actions.TestRewriteManifestsAction;
-
-public class TestRewriteManifestsAction3 extends TestRewriteManifestsAction {
-  public TestRewriteManifestsAction3(String snapshotIdInheritanceEnabled) {
-    super(snapshotIdInheritanceEnabled);
-  }
+public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
 }

--- a/spark3/src/test/java/org/apache/iceberg/actions/TestRewriteDataFilesAction3.java
+++ b/spark3/src/test/java/org/apache/iceberg/actions/TestRewriteDataFilesAction3.java
@@ -17,9 +17,7 @@
  * under the License.
  */
 
-package org.apache.iceberg.spark.actions;
+package org.apache.iceberg.actions;
 
-import org.apache.iceberg.actions.TestRemoveOrphanFilesAction;
-
-public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
+public class TestRewriteDataFilesAction3 extends TestRewriteDataFilesAction {
 }

--- a/spark3/src/test/java/org/apache/iceberg/actions/TestRewriteManifestsAction3.java
+++ b/spark3/src/test/java/org/apache/iceberg/actions/TestRewriteManifestsAction3.java
@@ -17,9 +17,10 @@
  * under the License.
  */
 
-package org.apache.iceberg.spark.actions;
+package org.apache.iceberg.actions;
 
-import org.apache.iceberg.actions.TestRewriteDataFilesAction;
-
-public class TestRewriteDataFilesAction3 extends TestRewriteDataFilesAction {
+public class TestRewriteManifestsAction3 extends TestRewriteManifestsAction {
+  public TestRewriteManifestsAction3(String snapshotIdInheritanceEnabled) {
+    super(snapshotIdInheritanceEnabled);
+  }
 }


### PR DESCRIPTION
Previously these files lived in o.a.iceberg.spark.actions when they
should be in o.a.iceberg.actions