### PR TITLE
Allow duplicate files to be deduplicated when performing scans

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/DedupingIterable.java
+++ b/api/src/main/java/org/apache/iceberg/io/DedupingIterable.java
@@ -22,17 +22,15 @@ package org.apache.iceberg.io;
 import java.io.IOException;
 import java.util.function.Function;
 
-/**
- * @param <T> iterable object type
- * @param <O> key for deduping
- */
 public class DedupingIterable<T, O> implements CloseableIterable<T> {
   private final CloseableIterable<T> iterable;
   private final Function<T, O> getKey;
+
   public DedupingIterable(CloseableIterable<T> iterable, Function<T, O> getKey) {
     this.iterable = iterable;
     this.getKey = getKey;
   }
+
   @Override
   public CloseableIterator<T> iterator() {
     return new DedupingIterator<T, O>(iterable.iterator(), getKey);

--- a/api/src/main/java/org/apache/iceberg/io/DedupingIterable.java
+++ b/api/src/main/java/org/apache/iceberg/io/DedupingIterable.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+/**
+ * @param <T> iterable object type
+ * @param <O> key for deduping
+ */
+public class DedupingIterable<T, O> implements CloseableIterable<T> {
+  private final CloseableIterable<T> iterable;
+  private final Function<T, O> getKey;
+  public DedupingIterable(CloseableIterable<T> iterable, Function<T, O> getKey) {
+    this.iterable = iterable;
+    this.getKey = getKey;
+  }
+  @Override
+  public CloseableIterator<T> iterator() {
+    return new DedupingIterator<T, O>(iterable.iterator(), getKey);
+  }
+
+  @Override
+  public void close() throws IOException {
+    iterable.close();
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/io/DedupingIterator.java
+++ b/api/src/main/java/org/apache/iceberg/io/DedupingIterator.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Warning: This class is not thread safe
+ * @param <T> object type of the iterable
+ * @param <O> object type of the key for deduping
+ */
+public class DedupingIterator<T, O> implements CloseableIterator<T> {
+  private final CloseableIterator<T> iterator;
+  private final Function<T, O> getKey;
+  private final Set<O> seen;
+  private T buffer;
+  private long start;
+  public DedupingIterator(CloseableIterator<T> iterator, Function<T, O> getKey) {
+    this.iterator = iterator;
+    this.getKey = getKey;
+    this.seen = new HashSet<>();
+    buffer = null;
+  }
+
+  @Override
+  public void close() throws IOException {
+    iterator.close();
+  }
+
+  @Override
+  public boolean hasNext() {
+    return buffer != null || iterator.hasNext();
+  }
+
+  private void pump() {
+    while (buffer == null && iterator.hasNext()) {
+      T next = iterator.next();
+      O key = getKey.apply(next);
+      if (!seen.contains(key)) {
+        seen.add(key);
+        buffer = next;
+      }
+    }
+  }
+
+  @Override
+  public T next() {
+    T output;
+    if (buffer == null) {
+      T next = iterator.next();
+      O key = getKey.apply(next);
+      seen.add(key);
+      output = next;
+      start = System.currentTimeMillis();
+    } else {
+      output = buffer;
+      buffer = null;
+    }
+    pump();
+    return output;
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/io/DedupingIterator.java
+++ b/api/src/main/java/org/apache/iceberg/io/DedupingIterator.java
@@ -26,15 +26,15 @@ import java.util.function.Function;
 
 /**
  * Warning: This class is not thread safe
- * @param <T> object type of the iterable
- * @param <O> object type of the key for deduping
+ * @param <T> type of the iterable
+ * @param <O> type of the key for deduping
  */
 public class DedupingIterator<T, O> implements CloseableIterator<T> {
   private final CloseableIterator<T> iterator;
   private final Function<T, O> getKey;
   private final Set<O> seen;
   private T buffer;
-  private long start;
+
   public DedupingIterator(CloseableIterator<T> iterator, Function<T, O> getKey) {
     this.iterator = iterator;
     this.getKey = getKey;
@@ -71,7 +71,6 @@ public class DedupingIterator<T, O> implements CloseableIterator<T> {
       O key = getKey.apply(next);
       seen.add(key);
       output = next;
-      start = System.currentTimeMillis();
     } else {
       output = buffer;
       buffer = null;

--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -26,8 +26,6 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.util.ThreadPools;
 
-import java.util.Map;
-
 public class DataTableScan extends BaseTableScan {
   static final ImmutableList<String> SCAN_COLUMNS = ImmutableList.of(
       "snapshot_id", "file_path", "file_ordinal", "file_format", "block_size_in_bytes",

--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -37,7 +37,6 @@ public class DataTableScan extends BaseTableScan {
       .build();
   static final boolean PLAN_SCANS_WITH_WORKER_POOL =
       SystemProperties.getBoolean(SystemProperties.SCAN_THREAD_POOL_ENABLED, true);
-  public static final String DEDUPE_FILES_OPTION = "dedupe_files";
 
   public DataTableScan(TableOperations ops, Table table) {
     super(ops, table, table.schema());

--- a/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
@@ -22,7 +22,6 @@ package org.apache.iceberg;
 import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.io.CloseableIterable;
-import org.apache.iceberg.io.DedupingIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.FluentIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;

--- a/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
@@ -22,6 +22,7 @@ package org.apache.iceberg;
 import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.DedupingIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.FluentIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -97,7 +98,8 @@ class IncrementalDataTableScan extends DataTableScan {
       manifestGroup = manifestGroup.planWith(ThreadPools.getWorkerPool());
     }
 
-    return manifestGroup.planFiles();
+    CloseableIterable<FileScanTask> fileScanTasks = manifestGroup.planFiles();
+    return maybeDedupeFiles(fileScanTasks);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -45,6 +45,9 @@ public class TableProperties {
   public static final String MANIFEST_MERGE_ENABLED = "commit.manifest-merge.enabled";
   public static final boolean MANIFEST_MERGE_ENABLED_DEFAULT = true;
 
+  public static final String DEDUPE_DUPLICATE_FILES_IN_SCAN = "scan.manifest.dedupe-duplicate-files";
+  public static final boolean DEDUPE_DUPLICATE_FILES_IN_SCAN_DEFAULT = false;
+
   public static final String DEFAULT_FILE_FORMAT = "write.format.default";
   public static final String DEFAULT_FILE_FORMAT_DEFAULT = "parquet";
 

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestDuplicateFileDataTableScan.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestDuplicateFileDataTableScan.java
@@ -19,9 +19,20 @@
 
 package org.apache.iceberg.spark.source;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.iceberg.*;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.FileAppender;
@@ -38,11 +49,6 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 
 import static org.apache.iceberg.Files.localOutput;
 
@@ -129,8 +135,6 @@ public abstract class TestDuplicateFileDataTableScan extends AvroDataTest {
     // first verify that the files are normally read multiple times
     List<Row> rows = read(table.location(), startEndSnapshot).collectAsList();
     Assert.assertEquals("Should contain 300 rows", 300, rows.size());
-
-
 
     // then verify that the files are deduplicated with the property is set
     table

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestDuplicateFileDataTableScan.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestDuplicateFileDataTableScan.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+import org.apache.avro.generic.GenericData.Record;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.*;
+import org.apache.iceberg.avro.Avro;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.spark.data.AvroDataTest;
+import org.apache.iceberg.spark.data.RandomData;
+import org.apache.iceberg.spark.data.TestHelpers;
+import org.apache.iceberg.util.Pair;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.apache.iceberg.Files.localOutput;
+
+public abstract class TestDuplicateFileDataTableScan extends AvroDataTest {
+  private static final Configuration CONF = new Configuration();
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  protected static SparkSession spark = null;
+
+  @BeforeClass
+  public static void startSpark() {
+    TestDuplicateFileDataTableScan.spark = SparkSession.builder().master("local[2]").getOrCreate();
+  }
+
+  @AfterClass
+  public static void stopSpark() {
+    SparkSession currentSpark = TestDuplicateFileDataTableScan.spark;
+    TestDuplicateFileDataTableScan.spark = null;
+    currentSpark.stop();
+  }
+
+  protected String testName() {
+    return "duplicate-file-scan";
+  }
+
+  protected File createFileWithRecords(Schema tableSchema, File dataFolder, List<Record> records) throws IOException {
+    File avroFile = new File(dataFolder, FileFormat.AVRO.addExtension(UUID.randomUUID().toString()));
+    try (FileAppender<Record> writer = Avro.write(localOutput(avroFile))
+        .schema(tableSchema)
+        .build()) {
+      writer.addAll(records);
+    }
+    return avroFile;
+  }
+
+  protected DataFile toDataFile(File avroFile) {
+    return DataFiles.builder(PartitionSpec.unpartitioned())
+        .withRecordCount(100)
+        .withFileSizeInBytes(avroFile.length())
+        .withPath(avroFile.toString())
+        .build();
+  }
+
+  /**
+   * Create 2 snapshots:
+   * S0: holds 2 of the same file
+   * S1: holds 1 of the files from S1. is the end snapshot
+   */
+  protected Optional<Pair<Long, Long>> write(Table table, File dataFolder, List<Record> expected) throws IOException {
+    File avroFile = createFileWithRecords(table.schema(), dataFolder, expected);
+    DataFile file = toDataFile(avroFile);
+    // append the file in a snapshot twice
+    table.newAppend().appendFile(file).appendFile(file).commit();
+    // append the file in a single snapshot
+    table.newAppend().appendFile(file).commit();
+    return Optional.empty();
+  }
+
+  protected Dataset<Row> read(String location, Optional<Pair<Long, Long>> startEndSnapshot) {
+    return spark.read()
+        .format("iceberg")
+        .load(location);
+  }
+
+  @Override
+  protected void writeAndValidate(Schema schema) throws IOException {
+    File parent = temp.newFolder(testName());
+    File location = new File(parent, "test");
+    File dataFolder = new File(location, "data");
+    dataFolder.mkdirs();
+
+    HadoopTables tables = new HadoopTables(CONF);
+    Table table = tables.create(schema, PartitionSpec.unpartitioned(), location.toString());
+    // Important: use the table's schema for the rest of the test
+    // When tables are created, the column ids are reassigned.
+    Schema tableSchema = table.schema();
+
+    List<Record> expected = RandomData.generateList(tableSchema, 100, 1L);
+
+    Optional<Pair<Long, Long>> startEndSnapshot = write(table, dataFolder, expected);
+
+    // first verify that the files are normally read multiple times
+    List<Row> rows = read(table.location(), startEndSnapshot).collectAsList();
+    Assert.assertEquals("Should contain 300 rows", 300, rows.size());
+
+
+
+    // then verify that the files are deduplicated with the property is set
+    table
+        .updateProperties()
+        .set(TableProperties.DEDUPE_DUPLICATE_FILES_IN_SCAN, "true")
+        .commit();
+    List<Row> dedupeFileRows = read(table.location(), startEndSnapshot).collectAsList();
+    Assert.assertEquals("Should contain 100 rows", 100, dedupeFileRows.size());
+
+    for (int i = 0; i < expected.size(); i += 1) {
+      TestHelpers.assertEqualsSafe(tableSchema.asStruct(), expected.get(i), rows.get(i));
+    }
+  }
+}

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestDuplicateFileIncrementalDataTableScan.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestDuplicateFileIncrementalDataTableScan.java
@@ -19,32 +19,18 @@
 
 package org.apache.iceberg.spark.source;
 
-import org.apache.avro.generic.GenericData.Record;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.iceberg.*;
-import org.apache.iceberg.avro.Avro;
-import org.apache.iceberg.hadoop.HadoopTables;
-import org.apache.iceberg.io.FileAppender;
-import org.apache.iceberg.spark.data.AvroDataTest;
-import org.apache.iceberg.spark.data.RandomData;
-import org.apache.iceberg.spark.data.TestHelpers;
-import org.apache.iceberg.util.Pair;
-import org.apache.spark.sql.Dataset;
-import org.apache.spark.sql.Row;
-import org.apache.spark.sql.SparkSession;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
-
-import static org.apache.iceberg.Files.localOutput;
+import org.apache.avro.generic.GenericData.Record;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.spark.data.RandomData;
+import org.apache.iceberg.util.Pair;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 
 public abstract class TestDuplicateFileIncrementalDataTableScan extends TestDuplicateFileDataTableScan {
   private static final Configuration CONF = new Configuration();
@@ -66,7 +52,7 @@ public abstract class TestDuplicateFileIncrementalDataTableScan extends TestDupl
    * S0: ignored and provides the start snapshot id
    * S1: holds 2 of the same file
    * S2: holds 1 of the files from S1. is the end snapshot
-   * S3: ignored but added in case an optimization switches to fromSnapshot when currentSnapshot is the end-snapshot-id
+   * S3: ignored but added in case an optimization switches to appendsAfter when currentSnapshot is the end-snapshot-id
    */
   @Override
   protected Optional<Pair<Long, Long>> write(Table table, File dataFolder, List<Record> expected) throws IOException {

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestDuplicateFileIncrementalDataTableScan.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestDuplicateFileIncrementalDataTableScan.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+import org.apache.avro.generic.GenericData.Record;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.*;
+import org.apache.iceberg.avro.Avro;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.spark.data.AvroDataTest;
+import org.apache.iceberg.spark.data.RandomData;
+import org.apache.iceberg.spark.data.TestHelpers;
+import org.apache.iceberg.util.Pair;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.apache.iceberg.Files.localOutput;
+
+public abstract class TestDuplicateFileIncrementalDataTableScan extends TestDuplicateFileDataTableScan {
+  private static final Configuration CONF = new Configuration();
+
+  @Override
+  protected String testName() {
+    return "incremental-duplicate-file-scan";
+  }
+
+  protected void addIgnoredSnapshot(Table table, File dataFolder) throws IOException {
+    List<Record> ignoredData = RandomData.generateList(table.schema(), 100, 1L);
+    File ignoredFile = createFileWithRecords(table.schema(), dataFolder, ignoredData);
+    DataFile file = toDataFile(ignoredFile);
+    table.newAppend().appendFile(file).commit();
+  }
+
+  /**
+   * Create 4 snapshots:
+   * S0: ignored and provides the start snapshot id
+   * S1: holds 2 of the same file
+   * S2: holds 1 of the files from S1. is the end snapshot
+   * S3: ignored but added in case an optimization switches to fromSnapshot when currentSnapshot is the end-snapshot-id
+   */
+  @Override
+  protected Optional<Pair<Long, Long>> write(Table table, File dataFolder, List<Record> expected) throws IOException {
+    File avroFile = createFileWithRecords(table.schema(), dataFolder, expected);
+    DataFile file = toDataFile(avroFile);
+
+    addIgnoredSnapshot(table, dataFolder);
+    table.refresh();
+    long fromSnapshotId = table.currentSnapshot().snapshotId();
+
+    // append the file in a snapshot twice
+    table.newAppend().appendFile(file).appendFile(file).commit();
+    // append the file in a single snapshot
+    table.newAppend().appendFile(file).commit();
+
+    table.refresh();
+    long toSnapshotId = table.currentSnapshot().snapshotId();
+
+    addIgnoredSnapshot(table, dataFolder);
+
+    return Optional.of(Pair.of(fromSnapshotId, toSnapshotId));
+  }
+
+  @Override
+  protected Dataset<Row> read(String location, Optional<Pair<Long, Long>> startEndSnapshot) {
+    return spark.read()
+        .format("iceberg")
+        .option("start-snapshot-id", startEndSnapshot.get().first())
+        .option("end-snapshot-id", startEndSnapshot.get().second())
+        .load(location);
+  }
+}

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestDuplicateFileDataTableScan24.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestDuplicateFileDataTableScan24.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+public class TestDuplicateFileDataTableScan24 extends TestDuplicateFileDataTableScan {
+}

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestDuplicateFileIncrementalDataTableScan24.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestDuplicateFileIncrementalDataTableScan24.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+public class TestDuplicateFileIncrementalDataTableScan24 extends TestDuplicateFileIncrementalDataTableScan {
+}

--- a/spark3/src/test/java/org/apache/iceberg/spark/source/TestDuplicateFileDataTableScan3.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/source/TestDuplicateFileDataTableScan3.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+public class TestDuplicateFileDataTableScan3 extends TestDuplicateFileDataTableScan {
+}

--- a/spark3/src/test/java/org/apache/iceberg/spark/source/TestDuplicateFileIncrementalDataTableScan3.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/source/TestDuplicateFileIncrementalDataTableScan3.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+public class TestDuplicateFileIncrementalDataTableScan3 extends TestDuplicateFileIncrementalDataTableScan {
+}


### PR DESCRIPTION
This was the patch we used to cover up the issue we encountered here: https://github.com/apache/iceberg/issues/1637

It looks like a similar issue was encountered: https://github.com/apache/iceberg/issues/1511
Which resulted in the patch: https://github.com/apache/iceberg/pull/1514

Patch 1514 solves the issue we ran into in a better way than this patch set.

However, it can lead to reading the DataFile multiple times. For my use case, that's totally fine and I will get rid of this patch when we upgrade. But if someone needs to skip duplicate files within a single scan then they can hopefully find this PR.

I'll leave this up to confirm that @mehtaashish23 knows about the duplicates and that it is intended. Then I'll close this