### PR TITLE
Spark: Add stored procedure API

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -251,6 +251,7 @@ This product includes code from Presto.
 * S3FileIO logic derived from PrestoS3FileSystem.java in S3InputStream.java
   and S3OutputStream.java
 * SQL grammar rules for parsing CALL statements in IcebergSqlExtensions.g4
+* some aspects of handling stored procedures
 
 Copyright: 2016 Facebook and contributors
 Home page: https://prestodb.io/

--- a/project/scalastyle_config.xml
+++ b/project/scalastyle_config.xml
@@ -85,11 +85,6 @@
             <parameter name="maxTypes"><![CDATA[30]]></parameter>
         </parameters>
     </check>
-    <check level="error" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
-        <parameters>
-            <parameter name="maximum"><![CDATA[10]]></parameter>
-        </parameters>
-    </check>
     <check level="error" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"/>
     <check level="error" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"/>
     <check level="error" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">

--- a/spark3-extensions/src/main/scala/org/apache/iceberg/spark/extensions/IcebergSparkSessionExtensions.scala
+++ b/spark3-extensions/src/main/scala/org/apache/iceberg/spark/extensions/IcebergSparkSessionExtensions.scala
@@ -28,7 +28,7 @@ class IcebergSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
 
   override def apply(extensions: SparkSessionExtensions): Unit = {
     extensions.injectParser { case (_, parser) => new IcebergSparkSqlExtensionsParser(parser) }
-    extensions.injectResolutionRule { _ => ResolveProcedures }
+    extensions.injectResolutionRule { spark => ResolveProcedures(spark) }
     extensions.injectPlannerStrategy { _ => ExtendedDataSourceV2Strategy }
   }
 }

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveProcedures.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveProcedures.scala
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.spark.sql.{AnalysisException, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{Expression, Literal}
+import org.apache.spark.sql.catalyst.plans.logical.{Call, CallArgument, CallStatement, LogicalPlan, NamedArgument, PositionalArgument}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.connector.catalog.{CatalogManager, CatalogPlugin, LookupCatalog, Procedure, ProcedureCatalog, ProcedureParameter}
+import scala.collection.Seq
+
+object ResolveProcedures extends Rule[LogicalPlan] with LookupCatalog {
+
+  protected lazy val catalogManager: CatalogManager = SparkSession.active.sessionState.catalogManager
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
+    case CallStatement(CatalogAndIdentifier(catalog, ident), args) =>
+      val procedure = catalog.asProcedureCatalog.loadProcedure(ident)
+
+      validateParams(procedure)
+      validateMethodHandle(procedure)
+
+      Call(procedure, args = buildArgExprs(procedure, args))
+  }
+
+  private def validateParams(procedure: Procedure): Unit = {
+    // should not be any duplicate param names
+    val duplicateParamNames = procedure.parameters.groupBy(_.name).collect {
+      case (name, matchingParams) if matchingParams.length > 1 => name
+    }
+
+    if (duplicateParamNames.nonEmpty) {
+      throw new AnalysisException(s"Duplicate parameter names: ${duplicateParamNames.mkString("[", ",", "]")}")
+    }
+
+    // optional params should be at the end
+    procedure.parameters.sliding(2).foreach {
+      case Array(previousParam, currentParam) if previousParam.required && !currentParam.required =>
+        throw new AnalysisException("Optional parameters must be after required ones")
+      case _ =>
+    }
+  }
+
+  private def validateMethodHandle(procedure: Procedure): Unit = {
+    val params = procedure.parameters
+    val outputType = procedure.outputType
+
+    val methodHandle = procedure.methodHandle
+    val methodType = methodHandle.`type`
+    val methodReturnType = methodType.returnType
+
+    // method cannot accept var ags
+    if (methodHandle.isVarargsCollector) {
+      throw new AnalysisException("Method must have fixed arity")
+    }
+
+    // verify the number of params in the procedure match the number of params in the method
+    if (params.length != methodType.parameterCount) {
+      throw new AnalysisException("Method parameter count must match the number of procedure parameters")
+    }
+
+    // the MethodHandle API does not allow us to check the generic type
+    // so we only verify the return type is either void or iterable
+
+    if (outputType.nonEmpty && methodReturnType != classOf[java.lang.Iterable[_]]) {
+      throw new AnalysisException(
+        s"Wrong method return type: $methodReturnType; the procedure defines $outputType " +
+        "as its output so must return java.lang.Iterable of Spark Rows")
+    }
+
+    if (outputType.isEmpty && methodReturnType != classOf[Void]) {
+      throw new AnalysisException(
+        s"Wrong method return type: $methodReturnType; the procedure defines no output columns " +
+        "so must be void")
+    }
+  }
+
+  private def buildArgExprs(procedure: Procedure, args: Seq[CallArgument]): Seq[Expression] = {
+    val params = procedure.parameters
+
+    // build a map of declared parameter names to their positions
+    val nameToPositionMap = params.map(_.name).zipWithIndex.toMap
+
+    // build a map of parameter names to args
+    val nameToArgMap = buildNameToArgMap(params, args, nameToPositionMap)
+
+    // verify all required parameters are provided
+    val missingParamNames = params.filter(_.required).collect {
+      case param if !nameToArgMap.contains(param.name) => param.name
+    }
+
+    if (missingParamNames.nonEmpty) {
+      throw new AnalysisException(s"Missing required parameters: ${missingParamNames.mkString("[", ",", "]")}")
+    }
+
+    val argExprs = new Array[Expression](params.size)
+
+    nameToArgMap.foreach { case (name, arg) =>
+      val position = nameToPositionMap(name)
+      val param = params(position)
+      val paramType = param.dataType
+      val argType = arg.expr.dataType
+      if (paramType != argType) {
+        throw new AnalysisException(s"Wrong arg type for ${param.name}: expected $paramType but got $argType")
+      }
+      argExprs(position) = arg.expr
+    }
+
+    // assign nulls to optional params that were not set
+    params.foreach {
+      case p if !p.required && !nameToArgMap.contains(p.name) =>
+        val position = nameToPositionMap(p.name)
+        argExprs(position) = Literal.create(null, p.dataType)
+      case _ =>
+    }
+
+    argExprs
+  }
+
+  private def buildNameToArgMap(
+      params: Seq[ProcedureParameter],
+      args: Seq[CallArgument],
+      nameToPositionMap: Map[String, Int]): Map[String, CallArgument] = {
+
+    val containsNamedArg = args.exists(_.isInstanceOf[NamedArgument])
+    val containsPositionalArg = args.exists(_.isInstanceOf[PositionalArgument])
+
+    if (containsNamedArg && containsPositionalArg) {
+      throw new AnalysisException("Named and positional arguments cannot be mixed")
+    }
+
+    if (containsNamedArg) {
+      buildNameToArgMapUsingNames(args, nameToPositionMap)
+    } else {
+      buildNameToArgMapUsingPositions(args, params)
+    }
+  }
+
+  private def buildNameToArgMapUsingNames(
+      args: Seq[CallArgument],
+      nameToPositionMap: Map[String, Int]): Map[String, CallArgument] = {
+
+    val namedArgs = args.asInstanceOf[Seq[NamedArgument]]
+
+    val validationErrors = namedArgs.groupBy(_.name).collect {
+      case (name, matchingArgs) if matchingArgs.size > 1 => s"Duplicate procedure argument: $name"
+      case (name, _) if !nameToPositionMap.contains(name) => s"Unknown argument: $name"
+    }
+
+    if (validationErrors.nonEmpty) {
+      throw new AnalysisException(s"Could not build name to arg map: ${validationErrors.mkString(", ")}")
+    }
+
+    namedArgs.map(arg => arg.name -> arg).toMap
+  }
+
+  private def buildNameToArgMapUsingPositions(
+      args: Seq[CallArgument],
+      params: Seq[ProcedureParameter]): Map[String, CallArgument] = {
+
+    if (args.size > params.size) {
+      throw new AnalysisException("Too many arguments for procedure")
+    }
+
+    args.zipWithIndex.map { case (arg, position) =>
+      val param = params(position)
+      param.name -> arg
+    }.toMap
+  }
+
+  implicit class CatalogHelper(plugin: CatalogPlugin) {
+    def asProcedureCatalog: ProcedureCatalog = plugin match {
+      case procedureCatalog: ProcedureCatalog =>
+        procedureCatalog
+      case _ =>
+        throw new AnalysisException(s"Cannot use catalog ${plugin.name}: not a ProcedureCatalog")
+    }
+  }
+}

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Call.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Call.scala
@@ -20,9 +20,14 @@
 package org.apache.spark.sql.catalyst.plans.logical
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.connector.catalog.Procedure
 import scala.collection.Seq
 
 case class Call(procedure: Procedure, args: Seq[Expression]) extends Command {
-  override def output: Seq[Attribute] = procedure.outputType.toAttributes
+  override lazy val output: Seq[Attribute] = procedure.outputType.toAttributes
+
+  override def simpleString(maxFields: Int): String = {
+    s"Call${truncatedString(output, "[", ", ", "]", maxFields)} ${procedure.description}"
+  }
 }

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Call.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Call.scala
@@ -17,18 +17,12 @@
  * under the License.
  */
 
