### PR TITLE
ORC: Enable predicate pushdown and remove metrics workaround for Timestamps

### DIFF
--- a/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilterTypes.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilterTypes.java
@@ -249,13 +249,8 @@ public class TestMetricsRowGroupFilterTypes {
         { "orc", "double", 2.11d, 1.97d },
         { "orc", "date", "2018-06-29", "2018-05-03" },
         { "orc", "time", "10:02:34.000000", "10:02:34.000001" },
-        // Temporarily disable filters on Timestamp columns due to ORC-611.
-        // ORC-611 is closed with fix versions of ORC 1.6.4 and 1.7.0, but
-        // testing on 1.6.4 still lead to failures and 1.7.0 is not published.
-        //
-        // See also HIVE-23036, which is still open.
-        // { "orc", "timestamp", "2018-06-29T10:02:34.000000", "2018-06-29T15:02:34.000000" },
-        // { "orc", "timestamptz", "2018-06-29T10:02:34.000000+00:00", "2018-06-29T10:02:34.000000-07:00" },
+        { "orc", "timestamp", "2018-06-29T10:02:34.000000", "2018-06-29T15:02:34.000000" },
+        { "orc", "timestamptz", "2018-06-29T10:02:34.000000+00:00", "2018-06-29T10:02:34.000000-07:00" },
         { "orc", "string", "tapir", "monthly" },
         // uuid, fixed and binary types not supported yet
         // { "orc", "uuid", uuid, UUID.randomUUID() },

--- a/orc/src/main/java/org/apache/iceberg/orc/ExpressionToSearchArgument.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ExpressionToSearchArgument.java
@@ -53,7 +53,6 @@ class ExpressionToSearchArgument extends ExpressionVisitors.BoundVisitor<Express
 
   // Currently every predicate in ORC requires a PredicateLeaf.Type field which is not available for these Iceberg types
   private static final Set<TypeID> UNSUPPORTED_TYPES = ImmutableSet.of(
-      TypeID.TIMESTAMP, // Temporarily disable filters on Timestamp columns due to ORC-611
       TypeID.BINARY,
       TypeID.FIXED,
       TypeID.UUID,

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.MetricsConfig;
@@ -44,6 +43,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.iceberg.util.UnicodeUtil;
 import org.apache.orc.BooleanColumnStatistics;
 import org.apache.orc.ColumnStatistics;
@@ -198,7 +198,7 @@ public class OrcMetrics {
       TimestampColumnStatistics tColStats = (TimestampColumnStatistics) columnStats;
       Timestamp minValue = tColStats.getMinimumUTC();
       min = Optional.ofNullable(minValue)
-          .map(v -> TimeUnit.MILLISECONDS.toMicros(v.getTime()))
+          .map(v -> DateTimeUtil.microsFromInstant(v.toInstant()))
           .orElse(null);
     } else if (columnStats instanceof BooleanColumnStatistics) {
       BooleanColumnStatistics booleanStats = (BooleanColumnStatistics) columnStats;
@@ -235,8 +235,7 @@ public class OrcMetrics {
       TimestampColumnStatistics tColStats = (TimestampColumnStatistics) columnStats;
       Timestamp maxValue = tColStats.getMaximumUTC();
       max = Optional.ofNullable(maxValue)
-          .map(v -> TimeUnit.MILLISECONDS.toMicros(v.getTime()))
-          .map(v -> v + 1_000) // Add 1 millisecond to handle precision issue due to ORC-611
+          .map(v -> DateTimeUtil.microsFromInstant(v.toInstant()))
           .orElse(null);
     } else if (columnStats instanceof BooleanColumnStatistics) {
       BooleanColumnStatistics booleanStats = (BooleanColumnStatistics) columnStats;

--- a/orc/src/test/java/org/apache/iceberg/orc/TestExpressionToSearchArgument.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestExpressionToSearchArgument.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.orc;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.sql.Date;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
@@ -129,8 +130,8 @@ public class TestExpressionToSearchArgument {
         SearchArgument expected = SearchArgumentFactory.newBuilder()
             .startAnd()
             .equals("`date`", Type.DATE, Date.valueOf(LocalDate.parse("1970-01-11", DateTimeFormatter.ISO_LOCAL_DATE)))
-            // .equals("`tsTz`", Type.TIMESTAMP, Timestamp.from(tsTzPredicate.toInstant()))
-            // .equals("`ts`", Type.TIMESTAMP, Timestamp.from(tsPredicate.toInstant()))
+            .equals("`tsTz`", Type.TIMESTAMP, Timestamp.from(tsTzPredicate.toInstant()))
+            .equals("`ts`", Type.TIMESTAMP, Timestamp.from(tsPredicate.toInstant()))
             .end()
             .build();
 


### PR DESCRIPTION
Now that [ORC-611](https://issues.apache.org/jira/browse/ORC-611#) is fixed, ORC will store statistics for Timestamp types with nanosecond precision. So we can push down predicates and also rely on timestamp statistics reported back by ORC.

For older ORC files which only contain millisecond precision stats, ORC will subtract/add 1 millisecond to the min/max so that the lower/upper bounds are valid and correctly represent the values in the data.