### PR TITLE
Flink: Support configuring write parallelims for iceberg stream writer.

### DIFF
--- a/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
@@ -131,6 +131,7 @@ public class TestFlinkIcebergSink extends AbstractTestBase {
     FlinkSink.forRowData(dataStream)
         .table(table)
         .tableLoader(tableLoader)
+        .writeParallelism(parallelism)
         .build();
 
     // Execute the program.
@@ -153,6 +154,7 @@ public class TestFlinkIcebergSink extends AbstractTestBase {
         .table(table)
         .tableLoader(tableLoader)
         .tableSchema(tableSchema)
+        .writeParallelism(parallelism)
         .build();
 
     // Execute the program.


### PR DESCRIPTION
Adding a method in `FlinkSink` to configure write parallelism for iceberg stream writer. It's a comment from here https://github.com/apache/iceberg/issues/1403