### PR TITLE
Link directly to Presto connector  doc

### DIFF
--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -51,7 +51,7 @@ nav:
     - Flink: flink.md
     - Spark: spark.md
     - Spark Streaming: spark-structured-streaming.md
-    - Presto: presto.md
+    - Presto: https://prestosql.io/docs/current/connector/iceberg.html
     - Hive: hive.md
     - Maintenance: maintenance.md
     - Configuration: configuration.md


### PR DESCRIPTION
At @blue's suggestion, this PR changes site/mkdocs.yml to link directly
to the Presto connector documentation.  On @electrum's advice,  it leaves
docs/presto.md in place, in case folks link to it directly.