### PR TITLE
Add checkout step to rat check action

### DIFF
--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -24,5 +24,6 @@ jobs:
   rat:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v2
     - run: |
         dev/check-license


### PR DESCRIPTION
The workflow is currently failing because `dev/check-license` is not present.