### PR TITLE
Fix casting issues when joining two Iceberg tables together on Tez

### DIFF
--- a/hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergDateObjectInspectorHive3.java
+++ b/hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergDateObjectInspectorHive3.java
@@ -62,6 +62,8 @@ public final class IcebergDateObjectInspectorHive3 extends AbstractPrimitiveJava
 
     if (o instanceof Date) {
       return new Date((Date) o);
+    } else if (o instanceof LocalDate) {
+      return LocalDate.of(((LocalDate) o).getYear(), ((LocalDate) o).getMonth(), ((LocalDate) o).getDayOfMonth());
     } else {
       return o;
     }

--- a/hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergDateObjectInspectorHive3.java
+++ b/hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergDateObjectInspectorHive3.java
@@ -56,7 +56,15 @@ public final class IcebergDateObjectInspectorHive3 extends AbstractPrimitiveJava
 
   @Override
   public Object copyObject(Object o) {
-    return o == null ? null : new Date((Date) o);
+    if (o == null) {
+      return null;
+    }
+
+    if (o instanceof Date) {
+      return new Date((Date) o);
+    } else {
+      return o;
+    }
   }
 
 }

--- a/hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampObjectInspectorHive3.java
+++ b/hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampObjectInspectorHive3.java
@@ -81,10 +81,14 @@ public abstract class IcebergTimestampObjectInspectorHive3 extends AbstractPrimi
       return null;
     }
 
-    Timestamp ts = (Timestamp) o;
-    Timestamp copy = new Timestamp(ts);
-    copy.setNanos(ts.getNanos());
-    return copy;
+    if (o instanceof Timestamp) {
+      Timestamp ts = (Timestamp) o;
+      Timestamp copy = new Timestamp(ts);
+      copy.setNanos(ts.getNanos());
+      return copy;
+    } else {
+      return o;
+    }
   }
 
 }

--- a/hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampObjectInspectorHive3.java
+++ b/hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampObjectInspectorHive3.java
@@ -86,6 +86,10 @@ public abstract class IcebergTimestampObjectInspectorHive3 extends AbstractPrimi
       Timestamp copy = new Timestamp(ts);
       copy.setNanos(ts.getNanos());
       return copy;
+    } else if (o instanceof OffsetDateTime) {
+      return OffsetDateTime.of(((OffsetDateTime) o).toLocalDateTime(), ((OffsetDateTime) o).getOffset());
+    } else if (o instanceof LocalDateTime) {
+      return LocalDateTime.of(((LocalDateTime) o).toLocalDate(), ((LocalDateTime) o).toLocalTime());
     } else {
       return o;
     }

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergBinaryObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergBinaryObjectInspector.java
@@ -73,9 +73,12 @@ public abstract class IcebergBinaryObjectInspector extends AbstractPrimitiveJava
     if (o == null) {
       return null;
     }
-
-    byte[] bytes = (byte[]) o;
-    return Arrays.copyOf(bytes, bytes.length);
+    if (o instanceof byte[]) {
+      byte[] bytes = (byte[]) o;
+      return Arrays.copyOf(bytes, bytes.length);
+    } else {
+      return o;
+    }
   }
 
 }

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergBinaryObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergBinaryObjectInspector.java
@@ -76,6 +76,10 @@ public abstract class IcebergBinaryObjectInspector extends AbstractPrimitiveJava
     if (o instanceof byte[]) {
       byte[] bytes = (byte[]) o;
       return Arrays.copyOf(bytes, bytes.length);
+    } else if (o instanceof ByteBuffer) {
+      ByteBuffer copy = ByteBuffer.wrap(((ByteBuffer) o).array(), ((ByteBuffer) o).arrayOffset(),
+              ((ByteBuffer) o).limit());
+      return copy;
     } else {
       return o;
     }

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergDateObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergDateObjectInspector.java
@@ -52,7 +52,17 @@ public final class IcebergDateObjectInspector extends AbstractPrimitiveJavaObjec
 
   @Override
   public Object copyObject(Object o) {
-    return o == null ? null : new Date(((Date) o).getTime());
+    if (o == null) {
+      return null;
+    }
+
+    if (o instanceof Date) {
+      return new Date(((Date) o).getTime());
+    } else if (o instanceof LocalDate) {
+      return LocalDate.of(((LocalDate) o).getYear(), ((LocalDate) o).getMonth(), ((LocalDate) o).getDayOfMonth());
+    } else {
+      return o;
+    }
   }
 
 }

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergDecimalObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergDecimalObjectInspector.java
@@ -70,6 +70,9 @@ public final class IcebergDecimalObjectInspector extends AbstractPrimitiveJavaOb
     if (o instanceof HiveDecimal) {
       HiveDecimal decimal = (HiveDecimal) o;
       return HiveDecimal.create(decimal.bigDecimalValue());
+    } else if (o instanceof BigDecimal) {
+      BigDecimal copy = new BigDecimal(o.toString());
+      return copy;
     } else {
       return o;
     }

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergDecimalObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergDecimalObjectInspector.java
@@ -67,8 +67,12 @@ public final class IcebergDecimalObjectInspector extends AbstractPrimitiveJavaOb
       return null;
     }
 
-    HiveDecimal decimal = (HiveDecimal) o;
-    return HiveDecimal.create(decimal.bigDecimalValue());
+    if (o instanceof HiveDecimal) {
+      HiveDecimal decimal = (HiveDecimal) o;
+      return HiveDecimal.create(decimal.bigDecimalValue());
+    } else {
+      return o;
+    }
   }
 
 }

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampObjectInspector.java
@@ -72,10 +72,18 @@ public abstract class IcebergTimestampObjectInspector extends AbstractPrimitiveJ
       return null;
     }
 
