### PR TITLE
[python] Adding parquet package and the classes for reading parquet

### DIFF
--- a/python/iceberg/api/expressions/expression.py
+++ b/python/iceberg/api/expressions/expression.py
@@ -16,11 +16,23 @@
 # under the License.
 
 from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .predicate import Predicate
 
 
 class Expression(object):
+
+    left: 'Predicate'
+    right: 'Predicate'
+    child: 'Predicate'
+
     def __init__(self):
         pass
+
+    def op(self):
+        raise RuntimeError("No implementation for base class")
 
     def negate(self):
         raise RuntimeError("%s cannot be negated" % self)

--- a/python/iceberg/api/types/type.py
+++ b/python/iceberg/api/types/type.py
@@ -41,6 +41,10 @@ class TypeID(Enum):
 
 
 class Type(object):
+    length: int
+    scale: int
+    precision: int
+
     def __init__(self):
         pass
 

--- a/python/iceberg/api/types/types.py
+++ b/python/iceberg/api/types/types.py
@@ -310,10 +310,11 @@ class FixedType(PrimitiveType):
         return FixedType(length)
 
     def __init__(self, length):
-        self.length = length
+        self._length = length
 
+    @property
     def length(self):
-        return self.length
+        return self._length
 
     @property
     def type_id(self):
@@ -409,6 +410,8 @@ class DecimalType(PrimitiveType):
 
 
 class NestedField():
+    length: int
+
     @staticmethod
     def optional(id, name, type_var, doc=None):
         return NestedField(True, id, name, type_var, doc=doc)

--- a/python/iceberg/core/filesystem/__init__.py
+++ b/python/iceberg/core/filesystem/__init__.py
@@ -16,11 +16,12 @@
 # under the License.
 
 __all__ = ["get_fs", "FileStatus", "FileSystem", "FileSystemInputFile", "FileSystemOutputFile",
-           "FilesystemTableOperations", "FilesystemTables", "S3File", "S3FileSystem"]
+           "FilesystemTableOperations", "FilesystemTables", "LocalFileSystem", "S3File", "S3FileSystem"]
 
 from .file_status import FileStatus
 from .file_system import FileSystem, FileSystemInputFile, FileSystemOutputFile
 from .filesystem_table_operations import FilesystemTableOperations
 from .filesystem_tables import FilesystemTables
+from .local_filesystem import LocalFileSystem
 from .s3_filesystem import S3File, S3FileSystem
 from .util import get_fs

--- a/python/iceberg/core/util/profile.py
+++ b/python/iceberg/core/util/profile.py
@@ -15,24 +15,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from iceberg.core.filesystem import FileSystem
+from contextlib import contextmanager
+import logging
+import time
+
+_logger = logging.getLogger(__name__)
 
 
-class InputFile(object):
-    fs: 'FileSystem'
-    path: str
-
-    def get_length(self):
-        raise NotImplementedError()
-
-    def new_stream(self):
-        raise NotImplementedError()
-
-    def location(self):
-        raise NotImplementedError()
-
-    def new_fo(self):
-        raise NotImplementedError()
+@contextmanager
+def profile(label, stats_dict=None):
+    if stats_dict is None:
+        _logger.debug('PROFILE: %s starting' % label)
+    start = time.time()
+    yield
+    took = int((time.time() - start) * 1000)
+    if stats_dict is None:
+        _logger.debug('PROFILE: %s completed in %dms' % (label, took))
+    else:
+        stats_dict[label] = stats_dict.get(label, 0) + took

--- a/python/iceberg/exceptions/__init__.py
+++ b/python/iceberg/exceptions/__init__.py
@@ -17,10 +17,14 @@
 
 __all__ = ["AlreadyExistsException",
            "CommitFailedException",
+           "FileSystemNotFound",
+           "InvalidCastException",
            "NoSuchTableException",
            "ValidationException"]
 
 from .exceptions import (AlreadyExistsException,
                          CommitFailedException,
+                         FileSystemNotFound,
+                         InvalidCastException,
                          NoSuchTableException,
                          ValidationException)

--- a/python/iceberg/exceptions/exceptions.py
+++ b/python/iceberg/exceptions/exceptions.py
@@ -24,6 +24,14 @@ class CommitFailedException(RuntimeError):
     pass
 
 
+class FileSystemNotFound(Exception):
+    pass
+
+
+class InvalidCastException(ValueError):
+    pass
+
+
 class NoSuchTableException(RuntimeError):
     pass
 

--- a/python/iceberg/parquet/__init__.py
+++ b/python/iceberg/parquet/__init__.py
@@ -15,24 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import TYPE_CHECKING
+__all__ = ["ParquetReader"]
 
-if TYPE_CHECKING:
-    from iceberg.core.filesystem import FileSystem
-
-
-class InputFile(object):
-    fs: 'FileSystem'
-    path: str
-
-    def get_length(self):
-        raise NotImplementedError()
-
-    def new_stream(self):
-        raise NotImplementedError()
-
-    def location(self):
-        raise NotImplementedError()
-
-    def new_fo(self):
-        raise NotImplementedError()
+from .parquet_reader import ParquetReader

