### PR TITLE
Publish incremental scan event during planning

### DIFF
--- a/api/src/main/java/org/apache/iceberg/events/IncrementalScanEvent.java
+++ b/api/src/main/java/org/apache/iceberg/events/IncrementalScanEvent.java
@@ -23,7 +23,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.Expression;
 
 /**
- * Event sent to listeners when a table scan is planned.
+ * Event sent to listeners when an incremental table scan is planned.
  */
 public final class IncrementalScanEvent {
   private final String tableName;

--- a/api/src/main/java/org/apache/iceberg/events/IncrementalScanEvent.java
+++ b/api/src/main/java/org/apache/iceberg/events/IncrementalScanEvent.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.events;
+
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.expressions.Expression;
+
+/**
+ * Event sent to listeners when a table scan is planned.
+ */
+public final class IncrementalScanEvent {
+  private final String tableName;
+  private final long fromSnapshotId;
+  private final long toSnapshotId;
+  private final Expression filter;
+  private final Schema projection;
+
+  public IncrementalScanEvent(String tableName, long fromSnapshotId, long toSnapshotId, Expression filter,
+                              Schema projection) {
+    this.tableName = tableName;
+    this.fromSnapshotId = fromSnapshotId;
+    this.toSnapshotId = toSnapshotId;
+    this.filter = filter;
+    this.projection = projection;
+  }
+
+  public String tableName() {
+    return tableName;
+  }
+
+  public long fromSnapshotId() {
+    return fromSnapshotId;
+  }
+
+  public long toSnapshotId() {
+    return toSnapshotId;
+  }
+
+  public Expression filter() {
+    return filter;
+  }
+
+  public Schema projection() {
+    return projection;
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
@@ -21,6 +21,8 @@ package org.apache.iceberg;
 
 import java.util.List;
 import java.util.Set;
+import org.apache.iceberg.events.IncrementalScanEvent;
+import org.apache.iceberg.events.Listeners;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.FluentIterable;
@@ -92,6 +94,9 @@ class IncrementalDataTableScan extends DataTableScan {
     if (shouldIgnoreResiduals()) {
       manifestGroup = manifestGroup.ignoreResiduals();
     }
+
+    Listeners.notifyAll(new IncrementalScanEvent(table().name(), context().fromSnapshotId(),
+        context().toSnapshotId(), context().rowFilter(), schema()));
 
     if (PLAN_SCANS_WITH_WORKER_POOL && manifests.size() > 1) {
       manifestGroup = manifestGroup.planWith(ThreadPools.getWorkerPool());

--- a/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
@@ -70,7 +70,6 @@ class IncrementalDataTableScan extends DataTableScan {
 
   @Override
   public CloseableIterable<FileScanTask> planFiles() {
-    // TODO publish an incremental appends scan event
     List<Snapshot> snapshots = snapshotsWithin(table(),
         context().fromSnapshotId(), context().toSnapshotId());
     Set<Long> snapshotIds = Sets.newHashSet(Iterables.transform(snapshots, Snapshot::snapshotId));

--- a/core/src/test/java/org/apache/iceberg/TestIncrementalDataTableScan.java
+++ b/core/src/test/java/org/apache/iceberg/TestIncrementalDataTableScan.java
@@ -22,6 +22,9 @@ package org.apache.iceberg;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import org.apache.iceberg.events.IncrementalScanEvent;
+import org.apache.iceberg.events.Listener;
+import org.apache.iceberg.events.Listeners;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -78,8 +81,28 @@ public class TestIncrementalDataTableScan extends TableTestBase {
     add(table.newAppend(), files("C"));
     add(table.newAppend(), files("D"));
     add(table.newAppend(), files("E")); // 5
+
+    class MyListener implements Listener<IncrementalScanEvent> {
+
+      IncrementalScanEvent lastEvent = null;
+
+      public void notify(IncrementalScanEvent event) {
+        this.lastEvent = event;
+      }
+
+      public IncrementalScanEvent event() {
+        return lastEvent;
+      }
+    }
+
+    MyListener listener1 = new MyListener();
+    Listeners.register(listener1, IncrementalScanEvent.class);
     filesMatch(Lists.newArrayList("B", "C", "D", "E"), appendsBetweenScan(1, 5));
+    Assert.assertTrue(listener1.event().fromSnapshotId() == 1);
+    Assert.assertTrue(listener1.event().toSnapshotId() == 5);
     filesMatch(Lists.newArrayList("C", "D", "E"), appendsBetweenScan(2, 5));
+    Assert.assertTrue(listener1.event().fromSnapshotId() == 2);
+    Assert.assertTrue(listener1.event().toSnapshotId() == 5);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestIncrementalDataTableScan.java
+++ b/core/src/test/java/org/apache/iceberg/TestIncrementalDataTableScan.java
@@ -103,6 +103,9 @@ public class TestIncrementalDataTableScan extends TableTestBase {
     filesMatch(Lists.newArrayList("C", "D", "E"), appendsBetweenScan(2, 5));
     Assert.assertTrue(listener1.event().fromSnapshotId() == 2);
     Assert.assertTrue(listener1.event().toSnapshotId() == 5);
+    Assert.assertEquals(table.schema(), listener1.event().projection());
+    Assert.assertEquals(Expressions.alwaysTrue(), listener1.event().filter());
+    Assert.assertEquals("test", listener1.event().tableName());
   }
 
   @Test


### PR DESCRIPTION
Fixes #1711 

Changes include: 
- Create a new `IncrementalScanEvent` to keep track of the `from` and `to` snapshot id
- Publish the `IncrementalScanEvent` in` IncrementalDataTableScan` and remove the todo

Tests:
- Modify an existing test to check that the event is being published. 