### PR TITLE
Set Input/Output formats for the HMS storage descriptor

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -279,8 +279,8 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     storageDescriptor.setLocation(metadata.location());
     SerDeInfo serDeInfo = new SerDeInfo();
     if (hiveEngineEnabled) {
-      storageDescriptor.setInputFormat(null);
-      storageDescriptor.setOutputFormat(null);
+      storageDescriptor.setInputFormat("org.apache.iceberg.mr.hive.HiveIcebergInputFormat");
+      storageDescriptor.setOutputFormat("org.apache.iceberg.mr.hive.HiveIcebergOutputFormat");
       serDeInfo.setSerializationLib("org.apache.iceberg.mr.hive.HiveIcebergSerDe");
     } else {
       storageDescriptor.setOutputFormat("org.apache.hadoop.mapred.FileOutputFormat");

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
@@ -401,8 +401,10 @@ public class HiveTableTest extends HiveTableBaseTest {
           hmsTable.getParameters().get(hive_metastoreConstants.META_TABLE_STORAGE));
       Assert.assertEquals("org.apache.iceberg.mr.hive.HiveIcebergSerDe",
           hmsTable.getSd().getSerdeInfo().getSerializationLib());
-      Assert.assertNull(hmsTable.getSd().getInputFormat());
-      Assert.assertNull(hmsTable.getSd().getOutputFormat());
+      Assert.assertEquals("org.apache.iceberg.mr.hive.HiveIcebergInputFormat",
+          hmsTable.getSd().getInputFormat());
+      Assert.assertEquals("org.apache.iceberg.mr.hive.HiveIcebergOutputFormat",
+          hmsTable.getSd().getOutputFormat());
     } else {
       Assert.assertNull(hmsTable.getParameters().get(hive_metastoreConstants.META_TABLE_STORAGE));
       Assert.assertEquals("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",


### PR DESCRIPTION
Some engines (e.g. Impala) depend on the Input/Output format classes
being set in the HMS storage descriptor.