### PR TITLE
Parquet: Introduce a limit to evaluate IN predicates

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -84,6 +84,9 @@ public class TableProperties {
   public static final String PARQUET_BATCH_SIZE = "read.parquet.vectorization.batch-size";
   public static final int PARQUET_BATCH_SIZE_DEFAULT = 5000;
 
+  public static final String PARQUET_IN_LIMIT = "read.parquet.in-predicate-limit";
+  public static final int PARQUET_IN_LIMIT_DEFAULT = 200;
+
   public static final String OBJECT_STORE_ENABLED = "write.object-storage.enabled";
   public static final boolean OBJECT_STORE_ENABLED_DEFAULT = false;
 

--- a/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
@@ -165,6 +165,7 @@ public abstract class DeleteFilter<T> {
     return openDeletes(file, POS_DELETE_SCHEMA);
   }
 
+  // TODO: propagate read props
   private CloseableIterable<Record> openDeletes(DeleteFile deleteFile, Schema deleteSchema) {
     InputFile input = getInputFile(deleteFile.path().toString());
     switch (deleteFile.format()) {

--- a/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilterTypes.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilterTypes.java
@@ -67,6 +67,7 @@ import org.apache.iceberg.types.Types.TimestampType;
 import org.apache.iceberg.types.Types.UUIDType;
 import org.apache.orc.OrcFile;
 import org.apache.orc.Reader;
+import org.apache.parquet.ParquetReadOptions;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.io.DelegatingSeekableInputStream;
@@ -307,7 +308,8 @@ public class TestMetricsRowGroupFilterTypes {
   }
 
   private boolean shouldReadParquet(Object value) {
-    return new ParquetMetricsRowGroupFilter(SCHEMA, equal(column, value))
+    ParquetReadOptions options = ParquetReadOptions.builder().build();
+    return new ParquetMetricsRowGroupFilter(SCHEMA, equal(column, value), options)
         .shouldRead(parquetSchema, rowGroupMetadata);
   }
 

--- a/flink/src/main/java/org/apache/iceberg/flink/source/FlinkInputFormat.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/source/FlinkInputFormat.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.flink.source;
 
 import java.io.IOException;
+import java.util.Map;
 import org.apache.flink.api.common.io.DefaultInputSplitAssigner;
 import org.apache.flink.api.common.io.InputFormat;
 import org.apache.flink.api.common.io.RichInputFormat;
@@ -46,16 +47,18 @@ public class FlinkInputFormat extends RichInputFormat<RowData, FlinkInputSplit> 
   private final FileIO io;
   private final EncryptionManager encryption;
   private final ScanContext context;
+  private final Map<String, String> properties;
 
   private transient RowDataIterator iterator;
 
   FlinkInputFormat(TableLoader tableLoader, Schema tableSchema, FileIO io, EncryptionManager encryption,
-                   ScanContext context) {
+                   ScanContext context, Map<String, String> properties) {
     this.tableLoader = tableLoader;
     this.tableSchema = tableSchema;
     this.io = io;
     this.encryption = encryption;
     this.context = context;
+    this.properties = properties;
   }
 
   @VisibleForTesting
@@ -92,7 +95,7 @@ public class FlinkInputFormat extends RichInputFormat<RowData, FlinkInputSplit> 
   public void open(FlinkInputSplit split) {
     this.iterator = new RowDataIterator(
         split.getTask(), io, encryption, tableSchema, context.projectedSchema(), context.nameMapping(),
-        context.caseSensitive());
+        context.caseSensitive(), properties);
   }
 
   @Override

--- a/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSource.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSource.java
@@ -155,6 +155,7 @@ public class FlinkSource {
       Schema icebergSchema;
       FileIO io;
       EncryptionManager encryption;
+      Map<String, String> properties;
       if (table == null) {
         // load required fields by table loader.
         tableLoader.open();
@@ -163,6 +164,7 @@ public class FlinkSource {
           icebergSchema = table.schema();
           io = table.io();
           encryption = table.encryption();
+          properties = table.properties();
         } catch (IOException e) {
           throw new UncheckedIOException(e);
         }
@@ -170,6 +172,7 @@ public class FlinkSource {
         icebergSchema = table.schema();
         io = table.io();
         encryption = table.encryption();
+        properties = table.properties();
       }
 
       rowTypeInfo = RowDataTypeInfo.of((RowType) (
@@ -180,7 +183,7 @@ public class FlinkSource {
       context = context.project(projectedSchema == null ? icebergSchema :
           FlinkSchemaUtil.convert(icebergSchema, projectedSchema));
 
-      return new FlinkInputFormat(tableLoader, icebergSchema, io, encryption, context);
+      return new FlinkInputFormat(tableLoader, icebergSchema, io, encryption, context, properties);
     }
 
     public DataStream<RowData> build() {

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -547,6 +547,11 @@ public class Parquet {
       return this;
     }
 
+    public ReadBuilder setAll(Map<String, String> newProperties) {
+      properties.putAll(newProperties);
+      return this;
+    }
+
     public ReadBuilder callInit() {
       this.callInit = true;
       return this;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ReadConf.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ReadConf.java
@@ -95,7 +95,7 @@ class ReadConf<T> {
     ParquetMetricsRowGroupFilter statsFilter = null;
     ParquetDictionaryRowGroupFilter dictFilter = null;
     if (filter != null) {
-      statsFilter = new ParquetMetricsRowGroupFilter(expectedSchema, filter, caseSensitive);
+      statsFilter = new ParquetMetricsRowGroupFilter(expectedSchema, filter, caseSensitive, options);
       dictFilter = new ParquetDictionaryRowGroupFilter(expectedSchema, filter, caseSensitive);
     }
 

--- a/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -68,16 +68,18 @@ class RowDataReader extends BaseDataReader<InternalRow> {
   private final Schema expectedSchema;
   private final String nameMapping;
   private final boolean caseSensitive;
+  private final Map<String, String> properties;
 
   RowDataReader(
       CombinedScanTask task, Schema tableSchema, Schema expectedSchema, String nameMapping, FileIO io,
-      EncryptionManager encryptionManager, boolean caseSensitive) {
+      EncryptionManager encryptionManager, boolean caseSensitive, Map<String, String> properties) {
     super(task, io, encryptionManager);
     this.io = io;
     this.tableSchema = tableSchema;
     this.expectedSchema = expectedSchema;
     this.nameMapping = nameMapping;
     this.caseSensitive = caseSensitive;
+    this.properties = properties;
   }
 
   @Override
@@ -140,6 +142,9 @@ class RowDataReader extends BaseDataReader<InternalRow> {
       builder.withNameMapping(NameMappingParser.fromJson(nameMapping));
     }
 
+    // TODO: propagate properties for Avro
+    // properties.forEach(builder::set);
+
     return builder.build();
   }
 
@@ -149,6 +154,7 @@ class RowDataReader extends BaseDataReader<InternalRow> {
       Schema readSchema,
       Map<Integer, ?> idToConstant) {
     Parquet.ReadBuilder builder = Parquet.read(location)
+        .setAll(properties)
         .reuseContainers()
         .split(task.start(), task.length())
         .project(readSchema)
@@ -181,6 +187,9 @@ class RowDataReader extends BaseDataReader<InternalRow> {
     if (nameMapping != null) {
       builder.withNameMapping(NameMappingParser.fromJson(nameMapping));
     }
+
+    // TODO: propagate properties for ORC
+    // properties.forEach(builder::set);
 
     return builder.build();
   }

--- a/spark/src/main/java/org/apache/iceberg/spark/source/RowDataRewriter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/RowDataRewriter.java
@@ -95,7 +95,7 @@ public class RowDataRewriter implements Serializable {
     long taskId = context.taskAttemptId();
 
     RowDataReader dataReader = new RowDataReader(
-        task, schema, schema, nameMapping, io.value(), encryptionManager.value(), caseSensitive);
+        task, schema, schema, nameMapping, io.value(), encryptionManager.value(), caseSensitive, properties);
 
     StructType structType = SparkSchemaUtil.convert(schema);
     SparkAppenderFactory appenderFactory = new SparkAppenderFactory(properties, schema, structType);

--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
@@ -489,7 +489,9 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
                                                     String nameMapping, FileIO io,
                                                     EncryptionManager encryptionManager, boolean caseSensitive,
                                                     Map<String, String> properties) {
-      return new RowReader(task, tableSchema, expectedSchema, nameMapping, io, encryptionManager, caseSensitive, properties);
+      return new RowReader(
+          task, tableSchema, expectedSchema, nameMapping, io,
+          encryptionManager, caseSensitive, properties);
     }
   }
 


### PR DESCRIPTION
This PR introduces a limit for the number of elements inside IN predicates to apply min/max stats filtering.

Resolves #1588.