### PR TITLE
Parquet: Optimize IN predicates in ParquetDictionaryRowGroupFilter

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
@@ -278,8 +278,27 @@ public class ParquetDictionaryRowGroupFilter {
 
       Set<T> dictionary = dict(id, ref.comparator());
 
-      // ROWS_CANNOT_MATCH if all values of the dictionary are not in the set (the intersection is empty)
-      return Sets.intersection(dictionary, literalSet).isEmpty() ? ROWS_CANNOT_MATCH : ROWS_MIGHT_MATCH;
+      // we need to find out the smaller set to iterate through
+      Set<T> smallerSet;
+      Set<T> biggerSet;
+
+      if (literalSet.size() < dictionary.size()) {
+        smallerSet = literalSet;
+        biggerSet = dictionary;
+      } else {
+        smallerSet = dictionary;
+        biggerSet = literalSet;
+      }
+
+      for (T e : smallerSet) {
+        if (biggerSet.contains(e)) {
+          // value sets intersect so rows match
+          return ROWS_MIGHT_MATCH;
+        }
+      }
+
+      // value sets are disjoint so rows don't match
+      return ROWS_CANNOT_MATCH;
     }
 
     @Override


### PR DESCRIPTION
This PR optimizes the evaluation of IN predicates on dictionary encoded columns in Parquet.

The previous solution relied on `isEmpty` on top of `Sets$intersection`. That, in turn, used `Collections$disjoint(set2, set1)`. The latter checks whether the first argument is a set or not. If yes, it would simply iterate over the second argument ignoring the fact that the second argument can be also a set and may be even bigger. All of that led to the fact that we iterated through all dictionary values to evaluate IN predicates.