### PR TITLE
Entries Tables Working with Delete Manifests

### DIFF
--- a/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
@@ -115,7 +115,7 @@ public class AllEntriesTable extends BaseMetadataTable {
       ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(filter);
 
       return CloseableIterable.transform(manifests, manifest -> new ManifestEntriesTable.ManifestReadTask(
-          ops.io(), manifest, fileSchema, schemaString, specString, residuals));
+          ops.io(), manifest, fileSchema, schemaString, specString, residuals, ops.current().specsById()));
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg;
 
+import java.util.Map;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.ResidualEvaluator;
@@ -112,7 +113,8 @@ public class ManifestEntriesTable extends BaseMetadataTable {
       ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(filter);
 
       return CloseableIterable.transform(manifests, manifest ->
-          new ManifestReadTask(ops.io(), manifest, fileSchema, schemaString, specString, residuals));
+          new ManifestReadTask(ops.io(), manifest, fileSchema, schemaString, specString, residuals,
+              ops.current().specsById()));
     }
   }
 
@@ -120,20 +122,27 @@ public class ManifestEntriesTable extends BaseMetadataTable {
     private final Schema fileSchema;
     private final FileIO io;
     private final ManifestFile manifest;
+    private final Map<Integer, PartitionSpec> specsById;
 
     ManifestReadTask(FileIO io, ManifestFile manifest, Schema fileSchema, String schemaString,
-                     String specString, ResidualEvaluator residuals) {
+                     String specString, ResidualEvaluator residuals, Map<Integer, PartitionSpec> specsById) {
       super(DataFiles.fromManifest(manifest), null, schemaString, specString, residuals);
       this.fileSchema = fileSchema;
       this.io = io;
       this.manifest = manifest;
+      this.specsById = specsById;
     }
 
     @Override
     public CloseableIterable<StructLike> rows() {
-      return CloseableIterable.transform(
-          ManifestFiles.read(manifest, io).project(fileSchema).entries(),
-          file -> (GenericManifestEntry<?>) file);
+      if (manifest.content() == ManifestContent.DATA) {
+        return CloseableIterable.transform(ManifestFiles.read(manifest, io).project(fileSchema).entries(),
+            file -> (GenericManifestEntry<DataFile>) file);
+      } else {
+        return CloseableIterable.transform(ManifestFiles.readDeleteManifest(manifest, io, specsById)
+                .project(fileSchema).entries(),
+            file -> (GenericManifestEntry<DeleteFile>) file);
+      }
     }
 
     @Override


### PR DESCRIPTION
Previously the entries metadatat tables would throw an exception if a table
had been modified with a rowDelta and had a delete manifest. To fix this we
switch the reader based on the type of manifest that is being read by the
metadata table so that both type of manifest can be displayed.