-package org.apache.iceberg.spark.extensions
+package org.apache.spark.sql.catalyst.plans.logical
 
-import org.apache.spark.sql.SparkSessionExtensions
-import org.apache.spark.sql.catalyst.analysis.ResolveProcedures
-import org.apache.spark.sql.catalyst.parser.extensions.IcebergSparkSqlExtensionsParser
-import org.apache.spark.sql.execution.datasources.v2.ExtendedDataSourceV2Strategy
+import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
+import org.apache.spark.sql.connector.catalog.Procedure
+import scala.collection.Seq
 
-class IcebergSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
-
-  override def apply(extensions: SparkSessionExtensions): Unit = {
-    extensions.injectParser { case (_, parser) => new IcebergSparkSqlExtensionsParser(parser) }
-    extensions.injectResolutionRule { _ => ResolveProcedures }
-    extensions.injectPlannerStrategy { _ => ExtendedDataSourceV2Strategy }
-  }
+case class Call(procedure: Procedure, args: Seq[Expression]) extends Command {
+  override def output: Seq[Attribute] = procedure.outputType.toAttributes
 }

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CallExec.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CallExec.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import java.lang.invoke.MethodHandle
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.encoders.RowEncoder
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import scala.collection.JavaConverters._
+
+case class CallExec(
+    output: Seq[Attribute],
+    methodHandle: MethodHandle,
+    argValues: Seq[Any]) extends V2CommandExec {
+
+  private lazy val toInternalRow = RowEncoder(schema).resolveAndBind().createSerializer()
+
+  override protected def run(): Seq[InternalRow] = {
+    // convert Any to AnyRef since invokeWithArguments expects Java Object
+    val mappedArgValues = argValues.map(_.asInstanceOf[AnyRef])
+    val result = methodHandle.invokeWithArguments(mappedArgValues: _*)
+    if (output.nonEmpty) {
+      val outputRows = result.asInstanceOf[java.lang.Iterable[Row]]
+      outputRows.asScala.map(toInternalRow).toSeq
+    } else {
+      Seq.empty
+    }
+  }
+}

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CallExec.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CallExec.scala
@@ -21,6 +21,7 @@ package org.apache.spark.sql.execution.datasources.v2
 
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.connector.catalog.Procedure
 
 case class CallExec(
@@ -30,5 +31,9 @@ case class CallExec(
 
   override protected def run(): Seq[InternalRow] = {
     procedure.call(input)
+  }
+
+  override def simpleString(maxFields: Int): String = {
+    s"CallExec${truncatedString(output, "[", ", ", "]", maxFields)} ${procedure.description}"
   }
 }

--- a/spark3/src/main/java/org/apache/spark/sql/catalyst/analysis/NoSuchProcedureException.java
+++ b/spark3/src/main/java/org/apache/spark/sql/catalyst/analysis/NoSuchProcedureException.java
@@ -17,18 +17,14 @@
  * under the License.
  */
 
-package org.apache.iceberg.spark.extensions
+package org.apache.spark.sql.catalyst.analysis;
 
-import org.apache.spark.sql.SparkSessionExtensions
-import org.apache.spark.sql.catalyst.analysis.ResolveProcedures
-import org.apache.spark.sql.catalyst.parser.extensions.IcebergSparkSqlExtensionsParser
-import org.apache.spark.sql.execution.datasources.v2.ExtendedDataSourceV2Strategy
+import org.apache.spark.sql.AnalysisException;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import scala.Option;
 
-class IcebergSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
-
-  override def apply(extensions: SparkSessionExtensions): Unit = {
-    extensions.injectParser { case (_, parser) => new IcebergSparkSqlExtensionsParser(parser) }
-    extensions.injectResolutionRule { _ => ResolveProcedures }
-    extensions.injectPlannerStrategy { _ => ExtendedDataSourceV2Strategy }
+public class NoSuchProcedureException extends AnalysisException {
+  public NoSuchProcedureException(Identifier ident) {
+    super("Procedure " + ident + " not found", Option.empty(), Option.empty(), Option.empty(), Option.empty());
   }
 }

--- a/spark3/src/main/java/org/apache/spark/sql/connector/catalog/Procedure.java
+++ b/spark3/src/main/java/org/apache/spark/sql/connector/catalog/Procedure.java
@@ -17,18 +17,13 @@
  * under the License.
  */
 
-package org.apache.iceberg.spark.extensions
+package org.apache.spark.sql.connector.catalog;
 
-import org.apache.spark.sql.SparkSessionExtensions
-import org.apache.spark.sql.catalyst.analysis.ResolveProcedures
-import org.apache.spark.sql.catalyst.parser.extensions.IcebergSparkSqlExtensionsParser
-import org.apache.spark.sql.execution.datasources.v2.ExtendedDataSourceV2Strategy
+import java.lang.invoke.MethodHandle;
+import org.apache.spark.sql.types.StructType;
 
-class IcebergSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
-
-  override def apply(extensions: SparkSessionExtensions): Unit = {
-    extensions.injectParser { case (_, parser) => new IcebergSparkSqlExtensionsParser(parser) }
-    extensions.injectResolutionRule { _ => ResolveProcedures }
-    extensions.injectPlannerStrategy { _ => ExtendedDataSourceV2Strategy }
-  }
+public interface Procedure {
+  ProcedureParameter[] parameters();
+  StructType outputType();
+  MethodHandle methodHandle();
 }

--- a/spark3/src/main/java/org/apache/spark/sql/connector/catalog/Procedure.java
+++ b/spark3/src/main/java/org/apache/spark/sql/connector/catalog/Procedure.java
@@ -24,6 +24,12 @@ import org.apache.spark.sql.types.StructType;
 
 public interface Procedure {
   ProcedureParameter[] parameters();
+
   StructType outputType();
+
   InternalRow[] call(InternalRow input);
+
+  default String description() {
+    return this.getClass().toString();
+  }
 }

--- a/spark3/src/main/java/org/apache/spark/sql/connector/catalog/Procedure.java
+++ b/spark3/src/main/java/org/apache/spark/sql/connector/catalog/Procedure.java
@@ -19,11 +19,11 @@
 
 package org.apache.spark.sql.connector.catalog;
 
-import java.lang.invoke.MethodHandle;
+import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.types.StructType;
 
 public interface Procedure {
   ProcedureParameter[] parameters();
   StructType outputType();
-  MethodHandle methodHandle();
+  InternalRow[] call(InternalRow input);
 }

--- a/spark3/src/main/java/org/apache/spark/sql/connector/catalog/ProcedureCatalog.java
+++ b/spark3/src/main/java/org/apache/spark/sql/connector/catalog/ProcedureCatalog.java
@@ -17,18 +17,10 @@
  * under the License.
  */
 
-package org.apache.iceberg.spark.extensions
+package org.apache.spark.sql.connector.catalog;
 
-import org.apache.spark.sql.SparkSessionExtensions
-import org.apache.spark.sql.catalyst.analysis.ResolveProcedures
-import org.apache.spark.sql.catalyst.parser.extensions.IcebergSparkSqlExtensionsParser
-import org.apache.spark.sql.execution.datasources.v2.ExtendedDataSourceV2Strategy
+import org.apache.spark.sql.catalyst.analysis.NoSuchProcedureException;
 
-class IcebergSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
-
-  override def apply(extensions: SparkSessionExtensions): Unit = {
-    extensions.injectParser { case (_, parser) => new IcebergSparkSqlExtensionsParser(parser) }
-    extensions.injectResolutionRule { _ => ResolveProcedures }
-    extensions.injectPlannerStrategy { _ => ExtendedDataSourceV2Strategy }
-  }
+public interface ProcedureCatalog extends CatalogPlugin {
+  Procedure loadProcedure(Identifier ident) throws NoSuchProcedureException;
 }

--- a/spark3/src/main/java/org/apache/spark/sql/connector/catalog/ProcedureParameter.java
+++ b/spark3/src/main/java/org/apache/spark/sql/connector/catalog/ProcedureParameter.java
@@ -17,18 +17,21 @@
  * under the License.
  */
 
-package org.apache.iceberg.spark.extensions
+package org.apache.spark.sql.connector.catalog;
 
-import org.apache.spark.sql.SparkSessionExtensions
-import org.apache.spark.sql.catalyst.analysis.ResolveProcedures
-import org.apache.spark.sql.catalyst.parser.extensions.IcebergSparkSqlExtensionsParser
-import org.apache.spark.sql.execution.datasources.v2.ExtendedDataSourceV2Strategy
+import org.apache.spark.sql.types.DataType;
 
-class IcebergSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
+public interface ProcedureParameter {
 
-  override def apply(extensions: SparkSessionExtensions): Unit = {
-    extensions.injectParser { case (_, parser) => new IcebergSparkSqlExtensionsParser(parser) }
-    extensions.injectResolutionRule { _ => ResolveProcedures }
-    extensions.injectPlannerStrategy { _ => ExtendedDataSourceV2Strategy }
+  static ProcedureParameter required(String name, DataType dataType) {
+    return new ProcedureParameterImpl(name, dataType, true);
   }
+
+  static ProcedureParameter optional(String name, DataType dataType) {
+    return new ProcedureParameterImpl(name, dataType, false);
+  }
+
+  String name();
+  DataType dataType();
+  boolean required();
 }

--- a/spark3/src/main/java/org/apache/spark/sql/connector/catalog/ProcedureParameterImpl.java
+++ b/spark3/src/main/java/org/apache/spark/sql/connector/catalog/ProcedureParameterImpl.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.connector.catalog;
+
+import java.util.Objects;
+import org.apache.spark.sql.types.DataType;
+
+class ProcedureParameterImpl implements ProcedureParameter {
+  private final String name;
+  private final DataType dataType;
+  private final boolean required;
+
+  ProcedureParameterImpl(String name, DataType dataType, boolean required) {
+    this.name = name;
+    this.dataType = dataType;
+    this.required = required;
+  }
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public DataType dataType() {
+    return dataType;
+  }
+
+  @Override
+  public boolean required() {
+    return required;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    } else if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+
+    ProcedureParameterImpl that = (ProcedureParameterImpl) other;
+    return required == that.required &&
+        Objects.equals(name, that.name) &&
+        Objects.equals(dataType, that.dataType);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, dataType, required);
+  }
+}


### PR DESCRIPTION
This PR adds the stored procedure API.

The actual implementation in Iceberg and tests will come in a separate PR.

Resolves #1593.