### PR TITLE
Spark: Move connector classes to avoid conflicts

### DIFF
--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveProcedures.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveProcedures.scala
@@ -23,7 +23,8 @@ import org.apache.spark.sql.{AnalysisException, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.{Cast, Expression, Literal}
 import org.apache.spark.sql.catalyst.plans.logical.{Call, CallArgument, CallStatement, LogicalPlan, NamedArgument, PositionalArgument}
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.connector.catalog.{CatalogManager, CatalogPlugin, LookupCatalog, Procedure, ProcedureCatalog, ProcedureParameter}
+import org.apache.spark.sql.connector.catalog.{CatalogManager, CatalogPlugin, LookupCatalog}
+import org.apache.spark.sql.connector.iceberg.catalog.{Procedure, ProcedureCatalog, ProcedureParameter}
 import scala.collection.Seq
 
 case class ResolveProcedures(spark: SparkSession) extends Rule[LogicalPlan] with LookupCatalog {

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Call.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/Call.scala
@@ -21,7 +21,7 @@ package org.apache.spark.sql.catalyst.plans.logical
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, Expression}
 import org.apache.spark.sql.catalyst.util.truncatedString
-import org.apache.spark.sql.connector.catalog.Procedure
+import org.apache.spark.sql.connector.iceberg.catalog.Procedure
 import scala.collection.Seq
 
 case class Call(procedure: Procedure, args: Seq[Expression]) extends Command {

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CallExec.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CallExec.scala
@@ -22,7 +22,7 @@ package org.apache.spark.sql.execution.datasources.v2
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.util.truncatedString
-import org.apache.spark.sql.connector.catalog.Procedure
+import org.apache.spark.sql.connector.iceberg.catalog.Procedure
 
 case class CallExec(
     output: Seq[Attribute],

--- a/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/catalog/Procedure.java
+++ b/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/catalog/Procedure.java
@@ -17,21 +17,19 @@
  * under the License.
  */
 
-package org.apache.spark.sql.connector.catalog;
+package org.apache.spark.sql.connector.iceberg.catalog;
 
-import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.StructType;
 
-public interface ProcedureParameter {
+public interface Procedure {
+  ProcedureParameter[] parameters();
 
-  static ProcedureParameter required(String name, DataType dataType) {
-    return new ProcedureParameterImpl(name, dataType, true);
+  StructType outputType();
+
+  InternalRow[] call(InternalRow input);
+
+  default String description() {
+    return this.getClass().toString();
   }
-
-  static ProcedureParameter optional(String name, DataType dataType) {
-    return new ProcedureParameterImpl(name, dataType, false);
-  }
-
-  String name();
-  DataType dataType();
-  boolean required();
 }

--- a/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/catalog/ProcedureCatalog.java
+++ b/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/catalog/ProcedureCatalog.java
@@ -17,9 +17,11 @@
  * under the License.
  */
 
-package org.apache.spark.sql.connector.catalog;
+package org.apache.spark.sql.connector.iceberg.catalog;
 
 import org.apache.spark.sql.catalyst.analysis.NoSuchProcedureException;
+import org.apache.spark.sql.connector.catalog.CatalogPlugin;
+import org.apache.spark.sql.connector.catalog.Identifier;
 
 public interface ProcedureCatalog extends CatalogPlugin {
   Procedure loadProcedure(Identifier ident) throws NoSuchProcedureException;

--- a/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/catalog/ProcedureParameter.java
+++ b/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/catalog/ProcedureParameter.java
@@ -17,19 +17,21 @@
  * under the License.
  */
 
-package org.apache.spark.sql.connector.catalog;
+package org.apache.spark.sql.connector.iceberg.catalog;
 
-import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.types.DataType;
 
-public interface Procedure {
-  ProcedureParameter[] parameters();
+public interface ProcedureParameter {
 
-  StructType outputType();
-
-  InternalRow[] call(InternalRow input);
-
-  default String description() {
-    return this.getClass().toString();
+  static ProcedureParameter required(String name, DataType dataType) {
+    return new ProcedureParameterImpl(name, dataType, true);
   }
+
+  static ProcedureParameter optional(String name, DataType dataType) {
+    return new ProcedureParameterImpl(name, dataType, false);
+  }
+
+  String name();
+  DataType dataType();
+  boolean required();
 }

--- a/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/catalog/ProcedureParameterImpl.java
+++ b/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/catalog/ProcedureParameterImpl.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.spark.sql.connector.catalog;
+package org.apache.spark.sql.connector.iceberg.catalog;
 
 import java.util.Objects;
 import org.apache.spark.sql.types.DataType;


### PR DESCRIPTION
This PR moves connector interfaces to avoid conflicts when these interfaces appear in Spark.