--- a/python/iceberg/parquet/dataset_utils.py
+++ b/python/iceberg/parquet/dataset_utils.py
@@ -1,0 +1,158 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+from iceberg.api.expressions import Expression, Operation, Predicate
+import pyarrow.dataset as ds
+
+
+def get_dataset_filter(expr: Expression, expected_to_file_map: dict) -> ds.Expression:
+    """
+    Given an Iceberg Expression and a mapping of names in the iceberg schema to the file schema,
+    convert to an equivalent dataset filter using the file column names. Recursively iterate through the
+    expressions to convert each portion one predicate at a time
+
+    Parameters
+    ----------
+    expr : iceberg.api.expressions.Expression
+        An Iceberg Expression to be converted
+    expected_to_file_map : dict
+        A dict that maps the iceberg schema names to the names from the file schema
+    Returns
+    -------
+    pyarrow._dataset.Expression
+        An equivalent dataset expression
+    """
+    if expr is None:
+        return None
+
+    if isinstance(expr, Predicate):
+        return predicate(expr, expected_to_file_map)
+
+    if expr.op() == Operation.TRUE:
+        return None
+    elif expr.op() == Operation.FALSE:
+        return False
+    elif expr.op() == Operation.NOT:
+        return not_(get_dataset_filter(expr.child, expected_to_file_map))
+    elif expr.op() == Operation.AND:
+        return and_(get_dataset_filter(expr.left, expected_to_file_map),
+                    get_dataset_filter(expr.right, expected_to_file_map))
+    elif expr.op() == Operation.OR:
+        return or_(get_dataset_filter(expr.left, expected_to_file_map),
+                   get_dataset_filter(expr.right, expected_to_file_map))
+    else:
+        raise RuntimeError("Unknown operation: {}".format(expr.op()))
+
+
+def predicate(pred: Predicate, field_map: dict) -> ds.Expression:  # noqa: ignore=C901
+    """
+    Given an Iceberg Predicate and a mapping of names in the iceberg schema to the file schema,
+    convert to an equivalent dataset expression using the file column names.
+
+    Parameters
+    ----------
+    pred : iceberg.api.expressions.Predicate
+        An Iceberg Predicate to be converted
+    field_map : dict
+        A dict that maps the iceberg schema names to the names from the file schema
+    Returns
+    -------
+    pyarrow._dataset.Expression
+        An equivalent dataset expression
+    """
+    # get column name in the file schema so we can apply the predicate
+    col_name = field_map.get(pred.ref.name)
+
+    if col_name is None:
+        if pred.op == Operation.IS_NULL:
+            return ds.scalar(True) == ds.scalar(True)
+
+        return ds.scalar(True) == ds.scalar(False)
+
+    if pred.op == Operation.IS_NULL:
+        return ~ds.field(col_name).is_valid()
+    elif pred.op == Operation.NOT_NULL:
+        return ds.field(col_name).is_valid()
+    elif pred.op == Operation.LT:
+        return ds.field(col_name) < pred.lit.value
+    elif pred.op == Operation.LT_EQ:
+        return ds.field(col_name) <= pred.lit.value
+    elif pred.op == Operation.GT:
+        return ds.field(col_name) > pred.lit.value
+    elif pred.op == Operation.GT_EQ:
+        return ds.field(col_name) >= pred.lit.value
+    elif pred.op == Operation.EQ:
+        return ds.field(col_name) == pred.lit.value
+    elif pred.op == Operation.NOT_EQ:
+        return ds.field(col_name) != pred.lit.value
+    elif pred.op == Operation.IN:
+        return ds.field(col_name).isin(pred.lit.value)
+    elif pred.op == Operation.NOT_IN:
+        return ds.field(col_name).isin(pred.lit.value)
+
+
+def and_(left: ds.Expression, right: ds.Expression) -> ds.Expression:
+    """
+    Given a left and right expression combined them using the `AND` logical operator
+
+    Parameters
+    ----------
+    left : pyarrow._dataset.Expression
+        A Dataset `Expression` to logically `AND`
+    right : pyarrow._dataset.Expression
+       A Dataset `Expression` to logically `AND`
+    Returns
+    -------
+    pyarrow._dataset.Expression
+        The left and right `Expression` combined with `AND`
+    """
+    return left & right
+
+
+def or_(left: ds.Expression, right: ds.Expression) -> ds.Expression:
+    """
+    Given a left and right expression combined them using the `OR` logical operator
+
+    Parameters
+    ----------
+    left : pyarrow._dataset.Expression
+        A Dataset `Expression` to logically `OR`
+    right : pyarrow._dataset.Expression
+       A Dataset `Expression` to logically `OR`
+    Returns
+    -------
+    pyarrow._dataset.Expression
+        The left and right `Expression` combined with `OR`
+    """
+    return left | right
+
+
+def not_(child: ds.Expression) -> ds.Expression:
+    """
+    Given a child expression create the logical negation
+
+    Parameters
+    ----------
+    child : pyarrow._dataset.Expression
+        A Dataset `Expression` to logically `OR`
+    Returns
+    -------
+    pyarrow._dataset.Expression
+        The negation of the input `Expression`
+    """
+    return ~child

