### PR TITLE
ORC: Fix non-vectorized reader incorrectly skipping rows

### DIFF
--- a/data/src/test/java/org/apache/iceberg/data/orc/TestOrcRowIterator.java
+++ b/data/src/test/java/org/apache/iceberg/data/orc/TestOrcRowIterator.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.data.orc;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.DataTestHelpers;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.orc.ORC;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.apache.orc.OrcConf;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+public class TestOrcRowIterator {
+
+  private static final Schema DATA_SCHEMA = new Schema(
+      required(100, "id", Types.LongType.get())
+  );
+
+  private static final int NUM_ROWS = 8000;
+  private static final List<Record> DATA_ROWS;
+
+  static {
+    DATA_ROWS = Lists.newArrayListWithCapacity(NUM_ROWS);
+    for (long i = 0; i < NUM_ROWS; i++) {
+      Record row = GenericRecord.create(DATA_SCHEMA);
+      row.set(0, i);
+      DATA_ROWS.add(row);
+    }
+  }
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  private File testFile;
+
+  @Before
+  public void writeFile() throws IOException {
+    testFile = temp.newFile();
+    Assert.assertTrue("Delete should succeed", testFile.delete());
+
+    try (FileAppender<Record> writer = ORC.write(Files.localOutput(testFile))
+        .createWriterFunc(GenericOrcWriter::buildWriter)
+        .schema(DATA_SCHEMA)
+        // write in such a way that the file contains 2 stripes each with 4 row groups of 1000 rows
+        .config("iceberg.orc.vectorbatch.size", "1000")
+        .config(OrcConf.ROW_INDEX_STRIDE.getAttribute(), "1000")
+        .config(OrcConf.ROWS_BETWEEN_CHECKS.getAttribute(), "4000")
+        .config(OrcConf.STRIPE_SIZE.getAttribute(), "1")
+        .build()) {
+      writer.addAll(DATA_ROWS);
+    }
+  }
+
+  @Test
+  public void testReadAllStripes() throws IOException {
+    // With default batch size of 1024, will read the following batches
+    // Stripe 1: 1024, 1024, 1024, 928
+    // Stripe 2: 1024, 1024, 1024, 928
+    readAndValidate(Expressions.alwaysTrue(), DATA_ROWS);
+  }
+
+  @Test
+  public void testReadFilteredRowGroupInMiddle() throws IOException {
+    // We skip the 2nd row group [1000, 2000] in Stripe 1
+    // With default batch size of 1024, will read the following batches
+    // Stripe 1: 1000, 1024, 976
+    readAndValidate(Expressions.in("id", 500, 2500, 3500),
+        Lists.newArrayList(Iterables.concat(DATA_ROWS.subList(0, 1000), DATA_ROWS.subList(2000, 4000))));
+  }
+
+  private void readAndValidate(Expression filter, List<Record> expected) throws IOException {
+    List<Record> rows;
+    try (CloseableIterable<Record> reader = ORC.read(Files.localInput(testFile))
+        .project(DATA_SCHEMA)
+        .filter(filter)
+        .createReaderFunc(fileSchema -> GenericOrcReader.buildReader(DATA_SCHEMA, fileSchema))
+        .build()) {
+      rows = Lists.newArrayList(reader);
+    }
+
+    for (int i = 0; i < expected.size(); i += 1) {
+      DataTestHelpers.assertEquals(DATA_SCHEMA.asStruct(), expected.get(i), rows.get(i));
+    }
+  }
+}

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcIterable.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcIterable.java
@@ -151,7 +151,11 @@ class OrcIterable<T> extends CloseableGroup implements CloseableIterable<T> {
 
     @Override
     public T next() {
-      if (current == null || nextRow >= current.size) {
+      // batchIter.hasAdvanced() signifies that new data was already read into the VectorizedRowBatchIterator
+      // by the previous batchIter.hasNext() call and the current batch information must be reset/refetched
+      // batchIter.next() will set batchIter.hasAdvanced() to false until the row batch is exhausted and
+      // batchIter.hasNext() triggers another advance
+      if (current == null || nextRow >= current.size || batchIter.hasAdvanced()) {
         Pair<VectorizedRowBatch, Long> nextBatch = batchIter.next();
         current = nextBatch.first();
         nextRow = 0;

--- a/orc/src/main/java/org/apache/iceberg/orc/VectorizedRowBatchIterator.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/VectorizedRowBatchIterator.java
@@ -32,7 +32,7 @@ import org.apache.orc.storage.ql.exec.vector.VectorizedRowBatch;
  * Because the same VectorizedRowBatch is reused on each call to next,
  * it gets changed when hasNext or next is called.
  */
-public class VectorizedRowBatchIterator implements CloseableIterator<Pair<VectorizedRowBatch, Long>> {
+class VectorizedRowBatchIterator implements CloseableIterator<Pair<VectorizedRowBatch, Long>> {
   private final String fileLocation;
   private final RecordReader rows;
   private final VectorizedRowBatch batch;
@@ -75,5 +75,12 @@ public class VectorizedRowBatchIterator implements CloseableIterator<Pair<Vector
     // mark it as used
     advanced = false;
     return Pair.of(batch, batchOffsetInFile);
+  }
+
+  /**
+   * @return true if a new data was read into the {@link VectorizedRowBatch}
+   */
+  boolean hasAdvanced() {
+    return advanced;
   }
 }

--- a/orc/src/main/java/org/apache/iceberg/orc/VectorizedRowBatchIterator.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/VectorizedRowBatchIterator.java
@@ -32,7 +32,7 @@ import org.apache.orc.storage.ql.exec.vector.VectorizedRowBatch;
  * Because the same VectorizedRowBatch is reused on each call to next,
  * it gets changed when hasNext or next is called.
  */
-class VectorizedRowBatchIterator implements CloseableIterator<Pair<VectorizedRowBatch, Long>> {
+public class VectorizedRowBatchIterator implements CloseableIterator<Pair<VectorizedRowBatch, Long>> {
   private final String fileLocation;
   private final RecordReader rows;
   private final VectorizedRowBatch batch;
@@ -75,12 +75,5 @@ class VectorizedRowBatchIterator implements CloseableIterator<Pair<VectorizedRow
     // mark it as used
     advanced = false;
     return Pair.of(batch, batchOffsetInFile);
-  }
-
-  /**
-   * @return true if a new data was read into the {@link VectorizedRowBatch}
-   */
-  boolean hasAdvanced() {
-    return advanced;
   }
 }


### PR DESCRIPTION
ORC non-vectorized code path uses the following condition in `OrcRowIterator#next()` to determine if a new batch should be read and row batch counter should be reset.
`if (batch == null || nextRow >= batch.size)` (Note: the code uses `current` as the variable name instead of `batch`)

Since the batch object is reused, `#hasNext()` can cause a new batch to be loaded in case the existing batch was consumed. In such a case, the condition in `#next()` will cause the row batch counter to be reset. However, if `#hasNext()` was called prior to this, the `batch` variable will already have data loaded for the next batch and so `batch.size` will give size of the newly loaded batch.

In some cases, the batch sizes across batches will remain the same and so the current condition works fine. However, there can be cases where batch size of the next batch is greater than the current batch and so the condition  `nextRow >= batch.size` will be false even if a new batch was loaded causing `nextRow` to not be reset and rows from the new row batch being skipped.

The conditions under which this case can occur:
1) The first batch of a stripe will in most cases have batch size greater than the last batch of the previous stripe. This is because ORC will avoid loading rows from two stripes in the same batch, causing the last batch of a stripe to be small.   
1) Filters may cause some row groups to be skipped. ORC will only load rows in a batch which come from contiguous row groups within a stripe. So similar to 1. the first batch of a contiguous row group will in most cases have batch size greater than the last batch of the previous read row group.

This PR stores the current batch size in a local variable when the batch is loaded so that calls to `#hasNext()` do not affect the condition in `#next()`.