### PR TITLE
Allow loading custom Catalog implementation in Spark and Flink

### DIFF
--- a/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
@@ -326,6 +326,19 @@ public interface Catalog {
   }
 
   /**
+   * Initialize a catalog given a custom name and a map of catalog properties.
+   * <p>
+   * A custom Catalog implementation must have a no-arg constructor.
+   * A compute engine like Spark or Flink will first initialize the catalog without any arguments,
+   * and then call this method to complete catalog initialization with properties passed into the engine.
+   *
+   * @param name a custom name for the catalog
+   * @param properties catalog properties
+   */
+  default void initialize(String name, Map<String, String> properties) {
+  }
+
+  /**
    * A builder used to create valid {@link Table tables} or start create/replace {@link Transaction transactions}.
    * <p>
    * Call {@link #buildTable(TableIdentifier, Schema)} to create a new builder.

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+public class CatalogProperties {
+
+  private CatalogProperties() {
+  }
+
+  public static final String CATALOG_IMPL = "catalog-impl";
+}

--- a/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestCatalogUtil {
+
+  @Test
+  public void loadCustomCatalog() {
+    Map<String, String> options = new HashMap<>();
+    options.put("key", "val");
+    Configuration hadoopConf = new Configuration();
+    String name = "custom";
+    Catalog catalog = CatalogUtil.loadCatalog(TestCatalog.class.getName(), name, options, hadoopConf);
+    Assert.assertTrue(catalog instanceof TestCatalog);
+    Assert.assertEquals(name, ((TestCatalog) catalog).catalogName);
+    Assert.assertEquals(options, ((TestCatalog) catalog).flinkOptions);
+  }
+
+  @Test
+  public void loadCustomCatalog_withHadoopConfig() {
+    Map<String, String> options = new HashMap<>();
+    options.put("key", "val");
+    Configuration hadoopConf = new Configuration();
+    hadoopConf.set("key", "val");
+    String name = "custom";
+    Catalog catalog = CatalogUtil.loadCatalog(TestCatalogConfigurable.class.getName(), name, options, hadoopConf);
+    Assert.assertTrue(catalog instanceof TestCatalogConfigurable);
+    Assert.assertEquals(name, ((TestCatalogConfigurable) catalog).catalogName);
+    Assert.assertEquals(options, ((TestCatalogConfigurable) catalog).flinkOptions);
+    Assert.assertEquals(hadoopConf, ((TestCatalogConfigurable) catalog).configuration);
+  }
+
+  @Test
+  public void loadCustomCatalog_NoArgConstructorNotFound() {
+    Map<String, String> options = new HashMap<>();
+    options.put("key", "val");
+    Configuration hadoopConf = new Configuration();
+    String name = "custom";
+    AssertHelpers.assertThrows("must have no-arg constructor",
+        IllegalArgumentException.class,
+        "missing no-arg constructor",
+        () -> CatalogUtil.loadCatalog(TestCatalogBadConstructor.class.getName(), name, options, hadoopConf));
+  }
+
+  @Test
+  public void loadCustomCatalog_NotImplementCatalog() {
+    Map<String, String> options = new HashMap<>();
+    options.put("key", "val");
+    Configuration hadoopConf = new Configuration();
+    String name = "custom";
+
+    AssertHelpers.assertThrows("must implement catalog",
+        IllegalArgumentException.class,
+        "does not implement Catalog",
+        () -> CatalogUtil.loadCatalog(TestCatalogNoInterface.class.getName(), name, options, hadoopConf));
+  }
+
+  public static class TestCatalog extends BaseMetastoreCatalog {
+
+    private String catalogName;
+    private Map<String, String> flinkOptions;
+
+    public TestCatalog() {
+    }
+
+    @Override
+    public void initialize(String name, Map<String, String> properties) {
+      this.catalogName = name;
+      this.flinkOptions = properties;
+    }
+
+    @Override
+    protected TableOperations newTableOps(TableIdentifier tableIdentifier) {
+      return null;
+    }
+
+    @Override
+    protected String defaultWarehouseLocation(TableIdentifier tableIdentifier) {
+      return null;
+    }
+
+    @Override
+    public List<TableIdentifier> listTables(Namespace namespace) {
+      return null;
+    }
+
+    @Override
+    public boolean dropTable(TableIdentifier identifier, boolean purge) {
+      return false;
+    }
+
+    @Override
+    public void renameTable(TableIdentifier from, TableIdentifier to) {
+
+    }
+  }
+
+  public static class TestCatalogConfigurable extends BaseMetastoreCatalog implements Configurable {
+
+    private String catalogName;
+    private Map<String, String> flinkOptions;
+    private Configuration configuration;
+
+    public TestCatalogConfigurable() {
+    }
+
+    @Override
+    public void initialize(String name, Map<String, String> properties) {
+      this.catalogName = name;
+      this.flinkOptions = properties;
+    }
+
+    @Override
+    public void setConf(Configuration conf) {
+      this.configuration = conf;
+    }
+
+    @Override
+    public Configuration getConf() {
+      return configuration;
+    }
+
+    @Override
+    protected TableOperations newTableOps(TableIdentifier tableIdentifier) {
+      return null;
+    }
+
+    @Override
+    protected String defaultWarehouseLocation(TableIdentifier tableIdentifier) {
+      return null;
+    }
+
+    @Override
+    public List<TableIdentifier> listTables(Namespace namespace) {
+      return null;
+    }
+
+    @Override
+    public boolean dropTable(TableIdentifier identifier, boolean purge) {
+      return false;
+    }
+
+    @Override
+    public void renameTable(TableIdentifier from, TableIdentifier to) {
+
+    }
+  }
+
+  public static class TestCatalogBadConstructor extends BaseMetastoreCatalog {
+
+    public TestCatalogBadConstructor(String arg) {
+    }
+
+    @Override
+    protected TableOperations newTableOps(TableIdentifier tableIdentifier) {
+      return null;
+    }
+
+    @Override
+    protected String defaultWarehouseLocation(TableIdentifier tableIdentifier) {
+      return null;
+    }
+
+    @Override
+    public List<TableIdentifier> listTables(Namespace namespace) {
+      return null;
+    }
+
+    @Override
+    public boolean dropTable(TableIdentifier identifier, boolean purge) {
+      return false;
+    }
+
+    @Override
+    public void renameTable(TableIdentifier from, TableIdentifier to) {
+
+    }
+
+    @Override
+    public void initialize(String name, Map<String, String> properties) {
+    }
+  }
+
+  public static class TestCatalogNoInterface {
+    public TestCatalogNoInterface() {
+    }
+  }
+}

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -23,6 +23,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.runtime.util.HadoopUtils;
@@ -31,6 +32,7 @@ import org.apache.flink.table.descriptors.CatalogDescriptorValidator;
 import org.apache.flink.table.factories.CatalogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
@@ -58,6 +60,9 @@ public class FlinkCatalogFactory implements CatalogFactory {
 
   // Can not just use "type", it conflicts with CATALOG_TYPE.
   public static final String ICEBERG_CATALOG_TYPE = "catalog-type";
+  public static final String ICEBERG_CATALOG_TYPE_HADOOP = "hadoop";
+  public static final String ICEBERG_CATALOG_TYPE_HIVE = "hive";
+
   public static final String HIVE_URI = "uri";
   public static final String HIVE_CLIENT_POOL_SIZE = "clients";
   public static final String HIVE_CONF_DIR = "hive-conf-dir";
@@ -75,9 +80,14 @@ public class FlinkCatalogFactory implements CatalogFactory {
    * @return an Iceberg catalog loader
    */
   protected CatalogLoader createCatalogLoader(String name, Map<String, String> properties, Configuration hadoopConf) {
-    String catalogType = properties.getOrDefault(ICEBERG_CATALOG_TYPE, "hive");
-    switch (catalogType) {
-      case "hive":
+    String catalogImpl = properties.get(CatalogProperties.CATALOG_IMPL);
+    if (catalogImpl != null) {
+      return CatalogLoader.custom(name, properties, hadoopConf, catalogImpl);
+    }
+
+    String catalogType = properties.getOrDefault(ICEBERG_CATALOG_TYPE, ICEBERG_CATALOG_TYPE_HIVE);
+    switch (catalogType.toLowerCase(Locale.ENGLISH)) {
+      case ICEBERG_CATALOG_TYPE_HIVE:
         // The values of properties 'uri', 'warehouse', 'hive-conf-dir' are allowed to be null, in that case it will
         // fallback to parse those values from hadoop configuration which is loaded from classpath.
         String uri = properties.get(HIVE_URI);
@@ -87,7 +97,7 @@ public class FlinkCatalogFactory implements CatalogFactory {
         Configuration newHadoopConf = mergeHiveConf(hadoopConf, hiveConfDir);
         return CatalogLoader.hive(name, newHadoopConf, uri, warehouse, clientPoolSize);
 
-      case "hadoop":
+      case ICEBERG_CATALOG_TYPE_HADOOP:
         String warehouseLocation = properties.get(WAREHOUSE_LOCATION);
         return CatalogLoader.hadoop(name, hadoopConf, warehouseLocation);
 


### PR DESCRIPTION
As we are having multiple new Catalog implementations added to Iceberg, we need a way to load those Catalogs in Spark and Flink easily. Currently there is a simple switch branch that chooses between `hive` and `hadoop` catalogs. This approach requires the `iceberg-spark` and `iceberg-flink` module to take a dependency on the catalog implementation modules. This would potentially bring in many unnecessary dependencies as more and more cloud providers try to add support for Iceberg.

This PR proposes the following way to load custom Catalog implementations:
1. the `type` of a catalog can be `hive` or `hadoop` to keep existing behaviors
2. if `catalog-impl` is set, `type` is ignored and we will load catalog based on the class value
3. A catalog must have a no-arg constructor be initialized by calling `initialize()`
4. A catalog must implement Hadoop `Configurable` to read Hadoop configuration

For example, a `GlueCatalog` will be used in Spark like the following:

```
spark.sql.catalog.glue = org.apache.iceberg.spark.SparkCatalog
spark.sql.catalog.glue.catalog-impl = org.apache.iceberg.aws.glue.GlueCatalog
```