### PR TITLE
Improve log settings in Hive unit tests

### DIFF
--- a/hive3/src/test/resources/log4j2.properties
+++ b/hive3/src/test/resources/log4j2.properties
@@ -1,14 +1,19 @@
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-#       http://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 # Configuration for modules which are using log4j v2 (e.g. Hive3)
 

--- a/hive3/src/test/resources/log4j2.properties
+++ b/hive3/src/test/resources/log4j2.properties
@@ -10,7 +10,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-# Configuration for modules which are using log4j v2 (e.g. Hive, Tez)
+# Configuration for modules which are using log4j v2 (e.g. Hive3)
 
 appenders = console
 appender.console.type = Console

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandlerBaseTest.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandlerBaseTest.java
@@ -138,6 +138,7 @@ public abstract class HiveIcebergStorageHandlerBaseTest {
   public static void beforeClass() {
     shell = new TestHiveShell();
     shell.setHiveConfValue("hive.notification.event.poll.interval", "-1");
+    shell.setHiveConfValue("hive.tez.exec.print.summary", "true");
     shell.start();
   }
 

--- a/mr/src/test/resources/log4j.properties
+++ b/mr/src/test/resources/log4j.properties
@@ -1,14 +1,19 @@
-#   Licensed under the Apache License, Version 2.0 (the "License");
-#   you may not use this file except in compliance with the License.
-#   You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
 #
-#       http://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
-#   Unless required by applicable law or agreed to in writing, software
-#   distributed under the License is distributed on an "AS IS" BASIS,
-#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#   See the License for the specific language governing permissions and
-#   limitations under the License.
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 
 # Configuration for modules which are using log4j v1 (e.g. Hive2, DataNucleus)
 

--- a/mr/src/test/resources/log4j.properties
+++ b/mr/src/test/resources/log4j.properties
@@ -10,7 +10,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-# Configuration for modules which are using log4j v1 (e.g. DataNucleus)
+# Configuration for modules which are using log4j v1 (e.g. Hive2, DataNucleus)
 
 log4j.rootLogger=WARN,stdout
 log4j.threshold=ALL

--- a/mr/src/test/resources/log4j2.properties
+++ b/mr/src/test/resources/log4j2.properties
@@ -18,11 +18,11 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{ISO8601} %-5p [%t] %c{2} (%F:%M(%L)) - %m%n
 
-rootLogger.level = warn
+rootLogger.level = WARN
 rootLogger.appenderRefs = stdout
 rootLogger.appenderRef.stdout.ref = STDOUT
 
 # custom logger to print Counter values after Tez queries
 logger = counters
 logger.counters.name = org.apache.hadoop.hive.ql.exec.Task
-logger.counters.level = info
+logger.counters.level = INFO

--- a/mr/src/test/resources/log4j2.properties
+++ b/mr/src/test/resources/log4j2.properties
@@ -10,10 +10,19 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-# Configuration for modules which are using log4j v1 (e.g. DataNucleus)
+# Configuration for modules which are using log4j v2 (e.g. Hive, Tez)
 
-log4j.rootLogger=WARN,stdout
-log4j.threshold=ALL
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c{2} (%F:%M(%L)) - %m%n
+appenders = console
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{ISO8601} %-5p [%t] %c{2} (%F:%M(%L)) - %m%n
+
+rootLogger.level = warn
+rootLogger.appenderRefs = stdout
+rootLogger.appenderRef.stdout.ref = STDOUT
+
+# custom logger to print Counter values after Tez queries
+logger = counters
+logger.counters.name = org.apache.hadoop.hive.ql.exec.Task
+logger.counters.level = info


### PR DESCRIPTION
- Current log4j properties is only used by Hive2 and DataNucleus but not Hive3 -> adding a log4j2 props file to drive logging configuration for Hive3
- Changing root log level to warn to remove log noise (e.g. datanucleus debug logs), this can be tuned back to lower levels whenever debugging is needed
- Enabling a flag to print execution summary and counter values for Tez queries (DAG stages, execution times, number of records/bytes read/written, etc.)

cc @rdblue @pvary 