### PR TITLE
add clean for TestFlinkCatalogTable

### DIFF
--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -71,6 +71,7 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
     sql("DROP TABLE IF EXISTS %s.tl", flinkDatabase);
     sql("DROP TABLE IF EXISTS %s.tl2", flinkDatabase);
     sql("DROP DATABASE IF EXISTS %s", flinkDatabase);
+    super.clean();
   }
 
   @Test


### PR DESCRIPTION
I think we should add `super.clean();` for TestFlinkCatalogTable#After method