### PR TITLE
ORC: OrcFileAppender#length should return file size on disk

### DIFF
--- a/orc/src/main/java/org/apache/iceberg/orc/OrcFileAppender.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcFileAppender.java
@@ -101,7 +101,7 @@ class OrcFileAppender<D> implements FileAppender<D> {
   public long length() {
     Preconditions.checkState(isClosed,
         "Cannot return length while appending to an open file.");
-    return writer.getRawDataSize();
+    return file.toInputFile().getLength();
   }
 
   @Override


### PR DESCRIPTION
Fixes #1666

There doesn't seem to be a way to get physical file size from the ORC writer itself, so we can do an FS call to get the length. 

cc: @rdblue @zhangjun0x01