### PR TITLE
API: one line fix in Expressions with tests

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -120,7 +120,7 @@ public class Expressions {
   }
 
   public static <T> UnboundPredicate<T> notNull(UnboundTerm<T> expr) {
-    return new UnboundPredicate<>(Expression.Operation.IS_NULL, expr);
+    return new UnboundPredicate<>(Expression.Operation.NOT_NULL, expr);
   }
 
   public static <T> UnboundPredicate<T> lessThan(String name, T value) {

--- a/api/src/test/java/org/apache/iceberg/expressions/TestEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestEvaluator.java
@@ -26,8 +26,6 @@ import org.apache.avro.util.Utf8;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.exceptions.ValidationException;
-import org.apache.iceberg.transforms.Transforms;
-import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.StructType;
 import org.junit.Assert;
@@ -49,7 +47,6 @@ import static org.apache.iceberg.expressions.Expressions.notIn;
 import static org.apache.iceberg.expressions.Expressions.notNull;
 import static org.apache.iceberg.expressions.Expressions.or;
 import static org.apache.iceberg.expressions.Expressions.predicate;
-import static org.apache.iceberg.expressions.Expressions.ref;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
@@ -66,20 +63,11 @@ public class TestEvaluator {
 
   @Test
   public void testLessThan() {
-    testLessThan(new Evaluator(STRUCT, lessThan("x", 7)),
-        new Evaluator(STRUCT, lessThan("s1.s2.s3.s4.i", 7)));
-  }
-
-  @Test
-  public void testLessThanWithUnboundTerm() {
-    testLessThan(new Evaluator(STRUCT, lessThan(self("x"), 7)),
-        new Evaluator(STRUCT, lessThan(self("s1.s2.s3.s4.i"), 7)));
-  }
-
-  private void testLessThan(Evaluator evaluator, Evaluator structEvaluator) {
+    Evaluator evaluator = new Evaluator(STRUCT, lessThan("x", 7));
     Assert.assertFalse("7 < 7 => false", evaluator.eval(TestHelpers.Row.of(7, 8, null, null)));
     Assert.assertTrue("6 < 7 => true", evaluator.eval(TestHelpers.Row.of(6, 8, null, null)));
 
+    Evaluator structEvaluator = new Evaluator(STRUCT, lessThan("s1.s2.s3.s4.i", 7));
     Assert.assertFalse("7 < 7 => false",
         structEvaluator.eval(TestHelpers.Row.of(7, 8, null,
             TestHelpers.Row.of(
@@ -96,21 +84,12 @@ public class TestEvaluator {
 
   @Test
   public void testLessThanOrEqual() {
-    testLessThanOrEqual(new Evaluator(STRUCT, lessThanOrEqual("x", 7)),
-        new Evaluator(STRUCT, lessThanOrEqual("s1.s2.s3.s4.i", 7)));
-  }
-
-  @Test
-  public void testLessThanOrEqualWithUnboundTerm() {
-    testLessThanOrEqual(new Evaluator(STRUCT, lessThanOrEqual(self("x"), 7)),
-        new Evaluator(STRUCT, lessThanOrEqual(self("s1.s2.s3.s4.i"), 7)));
-  }
-
-  private void testLessThanOrEqual(Evaluator evaluator, Evaluator structEvaluator) {
+    Evaluator evaluator = new Evaluator(STRUCT, lessThanOrEqual("x", 7));
     Assert.assertTrue("7 <= 7 => true", evaluator.eval(TestHelpers.Row.of(7, 8, null)));
     Assert.assertTrue("6 <= 7 => true", evaluator.eval(TestHelpers.Row.of(6, 8, null)));
     Assert.assertFalse("8 <= 7 => false", evaluator.eval(TestHelpers.Row.of(8, 8, null)));
 
+    Evaluator structEvaluator = new Evaluator(STRUCT, lessThanOrEqual("s1.s2.s3.s4.i", 7));
     Assert.assertTrue("7 <= 7 => true",
         structEvaluator.eval(TestHelpers.Row.of(7, 8, null,
             TestHelpers.Row.of(
@@ -135,21 +114,12 @@ public class TestEvaluator {
 
   @Test
   public void testGreaterThan() {
-    testGreaterThan(new Evaluator(STRUCT, greaterThan("x", 7)),
-        new Evaluator(STRUCT, greaterThan("s1.s2.s3.s4.i", 7)));
-  }
-
-  @Test
-  public void testGreaterThanWithUnboundTerm() {
-    testGreaterThan(new Evaluator(STRUCT, greaterThan(self("x"), 7)),
-        new Evaluator(STRUCT, greaterThan(self("s1.s2.s3.s4.i"), 7)));
-  }
-
-  private void testGreaterThan(Evaluator evaluator, Evaluator structEvaluator) {
+    Evaluator evaluator = new Evaluator(STRUCT, greaterThan("x", 7));
     Assert.assertFalse("7 > 7 => false", evaluator.eval(TestHelpers.Row.of(7, 8, null)));
     Assert.assertFalse("6 > 7 => false", evaluator.eval(TestHelpers.Row.of(6, 8, null)));
     Assert.assertTrue("8 > 7 => true", evaluator.eval(TestHelpers.Row.of(8, 8, null)));
 
+    Evaluator structEvaluator = new Evaluator(STRUCT, greaterThan("s1.s2.s3.s4.i", 7));
     Assert.assertFalse("7 > 7 => false",
         structEvaluator.eval(TestHelpers.Row.of(7, 8, null,
             TestHelpers.Row.of(
@@ -172,21 +142,12 @@ public class TestEvaluator {
 
   @Test
   public void testGreaterThanOrEqual() {
-    testGreaterThanOrEqual(new Evaluator(STRUCT, greaterThanOrEqual("x", 7)),
-        new Evaluator(STRUCT, greaterThanOrEqual("s1.s2.s3.s4.i", 7)));
-  }
-
-  @Test
-  public void testGreaterThanOrEqualWithUnboundTerm() {
-    testGreaterThanOrEqual(new Evaluator(STRUCT, greaterThanOrEqual(self("x"), 7)),
-        new Evaluator(STRUCT, greaterThanOrEqual(self("s1.s2.s3.s4.i"), 7)));
-  }
-
-  private void testGreaterThanOrEqual(Evaluator evaluator, Evaluator structEvaluator) {
+    Evaluator evaluator = new Evaluator(STRUCT, greaterThanOrEqual("x", 7));
     Assert.assertTrue("7 >= 7 => true", evaluator.eval(TestHelpers.Row.of(7, 8, null)));
     Assert.assertFalse("6 >= 7 => false", evaluator.eval(TestHelpers.Row.of(6, 8, null)));
     Assert.assertTrue("8 >= 7 => true", evaluator.eval(TestHelpers.Row.of(8, 8, null)));
 
+    Evaluator structEvaluator = new Evaluator(STRUCT, greaterThanOrEqual("s1.s2.s3.s4.i", 7));
     Assert.assertTrue("7 >= 7 => true",
         structEvaluator.eval(TestHelpers.Row.of(7, 8, null,
             TestHelpers.Row.of(
@@ -209,22 +170,13 @@ public class TestEvaluator {
 
   @Test
   public void testEqual() {
-    testEqual(new Evaluator(STRUCT, equal("x", 7)),
-        new Evaluator(STRUCT, equal("s1.s2.s3.s4.i", 7)));
-  }
-
-  @Test
-  public void testEqualWithUnboundTerm() {
-    testEqual(new Evaluator(STRUCT, equal(self("x"), 7)),
-        new Evaluator(STRUCT, equal(self("s1.s2.s3.s4.i"), 7)));
-  }
-
-  private void testEqual(Evaluator evaluator, Evaluator structEvaluator) {
     Assert.assertEquals(1, equal("x", 5).literals().size());
 
+    Evaluator evaluator = new Evaluator(STRUCT, equal("x", 7));
     Assert.assertTrue("7 == 7 => true", evaluator.eval(TestHelpers.Row.of(7, 8, null)));
     Assert.assertFalse("6 == 7 => false", evaluator.eval(TestHelpers.Row.of(6, 8, null)));
 
+    Evaluator structEvaluator = new Evaluator(STRUCT, equal("s1.s2.s3.s4.i", 7));
     Assert.assertTrue("7 == 7 => true",
         structEvaluator.eval(TestHelpers.Row.of(7, 8, null,
             TestHelpers.Row.of(
@@ -241,22 +193,13 @@ public class TestEvaluator {
 
   @Test
   public void testNotEqual() {
-    testNotEqual(notEqual("x", 7), notEqual("s1.s2.s3.s4.i", 7));
-  }
+    Assert.assertEquals(1, notEqual("x", 5).literals().size());
 
-  @Test
-  public void testNotEqualWithUnboundTerm() {
-    testNotEqual(notEqual(self("x"), 7), notEqual(self("s1.s2.s3.s4.i"), 7));
-  }
-
-  private void testNotEqual(UnboundPredicate<?> predicate, UnboundPredicate<?> structPredicate) {
-    Assert.assertEquals(1, predicate.literals().size());
-
-    Evaluator evaluator = new Evaluator(STRUCT, predicate);
+    Evaluator evaluator = new Evaluator(STRUCT, notEqual("x", 7));
     Assert.assertFalse("7 != 7 => false", evaluator.eval(TestHelpers.Row.of(7, 8, null)));
     Assert.assertTrue("6 != 7 => true", evaluator.eval(TestHelpers.Row.of(6, 8, null)));
 
-    Evaluator structEvaluator = new Evaluator(STRUCT, structPredicate);
+    Evaluator structEvaluator = new Evaluator(STRUCT, notEqual("s1.s2.s3.s4.i", 7));
     Assert.assertFalse("7 != 7 => false",
         structEvaluator.eval(TestHelpers.Row.of(7, 8, null,
             TestHelpers.Row.of(
@@ -269,6 +212,7 @@ public class TestEvaluator {
                 TestHelpers.Row.of(
                     TestHelpers.Row.of(
                         TestHelpers.Row.of(6)))))));
+
   }
 
   @Test
@@ -285,20 +229,11 @@ public class TestEvaluator {
 
   @Test
   public void testIsNull() {
-    testIsNull(new Evaluator(STRUCT, isNull("z")),
-        new Evaluator(STRUCT, isNull("s1.s2.s3.s4.i")));
-  }
-
-  @Test
-  public void testIsNullWithUnboundTerm() {
-    testIsNull(new Evaluator(STRUCT, isNull(self("z"))),
-        new Evaluator(STRUCT, isNull(self("s1.s2.s3.s4.i"))));
-  }
-
-  private void testIsNull(Evaluator evaluator, Evaluator structEvaluator) {
+    Evaluator evaluator = new Evaluator(STRUCT, isNull("z"));
     Assert.assertTrue("null is null", evaluator.eval(TestHelpers.Row.of(1, 2, null)));
     Assert.assertFalse("3 is not null", evaluator.eval(TestHelpers.Row.of(1, 2, 3)));
 
+    Evaluator structEvaluator = new Evaluator(STRUCT, isNull("s1.s2.s3.s4.i"));
     Assert.assertFalse("3 is not null", structEvaluator.eval(TestHelpers.Row.of(1, 2, 3,
         TestHelpers.Row.of(
             TestHelpers.Row.of(
@@ -308,20 +243,12 @@ public class TestEvaluator {
 
   @Test
   public void testNotNull() {
-    testNotNull(new Evaluator(STRUCT, notNull("z")),
-        new Evaluator(STRUCT, notNull("s1.s2.s3.s4.i")));
-  }
-
-  @Test
-  public void testNotNullWithUnboundTerm() {
-    testNotNull(new Evaluator(STRUCT, notNull(self("z"))),
-        new Evaluator(STRUCT, notNull(self("s1.s2.s3.s4.i"))));
-  }
-
-  private void testNotNull(Evaluator evaluator, Evaluator structEvaluator) {
+    Evaluator evaluator = new Evaluator(STRUCT, notNull("z"));
     Assert.assertFalse("null is null", evaluator.eval(TestHelpers.Row.of(1, 2, null)));
     Assert.assertTrue("3 is not null", evaluator.eval(TestHelpers.Row.of(1, 2, 3)));
 
+
+    Evaluator structEvaluator = new Evaluator(STRUCT, notNull("s1.s2.s3.s4.i"));
     Assert.assertTrue("3 is not null", structEvaluator.eval(TestHelpers.Row.of(1, 2, 3,
         TestHelpers.Row.of(
             TestHelpers.Row.of(
@@ -458,60 +385,18 @@ public class TestEvaluator {
     Assert.assertEquals(2, in("s", Arrays.asList(5, 5)).literals().size());
     Assert.assertEquals(0, in("s", Collections.emptyList()).literals().size());
 
-    StructType charSeqStruct = StructType.of(required(34, "s", Types.StringType.get()));
-    Evaluator charSeqEvaluator = new Evaluator(charSeqStruct, in("s", "abc", "abd", "abc"));
-
-    testIn(new Evaluator(STRUCT, in("x", 7, 8, Long.MAX_VALUE)),
-        new Evaluator(STRUCT, in("x", Long.MAX_VALUE, Integer.MAX_VALUE, Long.MIN_VALUE)),
-        new Evaluator(STRUCT, in("s1.s2.s3.s4.i", 7, 8, 9)),
-        new Evaluator(STRUCT, in("y", 7, 8, 9.1)),
-        charSeqEvaluator);
-  }
-
-  @Test
-  public void testInWithUnboundTerm() {
-    Assert.assertEquals(3, in(self("s"), 7, 8, 9).literals().size());
-    Assert.assertEquals(3, in(self("s"), 7, 8.1, Long.MAX_VALUE).literals().size());
-    Assert.assertEquals(3, in(self("s"), "abc", "abd", "abc").literals().size());
-    Assert.assertEquals(0, in(self("s")).literals().size());
-    Assert.assertEquals(1, in(self("s"), 5).literals().size());
-    Assert.assertEquals(2, in(self("s"), 5, 5).literals().size());
-    Assert.assertEquals(2, in(self("s"), Arrays.asList(5, 5)).literals().size());
-    Assert.assertEquals(0, in(self("s"), Collections.emptyList()).literals().size());
-
-    StructType charSeqStruct = StructType.of(required(34, "s", Types.StringType.get()));
-    Evaluator charSeqEvaluator = new Evaluator(charSeqStruct, in(self("s"), "abc", "abd", "abc"));
-
-    testIn(new Evaluator(STRUCT, in(self("x"), 7, 8, Long.MAX_VALUE)),
-        new Evaluator(STRUCT, in(self("x"), Long.MAX_VALUE, Integer.MAX_VALUE, Long.MIN_VALUE)),
-        new Evaluator(STRUCT, in(self("s1.s2.s3.s4.i"), 7, 8, 9)),
-        new Evaluator(STRUCT, in(self("y"), 7, 8, 9.1)),
-        charSeqEvaluator);
-  }
-
-  private void testIn(Evaluator evaluator, Evaluator intSetEvaluator,
-                      Evaluator structEvaluator, Evaluator integerEvaluator, Evaluator charSeqEvaluator) {
+    Evaluator evaluator = new Evaluator(STRUCT, in("x", 7, 8, Long.MAX_VALUE));
     Assert.assertTrue("7 in [7, 8] => true", evaluator.eval(TestHelpers.Row.of(7, 8, null)));
     Assert.assertFalse("9 in [7, 8]  => false", evaluator.eval(TestHelpers.Row.of(9, 8, null)));
 
+    Evaluator intSetEvaluator = new Evaluator(STRUCT,
+        in("x", Long.MAX_VALUE, Integer.MAX_VALUE, Long.MIN_VALUE));
     Assert.assertTrue("Integer.MAX_VALUE in [Integer.MAX_VALUE] => true",
         intSetEvaluator.eval(TestHelpers.Row.of(Integer.MAX_VALUE, 7.0, null)));
     Assert.assertFalse("6 in [Integer.MAX_VALUE]  => false",
         intSetEvaluator.eval(TestHelpers.Row.of(6, 6.8, null)));
 
-    Assert.assertTrue("7 in [7, 8, 9] => true",
-        structEvaluator.eval(TestHelpers.Row.of(7, 8, null,
-            TestHelpers.Row.of(
-                TestHelpers.Row.of(
-                    TestHelpers.Row.of(
-                        TestHelpers.Row.of(7)))))));
-    Assert.assertFalse("6 in [7, 8, 9]  => false",
-        structEvaluator.eval(TestHelpers.Row.of(6, 8, null,
-            TestHelpers.Row.of(
-                TestHelpers.Row.of(
-                    TestHelpers.Row.of(
-                        TestHelpers.Row.of(6)))))));
-
+    Evaluator integerEvaluator = new Evaluator(STRUCT, in("y", 7, 8, 9.1));
     Assert.assertTrue("7.0 in [7, 8, 9.1] => true",
         integerEvaluator.eval(TestHelpers.Row.of(0, 7.0, null)));
     Assert.assertTrue("9.1 in [7, 8, 9.1] => true",
@@ -519,10 +404,26 @@ public class TestEvaluator {
     Assert.assertFalse("6.8 in [7, 8, 9.1]  => false",
         integerEvaluator.eval(TestHelpers.Row.of(6, 6.8, null)));
 
+    Evaluator structEvaluator = new Evaluator(STRUCT, in("s1.s2.s3.s4.i", 7, 8, 9));
+    Assert.assertTrue("7 in [7, 8, 9] => true",
+            structEvaluator.eval(TestHelpers.Row.of(7, 8, null,
+                    TestHelpers.Row.of(
+                            TestHelpers.Row.of(
+                                    TestHelpers.Row.of(
+                                            TestHelpers.Row.of(7)))))));
+    Assert.assertFalse("6 in [7, 8, 9]  => false",
+            structEvaluator.eval(TestHelpers.Row.of(6, 8, null,
+                    TestHelpers.Row.of(
+                            TestHelpers.Row.of(
+                                    TestHelpers.Row.of(
+                                            TestHelpers.Row.of(6)))))));
+
+    StructType charSeqStruct = StructType.of(required(34, "s", Types.StringType.get()));
+    Evaluator charSeqEvaluator = new Evaluator(charSeqStruct, in("s", "abc", "abd", "abc"));
     Assert.assertTrue("utf8(abc) in [string(abc), string(abd)] => true",
-        charSeqEvaluator.eval(TestHelpers.Row.of(new Utf8("abc"))));
+            charSeqEvaluator.eval(TestHelpers.Row.of(new Utf8("abc"))));
     Assert.assertFalse("utf8(abcd) in [string(abc), string(abd)] => false",
-        charSeqEvaluator.eval(TestHelpers.Row.of(new Utf8("abcd"))));
+            charSeqEvaluator.eval(TestHelpers.Row.of(new Utf8("abcd"))));
   }
 
   @Test
@@ -536,20 +437,8 @@ public class TestEvaluator {
     AssertHelpers.assertThrows(
         "Throw exception if value is null",
         NullPointerException.class,
-        "Cannot create expression literal from null",
-        () -> in(self("x"), (Literal) null));
-
-    AssertHelpers.assertThrows(
-        "Throw exception if value is null",
-        NullPointerException.class,
         "Values cannot be null for IN predicate",
         () -> in("x", (Collection<?>) null));
-
-    AssertHelpers.assertThrows(
-        "Throw exception if value is null",
-        NullPointerException.class,
-        "Values cannot be null for IN predicate",
-        () -> in(self("x"), (Collection<?>) null));
 
     AssertHelpers.assertThrows(
         "Throw exception if calling literal() for IN predicate",
@@ -558,34 +447,16 @@ public class TestEvaluator {
         () -> in("x", 5, 6).literal());
 
     AssertHelpers.assertThrows(
-        "Throw exception if calling literal() for IN predicate",
-        IllegalArgumentException.class,
-        "IN predicate cannot return a literal",
-        () -> in(self("x"), 5, 6).literal());
-
-    AssertHelpers.assertThrows(
         "Throw exception if any value in the input is null",
         NullPointerException.class,
         "Cannot create expression literal from null",
         () -> in("x", 1, 2, null));
 
     AssertHelpers.assertThrows(
-        "Throw exception if any value in the input is null",
-        NullPointerException.class,
-        "Cannot create expression literal from null",
-        () -> in(self("x"), 1, 2, null));
-
-    AssertHelpers.assertThrows(
         "Throw exception if binding fails for any element in the set",
         ValidationException.class,
         "Invalid value for conversion to type int",
         () -> new Evaluator(STRUCT, in("x", 7, 8, 9.1)));
-
-    AssertHelpers.assertThrows(
-        "Throw exception if binding fails for any element in the set",
-        ValidationException.class,
-        "Invalid value for conversion to type int",
-        () -> new Evaluator(STRUCT, in(self("x"), 7, 8, 9.1)));
 
     AssertHelpers.assertThrows(
         "Throw exception if no input value",
@@ -611,67 +482,18 @@ public class TestEvaluator {
     Assert.assertEquals(2, notIn("s", Arrays.asList(5, 5)).literals().size());
     Assert.assertEquals(0, notIn("s", Collections.emptyList()).literals().size());
 
-    StructType charSeqStruct = StructType.of(required(34, "s", Types.StringType.get()));
-    Evaluator charSeqEvaluator = new Evaluator(charSeqStruct, notIn("s", "abc", "abd", "abc"));
-
-    testNotIn(
-        new Evaluator(STRUCT, notIn("x", 7, 8, Long.MAX_VALUE)),
-        new Evaluator(STRUCT, notIn("x", Long.MAX_VALUE, Integer.MAX_VALUE, Long.MIN_VALUE)),
-        new Evaluator(STRUCT, notIn("s1.s2.s3.s4.i", 7, 8, 9)),
-        charSeqEvaluator,
-        new Evaluator(STRUCT, notIn("y", 7, 8, 9.1)));
-  }
-
-  @Test
-  public void testNotInWithUnboundTerm() {
-    Assert.assertEquals(3, notIn(self("s"), 7, 8, 9).literals().size());
-    Assert.assertEquals(3, notIn(self("s"), 7, 8.1, Long.MAX_VALUE).literals().size());
-    Assert.assertEquals(3, notIn(self("s"), "abc", "abd", "abc").literals().size());
-    Assert.assertEquals(0, notIn(self("s")).literals().size());
-    Assert.assertEquals(1, notIn(self("s"), 5).literals().size());
-    Assert.assertEquals(2, notIn(self("s"), 5, 5).literals().size());
-    Assert.assertEquals(2, notIn(self("s"), Arrays.asList(5, 5)).literals().size());
-    Assert.assertEquals(0, notIn(self("s"), Collections.emptyList()).literals().size());
-
-    StructType charSeqStruct = StructType.of(required(34, "s", Types.StringType.get()));
-    Evaluator charSeqEvaluator = new Evaluator(charSeqStruct, notIn(self("s"), "abc", "abd", "abc"));
-
-    testNotIn(
-        new Evaluator(STRUCT, notIn(self("x"), 7, 8, Long.MAX_VALUE)),
-        new Evaluator(STRUCT, notIn(self("x"), Long.MAX_VALUE, Integer.MAX_VALUE, Long.MIN_VALUE)),
-        new Evaluator(STRUCT, notIn(self("s1.s2.s3.s4.i"), 7, 8, 9)),
-        charSeqEvaluator,
-        new Evaluator(STRUCT, notIn(self("y"), 7, 8, 9.1)));
-  }
-
-  private void testNotIn(Evaluator evaluator, Evaluator intSetEvaluator,
-                         Evaluator structEvaluator, Evaluator charSeqEvaluator, Evaluator integerEvaluator) {
+    Evaluator evaluator = new Evaluator(STRUCT, notIn("x", 7, 8, Long.MAX_VALUE));
     Assert.assertFalse("7 not in [7, 8] => false", evaluator.eval(TestHelpers.Row.of(7, 8, null)));
     Assert.assertTrue("6 not in [7, 8]  => true", evaluator.eval(TestHelpers.Row.of(9, 8, null)));
 
+    Evaluator intSetEvaluator = new Evaluator(STRUCT,
+        notIn("x", Long.MAX_VALUE, Integer.MAX_VALUE, Long.MIN_VALUE));
     Assert.assertFalse("Integer.MAX_VALUE not_in [Integer.MAX_VALUE] => false",
         intSetEvaluator.eval(TestHelpers.Row.of(Integer.MAX_VALUE, 7.0, null)));
     Assert.assertTrue("6 not_in [Integer.MAX_VALUE]  => true",
         intSetEvaluator.eval(TestHelpers.Row.of(6, 6.8, null)));
 
-    Assert.assertFalse("7 not in [7, 8, 9] => false",
-        structEvaluator.eval(TestHelpers.Row.of(7, 8, null,
-            TestHelpers.Row.of(
-                TestHelpers.Row.of(
-                    TestHelpers.Row.of(
-                        TestHelpers.Row.of(7)))))));
-    Assert.assertTrue("6 not in [7, 8, 9]  => true",
-        structEvaluator.eval(TestHelpers.Row.of(6, 8, null,
-            TestHelpers.Row.of(
-                TestHelpers.Row.of(
-                    TestHelpers.Row.of(
-                        TestHelpers.Row.of(6)))))));
-
-    Assert.assertFalse("utf8(abc) not in [string(abc), string(abd)] => false",
-        charSeqEvaluator.eval(TestHelpers.Row.of(new Utf8("abc"))));
-    Assert.assertTrue("utf8(abcd) not in [string(abc), string(abd)] => true",
-        charSeqEvaluator.eval(TestHelpers.Row.of(new Utf8("abcd"))));
-
+    Evaluator integerEvaluator = new Evaluator(STRUCT, notIn("y", 7, 8, 9.1));
     Assert.assertFalse("7.0 not in [7, 8, 9] => false",
         integerEvaluator.eval(TestHelpers.Row.of(0, 7.0, null)));
     Assert.assertFalse("9.1 not in [7, 8, 9.1] => false",
@@ -679,6 +501,26 @@ public class TestEvaluator {
     Assert.assertTrue("6.8 not in [7, 8, 9.1]  => true",
         integerEvaluator.eval(TestHelpers.Row.of(6, 6.8, null)));
 
+    Evaluator structEvaluator = new Evaluator(STRUCT, notIn("s1.s2.s3.s4.i", 7, 8, 9));
+    Assert.assertFalse("7 not in [7, 8, 9] => false",
+            structEvaluator.eval(TestHelpers.Row.of(7, 8, null,
+                    TestHelpers.Row.of(
+                            TestHelpers.Row.of(
+                                    TestHelpers.Row.of(
+                                            TestHelpers.Row.of(7)))))));
+    Assert.assertTrue("6 not in [7, 8, 9]  => true",
+            structEvaluator.eval(TestHelpers.Row.of(6, 8, null,
+                    TestHelpers.Row.of(
+                            TestHelpers.Row.of(
+                                    TestHelpers.Row.of(
+                                            TestHelpers.Row.of(6)))))));
+
+    StructType charSeqStruct = StructType.of(required(34, "s", Types.StringType.get()));
+    Evaluator charSeqEvaluator = new Evaluator(charSeqStruct, notIn("s", "abc", "abd", "abc"));
+    Assert.assertFalse("utf8(abc) not in [string(abc), string(abd)] => false",
+            charSeqEvaluator.eval(TestHelpers.Row.of(new Utf8("abc"))));
+    Assert.assertTrue("utf8(abcd) not in [string(abc), string(abd)] => true",
+            charSeqEvaluator.eval(TestHelpers.Row.of(new Utf8("abcd"))));
   }
 
   @Test
@@ -692,20 +534,8 @@ public class TestEvaluator {
     AssertHelpers.assertThrows(
         "Throw exception if value is null",
         NullPointerException.class,
-        "Cannot create expression literal from null",
-        () -> notIn(self("x"), (Literal) null));
-
-    AssertHelpers.assertThrows(
-        "Throw exception if value is null",
-        NullPointerException.class,
         "Values cannot be null for NOT_IN predicate",
         () -> notIn("x", (Collection<?>) null));
-
-    AssertHelpers.assertThrows(
-        "Throw exception if value is null",
-        NullPointerException.class,
-        "Values cannot be null for NOT_IN predicate",
-        () -> notIn(self("x"), (Collection<?>) null));
 
     AssertHelpers.assertThrows(
         "Throw exception if calling literal() for IN predicate",
@@ -714,34 +544,16 @@ public class TestEvaluator {
         () -> notIn("x", 5, 6).literal());
 
     AssertHelpers.assertThrows(
-        "Throw exception if calling literal() for IN predicate",
-        IllegalArgumentException.class,
-        "NOT_IN predicate cannot return a literal",
-        () -> notIn(self("x"), 5, 6).literal());
-
-    AssertHelpers.assertThrows(
         "Throw exception if any value in the input is null",
         NullPointerException.class,
         "Cannot create expression literal from null",
         () -> notIn("x", 1, 2, null));
 
     AssertHelpers.assertThrows(
-        "Throw exception if any value in the input is null",
-        NullPointerException.class,
-        "Cannot create expression literal from null",
-        () -> notIn(self("x"), 1, 2, null));
-
-    AssertHelpers.assertThrows(
         "Throw exception if binding fails for any element in the set",
         ValidationException.class,
         "Invalid value for conversion to type int",
         () -> new Evaluator(STRUCT, notIn("x", 7, 8, 9.1)));
-
-    AssertHelpers.assertThrows(
-        "Throw exception if binding fails for any element in the set",
-        ValidationException.class,
-        "Invalid value for conversion to type int",
-        () -> new Evaluator(STRUCT, notIn(self("x"), 7, 8, 9.1)));
 
     AssertHelpers.assertThrows(
         "Throw exception if no input value",
@@ -754,13 +566,5 @@ public class TestEvaluator {
         ValidationException.class,
         "Invalid value for conversion to type int",
         () -> new Evaluator(STRUCT, predicate(Expression.Operation.NOT_IN, "x", 5.1)));
-  }
-
-  private <T> UnboundTerm<T> self(String name) {
-    Type type = Types.IntegerType.get();
-    if (name.equals("y")) {
-      type = Types.DoubleType.get();
-    }
-    return new UnboundTransform<>(ref(name), Transforms.identity(type));
   }
 }

--- a/api/src/test/java/org/apache/iceberg/expressions/TestEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestEvaluator.java
@@ -26,6 +26,8 @@ import org.apache.avro.util.Utf8;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.transforms.Transforms;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.StructType;
 import org.junit.Assert;
@@ -47,6 +49,7 @@ import static org.apache.iceberg.expressions.Expressions.notIn;
 import static org.apache.iceberg.expressions.Expressions.notNull;
 import static org.apache.iceberg.expressions.Expressions.or;
 import static org.apache.iceberg.expressions.Expressions.predicate;
+import static org.apache.iceberg.expressions.Expressions.ref;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
@@ -63,11 +66,20 @@ public class TestEvaluator {
 
   @Test
   public void testLessThan() {
-    Evaluator evaluator = new Evaluator(STRUCT, lessThan("x", 7));
+    testLessThan(new Evaluator(STRUCT, lessThan("x", 7)),
+        new Evaluator(STRUCT, lessThan("s1.s2.s3.s4.i", 7)));
+  }
+
+  @Test
+  public void testLessThanWithUnboundTerm() {
+    testLessThan(new Evaluator(STRUCT, lessThan(self("x"), 7)),
+        new Evaluator(STRUCT, lessThan(self("s1.s2.s3.s4.i"), 7)));
+  }
+
+  private void testLessThan(Evaluator evaluator, Evaluator structEvaluator) {
     Assert.assertFalse("7 < 7 => false", evaluator.eval(TestHelpers.Row.of(7, 8, null, null)));
     Assert.assertTrue("6 < 7 => true", evaluator.eval(TestHelpers.Row.of(6, 8, null, null)));
 
-    Evaluator structEvaluator = new Evaluator(STRUCT, lessThan("s1.s2.s3.s4.i", 7));
     Assert.assertFalse("7 < 7 => false",
         structEvaluator.eval(TestHelpers.Row.of(7, 8, null,
             TestHelpers.Row.of(
@@ -84,12 +96,21 @@ public class TestEvaluator {
 
   @Test
   public void testLessThanOrEqual() {
-    Evaluator evaluator = new Evaluator(STRUCT, lessThanOrEqual("x", 7));
+    testLessThanOrEqual(new Evaluator(STRUCT, lessThanOrEqual("x", 7)),
+        new Evaluator(STRUCT, lessThanOrEqual("s1.s2.s3.s4.i", 7)));
+  }
+
+  @Test
+  public void testLessThanOrEqualWithUnboundTerm() {
+    testLessThanOrEqual(new Evaluator(STRUCT, lessThanOrEqual(self("x"), 7)),
+        new Evaluator(STRUCT, lessThanOrEqual(self("s1.s2.s3.s4.i"), 7)));
+  }
+
+  private void testLessThanOrEqual(Evaluator evaluator, Evaluator structEvaluator) {
     Assert.assertTrue("7 <= 7 => true", evaluator.eval(TestHelpers.Row.of(7, 8, null)));
     Assert.assertTrue("6 <= 7 => true", evaluator.eval(TestHelpers.Row.of(6, 8, null)));
     Assert.assertFalse("8 <= 7 => false", evaluator.eval(TestHelpers.Row.of(8, 8, null)));
 
-    Evaluator structEvaluator = new Evaluator(STRUCT, lessThanOrEqual("s1.s2.s3.s4.i", 7));
     Assert.assertTrue("7 <= 7 => true",
         structEvaluator.eval(TestHelpers.Row.of(7, 8, null,
             TestHelpers.Row.of(
@@ -114,12 +135,21 @@ public class TestEvaluator {
 
   @Test
   public void testGreaterThan() {
-    Evaluator evaluator = new Evaluator(STRUCT, greaterThan("x", 7));
+    testGreaterThan(new Evaluator(STRUCT, greaterThan("x", 7)),
+        new Evaluator(STRUCT, greaterThan("s1.s2.s3.s4.i", 7)));
+  }
+
+  @Test
+  public void testGreaterThanWithUnboundTerm() {
+    testGreaterThan(new Evaluator(STRUCT, greaterThan(self("x"), 7)),
+        new Evaluator(STRUCT, greaterThan(self("s1.s2.s3.s4.i"), 7)));
+  }
+
+  private void testGreaterThan(Evaluator evaluator, Evaluator structEvaluator) {
     Assert.assertFalse("7 > 7 => false", evaluator.eval(TestHelpers.Row.of(7, 8, null)));
     Assert.assertFalse("6 > 7 => false", evaluator.eval(TestHelpers.Row.of(6, 8, null)));
     Assert.assertTrue("8 > 7 => true", evaluator.eval(TestHelpers.Row.of(8, 8, null)));
 
-    Evaluator structEvaluator = new Evaluator(STRUCT, greaterThan("s1.s2.s3.s4.i", 7));
     Assert.assertFalse("7 > 7 => false",
         structEvaluator.eval(TestHelpers.Row.of(7, 8, null,
             TestHelpers.Row.of(
@@ -142,12 +172,21 @@ public class TestEvaluator {
 
   @Test
   public void testGreaterThanOrEqual() {
-    Evaluator evaluator = new Evaluator(STRUCT, greaterThanOrEqual("x", 7));
+    testGreaterThanOrEqual(new Evaluator(STRUCT, greaterThanOrEqual("x", 7)),
+        new Evaluator(STRUCT, greaterThanOrEqual("s1.s2.s3.s4.i", 7)));
+  }
+
+  @Test
+  public void testGreaterThanOrEqualWithUnboundTerm() {
+    testGreaterThanOrEqual(new Evaluator(STRUCT, greaterThanOrEqual(self("x"), 7)),
+        new Evaluator(STRUCT, greaterThanOrEqual(self("s1.s2.s3.s4.i"), 7)));
+  }
+
+  private void testGreaterThanOrEqual(Evaluator evaluator, Evaluator structEvaluator) {
     Assert.assertTrue("7 >= 7 => true", evaluator.eval(TestHelpers.Row.of(7, 8, null)));
     Assert.assertFalse("6 >= 7 => false", evaluator.eval(TestHelpers.Row.of(6, 8, null)));
     Assert.assertTrue("8 >= 7 => true", evaluator.eval(TestHelpers.Row.of(8, 8, null)));
 
-    Evaluator structEvaluator = new Evaluator(STRUCT, greaterThanOrEqual("s1.s2.s3.s4.i", 7));
     Assert.assertTrue("7 >= 7 => true",
         structEvaluator.eval(TestHelpers.Row.of(7, 8, null,
             TestHelpers.Row.of(
@@ -170,13 +209,22 @@ public class TestEvaluator {
 
   @Test
   public void testEqual() {
+    testEqual(new Evaluator(STRUCT, equal("x", 7)),
+        new Evaluator(STRUCT, equal("s1.s2.s3.s4.i", 7)));
+  }
+
+  @Test
+  public void testEqualWithUnboundTerm() {
+    testEqual(new Evaluator(STRUCT, equal(self("x"), 7)),
+        new Evaluator(STRUCT, equal(self("s1.s2.s3.s4.i"), 7)));
+  }
+
+  private void testEqual(Evaluator evaluator, Evaluator structEvaluator) {
     Assert.assertEquals(1, equal("x", 5).literals().size());
 
-    Evaluator evaluator = new Evaluator(STRUCT, equal("x", 7));
     Assert.assertTrue("7 == 7 => true", evaluator.eval(TestHelpers.Row.of(7, 8, null)));
     Assert.assertFalse("6 == 7 => false", evaluator.eval(TestHelpers.Row.of(6, 8, null)));
 
-    Evaluator structEvaluator = new Evaluator(STRUCT, equal("s1.s2.s3.s4.i", 7));
     Assert.assertTrue("7 == 7 => true",
         structEvaluator.eval(TestHelpers.Row.of(7, 8, null,
             TestHelpers.Row.of(
@@ -193,13 +241,22 @@ public class TestEvaluator {
 
   @Test
   public void testNotEqual() {
-    Assert.assertEquals(1, notEqual("x", 5).literals().size());
+    testNotEqual(notEqual("x", 7), notEqual("s1.s2.s3.s4.i", 7));
+  }
 
-    Evaluator evaluator = new Evaluator(STRUCT, notEqual("x", 7));
+  @Test
+  public void testNotEqualWithUnboundTerm() {
+    testNotEqual(notEqual(self("x"), 7), notEqual(self("s1.s2.s3.s4.i"), 7));
+  }
+
+  private void testNotEqual(UnboundPredicate<?> predicate, UnboundPredicate<?> structPredicate) {
+    Assert.assertEquals(1, predicate.literals().size());
+
+    Evaluator evaluator = new Evaluator(STRUCT, predicate);
     Assert.assertFalse("7 != 7 => false", evaluator.eval(TestHelpers.Row.of(7, 8, null)));
     Assert.assertTrue("6 != 7 => true", evaluator.eval(TestHelpers.Row.of(6, 8, null)));
 
-    Evaluator structEvaluator = new Evaluator(STRUCT, notEqual("s1.s2.s3.s4.i", 7));
+    Evaluator structEvaluator = new Evaluator(STRUCT, structPredicate);
     Assert.assertFalse("7 != 7 => false",
         structEvaluator.eval(TestHelpers.Row.of(7, 8, null,
             TestHelpers.Row.of(
@@ -212,7 +269,6 @@ public class TestEvaluator {
                 TestHelpers.Row.of(
                     TestHelpers.Row.of(
                         TestHelpers.Row.of(6)))))));
-
   }
 
   @Test
@@ -229,11 +285,20 @@ public class TestEvaluator {
 
   @Test
   public void testIsNull() {
-    Evaluator evaluator = new Evaluator(STRUCT, isNull("z"));
+    testIsNull(new Evaluator(STRUCT, isNull("z")),
+        new Evaluator(STRUCT, isNull("s1.s2.s3.s4.i")));
+  }
+
+  @Test
+  public void testIsNullWithUnboundTerm() {
+    testIsNull(new Evaluator(STRUCT, isNull(self("z"))),
+        new Evaluator(STRUCT, isNull(self("s1.s2.s3.s4.i"))));
+  }
+
+  private void testIsNull(Evaluator evaluator, Evaluator structEvaluator) {
     Assert.assertTrue("null is null", evaluator.eval(TestHelpers.Row.of(1, 2, null)));
     Assert.assertFalse("3 is not null", evaluator.eval(TestHelpers.Row.of(1, 2, 3)));
 
-    Evaluator structEvaluator = new Evaluator(STRUCT, isNull("s1.s2.s3.s4.i"));
     Assert.assertFalse("3 is not null", structEvaluator.eval(TestHelpers.Row.of(1, 2, 3,
         TestHelpers.Row.of(
             TestHelpers.Row.of(
@@ -243,12 +308,20 @@ public class TestEvaluator {
 
   @Test
   public void testNotNull() {
-    Evaluator evaluator = new Evaluator(STRUCT, notNull("z"));
+    testNotNull(new Evaluator(STRUCT, notNull("z")),
+        new Evaluator(STRUCT, notNull("s1.s2.s3.s4.i")));
+  }
+
+  @Test
+  public void testNotNullWithUnboundTerm() {
+    testNotNull(new Evaluator(STRUCT, notNull(self("z"))),
+        new Evaluator(STRUCT, notNull(self("s1.s2.s3.s4.i"))));
+  }
+
+  private void testNotNull(Evaluator evaluator, Evaluator structEvaluator) {
     Assert.assertFalse("null is null", evaluator.eval(TestHelpers.Row.of(1, 2, null)));
     Assert.assertTrue("3 is not null", evaluator.eval(TestHelpers.Row.of(1, 2, 3)));
 
-
-    Evaluator structEvaluator = new Evaluator(STRUCT, notNull("s1.s2.s3.s4.i"));
     Assert.assertTrue("3 is not null", structEvaluator.eval(TestHelpers.Row.of(1, 2, 3,
         TestHelpers.Row.of(
             TestHelpers.Row.of(
@@ -385,18 +458,60 @@ public class TestEvaluator {
     Assert.assertEquals(2, in("s", Arrays.asList(5, 5)).literals().size());
     Assert.assertEquals(0, in("s", Collections.emptyList()).literals().size());
 
-    Evaluator evaluator = new Evaluator(STRUCT, in("x", 7, 8, Long.MAX_VALUE));
+    StructType charSeqStruct = StructType.of(required(34, "s", Types.StringType.get()));
+    Evaluator charSeqEvaluator = new Evaluator(charSeqStruct, in("s", "abc", "abd", "abc"));
+
+    testIn(new Evaluator(STRUCT, in("x", 7, 8, Long.MAX_VALUE)),
+        new Evaluator(STRUCT, in("x", Long.MAX_VALUE, Integer.MAX_VALUE, Long.MIN_VALUE)),
+        new Evaluator(STRUCT, in("s1.s2.s3.s4.i", 7, 8, 9)),
+        new Evaluator(STRUCT, in("y", 7, 8, 9.1)),
+        charSeqEvaluator);
+  }
+
+  @Test
+  public void testInWithUnboundTerm() {
+    Assert.assertEquals(3, in(self("s"), 7, 8, 9).literals().size());
+    Assert.assertEquals(3, in(self("s"), 7, 8.1, Long.MAX_VALUE).literals().size());
+    Assert.assertEquals(3, in(self("s"), "abc", "abd", "abc").literals().size());
+    Assert.assertEquals(0, in(self("s")).literals().size());
+    Assert.assertEquals(1, in(self("s"), 5).literals().size());
+    Assert.assertEquals(2, in(self("s"), 5, 5).literals().size());
+    Assert.assertEquals(2, in(self("s"), Arrays.asList(5, 5)).literals().size());
+    Assert.assertEquals(0, in(self("s"), Collections.emptyList()).literals().size());
+
+    StructType charSeqStruct = StructType.of(required(34, "s", Types.StringType.get()));
+    Evaluator charSeqEvaluator = new Evaluator(charSeqStruct, in(self("s"), "abc", "abd", "abc"));
+
+    testIn(new Evaluator(STRUCT, in(self("x"), 7, 8, Long.MAX_VALUE)),
+        new Evaluator(STRUCT, in(self("x"), Long.MAX_VALUE, Integer.MAX_VALUE, Long.MIN_VALUE)),
+        new Evaluator(STRUCT, in(self("s1.s2.s3.s4.i"), 7, 8, 9)),
+        new Evaluator(STRUCT, in(self("y"), 7, 8, 9.1)),
+        charSeqEvaluator);
+  }
+
+  private void testIn(Evaluator evaluator, Evaluator intSetEvaluator,
+                      Evaluator structEvaluator, Evaluator integerEvaluator, Evaluator charSeqEvaluator) {
     Assert.assertTrue("7 in [7, 8] => true", evaluator.eval(TestHelpers.Row.of(7, 8, null)));
     Assert.assertFalse("9 in [7, 8]  => false", evaluator.eval(TestHelpers.Row.of(9, 8, null)));
 
-    Evaluator intSetEvaluator = new Evaluator(STRUCT,
-        in("x", Long.MAX_VALUE, Integer.MAX_VALUE, Long.MIN_VALUE));
     Assert.assertTrue("Integer.MAX_VALUE in [Integer.MAX_VALUE] => true",
         intSetEvaluator.eval(TestHelpers.Row.of(Integer.MAX_VALUE, 7.0, null)));
     Assert.assertFalse("6 in [Integer.MAX_VALUE]  => false",
         intSetEvaluator.eval(TestHelpers.Row.of(6, 6.8, null)));
 
-    Evaluator integerEvaluator = new Evaluator(STRUCT, in("y", 7, 8, 9.1));
+    Assert.assertTrue("7 in [7, 8, 9] => true",
+        structEvaluator.eval(TestHelpers.Row.of(7, 8, null,
+            TestHelpers.Row.of(
+                TestHelpers.Row.of(
+                    TestHelpers.Row.of(
+                        TestHelpers.Row.of(7)))))));
+    Assert.assertFalse("6 in [7, 8, 9]  => false",
+        structEvaluator.eval(TestHelpers.Row.of(6, 8, null,
+            TestHelpers.Row.of(
+                TestHelpers.Row.of(
+                    TestHelpers.Row.of(
+                        TestHelpers.Row.of(6)))))));
+
     Assert.assertTrue("7.0 in [7, 8, 9.1] => true",
         integerEvaluator.eval(TestHelpers.Row.of(0, 7.0, null)));
     Assert.assertTrue("9.1 in [7, 8, 9.1] => true",
@@ -404,26 +519,10 @@ public class TestEvaluator {
     Assert.assertFalse("6.8 in [7, 8, 9.1]  => false",
         integerEvaluator.eval(TestHelpers.Row.of(6, 6.8, null)));
 
-    Evaluator structEvaluator = new Evaluator(STRUCT, in("s1.s2.s3.s4.i", 7, 8, 9));
-    Assert.assertTrue("7 in [7, 8, 9] => true",
-            structEvaluator.eval(TestHelpers.Row.of(7, 8, null,
-                    TestHelpers.Row.of(
-                            TestHelpers.Row.of(
-                                    TestHelpers.Row.of(
-                                            TestHelpers.Row.of(7)))))));
-    Assert.assertFalse("6 in [7, 8, 9]  => false",
-            structEvaluator.eval(TestHelpers.Row.of(6, 8, null,
-                    TestHelpers.Row.of(
-                            TestHelpers.Row.of(
-                                    TestHelpers.Row.of(
-                                            TestHelpers.Row.of(6)))))));
-
-    StructType charSeqStruct = StructType.of(required(34, "s", Types.StringType.get()));
-    Evaluator charSeqEvaluator = new Evaluator(charSeqStruct, in("s", "abc", "abd", "abc"));
     Assert.assertTrue("utf8(abc) in [string(abc), string(abd)] => true",
-            charSeqEvaluator.eval(TestHelpers.Row.of(new Utf8("abc"))));
+        charSeqEvaluator.eval(TestHelpers.Row.of(new Utf8("abc"))));
     Assert.assertFalse("utf8(abcd) in [string(abc), string(abd)] => false",
-            charSeqEvaluator.eval(TestHelpers.Row.of(new Utf8("abcd"))));
+        charSeqEvaluator.eval(TestHelpers.Row.of(new Utf8("abcd"))));
   }
 
   @Test
@@ -437,8 +536,20 @@ public class TestEvaluator {
     AssertHelpers.assertThrows(
         "Throw exception if value is null",
         NullPointerException.class,
+        "Cannot create expression literal from null",
+        () -> in(self("x"), (Literal) null));
+
+    AssertHelpers.assertThrows(
+        "Throw exception if value is null",
+        NullPointerException.class,
         "Values cannot be null for IN predicate",
         () -> in("x", (Collection<?>) null));
+
+    AssertHelpers.assertThrows(
+        "Throw exception if value is null",
+        NullPointerException.class,
+        "Values cannot be null for IN predicate",
+        () -> in(self("x"), (Collection<?>) null));
 
     AssertHelpers.assertThrows(
         "Throw exception if calling literal() for IN predicate",
@@ -447,16 +558,34 @@ public class TestEvaluator {
         () -> in("x", 5, 6).literal());
 
     AssertHelpers.assertThrows(
+        "Throw exception if calling literal() for IN predicate",
+        IllegalArgumentException.class,
+        "IN predicate cannot return a literal",
+        () -> in(self("x"), 5, 6).literal());
+
+    AssertHelpers.assertThrows(
         "Throw exception if any value in the input is null",
         NullPointerException.class,
         "Cannot create expression literal from null",
         () -> in("x", 1, 2, null));
 
     AssertHelpers.assertThrows(
+        "Throw exception if any value in the input is null",
+        NullPointerException.class,
+        "Cannot create expression literal from null",
+        () -> in(self("x"), 1, 2, null));
+
+    AssertHelpers.assertThrows(
         "Throw exception if binding fails for any element in the set",
         ValidationException.class,
         "Invalid value for conversion to type int",
         () -> new Evaluator(STRUCT, in("x", 7, 8, 9.1)));
+
+    AssertHelpers.assertThrows(
+        "Throw exception if binding fails for any element in the set",
+        ValidationException.class,
+        "Invalid value for conversion to type int",
+        () -> new Evaluator(STRUCT, in(self("x"), 7, 8, 9.1)));
 
     AssertHelpers.assertThrows(
         "Throw exception if no input value",
@@ -482,18 +611,67 @@ public class TestEvaluator {
     Assert.assertEquals(2, notIn("s", Arrays.asList(5, 5)).literals().size());
     Assert.assertEquals(0, notIn("s", Collections.emptyList()).literals().size());
 
-    Evaluator evaluator = new Evaluator(STRUCT, notIn("x", 7, 8, Long.MAX_VALUE));
+    StructType charSeqStruct = StructType.of(required(34, "s", Types.StringType.get()));
+    Evaluator charSeqEvaluator = new Evaluator(charSeqStruct, notIn("s", "abc", "abd", "abc"));
+
+    testNotIn(
+        new Evaluator(STRUCT, notIn("x", 7, 8, Long.MAX_VALUE)),
+        new Evaluator(STRUCT, notIn("x", Long.MAX_VALUE, Integer.MAX_VALUE, Long.MIN_VALUE)),
+        new Evaluator(STRUCT, notIn("s1.s2.s3.s4.i", 7, 8, 9)),
+        charSeqEvaluator,
+        new Evaluator(STRUCT, notIn("y", 7, 8, 9.1)));
+  }
+
+  @Test
+  public void testNotInWithUnboundTerm() {
+    Assert.assertEquals(3, notIn(self("s"), 7, 8, 9).literals().size());
+    Assert.assertEquals(3, notIn(self("s"), 7, 8.1, Long.MAX_VALUE).literals().size());
+    Assert.assertEquals(3, notIn(self("s"), "abc", "abd", "abc").literals().size());
+    Assert.assertEquals(0, notIn(self("s")).literals().size());
+    Assert.assertEquals(1, notIn(self("s"), 5).literals().size());
+    Assert.assertEquals(2, notIn(self("s"), 5, 5).literals().size());
+    Assert.assertEquals(2, notIn(self("s"), Arrays.asList(5, 5)).literals().size());
+    Assert.assertEquals(0, notIn(self("s"), Collections.emptyList()).literals().size());
+
+    StructType charSeqStruct = StructType.of(required(34, "s", Types.StringType.get()));
+    Evaluator charSeqEvaluator = new Evaluator(charSeqStruct, notIn(self("s"), "abc", "abd", "abc"));
+
+    testNotIn(
+        new Evaluator(STRUCT, notIn(self("x"), 7, 8, Long.MAX_VALUE)),
+        new Evaluator(STRUCT, notIn(self("x"), Long.MAX_VALUE, Integer.MAX_VALUE, Long.MIN_VALUE)),
+        new Evaluator(STRUCT, notIn(self("s1.s2.s3.s4.i"), 7, 8, 9)),
+        charSeqEvaluator,
+        new Evaluator(STRUCT, notIn(self("y"), 7, 8, 9.1)));
+  }
+
+  private void testNotIn(Evaluator evaluator, Evaluator intSetEvaluator,
+                         Evaluator structEvaluator, Evaluator charSeqEvaluator, Evaluator integerEvaluator) {
     Assert.assertFalse("7 not in [7, 8] => false", evaluator.eval(TestHelpers.Row.of(7, 8, null)));
     Assert.assertTrue("6 not in [7, 8]  => true", evaluator.eval(TestHelpers.Row.of(9, 8, null)));
 
-    Evaluator intSetEvaluator = new Evaluator(STRUCT,
-        notIn("x", Long.MAX_VALUE, Integer.MAX_VALUE, Long.MIN_VALUE));
     Assert.assertFalse("Integer.MAX_VALUE not_in [Integer.MAX_VALUE] => false",
         intSetEvaluator.eval(TestHelpers.Row.of(Integer.MAX_VALUE, 7.0, null)));
     Assert.assertTrue("6 not_in [Integer.MAX_VALUE]  => true",
         intSetEvaluator.eval(TestHelpers.Row.of(6, 6.8, null)));
 
-    Evaluator integerEvaluator = new Evaluator(STRUCT, notIn("y", 7, 8, 9.1));
+    Assert.assertFalse("7 not in [7, 8, 9] => false",
+        structEvaluator.eval(TestHelpers.Row.of(7, 8, null,
+            TestHelpers.Row.of(
+                TestHelpers.Row.of(
+                    TestHelpers.Row.of(
+                        TestHelpers.Row.of(7)))))));
+    Assert.assertTrue("6 not in [7, 8, 9]  => true",
+        structEvaluator.eval(TestHelpers.Row.of(6, 8, null,
+            TestHelpers.Row.of(
+                TestHelpers.Row.of(
+                    TestHelpers.Row.of(
+                        TestHelpers.Row.of(6)))))));
+
+    Assert.assertFalse("utf8(abc) not in [string(abc), string(abd)] => false",
+        charSeqEvaluator.eval(TestHelpers.Row.of(new Utf8("abc"))));
+    Assert.assertTrue("utf8(abcd) not in [string(abc), string(abd)] => true",
+        charSeqEvaluator.eval(TestHelpers.Row.of(new Utf8("abcd"))));
+
     Assert.assertFalse("7.0 not in [7, 8, 9] => false",
         integerEvaluator.eval(TestHelpers.Row.of(0, 7.0, null)));
     Assert.assertFalse("9.1 not in [7, 8, 9.1] => false",
@@ -501,26 +679,6 @@ public class TestEvaluator {
     Assert.assertTrue("6.8 not in [7, 8, 9.1]  => true",
         integerEvaluator.eval(TestHelpers.Row.of(6, 6.8, null)));
 
-    Evaluator structEvaluator = new Evaluator(STRUCT, notIn("s1.s2.s3.s4.i", 7, 8, 9));
-    Assert.assertFalse("7 not in [7, 8, 9] => false",
-            structEvaluator.eval(TestHelpers.Row.of(7, 8, null,
-                    TestHelpers.Row.of(
-                            TestHelpers.Row.of(
-                                    TestHelpers.Row.of(
-                                            TestHelpers.Row.of(7)))))));
-    Assert.assertTrue("6 not in [7, 8, 9]  => true",
-            structEvaluator.eval(TestHelpers.Row.of(6, 8, null,
-                    TestHelpers.Row.of(
-                            TestHelpers.Row.of(
-                                    TestHelpers.Row.of(
-                                            TestHelpers.Row.of(6)))))));
-
-    StructType charSeqStruct = StructType.of(required(34, "s", Types.StringType.get()));
-    Evaluator charSeqEvaluator = new Evaluator(charSeqStruct, notIn("s", "abc", "abd", "abc"));
-    Assert.assertFalse("utf8(abc) not in [string(abc), string(abd)] => false",
-            charSeqEvaluator.eval(TestHelpers.Row.of(new Utf8("abc"))));
-    Assert.assertTrue("utf8(abcd) not in [string(abc), string(abd)] => true",
-            charSeqEvaluator.eval(TestHelpers.Row.of(new Utf8("abcd"))));
   }
 
   @Test
@@ -534,8 +692,20 @@ public class TestEvaluator {
     AssertHelpers.assertThrows(
         "Throw exception if value is null",
         NullPointerException.class,
+        "Cannot create expression literal from null",
+        () -> notIn(self("x"), (Literal) null));
+
+    AssertHelpers.assertThrows(
+        "Throw exception if value is null",
+        NullPointerException.class,
         "Values cannot be null for NOT_IN predicate",
         () -> notIn("x", (Collection<?>) null));
+
+    AssertHelpers.assertThrows(
+        "Throw exception if value is null",
+        NullPointerException.class,
+        "Values cannot be null for NOT_IN predicate",
+        () -> notIn(self("x"), (Collection<?>) null));
 
     AssertHelpers.assertThrows(
         "Throw exception if calling literal() for IN predicate",
@@ -544,16 +714,34 @@ public class TestEvaluator {
         () -> notIn("x", 5, 6).literal());
 
     AssertHelpers.assertThrows(
+        "Throw exception if calling literal() for IN predicate",
+        IllegalArgumentException.class,
+        "NOT_IN predicate cannot return a literal",
+        () -> notIn(self("x"), 5, 6).literal());
+
+    AssertHelpers.assertThrows(
         "Throw exception if any value in the input is null",
         NullPointerException.class,
         "Cannot create expression literal from null",
         () -> notIn("x", 1, 2, null));
 
     AssertHelpers.assertThrows(
+        "Throw exception if any value in the input is null",
+        NullPointerException.class,
+        "Cannot create expression literal from null",
+        () -> notIn(self("x"), 1, 2, null));
+
+    AssertHelpers.assertThrows(
         "Throw exception if binding fails for any element in the set",
         ValidationException.class,
         "Invalid value for conversion to type int",
         () -> new Evaluator(STRUCT, notIn("x", 7, 8, 9.1)));
+
+    AssertHelpers.assertThrows(
+        "Throw exception if binding fails for any element in the set",
+        ValidationException.class,
+        "Invalid value for conversion to type int",
+        () -> new Evaluator(STRUCT, notIn(self("x"), 7, 8, 9.1)));
 
     AssertHelpers.assertThrows(
         "Throw exception if no input value",
@@ -566,5 +754,13 @@ public class TestEvaluator {
         ValidationException.class,
         "Invalid value for conversion to type int",
         () -> new Evaluator(STRUCT, predicate(Expression.Operation.NOT_IN, "x", 5.1)));
+  }
+
+  private <T> UnboundTerm<T> self(String name) {
+    Type type = Types.IntegerType.get();
+    if (name.equals("y")) {
+      type = Types.DoubleType.get();
+    }
+    return new UnboundTransform<>(ref(name), Transforms.identity(type));
   }
 }


### PR DESCRIPTION
Noticed this copy paste issue while updating `Expressions`. Verified that no code is actually using it, so updating it shouldn't impact any test.