### PR TITLE
Fix decimal scale issue in predicate literals

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/Literals.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Literals.java
@@ -461,10 +461,7 @@ class Literals {
       switch (type.typeId()) {
         case DECIMAL:
           // do not change decimal scale
-          if (value().scale() == ((Types.DecimalType) type).scale()) {
-            return (Literal<T>) this;
-          }
-          return null;
+          return (Literal<T>) this;
         default:
           return null;
       }
@@ -517,12 +514,9 @@ class Literals {
           return (Literal<T>) new UUIDLiteral(UUID.fromString(value().toString()));
 
         case DECIMAL:
-          int scale = ((Types.DecimalType) type).scale();
+          // do not change decimal scale
           BigDecimal decimal = new BigDecimal(value().toString());
-          if (scale == decimal.scale()) {
-            return (Literal<T>) new DecimalLiteral(decimal);
-          }
-          return null;
+          return (Literal<T>) new DecimalLiteral(decimal);
 
         default:
           return null;

--- a/api/src/test/java/org/apache/iceberg/expressions/TestMiscLiteralConversions.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestMiscLiteralConversions.java
@@ -231,7 +231,6 @@ public class TestMiscLiteralConversions {
         Types.TimeType.get(),
         Types.TimestampType.withZone(),
         Types.TimestampType.withoutZone(),
-        Types.DecimalType.of(9, 4),
         Types.StringType.get(),
         Types.UUIDType.get(),
         Types.FixedType.ofLength(1),

--- a/api/src/test/java/org/apache/iceberg/expressions/TestNumericLiteralConversions.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestNumericLiteralConversions.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.expressions;
 
 import java.math.BigDecimal;
+import java.util.stream.IntStream;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.Test;
@@ -153,17 +154,12 @@ public class TestNumericLiteralConversions {
   public void testDecimalToDecimalConversion() {
     Literal<BigDecimal> lit = Literal.of(new BigDecimal("34.11"));
 
-    Assert.assertSame("Should return identical object when converting to same scale",
-        lit, lit.to(Types.DecimalType.of(9, 2)));
-    Assert.assertSame("Should return identical object when converting to same scale",
-        lit, lit.to(Types.DecimalType.of(11, 2)));
-
-    Assert.assertNull("Changing decimal scale is not allowed",
-        lit.to(Types.DecimalType.of(9, 0)));
-    Assert.assertNull("Changing decimal scale is not allowed",
-        lit.to(Types.DecimalType.of(9, 1)));
-    Assert.assertNull("Changing decimal scale is not allowed",
-        lit.to(Types.DecimalType.of(9, 3)));
+    IntStream.range(0, 10).forEach(scale -> {
+      Assert.assertSame("Should return identical object",
+              lit, lit.to(Types.DecimalType.of(9, scale)));
+      Assert.assertSame("Should return identical object",
+              lit, lit.to(Types.DecimalType.of(11, scale)));
+    });
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/expressions/TestStringLiteralConversions.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestStringLiteralConversions.java
@@ -26,6 +26,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.util.UUID;
+import java.util.stream.IntStream;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.data.TimeConversions;
@@ -132,14 +133,11 @@ public class TestStringLiteralConversions {
   public void testStringToDecimalLiteral() {
     BigDecimal expected = new BigDecimal("34.560");
     Literal<CharSequence> decimalStr = Literal.of("34.560");
-    Literal<BigDecimal> decimal = decimalStr.to(Types.DecimalType.of(9, 3));
 
-    Assert.assertEquals("Decimal should have scale 3", 3, decimal.value().scale());
-    Assert.assertEquals("Decimal should match", expected, decimal.value());
-
-    Assert.assertNull("Wrong scale in conversion should return null",
-        decimalStr.to(Types.DecimalType.of(9, 2)));
-    Assert.assertNull("Wrong scale in conversion should return null",
-        decimalStr.to(Types.DecimalType.of(9, 4)));
+    IntStream.range(0, 10).forEach(scale -> {
+      Literal<BigDecimal> decimal = decimalStr.to(Types.DecimalType.of(9, scale));
+      Assert.assertEquals("Decimal should have scale 3", 3, decimal.value().scale());
+      Assert.assertEquals("Decimal should match", expected, decimal.value());
+    });
   }
 }


### PR DESCRIPTION
Proposing a fix for the issue: https://github.com/apache/iceberg/issues/1699 - 
In summary, the problem is that for a predicate literal you cannot use a decimal type which has a different scale than the column’s type you compare it against. 

To resolve this, I’ve considered three options:
1. Keeping the status quo: This would entail that we keep the current logic as is, and provide clear documentation that when using decimals in predicate literals, the same scale needs to be used as the type you compare it against. This may go against user expectations (e.g. this is not how it works in Hive at the moment).
2. Change the literal’s scale to match that of the type definition in `DecimalLiteral.to()`. This would involve rounding if the literal’s scale was the higher one. This introduces the problem that, for example, if we have 100.22 and 100.23 in our table, then running `SELECT * FROM tbl WHERE val >= 100.225` could give unexpected results for users due to rounding. 
3. We ignore the scale differences during conversion (`DecimalLiteral.to()`) to other decimal types, since decimals with different scales can still be compared in predicates. This avoids any information loss. 

I’ve decided to go with option 3 considering the pros and cons. What do you think @rdblue?