### PR TITLE
dynamically load custom FileIO implementation

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/FileIO.java
+++ b/api/src/main/java/org/apache/iceberg/io/FileIO.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.io;
 
 import java.io.Serializable;
+import java.util.Map;
 
 /**
  * Pluggable module for reading, writing, and deleting files.
@@ -57,5 +58,12 @@ public interface FileIO extends Serializable {
    */
   default void deleteFile(OutputFile file) {
     deleteFile(file.location());
+  }
+
+  /**
+   * Initialize File IO from catalog properties.
+   * @param properties catalog properties
+   */
+  default void initialize(Map<String, String> properties) {
   }
 }

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -25,4 +25,10 @@ public class CatalogProperties {
   }
 
   public static final String CATALOG_IMPL = "catalog-impl";
+  public static final String FILE_IO_IMPL = "io-impl";
+  public static final String WAREHOUSE_LOCATION = "warehouse";
+
+  public static final String HIVE_URI = "uri";
+  public static final String HIVE_CLIENT_POOL_SIZE = "clients";
+  public static final int HIVE_CLIENT_POOL_SIZE_DEFAULT = 2;
 }

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -103,13 +103,24 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
   }
 
   /**
+   * The constructor of the HadoopCatalog. It uses an empty catalog properties map.
+   *
+   * @param name The catalog name
+   * @param conf The Hadoop configuration
+   * @param warehouseLocation The location used as warehouse directory
+   */
+  public HadoopCatalog(String name, Configuration conf, String warehouseLocation) {
+    this(name, conf, warehouseLocation, Maps.newHashMap());
+  }
+
+  /**
    * The constructor of the HadoopCatalog. It uses the passed location as its warehouse directory.
    *
    * @param conf The Hadoop configuration
    * @param warehouseLocation The location used as warehouse directory
    */
   public HadoopCatalog(Configuration conf, String warehouseLocation) {
-    this("hadoop", conf, warehouseLocation, Maps.newHashMap());
+    this("hadoop", conf, warehouseLocation);
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -87,6 +87,17 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
    * @param name The catalog name
    * @param conf The Hadoop configuration
    * @param warehouseLocation The location used as warehouse directory
+   */
+  public HadoopCatalog(String name, Configuration conf, String warehouseLocation) {
+    this(name, conf, warehouseLocation, Maps.newHashMap());
+  }
+
+  /**
+   * The all-arg constructor of the HadoopCatalog.
+   *
+   * @param name The catalog name
+   * @param conf The Hadoop configuration
+   * @param warehouseLocation The location used as warehouse directory
    * @param properties catalog properties
    */
   public HadoopCatalog(String name, Configuration conf, String warehouseLocation, Map<String, String> properties) {
@@ -100,17 +111,6 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
 
     String fileIOImpl = properties.get(CatalogProperties.FILE_IO_IMPL);
     this.fileIO = fileIOImpl == null ? new HadoopFileIO(conf) : CatalogUtil.loadFileIO(fileIOImpl, properties, conf);
-  }
-
-  /**
-   * The constructor of the HadoopCatalog. It uses an empty catalog properties map.
-   *
-   * @param name The catalog name
-   * @param conf The Hadoop configuration
-   * @param warehouseLocation The location used as warehouse directory
-   */
-  public HadoopCatalog(String name, Configuration conf, String warehouseLocation) {
-    this(name, conf, warehouseLocation, Maps.newHashMap());
   }
 
   /**
@@ -131,7 +131,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
    * @param conf The Hadoop configuration
    */
   public HadoopCatalog(Configuration conf) {
-    this("hadoop", conf, conf.get("fs.defaultFS") + "/" + ICEBERG_HADOOP_WAREHOUSE_BASE, Maps.newHashMap());
+    this("hadoop", conf, conf.get("fs.defaultFS") + "/" + ICEBERG_HADOOP_WAREHOUSE_BASE);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 import org.apache.iceberg.BaseMetastoreCatalog;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableMetadata;
@@ -45,11 +46,13 @@ import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 
 /**
@@ -76,6 +79,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
   private final Configuration conf;
   private final String warehouseLocation;
   private final FileSystem fs;
+  private final FileIO fileIO;
 
   /**
    * The constructor of the HadoopCatalog. It uses the passed location as its warehouse directory.
@@ -83,8 +87,9 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
    * @param name The catalog name
    * @param conf The Hadoop configuration
    * @param warehouseLocation The location used as warehouse directory
+   * @param properties catalog properties
    */
-  public HadoopCatalog(String name, Configuration conf, String warehouseLocation) {
+  public HadoopCatalog(String name, Configuration conf, String warehouseLocation, Map<String, String> properties) {
     Preconditions.checkArgument(warehouseLocation != null && !warehouseLocation.equals(""),
         "no location provided for warehouse");
 
@@ -92,6 +97,9 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
     this.conf = conf;
     this.warehouseLocation = warehouseLocation.replaceAll("/*$", "");
     this.fs = Util.getFs(new Path(warehouseLocation), conf);
+
+    String fileIOImpl = properties.get(CatalogProperties.FILE_IO_IMPL);
+    this.fileIO = fileIOImpl == null ? new HadoopFileIO(conf) : CatalogUtil.loadFileIO(fileIOImpl, properties, conf);
   }
 
   /**
@@ -101,7 +109,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
    * @param warehouseLocation The location used as warehouse directory
    */
   public HadoopCatalog(Configuration conf, String warehouseLocation) {
-    this("hadoop", conf, warehouseLocation);
+    this("hadoop", conf, warehouseLocation, Maps.newHashMap());
   }
 
   /**
@@ -112,7 +120,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
    * @param conf The Hadoop configuration
    */
   public HadoopCatalog(Configuration conf) {
-    this("hadoop", conf, conf.get("fs.defaultFS") + "/" + ICEBERG_HADOOP_WAREHOUSE_BASE);
+    this("hadoop", conf, conf.get("fs.defaultFS") + "/" + ICEBERG_HADOOP_WAREHOUSE_BASE, Maps.newHashMap());
   }
 
   @Override
@@ -163,7 +171,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
 
   @Override
   protected TableOperations newTableOps(TableIdentifier identifier) {
-    return new HadoopTableOperations(new Path(defaultWarehouseLocation(identifier)), conf);
+    return new HadoopTableOperations(new Path(defaultWarehouseLocation(identifier)), fileIO, conf);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -62,15 +62,16 @@ public class HadoopTableOperations implements TableOperations {
 
   private final Configuration conf;
   private final Path location;
-  private HadoopFileIO defaultFileIo = null;
+  private final FileIO fileIO;
 
   private volatile TableMetadata currentMetadata = null;
   private volatile Integer version = null;
   private volatile boolean shouldRefresh = true;
 
-  protected HadoopTableOperations(Path location, Configuration conf) {
+  protected HadoopTableOperations(Path location, FileIO fileIO, Configuration conf) {
     this.conf = conf;
     this.location = location;
+    this.fileIO = fileIO;
   }
 
   @Override
@@ -173,10 +174,7 @@ public class HadoopTableOperations implements TableOperations {
 
   @Override
   public FileIO io() {
-    if (defaultFileIo == null) {
-      defaultFileIo = new HadoopFileIO(conf);
-    }
-    return defaultFileIo;
+    return fileIO;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTables.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTables.java
@@ -196,7 +196,7 @@ public class HadoopTables implements Tables, Configurable {
     if (location.contains(METADATA_JSON)) {
       return new StaticTableOperations(location, new HadoopFileIO(conf));
     } else {
-      return new HadoopTableOperations(new Path(location), conf);
+      return new HadoopTableOperations(new Path(location), new HadoopFileIO(conf), conf);
     }
   }
 

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -63,11 +63,7 @@ public class FlinkCatalogFactory implements CatalogFactory {
   public static final String ICEBERG_CATALOG_TYPE_HADOOP = "hadoop";
   public static final String ICEBERG_CATALOG_TYPE_HIVE = "hive";
 
-  public static final String HIVE_URI = "uri";
-  public static final String HIVE_CLIENT_POOL_SIZE = "clients";
   public static final String HIVE_CONF_DIR = "hive-conf-dir";
-  public static final String WAREHOUSE_LOCATION = "warehouse";
-
   public static final String DEFAULT_DATABASE = "default-database";
   public static final String BASE_NAMESPACE = "base-namespace";
 
@@ -90,16 +86,12 @@ public class FlinkCatalogFactory implements CatalogFactory {
       case ICEBERG_CATALOG_TYPE_HIVE:
         // The values of properties 'uri', 'warehouse', 'hive-conf-dir' are allowed to be null, in that case it will
         // fallback to parse those values from hadoop configuration which is loaded from classpath.
-        String uri = properties.get(HIVE_URI);
-        String warehouse = properties.get(WAREHOUSE_LOCATION);
-        int clientPoolSize = Integer.parseInt(properties.getOrDefault(HIVE_CLIENT_POOL_SIZE, "2"));
         String hiveConfDir = properties.get(HIVE_CONF_DIR);
         Configuration newHadoopConf = mergeHiveConf(hadoopConf, hiveConfDir);
-        return CatalogLoader.hive(name, newHadoopConf, uri, warehouse, clientPoolSize);
+        return CatalogLoader.hive(name, newHadoopConf, properties);
 
       case ICEBERG_CATALOG_TYPE_HADOOP:
-        String warehouseLocation = properties.get(WAREHOUSE_LOCATION);
-        return CatalogLoader.hadoop(name, hadoopConf, warehouseLocation);
+        return CatalogLoader.hadoop(name, hadoopConf, properties);
 
       default:
         throw new UnsupportedOperationException("Unknown catalog type: " + catalogType);
@@ -118,12 +110,13 @@ public class FlinkCatalogFactory implements CatalogFactory {
   public List<String> supportedProperties() {
     List<String> properties = Lists.newArrayList();
     properties.add(ICEBERG_CATALOG_TYPE);
-    properties.add(HIVE_URI);
-    properties.add(HIVE_CLIENT_POOL_SIZE);
     properties.add(HIVE_CONF_DIR);
-    properties.add(WAREHOUSE_LOCATION);
     properties.add(DEFAULT_DATABASE);
     properties.add(BASE_NAMESPACE);
+    properties.add(CatalogProperties.FILE_IO_IMPL);
+    properties.add(CatalogProperties.WAREHOUSE_LOCATION);
+    properties.add(CatalogProperties.HIVE_URI);
+    properties.add(CatalogProperties.HIVE_CLIENT_POOL_SIZE);
     return properties;
   }
 

--- a/flink/src/test/java/org/apache/iceberg/flink/FlinkCatalogTestBase.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/FlinkCatalogTestBase.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.Map;
 import org.apache.flink.util.ArrayUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
@@ -104,11 +105,11 @@ public abstract class FlinkCatalogTestBase extends FlinkTestBase {
     }
     if (isHadoopCatalog) {
       config.put(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE, "hadoop");
-      config.put(FlinkCatalogFactory.WAREHOUSE_LOCATION, "file://" + hadoopWarehouse.getRoot());
+      config.put(CatalogProperties.WAREHOUSE_LOCATION, "file://" + hadoopWarehouse.getRoot());
     } else {
       config.put(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE, "hive");
-      config.put(FlinkCatalogFactory.WAREHOUSE_LOCATION, "file://" + hiveWarehouse.getRoot());
-      config.put(FlinkCatalogFactory.HIVE_URI, getURI(hiveConf));
+      config.put(CatalogProperties.WAREHOUSE_LOCATION, "file://" + hiveWarehouse.getRoot());
+      config.put(CatalogProperties.HIVE_URI, getURI(hiveConf));
     }
 
     this.flinkDatabase = catalogName + "." + DATABASE;

--- a/flink/src/test/java/org/apache/iceberg/flink/TestCatalogTableLoader.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestCatalogTableLoader.java
@@ -25,12 +25,15 @@ import java.io.File;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.Map;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -62,13 +65,15 @@ public class TestCatalogTableLoader extends FlinkTestBase {
 
   @Test
   public void testHadoopCatalogLoader() throws IOException, ClassNotFoundException {
-    CatalogLoader loader = CatalogLoader.hadoop("my_catalog", hiveConf, "file:" + warehouse);
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(CatalogProperties.WAREHOUSE_LOCATION, "file:" + warehouse);
+    CatalogLoader loader = CatalogLoader.hadoop("my_catalog", hiveConf, properties);
     validateCatalogLoader(loader);
   }
 
   @Test
   public void testHiveCatalogLoader() throws IOException, ClassNotFoundException {
-    CatalogLoader loader = CatalogLoader.hive("my_catalog", hiveConf, null, null, 2);
+    CatalogLoader loader = CatalogLoader.hive("my_catalog", hiveConf, Maps.newHashMap());
     validateCatalogLoader(loader);
   }
 
@@ -81,7 +86,7 @@ public class TestCatalogTableLoader extends FlinkTestBase {
 
   @Test
   public void testHiveCatalogTableLoader() throws IOException, ClassNotFoundException {
-    CatalogLoader catalogLoader = CatalogLoader.hive("my_catalog", hiveConf, null, null, 2);
+    CatalogLoader catalogLoader = CatalogLoader.hive("my_catalog", hiveConf, Maps.newHashMap());
     validateTableLoader(TableLoader.fromCatalog(catalogLoader, IDENTIFIER));
   }
 

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkHiveCatalog.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkHiveCatalog.java
@@ -27,6 +27,7 @@ import java.nio.file.Path;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -43,10 +44,10 @@ public class TestFlinkHiveCatalog extends FlinkTestBase {
     Map<String, String> props = Maps.newHashMap();
     props.put("type", "iceberg");
     props.put(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE, "hive");
-    props.put(FlinkCatalogFactory.HIVE_URI, FlinkCatalogTestBase.getURI(hiveConf));
+    props.put(CatalogProperties.HIVE_URI, FlinkCatalogTestBase.getURI(hiveConf));
 
     File warehouseDir = tempFolder.newFolder();
-    props.put(FlinkCatalogFactory.WAREHOUSE_LOCATION, "file://" + warehouseDir.getAbsolutePath());
+    props.put(CatalogProperties.WAREHOUSE_LOCATION, "file://" + warehouseDir.getAbsolutePath());
 
     checkSQLQuery(props, warehouseDir);
   }
@@ -69,7 +70,7 @@ public class TestFlinkHiveCatalog extends FlinkTestBase {
     Map<String, String> props = Maps.newHashMap();
     props.put("type", "iceberg");
     props.put(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE, "hive");
-    props.put(FlinkCatalogFactory.HIVE_URI, FlinkCatalogTestBase.getURI(hiveConf));
+    props.put(CatalogProperties.HIVE_URI, FlinkCatalogTestBase.getURI(hiveConf));
     // Set the 'hive-conf-dir' instead of 'warehouse'
     props.put(FlinkCatalogFactory.HIVE_CONF_DIR, hiveConfDir.getAbsolutePath());
 

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.UnknownDBException;
 import org.apache.iceberg.BaseMetastoreCatalog;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
@@ -45,6 +46,8 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.hadoop.HadoopFileIO;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -61,6 +64,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable, Supp
   private final HiveClientPool clients;
   private final Configuration conf;
   private final StackTraceElement[] createStack;
+  private final FileIO fileIO;
   private boolean closed;
 
   public HiveCatalog(Configuration conf) {
@@ -69,13 +73,20 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable, Supp
     this.conf = conf;
     this.createStack = Thread.currentThread().getStackTrace();
     this.closed = false;
+    this.fileIO = new HadoopFileIO(conf);
   }
 
   public HiveCatalog(String name, String uri, int clientPoolSize, Configuration conf) {
-    this(name, uri, null, clientPoolSize, conf);
+    this(name, uri, null, clientPoolSize, conf, Maps.newHashMap());
   }
 
-  public HiveCatalog(String name, String uri, String warehouse, int clientPoolSize, Configuration conf) {
+  public HiveCatalog(
+      String name,
+      String uri,
+      String warehouse,
+      int clientPoolSize,
+      Configuration conf,
+      Map<String, String> properties) {
     this.name = name;
     this.conf = new Configuration(conf);
     // before building the client pool, overwrite the configuration's URIs if the argument is non-null
@@ -90,6 +101,9 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable, Supp
     this.clients = new HiveClientPool(clientPoolSize, this.conf);
     this.createStack = Thread.currentThread().getStackTrace();
     this.closed = false;
+
+    String fileIOImpl = properties.get(CatalogProperties.FILE_IO_IMPL);
+    this.fileIO = fileIOImpl == null ? new HadoopFileIO(conf) : CatalogUtil.loadFileIO(fileIOImpl, properties, conf);
   }
 
   @Override
@@ -403,7 +417,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable, Supp
   public TableOperations newTableOps(TableIdentifier tableIdentifier) {
     String dbName = tableIdentifier.namespace().level(0);
     String tableName = tableIdentifier.name();
-    return new HiveTableOperations(conf, clients, name, dbName, tableName);
+    return new HiveTableOperations(conf, clients, fileIO, name, dbName, tableName);
   }
 
   @Override

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -77,7 +77,11 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable, Supp
   }
 
   public HiveCatalog(String name, String uri, int clientPoolSize, Configuration conf) {
-    this(name, uri, null, clientPoolSize, conf, Maps.newHashMap());
+    this(name, uri, null, clientPoolSize, conf);
+  }
+
+  public HiveCatalog(String name, String uri, String warehouse, int clientPoolSize, Configuration conf) {
+    this(name, uri, warehouse, clientPoolSize, conf, Maps.newHashMap());
   }
 
   public HiveCatalog(

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -56,7 +56,6 @@ import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NoSuchIcebergTableException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.hadoop.ConfigProperties;
-import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -86,13 +85,13 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
   private final String tableName;
   private final Configuration conf;
   private final long lockAcquireTimeout;
+  private final FileIO fileIO;
 
-  private FileIO fileIO;
-
-  protected HiveTableOperations(Configuration conf, HiveClientPool metaClients,
+  protected HiveTableOperations(Configuration conf, HiveClientPool metaClients, FileIO fileIO,
                                 String catalogName, String database, String table) {
     this.conf = conf;
     this.metaClients = metaClients;
+    this.fileIO = fileIO;
     this.fullName = catalogName + "." + database + "." + table;
     this.database = database;
     this.tableName = table;
@@ -107,10 +106,6 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
 
   @Override
   public FileIO io() {
-    if (fileIO == null) {
-      fileIO = new HadoopFileIO(conf);
-    }
-
     return fileIO;
   }
 

--- a/spark3/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -109,13 +109,14 @@ public class SparkCatalog implements StagingTableCatalog, org.apache.spark.sql.c
     String catalogType = options.getOrDefault(ICEBERG_CATALOG_TYPE, ICEBERG_CATALOG_TYPE_HIVE);
     switch (catalogType.toLowerCase(Locale.ENGLISH)) {
       case ICEBERG_CATALOG_TYPE_HIVE:
-        int clientPoolSize = options.getInt("clients", 2);
-        String uri = options.get("uri");
+        int clientPoolSize = options.getInt(CatalogProperties.HIVE_CLIENT_POOL_SIZE,
+            CatalogProperties.HIVE_CLIENT_POOL_SIZE_DEFAULT);
+        String uri = options.get(CatalogProperties.HIVE_URI);
         return new HiveCatalog(name, uri, clientPoolSize, conf);
 
       case ICEBERG_CATALOG_TYPE_HADOOP:
-        String warehouseLocation = options.get("warehouse");
-        return new HadoopCatalog(name, conf, warehouseLocation);
+        String warehouseLocation = options.get(CatalogProperties.WAREHOUSE_LOCATION);
+        return new HadoopCatalog(name, conf, warehouseLocation, options.asCaseSensitiveMap());
 
       default:
         throw new UnsupportedOperationException("Unknown catalog type: " + catalogType);


### PR DESCRIPTION
- refactor the class loader logic in `LocationProviders` to a util class
- add functionality to dynamically load FileIO in Hadoop and Hive table operations
- introduce a catalog property `io-impl`