### PR TITLE
API: Extend partitioning and sort order

### DIFF
--- a/api/src/main/java/org/apache/iceberg/SortField.java
+++ b/api/src/main/java/org/apache/iceberg/SortField.java
@@ -73,6 +73,22 @@ public class SortField implements Serializable {
     return nullOrder;
   }
 
+  /**
+   * Checks whether this field's order satisfies another field's order.
+   *
+   * @param other another sort field
+   * @return true if this order satisfies the given order
+   */
+  public boolean satisfies(SortField other) {
+    if (this == other) {
+      return true;
+    } else if (sourceId != other.sourceId || direction != other.direction || nullOrder != other.nullOrder) {
+      return false;
+    }
+
+    return transform.satisfiesOrderOf(other.transform);
+  }
+
   @Override
   public String toString() {
     return transform + "(" + sourceId + ") " + direction + " " + nullOrder;

--- a/api/src/main/java/org/apache/iceberg/SortOrder.java
+++ b/api/src/main/java/org/apache/iceberg/SortOrder.java
@@ -227,6 +227,15 @@ public class SortOrder implements Serializable {
       return addSortField(term, SortDirection.DESC, nullOrder);
     }
 
+    public Builder sortBy(String name, SortDirection direction, NullOrder nullOrder) {
+      return addSortField(Expressions.ref(name), direction, nullOrder);
+    }
+
+    public Builder sortBy(Term term, SortDirection direction, NullOrder nullOrder) {
+      return addSortField(term, direction, nullOrder);
+    }
+
+
     public Builder withOrderId(int newOrderId) {
       this.orderId = newOrderId;
       return this;

--- a/api/src/main/java/org/apache/iceberg/SortOrder.java
+++ b/api/src/main/java/org/apache/iceberg/SortOrder.java
@@ -104,7 +104,7 @@ public class SortOrder implements Serializable {
 
     // this ordering has either more or the same number of sort fields
     return IntStream.range(0, anotherSortOrder.fields.length)
-        .allMatch(index -> fields[index].equals(anotherSortOrder.fields[index]));
+        .allMatch(index -> fields[index].satisfies(anotherSortOrder.fields[index]));
   }
 
   /**

--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -263,4 +263,16 @@ public class Expressions {
   public static <T> NamedReference<T> ref(String name) {
     return new NamedReference<>(name);
   }
+
+  /**
+   * Constructs a transform expression for a given column.
+   *
+   * @param name a column name
+   * @param transform a transform function
+   * @param <T> the Java type of this term
+   * @return an unbound transform expression
+   */
+  public static <T> UnboundTerm<T> transform(String name, Transform<?, T> transform) {
+    return new UnboundTransform<>(ref(name), transform);
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/transforms/Dates.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Dates.java
@@ -72,6 +72,26 @@ enum Dates implements Transform<Integer, Integer> {
   }
 
   @Override
+  public boolean preservesOrder() {
+    return true;
+  }
+
+  @Override
+  public boolean satisfiesOrderOf(Transform<?, ?> other) {
+    if (this == other) {
+      return true;
+    }
+
+    if (other instanceof Dates) {
+      // test the granularity, in days. day(ts) => 1 day, months(ts) => 30 days, and day satisfies the order of months
+      Dates otherTransform = (Dates) other;
+      return granularity.getDuration().toDays() <= otherTransform.granularity.getDuration().toDays();
+    }
+
+    return false;
+  }
+
+  @Override
   public UnboundPredicate<Integer> project(String fieldName, BoundPredicate<Integer> pred) {
     if (pred.term() instanceof BoundTransform) {
       return ProjectionUtil.projectTransformPredicate(this, name, pred);

--- a/api/src/main/java/org/apache/iceberg/transforms/Identity.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Identity.java
@@ -55,6 +55,17 @@ class Identity<T> implements Transform<T, T> {
   }
 
   @Override
+  public boolean preservesOrder() {
+    return true;
+  }
+
+  @Override
+  public boolean satisfiesOrderOf(Transform<?, ?> other) {
+    // ordering by value is the same as long as the other preserves order
+    return other.preservesOrder();
+  }
+
+  @Override
   public UnboundPredicate<T> project(String name, BoundPredicate<T> predicate) {
     return projectStrict(name, predicate);
   }

--- a/api/src/main/java/org/apache/iceberg/transforms/PartitionSpecVisitor.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/PartitionSpecVisitor.java
@@ -34,11 +34,11 @@ public interface PartitionSpecVisitor<T> {
     throw new UnsupportedOperationException("Identity transform is not supported");
   }
 
-  default T bucket(int fieldId, String sourceName, int sourceId, int width) {
-    return bucket(sourceName, sourceId, width);
+  default T bucket(int fieldId, String sourceName, int sourceId, int numBuckets) {
+    return bucket(sourceName, sourceId, numBuckets);
   }
 
-  default T bucket(String sourceName, int sourceId, int width) {
+  default T bucket(String sourceName, int sourceId, int numBuckets) {
     throw new UnsupportedOperationException("Bucket transform is not supported");
   }
 

--- a/api/src/main/java/org/apache/iceberg/transforms/PartitionSpecVisitor.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/PartitionSpecVisitor.java
@@ -26,20 +26,93 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
 public interface PartitionSpecVisitor<T> {
-  T identity(String sourceName, int sourceId);
+  default T identity(int fieldId, String sourceName, int sourceId) {
+    return identity(sourceName, sourceId);
+  }
 
-  T bucket(String sourceName, int sourceId, int width);
+  default T identity(String sourceName, int sourceId) {
+    throw new UnsupportedOperationException("Identity transform is not supported");
+  }
 
-  T truncate(String sourceName, int sourceId, int width);
+  default T bucket(int fieldId, String sourceName, int sourceId, int width) {
+    return bucket(sourceName, sourceId, width);
+  }
 
-  T year(String sourceName, int sourceId);
+  default T bucket(String sourceName, int sourceId, int width) {
+    throw new UnsupportedOperationException("Bucket transform is not supported");
+  }
 
-  T month(String sourceName, int sourceId);
+  default T truncate(int fieldId, String sourceName, int sourceId, int width) {
+    return truncate(sourceName, sourceId, width);
+  }
 
-  T day(String sourceName, int sourceId);
+  default T truncate(String sourceName, int sourceId, int width) {
+    throw new UnsupportedOperationException("Truncate transform is not supported");
+  }
 
-  T hour(String sourceName, int sourceId);
+  default T year(int fieldId, String sourceName, int sourceId) {
+    return year(sourceName, sourceId);
+  }
 
+  default T year(String sourceName, int sourceId) {
+    throw new UnsupportedOperationException("Year transform is not supported");
+  }
+
+  default T month(int fieldId, String sourceName, int sourceId) {
+    return month(sourceName, sourceId);
+  }
+
+  default T month(String sourceName, int sourceId) {
+    throw new UnsupportedOperationException("Month transform is not supported");
+  }
+
+  default T day(int fieldId, String sourceName, int sourceId) {
+    return day(sourceName, sourceId);
+  }
+
+  default T day(String sourceName, int sourceId) {
+    throw new UnsupportedOperationException("Day transform is not supported");
+  }
+
+  default T hour(int fieldId, String sourceName, int sourceId) {
+    return hour(sourceName, sourceId);
+  }
+
+  default T hour(String sourceName, int sourceId) {
+    throw new UnsupportedOperationException("Hour transform is not supported");
+  }
+
+  default T alwaysNull(int fieldId, String sourceName, int sourceId) {
+    throw new UnsupportedOperationException("Void transform is not supported");
+  }
+
+  default T unknown(int fieldId, String sourceName, int sourceId, String transform) {
+    throw new UnsupportedOperationException(String.format("Unknown transform %s is not supported", transform));
+  }
+
+  /**
+   * Visit the fields of a {@link PartitionSpec}.
+   *
+   * @param spec a partition spec to visit
+   * @param visitor a partition spec visitor
+   * @param <R> return type of the visitor
+   * @return a list of the result produced by visiting each partition field
+   */
+  static <R> List<R> visit(PartitionSpec spec, PartitionSpecVisitor<R> visitor) {
+    return visit(spec.schema(), spec, visitor);
+  }
+
+  /**
+   * Visit the fields of a {@link PartitionSpec}.
+   *
+   * @param schema a schema for source field lookups
+   * @param spec a partition spec to visit
+   * @param visitor a partition spec visitor
+   * @param <R> return type of the visitor
+   * @return a list of the result produced by visiting each partition field
+   * @deprecated this will be removed in 0.11.0; use {@link #visit(PartitionSpec, PartitionSpecVisitor)} instead.
+   */
+  @Deprecated
   static <R> List<R> visit(Schema schema, PartitionSpec spec, PartitionSpecVisitor<R> visitor) {
     List<R> results = Lists.newArrayListWithExpectedSize(spec.fields().size());
 
@@ -48,21 +121,25 @@ public interface PartitionSpecVisitor<T> {
       Transform<?, ?> transform = field.transform();
 
       if (transform instanceof Identity) {
-        results.add(visitor.identity(sourceName, field.sourceId()));
+        results.add(visitor.identity(field.fieldId(), sourceName, field.sourceId()));
       } else if (transform instanceof Bucket) {
-        results.add(visitor.bucket(sourceName, field.sourceId(),
-            ((Bucket<?>) transform).numBuckets()));
+        int numBuckets = ((Bucket<?>) transform).numBuckets();
+        results.add(visitor.bucket(field.fieldId(), sourceName, field.sourceId(), numBuckets));
       } else if (transform instanceof Truncate) {
-        results.add(visitor.truncate(sourceName, field.sourceId(),
-            ((Truncate<?>) transform).width()));
+        int width = ((Truncate<?>) transform).width();
+        results.add(visitor.truncate(field.fieldId(), sourceName, field.sourceId(), width));
       } else if (transform == Dates.YEAR || transform == Timestamps.YEAR) {
-        results.add(visitor.year(sourceName, field.sourceId()));
+        results.add(visitor.year(field.fieldId(), sourceName, field.sourceId()));
       } else if (transform == Dates.MONTH || transform == Timestamps.MONTH) {
-        results.add(visitor.month(sourceName, field.sourceId()));
+        results.add(visitor.month(field.fieldId(), sourceName, field.sourceId()));
       } else if (transform == Dates.DAY || transform == Timestamps.DAY) {
-        results.add(visitor.day(sourceName, field.sourceId()));
+        results.add(visitor.day(field.fieldId(), sourceName, field.sourceId()));
       } else if (transform == Timestamps.HOUR) {
-        results.add(visitor.hour(sourceName, field.sourceId()));
+        results.add(visitor.hour(field.fieldId(), sourceName, field.sourceId()));
+      } else if (transform instanceof VoidTransform) {
+        results.add(visitor.alwaysNull(field.fieldId(), sourceName, field.sourceId()));
+      } else if (transform instanceof UnknownTransform) {
+        results.add(visitor.unknown(field.fieldId(), sourceName, field.sourceId(), transform.toString()));
       }
     }
 

--- a/api/src/main/java/org/apache/iceberg/transforms/PartitionSpecVisitor.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/PartitionSpecVisitor.java
@@ -113,6 +113,7 @@ public interface PartitionSpecVisitor<T> {
    * @deprecated this will be removed in 0.11.0; use {@link #visit(PartitionSpec, PartitionSpecVisitor)} instead.
    */
   @Deprecated
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
   static <R> List<R> visit(Schema schema, PartitionSpec spec, PartitionSpecVisitor<R> visitor) {
     List<R> results = Lists.newArrayListWithExpectedSize(spec.fields().size());
 

--- a/api/src/main/java/org/apache/iceberg/transforms/SortOrderVisitor.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/SortOrderVisitor.java
@@ -55,8 +55,9 @@ public interface SortOrderVisitor<T> {
    * @param <R> return type of the visitor
    * @return a list of the result produced by visiting each sort field
    */
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
   static <R> List<R> visit(SortOrder sortOrder, SortOrderVisitor<R> visitor) {
-    Schema schema = sortOrder.schema();;
+    Schema schema = sortOrder.schema();
     List<R> results = Lists.newArrayListWithExpectedSize(sortOrder.fields().size());
 
     for (SortField field : sortOrder.fields()) {

--- a/api/src/main/java/org/apache/iceberg/transforms/SortOrderVisitor.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/SortOrderVisitor.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.transforms;
+
+import java.util.List;
+import org.apache.iceberg.NullOrder;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortDirection;
+import org.apache.iceberg.SortField;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+public interface SortOrderVisitor<T> {
+
+  T field(String sourceName, int sourceId, SortDirection direction, NullOrder nullOrder);
+
+  T bucket(String sourceName, int sourceId, int width, SortDirection direction, NullOrder nullOrder);
+
+  T truncate(String sourceName, int sourceId, int width, SortDirection direction, NullOrder nullOrder);
+
+  T year(String sourceName, int sourceId, SortDirection direction, NullOrder nullOrder);
+
+  T month(String sourceName, int sourceId, SortDirection direction, NullOrder nullOrder);
+
+  T day(String sourceName, int sourceId, SortDirection direction, NullOrder nullOrder);
+
+  T hour(String sourceName, int sourceId, SortDirection direction, NullOrder nullOrder);
+
+  default T unknown(String sourceName, int sourceId, String transform, SortDirection direction, NullOrder nullOrder) {
+    throw new UnsupportedOperationException(String.format("Unknown transform %s is not supported", transform));
+  }
+
+  /**
+   * Visit the fields of a {@link SortOrder}.
+   *
+   * @param sortOrder a sort order to visit
+   * @param visitor a sort order visitor
+   * @param <R> return type of the visitor
+   * @return a list of the result produced by visiting each sort field
+   */
+  static <R> List<R> visit(SortOrder sortOrder, SortOrderVisitor<R> visitor) {
+    Schema schema = sortOrder.schema();;
+    List<R> results = Lists.newArrayListWithExpectedSize(sortOrder.fields().size());
+
+    for (SortField field : sortOrder.fields()) {
+      String sourceName = schema.findColumnName(field.sourceId());
+      Transform<?, ?> transform = field.transform();
+
+      if (transform == null || transform instanceof Identity) {
+        results.add(visitor.field(sourceName, field.sourceId(), field.direction(), field.nullOrder()));
+      } else if (transform instanceof Bucket) {
+        int numBuckets = ((Bucket<?>) transform).numBuckets();
+        results.add(visitor.bucket(sourceName, field.sourceId(), numBuckets, field.direction(), field.nullOrder()));
+      } else if (transform instanceof Truncate) {
+        int width = ((Truncate<?>) transform).width();
+        results.add(visitor.truncate(sourceName, field.sourceId(), width, field.direction(), field.nullOrder()));
+      } else if (transform == Dates.YEAR || transform == Timestamps.YEAR) {
+        results.add(visitor.year(sourceName, field.sourceId(), field.direction(), field.nullOrder()));
+      } else if (transform == Dates.MONTH || transform == Timestamps.MONTH) {
+        results.add(visitor.month(sourceName, field.sourceId(), field.direction(), field.nullOrder()));
+      } else if (transform == Dates.DAY || transform == Timestamps.DAY) {
+        results.add(visitor.day(sourceName, field.sourceId(), field.direction(), field.nullOrder()));
+      } else if (transform == Timestamps.HOUR) {
+        results.add(visitor.hour(sourceName, field.sourceId(), field.direction(), field.nullOrder()));
+      } else if (transform instanceof UnknownTransform) {
+        results.add(visitor.unknown(
+            sourceName, field.sourceId(), transform.toString(), field.direction(), field.nullOrder()));
+      }
+    }
+
+    return results;
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/transforms/Timestamps.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Timestamps.java
@@ -74,6 +74,26 @@ enum Timestamps implements Transform<Long, Integer> {
   }
 
   @Override
+  public boolean preservesOrder() {
+    return true;
+  }
+
+  @Override
+  public boolean satisfiesOrderOf(Transform<?, ?> other) {
+    if (this == other) {
+      return true;
+    }
+
+    if (other instanceof Timestamps) {
+      // test the granularity, in hours. hour(ts) => 1 hour, day(ts) => 24 hours, and hour satisfies the order of day
+      Timestamps otherTransform = (Timestamps) other;
+      return granularity.getDuration().toHours() <= otherTransform.granularity.getDuration().toHours();
+    }
+
+    return false;
+  }
+
+  @Override
   public UnboundPredicate<Integer> project(String fieldName, BoundPredicate<Long> pred) {
     if (pred.term() instanceof BoundTransform) {
       return ProjectionUtil.projectTransformPredicate(this, name, pred);

--- a/api/src/main/java/org/apache/iceberg/transforms/Transform.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Transform.java
@@ -61,7 +61,7 @@ public interface Transform<S, T> extends Serializable {
   /**
    * Whether the transform preserves the order of values (is monotonic).
    * <p>
-   * A transform preserves order for values when for any given a and b, if a < b then apply(a) <= apply(b).
+   * A transform preserves order for values when for any given a and b, if a &lt; b then apply(a) &lt;= apply(b).
    *
    * @return true if the transform preserves the order of values
    */

--- a/api/src/main/java/org/apache/iceberg/transforms/Transform.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Transform.java
@@ -59,6 +59,29 @@ public interface Transform<S, T> extends Serializable {
   Type getResultType(Type sourceType);
 
   /**
+   * Whether the transform preserves the order of values (is monotonic).
+   * <p>
+   * A transform preserves order for values when for any given a and b, if a < b then apply(a) <= apply(b).
+   *
+   * @return true if the transform preserves the order of values
+   */
+  default boolean preservesOrder() {
+    return false;
+  }
+
+  /**
+   * Whether ordering by this transform's result satisfies the ordering of another transform's result.
+   * <p>
+   * For example, sorting by day(ts) will produce an ordering that is also by month(ts) or year(ts). However, sorting
+   * by day(ts) will not satisfy the order of hour(ts) or identity(ts).
+   *
+   * @return true if ordering by this transform is equivalent to ordering by the other transform
+   */
+  default boolean satisfiesOrderOf(Transform<?, ?> other) {
+    return equals(other);
+  }
+
+  /**
    * Transforms a {@link BoundPredicate predicate} to an inclusive predicate on the partition
    * values produced by {@link #apply(Object)}.
    * <p>

--- a/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
@@ -67,6 +67,11 @@ abstract class Truncate<T> implements Transform<T, T> {
     return sourceType;
   }
 
+  @Override
+  public boolean preservesOrder() {
+    return true;
+  }
+
   private static class TruncateInteger extends Truncate<Integer> {
     private final int width;
 
@@ -256,6 +261,18 @@ abstract class Truncate<T> implements Transform<T, T> {
     @Override
     public boolean canTransform(Type type) {
       return type.typeId() == Type.TypeID.STRING;
+    }
+
+    @Override
+    public boolean satisfiesOrderOf(Transform<?, ?> other) {
+      if (this == other) {
+        return true;
+      } else if (other instanceof TruncateString) {
+        TruncateString otherTransform = (TruncateString) other;
+        return width() >= otherTransform.width();
+      }
+
+      return false;
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/CopySortOrderFields.java
+++ b/core/src/main/java/org/apache/iceberg/CopySortOrderFields.java
@@ -31,71 +31,43 @@ class CopySortOrderFields implements SortOrderVisitor<Void> {
 
   @Override
   public Void field(String sourceName, int sourceId, SortDirection direction, NullOrder nullOrder) {
-    if (direction == SortDirection.ASC) {
-      builder.asc(sourceName, nullOrder);
-    } else {
-      builder.desc(sourceName, nullOrder);
-    }
+    builder.sortBy(sourceName, direction, nullOrder);
     return null;
   }
 
   @Override
   public Void bucket(String sourceName, int sourceId, int numBuckets, SortDirection direction, NullOrder nullOrder) {
-    if (direction == SortDirection.ASC) {
-      builder.asc(Expressions.bucket(sourceName, numBuckets), nullOrder);
-    } else {
-      builder.desc(Expressions.bucket(sourceName, numBuckets), nullOrder);
-    }
+    builder.sortBy(Expressions.bucket(sourceName, numBuckets), direction, nullOrder);
     return null;
   }
 
   @Override
   public Void truncate(String sourceName, int sourceId, int width, SortDirection direction, NullOrder nullOrder) {
-    if (direction == SortDirection.ASC) {
-      builder.asc(Expressions.truncate(sourceName, width), nullOrder);
-    } else {
-      builder.desc(Expressions.truncate(sourceName, width), nullOrder);
-    }
+    builder.sortBy(Expressions.truncate(sourceName, width), direction, nullOrder);
     return null;
   }
 
   @Override
   public Void year(String sourceName, int sourceId, SortDirection direction, NullOrder nullOrder) {
-    if (direction == SortDirection.ASC) {
-      builder.asc(Expressions.year(sourceName), nullOrder);
-    } else {
-      builder.desc(Expressions.year(sourceName), nullOrder);
-    }
+    builder.sortBy(Expressions.year(sourceName), direction, nullOrder);
     return null;
   }
 
   @Override
   public Void month(String sourceName, int sourceId, SortDirection direction, NullOrder nullOrder) {
-    if (direction == SortDirection.ASC) {
-      builder.asc(Expressions.month(sourceName), nullOrder);
-    } else {
-      builder.desc(Expressions.month(sourceName), nullOrder);
-    }
+    builder.sortBy(Expressions.month(sourceName), direction, nullOrder);
     return null;
   }
 
   @Override
   public Void day(String sourceName, int sourceId, SortDirection direction, NullOrder nullOrder) {
-    if (direction == SortDirection.ASC) {
-      builder.asc(Expressions.day(sourceName), nullOrder);
-    } else {
-      builder.desc(Expressions.day(sourceName), nullOrder);
-    }
+    builder.sortBy(Expressions.day(sourceName), direction, nullOrder);
     return null;
   }
 
   @Override
   public Void hour(String sourceName, int sourceId, SortDirection direction, NullOrder nullOrder) {
-    if (direction == SortDirection.ASC) {
-      builder.asc(Expressions.hour(sourceName), nullOrder);
-    } else {
-      builder.desc(Expressions.hour(sourceName), nullOrder);
-    }
+    builder.sortBy(Expressions.hour(sourceName), direction, nullOrder);
     return null;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/CopySortOrderFields.java
+++ b/core/src/main/java/org/apache/iceberg/CopySortOrderFields.java
@@ -1,15 +1,20 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.iceberg;

--- a/core/src/main/java/org/apache/iceberg/CopySortOrderFields.java
+++ b/core/src/main/java/org/apache/iceberg/CopySortOrderFields.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg;
+
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.transforms.SortOrderVisitor;
+
+class CopySortOrderFields implements SortOrderVisitor<Void> {
+  private final SortOrder.Builder builder;
+
+  CopySortOrderFields(SortOrder.Builder builder) {
+    this.builder = builder;
+  }
+
+  @Override
+  public Void field(String sourceName, int sourceId, SortDirection direction, NullOrder nullOrder) {
+    if (direction == SortDirection.ASC) {
+      builder.asc(sourceName, nullOrder);
+    } else {
+      builder.desc(sourceName, nullOrder);
+    }
+    return null;
+  }
+
+  @Override
+  public Void bucket(String sourceName, int sourceId, int numBuckets, SortDirection direction, NullOrder nullOrder) {
+    if (direction == SortDirection.ASC) {
+      builder.asc(Expressions.bucket(sourceName, numBuckets), nullOrder);
+    } else {
+      builder.desc(Expressions.bucket(sourceName, numBuckets), nullOrder);
+    }
+    return null;
+  }
+
+  @Override
+  public Void truncate(String sourceName, int sourceId, int width, SortDirection direction, NullOrder nullOrder) {
+    if (direction == SortDirection.ASC) {
+      builder.asc(Expressions.truncate(sourceName, width), nullOrder);
+    } else {
+      builder.desc(Expressions.truncate(sourceName, width), nullOrder);
+    }
+    return null;
+  }
+
+  @Override
+  public Void year(String sourceName, int sourceId, SortDirection direction, NullOrder nullOrder) {
+    if (direction == SortDirection.ASC) {
+      builder.asc(Expressions.year(sourceName), nullOrder);
+    } else {
+      builder.desc(Expressions.year(sourceName), nullOrder);
+    }
+    return null;
+  }
+
+  @Override
+  public Void month(String sourceName, int sourceId, SortDirection direction, NullOrder nullOrder) {
+    if (direction == SortDirection.ASC) {
+      builder.asc(Expressions.month(sourceName), nullOrder);
+    } else {
+      builder.desc(Expressions.month(sourceName), nullOrder);
+    }
+    return null;
+  }
+
+  @Override
+  public Void day(String sourceName, int sourceId, SortDirection direction, NullOrder nullOrder) {
+    if (direction == SortDirection.ASC) {
+      builder.asc(Expressions.day(sourceName), nullOrder);
+    } else {
+      builder.desc(Expressions.day(sourceName), nullOrder);
+    }
+    return null;
+  }
+
+  @Override
+  public Void hour(String sourceName, int sourceId, SortDirection direction, NullOrder nullOrder) {
+    if (direction == SortDirection.ASC) {
+      builder.asc(Expressions.hour(sourceName), nullOrder);
+    } else {
+      builder.desc(Expressions.hour(sourceName), nullOrder);
+    }
+    return null;
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/Partitioning.java
+++ b/core/src/main/java/org/apache/iceberg/Partitioning.java
@@ -94,6 +94,10 @@ public class Partitioning {
    * @return a sort order that will cluster data for the spec
    */
   public static SortOrder sortOrderFor(PartitionSpec spec) {
+    if (spec.isUnpartitioned()) {
+      return SortOrder.unsorted();
+    }
+
     SortOrder.Builder builder = SortOrder.builderFor(spec.schema());
     SpecToOrderVisitor converter = new SpecToOrderVisitor(builder);
     PartitionSpecVisitor.visit(spec, converter);

--- a/core/src/main/java/org/apache/iceberg/Partitioning.java
+++ b/core/src/main/java/org/apache/iceberg/Partitioning.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.List;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.transforms.PartitionSpecVisitor;
+
+public class Partitioning {
+  private Partitioning() {
+  }
+
+  /**
+   * Check whether the spec contains a bucketed partition field.
+   *
+   * @param spec a partition spec
+   * @return true if the spec has field with a bucket transform
+   */
+  public static boolean hasBucketField(PartitionSpec spec) {
+    List<Boolean> bucketList = PartitionSpecVisitor.visit(spec, new PartitionSpecVisitor<Boolean>() {
+      @Override
+      public Boolean identity(int fieldId, String sourceName, int sourceId) {
+        return false;
+      }
+
+      @Override
+      public Boolean bucket(int fieldId, String sourceName, int sourceId, int width) {
+        return true;
+      }
+
+      @Override
+      public Boolean truncate(int fieldId, String sourceName, int sourceId, int width) {
+        return false;
+      }
+
+      @Override
+      public Boolean year(int fieldId, String sourceName, int sourceId) {
+        return false;
+      }
+
+      @Override
+      public Boolean month(int fieldId, String sourceName, int sourceId) {
+        return false;
+      }
+
+      @Override
+      public Boolean day(int fieldId, String sourceName, int sourceId) {
+        return false;
+      }
+
+      @Override
+      public Boolean hour(int fieldId, String sourceName, int sourceId) {
+        return false;
+      }
+
+      @Override
+      public Boolean alwaysNull(int fieldId, String sourceName, int sourceId) {
+        return false;
+      }
+
+      @Override
+      public Boolean unknown(int fieldId, String sourceName, int sourceId, String transform) {
+        return false;
+      }
+    });
+
+    return bucketList.stream().anyMatch(Boolean::booleanValue);
+  }
+
+  /**
+   * Create a sort order that will group data for a partition spec.
+   * <p>
+   * If the partition spec contains bucket columns, the sort order will also have a field to sort by a column that is
+   * bucketed in the spec. The column is selected by the highest number of buckets in the transform.
+   *
+   * @param spec a partition spec
+   * @return a sort order that will cluster data for the spec
+   */
+  public static SortOrder sortOrderFor(PartitionSpec spec) {
+    SortOrder.Builder builder = SortOrder.builderFor(spec.schema());
+    SpecToOrderVisitor converter = new SpecToOrderVisitor(builder);
+    PartitionSpecVisitor.visit(spec, converter);
+
+    // columns used for bucketing are high cardinality; add one to the sort at the end
+    String bucketColumn = converter.bucketColumn();
+    if (bucketColumn != null) {
+      builder.asc(bucketColumn);
+    }
+
+    return builder.build();
+  }
+
+  private static class SpecToOrderVisitor implements PartitionSpecVisitor<Void> {
+    private final SortOrder.Builder builder;
+    private String bucketColumn = null;
+    private int highestNumBuckets = 0;
+
+    private SpecToOrderVisitor(SortOrder.Builder builder) {
+      this.builder = builder;
+    }
+
+    String bucketColumn() {
+      return bucketColumn;
+    }
+
+    @Override
+    public Void identity(int fieldId, String sourceName, int sourceId) {
+      builder.asc(sourceName);
+      return null;
+    }
+
+    @Override
+    public Void bucket(int fieldId, String sourceName, int sourceId, int numBuckets) {
+      // the column with highest cardinality is usually the one with the highest number of buckets
+      if (numBuckets > highestNumBuckets) {
+        this.highestNumBuckets = numBuckets;
+        this.bucketColumn = sourceName;
+      }
+      builder.asc(Expressions.bucket(sourceName, numBuckets));
+      return null;
+    }
+
+    @Override
+    public Void truncate(int fieldId, String sourceName, int sourceId, int width) {
+      builder.asc(Expressions.truncate(sourceName, width));
+      return null;
+    }
+
+    @Override
+    public Void year(int fieldId, String sourceName, int sourceId) {
+      builder.asc(Expressions.year(sourceName));
+      return null;
+    }
+
+    @Override
+    public Void month(int fieldId, String sourceName, int sourceId) {
+      builder.asc(Expressions.month(sourceName));
+      return null;
+    }
+
+    @Override
+    public Void day(int fieldId, String sourceName, int sourceId) {
+      builder.asc(Expressions.day(sourceName));
+      return null;
+    }
+
+    @Override
+    public Void hour(int fieldId, String sourceName, int sourceId) {
+      builder.asc(Expressions.hour(sourceName));
+      return null;
+    }
+
+    @Override
+    public Void alwaysNull(int fieldId, String sourceName, int sourceId) {
+      // do nothing for alwaysNull, it doesn't need to be added to the sort
+      return null;
+    }
+  }
+}

--- a/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -211,8 +211,8 @@ public class Spark3Util {
           }
 
           @Override
-          public Transform bucket(String sourceName, int sourceId, int width) {
-            return Expressions.bucket(width, sourceName);
+          public Transform bucket(String sourceName, int sourceId, int numBuckets) {
+            return Expressions.bucket(numBuckets, sourceName);
           }
 
           @Override

--- a/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -23,7 +23,6 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.iceberg.PartitionSpec;

--- a/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.iceberg.PartitionSpec;
@@ -238,6 +239,11 @@ public class Spark3Util {
           @Override
           public Transform hour(String sourceName, int sourceId) {
             return Expressions.hours(sourceName);
+          }
+
+          @Override
+          public Transform unknown(int fieldId, String sourceName, int sourceId, String transform) {
+            return Expressions.apply(transform, Expressions.column(sourceName));
           }
         });
 


### PR DESCRIPTION
This updates the partitioning and sort order API with utilities needed for required distribution and ordering.

* Adds `Expressions.transform` to create an `UnboundTransform` term from an existing `Transform` and a field name
* Adds `SortField.satisfies` and `Transform.satisfiesOrderOf` to implement satisfies between compatible fields, like days and hours. Hours satisfies the ordering of days
* Updates `PartitionSpecVisitor` to pass partition field IDs and adds `unknown` and `alwaysNull` visitor methods.
* Adds `SortOrderVisitor` to visit a sort order
* Adds `Partitioning` helper methods `hasBucketField(PartitionSpec)` and `sortOrderFor(PartitionSpec)`
* Adds `CopySortOrderFields` visitor to copy a sort order fields to a sort order builder