### PR TITLE
Hive: Make the TestHiveMetastore connection pool size configurable

### DIFF
--- a/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandlerBaseTest.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandlerBaseTest.java
@@ -108,6 +108,8 @@ public abstract class HiveIcebergStorageHandlerBaseTest {
       ImmutableSet.of("bucketing_version", StatsSetupConst.ROW_COUNT,
           StatsSetupConst.RAW_DATA_SIZE, StatsSetupConst.TOTAL_SIZE, StatsSetupConst.NUM_FILES);
 
+  private static final int METASTORE_POOL_SIZE = 15;
+
   // before variables
   protected static TestHiveMetastore metastore;
 
@@ -119,7 +121,8 @@ public abstract class HiveIcebergStorageHandlerBaseTest {
   @BeforeClass
   public static void beforeClass() {
     metastore = new TestHiveMetastore();
-    metastore.start();
+    // We need to use increased pool size in these tests. See: #1620
+    metastore.start(METASTORE_POOL_SIZE);
   }
 
   @AfterClass


### PR DESCRIPTION
As discussed in #1620 we should make the pool size configurable