--- a/python/iceberg/parquet/parquet_reader.py
+++ b/python/iceberg/parquet/parquet_reader.py
@@ -1,0 +1,224 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+from datetime import datetime
+import decimal
+import logging
+import typing
+
+from iceberg.api import Schema
+from iceberg.api.expressions import Expression
+from iceberg.api.io import InputFile
+from iceberg.api.types import NestedField, Type, TypeID
+from iceberg.core.filesystem import FileSystem, LocalFileSystem, S3FileSystem
+from iceberg.core.util.profile import profile
+from iceberg.exceptions import FileSystemNotFound, InvalidCastException
+import numpy as np
+import pyarrow as pa
+from pyarrow import fs
+import pyarrow.dataset as ds
+import pyarrow.parquet as pq
+
+from .dataset_utils import get_dataset_filter
+from .parquet_schema_utils import prune_columns
+from .parquet_to_iceberg import convert_parquet_to_iceberg
+
+_logger = logging.getLogger(__name__)
+
+DTYPE_MAP: typing.Dict[TypeID,
+                       typing.Callable[[NestedField], typing.Tuple[pa.Field, typing.Any]]] = \
+    {TypeID.BINARY: lambda field: pa.binary(),
+     TypeID.BOOLEAN: lambda field: (pa.bool_(), False),
+     TypeID.DATE: lambda field: (pa.date32(), datetime.now()),
+     TypeID.DECIMAL: lambda field: (pa.decimal128(field.type.precision, field.type.scale),
+                                    decimal.Decimal()),
+     TypeID.DOUBLE: lambda field: (pa.float64(), np.nan),
+     TypeID.FIXED: lambda field: pa.binary(field.length),
+     TypeID.FLOAT: lambda field: (pa.float32(), np.nan),
+     TypeID.INTEGER: lambda field: (pa.int32(), np.nan),
+     TypeID.LIST: lambda field: (pa.list_(pa.field("element",
+                                                   DTYPE_MAP[field.type.element_type.type_id](field.type)[0])),
+                                 None),
+     TypeID.LONG: lambda field: (pa.int64(), np.nan),
+     # To-Do: update to support reading map fields
+     # TypeID.MAP: lambda field: (,),
+     TypeID.STRING: lambda field: (pa.string(), ""),
+     TypeID.STRUCT: lambda field: (pa.struct([(nested_field.name,
+                                               DTYPE_MAP[nested_field.type.type_id](nested_field.type)[0])
+                                              for nested_field in field.type.fields]), {}),
+     TypeID.TIMESTAMP: lambda field: (pa.timestamp("us"), datetime.now()),
+     # not used in SPARK, so not implementing for now
+     # TypeID.TIME: pa.time64(None)
+     }
+
+FS_MAP: typing.Dict[typing.Type[FileSystem], typing.Type[fs.FileSystem]] = {LocalFileSystem: fs.LocalFileSystem}
+
+try:
+    FS_MAP[S3FileSystem] = fs.S3FileSystem
+
+except ImportError:
+    _logger.warning("Mapped filesystem not available")
+
+
+class ParquetReader(object):
+
+    def __init__(self, input: InputFile, expected_schema: Schema, options, filter_expr: Expression,
+                 case_sensitive: bool, start: int = None, end: int = None):
+        self._stats: typing.Dict[str, int] = dict()
+
+        self._input = input
+        self._input_fo = input.new_fo()
+
+        self._arrow_file = pq.ParquetFile(self._input_fo)
+        self._file_schema = convert_parquet_to_iceberg(self._arrow_file)
+        self._expected_schema = expected_schema
+        self._file_to_expected_name_map = ParquetReader.get_field_map(self._file_schema,
+                                                                      self._expected_schema)
+        self._options = options
+        self._filter = get_dataset_filter(filter_expr, ParquetReader.get_reverse_field_map(self._file_schema,
+                                                                                           self._expected_schema))
+
+        self._case_sensitive = case_sensitive
+        if start is not None or end is not None:
+            raise NotImplementedError("Partial file reads are not yet supported")
+            # self.start = start
+            # self.end = end
+
+        self.materialized_table = False
+        self._table = None
+
+        _logger.debug("Reader initialized for %s" % self._input.path)
+
+    @property
+    def stats(self) -> typing.Dict[str, int]:
+        return dict(self._stats)
+
+    def read(self, force=False) -> pa.Table:
+        if not self.materialized_table or force:
+            self._read_data()
+
+        return self._table
+
+    def _read_data(self) -> None:
+        _logger.debug("Starting data read")
+
+        # only scan the columns projected and in our file
+        cols_to_read = prune_columns(self._file_schema, self._expected_schema)
+
+        with profile("read data", self._stats):
+            try:
+                read_fs = FS_MAP[type(self._input.fs)]
+            except KeyError:
+                raise FileSystemNotFound(f"No mapped filesystem found for {type(self._input.fs)}")
+
+            arrow_dataset = ds.FileSystemDataset.from_paths([self._input.location()],
+                                                            schema=self._arrow_file.schema_arrow,
+                                                            format=ds.ParquetFileFormat(),
+                                                            filesystem=read_fs())
+
+            arrow_table = arrow_dataset.to_table(columns=cols_to_read, filter=self._filter)
+
+        # process schema evolution if needed
+        with profile("schema_evol_proc", self._stats):
+            processed_tbl = self.migrate_schema(arrow_table)
+            for i, field in self.get_missing_fields():
+                dtype_func = DTYPE_MAP.get(field.type.type_id)
+                if dtype_func is None:
+                    raise RuntimeError("Unable to create null column for type %s" % field.type.type_id)
+
+                dtype = dtype_func(field)
+                processed_tbl = (processed_tbl.add_column(i,
+                                                          pa.field(field.name, dtype[0], True, None),
+                                                          ParquetReader.create_null_column(processed_tbl[0],
+                                                                                           dtype)))
+        self._table = processed_tbl
+        self.materialized_table = True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        _logger.debug(self._stats)
+        self.close()
+
+    def close(self):
+        self._input_fo.close()
+
+    def get_missing_fields(self) -> typing.List[typing.Tuple[int, NestedField]]:
+        return [(i, field) for i, field in enumerate(self._expected_schema.as_struct().fields)
+                if self._file_schema.find_field(field.id) is None]
+
+    @staticmethod
+    def get_field_map(file_schema, expected_schema) -> typing.Dict[str, str]:
+        return {file_schema.find_field(field.id).name: field.name
+                for field in expected_schema.as_struct().fields
+                if file_schema.find_field(field.id) is not None}
+
+    @staticmethod
+    def get_reverse_field_map(file_schema, expected_schema) -> typing.Dict[str, str]:
+        return {expected_schema.find_field(field.id).name: field.name
+                for field in file_schema.as_struct().fields
+                if expected_schema.find_field(field.id) is not None}
+
+    def migrate_schema(self, table: pa.Table) -> pa.Table:
+        data_arrays: typing.List[pa.ChunkedArray] = []
+        schema: typing.List[pa.Field] = []
+        for key, value in self._file_to_expected_name_map.items():
+            column_idx: int = table.schema.get_field_index(key)
+            column_field: pa.Field = table.schema[column_idx]
+            column_arrow_type: pa.DataType = column_field.type
+            column_data: pa.ChunkedArray = table[column_idx]
+
+            iceberg_field: NestedField = self._expected_schema.find_field(value)
+            converted_field: NestedField = self._file_schema.find_field(key)
+
+            if iceberg_field.type != converted_field.type:
+                if not ParquetReader.is_supported_cast(converted_field.type, iceberg_field.type):
+                    _logger.error(f"unsupported cast {converted_field.type} -> {iceberg_field.type}")
+                    raise InvalidCastException("")
+                try:
+                    column_arrow_type = DTYPE_MAP[iceberg_field.type.type_id](iceberg_field)[0]
+                    column_data = column_data.cast(column_arrow_type)
+                except KeyError:
+                    _logger.error(f"Unable to map {iceberg_field.type} to an arrow type")
+                    raise
+
+            data_arrays.append(column_data)
+            schema.append(pa.field(value, column_arrow_type, column_field.nullable, column_field.metadata))
+
+        return pa.table(data_arrays, schema=pa.schema(schema))
+
+    @staticmethod
+    def create_null_column(reference_column: pa.ChunkedArray, dtype_tuple: typing.Tuple[pa.DataType, typing.Any]) -> pa.ChunkedArray:
+        dtype, init_val = dtype_tuple
+        return pa.chunked_array([pa.array(np.full(len(c), init_val),
+                                          type=dtype,
+                                          mask=np.array([True] * len(reference_column.chunks[0]), dtype="bool"))
+                                 for c in reference_column.chunks], type=dtype)
+
+    @staticmethod
+    def is_supported_cast(old_type: Type, new_type: Type) -> bool:
+        if old_type.type_id == TypeID.INTEGER and new_type.type_id == TypeID.LONG:
+            return True
+        elif old_type.type_id == TypeID.FLOAT and new_type.type_id == TypeID.DOUBLE:
+            return True
+        elif old_type.type_id == TypeID.DECIMAL and new_type.type_id == TypeID.DECIMAL \
+                and old_type.precision < new_type.precision \
+                and old_type.scale == new_type.scale:
+            return True
+        return False

--- a/python/iceberg/parquet/parquet_schema_utils.py
+++ b/python/iceberg/parquet/parquet_schema_utils.py
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import List
+
+from iceberg.api import Schema
+from iceberg.api.types import get_projected_ids
+
+
+def prune_columns(file_schema: Schema, expected_schema: Schema) -> List[str]:
+    """
+    Given two Iceberg schema's returns a list of column_names for all id's in the
+    file schema that are projected in the expected schema
+
+    Parameters
+    ----------
+    file_schema : iceberg.api.Schema
+        An Iceberg schema of the file being read
+    expected_schema : iceberg.api.Schema
+        An Iceberg schema of the final projection
+    Returns
+    -------
+    list
+        The column names in the file that matched ids in the expected schema
+    """
+    return [column.name for column in file_schema.as_struct().fields
+            if column.id in get_projected_ids(expected_schema)]

