### PR TITLE
Seperate Action Implementations into Spark Specific Modules - With Reflection

### DIFF
--- a/spark/src/main/java/org/apache/iceberg/actions/Actions.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/Actions.java
@@ -19,25 +19,57 @@
 
 package org.apache.iceberg.actions;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import org.apache.iceberg.Table;
 import org.apache.spark.sql.SparkSession;
 
 public class Actions {
+  private static final String IMPL_NAME = "SparkActions";
+
+  private static Class<Actions> implClass;
+  private static Constructor<Actions> implConstructor;
 
   private SparkSession spark;
   private Table table;
 
-  private Actions(SparkSession spark, Table table) {
+  protected Actions(SparkSession spark, Table table) {
     this.spark = spark;
     this.table = table;
   }
 
+  private static Constructor actionConstructor() {
+    if (implClass == null) {
+      String className = Actions.class.getPackage().getName() + "." + IMPL_NAME;
+      try {
+        implClass = (Class<Actions>) Class.forName(className);
+      } catch (ClassNotFoundException e) {
+        throw new IllegalArgumentException("Cannot use Actions if no Spark Module is on the classpath.", e);
+      }
+    }
+    if (implConstructor == null) {
+      try {
+        implConstructor = implClass.getDeclaredConstructor(SparkSession.class, Table.class);
+      } catch (NoSuchMethodException e) {
+        throw new IllegalArgumentException(
+            "Cannot use Actions if SparkAction implementation does not have a constructor of (SparkSession, Table).",
+            e);
+      }
+    }
+    return implConstructor;
+  }
+
   public static Actions forTable(SparkSession spark, Table table) {
-    return new Actions(spark, table);
+    try {
+      return (Actions) actionConstructor().newInstance(spark, table);
+    } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+      throw new IllegalStateException("Cannot create new Actions, this most likely means there is a classpath issue.",
+          e);
+    }
   }
 
   public static Actions forTable(Table table) {
-    return new Actions(SparkSession.active(), table);
+    return forTable(SparkSession.active(), table);
   }
 
   public RemoveOrphanFilesAction removeOrphanFiles() {

--- a/spark/src/main/java/org/apache/iceberg/actions/Actions.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/Actions.java
@@ -36,7 +36,8 @@ public class Actions {
     if (implConstructor == null) {
       String className = Actions.class.getPackage().getName() + "." + IMPL_NAME;
       try {
-        implConstructor = DynConstructors.builder().impl(className, SparkSession.class, Table.class).buildChecked();
+        implConstructor =
+            DynConstructors.builder().hiddenImpl(className, SparkSession.class, Table.class).buildChecked();
       } catch (NoSuchMethodException e) {
         throw new IllegalArgumentException("Cannot find appropriate Actions implementation on the classpath.", e);
       }

--- a/spark/src/main/java/org/apache/iceberg/actions/Actions.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/Actions.java
@@ -19,16 +19,30 @@
 
 package org.apache.iceberg.actions;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.common.DynConstructors;
 import org.apache.spark.sql.SparkSession;
 
 public class Actions {
-  private static final String IMPL_NAME = "SparkActions";
 
-  private static Class<Actions> implClass;
-  private static Constructor<Actions> implConstructor;
+  /*
+  We load the actual implementation of Actions via reflection to allow for differences
+  between the major Spark APIs while still defining the API in this class.
+  */
+  private static final String IMPL_NAME = "SparkActions";
+  private static DynConstructors.Ctor<Actions> implConstructor;
+
+  private static DynConstructors.Ctor<Actions> actionConstructor() {
+    if (implConstructor == null) {
+      String className = Actions.class.getPackage().getName() + "." + IMPL_NAME;
+      try {
+        implConstructor = DynConstructors.builder().impl(className, SparkSession.class, Table.class).buildChecked();
+      } catch (NoSuchMethodException e) {
+        throw new IllegalArgumentException("Cannot find appropriate Actions implementation on the classpath.", e);
+      }
+    }
+    return implConstructor;
+  }
 
   private SparkSession spark;
   private Table table;
@@ -38,34 +52,8 @@ public class Actions {
     this.table = table;
   }
 
-  private static Constructor actionConstructor() {
-    if (implClass == null) {
-      String className = Actions.class.getPackage().getName() + "." + IMPL_NAME;
-      try {
-        implClass = (Class<Actions>) Class.forName(className);
-      } catch (ClassNotFoundException e) {
-        throw new IllegalArgumentException("Cannot use Actions if no Spark Module is on the classpath.", e);
-      }
-    }
-    if (implConstructor == null) {
-      try {
-        implConstructor = implClass.getDeclaredConstructor(SparkSession.class, Table.class);
-      } catch (NoSuchMethodException e) {
-        throw new IllegalArgumentException(
-            "Cannot use Actions if SparkAction implementation does not have a constructor of (SparkSession, Table).",
-            e);
-      }
-    }
-    return implConstructor;
-  }
-
   public static Actions forTable(SparkSession spark, Table table) {
-    try {
-      return (Actions) actionConstructor().newInstance(spark, table);
-    } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
-      throw new IllegalStateException("Cannot create new Actions, this most likely means there is a classpath issue.",
-          e);
-    }
+    return actionConstructor().newInstance(spark, table);
   }
 
   public static Actions forTable(Table table) {
@@ -87,4 +75,13 @@ public class Actions {
   public ExpireSnapshotsAction expireSnapshots() {
     return new ExpireSnapshotsAction(spark, table);
   }
+
+  protected SparkSession spark() {
+    return spark;
+  }
+
+  protected Table table() {
+    return table;
+  }
+
 }

--- a/spark2/src/main/java/org/apache/iceberg/actions/SparkActions.java
+++ b/spark2/src/main/java/org/apache/iceberg/actions/SparkActions.java
@@ -22,7 +22,7 @@ package org.apache.iceberg.actions;
 import org.apache.iceberg.Table;
 import org.apache.spark.sql.SparkSession;
 
-public class SparkActions extends Actions {
+class SparkActions extends Actions {
   protected SparkActions(SparkSession spark, Table table) {
     super(spark, table);
   }

--- a/spark2/src/main/java/org/apache/iceberg/actions/SparkActions.java
+++ b/spark2/src/main/java/org/apache/iceberg/actions/SparkActions.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.actions;
+
+import org.apache.iceberg.Table;
+import org.apache.spark.sql.SparkSession;
+
+public class SparkActions extends Actions {
+  protected SparkActions(SparkSession spark, Table table) {
+    super(spark, table);
+  }
+}

--- a/spark3/src/main/java/org/apache/iceberg/actions/SparkActions.java
+++ b/spark3/src/main/java/org/apache/iceberg/actions/SparkActions.java
@@ -22,7 +22,7 @@ package org.apache.iceberg.actions;
 import org.apache.iceberg.Table;
 import org.apache.spark.sql.SparkSession;
 
-public class SparkActions extends Actions {
+class SparkActions extends Actions {
   protected SparkActions(SparkSession spark, Table table) {
     super(spark, table);
   }

--- a/spark3/src/main/java/org/apache/iceberg/actions/SparkActions.java
+++ b/spark3/src/main/java/org/apache/iceberg/actions/SparkActions.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.actions;
+
+import org.apache.iceberg.Table;
+import org.apache.spark.sql.SparkSession;
+
+public class SparkActions extends Actions {
+  protected SparkActions(SparkSession spark, Table table) {
+    super(spark, table);
+  }
+}


### PR DESCRIPTION
Uses reflection in the base Actions class to determine the actual
implementation on the classloader to use. This allows both Spark2
and Spark3 to use different implementations of Actions while not
changing the location of the original Actions class.