### PR TITLE
Update Presto documentation link

### DIFF
--- a/site/docs/presto.md
+++ b/site/docs/presto.md
@@ -17,4 +17,4 @@
 
 # Presto
 
-Iceberg connector is part of Presto SQL's master branch, although support for many features is still under development. Current status of the connector is detailed in the [presto-iceberg README](https://github.com/prestosql/presto/blob/master/presto-iceberg/README.md).
+The Iceberg connector is available with Presto SQL. It is feature complete and usage details can be found in the [documentation](https://prestosql.io/docs/current/connector/iceberg.html)


### PR DESCRIPTION
Current and relatively complete documentation for the Iceberg Presto
connector was added to Presto in July.  This PR removes the pointer
to the obsolete Presto README.md file, and changes the link to point
to the Iceberg Presto connector documentation.