--- a/python/iceberg/parquet/parquet_to_iceberg.py
+++ b/python/iceberg/parquet/parquet_to_iceberg.py
@@ -1,0 +1,152 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+import logging
+
+from iceberg.api import Schema
+from iceberg.api.types import (BinaryType,
+                               BooleanType,
+                               DateType,
+                               DecimalType,
+                               DoubleType,
+                               FixedType,
+                               FloatType,
+                               IntegerType,
+                               ListType,
+                               LongType,
+                               MapType,
+                               NestedField,
+                               StringType,
+                               StructType,
+                               TimestampType)
+from iceberg.api.types import Type
+import pyarrow as pa
+from pyarrow.parquet import lib, ParquetFile
+
+_logger = logging.getLogger(__name__)
+
+arrow_type_map = {lib.Type_BOOL: lambda x=None: BooleanType.get(),
+                  lib.Type_DATE32: lambda x=None: DateType.get(),
+                  lib.Type_DECIMAL: lambda x=None: DecimalType.of(x.precision, x.scale),
+                  lib.Type_DOUBLE: lambda x=None: DoubleType.get(),
+                  lib.Type_FIXED_SIZE_BINARY: lambda x=None: FixedType.of_length(x.byte_width),
+                  lib.Type_BINARY: lambda x=None: BinaryType.get(),
+                  lib.Type_FLOAT: lambda x=None: FloatType.get(),
+                  lib.Type_STRING: lambda x=None: StringType.get(),
+                  lib.Type_INT32: lambda x=None: IntegerType.get(),
+                  lib.Type_INT64: lambda x=None: LongType.get(),
+                  lib.Type_TIMESTAMP: lambda x=None: (TimestampType.without_timezone()
+                                                      if x.tz is None
+                                                      else TimestampType.with_timezone())
+                  }
+
+
+def get_nested_field(field_id: int, field_name: str, field_type: Type, nullable: bool) -> NestedField:
+    if nullable:
+        return NestedField.optional(field_id, field_name, field_type)
+    else:
+        return NestedField.required(field_id, field_name, field_type)
+
+
+def get_list_field(col_type: pa.ListType) -> ListType:
+    if col_type.value_field.nullable:
+        return ListType.of_optional(int(col_type.value_field.metadata[b"PARQUET:field_id"].decode("utf-8")),
+                                    arrow_type_map[col_type.value_field.type.id](col_type.value_field.type))
+    else:
+        return ListType.of_required(col_type.value_field.metadata[b"PARQUET:field_id"].decode("utf-8"),
+                                    arrow_type_map[col_type.value_field.type.id](col_type.value_field.type))
+
+
+def get_field(col: pa.Field) -> NestedField:
+    try:
+        return get_nested_field(int(col.metadata[b"PARQUET:field_id"].decode("utf-8")),
+                                col.name,
+                                arrow_type_map[col.type.id](col.type),
+                                col.nullable)
+    except KeyError:
+        _logger.error(f"\t{int(col.metadata[b'PARQUET:field_id'].decode('utf-8'))}: {col.type}")
+        raise
+
+
+def get_struct_field(col_type: pa.StructType) -> StructType:
+    if col_type.num_fields > 0:
+        if col_type[0].name == "map":
+            return get_inferred_map(col_type)
+        else:
+            return StructType.of([get_field(child) for child in col_type])
+    else:
+        raise RuntimeError("Unable to convert type to iceberg %s" % col_type)
+
+
+def get_inferred_map(col_type: pa.StructType):
+    base_field = col_type[0]
+    key_field = get_field(col_type[0].type.value_field.type[0])
+    value_field = get_field(col_type[0].type.value_field.type[1])
+
+    if base_field.nullable:
+        return MapType.of_optional(key_field.field_id, value_field.field_id,
+                                   key_field.type, value_field.type)
+    else:
+        return MapType.of_required(key_field.field_id, value_field.field_id,
+                                   key_field.type, value_field.type)
+
+
+def get_map_field(col):
+    # Spark Map type gets serialized to Struct<List<Struct<>>>
+    raise NotImplementedError("Arrow Map type not implemented yet")
+
+
+# adding function mappings for nested types
+arrow_type_map.update({lib.Type_LIST: get_list_field,
+                       lib.Type_MAP: get_map_field,
+                       lib.Type_STRUCT: get_struct_field})
+
+
+def convert_parquet_to_iceberg(parquet_file: ParquetFile) -> Schema:  # noqa: ignore=C901
+    """
+    Given two Iceberg schema's returns a list of column_names for all id's in the
+    file schema that are projected in the expected schema
+
+    Parameters
+    ----------
+    parquet_file : pyarrow.parquet.ParquetFile
+        The Parquet File to use to extract the iceberg schema
+
+    Returns
+    -------
+    iceberg.api.Schema
+        returns an equivalent iceberg Schema based on the arrow schema read from the file
+    """
+    return arrow_to_iceberg(parquet_file.schema_arrow)
+
+
+def arrow_to_iceberg(arrow_schema: pa.Schema) -> Schema:
+    """
+    Use an arrow schema, which contains the field_id metadata, to create an equivalent iceberg Schema
+
+    Parameters
+    ----------
+    arrow_schema : pyarrow.Schema
+        An Arrow schema with the parquet field_id metadata
+
+    Returns
+    -------
+    iceberg.api.Schema
+        returns an equivalent iceberg Schema based on the arrow schema read from the file
+    """
+    return Schema([get_field(col) for col in arrow_schema])

