### PR TITLE
Run all StorageHandler tests with both MR and Tez

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -466,6 +466,8 @@ project(':iceberg-mr') {
     testCompile("org.apache.hive:hive-service") {
       exclude group: 'org.apache.hive', module: 'hive-exec'
     }
+    testCompile("org.apache.tez:tez-dag")
+    testCompile("org.apache.tez:tez-mapreduce")
   }
 
   test {
@@ -531,6 +533,7 @@ if (jdkVersion == '8') {
         exclude group: 'org.apache.hive', module: 'hive-exec'
       }
       testCompile("org.apache.tez:tez-dag:0.9.1")
+      testCompile("org.apache.tez:tez-mapreduce:0.9.1")
     }
 
     test {

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
@@ -51,9 +51,8 @@ public class HiveIcebergSerDe extends AbstractSerDe {
     // the resulting properties are serialized and distributed to the executors
 
     Schema tableSchema;
-    String tableSchemaKey = InputFormatConfig.TABLE_SCHEMA + "." + serDeProperties.get(Catalogs.NAME);
-    if (configuration.get(tableSchemaKey) != null) {
-      tableSchema = SchemaParser.fromJson(configuration.get(tableSchemaKey));
+    if (configuration.get(InputFormatConfig.TABLE_SCHEMA) != null) {
+      tableSchema = SchemaParser.fromJson(configuration.get(InputFormatConfig.TABLE_SCHEMA));
     } else if (serDeProperties.get(InputFormatConfig.TABLE_SCHEMA) != null) {
       tableSchema = SchemaParser.fromJson((String) serDeProperties.get(InputFormatConfig.TABLE_SCHEMA));
     } else {

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
@@ -51,8 +51,9 @@ public class HiveIcebergSerDe extends AbstractSerDe {
     // the resulting properties are serialized and distributed to the executors
 
     Schema tableSchema;
-    if (configuration.get(InputFormatConfig.TABLE_SCHEMA) != null) {
-      tableSchema = SchemaParser.fromJson(configuration.get(InputFormatConfig.TABLE_SCHEMA));
+    String tableSchemaKey = InputFormatConfig.TABLE_SCHEMA + "." + serDeProperties.get(Catalogs.NAME);
+    if (configuration.get(tableSchemaKey) != null) {
+      tableSchema = SchemaParser.fromJson(configuration.get(tableSchemaKey));
     } else if (serDeProperties.get(InputFormatConfig.TABLE_SCHEMA) != null) {
       tableSchema = SchemaParser.fromJson((String) serDeProperties.get(InputFormatConfig.TABLE_SCHEMA));
     } else {

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -97,17 +97,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
 
   @Override
   public void configureJobConf(TableDesc tableDesc, JobConf jobConf) {
-    Properties props = tableDesc.getProperties();
-    Table table = Catalogs.loadTable(conf, props);
-    String schemaString = SchemaParser.toJson(table.schema());
 
-    jobConf.set(InputFormatConfig.TABLE_IDENTIFIER, props.getProperty(Catalogs.NAME));
-    jobConf.set(InputFormatConfig.TABLE_LOCATION, table.location());
-    jobConf.set(InputFormatConfig.TABLE_SCHEMA, schemaString);
-
-    // cache the schema of each table separately in the conf, so they're not overwritten by each other
-    String tableSchemaKey = InputFormatConfig.TABLE_SCHEMA + "." + props.getProperty(Catalogs.NAME);
-    jobConf.set(tableSchemaKey, schemaString);
   }
 
   @Override

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -99,10 +99,15 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
   public void configureJobConf(TableDesc tableDesc, JobConf jobConf) {
     Properties props = tableDesc.getProperties();
     Table table = Catalogs.loadTable(conf, props);
+    String schemaString = SchemaParser.toJson(table.schema());
 
     jobConf.set(InputFormatConfig.TABLE_IDENTIFIER, props.getProperty(Catalogs.NAME));
     jobConf.set(InputFormatConfig.TABLE_LOCATION, table.location());
-    jobConf.set(InputFormatConfig.TABLE_SCHEMA, SchemaParser.toJson(table.schema()));
+    jobConf.set(InputFormatConfig.TABLE_SCHEMA, schemaString);
+
+    // cache the schema of each table separately in the conf, so they're not overwritten by each other
+    String tableSchemaKey = InputFormatConfig.TABLE_SCHEMA + "." + props.getProperty(Catalogs.NAME);
+    jobConf.set(tableSchemaKey, schemaString);
   }
 
   @Override

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandlerBaseTest.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandlerBaseTest.java
@@ -109,13 +109,23 @@ public abstract class HiveIcebergStorageHandlerBaseTest {
 
   public abstract TestTables testTables(Configuration conf, TemporaryFolder tmp) throws IOException;
 
-  @Parameters(name = "fileFormat={0}")
-  public static Iterable<FileFormat> fileFormats() {
-    return ImmutableList.of(FileFormat.PARQUET, FileFormat.ORC, FileFormat.AVRO);
+  @Parameters(name = "fileFormat={0}, engine={1}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+        { FileFormat.PARQUET, "mr" },
+        { FileFormat.ORC,     "mr" },
+        { FileFormat.AVRO,    "mr" },
+        { FileFormat.PARQUET, "tez" },
+        { FileFormat.ORC,     "tez" },
+        { FileFormat.AVRO,    "tez" }
+    };
   }
 
-  @Parameter
+  @Parameter(0)
   public FileFormat fileFormat;
+
+  @Parameter(1)
+  public String executionEngine;
 
   @BeforeClass
   public static void beforeClass() {
@@ -136,6 +146,9 @@ public abstract class HiveIcebergStorageHandlerBaseTest {
     for (Map.Entry<String, String> property : testTables.properties().entrySet()) {
       shell.setHiveSessionValue(property.getKey(), property.getValue());
     }
+    shell.setHiveSessionValue("hive.execution.engine", executionEngine);
+    shell.setHiveSessionValue("hive.jar.directory", temp.getRoot().getAbsolutePath());
+    shell.setHiveSessionValue("tez.staging-dir", temp.getRoot().getAbsolutePath());
   }
 
   @After

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandlerBaseTest.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandlerBaseTest.java
@@ -20,6 +20,8 @@
 package org.apache.iceberg.mr.hive;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -110,15 +112,20 @@ public abstract class HiveIcebergStorageHandlerBaseTest {
   public abstract TestTables testTables(Configuration conf, TemporaryFolder tmp) throws IOException;
 
   @Parameters(name = "fileFormat={0}, engine={1}")
-  public static Object[][] parameters() {
-    return new Object[][] {
-        { FileFormat.PARQUET, "mr" },
-        { FileFormat.ORC,     "mr" },
-        { FileFormat.AVRO,    "mr" },
-        { FileFormat.PARQUET, "tez" },
-        { FileFormat.ORC,     "tez" },
-        { FileFormat.AVRO,    "tez" }
-    };
+  public static Collection<Object[]> parameters() {
+    Collection<Object[]> testParams = new ArrayList<>();
+    testParams.add(new Object[] { FileFormat.PARQUET, "mr" });
+    testParams.add(new Object[] { FileFormat.ORC, "mr" });
+    testParams.add(new Object[] { FileFormat.AVRO, "mr" });
+
+    // include Tez tests only for Java 8
+    String javaVersion = System.getProperty("java.specification.version");
+    if (javaVersion.equals("1.8")) {
+      testParams.add(new Object[] { FileFormat.PARQUET, "tez" });
+      testParams.add(new Object[] { FileFormat.ORC, "tez" });
+      testParams.add(new Object[] { FileFormat.AVRO, "tez" });
+    }
+    return testParams;
   }
 
   @Parameter(0)

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveShell.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveShell.java
@@ -171,6 +171,12 @@ public class TestHiveShell {
     hiveConf.setLongVar(HiveConf.ConfVars.HIVECOUNTERSPULLINTERVAL, 1L);
     hiveConf.setBoolVar(HiveConf.ConfVars.HIVESTATSAUTOGATHER, false);
 
+    // Resource configuration
+    hiveConf.setInt("mapreduce.map.memory.mb", 1024);
+
+    // Tez configuration
+    hiveConf.setBoolean("tez.local.mode", true);
+
     return hiveConf;
   }
 }

--- a/versions.props
+++ b/versions.props
@@ -23,3 +23,5 @@ junit:junit = 4.12
 org.mockito:mockito-core = 1.10.19
 org.apache.hive:hive-exec = 2.3.7
 org.apache.hive:hive-service = 2.3.7
+org.apache.tez:tez-dag = 0.8.4
+org.apache.tez:tez-mapreduce = 0.8.4


### PR DESCRIPTION
Use the execution engine as a test parameter to run all hive storage handler tests with both MR and Tez.

Note: setting the table schema in the global job conf (see https://github.com/apache/iceberg/pull/1557) in `HiveIcebergStorageHandler#configureJobConf()` meant that whichever table called this function last, ended up having its schema stored in the global conf. Then in `HiveIcebergSerde#initialize()`, the schema was taken from the conf when present, but that led to failures since all tables were now using the schema of the table that was the "winner" (setting its schema last in the previous step). To keep the caching nonetheless, I'm now storing and retrieving the schemas of each table separately with no risk of overwriting.

I can't rule out that there are other issues with how job conf is set in https://github.com/apache/iceberg/pull/1557, but I haven't observed any other ones for now. The tests are working with this small tweak.

@rdblue @pvary @lcspinter - could you please review when you have the chance? Thanks!