### PR TITLE
Ignore generated-src directory in errorprone

### DIFF
--- a/baseline.gradle
+++ b/baseline.gradle
@@ -63,8 +63,8 @@ subprojects {
   pluginManager.withPlugin('com.palantir.baseline-error-prone') {
     tasks.withType(JavaCompile).configureEach {
       options.errorprone.errorproneArgs.addAll (
-          // error-prone is slow, don't run on tests
-          '-XepExcludedPaths:.*/test/.*',
+          // error-prone is slow, don't run on tests and generated src
+          '-XepExcludedPaths:.*/(test|generated-src)/.*',
           // specific to Palantir
           '-Xep:FinalClass:OFF',
           '-Xep:PreferSafeLoggingPreconditions:OFF',


### PR DESCRIPTION
After `iceberg-spark3-extensions` module is added, there are a ton of warnings emitted during build because of the generated files by antlr. This change avoids running errorprone for generated files in any `generated-src` directory.