--- a/python/setup.py
+++ b/python/setup.py
@@ -29,7 +29,6 @@ setup(
     install_requires=['botocore',
                       'boto3',
                       'fastavro',
-                      'fastparquet>=0.3.1',
                       'hmsclient',
                       'mmh3',
                       'pyparsing',
@@ -38,7 +37,7 @@ setup(
                       'requests',
                       'retrying',
                       'pandas',
-                      'pyarrow'
+                      'pyarrow>=2.0.0'
                       ],
     extras_require={
         "dev": [

--- a/python/tests/parquet/__init__.py
+++ b/python/tests/parquet/__init__.py
@@ -14,25 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from iceberg.core.filesystem import FileSystem
-
-
-class InputFile(object):
-    fs: 'FileSystem'
-    path: str
-
-    def get_length(self):
-        raise NotImplementedError()
-
-    def new_stream(self):
-        raise NotImplementedError()
-
-    def location(self):
-        raise NotImplementedError()
-
-    def new_fo(self):
-        raise NotImplementedError()

--- a/python/tests/parquet/conftest.py
+++ b/python/tests/parquet/conftest.py
@@ -1,0 +1,226 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from collections import namedtuple
+from datetime import datetime
+from decimal import Decimal
+from tempfile import NamedTemporaryFile
+
+from iceberg.api import Schema
+from iceberg.api.types import (DateType,
+                               DecimalType,
+                               FloatType,
+                               IntegerType,
+                               LongType,
+                               NestedField,
+                               StringType,
+                               TimestampType)
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+
+TestRowGroupColumnStatistics = namedtuple("TestRowGroupColumnStatistics", ["min", "max", "null_count"])
+TestRowGroupColumn = namedtuple("TestRowGroupColumn", ["path_in_schema",
+                                                       "file_offset",
+                                                       "total_compressed_size",
+                                                       "statistics"])
+
+
+class TestArrowParquetMetadata:
+    __test__ = False
+
+    def __init__(self, col_metadata, num_rows=100):
+        self._col_metadata = col_metadata
+        self._num_rows = num_rows
+
+    @property
+    def num_rows(self):
+        return self._num_rows
+
+    @property
+    def num_columns(self):
+        return len(self._col_metadata)
+
+    def column(self, i):
+        return self._col_metadata[i]
+
+    def __getitem__(self, index):
+        return self._col_metadata[index]
+
+
+@pytest.fixture(scope="session")
+def pyarrow_array():
+    return [pa.array([1, 2, 3, None, 5], type=pa.int32()),
+            pa.array(['us', 'can', 'us', 'us', 'can'], type=pa.string()),
+            pa.array([[0], [1, 2], [1], [1, 2, 3], None], type=pa.list_(pa.int64())),
+            pa.array([True, None, False, True, True], pa.bool_())]
+
+
+@pytest.fixture(scope="session")
+def pytable_colnames():
+    return ['int_col', 'str_col', 'list_col', 'bool_col']
+
+
+@pytest.fixture(scope="session")
+def rg_expected_schema():
+    return Schema([NestedField.required(1, "string_col", StringType.get()),
+                   NestedField.required(2, "long_col", LongType.get()),
+                   NestedField.required(3, "int_col", IntegerType.get()),
+                   NestedField.optional(4, "float_col", FloatType.get()),
+                   NestedField.optional(5, "null_col", StringType.get()),
+                   NestedField.optional(6, "missing_col", StringType.get()),
+                   NestedField.optional(7, "no_stats_col", StringType.get()),
+                   NestedField.optional(8, "ts_wtz_col", TimestampType.with_timezone()),
+                   NestedField.optional(9, "ts_wotz_col", TimestampType.without_timezone()),
+                   NestedField.optional(10, "big_decimal_type", DecimalType.of(38, 5)),
+                   NestedField.optional(11, "small_decimal_type", DecimalType.of(10, 2)),
+                   NestedField.optional(12, "date_type", DateType.get()),
+                   ])
+
+
+@pytest.fixture(scope="session")
+def rg_expected_schema_map():
+    return {"string_col": "string_col",
+            "long_col": "long_col",
+            "int_col_renamed": "int_col",
+            "float_col": "float_col",
+            "null_col": "null_col",
+            "no_stats_col": "no_stats_col",
+            "ts_wtz_col": "ts_wtz_col",
+            "ts_wotz_col": "ts_wotz_col",
+            "big_decimal_type": "big_decimal_type",
+            "small_decimal_type": "small_decimal_type",
+            "date_type": "date_type"
+            }
+
+
+@pytest.fixture(scope="session")
+def rg_col_metadata():
+    return [TestRowGroupColumn("string_col", 4, 12345, TestRowGroupColumnStatistics("b", "e", 0)),
+            TestRowGroupColumn("long_col", 12349, 12345, TestRowGroupColumnStatistics(0, 1234567890123, 0)),
+            TestRowGroupColumn("int_col_renamed", 24698, 12345, TestRowGroupColumnStatistics(0, 12345, 0)),
+            TestRowGroupColumn("float_col", 37043, 12345, TestRowGroupColumnStatistics(0.0, 123.45, 50)),
+            TestRowGroupColumn("null_col", 49388, 4, TestRowGroupColumnStatistics(None, None, 100)),
+            TestRowGroupColumn("no_stats_col", 61733, 4, None),
+            TestRowGroupColumn("ts_wtz_col", 74078, 4,
+                               TestRowGroupColumnStatistics(datetime.strptime("2019-01-01 00:00:00-0000",
+                                                                              "%Y-%m-%d %H:%M:%S%z"),
+                                                            datetime.strptime("2019-12-31 00:00:00-0000",
+                                                                              "%Y-%m-%d %H:%M:%S%z"),
+                                                            0)),
+            TestRowGroupColumn("ts_wotz_col", 86423, 4,
+                               TestRowGroupColumnStatistics(datetime.strptime("2019-01-01 00:00:00-0000",
+                                                                              "%Y-%m-%d %H:%M:%S%z"),
+                                                            datetime.strptime("2019-12-31 00:00:00-0000",
+                                                                              "%Y-%m-%d %H:%M:%S%z"),
+                                                            10)),
+            TestRowGroupColumn("big_decimal_type", 98768, 4,
+                               # -123456789012345678.12345 to 123456789012345678.12345
+                               TestRowGroupColumnStatistics(b'\xff\xff\xff\xff\xff\xff\xfdb\xbdI\xb1\x89\x8e\xbe\xeb\x07',
+                                                            b'\x00\x00\x00\x00\x00\x00\x02\x9dB\xb6NvqA\x14\xf9',
+                                                            10)),
+            TestRowGroupColumn("small_decimal_type", 111113, 4,
+                               # 0 to 123.45
+                               TestRowGroupColumnStatistics(0,
+                                                            12345,
+                                                            10)),
+            TestRowGroupColumn("date_type", 123458, 4,
+                               # 2020-01-01 to 2020-12-31
+                               TestRowGroupColumnStatistics(18262, 18262 + 365, 10))
+            ]
+
+
+@pytest.fixture(scope="session")
+def pyarrow_schema():
+    return pa.schema([pa.field("int_col", pa.int32(), False),
+                      pa.field("bigint_col", pa.int64(), True),
+                      pa.field("str_col", pa.string(), True),
+                      pa.field("float_col", pa.float32(), True),
+                      pa.field("dbl_col", pa.float64(), True),
+                      pa.field("decimal_col",
+                               pa.decimal128(9, 2), True),
+                      pa.field("big_decimal_col",
+                               pa.decimal128(19, 5), True),
+                      pa.field("huge_decimal_col",
+                               pa.decimal128(38, 9), True),
+                      pa.field("date_col", pa.date32(), True),
+                      pa.field("ts_col", pa.timestamp('us'), True),
+                      pa.field("ts_wtz_col",
+                               pa.timestamp('us',
+                                            'America/New_York'),
+                               True),
+                      pa.field("bool_col", pa.bool_(), True)])
+
+
+@pytest.fixture(scope="session")
+def pyarrow_primitive_array():
+    return [pa.array([1, 2, 3, 4, 5], type=pa.int32()),
+            pa.array([1, 2, 3, None, 5], type=pa.int64()),
+            pa.array(['us', 'can', 'us', 'us', 'can'], type=pa.string()),
+            pa.array([1.0, 2.0, 3.0, 4.0, 5.0], type=pa.float32()),
+            pa.array([1.0, 2.0, 3.0, 4.0, 5.0], type=pa.float64()),
+            pa.array([Decimal("1.0"), Decimal("2.0"), Decimal("3.0"),
+                      Decimal("4.0"), Decimal("5.0")], type=pa.decimal128(9, 2)),
+            pa.array([Decimal("1.0"), Decimal("2.0"), Decimal("3.0"),
+                      Decimal("4.0"), Decimal("5.0")], type=pa.decimal128(19, 5)),
+            pa.array([Decimal("1.0"), Decimal("2.0"), Decimal("3.0"),
+                      Decimal("4.0"), Decimal("5.0")], type=pa.decimal128(38, 9)),
+            pa.array([18506, 18507, 18508, 18508, 18510], type=pa.date32()),
+            pa.array([1598918400000000, 1599004800000000,
+                      1599091200000000, 1599177600000000, 1599264000000000],
+                     type=pa.timestamp("us")),
+            pa.array([1598918400000000, 1599004800000000,
+                      1599091200000000, 1599177600000000, 1599264000000000],
+                     type=pa.timestamp("us", 'America/New_York')),
+            pa.array([True, None, False, True, True], pa.bool_())]
+
+
+@pytest.fixture(scope="session")
+def primitive_type_test_file(pyarrow_primitive_array, pyarrow_schema):
+    with NamedTemporaryFile() as temp_file:
+        pq.write_table(pa.table(pyarrow_primitive_array, schema=pyarrow_schema), temp_file.name)
+        yield temp_file.name
+
+
+@pytest.fixture(scope="session")
+def primitive_type_test_parquet_file(primitive_type_test_file):
+    yield pq.ParquetFile(primitive_type_test_file)
+
+
+@pytest.fixture(scope="session")
+def unnested_complex_type_test_parquet_file():
+    struct_fields = [("f1", pa.int32()), ("f2", pa.string())]
+    struct_type = pa.struct(struct_fields)
+    pyarrow_array = [pa.array([[1, 2, 3], [4, None, 6], None, [7, 8, 9]], type=pa.list_(pa.int32())),
+                     pa.array([["a", "b", "c"], ["d", None, "e"], None, ["f", "g", "h"]], type=pa.list_(pa.string())),
+                     pa.array([None, None, {"f1": 3, "f2": "c"}, {"f1": 4, "f2": "d"}], type=struct_type)
+                     ]
+    with NamedTemporaryFile() as temp_file:
+        pq.write_table(pa.table(pyarrow_array, names=["list_int_col", 'list_str_col', 'struct_col']),
+                       temp_file.name)
+        yield pq.ParquetFile(temp_file.name)
+
+
+@pytest.fixture(scope="session")
+def parquet_schema(type_test_parquet_file):
+    return type_test_parquet_file.schema
+
+
+@pytest.fixture(scope="session")
+def arrow_schema(type_test_parquet_file):
+    return type_test_parquet_file.schema_arrow

--- a/python/tests/parquet/test_dataset_utils.py
+++ b/python/tests/parquet/test_dataset_utils.py
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from iceberg.api.expressions import Expressions
+from iceberg.parquet.dataset_utils import get_dataset_filter
+import pyarrow.dataset as ds
+import pytest
+
+
+@pytest.mark.parametrize("expr, dataset_filter, column_map",
+                         [(Expressions.greater_than('a', 1), ds.field('a') > 1, {'a': 'a'}),
+                          (Expressions.greater_than_or_equal('a', 1), ds.field('a') >= 1, {'a': 'a'}),
+                          (Expressions.less_than('a', 1), ds.field('a') < 1, {'a': 'a'}),
+                          (Expressions.less_than_or_equal('a', 1), ds.field('a') <= 1, {'a': 'a'}),
+                          (Expressions.equal('a', 1), ds.field('a') == 1, {'a': 'a'}),
+                          (Expressions.not_equal('a', 1), ds.field('a') != 1, {'a': 'a'}),
+                          (Expressions.not_null('a'), ds.field('a').is_valid(), {'a': 'a'}),
+                          (Expressions.is_null('a'), ~ds.field('a').is_valid(), {'a': 'a'})
+
+                          ])
+def test_simple(expr, dataset_filter, column_map):
+    translated_dataset_filter = get_dataset_filter(expr, column_map)
+    assert dataset_filter.equals(translated_dataset_filter)
+
+
+def test_not_conversion():
+    expr = Expressions.not_(Expressions.greater_than('a', 1))
+    translated_dataset_filter = get_dataset_filter(expr, {'a': 'a'})
+    assert (~(ds.field("a") > 1)).equals(translated_dataset_filter)
+
+
+def test_complex_expr():
+    expr = Expressions.or_(Expressions.and_(Expressions.greater_than('a', 1), Expressions.equal("b", "US")),
+                           Expressions.equal("c", True))
+
+    translated_dataset_filter = get_dataset_filter(expr, {'a': 'a', 'b': 'b', 'c': 'c'})
+    dataset_filter = (((ds.field("a") > 1) & (ds.field("b") == "US")) | (ds.field("c") == True))  # noqa: E712
+    assert dataset_filter.equals(translated_dataset_filter)

--- a/python/tests/parquet/test_parquet_reader.py
+++ b/python/tests/parquet/test_parquet_reader.py
@@ -1,0 +1,285 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from iceberg.api import Schema
+from iceberg.api.expressions import Expressions
+from iceberg.api.types import (BooleanType,
+                               DateType,
+                               DecimalType,
+                               DoubleType,
+                               FloatType,
+                               IntegerType,
+                               LongType,
+                               NestedField,
+                               StringType,
+                               TimestampType)
+from iceberg.core.filesystem import FileSystemInputFile, get_fs
+from iceberg.parquet import ParquetReader
+import pyarrow as pa
+
+
+def test_basic_read(primitive_type_test_file, pyarrow_primitive_array, pyarrow_schema):
+    expected_schema = Schema([NestedField.required(1, "int_col", IntegerType.get()),
+                              NestedField.optional(2, "bigint_col", LongType.get()),
+                              NestedField.optional(3, "str_col", StringType.get()),
+                              NestedField.optional(4, "float_col", FloatType.get()),
+                              NestedField.optional(5, "dbl_col", DoubleType.get()),
+                              NestedField.optional(6, "decimal_col", DecimalType.of(9, 2)),
+                              NestedField.optional(7, "big_decimal_col", DecimalType.of(19, 5)),
+                              NestedField.optional(8, "huge_decimal_col", DecimalType.of(38, 9)),
+                              NestedField.optional(9, "date_col", DateType.get()),
+                              NestedField.optional(10, "ts_col", TimestampType.without_timezone()),
+                              NestedField.optional(11, "ts_wtz_col", TimestampType.with_timezone()),
+                              NestedField.optional(12, "bool_col", BooleanType.get())])
+
+    input_file = FileSystemInputFile(get_fs(primitive_type_test_file, conf={}), primitive_type_test_file, {})
+    reader = ParquetReader(input_file, expected_schema, {}, Expressions.always_true(), True)
+
+    source_table = pa.table(pyarrow_primitive_array, schema=pyarrow_schema)
+    assert reader.read() == source_table
+
+
+def test_projection(primitive_type_test_file, pyarrow_primitive_array, pyarrow_schema):
+    expected_schema = Schema([NestedField.required(1, "int_col", IntegerType.get()),
+                              NestedField.optional(2, "bigint_col", LongType.get())])
+
+    input_file = FileSystemInputFile(get_fs(primitive_type_test_file, conf={}), primitive_type_test_file, {})
+    reader = ParquetReader(input_file, expected_schema, {}, Expressions.always_true(), True)
+
+    source_table = pa.table(pyarrow_primitive_array, schema=pyarrow_schema)
+    num_cols = source_table.num_columns
+    for i in range(1, num_cols - 1):
+        source_table = source_table.remove_column(num_cols - i)
+
+    assert source_table == reader.read()
+
+
+def test_column_rename(primitive_type_test_file):
+    expected_schema = Schema([NestedField.required(1, "int_col", IntegerType.get()),
+                              NestedField.optional(2, "bigint_col", LongType.get()),
+                              NestedField.optional(3, "string_col", StringType.get()),
+                              NestedField.optional(4, "float_col", FloatType.get()),
+                              NestedField.optional(5, "dbl_col", DoubleType.get())])
+
+    input_file = FileSystemInputFile(get_fs(primitive_type_test_file, conf={}), primitive_type_test_file, {})
+    reader = ParquetReader(input_file, expected_schema, {}, Expressions.always_true(), True)
+    pyarrow_array = [pa.array([1, 2, 3, 4, 5], type=pa.int32()),
+                     pa.array([1, 2, 3, None, 5], type=pa.int64()),
+                     pa.array(['us', 'can', 'us', 'us', 'can'], type=pa.string()),
+                     pa.array([1.0, 2.0, 3.0, 4.0, 5.0], type=pa.float32()),
+                     pa.array([1.0, 2.0, 3.0, 4.0, 5.0], type=pa.float64())]
+    schema = pa.schema([pa.field("int_col", pa.int32(), False),
+                        pa.field("bigint_col", pa.int64(), True),
+                        pa.field("string_col", pa.string(), True),
+                        pa.field("float_col", pa.float32(), True),
+                        pa.field("dbl_col", pa.float64(), True)])
+
+    source_table = pa.table(pyarrow_array, schema=schema)
+
+    target_table = reader.read()
+    assert source_table == target_table
+
+
+def test_column_add(primitive_type_test_file):
+    expected_schema = Schema([NestedField.required(1, "int_col", IntegerType.get()),
+                              NestedField.optional(2, "bigint_col", LongType.get()),
+                              NestedField.optional(3, "string_col", StringType.get()),
+                              NestedField.optional(4, "float_col", FloatType.get()),
+                              NestedField.optional(5, "dbl_col", DoubleType.get()),
+                              NestedField.optional(13, "int_col2", IntegerType.get())])
+
+    input_file = FileSystemInputFile(get_fs(primitive_type_test_file, conf={}), primitive_type_test_file, {})
+    reader = ParquetReader(input_file, expected_schema, {}, Expressions.always_true(), True)
+    pyarrow_array = [pa.array([1, 2, 3, 4, 5], type=pa.int32()),
+                     pa.array([1, 2, 3, None, 5], type=pa.int64()),
+                     pa.array(['us', 'can', 'us', 'us', 'can'], type=pa.string()),
+                     pa.array([1.0, 2.0, 3.0, 4.0, 5.0], type=pa.float32()),
+                     pa.array([1.0, 2.0, 3.0, 4.0, 5.0], type=pa.float64()),
+                     pa.array([None, None, None, None, None], type=pa.int32())]
+    source_table = pa.table(pyarrow_array, schema=pa.schema([pa.field("int_col", pa.int32(), nullable=False),
+                                                             pa.field("bigint_col", pa.int64(), nullable=True),
+                                                             pa.field("string_col", pa.string(), nullable=True),
+                                                             pa.field("float_col", pa.float32(), nullable=True),
+                                                             pa.field("dbl_col", pa.float64(), nullable=True),
+                                                             pa.field("int_col2", pa.int32(), nullable=True),
+                                                             ]))
+
+    target_table = reader.read()
+    assert source_table == target_table
+
+
+def test_decimal_column_add(primitive_type_test_file):
+    expected_schema = Schema([NestedField.required(1, "int_col", IntegerType.get()),
+                              NestedField.optional(2, "bigint_col", LongType.get()),
+                              NestedField.optional(4, "float_col", FloatType.get()),
+                              NestedField.optional(5, "dbl_col", DoubleType.get()),
+                              NestedField.optional(13, "new_dec_col", DecimalType.of(38, 9))
+                              ])
+
+    input_file = FileSystemInputFile(get_fs(primitive_type_test_file, conf={}), primitive_type_test_file, {})
+    reader = ParquetReader(input_file, expected_schema, {}, Expressions.always_true(), True)
+    pyarrow_array = [pa.array([1, 2, 3, 4, 5], type=pa.int32()),
+                     pa.array([1, 2, 3, None, 5], type=pa.int64()),
+                     pa.array([1.0, 2.0, 3.0, 4.0, 5.0], type=pa.float32()),
+                     pa.array([1.0, 2.0, 3.0, 4.0, 5.0], type=pa.float64()),
+                     pa.array([None, None, None, None, None], type=pa.decimal128(38, 9))]
+
+    source_table = pa.table(pyarrow_array, schema=pa.schema([pa.field("int_col", pa.int32(), nullable=False),
+                                                             pa.field("bigint_col", pa.int64(), nullable=True),
+                                                             pa.field("float_col", pa.float32(), nullable=True),
+                                                             pa.field("dbl_col", pa.float64(), nullable=True),
+                                                             pa.field("new_dec_col", pa.decimal128(38, 9), nullable=True)
+                                                             ]))
+
+    target_table = reader.read()
+    assert source_table == target_table
+
+
+def test_column_reorder(primitive_type_test_file):
+    expected_schema = Schema([NestedField.required(1, "int_col", IntegerType.get()),
+                              NestedField.optional(2, "bigint_col", LongType.get()),
+                              NestedField.optional(4, "float_col", FloatType.get()),
+                              NestedField.optional(5, "dbl_col", DoubleType.get()),
+                              NestedField.optional(3, "string_col", StringType.get())])
+
+    input_file = FileSystemInputFile(get_fs(primitive_type_test_file, conf={}), primitive_type_test_file, {})
+    reader = ParquetReader(input_file, expected_schema, {}, Expressions.always_true(), True)
+    pyarrow_array = [pa.array([1, 2, 3, 4, 5], type=pa.int32()),
+                     pa.array([1, 2, 3, None, 5], type=pa.int64()),
+                     pa.array([1.0, 2.0, 3.0, 4.0, 5.0], type=pa.float32()),
+                     pa.array([1.0, 2.0, 3.0, 4.0, 5.0], type=pa.float64()),
+                     pa.array(['us', 'can', 'us', 'us', 'can'], type=pa.string())]
+    source_table = pa.table(pyarrow_array, schema=pa.schema([pa.field("int_col", pa.int32(), nullable=False),
+                                                             pa.field("bigint_col", pa.int64(), nullable=True),
+                                                             pa.field("float_col", pa.float32(), nullable=True),
+                                                             pa.field("dbl_col", pa.float64(), nullable=True),
+                                                             pa.field("string_col", pa.string(), nullable=True)
+                                                             ]))
+
+    target_table = reader.read()
+    assert source_table == target_table
+
+
+def test_column_upcast(primitive_type_test_file):
+    expected_schema = Schema([NestedField.required(1, "int_col", LongType.get())])
+
+    input_file = FileSystemInputFile(get_fs(primitive_type_test_file, conf={}), primitive_type_test_file, {})
+    reader = ParquetReader(input_file, expected_schema, {}, Expressions.always_true(), True)
+    pyarrow_array = [pa.array([1, 2, 3, 4, 5], type=pa.int32())]
+    source_table = pa.table(pyarrow_array, schema=pa.schema([pa.field("int_col", pa.int64(), nullable=False)]))
+
+    target_table = reader.read()
+    assert source_table == target_table
+
+
+def test_filter(primitive_type_test_file):
+    expected_schema = Schema([NestedField.required(1, "int_col", IntegerType.get()),
+                              NestedField.optional(2, "bigint_col", LongType.get()),
+                              NestedField.optional(4, "float_col", FloatType.get()),
+                              NestedField.optional(5, "dbl_col", DoubleType.get()),
+                              NestedField.optional(3, "string_col", StringType.get())])
+
+    input_file = FileSystemInputFile(get_fs(primitive_type_test_file, conf={}), primitive_type_test_file, {})
+    reader = ParquetReader(input_file, expected_schema, {}, Expressions.equal("string_col", "us"), True)
+    pyarrow_array = [pa.array([1, 3, 4], type=pa.int32()),
+                     pa.array([1, 3, None], type=pa.int64()),
+                     pa.array([1.0, 3.0, 4.0], type=pa.float32()),
+                     pa.array([1.0, 3.0, 4.0], type=pa.float64()),
+                     pa.array(['us', 'us', 'us'], type=pa.string())]
+    source_table = pa.table(pyarrow_array, schema=pa.schema([pa.field("int_col", pa.int32(), nullable=False),
+                                                             pa.field("bigint_col", pa.int64(), nullable=True),
+                                                             pa.field("float_col", pa.float32(), nullable=True),
+                                                             pa.field("dbl_col", pa.float64(), nullable=True),
+                                                             pa.field("string_col", pa.string(), nullable=True)
+                                                             ]))
+
+    target_table = reader.read()
+    assert source_table == target_table
+
+
+def test_compound_filter(primitive_type_test_file):
+    expected_schema = Schema([NestedField.required(1, "int_col", IntegerType.get()),
+                              NestedField.optional(2, "bigint_col", LongType.get()),
+                              NestedField.optional(4, "float_col", FloatType.get()),
+                              NestedField.optional(5, "dbl_col", DoubleType.get()),
+                              NestedField.optional(3, "string_col", StringType.get())])
+
+    input_file = FileSystemInputFile(get_fs(primitive_type_test_file, conf={}), primitive_type_test_file, {})
+    reader = ParquetReader(input_file, expected_schema, {}, Expressions.and_(Expressions.equal("string_col", "us"),
+                                                                             Expressions.equal("int_col", 1)),
+                           True)
+    pyarrow_array = [pa.array([1], type=pa.int32()),
+                     pa.array([1], type=pa.int64()),
+                     pa.array([1.0], type=pa.float32()),
+                     pa.array([1.0], type=pa.float64()),
+                     pa.array(['us'], type=pa.string())]
+
+    source_table = pa.table(pyarrow_array, schema=pa.schema([pa.field("int_col", pa.int32(), nullable=False),
+                                                             pa.field("bigint_col", pa.int64(), nullable=True),
+                                                             pa.field("float_col", pa.float32(), nullable=True),
+                                                             pa.field("dbl_col", pa.float64(), nullable=True),
+                                                             pa.field("string_col", pa.string(), nullable=True)
+                                                             ]))
+
+    target_table = reader.read()
+    assert source_table == target_table
+
+
+def test_schema_evolution_filter(primitive_type_test_file):
+    expected_schema = Schema([NestedField.required(1, "int_col", IntegerType.get()),
+                              NestedField.optional(2, "bigint_col", LongType.get()),
+                              NestedField.optional(16, "other_new_col", LongType.get()),
+                              NestedField.optional(4, "float_col", FloatType.get()),
+                              NestedField.optional(5, "dbl_col", DoubleType.get()),
+                              NestedField.optional(3, "string_col", StringType.get()),
+                              NestedField.optional(15, "new_col", StringType.get())])
+
+    input_file = FileSystemInputFile(get_fs(primitive_type_test_file, conf={}), primitive_type_test_file, {})
+    reader = ParquetReader(input_file, expected_schema, {}, Expressions.not_null("new_col"), True)
+
+    schema = pa.schema([pa.field("int_col", pa.int32(), nullable=False),
+                        pa.field("bigint_col", pa.int64(), nullable=True),
+                        pa.field("other_new_col", pa.int64(), nullable=True),
+                        pa.field("float_col", pa.float32(), nullable=True),
+                        pa.field("dbl_col", pa.float64(), nullable=True),
+                        pa.field("string_col", pa.string(), nullable=True),
+                        pa.field("new_col", pa.string(), nullable=True)])
+
+    pyarrow_not_null_array = [pa.array([], type=pa.int32()),
+                              pa.array([], type=pa.int64()),
+                              pa.array([], type=pa.int32()),
+                              pa.array([], type=pa.float32()),
+                              pa.array([], type=pa.float64()),
+                              pa.array([], type=pa.string()),
+                              pa.array([], type=pa.string())]
+
+    not_null_table = pa.table(pyarrow_not_null_array, schema=schema)
+    pyarrow_null_array = [pa.array([1, 2, 3, 4, 5], type=pa.int32()),
+                          pa.array([1, 2, 3, None, 5], type=pa.int64()),
+                          pa.array([None, None, None, None, None], type=pa.int64()),
+                          pa.array([1.0, 2.0, 3.0, 4.0, 5.0], type=pa.float32()),
+                          pa.array([1.0, 2.0, 3.0, 4.0, 5.0], type=pa.float64()),
+                          pa.array(['us', 'can', 'us', 'us', 'can'], type=pa.string()),
+                          pa.array([None, None, None, None, None], type=pa.string())]
+    null_table = pa.table(pyarrow_null_array, schema=schema)
+
+    target_table = reader.read()
+    assert not_null_table == target_table
+
+    reader = ParquetReader(input_file, expected_schema, {}, Expressions.is_null("new_col"), True)
+    target_table = reader.read()
+    assert null_table == target_table

--- a/python/tests/parquet/test_parquet_to_iceberg.py
+++ b/python/tests/parquet/test_parquet_to_iceberg.py
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from iceberg.api import Schema
+from iceberg.api.types import (BooleanType,
+                               DateType,
+                               DecimalType,
+                               DoubleType,
+                               FloatType,
+                               IntegerType,
+                               ListType,
+                               LongType,
+                               NestedField,
+                               StringType,
+                               StructType,
+                               TimestampType)
+from iceberg.parquet.parquet_to_iceberg import convert_parquet_to_iceberg
+
+
+def compare_schema(expected_schema, converted_schema):
+
+    assert len(expected_schema) == len(converted_schema)
+    for field in expected_schema.as_struct().fields:
+        converted_field = converted_schema.find_field(field.id)
+        assert converted_field is not None
+        assert field.name == converted_field.name
+        assert field.is_optional == converted_field.is_optional
+        assert field.type == converted_field.type
+
+
+def test_primitive_types(primitive_type_test_parquet_file):
+    expected_schema = Schema([NestedField.required(1, "int_col", IntegerType.get()),
+                              NestedField.optional(2, "bigint_col", LongType.get()),
+                              NestedField.optional(3, "str_col", StringType.get()),
+                              NestedField.optional(4, "float_col", FloatType.get()),
+                              NestedField.optional(5, "dbl_col", DoubleType.get()),
+                              NestedField.optional(6, "decimal_col", DecimalType.of(9, 2)),
+                              NestedField.optional(7, "big_decimal_col", DecimalType.of(19, 5)),
+                              NestedField.optional(8, "huge_decimal_col", DecimalType.of(38, 9)),
+                              NestedField.optional(9, "date_col", DateType.get()),
+                              NestedField.optional(10, "ts_col", TimestampType.without_timezone()),
+                              NestedField.optional(11, "ts_wtz_col", TimestampType.with_timezone()),
+                              NestedField.optional(12, "bool_col", BooleanType.get())])
+    compare_schema(expected_schema, convert_parquet_to_iceberg(primitive_type_test_parquet_file))
+
+
+def test_unnested_complex_types(unnested_complex_type_test_parquet_file):
+    expected_schema = Schema([NestedField.optional(1, "list_int_col", ListType.of_optional(3, IntegerType.get())),
+                              NestedField.optional(4, "list_str_col", ListType.of_optional(6, StringType.get())),
+                              NestedField.optional(7, "struct_col",
+                                                   StructType.of([NestedField.optional(8, "f1", IntegerType.get()),
+                                                                  NestedField.optional(9, "f2", StringType.get())]))
+                              ])
+    converted_schema = convert_parquet_to_iceberg(unnested_complex_type_test_parquet_file)
+    compare_schema(expected_schema, converted_schema)
+
+
+def test_nested_complex_types():
+    # This is a placeholder until pyarrow fully supports reading and writing nested types.
+    # Following a release containing this PR:
+    # https://github.com/apache/arrow/pull/8177
+    pass


### PR DESCRIPTION
This adds a parquet reader class that leverages pyarrow.datasets to read parquet files and apply row-level filters.  Additionally, there are some helper classes to convert between arrow schemas and iceberg schemas, so that we can apply any necessary schema evolution.

cc @danielcweeks @rymurr 