### PR TITLE
Fix Actions to be Compatible with V2 Catalogs

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -82,22 +82,23 @@
         <module name="AvoidStarImport"/> <!-- Java Style Guide: No wildcard imports -->
         <module name="AvoidStaticImport"> <!-- Java Style Guide: No static imports -->
             <property name="excludes" value="
+                com.google.common.base.Preconditions.*,
+                com.palantir.logsafe.Preconditions.*,
                 java.util.Collections.*,
                 java.util.stream.Collectors.*,
-                com.palantir.logsafe.Preconditions.*,
-                com.google.common.base.Preconditions.*,
                 org.apache.commons.lang3.Validate.*,
                 org.apache.iceberg.expressions.Expressions.*,
                 org.apache.iceberg.expressions.Expression.Operation.*,
+                org.apache.iceberg.NullOrder.*,
+                org.apache.iceberg.MetadataTableType.*,
+                org.apache.iceberg.SortDirection.*,
+                org.apache.iceberg.TableProperties.*,
+                org.apache.iceberg.types.Type.*,
+                org.apache.iceberg.types.Types.NestedField.*,
                 org.apache.parquet.schema.OriginalType.*,
                 org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.*,
-                org.apache.iceberg.types.Types.NestedField.*,
-                org.apache.iceberg.TableProperties.*,
-                org.apache.iceberg.NullOrder.*,
-                org.apache.iceberg.SortDirection.*,
-                org.apache.iceberg.types.Type.*,
-                org.junit.Assert.*,
-                org.apache.spark.sql.functions.*"/>
+                org.apache.spark.sql.functions.*,
+                org.junit.Assert.*"/>
         </module>
         <module name="ClassTypeParameterName"> <!-- Java Style Guide: Type variable names -->
             <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>

