### PR TITLE
add warehouse location check

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -449,6 +449,10 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable, Supp
   Database convertToDatabase(Namespace namespace, Map<String, String> meta) {
     String warehouseLocation = conf.get("hive.metastore.warehouse.dir");
 
+    Preconditions.checkNotNull(
+            warehouseLocation,
+            "Warehouse location is not set: hive.metastore.warehouse.dir=null");
+
     if (!isValidateNamespace(namespace)) {
       throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);
     }


### PR DESCRIPTION
We should add check `hive.metastore.warehouse.dir` here, otherwise users must check the source code to solve.