### PR TITLE
Remove cache expiration in HiveCatalogs cache

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalogs.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalogs.java
@@ -28,10 +28,7 @@ import org.apache.hadoop.hive.conf.HiveConf;
 
 public final class HiveCatalogs {
 
-  private static final Cache<String, HiveCatalog> CATALOG_CACHE = Caffeine.newBuilder()
-      .expireAfterAccess(10, TimeUnit.MINUTES)
-      .removalListener((RemovalListener<String, HiveCatalog>) (uri, catalog, cause) -> catalog.close())
-      .build();
+  private static final Cache<String, HiveCatalog> CATALOG_CACHE = Caffeine.newBuilder().build();
 
   private HiveCatalogs() {
   }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalogs.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalogs.java
@@ -21,8 +21,6 @@ package org.apache.iceberg.hive;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.RemovalListener;
-import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 


### PR DESCRIPTION
This removes the time limit that expires cache entries in `HiveCatalogs`. When a catalog is evicted from the cache it is closed, which closes the client pool used by all of the tables loaded by the catalog. Any table still referenced can no longer be used, which breaks some Spark uses that keep DataFrames around.