### PR TITLE
Enable testInsertOverwrite, passing with Spark 3.0.1

### DIFF
--- a/spark3/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWrites.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWrites.java
@@ -31,7 +31,6 @@ import org.apache.spark.sql.functions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class TestPartitionedWrites extends SparkCatalogTestBase {
@@ -69,7 +68,7 @@ public class TestPartitionedWrites extends SparkCatalogTestBase {
     assertEquals("Row data should match expected", expected, sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 
-  @Ignore // broken because of SPARK-32168, which should be fixed in 3.0.1
+  @Test
   public void testInsertOverwrite() {
     Assert.assertEquals("Should have 3 rows", 3L, scalarSql("SELECT count(*) FROM %s", tableName));
 


### PR DESCRIPTION
This enables a test that was disabled in Spark 3 due to [SPARK-32168](https://issues.apache.org/jira/browse/SPARK-32168).