### PR TITLE
Flink : Fix Repeated Rewrite for RewriteDataFilesAction

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
@@ -228,9 +228,17 @@ public abstract class BaseRewriteDataFilesAction<ThisT>
         .flatMap(Streams::stream)
         .collect(Collectors.toList());
 
-    List<DataFile> addedDataFiles = rewriteDataForTasks(combinedScanTasks);
-    List<DataFile> currentDataFiles = filteredGroupedTasks.values().stream()
-        .flatMap(tasks -> tasks.stream().map(FileScanTask::file))
+    // add a filter  to the CombinedScanTask list to avoid repeated rewrite datafile
+    List<CombinedScanTask> filteredCombinedScanTasks =
+        combinedScanTasks.stream().filter(task -> task.files().size() > 1).collect(Collectors.toList());
+
+    if (filteredCombinedScanTasks.isEmpty()) {
+      return RewriteDataFilesActionResult.empty();
+    }
+
+    List<DataFile> addedDataFiles = rewriteDataForTasks(filteredCombinedScanTasks);
+    List<DataFile> currentDataFiles = filteredCombinedScanTasks.stream()
+        .flatMap(tasks -> tasks.files().stream().map(FileScanTask::file))
         .collect(Collectors.toList());
     replaceDataFiles(currentDataFiles, addedDataFiles);
 

--- a/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
@@ -281,4 +281,91 @@ public class TestRewriteDataFilesAction extends FlinkCatalogTestBase {
     // Assert the table records as expected.
     SimpleDataUtil.assertTableRecords(icebergTableUnPartitioned, expected);
   }
+
+  /**
+   * a test case to test avoid repeate compress
+   * <p>
+   * If datafile cannot be combined to CombinedScanTask with other DataFiles, the size of the CombinedScanTask list size
+   * is 1, so we remove these CombinedScanTasks to avoid compressed repeatedly.
+   * <p>
+   * In this test case,we generated 3 data files and set targetSizeInBytes greater than the largest file size so that
+   * it cannot be  combined a CombinedScanTask with other datafiles. The datafile with the largest file size will not be
+   * compressed.
+   * <p>
+   * For the same data, the file sizes of different formats are different. The file sizes of different formats generated
+   * by the data in the current test case are as follows:
+   * <p>
+   *   avro :
+   *  size  file
+   *  408 00000-0-5a218337-1742-4ed1-83d8-55e301da49b8-00001.avro
+   * 2390 00000-0-8f431924-ec8d-4957-a238-b8fe2b136210-00001.avro
+   *  408 00000-0-9c75bcc4-49f0-4722-9528-c1d5faa50fa7-00001.avro
+   *
+   * orc :
+   * size  file
+   * 1626 00000-0-260d42d1-f00f-4c5f-9628-5f41f6395093-00001.orc
+   *  331 00000-0-942fd38b-d7af-4ad2-a985-0e6ccdb4d8d3-00001.orc
+   *  333 00000-0-ad8f2c34-6cf7-43fe-990f-f8f6389d198e-00001.orc
+   *
+   * parquet :
+   * size  file
+   *  611 00000-0-84e1fd63-a840-4a23-983f-5247e9218cbe-00001.parquet
+   *  611 00000-0-91b070f0-7d17-487c-97ec-de0f0b09aa31-00001.parquet
+   * 2691 00000-0-e09c969d-d6ee-4a41-9e42-9dcbf42bc4e1-00001.parquet
+   *
+   * @throws IOException IOException
+   */
+  @Test
+  public void testRewriteAvoidRepeateCompress() throws IOException {
+    List<String> records = Lists.newArrayList();
+    List<Record> expected = Lists.newArrayList();
+    for (int i = 0; i < 500; i++) {
+      String data = String.valueOf(i) + "hello iceberg,hello flink";
+      records.add("(" + i + ",'" + data + "')");
+      Record record = RECORD.copy();
+      record.setField("id", i);
+      record.setField("data", data);
+      expected.add(record);
+    }
+
+    sql("INSERT INTO %s values " + StringUtils.join(records, ","), TABLE_NAME_UNPARTITIONED);
+    sql("INSERT INTO %s select 1,'a' ", TABLE_NAME_UNPARTITIONED);
+    sql("INSERT INTO %s select 2,'b' ", TABLE_NAME_UNPARTITIONED);
+
+    icebergTableUnPartitioned.refresh();
+
+    CloseableIterable<FileScanTask> tasks = icebergTableUnPartitioned.newScan().planFiles();
+    List<DataFile> dataFiles = Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
+    Assert.assertEquals("Should have 3 data files before rewrite", 3, dataFiles.size());
+
+    Actions actions = Actions.forTable(icebergTableUnPartitioned);
+
+    long targetSizeInBytes = 0L;
+    if (format.equals(FileFormat.AVRO)) {
+      targetSizeInBytes = 2500L;
+    } else if (format.equals(FileFormat.ORC)) {
+      targetSizeInBytes = 1800L;
+    } else if (format.equals(FileFormat.PARQUET)) {
+      targetSizeInBytes = 2800L;
+    }
+
+    RewriteDataFilesActionResult result = actions
+        .rewriteDataFiles()
+        .targetSizeInBytes(targetSizeInBytes)
+        .splitOpenFileCost(1)
+        .execute();
+    Assert.assertEquals("Action should rewrite 2 data files", 2, result.deletedDataFiles().size());
+    Assert.assertEquals("Action should add 1 data file", 1, result.addedDataFiles().size());
+
+    icebergTableUnPartitioned.refresh();
+
+    CloseableIterable<FileScanTask> tasks1 = icebergTableUnPartitioned.newScan().planFiles();
+    List<DataFile> dataFiles1 = Lists.newArrayList(CloseableIterable.transform(tasks1, FileScanTask::file));
+    Assert.assertEquals("Should have 2 data files after rewrite", 2, dataFiles1.size());
+
+    // Assert the table records as expected.
+    expected.add(SimpleDataUtil.createRecord(1, "a"));
+    expected.add(SimpleDataUtil.createRecord(2, "b"));
+    SimpleDataUtil.assertTableRecords(icebergTableUnPartitioned, expected);
+  }
 }


### PR DESCRIPTION
the pr fix #1661 

If DataFile cannot be  combined to CombinedScanTask with other DataFiles, the size of CombinedScanTask list size is 1, so we remove these CombinedScanTasks to avoid compressed repeatedly.