### PR TITLE
FIX table refresh missing metadata file. 

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -101,7 +101,11 @@ public class HadoopTableOperations implements TableOperations {
       if (version == null && metadataFile == null && ver == 0) {
         // no v0 metadata means the table doesn't exist yet
         return null;
-      } else if (metadataFile == null) {
+      } else if (metadataFile == null && version != null) {
+        ver = findVersion();
+        metadataFile = getMetadataFile(ver);
+      }
+      if (metadataFile == null) {
         throw new ValidationException("Metadata file for version %d is missing", ver);
       }
 


### PR DESCRIPTION
issue #1702 .

Resolved an asynchronous cleanup file that caused the Metadata file to fail to read.