### PR TITLE
Fix ArrayIndexOutOfBounds for tables with migrated partition specs

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestsTable.java
@@ -114,7 +114,7 @@ public class ManifestsTable extends BaseMetadataTable {
 
     List<StaticDataTask.Row> rows = Lists.newArrayList();
 
-    for (int i = 0; i < spec.fields().size(); i += 1) {
+    for (int i = 0; i < summaries.size(); i += 1) {
       ManifestFile.PartitionFieldSummary summary = summaries.get(i);
       rows.add(StaticDataTask.Row.of(
           summary.containsNull(),


### PR DESCRIPTION
This fixes a small bug in the manifest table for tables that have a current partition spec with more fields than previously used spec.