### PR TITLE
Flink : exclude large data file when do the rewrite action

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
@@ -250,7 +250,7 @@ public abstract class BaseRewriteDataFilesAction<ThisT>
     try (CloseableIterator<FileScanTask> iterator = tasksIter) {
       iterator.forEachRemaining(task -> {
         // if there is a data file which file size > targetSizeInBytes,
-        // we should remove it and do not do the rewrite
+        // we should exclude it and do not do the rewrite
         if (task.file().fileSizeInBytes() < targetSizeInBytes) {
           StructLikeWrapper structLike = StructLikeWrapper.forType(spec.partitionType()).set(task.file().partition());
           tasksGroupedByPartition.put(structLike, task);

--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
@@ -249,8 +249,12 @@ public abstract class BaseRewriteDataFilesAction<ThisT>
         Maps.newHashMap(), Lists::newArrayList);
     try (CloseableIterator<FileScanTask> iterator = tasksIter) {
       iterator.forEachRemaining(task -> {
-        StructLikeWrapper structLike = StructLikeWrapper.forType(spec.partitionType()).set(task.file().partition());
-        tasksGroupedByPartition.put(structLike, task);
+        // if there is a data file which file size > targetSizeInBytes,
+        // we should remove it and do not do the rewrite
+        if (task.file().fileSizeInBytes() < targetSizeInBytes) {
+          StructLikeWrapper structLike = StructLikeWrapper.forType(spec.partitionType()).set(task.file().partition());
+          tasksGroupedByPartition.put(structLike, task);
+        }
       });
     } catch (IOException e) {
       LOG.warn("Failed to close task iterator", e);


### PR DESCRIPTION
in the current RewriteDataFilesAction, we should add a judge, if the filesize of datafile > targetSizeInBytes, it will not be rewrited