### PR TITLE
Provide Actions class for Spark2 and Spark3

### DIFF
--- a/spark/src/main/java/org/apache/iceberg/actions/BaseActions.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/BaseActions.java
@@ -22,12 +22,12 @@ package org.apache.iceberg.actions;
 import org.apache.iceberg.Table;
 import org.apache.spark.sql.SparkSession;
 
-public abstract class CommonActions {
+public abstract class BaseActions {
 
   private SparkSession spark;
   private Table table;
 
-  protected CommonActions(SparkSession spark, Table table) {
+  protected BaseActions(SparkSession spark, Table table) {
     this.spark = spark;
     this.table = table;
   }

--- a/spark/src/main/java/org/apache/iceberg/actions/CommonActions.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/CommonActions.java
@@ -22,22 +22,14 @@ package org.apache.iceberg.actions;
 import org.apache.iceberg.Table;
 import org.apache.spark.sql.SparkSession;
 
-public class Actions {
+public abstract class CommonActions {
 
   private SparkSession spark;
   private Table table;
 
-  private Actions(SparkSession spark, Table table) {
+  protected CommonActions(SparkSession spark, Table table) {
     this.spark = spark;
     this.table = table;
-  }
-
-  public static Actions forTable(SparkSession spark, Table table) {
-    return new Actions(spark, table);
-  }
-
-  public static Actions forTable(Table table) {
-    return new Actions(SparkSession.active(), table);
   }
 
   public RemoveOrphanFilesAction removeOrphanFiles() {

--- a/spark/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction.java
@@ -149,7 +149,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
 
     long end = rightAfterSnapshot();
 
-    ExpireSnapshotsActionResult results = Actions.forTable(table).expireSnapshots().expireOlderThan(end).execute();
+    ExpireSnapshotsActionResult results = actionsForTable(table).expireSnapshots().expireOlderThan(end).execute();
 
     Assert.assertEquals("Table does not have 1 snapshot after expiration", 1, Iterables.size(table.snapshots()));
 
@@ -181,7 +181,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
     Set<String> deleteThreads = ConcurrentHashMap.newKeySet();
     AtomicInteger deleteThreadsIndex = new AtomicInteger(0);
 
-    ExpireSnapshotsActionResult result = Actions.forTable(table).expireSnapshots()
+    ExpireSnapshotsActionResult result = actionsForTable(table).expireSnapshots()
         .executeDeleteWith(Executors.newFixedThreadPool(4, runnable -> {
           Thread thread = new Thread(runnable);
           thread.setName("remove-snapshot-" + deleteThreadsIndex.getAndIncrement());
@@ -211,7 +211,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
         .appendFile(FILE_A)
         .commit();
 
-    ExpireSnapshotsActionResult results = Actions.forTable(table).expireSnapshots().execute();
+    ExpireSnapshotsActionResult results = actionsForTable(table).expireSnapshots().execute();
     checkExpirationResults(0L, 0L, 0L, results);
   }
 
@@ -234,7 +234,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
     }
 
     long end = rightAfterSnapshot();
-    ExpireSnapshotsActionResult results = Actions.forTable(table).expireSnapshots().expireOlderThan(end).execute();
+    ExpireSnapshotsActionResult results = actionsForTable(table).expireSnapshots().expireOlderThan(end).execute();
     checkExpirationResults(1L, 39L, 20L, results);
   }
 
@@ -260,7 +260,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
     long t3 = rightAfterSnapshot();
 
     // Retain last 2 snapshots
-    Actions.forTable(table).expireSnapshots()
+    actionsForTable(table).expireSnapshots()
         .expireOlderThan(t3)
         .retainLast(2)
         .execute();
@@ -287,7 +287,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
         .commit();
 
     // Retain last 2 snapshots
-    ExpireSnapshotsActionResult result = Actions.forTable(table).expireSnapshots()
+    ExpireSnapshotsActionResult result = actionsForTable(table).expireSnapshots()
         .expireSnapshotId(firstSnapshotId)
         .expireSnapshotId(secondSnapshotID)
         .execute();
@@ -315,7 +315,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
         .commit();
 
     // Retain last 3 snapshots, but explicitly remove the first snapshot
-    ExpireSnapshotsActionResult result = Actions.forTable(table).expireSnapshots()
+    ExpireSnapshotsActionResult result = actionsForTable(table).expireSnapshots()
         .expireSnapshotId(firstSnapshotId)
         .retainLast(3)
         .execute();
@@ -340,7 +340,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
     long t2 = rightAfterSnapshot();
 
     // Retain last 3 snapshots
-    ExpireSnapshotsActionResult result = Actions.forTable(table).expireSnapshots()
+    ExpireSnapshotsActionResult result = actionsForTable(table).expireSnapshots()
         .expireOlderThan(t2)
         .retainLast(3)
         .execute();
@@ -372,7 +372,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
         .commit();
 
     // Retain last 2 snapshots and expire older than t3
-    ExpireSnapshotsActionResult result = Actions.forTable(table).expireSnapshots()
+    ExpireSnapshotsActionResult result = actionsForTable(table).expireSnapshots()
         .expireOlderThan(secondSnapshot.timestampMillis())
         .retainLast(2)
         .execute();
@@ -401,7 +401,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
     Snapshot thirdSnapshot = table.currentSnapshot();
 
     // Retain last 2 snapshots and expire older than t3
-    ExpireSnapshotsActionResult result =  Actions.forTable(table).expireSnapshots()
+    ExpireSnapshotsActionResult result =  actionsForTable(table).expireSnapshots()
         .expireOlderThan(secondSnapshot.timestampMillis())
         .expireOlderThan(thirdSnapshot.timestampMillis())
         .execute();
@@ -430,7 +430,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
     long t3 = rightAfterSnapshot();
 
     // Retain last 2 snapshots and expire older than t3
-    ExpireSnapshotsActionResult result = Actions.forTable(table).expireSnapshots()
+    ExpireSnapshotsActionResult result = actionsForTable(table).expireSnapshots()
         .expireOlderThan(t3)
         .retainLast(2)
         .retainLast(1)
@@ -447,7 +447,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
             "because number of snapshots to retain cannot be zero",
         IllegalArgumentException.class,
         "Number of snapshots to retain must be at least 1, cannot be: 0",
-        () -> Actions.forTable(table).expireSnapshots().retainLast(0).execute());
+        () -> actionsForTable(table).expireSnapshots().retainLast(0).execute());
   }
 
   @Test
@@ -470,7 +470,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
 
     Set<String> deletedFiles = Sets.newHashSet();
 
-    ExpireSnapshotsActionResult result = Actions.forTable(table).expireSnapshots()
+    ExpireSnapshotsActionResult result = actionsForTable(table).expireSnapshots()
         .expireOlderThan(t3)
         .deleteWith(deletedFiles::add)
         .execute();
@@ -504,7 +504,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
 
     Set<String> deletedFiles = Sets.newHashSet();
 
-    ExpireSnapshotsActionResult result = Actions.forTable(table).expireSnapshots()
+    ExpireSnapshotsActionResult result = actionsForTable(table).expireSnapshots()
         .expireOlderThan(t3)
         .deleteWith(deletedFiles::add)
         .execute();
@@ -543,7 +543,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
     Set<String> deletedFiles = new HashSet<>();
 
     // Expire all commits including dangling staged snapshot.
-    ExpireSnapshotsActionResult result = Actions.forTable(table).expireSnapshots()
+    ExpireSnapshotsActionResult result = actionsForTable(table).expireSnapshots()
         .deleteWith(deletedFiles::add)
         .expireOlderThan(snapshotB.timestampMillis() + 1)
         .execute();
@@ -622,7 +622,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
     List<String> deletedFiles = new ArrayList<>();
 
     // Expire `C`
-    ExpireSnapshotsActionResult result = Actions.forTable(table).expireSnapshots()
+    ExpireSnapshotsActionResult result = actionsForTable(table).expireSnapshots()
         .deleteWith(deletedFiles::add)
         .expireOlderThan(snapshotC.timestampMillis() + 1)
         .execute();
@@ -677,7 +677,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
     List<String> deletedFiles = new ArrayList<>();
 
     // Expire `B` commit.
-    ExpireSnapshotsActionResult firstResult = Actions.forTable(table).expireSnapshots()
+    ExpireSnapshotsActionResult firstResult = actionsForTable(table).expireSnapshots()
         .deleteWith(deletedFiles::add)
         .expireSnapshotId(snapshotB.snapshotId())
         .execute();
@@ -691,7 +691,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
     checkExpirationResults(0L, 1L, 1L, firstResult);
 
     // Expire all snapshots including cherry-pick
-    ExpireSnapshotsActionResult secondResult = Actions.forTable(table).expireSnapshots()
+    ExpireSnapshotsActionResult secondResult = actionsForTable(table).expireSnapshots()
         .deleteWith(deletedFiles::add)
         .expireOlderThan(table.currentSnapshot().timestampMillis() + 1)
         .execute();
@@ -725,7 +725,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
 
     Set<String> deletedFiles = Sets.newHashSet();
 
-    ExpireSnapshotsActionResult result = Actions.forTable(table).expireSnapshots()
+    ExpireSnapshotsActionResult result = actionsForTable(table).expireSnapshots()
         .expireOlderThan(tAfterCommits)
         .deleteWith(deletedFiles::add)
         .execute();
@@ -770,7 +770,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
 
     Set<String> deletedFiles = Sets.newHashSet();
 
-    ExpireSnapshotsActionResult result = Actions.forTable(table).expireSnapshots()
+    ExpireSnapshotsActionResult result = actionsForTable(table).expireSnapshots()
         .expireOlderThan(tAfterCommits)
         .deleteWith(deletedFiles::add)
         .execute();
@@ -829,7 +829,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
 
     Set<String> deletedFiles = Sets.newHashSet();
 
-    ExpireSnapshotsActionResult result = Actions.forTable(table).expireSnapshots()
+    ExpireSnapshotsActionResult result = actionsForTable(table).expireSnapshots()
         .expireOlderThan(tAfterCommits)
         .deleteWith(deletedFiles::add)
         .execute();
@@ -886,7 +886,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
 
     Set<String> deletedFiles = Sets.newHashSet();
 
-    ExpireSnapshotsActionResult result = Actions.forTable(table).expireSnapshots()
+    ExpireSnapshotsActionResult result = actionsForTable(table).expireSnapshots()
         .expireOlderThan(tAfterCommits)
         .deleteWith(deletedFiles::add)
         .execute();
@@ -935,7 +935,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
 
     Set<String> deletedFiles = Sets.newHashSet();
 
-    ExpireSnapshotsActionResult result = Actions.forTable(table).expireSnapshots()
+    ExpireSnapshotsActionResult result = actionsForTable(table).expireSnapshots()
         .expireOlderThan(tAfterCommits)
         .deleteWith(deletedFiles::add)
         .execute();
@@ -959,7 +959,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
     Set<String> deletedFiles = Sets.newHashSet();
 
     // table has no data, testing ExpireSnapshots should not fail with no snapshot
-    ExpireSnapshotsActionResult result = Actions.forTable(table).expireSnapshots()
+    ExpireSnapshotsActionResult result = actionsForTable(table).expireSnapshots()
         .expireOlderThan(System.currentTimeMillis())
         .deleteWith(deletedFiles::add)
         .execute();
@@ -987,7 +987,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
 
     Set<String> deletedFiles = Sets.newHashSet();
 
-    ExpireSnapshotsAction action = Actions.forTable(table).expireSnapshots()
+    ExpireSnapshotsAction action = actionsForTable(table).expireSnapshots()
         .expireOlderThan(tAfterCommits)
         .deleteWith(deletedFiles::add);
     Dataset<Row> pendingDeletes = action.expire();
@@ -1029,7 +1029,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
     int jobsBefore = spark.sparkContext().dagScheduler().nextJobId().get();
 
     ExpireSnapshotsActionResult results =
-        Actions.forTable(table).expireSnapshots().expireOlderThan(end).streamDeleteResults(true).execute();
+        actionsForTable(table).expireSnapshots().expireOlderThan(end).streamDeleteResults(true).execute();
 
     Assert.assertEquals("Table does not have 1 snapshot after expiration", 1, Iterables.size(table.snapshots()));
 

--- a/spark/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction.java
@@ -125,7 +125,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     // sleep for 1 second to unsure files will be old enough
     Thread.sleep(1000);
 
-    CommonActions actions = actionsForTable(table);
+    BaseActions actions = actionsForTable(table);
 
     List<String> result1 = actions.removeOrphanFiles()
         .deleteWith(s -> { })
@@ -210,7 +210,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     // sleep for 1 second to unsure files will be old enough
     Thread.sleep(1000);
 
-    CommonActions actions = actionsForTable(table);
+    BaseActions actions = actionsForTable(table);
 
     List<String> result = actions.removeOrphanFiles()
         .olderThan(System.currentTimeMillis())
@@ -270,7 +270,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     // sleep for 1 second to unsure files will be old enough
     Thread.sleep(1000);
 
-    CommonActions actions = actionsForTable(table);
+    BaseActions actions = actionsForTable(table);
 
     List<String> result = actions.removeOrphanFiles()
         .olderThan(System.currentTimeMillis())
@@ -302,7 +302,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     // sleep for 1 second to unsure files will be old enough
     Thread.sleep(1000);
 
-    CommonActions actions = actionsForTable(table);
+    BaseActions actions = actionsForTable(table);
 
     List<String> result = actions.removeOrphanFiles()
         .olderThan(System.currentTimeMillis())
@@ -343,7 +343,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
 
     df.write().mode("append").parquet(tableLocation + "/data/c2_trunc=AA/c3=AAAA");
 
-    CommonActions actions = actionsForTable(table);
+    BaseActions actions = actionsForTable(table);
 
     List<String> result = actions.removeOrphanFiles()
         .olderThan(timestamp)
@@ -379,7 +379,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     // sleep for 1 second to unsure files will be old enough
     Thread.sleep(1000);
 
-    CommonActions actions = actionsForTable(table);
+    BaseActions actions = actionsForTable(table);
 
     List<String> result = actions.removeOrphanFiles()
         .olderThan(System.currentTimeMillis())
@@ -419,7 +419,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     // sleep for 1 second to unsure files will be old enough
     Thread.sleep(1000);
 
-    CommonActions actions = actionsForTable(table);
+    BaseActions actions = actionsForTable(table);
 
     List<String> result = actions.removeOrphanFiles()
         .olderThan(System.currentTimeMillis())
@@ -454,7 +454,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     // sleep for 1 second to unsure files will be old enough
     Thread.sleep(1000);
 
-    CommonActions actions = actionsForTable(table);
+    BaseActions actions = actionsForTable(table);
 
     List<String> result = actions.removeOrphanFiles()
         .olderThan(System.currentTimeMillis())
@@ -519,7 +519,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     // sleep for 1 second to unsure files will be old enough
     Thread.sleep(1000);
 
-    CommonActions actions = actionsForTable(table);
+    BaseActions actions = actionsForTable(table);
     List<String> result = actions.removeOrphanFiles()
         .olderThan(System.currentTimeMillis())
         .deleteWith(s -> { })

--- a/spark/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction.java
@@ -125,7 +125,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     // sleep for 1 second to unsure files will be old enough
     Thread.sleep(1000);
 
-    Actions actions = Actions.forTable(table);
+    CommonActions actions = actionsForTable(table);
 
     List<String> result1 = actions.removeOrphanFiles()
         .deleteWith(s -> { })
@@ -210,7 +210,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     // sleep for 1 second to unsure files will be old enough
     Thread.sleep(1000);
 
-    Actions actions = Actions.forTable(table);
+    CommonActions actions = actionsForTable(table);
 
     List<String> result = actions.removeOrphanFiles()
         .olderThan(System.currentTimeMillis())
@@ -270,7 +270,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     // sleep for 1 second to unsure files will be old enough
     Thread.sleep(1000);
 
-    Actions actions = Actions.forTable(table);
+    CommonActions actions = actionsForTable(table);
 
     List<String> result = actions.removeOrphanFiles()
         .olderThan(System.currentTimeMillis())
@@ -302,7 +302,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     // sleep for 1 second to unsure files will be old enough
     Thread.sleep(1000);
 
-    Actions actions = Actions.forTable(table);
+    CommonActions actions = actionsForTable(table);
 
     List<String> result = actions.removeOrphanFiles()
         .olderThan(System.currentTimeMillis())
@@ -343,7 +343,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
 
     df.write().mode("append").parquet(tableLocation + "/data/c2_trunc=AA/c3=AAAA");
 
-    Actions actions = Actions.forTable(table);
+    CommonActions actions = actionsForTable(table);
 
     List<String> result = actions.removeOrphanFiles()
         .olderThan(timestamp)
@@ -379,7 +379,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     // sleep for 1 second to unsure files will be old enough
     Thread.sleep(1000);
 
-    Actions actions = Actions.forTable(table);
+    CommonActions actions = actionsForTable(table);
 
     List<String> result = actions.removeOrphanFiles()
         .olderThan(System.currentTimeMillis())
@@ -419,7 +419,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     // sleep for 1 second to unsure files will be old enough
     Thread.sleep(1000);
 
-    Actions actions = Actions.forTable(table);
+    CommonActions actions = actionsForTable(table);
 
     List<String> result = actions.removeOrphanFiles()
         .olderThan(System.currentTimeMillis())
@@ -454,7 +454,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     // sleep for 1 second to unsure files will be old enough
     Thread.sleep(1000);
 
-    Actions actions = Actions.forTable(table);
+    CommonActions actions = actionsForTable(table);
 
     List<String> result = actions.removeOrphanFiles()
         .olderThan(System.currentTimeMillis())
@@ -519,7 +519,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
     // sleep for 1 second to unsure files will be old enough
     Thread.sleep(1000);
 
-    Actions actions = Actions.forTable(table);
+    CommonActions actions = actionsForTable(table);
     List<String> result = actions.removeOrphanFiles()
         .olderThan(System.currentTimeMillis())
         .deleteWith(s -> { })
@@ -556,7 +556,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
 
     table.refresh();
 
-    List<String> result = Actions.forTable(table)
+    List<String> result = actionsForTable(table)
         .removeOrphanFiles()
         .olderThan(System.currentTimeMillis())
         .execute();

--- a/spark/src/test/java/org/apache/iceberg/actions/TestRewriteDataFilesAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestRewriteDataFilesAction.java
@@ -76,7 +76,7 @@ public abstract class TestRewriteDataFilesAction extends SparkTestBase {
 
     Assert.assertNull("Table must be empty", table.currentSnapshot());
 
-    Actions actions = Actions.forTable(table);
+    CommonActions actions = actionsForTable(table);
 
     actions.rewriteDataFiles().execute();
 
@@ -107,7 +107,7 @@ public abstract class TestRewriteDataFilesAction extends SparkTestBase {
     List<DataFile> dataFiles = Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
     Assert.assertEquals("Should have 4 data files before rewrite", 4, dataFiles.size());
 
-    Actions actions = Actions.forTable(table);
+    CommonActions actions = actionsForTable(table);
 
     RewriteDataFilesActionResult result = actions.rewriteDataFiles().execute();
     Assert.assertEquals("Action should rewrite 4 data files", 4, result.deletedDataFiles().size());
@@ -170,7 +170,7 @@ public abstract class TestRewriteDataFilesAction extends SparkTestBase {
     List<DataFile> dataFiles = Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
     Assert.assertEquals("Should have 8 data files before rewrite", 8, dataFiles.size());
 
-    Actions actions = Actions.forTable(table);
+    CommonActions actions = actionsForTable(table);
 
     RewriteDataFilesActionResult result = actions.rewriteDataFiles().execute();
     Assert.assertEquals("Action should rewrite 8 data files", 8, result.deletedDataFiles().size());
@@ -235,7 +235,7 @@ public abstract class TestRewriteDataFilesAction extends SparkTestBase {
     List<DataFile> dataFiles = Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
     Assert.assertEquals("Should have 8 data files before rewrite", 8, dataFiles.size());
 
-    Actions actions = Actions.forTable(table);
+    CommonActions actions = actionsForTable(table);
 
     RewriteDataFilesActionResult result = actions
         .rewriteDataFiles()
@@ -292,7 +292,7 @@ public abstract class TestRewriteDataFilesAction extends SparkTestBase {
     List<DataFile> dataFiles = Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
     Assert.assertEquals("Should have 2 data files before rewrite", 2, dataFiles.size());
 
-    Actions actions = Actions.forTable(table);
+    CommonActions actions = actionsForTable(table);
 
     RewriteDataFilesActionResult result = actions
         .rewriteDataFiles()

--- a/spark/src/test/java/org/apache/iceberg/actions/TestRewriteDataFilesAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestRewriteDataFilesAction.java
@@ -76,7 +76,7 @@ public abstract class TestRewriteDataFilesAction extends SparkTestBase {
 
     Assert.assertNull("Table must be empty", table.currentSnapshot());
 
-    CommonActions actions = actionsForTable(table);
+    BaseActions actions = actionsForTable(table);
 
     actions.rewriteDataFiles().execute();
 
@@ -107,7 +107,7 @@ public abstract class TestRewriteDataFilesAction extends SparkTestBase {
     List<DataFile> dataFiles = Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
     Assert.assertEquals("Should have 4 data files before rewrite", 4, dataFiles.size());
 
-    CommonActions actions = actionsForTable(table);
+    BaseActions actions = actionsForTable(table);
 
     RewriteDataFilesActionResult result = actions.rewriteDataFiles().execute();
     Assert.assertEquals("Action should rewrite 4 data files", 4, result.deletedDataFiles().size());
@@ -170,7 +170,7 @@ public abstract class TestRewriteDataFilesAction extends SparkTestBase {
     List<DataFile> dataFiles = Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
     Assert.assertEquals("Should have 8 data files before rewrite", 8, dataFiles.size());
 
-    CommonActions actions = actionsForTable(table);
+    BaseActions actions = actionsForTable(table);
 
     RewriteDataFilesActionResult result = actions.rewriteDataFiles().execute();
     Assert.assertEquals("Action should rewrite 8 data files", 8, result.deletedDataFiles().size());
@@ -235,7 +235,7 @@ public abstract class TestRewriteDataFilesAction extends SparkTestBase {
     List<DataFile> dataFiles = Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
     Assert.assertEquals("Should have 8 data files before rewrite", 8, dataFiles.size());
 
-    CommonActions actions = actionsForTable(table);
+    BaseActions actions = actionsForTable(table);
 
     RewriteDataFilesActionResult result = actions
         .rewriteDataFiles()
@@ -292,7 +292,7 @@ public abstract class TestRewriteDataFilesAction extends SparkTestBase {
     List<DataFile> dataFiles = Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
     Assert.assertEquals("Should have 2 data files before rewrite", 2, dataFiles.size());
 
-    CommonActions actions = actionsForTable(table);
+    BaseActions actions = actionsForTable(table);
 
     RewriteDataFilesActionResult result = actions
         .rewriteDataFiles()

--- a/spark/src/test/java/org/apache/iceberg/actions/TestRewriteManifestsAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestRewriteManifestsAction.java
@@ -91,7 +91,7 @@ public abstract class TestRewriteManifestsAction extends SparkTestBase {
 
     Assert.assertNull("Table must be empty", table.currentSnapshot());
 
-    Actions actions = Actions.forTable(table);
+    CommonActions actions = actionsForTable(table);
 
     actions.rewriteManifests()
         .rewriteIf(manifest -> true)
@@ -125,7 +125,7 @@ public abstract class TestRewriteManifestsAction extends SparkTestBase {
     List<ManifestFile> manifests = table.currentSnapshot().allManifests();
     Assert.assertEquals("Should have 2 manifests before rewrite", 2, manifests.size());
 
-    Actions actions = Actions.forTable(table);
+    CommonActions actions = actionsForTable(table);
 
     RewriteManifestsActionResult result = actions.rewriteManifests()
         .rewriteIf(manifest -> true)
@@ -194,7 +194,7 @@ public abstract class TestRewriteManifestsAction extends SparkTestBase {
     List<ManifestFile> manifests = table.currentSnapshot().allManifests();
     Assert.assertEquals("Should have 4 manifests before rewrite", 4, manifests.size());
 
-    Actions actions = Actions.forTable(table);
+    CommonActions actions = actionsForTable(table);
 
     // we will expect to have 2 manifests with 4 entries in each after rewrite
     long manifestEntrySizeBytes = computeManifestEntrySizeBytes(manifests);
@@ -269,7 +269,7 @@ public abstract class TestRewriteManifestsAction extends SparkTestBase {
 
       Snapshot snapshot = table.currentSnapshot();
 
-      Actions actions = Actions.forTable(table);
+      CommonActions actions = actionsForTable(table);
 
       RewriteManifestsActionResult result = actions.rewriteManifests()
           .rewriteIf(manifest -> true)
@@ -312,7 +312,7 @@ public abstract class TestRewriteManifestsAction extends SparkTestBase {
         .set(TableProperties.MANIFEST_TARGET_SIZE_BYTES, String.valueOf(manifests.get(0).length() / 2))
         .commit();
 
-    Actions actions = Actions.forTable(table);
+    CommonActions actions = actionsForTable(table);
 
     RewriteManifestsActionResult result = actions.rewriteManifests()
         .rewriteIf(manifest -> true)
@@ -362,7 +362,7 @@ public abstract class TestRewriteManifestsAction extends SparkTestBase {
     List<ManifestFile> manifests = table.currentSnapshot().allManifests();
     Assert.assertEquals("Should have 2 manifests before rewrite", 2, manifests.size());
 
-    Actions actions = Actions.forTable(table);
+    CommonActions actions = actionsForTable(table);
 
     // rewrite only the first manifest without caching
     RewriteManifestsActionResult result = actions.rewriteManifests()

--- a/spark/src/test/java/org/apache/iceberg/actions/TestRewriteManifestsAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestRewriteManifestsAction.java
@@ -91,7 +91,7 @@ public abstract class TestRewriteManifestsAction extends SparkTestBase {
 
     Assert.assertNull("Table must be empty", table.currentSnapshot());
 
-    CommonActions actions = actionsForTable(table);
+    BaseActions actions = actionsForTable(table);
 
     actions.rewriteManifests()
         .rewriteIf(manifest -> true)
@@ -125,7 +125,7 @@ public abstract class TestRewriteManifestsAction extends SparkTestBase {
     List<ManifestFile> manifests = table.currentSnapshot().allManifests();
     Assert.assertEquals("Should have 2 manifests before rewrite", 2, manifests.size());
 
-    CommonActions actions = actionsForTable(table);
+    BaseActions actions = actionsForTable(table);
 
     RewriteManifestsActionResult result = actions.rewriteManifests()
         .rewriteIf(manifest -> true)
@@ -194,7 +194,7 @@ public abstract class TestRewriteManifestsAction extends SparkTestBase {
     List<ManifestFile> manifests = table.currentSnapshot().allManifests();
     Assert.assertEquals("Should have 4 manifests before rewrite", 4, manifests.size());
 
-    CommonActions actions = actionsForTable(table);
+    BaseActions actions = actionsForTable(table);
 
     // we will expect to have 2 manifests with 4 entries in each after rewrite
     long manifestEntrySizeBytes = computeManifestEntrySizeBytes(manifests);
@@ -269,7 +269,7 @@ public abstract class TestRewriteManifestsAction extends SparkTestBase {
 
       Snapshot snapshot = table.currentSnapshot();
 
-      CommonActions actions = actionsForTable(table);
+      BaseActions actions = actionsForTable(table);
 
       RewriteManifestsActionResult result = actions.rewriteManifests()
           .rewriteIf(manifest -> true)
@@ -312,7 +312,7 @@ public abstract class TestRewriteManifestsAction extends SparkTestBase {
         .set(TableProperties.MANIFEST_TARGET_SIZE_BYTES, String.valueOf(manifests.get(0).length() / 2))
         .commit();
 
-    CommonActions actions = actionsForTable(table);
+    BaseActions actions = actionsForTable(table);
 
     RewriteManifestsActionResult result = actions.rewriteManifests()
         .rewriteIf(manifest -> true)
@@ -362,7 +362,7 @@ public abstract class TestRewriteManifestsAction extends SparkTestBase {
     List<ManifestFile> manifests = table.currentSnapshot().allManifests();
     Assert.assertEquals("Should have 2 manifests before rewrite", 2, manifests.size());
 
-    CommonActions actions = actionsForTable(table);
+    BaseActions actions = actionsForTable(table);
 
     // rewrite only the first manifest without caching
     RewriteManifestsActionResult result = actions.rewriteManifests()

--- a/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.actions.CommonActions;
+import org.apache.iceberg.actions.BaseActions;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.hive.HiveCatalog;
@@ -127,7 +127,7 @@ public abstract class SparkTestBase {
     return metastore.getDatabasePath(dbName);
   }
 
-  protected CommonActions actionsForTable(Table table) {
+  protected BaseActions actionsForTable(Table table) {
     throw new UnsupportedOperationException("Reimplement actionsForTable with Actions.forTable() if needed");
   }
 }

--- a/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.actions.CommonActions;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.hive.HiveCatalog;
@@ -38,7 +40,7 @@ import org.junit.BeforeClass;
 
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS;
 
-public class SparkTestBase {
+public abstract class SparkTestBase {
 
   protected static final Object ANY = new Object();
 
@@ -123,5 +125,9 @@ public class SparkTestBase {
 
   protected static String dbPath(String dbName) {
     return metastore.getDatabasePath(dbName);
+  }
+
+  protected CommonActions actionsForTable(Table table) {
+    throw new UnsupportedOperationException("Reimplement actionsForTable with Actions.forTable() if needed");
   }
 }

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -31,7 +31,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
-import org.apache.iceberg.actions.CommonActions;
+import org.apache.iceberg.actions.BaseActions;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -900,7 +900,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     // sleep for 1 second to ensure files will be old enough
     Thread.sleep(1000);
 
-    CommonActions actions = actionsForTable(table);
+    BaseActions actions = actionsForTable(table);
 
     List<String> result1 = actions.removeOrphanFiles()
         .location(table.location() + "/metadata")

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -31,7 +31,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
-import org.apache.iceberg.actions.Actions;
+import org.apache.iceberg.actions.CommonActions;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -900,7 +900,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     // sleep for 1 second to ensure files will be old enough
     Thread.sleep(1000);
 
-    Actions actions = Actions.forTable(table);
+    CommonActions actions = actionsForTable(table);
 
     List<String> result1 = actions.removeOrphanFiles()
         .location(table.location() + "/metadata")

--- a/spark2/src/main/java/org/apache/iceberg/actions/Actions.java
+++ b/spark2/src/main/java/org/apache/iceberg/actions/Actions.java
@@ -22,7 +22,7 @@ package org.apache.iceberg.actions;
 import org.apache.iceberg.Table;
 import org.apache.spark.sql.SparkSession;
 
-public class Actions extends CommonActions {
+public class Actions extends BaseActions {
 
   protected Actions(SparkSession spark, Table table) {
     super(spark, table);

--- a/spark2/src/main/java/org/apache/iceberg/actions/Actions.java
+++ b/spark2/src/main/java/org/apache/iceberg/actions/Actions.java
@@ -17,15 +17,22 @@
  * under the License.
  */
 
-package org.apache.iceberg.spark.source;
+package org.apache.iceberg.actions;
 
 import org.apache.iceberg.Table;
-import org.apache.iceberg.actions.Actions;
-import org.apache.iceberg.actions.CommonActions;
+import org.apache.spark.sql.SparkSession;
 
-public class TestIcebergSourceHiveTables24 extends TestIcebergSourceHiveTables {
-  @Override
-  protected CommonActions actionsForTable(Table table) {
-    return Actions.forTable(table);
+public class Actions extends CommonActions {
+
+  protected Actions(SparkSession spark, Table table) {
+    super(spark, table);
+  }
+
+  public static Actions forTable(SparkSession spark, Table table) {
+    return new Actions(spark, table);
+  }
+
+  public static Actions forTable(Table table) {
+    return new Actions(SparkSession.active(), table);
   }
 }

--- a/spark2/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction24.java
+++ b/spark2/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction24.java
@@ -23,7 +23,7 @@ import org.apache.iceberg.Table;
 
 public class TestExpireSnapshotsAction24 extends TestExpireSnapshotsAction {
   @Override
-  protected CommonActions actionsForTable(Table table) {
+  protected BaseActions actionsForTable(Table table) {
     return Actions.forTable(table);
   }
 }

--- a/spark2/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction24.java
+++ b/spark2/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction24.java
@@ -19,5 +19,11 @@
 
 package org.apache.iceberg.actions;
 
-public class TestExpireSnapshotsAction24 extends TestExpireSnapshotsAction{
+import org.apache.iceberg.Table;
+
+public class TestExpireSnapshotsAction24 extends TestExpireSnapshotsAction {
+  @Override
+  protected CommonActions actionsForTable(Table table) {
+    return Actions.forTable(table);
+  }
 }

--- a/spark2/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction24.java
+++ b/spark2/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction24.java
@@ -23,7 +23,7 @@ import org.apache.iceberg.Table;
 
 public class TestRemoveOrphanFilesAction24 extends TestRemoveOrphanFilesAction {
   @Override
-  protected CommonActions actionsForTable(Table table) {
+  protected BaseActions actionsForTable(Table table) {
     return Actions.forTable(table);
   }
 }

--- a/spark2/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction24.java
+++ b/spark2/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction24.java
@@ -19,5 +19,11 @@
 
 package org.apache.iceberg.actions;
 
+import org.apache.iceberg.Table;
+
 public class TestRemoveOrphanFilesAction24 extends TestRemoveOrphanFilesAction {
+  @Override
+  protected CommonActions actionsForTable(Table table) {
+    return Actions.forTable(table);
+  }
 }

--- a/spark2/src/test/java/org/apache/iceberg/actions/TestRewriteDataFilesAction24.java
+++ b/spark2/src/test/java/org/apache/iceberg/actions/TestRewriteDataFilesAction24.java
@@ -19,5 +19,11 @@
 
 package org.apache.iceberg.actions;
 
+import org.apache.iceberg.Table;
+
 public class TestRewriteDataFilesAction24 extends TestRewriteDataFilesAction {
+  @Override
+  protected CommonActions actionsForTable(Table table) {
+    return Actions.forTable(table);
+  }
 }

--- a/spark2/src/test/java/org/apache/iceberg/actions/TestRewriteDataFilesAction24.java
+++ b/spark2/src/test/java/org/apache/iceberg/actions/TestRewriteDataFilesAction24.java
@@ -23,7 +23,7 @@ import org.apache.iceberg.Table;
 
 public class TestRewriteDataFilesAction24 extends TestRewriteDataFilesAction {
   @Override
-  protected CommonActions actionsForTable(Table table) {
+  protected BaseActions actionsForTable(Table table) {
     return Actions.forTable(table);
   }
 }

--- a/spark2/src/test/java/org/apache/iceberg/actions/TestRewriteManifestsAction24.java
+++ b/spark2/src/test/java/org/apache/iceberg/actions/TestRewriteManifestsAction24.java
@@ -19,8 +19,15 @@
 
 package org.apache.iceberg.actions;
 
+import org.apache.iceberg.Table;
+
 public class TestRewriteManifestsAction24 extends TestRewriteManifestsAction {
   public TestRewriteManifestsAction24(String snapshotIdInheritanceEnabled) {
     super(snapshotIdInheritanceEnabled);
+  }
+
+  @Override
+  protected CommonActions actionsForTable(Table table) {
+    return Actions.forTable(table);
   }
 }

--- a/spark2/src/test/java/org/apache/iceberg/actions/TestRewriteManifestsAction24.java
+++ b/spark2/src/test/java/org/apache/iceberg/actions/TestRewriteManifestsAction24.java
@@ -27,7 +27,7 @@ public class TestRewriteManifestsAction24 extends TestRewriteManifestsAction {
   }
 
   @Override
-  protected CommonActions actionsForTable(Table table) {
+  protected BaseActions actionsForTable(Table table) {
     return Actions.forTable(table);
   }
 }

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHadoopTables24.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHadoopTables24.java
@@ -19,5 +19,13 @@
 
 package org.apache.iceberg.spark.source;
 
+import org.apache.iceberg.Table;
+import org.apache.iceberg.actions.Actions;
+import org.apache.iceberg.actions.CommonActions;
+
 public class TestIcebergSourceHadoopTables24 extends TestIcebergSourceHadoopTables {
+  @Override
+  protected CommonActions actionsForTable(Table table) {
+    return Actions.forTable(table);
+  }
 }

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHadoopTables24.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHadoopTables24.java
@@ -21,11 +21,11 @@ package org.apache.iceberg.spark.source;
 
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.Actions;
-import org.apache.iceberg.actions.CommonActions;
+import org.apache.iceberg.actions.BaseActions;
 
 public class TestIcebergSourceHadoopTables24 extends TestIcebergSourceHadoopTables {
   @Override
-  protected CommonActions actionsForTable(Table table) {
+  protected BaseActions actionsForTable(Table table) {
     return Actions.forTable(table);
   }
 }

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables24.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables24.java
@@ -21,11 +21,11 @@ package org.apache.iceberg.spark.source;
 
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.Actions;
-import org.apache.iceberg.actions.CommonActions;
+import org.apache.iceberg.actions.BaseActions;
 
 public class TestIcebergSourceHiveTables24 extends TestIcebergSourceHiveTables {
   @Override
-  protected CommonActions actionsForTable(Table table) {
+  protected BaseActions actionsForTable(Table table) {
     return Actions.forTable(table);
   }
 }

--- a/spark3/src/main/java/org/apache/iceberg/actions/Actions.java
+++ b/spark3/src/main/java/org/apache/iceberg/actions/Actions.java
@@ -22,7 +22,7 @@ package org.apache.iceberg.actions;
 import org.apache.iceberg.Table;
 import org.apache.spark.sql.SparkSession;
 
-public class Actions extends CommonActions {
+public class Actions extends BaseActions {
 
   protected Actions(SparkSession spark, Table table) {
     super(spark, table);

--- a/spark3/src/main/java/org/apache/iceberg/actions/Actions.java
+++ b/spark3/src/main/java/org/apache/iceberg/actions/Actions.java
@@ -17,15 +17,23 @@
  * under the License.
  */
 
-package org.apache.iceberg.spark.source;
+package org.apache.iceberg.actions;
 
 import org.apache.iceberg.Table;
-import org.apache.iceberg.actions.Actions;
-import org.apache.iceberg.actions.CommonActions;
+import org.apache.spark.sql.SparkSession;
 
-public class TestIcebergSourceHiveTables24 extends TestIcebergSourceHiveTables {
-  @Override
-  protected CommonActions actionsForTable(Table table) {
-    return Actions.forTable(table);
+public class Actions extends CommonActions {
+
+  protected Actions(SparkSession spark, Table table) {
+    super(spark, table);
   }
+
+  public static Actions forTable(SparkSession spark, Table table) {
+    return new Actions(spark, table);
+  }
+
+  public static Actions forTable(Table table) {
+    return new Actions(SparkSession.active(), table);
+  }
+
 }

--- a/spark3/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction3.java
+++ b/spark3/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction3.java
@@ -19,5 +19,11 @@
 
 package org.apache.iceberg.actions;
 
+import org.apache.iceberg.Table;
+
 public class TestExpireSnapshotsAction3 extends TestExpireSnapshotsAction {
+  @Override
+  protected CommonActions actionsForTable(Table table) {
+    return Actions.forTable(table);
+  }
 }

--- a/spark3/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction3.java
+++ b/spark3/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction3.java
@@ -23,7 +23,7 @@ import org.apache.iceberg.Table;
 
 public class TestExpireSnapshotsAction3 extends TestExpireSnapshotsAction {
   @Override
-  protected CommonActions actionsForTable(Table table) {
+  protected BaseActions actionsForTable(Table table) {
     return Actions.forTable(table);
   }
 }

--- a/spark3/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction3.java
+++ b/spark3/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction3.java
@@ -23,7 +23,7 @@ import org.apache.iceberg.Table;
 
 public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
   @Override
-  protected CommonActions actionsForTable(Table table) {
+  protected BaseActions actionsForTable(Table table) {
     return Actions.forTable(table);
   }
 }

--- a/spark3/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction3.java
+++ b/spark3/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction3.java
@@ -19,5 +19,11 @@
 
 package org.apache.iceberg.actions;
 
+import org.apache.iceberg.Table;
+
 public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
+  @Override
+  protected CommonActions actionsForTable(Table table) {
+    return Actions.forTable(table);
+  }
 }

--- a/spark3/src/test/java/org/apache/iceberg/actions/TestRewriteDataFilesAction3.java
+++ b/spark3/src/test/java/org/apache/iceberg/actions/TestRewriteDataFilesAction3.java
@@ -23,7 +23,7 @@ import org.apache.iceberg.Table;
 
 public class TestRewriteDataFilesAction3 extends TestRewriteDataFilesAction {
   @Override
-  protected CommonActions actionsForTable(Table table) {
+  protected BaseActions actionsForTable(Table table) {
     return Actions.forTable(table);
   }
 }

--- a/spark3/src/test/java/org/apache/iceberg/actions/TestRewriteDataFilesAction3.java
+++ b/spark3/src/test/java/org/apache/iceberg/actions/TestRewriteDataFilesAction3.java
@@ -19,5 +19,11 @@
 
 package org.apache.iceberg.actions;
 
+import org.apache.iceberg.Table;
+
 public class TestRewriteDataFilesAction3 extends TestRewriteDataFilesAction {
+  @Override
+  protected CommonActions actionsForTable(Table table) {
+    return Actions.forTable(table);
+  }
 }

--- a/spark3/src/test/java/org/apache/iceberg/actions/TestRewriteManifestsAction3.java
+++ b/spark3/src/test/java/org/apache/iceberg/actions/TestRewriteManifestsAction3.java
@@ -27,7 +27,7 @@ public class TestRewriteManifestsAction3 extends TestRewriteManifestsAction {
   }
 
   @Override
-  protected CommonActions actionsForTable(Table table) {
+  protected BaseActions actionsForTable(Table table) {
     return Actions.forTable(table);
   }
 }

--- a/spark3/src/test/java/org/apache/iceberg/actions/TestRewriteManifestsAction3.java
+++ b/spark3/src/test/java/org/apache/iceberg/actions/TestRewriteManifestsAction3.java
@@ -19,8 +19,15 @@
 
 package org.apache.iceberg.actions;
 
+import org.apache.iceberg.Table;
+
 public class TestRewriteManifestsAction3 extends TestRewriteManifestsAction {
   public TestRewriteManifestsAction3(String snapshotIdInheritanceEnabled) {
     super(snapshotIdInheritanceEnabled);
+  }
+
+  @Override
+  protected CommonActions actionsForTable(Table table) {
+    return Actions.forTable(table);
   }
 }

--- a/spark3/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHadoopTables3.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHadoopTables3.java
@@ -21,11 +21,11 @@ package org.apache.iceberg.spark.source;
 
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.Actions;
-import org.apache.iceberg.actions.CommonActions;
+import org.apache.iceberg.actions.BaseActions;
 
 public class TestIcebergSourceHadoopTables3 extends TestIcebergSourceHadoopTables {
   @Override
-  protected CommonActions actionsForTable(Table table) {
+  protected BaseActions actionsForTable(Table table) {
     return Actions.forTable(table);
   }
 }

--- a/spark3/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHadoopTables3.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHadoopTables3.java
@@ -19,5 +19,13 @@
 
 package org.apache.iceberg.spark.source;
 
+import org.apache.iceberg.Table;
+import org.apache.iceberg.actions.Actions;
+import org.apache.iceberg.actions.CommonActions;
+
 public class TestIcebergSourceHadoopTables3 extends TestIcebergSourceHadoopTables {
+  @Override
+  protected CommonActions actionsForTable(Table table) {
+    return Actions.forTable(table);
+  }
 }

--- a/spark3/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables3.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables3.java
@@ -19,5 +19,13 @@
 
 package org.apache.iceberg.spark.source;
 
+import org.apache.iceberg.Table;
+import org.apache.iceberg.actions.Actions;
+import org.apache.iceberg.actions.CommonActions;
+
 public class TestIcebergSourceHiveTables3 extends TestIcebergSourceHiveTables {
+  @Override
+  protected CommonActions actionsForTable(Table table) {
+    return Actions.forTable(table);
+  }
 }

--- a/spark3/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables3.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables3.java
@@ -21,11 +21,11 @@ package org.apache.iceberg.spark.source;
 
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.Actions;
-import org.apache.iceberg.actions.CommonActions;
+import org.apache.iceberg.actions.BaseActions;
 
 public class TestIcebergSourceHiveTables3 extends TestIcebergSourceHiveTables {
   @Override
-  protected CommonActions actionsForTable(Table table) {
+  protected BaseActions actionsForTable(Table table) {
     return Actions.forTable(table);
   }
 }


### PR DESCRIPTION
Previously there was a sole Action class used by Spark2 and Spark3 modules. This
made it difficult to provide Actions that were only compatible with a single version
of Spark. To fix this we provide a common base class for Actions which are Spark
version agnositic and give each Spark Module an Action class which extends the
common class.

Names, Packages and such remain identical for the end user.