### PR TITLE
Bump to Apache Arrow 2.0

### DIFF
--- a/versions.props
+++ b/versions.props
@@ -14,8 +14,8 @@ org.apache.commons:commons-lang3 = 3.9
 com.fasterxml.jackson.*:* = 2.10.0
 com.google.guava:guava = 28.0-jre
 com.github.ben-manes.caffeine:caffeine = 2.7.0
-org.apache.arrow:arrow-vector = 1.0.0
-org.apache.arrow:arrow-memory-netty = 1.0.0
+org.apache.arrow:arrow-vector = 2.0.0
+org.apache.arrow:arrow-memory-netty = 2.0.0
 com.github.stephenc.findbugs:findbugs-annotations = 1.3.9-1
 
 # test deps


### PR DESCRIPTION
Apache Arrow 2.0 has been released. For Java nothing big has changed.

Changelog: http://arrow.apache.org/blog/2020/10/22/2.0.0-release/