### PR TITLE
Build standalone jar for hive3 module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -506,7 +506,6 @@ if (jdkVersion == '8') {
       compile project(':iceberg-hive-metastore')
       compile project(':iceberg-orc')
       compile project(':iceberg-parquet')
-      compile project(':iceberg-mr')
 
       compileOnly("org.apache.hadoop:hadoop-client:3.1.0") {
         exclude group: 'org.apache.avro', module: 'avro'

--- a/build.gradle
+++ b/build.gradle
@@ -483,18 +483,18 @@ if (jdkVersion == '8') {
     sourceSets {
       main {
         java {
-            srcDirs = ['../mr/src/main/java', 'src/main/java']
-            exclude '**/IcebergDateObjectInspector.java'
-            exclude '**/IcebergTimestampObjectInspector.java'
-          }
+          srcDirs = ['../mr/src/main/java', 'src/main/java']
+          exclude '**/IcebergDateObjectInspector.java'
+          exclude '**/IcebergTimestampObjectInspector.java'
+        }
         resources.srcDirs = ['../mr/src/main/resources', 'src/main/resources']
       }
       test {
         java {
-            srcDirs = ['../mr/src/test/java', 'src/test/java']
-            exclude '**/TestIcebergDateObjectInspector.java'
-            exclude '**/TestIcebergTimestampObjectInspector.java'
-          }
+          srcDirs = ['../mr/src/test/java', 'src/test/java']
+          exclude '**/TestIcebergDateObjectInspector.java'
+          exclude '**/TestIcebergTimestampObjectInspector.java'
+        }
         resources.srcDirs = ['../mr/src/test/resources', 'src/test/resources']
       }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -480,18 +480,23 @@ project(':iceberg-mr') {
 if (jdkVersion == '8') {
   project(':iceberg-hive3') {
 
-    // run the tests in iceberg-mr with Hive3 dependencies
     sourceSets {
+      main {
+        java {
+            srcDirs = ['../mr/src/main/java', 'src/main/java']
+            exclude '**/IcebergDateObjectInspector.java'
+            exclude '**/IcebergTimestampObjectInspector.java'
+          }
+        resources.srcDirs = ['../mr/src/main/resources', 'src/main/resources']
+      }
       test {
-        java.srcDirs = ['../mr/src/test/java', 'src/test/java']
+        java {
+            srcDirs = ['../mr/src/test/java', 'src/test/java']
+            exclude '**/TestIcebergDateObjectInspector.java'
+            exclude '**/TestIcebergTimestampObjectInspector.java'
+          }
         resources.srcDirs = ['../mr/src/test/resources', 'src/test/resources']
       }
-    }
-
-    // exclude these Hive2-specific tests from iceberg-mr
-    test {
-      exclude '**/TestIcebergDateObjectInspector.class'
-      exclude '**/TestIcebergTimestampObjectInspector.class'
     }
 
     dependencies {

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergObjectInspector.java
@@ -157,7 +157,8 @@ public class TestIcebergObjectInspector {
       Assert.assertTrue(timestampField.getFieldObjectInspector().getClass().getName()
               .startsWith("org.apache.iceberg.mr.hive.serde.objectinspector.IcebergTimestampObjectInspectorHive3"));
     } else {
-      Assert.assertEquals(IcebergTimestampObjectInspector.get(false), timestampField.getFieldObjectInspector());
+      Assert.assertTrue(timestampField.getFieldObjectInspector().getClass().getName()
+              .startsWith("org.apache.iceberg.mr.hive.serde.objectinspector.IcebergTimestampObjectInspector$"));
     }
 
     // timestamp with tz
@@ -169,7 +170,8 @@ public class TestIcebergObjectInspector {
       Assert.assertTrue(timestampTzField.getFieldObjectInspector().getClass().getName()
               .startsWith("org.apache.iceberg.mr.hive.serde.objectinspector.IcebergTimestampObjectInspectorHive3"));
     } else {
-      Assert.assertEquals(IcebergTimestampObjectInspector.get(true), timestampTzField.getFieldObjectInspector());
+      Assert.assertTrue(timestampTzField.getFieldObjectInspector().getClass().getName()
+              .startsWith("org.apache.iceberg.mr.hive.serde.objectinspector.IcebergTimestampObjectInspector$"));
     }
 
     // UUID


### PR DESCRIPTION
Currently Hive engine-related Iceberg classes are split between `iceberg-mr` and `iceberg-hive3`. This makes it potentially confusing for clients to pull them in as a dependency. For example, if a client uses Hive3, they would - a bit counterintuitively - need to pull in both jars instead of just the `hive3` jar, since `mr` does not contain the hive3-compatible object inspector classes and `hive3` only contains those and nothing else.

To solve that, we should build the `mr` main source files as well with Hive3 dependencies in the `hive3` module, and just exclude those couple of object inspectors that rely on Hive2 classes. This ensures that in the end we get a nice standalone `hive3` jar that clients can readily use. 

@rdblue @massdosage @pvary - Could you please take a look whenever suitable? Thank you