-    Timestamp ts = (Timestamp) o;
-    Timestamp copy = new Timestamp(ts.getTime());
-    copy.setNanos(ts.getNanos());
-    return copy;
+    if (o instanceof Timestamp) {
+      Timestamp ts = (Timestamp) o;
+      Timestamp copy = new Timestamp(ts.getTime());
+      copy.setNanos(ts.getNanos());
+      return copy;
+    } else if (o instanceof OffsetDateTime) {
+      return OffsetDateTime.of(((OffsetDateTime) o).toLocalDateTime(), ((OffsetDateTime) o).getOffset());
+    } else if (o instanceof LocalDateTime) {
+      return LocalDateTime.of(((LocalDateTime) o).toLocalDate(), ((LocalDateTime) o).toLocalTime());
+    } else {
+      return o;
+    }
   }
 
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandlerBaseTest.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandlerBaseTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -107,6 +108,12 @@ public abstract class HiveIcebergStorageHandlerBaseTest {
           StatsSetupConst.RAW_DATA_SIZE, StatsSetupConst.TOTAL_SIZE, StatsSetupConst.NUM_FILES, "numFilesErasureCoded");
 
   private static TestHiveShell shell;
+
+  private static final List<Type> SUPPORTED_TYPES =
+          ImmutableList.of(Types.BooleanType.get(), Types.IntegerType.get(), Types.LongType.get(),
+                  Types.FloatType.get(), Types.DoubleType.get(), Types.DateType.get(), Types.TimestampType.withZone(),
+                  Types.TimestampType.withoutZone(), Types.StringType.get(), Types.BinaryType.get(),
+                  Types.DecimalType.of(3, 1));
 
   private TestTables testTables;
 
@@ -212,11 +219,43 @@ public abstract class HiveIcebergStorageHandlerBaseTest {
     Assert.assertArrayEquals(new Object[] {0L, "Alice", 100L, 11.11d}, rows.get(0));
     Assert.assertArrayEquals(new Object[] {0L, "Alice", 101L, 22.22d}, rows.get(1));
     Assert.assertArrayEquals(new Object[] {1L, "Bob", 102L, 33.33d}, rows.get(2));
+  }
 
-    joinTables("decimaltable", "decimal_col", Types.DecimalType.of(3, 1));
-    joinTables("timestamptable", "timestamp_col", Types.TimestampType.withZone());
-    joinTables("binarytable", "binary_col", Types.BinaryType.get());
-    joinTables("datetable", "date_col", Types.DateType.get());
+  @Test
+  public void testJoinTablesSupportedTypes() throws IOException {
+    for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
+      Type type = SUPPORTED_TYPES.get(i);
+      String tableName = type.typeId().toString().toLowerCase() + "_table_" + i;
+      String columnName = type.typeId().toString().toLowerCase() + "_column";
+
+      Schema schema = new Schema(required(1, columnName, type));
+      List<Record> records = TestHelper.generateRandomRecords(schema, 1, 0L);
+
+      createTable(tableName, schema, records);
+      List<Object[]> queryResult = shell.executeStatement("select s." + columnName + ", h." + columnName +
+              " from default." + tableName + " s join default." + tableName + " h on h." + columnName + "=s." +
+              columnName);
+      Assert.assertEquals("Non matching record count for table " + tableName + " with type " + type,
+              1, queryResult.size());
+    }
+  }
+
+  @Test
+  public void testSelectDistinctFromTable() throws IOException {
+    for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
+      Type type = SUPPORTED_TYPES.get(i);
+      String tableName = type.typeId().toString().toLowerCase() + "_table_" + i;
+      String columnName = type.typeId().toString().toLowerCase() + "_column";
+
+      Schema schema = new Schema(required(1, columnName, type));
+      List<Record> records = TestHelper.generateRandomRecords(schema, 4, 0L);
+      int size = records.stream().map(r -> r.getField(columnName)).collect(Collectors.toSet()).size();
+      createTable(tableName, schema, records);
+      List<Object[]> queryResult = shell.executeStatement("select count(distinct(" + columnName +
+              ")) from default." + tableName);
+      int distincIds = ((Long) queryResult.get(0)[0]).intValue();
+      Assert.assertEquals(tableName, size, distincIds);
+    }
   }
 
   @Test
@@ -537,18 +576,5 @@ public abstract class HiveIcebergStorageHandlerBaseTest {
 
   protected String locationForCreateTable(String tempDirName, String tableName) {
     return null;
-  }
-
-  private void joinTables(String tableName, String columnName, Type type) throws IOException {
-    Schema schema = new Schema(required(1, "id", Types.IntegerType.get()),
-            required(2, columnName, type));
-    List<Record> records = TestHelper.generateRandomRecords(schema, 10, 0L);
-    createTable(tableName, schema, records);
-    List<Object[]> queryResult = shell.executeStatement("select count(distinct(id)) from default." + tableName);
-    int distinctIds = ((Long) queryResult.get(0)[0]).intValue();
-
-    queryResult = shell.executeStatement("select s." + columnName + ", h." + columnName +
-            " from default." + tableName + " s join default." + tableName + " h on h.id=s.id");
-    Assert.assertEquals((records.size() - distinctIds) * 2 + records.size(), queryResult.size());
   }
 }


### PR DESCRIPTION
The following casting exceptions were observed when joining two Iceberg tables on Tez:

- java.math.BigDecimal cannot be cast to org.apache.hadoop.hive.common.type.HiveDecimal

- java.time.OffsetDateTime cannot be cast to org.apache.hadoop.hive.common.type.Timestamp

- java.nio.HeapByteBuffer cannot be cast to [B

- java.time.LocalDate cannot be cast to org.apache.hadoop.hive.common.type.Date

Doesn't happen with Iceberg table - non-Iceberg table joins, or with order by queries on a single table.