--- a/spark/src/main/java/org/apache/iceberg/actions/BaseSparkAction.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/BaseSparkAction.java
@@ -24,11 +24,14 @@ import java.util.List;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.StaticTableOperations;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.io.ClosingIterator;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.SparkUtil;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.FlatMapFunction;
@@ -38,7 +41,43 @@ import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 
-abstract class BaseSparkAction<R> extends BaseAction<R> implements Action<R> {
+abstract class BaseSparkAction<R> implements Action<R> {
+
+  protected abstract Table table();
+
+  /**
+   * Returns all the path locations of all Manifest Lists for a given list of snapshots
+   * @param snapshots snapshots
+   * @return the paths of the Manifest Lists
+   */
+  private List<String> getManifestListPaths(Iterable<Snapshot> snapshots) {
+    List<String> manifestLists = Lists.newArrayList();
+    for (Snapshot snapshot : snapshots) {
+      String manifestListLocation = snapshot.manifestListLocation();
+      if (manifestListLocation != null) {
+        manifestLists.add(manifestListLocation);
+      }
+    }
+    return manifestLists;
+  }
+
+  /**
+   * Returns all Metadata file paths which may not be in the current metadata. Specifically
+   * this includes "version-hint" files as well as entries in metadata.previousFiles.
+   * @param ops TableOperations for the table we will be getting paths from
+   * @return a list of paths to metadata files
+   */
+  private List<String> getOtherMetadataFilePaths(TableOperations ops) {
+    List<String> otherMetadataFiles = Lists.newArrayList();
+    otherMetadataFiles.add(ops.metadataFileLocation("version-hint.text"));
+
+    TableMetadata metadata = ops.current();
+    otherMetadataFiles.add(metadata.metadataFileLocation());
+    for (TableMetadata.MetadataLogEntry previousMetadataFile : metadata.previousFiles()) {
+      otherMetadataFiles.add(previousMetadataFile.file());
+    }
+    return otherMetadataFiles;
+  }
 
   protected Dataset<Row> buildValidDataFileDF(SparkSession spark) {
     return buildValidDataFileDF(spark, table().name());
@@ -47,9 +86,9 @@ abstract class BaseSparkAction<R> extends BaseAction<R> implements Action<R> {
   protected Dataset<Row> buildValidDataFileDF(SparkSession spark, String tableName) {
     JavaSparkContext context = new JavaSparkContext(spark.sparkContext());
     Broadcast<FileIO> ioBroadcast = context.broadcast(SparkUtil.serializableFileIO(table()));
-    String allManifestsMetadataTable = metadataTableName(tableName, MetadataTableType.ALL_MANIFESTS);
 
-    Dataset<ManifestFileBean> allManifests = spark.read().format("iceberg").load(allManifestsMetadataTable)
+    Dataset<ManifestFileBean> allManifests = loadMetadataTable(spark, tableName, table().location(),
+        MetadataTableType.ALL_MANIFESTS)
         .selectExpr("path", "length", "partition_spec_id as partitionSpecId", "added_snapshot_id as addedSnapshotId")
         .dropDuplicates("path")
         .repartition(spark.sessionState().conf().numShufflePartitions()) // avoid adaptive execution combining tasks
@@ -59,8 +98,8 @@ abstract class BaseSparkAction<R> extends BaseAction<R> implements Action<R> {
   }
 
   protected Dataset<Row> buildManifestFileDF(SparkSession spark, String tableName) {
-    String allManifestsMetadataTable = metadataTableName(tableName, MetadataTableType.ALL_MANIFESTS);
-    return spark.read().format("iceberg").load(allManifestsMetadataTable).selectExpr("path as file_path");
+    return loadMetadataTable(spark, tableName, table().location(), MetadataTableType.ALL_MANIFESTS)
+        .selectExpr("path as file_path");
   }
 
   protected Dataset<Row> buildManifestListDF(SparkSession spark, Table table) {
@@ -84,6 +123,33 @@ abstract class BaseSparkAction<R> extends BaseAction<R> implements Action<R> {
     Dataset<Row> otherMetadataFileDF = buildOtherMetadataFileDF(spark, ops);
 
     return manifestDF.union(otherMetadataFileDF).union(manifestListDF);
+  }
+
+  protected static Dataset<Row> loadMetadataTable(SparkSession spark, String tableName, String tableLocation,
+                                                  MetadataTableType type) {
+    String metadataTableName = metadataTableName(tableName, tableLocation, type);
+    if (!metadataTableName.contains("/") && metadataTableName.split("\\.").length > 3) {
+      // This table has a three or more components and is not a file (catalog.db.table.meta), use the V2 read path
+      return spark.table(metadataTableName);
+    } else {
+      // This table is file based or has no catalog (db.tableName.meta) or (/some/path#meta), read via non-catalog path
+      return spark.read().format("iceberg").load(metadataTableName);
+    }
+  }
+
+  private static String metadataTableName(String tableName, String tableLocation, MetadataTableType type) {
+    if (tableName.contains("/")) {
+      return tableName + "#" + type;
+    } else if (tableName.startsWith("hadoop.")) {
+      // for HadoopCatalog tables, use the table location to load the metadata table
+      // because IcebergCatalog uses HiveCatalog when the table is identified by name
+      return tableLocation + "#" + type;
+    } else if (tableName.startsWith("hive.")) {
+      // HiveCatalog prepend a logical name which we need to drop for Spark 2.4
+      return tableName.replaceFirst("hive\\.", "") + "." + type;
+    } else {
+      return tableName + "." + type;
+    }
   }
 
   private static class ReadManifest implements FlatMapFunction<ManifestFileBean, String> {

--- a/spark/src/main/java/org/apache/iceberg/actions/BaseSparkAction.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/BaseSparkAction.java
@@ -44,9 +44,7 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.parser.ParseException;
 
-// CHECKSTYLE:OFF
 import static org.apache.iceberg.MetadataTableType.ALL_MANIFESTS;
-// CHECKSTYLE:ON
 
 abstract class BaseSparkAction<R> implements Action<R> {
 

--- a/spark/src/main/java/org/apache/iceberg/actions/RewriteManifestsAction.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/RewriteManifestsAction.java
@@ -202,9 +202,8 @@ public class RewriteManifestsAction
         .createDataset(Lists.transform(manifests, ManifestFile::path), Encoders.STRING())
         .toDF("manifest");
 
-    String entriesMetadataTable = metadataTableName(MetadataTableType.ENTRIES);
-    Dataset<Row> manifestEntryDF = spark.read().format("iceberg")
-        .load(entriesMetadataTable)
+    Dataset<Row> manifestEntryDF = BaseSparkAction.loadMetadataTable(spark, table.name(), table().location(),
+        MetadataTableType.ENTRIES)
         .filter("status < 2") // select only live entries
         .selectExpr("input_file_name() as manifest", "snapshot_id", "sequence_number", "data_file");
 

--- a/spark/src/main/java/org/apache/iceberg/actions/RewriteManifestsAction.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/RewriteManifestsAction.java
@@ -33,7 +33,6 @@ import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.ManifestWriter;
-import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RewriteManifests;
 import org.apache.iceberg.Snapshot;
@@ -66,6 +65,10 @@ import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+// CHECKSTYLE:OFF
+import static org.apache.iceberg.MetadataTableType.ENTRIES;
+// CHECKSTYLE:ON
 
 /**
  * An action that rewrites manifests in a distributed manner and co-locates metadata for partitions.
@@ -202,8 +205,7 @@ public class RewriteManifestsAction
         .createDataset(Lists.transform(manifests, ManifestFile::path), Encoders.STRING())
         .toDF("manifest");
 
-    Dataset<Row> manifestEntryDF = BaseSparkAction.loadMetadataTable(spark, table.name(), table().location(),
-        MetadataTableType.ENTRIES)
+    Dataset<Row> manifestEntryDF = BaseSparkAction.loadMetadataTable(spark, table.name(), table().location(), ENTRIES)
         .filter("status < 2") // select only live entries
         .selectExpr("input_file_name() as manifest", "snapshot_id", "sequence_number", "data_file");
 

--- a/spark/src/main/java/org/apache/iceberg/actions/RewriteManifestsAction.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/RewriteManifestsAction.java
@@ -66,9 +66,7 @@ import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// CHECKSTYLE:OFF
 import static org.apache.iceberg.MetadataTableType.ENTRIES;
-// CHECKSTYLE:ON
 
 /**
  * An action that rewrites manifests in a distributed manner and co-locates metadata for partitions.

--- a/spark3/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction3.java
+++ b/spark3/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction3.java
@@ -19,5 +19,46 @@
 
 package org.apache.iceberg.actions;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.spark.source.SparkTable;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.expressions.Transform;
+import org.junit.Assert;
+import org.junit.Test;
+
 public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
+  @Test
+  public void testSparkCatalogTable() throws TableAlreadyExistsException, NoSuchTableException, IOException {
+    spark.conf().set("spark.sql.catalog.mycat", "org.apache.iceberg.spark.SparkCatalog");
+    spark.conf().set("spark.sql.catalog.mycat.type", "hadoop");
+    spark.conf().set("spark.sql.catalog.mycat.warehouse", tableLocation);
+    SparkCatalog cat = (SparkCatalog) spark.sessionState().catalogManager().catalog("mycat");
+
+    String[] database = {"default"};
+    Identifier id = Identifier.of(database, "table");
+    Map<String, String> options = Maps.newHashMap();
+    Transform[] transforms = {};
+    cat.createTable(id, SparkSchemaUtil.convert(SCHEMA), transforms, options);
+    SparkTable table = cat.loadTable(id);
+
+    spark.sql("INSERT INTO mycat.default.table VALUES (1,1,1)");
+
+    String location = table.table().location().replaceFirst("file:", "");
+    new File(location + "/data/trashfile").createNewFile();
+
+    List<String> results = Actions.forTable(table.table()).removeOrphanFiles()
+        .olderThan(System.currentTimeMillis() + 1000).execute();
+    Assert.assertTrue("trash file should be removed",
+        results.contains("file:" + location + "/data/trashfile"));
+  }
+
+
 }


### PR DESCRIPTION
Previously the Action code would use the table name when attempting to look
up MetadataTable names. This is an issue in Spark3 with V2 catalogs because
we strip off the catalog information if the catalog is named "hadoop" or "hive"
and include it in all other cases. When we include the catalog name this breaks
the lookup code which uses the DataSourceRegistry pathway and not the V2 Table
pathway. To fix this we introduce a method for using the V2 pathway when a catalog
name is present.