### PR TITLE
Flink: add maxParallelism method to method chain in flink RewriteDataFilesAction

### DIFF
--- a/flink/src/main/java/org/apache/iceberg/flink/actions/RewriteDataFilesAction.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/actions/RewriteDataFilesAction.java
@@ -61,8 +61,9 @@ public class RewriteDataFilesAction extends BaseRewriteDataFilesAction<RewriteDa
     return this;
   }
 
-  public void maxParallelism(int parallelism) {
+  public RewriteDataFilesAction maxParallelism(int parallelism) {
     Preconditions.checkArgument(parallelism > 0, "Invalid max parallelism %d", parallelism);
     this.maxParallelism = parallelism;
+    return this;
   }
 }


### PR DESCRIPTION
We should add the `maxParallelism` method to the method chain so that users can set some Action parameters easily.