### PR TITLE
Add position in manifest to DataFile and DeleteFile

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ContentFile.java
+++ b/api/src/main/java/org/apache/iceberg/ContentFile.java
@@ -30,6 +30,11 @@ import java.util.Map;
  */
 public interface ContentFile<F> {
   /**
+   * Returns the ordinal position of the file in a manifest, or null if it was not read from a manifest.
+   */
+  Long pos();
+
+  /**
    * Returns id of the partition spec used for partition metadata.
    */
   int specId();

--- a/api/src/test/java/org/apache/iceberg/TestHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/TestHelpers.java
@@ -333,6 +333,11 @@ public class TestHelpers {
     }
 
     @Override
+    public Long pos() {
+      return null;
+    }
+
+    @Override
     public int specId() {
       return 0;
     }

--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -54,7 +54,7 @@ abstract class BaseFile<F>
   private int[] fromProjectionPos;
   private Types.StructType partitionType;
 
-  private Long pos = null;
+  private Long fileOrdinal = null;
   private int partitionSpecId = -1;
   private FileContent content = FileContent.DATA;
   private String filePath = null;
@@ -154,7 +154,7 @@ abstract class BaseFile<F>
    * @param fullCopy whether to copy all fields or to drop column-level stats
    */
   BaseFile(BaseFile<F> toCopy, boolean fullCopy) {
-    this.pos = toCopy.pos;
+    this.fileOrdinal = toCopy.fileOrdinal;
     this.partitionSpecId = toCopy.partitionSpecId;
     this.content = toCopy.content;
     this.filePath = toCopy.filePath;
@@ -262,7 +262,7 @@ abstract class BaseFile<F>
         this.equalityIds = ArrayUtil.toIntArray((List<Integer>) value);
         return;
       case 14:
-        this.pos = (long) value;
+        this.fileOrdinal = (long) value;
         return;
       default:
         // ignore the object, it must be from a newer version of the format
@@ -329,7 +329,7 @@ abstract class BaseFile<F>
 
   @Override
   public Long pos() {
-    return pos;
+    return fileOrdinal;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -24,6 +24,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.avro.AvroIterable;
 import org.apache.iceberg.exceptions.RuntimeIOException;
@@ -189,10 +191,14 @@ public class ManifestReader<F extends ContentFile<F>>
     FileFormat format = FileFormat.fromFileName(file.location());
     Preconditions.checkArgument(format != null, "Unable to determine format of manifest: %s", file);
 
+    List<Types.NestedField> fields = Lists.newArrayList();
+    fields.addAll(projection.asStruct().fields());
+    fields.add(MetadataColumns.ROW_POSITION);
+
     switch (format) {
       case AVRO:
         AvroIterable<ManifestEntry<F>> reader = Avro.read(file)
-            .project(ManifestEntry.wrapFileSchema(projection.asStruct()))
+            .project(ManifestEntry.wrapFileSchema(Types.StructType.of(fields)))
             .rename("manifest_entry", GenericManifestEntry.class.getName())
             .rename("partition", PartitionData.class.getName())
             .rename("r102", PartitionData.class.getName())

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -24,8 +24,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.avro.AvroIterable;
 import org.apache.iceberg.exceptions.RuntimeIOException;

--- a/core/src/main/java/org/apache/iceberg/V1Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V1Metadata.java
@@ -365,6 +365,11 @@ class V1Metadata {
     }
 
     @Override
+    public Long pos() {
+      return null;
+    }
+
+    @Override
     public int specId() {
       return wrapped.specId();
     }

--- a/core/src/main/java/org/apache/iceberg/V2Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V2Metadata.java
@@ -416,6 +416,11 @@ class V2Metadata {
     }
 
     @Override
+    public Long pos() {
+      return null;
+    }
+
+    @Override
     public int specId() {
       return wrapped.specId();
     }

--- a/core/src/main/java/org/apache/iceberg/avro/GenericAvroReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/GenericAvroReader.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.avro;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.function.Supplier;
 import org.apache.avro.LogicalType;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
@@ -30,7 +31,7 @@ import org.apache.avro.io.Decoder;
 import org.apache.iceberg.common.DynClasses;
 import org.apache.iceberg.data.avro.DecoderResolver;
 
-class GenericAvroReader<T> implements DatumReader<T> {
+class GenericAvroReader<T> implements DatumReader<T>, SupportsRowPosition {
 
   private final Schema readSchema;
   private ClassLoader loader = Thread.currentThread().getContextClassLoader();
@@ -54,6 +55,13 @@ class GenericAvroReader<T> implements DatumReader<T> {
 
   public void setClassLoader(ClassLoader newClassLoader) {
     this.loader = newClassLoader;
+  }
+
+  @Override
+  public void setRowPositionSupplier(Supplier<Long> posSupplier) {
+    if (reader instanceof SupportsRowPosition) {
+      ((SupportsRowPosition) reader).setRowPositionSupplier(posSupplier);
+    }
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
@@ -580,10 +580,19 @@ public class ValueReaders {
     private final Object[] constants;
     private int posField = -1;
 
-    protected StructReader(List<ValueReader<?>> readers) {
+    protected StructReader(List<ValueReader<?>> readers, Schema schema) {
       this.readers = readers.toArray(new ValueReader[0]);
       this.positions = new int[0];
       this.constants = new Object[0];
+
+      List<Schema.Field> fields = schema.getFields();
+      for (int pos = 0; pos < fields.size(); pos += 1) {
+        Schema.Field field = fields.get(pos);
+        if (AvroSchemaUtil.getFieldId(field) == MetadataColumns.ROW_POSITION.fieldId()) {
+          // track where the _pos field is located for setRowPositionSupplier
+          this.posField = pos;
+        }
+      }
     }
 
     protected StructReader(List<ValueReader<?>> readers, Types.StructType struct, Map<Integer, ?> idToConstant) {
@@ -667,7 +676,7 @@ public class ValueReaders {
     private final Schema recordSchema;
 
     private RecordReader(List<ValueReader<?>> readers, Schema recordSchema) {
-      super(readers);
+      super(readers, recordSchema);
       this.recordSchema = recordSchema;
     }
 
@@ -697,7 +706,7 @@ public class ValueReaders {
     private final Schema schema;
 
     IndexedRecordReader(List<ValueReader<?>> readers, Class<R> recordClass, Schema schema) {
-      super(readers);
+      super(readers, schema);
       this.recordClass = recordClass;
       this.ctor = DynConstructors.builder(IndexedRecord.class)
           .hiddenImpl(recordClass, Schema.class)

--- a/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
@@ -618,7 +618,7 @@ public class ValueReaders {
 
     @Override
     public void setRowPositionSupplier(Supplier<Long> posSupplier) {
-      if (posField > 0) {
+      if (posField >= 0) {
         long startingPos = posSupplier.get();
         this.readers[posField] = new PositionReader(startingPos);
         for (ValueReader<?> reader : readers) {

--- a/core/src/test/java/org/apache/iceberg/TestManifestReader.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReader.java
@@ -100,4 +100,15 @@ public class TestManifestReader extends TableTestBase {
     }
   }
 
+  @Test
+  public void testDataFilePositions() throws IOException {
+    ManifestFile manifest = writeManifest(1000L, FILE_A, FILE_B, FILE_C);
+    try (ManifestReader<DataFile> reader = ManifestFiles.read(manifest, FILE_IO)) {
+      long expectedPos = 0L;
+      for (DataFile file : reader) {
+        Assert.assertEquals("Position should match", (Long) expectedPos, file.pos());
+        expectedPos += 1;
+      }
+    }
+  }
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkDataFile.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkDataFile.java
@@ -88,6 +88,11 @@ public class SparkDataFile implements DataFile {
   }
 
   @Override
+  public Long pos() {
+    return null;
+  }
+
+  @Override
   public int specId() {
     return -1;
   }


### PR DESCRIPTION
This updates `ManifestReader` to project the file position metadata column so that `DataFile` and `DeleteFile` objects read from manifests include the position within the manifest. This is in support of streaming reads, where the data in a table is turned into a stream of snapshots, then new manifests, then data files. The position of each file in a manifest can be encoded as a recoverable offset.