### PR TITLE
Select correct ObjectInspector based on Hive version on classpath

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergObjectInspector.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.common.DynMethods;
+import org.apache.iceberg.hive.MetastoreUtil;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
@@ -36,23 +37,29 @@ public final class IcebergObjectInspector extends TypeUtil.SchemaVisitor<ObjectI
 
   // get the correct inspectors depending on whether we're working with Hive2 or Hive3 dependencies
   // we need to do this because there is a breaking API change in Date/TimestampObjectInspector between Hive2 and Hive3
-  private static final ObjectInspector DATE_INSPECTOR = DynMethods.builder("get")
-      .impl("org.apache.iceberg.mr.hive.serde.objectinspector.IcebergDateObjectInspectorHive3")
-      .impl("org.apache.iceberg.mr.hive.serde.objectinspector.IcebergDateObjectInspector")
-      .buildStatic()
-      .invoke();
+  private static final ObjectInspector DATE_INSPECTOR = getObjectInspectorBasedOnHiveVersion("get",
+          "org.apache.iceberg.mr.hive.serde.objectinspector.IcebergDateObjectInspector",
+          "org.apache.iceberg.mr.hive.serde.objectinspector.IcebergDateObjectInspectorHive3",
+          new Class[] {}, new Object[] {});
 
-  private static final ObjectInspector TIMESTAMP_INSPECTOR = DynMethods.builder("get")
-      .impl("org.apache.iceberg.mr.hive.serde.objectinspector.IcebergTimestampObjectInspectorHive3", boolean.class)
-      .impl("org.apache.iceberg.mr.hive.serde.objectinspector.IcebergTimestampObjectInspector", boolean.class)
-      .buildStatic()
-      .invoke(false);
+  private static final ObjectInspector TIMESTAMP_INSPECTOR = getObjectInspectorBasedOnHiveVersion("get",
+          "org.apache.iceberg.mr.hive.serde.objectinspector.IcebergTimestampObjectInspector",
+          "org.apache.iceberg.mr.hive.serde.objectinspector.IcebergTimestampObjectInspectorHive3",
+          new Class[] { boolean.class }, new Object[] { false });
 
-  private static final ObjectInspector TIMESTAMP_INSPECTOR_WITH_TZ = DynMethods.builder("get")
-      .impl("org.apache.iceberg.mr.hive.serde.objectinspector.IcebergTimestampObjectInspectorHive3", boolean.class)
-      .impl("org.apache.iceberg.mr.hive.serde.objectinspector.IcebergTimestampObjectInspector", boolean.class)
-      .buildStatic()
-      .invoke(true);
+  private static final ObjectInspector TIMESTAMP_INSPECTOR_WITH_TZ = getObjectInspectorBasedOnHiveVersion("get",
+          "org.apache.iceberg.mr.hive.serde.objectinspector.IcebergTimestampObjectInspector",
+          "org.apache.iceberg.mr.hive.serde.objectinspector.IcebergTimestampObjectInspectorHive3",
+          new Class[] { boolean.class }, new Object[] { true });
+
+  private static ObjectInspector getObjectInspectorBasedOnHiveVersion(
+          String staticMethod, String hive2Class, String hive3Class, Class[] argTypes, Object[] args) {
+    String classToUse = MetastoreUtil.hive3PresentOnClasspath() ? hive3Class : hive2Class;
+    return DynMethods.builder(staticMethod)
+            .impl(classToUse, argTypes)
+            .buildStatic()
+            .invoke(args);
+  }
 
   public static ObjectInspector create(@Nullable Schema schema) {
     if (schema == null) {


### PR DESCRIPTION
To fix https://github.com/apache/iceberg/issues/1630, the ObjectInspector selection logic needs to depend on checking the presence of Hive3 classes on the classpath.
cc @rdblue @massdosage @pvary - thanks for checking!

