### PR TITLE
Fix NullPointerException in ManifestReader

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -271,6 +271,7 @@ public class ManifestReader<F extends ContentFile<F>>
   private static boolean requireStatsProjection(Expression rowFilter, Collection<String> columns) {
     // Make sure we have all stats columns for metrics evaluator
     return rowFilter != Expressions.alwaysTrue() &&
+        columns != null &&
         !columns.containsAll(ManifestReader.ALL_COLUMNS) &&
         !columns.containsAll(STATS_COLUMNS);
   }
@@ -279,6 +280,7 @@ public class ManifestReader<F extends ContentFile<F>>
     // Make sure we only drop all stats if we had projected all stats
     // We do not drop stats even if we had partially added some stats columns
     return rowFilter != Expressions.alwaysTrue() &&
+        columns != null &&
         !columns.containsAll(ManifestReader.ALL_COLUMNS) &&
         Sets.intersection(Sets.newHashSet(columns), STATS_COLUMNS).isEmpty();
   }

--- a/core/src/test/java/org/apache/iceberg/TestManifestReader.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReader.java
@@ -21,8 +21,12 @@ package org.apache.iceberg;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.iceberg.ManifestEntry.Status;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.Test;
@@ -48,6 +52,22 @@ public class TestManifestReader extends TableTestBase {
       Assert.assertEquals(Status.EXISTING, entry.status());
       Assert.assertEquals(FILE_A.path(), entry.file().path());
       Assert.assertEquals(1000L, (long) entry.snapshotId());
+    }
+  }
+
+  @Test
+  public void testReaderWithFilterWithoutSelect() throws IOException {
+    ManifestFile manifest = writeManifest(1000L, FILE_A, FILE_B, FILE_C);
+    try (ManifestReader<DataFile> reader = ManifestFiles.read(manifest, FILE_IO)
+        .filterRows(Expressions.equal("id", 0))) {
+      List<String> files = Streams.stream(reader)
+          .map(file -> file.path().toString())
+          .collect(Collectors.toList());
+
+      // note that all files are returned because the reader returns data files that may match, and the partition is
+      // bucketing by data, which doesn't help filter files
+      Assert.assertEquals("Should read the expected files",
+          Lists.newArrayList(FILE_A.path(), FILE_B.path(), FILE_C.path()), files);
     }
   }
 


### PR DESCRIPTION
This fixes a `NullPointerException` that is thrown by a `ManifestReader` for delete files when there is a query filter. The `DeleteFileIndex` projects all fields of a delete manifest, so it doesn't call `select` to select specific columns, unlike `ManifestGroup`, which selects `*` by default. When select is not called, methods that check whether to add stats columns fail, but only if there is a row filter because stats columns are not needed if there is no row filter.

Existing tests either called `select` to configure the reader, or didn't pass a row filter and projected all rows. This adds a test that uses `DeleteFileIndex` and a test for `ManifestReader`. This also fixes `dropStats` in addition to `requireStatsProjection`.

Closes #1726, #1724.

Co-authored-by: 钟保罗 <zhongbaoluo@shxgroup.net>