### PR TITLE
Revert "Hive: Fix missing table schema in Hive 1.1 query (#1557)"

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -97,12 +97,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
 
   @Override
   public void configureJobConf(TableDesc tableDesc, JobConf jobConf) {
-    Properties props = tableDesc.getProperties();
-    Table table = Catalogs.loadTable(conf, props);
 
-    jobConf.set(InputFormatConfig.TABLE_IDENTIFIER, props.getProperty(Catalogs.NAME));
-    jobConf.set(InputFormatConfig.TABLE_LOCATION, table.location());
-    jobConf.set(InputFormatConfig.TABLE_SCHEMA, SchemaParser.toJson(table.schema()));
   }
 
   @Override


### PR DESCRIPTION
This reverts commit 13d94bc2e4e2dcae3d964b98dbb3aaeee19b46c2.

See issue: https://github.com/apache/iceberg/issues/1708