### PR TITLE
Minor MicroBatch Class Cleanup and Return to Spark Structured Streaming Reader

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MicroBatches.java
+++ b/core/src/main/java/org/apache/iceberg/MicroBatches.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -79,10 +80,6 @@ public class MicroBatches {
 
     public boolean lastIndexOfSnapshot() {
       return lastIndexOfSnapshot;
-    }
-
-    public boolean isEmpty() {
-      return tasks == null || tasks().isEmpty();
     }
 
     @Override
@@ -169,7 +166,8 @@ public class MicroBatches {
      * @return a sub-list of manifest file index which only contains the manifest indexes larger than the
      * startFileIndex.
      */
-    private static List<Pair<ManifestFile, Integer>> skipManifests(List<Pair<ManifestFile, Integer>> indexedManifests,
+    @VisibleForTesting
+    protected static List<Pair<ManifestFile, Integer>> skipManifests(List<Pair<ManifestFile, Integer>> indexedManifests,
                                                                    int startFileIndex) {
       if (startFileIndex == 0) {
         return indexedManifests;

--- a/core/src/main/java/org/apache/iceberg/MicroBatches.java
+++ b/core/src/main/java/org/apache/iceberg/MicroBatches.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -78,6 +79,22 @@ public class MicroBatches {
 
     public boolean lastIndexOfSnapshot() {
       return lastIndexOfSnapshot;
+    }
+
+    public boolean isEmpty() {
+      return tasks == null || tasks().isEmpty();
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+              .add("snapshotId", snapshotId())
+              .add("startFileIndex", startFileIndex())
+              .add("endFileIndex", endFileIndex())
+              .add("sizeInBytes", sizeInBytes())
+              .add("tasks", tasks())
+              .add("lastIndexOfSnapshot", lastIndexOfSnapshot())
+              .toString();
     }
   }
 
@@ -145,7 +162,7 @@ public class MicroBatches {
     /**
      * Method to skip the manifest file in which the index is smaller than startFileIndex. For example, if the
      * index list is : (m1, 0), (m2, 3), (m3, 5), and startFileIndex is 4, then the returned manifest index list is:
-     * (m2, 3), (m3, 5).
+     * (m3, 5).
      *
      * @param indexedManifests List of input manifests.
      * @param startFileIndex Index used to skip the processed manifests.

--- a/core/src/main/java/org/apache/iceberg/MicroBatches.java
+++ b/core/src/main/java/org/apache/iceberg/MicroBatches.java
@@ -27,7 +27,6 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileIO;
-import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -166,8 +165,7 @@ public class MicroBatches {
      * @return a sub-list of manifest file index which only contains the manifest indexes larger than the
      * startFileIndex.
      */
-    @VisibleForTesting
-    protected static List<Pair<ManifestFile, Integer>> skipManifests(List<Pair<ManifestFile, Integer>> indexedManifests,
+    private static List<Pair<ManifestFile, Integer>> skipManifests(List<Pair<ManifestFile, Integer>> indexedManifests,
                                                                    int startFileIndex) {
       if (startFileIndex == 0) {
         return indexedManifests;

--- a/core/src/test/java/org/apache/iceberg/TestMicroBatchBuilder.java
+++ b/core/src/test/java/org/apache/iceberg/TestMicroBatchBuilder.java
@@ -236,7 +236,7 @@ public class TestMicroBatchBuilder extends TableTestBase {
 
   // Returns default parquet file with size of 10b and 1 record in bucket 0.
   private static DataFile file(String name) {
-    return fileWithSize(name, 10l);
+    return fileWithSize(name, 10L);
   }
 
   private static void add(AppendFiles appendFiles, List<DataFile> adds) {

--- a/core/src/test/java/org/apache/iceberg/TestMicroBatchBuilder.java
+++ b/core/src/test/java/org/apache/iceberg/TestMicroBatchBuilder.java
@@ -225,11 +225,6 @@ public class TestMicroBatchBuilder extends TableTestBase {
 
   }
 
-  // TODO - Determine how and where to test with deletes (likely in this class - can test
-  //        filter pushdown and then when filtered data exists, as an initial implementation,
-  //        we can apply the deletes (most likely via IN) as will likely be small - need to check threshold
-  //        once that on going work is completed.
-
   private static DataFile fileWithSize(String name, long newFileSizeInBytes) {
     return DataFiles.builder(SPEC)
             .withPath(name + ".parquet")

--- a/core/src/test/java/org/apache/iceberg/TestMicroBatchBuilder.java
+++ b/core/src/test/java/org/apache/iceberg/TestMicroBatchBuilder.java
@@ -141,6 +141,8 @@ public class TestMicroBatchBuilder extends TableTestBase {
     Assert.assertTrue(batch5.lastIndexOfSnapshot());
   }
 
+  // TODO - Break this up into just the logic we're testing. At most 3 microbatches.
+  //        the intermediate ones aren't needed.
   @Test
   public void testGenerateMicroBatchOnlyReadsFromGivenSnapshot() {
     // Add files A-E and process in multiple microbatches.

--- a/core/src/test/java/org/apache/iceberg/TestMicroBatchBuilder.java
+++ b/core/src/test/java/org/apache/iceberg/TestMicroBatchBuilder.java
@@ -181,7 +181,7 @@ public class TestMicroBatchBuilder extends TableTestBase {
 
   @Test
   public void testReadingSnapshotIsNotInterruptedByChildSnapshot() {
-    // Add files A-E, all of 10kb, and process the single snapshot
+    // Add files A-E, all of 10kb, and process the single generated snapshot
     // in multiple microbatches.
     add(table.newAppend(), files("A", "B", "C", "D", "E"));
     Assert.assertEquals(1L, table.currentSnapshot().snapshotId());

--- a/core/src/test/java/org/apache/iceberg/TestMicroBatchBuilder.java
+++ b/core/src/test/java/org/apache/iceberg/TestMicroBatchBuilder.java
@@ -227,11 +227,11 @@ public class TestMicroBatchBuilder extends TableTestBase {
 
   private static DataFile fileWithSize(String name, long newFileSizeInBytes) {
     return DataFiles.builder(SPEC)
-            .withPath(name + ".parquet")
-            .withFileSizeInBytes(newFileSizeInBytes)
-            .withPartitionPath("data_bucket=0") // easy way to set partition data for now
-            .withRecordCount(1)
-            .build();
+        .withPath(name + ".parquet")
+        .withFileSizeInBytes(newFileSizeInBytes)
+        .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+        .withRecordCount(1)
+        .build();
   }
 
   // Returns default parquet file with size of 10b and 1 record in bucket 0.

--- a/core/src/test/java/org/apache/iceberg/TestMicroBatchBuilder.java
+++ b/core/src/test/java/org/apache/iceberg/TestMicroBatchBuilder.java
@@ -181,8 +181,8 @@ public class TestMicroBatchBuilder extends TableTestBase {
 
   @Test
   public void testReadingSnapshotIsNotInterruptedByChildSnapshot() {
-    // Add files A-E, all of 10kb, and process in multiple microbatches,
-    // generating snapshot 1 containing all of these.
+    // Add files A-E, all of 10kb, and process the single snapshot
+    // in multiple microbatches.
     add(table.newAppend(), files("A", "B", "C", "D", "E"));
     Assert.assertEquals(1L, table.currentSnapshot().snapshotId());
 

--- a/core/src/test/java/org/apache/iceberg/TestMicroBatchBuilder.java
+++ b/core/src/test/java/org/apache/iceberg/TestMicroBatchBuilder.java
@@ -196,14 +196,13 @@ public class TestMicroBatchBuilder extends TableTestBase {
     filesMatch(Lists.newArrayList("A", "B", "C", "D"), filesToScan(batch0.tasks()));
     Assert.assertFalse(batch0.lastIndexOfSnapshot());
 
-    // Concurrent sometime after the start of the last batch and before the next batch.
-    // Simulates desired stream behavior on Trigger.Once().
-    long sizeOfFileF = 25L;
+    // Concurrent write sometime after the start of the last batch and before the next batch.long sizeOfFileF = 25L;
     add(table.newAppend(),
             Collections.singletonList(fileWithSize("F", sizeOfFileF)));
     Assert.assertEquals(2L, table.currentSnapshot().snapshotId());
 
-    // Read the last 10kb
+    // Read the last 10kb of Snapshot 1.
+    // Simulates desired stream behavior for example on Trigger.Once().
     MicroBatch batch1 = MicroBatches.from(table.snapshot(1L), table.io())
             .specsById(table.specs())
             .generate(batch0.endFileIndex(), 40L, false);

--- a/core/src/test/java/org/apache/iceberg/TestMicroBatchBuilder.java
+++ b/core/src/test/java/org/apache/iceberg/TestMicroBatchBuilder.java
@@ -196,7 +196,8 @@ public class TestMicroBatchBuilder extends TableTestBase {
     filesMatch(Lists.newArrayList("A", "B", "C", "D"), filesToScan(batch0.tasks()));
     Assert.assertFalse(batch0.lastIndexOfSnapshot());
 
-    // Concurrent write sometime after the start of the last batch and before the next batch.long sizeOfFileF = 25L;
+    // Concurrent write sometime after the start of the last batch and before the next batch.
+    final long sizeOfFileF = 25L;
     add(table.newAppend(),
             Collections.singletonList(fileWithSize("F", sizeOfFileF)));
     Assert.assertEquals(2L, table.currentSnapshot().snapshotId());
@@ -238,8 +239,7 @@ public class TestMicroBatchBuilder extends TableTestBase {
             .build();
   }
 
-  // Previously we always tested with a size of 10 bytes.
-  // TODO - Should we use TableProperties.WRITE_TARGET_FILE_SIZE_BYTES?
+  // Returns default parquet file with size of 10b and 1 record in bucket 0.
   private static DataFile file(String name) {
     return fileWithSize(name, 10l);
   }


### PR DESCRIPTION
I have been looking into adding support for a proper Spark Structured Streaming V2 Data Source

I can see that there was previously a PR, and there was a large amount of discussion around that PR. However, that PR goes all the way back to February 13th.

I would love to pick up where that work left off if @jerryshao is not working on it. I can see there was a very large amount of discussion and it appears as though some code that was suggested by @aokolnychyi and others was added in.

I started by looking through some of the current code and I noticed this (likely) doc typo. I also added in two tests for behavior checks as I was exploring the behavior of the `MicroBatches.from` builder.

I'd like to have one implementation that could eventually possibly be shared by Flink and continuous streaming, as the implementaton is size based and could be dynamic as well, but supporting Trigger.Once() and then triggering sized based batches with deletes in Spark should be prioritized imo as Flink is already working well. Though it should definitely be a source of inspiration when possible.

Please let me know what you think and I'll open several tickets for initial areas that I think need to be addressed based on the comments left on the other PR and we can have further discussion. cc @rdblue @aokolnychyi @HeartSaVioR @RussellSpitzer