### PR TITLE
AWS: Add progressive multipart upload to S3FileIO

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -99,6 +99,12 @@ public class AwsProperties {
    */
   public static final String S3FILEIO_MULTIPART_THRESHOLD_FACTOR = "s3fileio.multipart.threshold";
 
+  /**
+   * Location to put staging files for upload to S3.
+   */
+  public static final String S3FILEIO_STAGING_DIRECTORY = "s3fileio.staging.dir";
+
+
   static final int MIN_MULTIPART_UPLOAD_SIZE = 5 * 1024 * 1024;
   static final int DEFAULT_MULTIPART_SIZE = 32 * 1024 * 1024;
   static final double DEFAULT_MULTIPART_THRESHOLD = 1.5;
@@ -108,7 +114,8 @@ public class AwsProperties {
   private String s3FileIoSseMd5;
   private int s3FileIoMultipartUploadThreads;
   private int s3FileIoMultiPartSize;
-  private double s3FileIOMultipartThresholdFactor;
+  private double s3FileIoMultipartThresholdFactor;
+  private String s3fileIoStagingDirectory;
 
   private String glueCatalogId;
   private boolean glueCatalogSkipArchive;
@@ -120,8 +127,9 @@ public class AwsProperties {
 
     this.s3FileIoMultipartUploadThreads = Runtime.getRuntime().availableProcessors();
     this.s3FileIoMultiPartSize = DEFAULT_MULTIPART_SIZE;
-    this.s3FileIOMultipartThresholdFactor = DEFAULT_MULTIPART_THRESHOLD;
-    
+    this.s3FileIoMultipartThresholdFactor = DEFAULT_MULTIPART_THRESHOLD;
+    this.s3fileIoStagingDirectory = System.getProperty("java.io.tmpdir");
+
     this.glueCatalogId = null;
     this.glueCatalogSkipArchive = GLUE_CATALOG_SKIP_ARCHIVE_DEFAULT;
   }
@@ -146,11 +154,17 @@ public class AwsProperties {
     this.s3FileIoMultiPartSize = PropertyUtil.propertyAsInt(properties, S3FILEIO_MULTIPART_SIZE,
         DEFAULT_MULTIPART_SIZE);
 
-    this.s3FileIOMultipartThresholdFactor = PropertyUtil.propertyAsDouble(properties,
+    this.s3FileIoMultipartThresholdFactor = PropertyUtil.propertyAsDouble(properties,
         S3FILEIO_MULTIPART_THRESHOLD_FACTOR, DEFAULT_MULTIPART_THRESHOLD);
+
+    Preconditions.checkArgument(s3FileIoMultipartThresholdFactor >= 1.0,
+        "Multipart threshold factor must be >= to 1.0");
 
     Preconditions.checkArgument(s3FileIoMultiPartSize >= MIN_MULTIPART_UPLOAD_SIZE,
         "Minimum multipart upload object size must be larger than 5 MB.");
+
+    this.s3fileIoStagingDirectory = PropertyUtil.propertyAsString(properties, S3FILEIO_STAGING_DIRECTORY,
+        System.getProperty("java.io.tmpdir"));
   }
 
   public String s3FileIoSseType() {
@@ -202,6 +216,10 @@ public class AwsProperties {
   }
 
   public double s3FileIOMultipartThresholdFactor() {
-    return s3FileIOMultipartThresholdFactor;
+    return s3FileIoMultipartThresholdFactor;
+  }
+
+  public String getS3fileIoStagingDirectory() {
+    return s3fileIoStagingDirectory;
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -82,9 +82,33 @@ public class AwsProperties {
   public static final String GLUE_CATALOG_SKIP_ARCHIVE = "gluecatalog.skip-archive";
   public static final boolean GLUE_CATALOG_SKIP_ARCHIVE_DEFAULT = false;
 
+  /**
+   * Number of threads to use for uploading parts to S3 (shared pool across all output streams).
+   */
+  public static final String S3FILEIO_MULTIPART_UPLOAD_THREADS  = "s3fileio.multipart.num-threads";
+
+  /**
+   * The size of a single part for multipart upload requests (default: 32MB).
+   */
+  public static final String S3FILEIO_MULTIPART_SIZE = "s3fileio.multipart.part.size";
+
+  /**
+   * The threshold expressed as a factor times the multipart size at which to
+   * switch from uploading using a single put object request to uploading using multipart upload
+   * (default: 1.5).
+   */
+  public static final String S3FILEIO_MULTIPART_THRESHOLD_FACTOR = "s3fileio.multipart.threshold";
+
+  static final int MIN_MULTIPART_UPLOAD_SIZE = 5 * 1024 * 1024;
+  static final int DEFAULT_MULTIPART_SIZE = 32 * 1024 * 1024;
+  static final double DEFAULT_MULTIPART_THRESHOLD = 1.5;
+
   private String s3FileIoSseType;
   private String s3FileIoSseKey;
   private String s3FileIoSseMd5;
+  private int s3FileIoMultipartUploadThreads;
+  private int s3FileIoMultiPartSize;
+  private double s3FileIOMultipartThresholdFactor;
 
   private String glueCatalogId;
   private boolean glueCatalogSkipArchive;
@@ -111,6 +135,18 @@ public class AwsProperties {
     this.glueCatalogId = properties.get(GLUE_CATALOG_ID);
     this.glueCatalogSkipArchive = PropertyUtil.propertyAsBoolean(properties,
         AwsProperties.GLUE_CATALOG_SKIP_ARCHIVE, AwsProperties.GLUE_CATALOG_SKIP_ARCHIVE_DEFAULT);
+
+    this.s3FileIoMultipartUploadThreads = PropertyUtil.propertyAsInt(properties, S3FILEIO_MULTIPART_UPLOAD_THREADS,
+        Runtime.getRuntime().availableProcessors());
+
+    this.s3FileIoMultiPartSize = PropertyUtil.propertyAsInt(properties, S3FILEIO_MULTIPART_SIZE,
+        DEFAULT_MULTIPART_SIZE);
+
+    this.s3FileIOMultipartThresholdFactor = PropertyUtil.propertyAsDouble(properties,
+        S3FILEIO_MULTIPART_THRESHOLD_FACTOR, DEFAULT_MULTIPART_THRESHOLD);
+
+    Preconditions.checkArgument(s3FileIoMultiPartSize >= MIN_MULTIPART_UPLOAD_SIZE,
+        "Minimum multipart upload object size must be larger than 5 MB.");
   }
 
   public String s3FileIoSseType() {
@@ -151,5 +187,17 @@ public class AwsProperties {
 
   public void setGlueCatalogSkipArchive(boolean skipArchive) {
     this.glueCatalogSkipArchive = skipArchive;
+  }
+
+  public int s3FileIoMultipartUploadThreads() {
+    return s3FileIoMultipartUploadThreads;
+  }
+
+  public int s3FileIoMultiPartSize() {
+    return s3FileIoMultiPartSize;
+  }
+
+  public double s3FileIOMultipartThresholdFactor() {
+    return s3FileIOMultipartThresholdFactor;
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -118,6 +118,10 @@ public class AwsProperties {
     this.s3FileIoSseKey = null;
     this.s3FileIoSseMd5 = null;
 
+    this.s3FileIoMultipartUploadThreads = Runtime.getRuntime().availableProcessors();
+    this.s3FileIoMultiPartSize = DEFAULT_MULTIPART_SIZE;
+    this.s3FileIOMultipartThresholdFactor = DEFAULT_MULTIPART_THRESHOLD;
+    
     this.glueCatalogId = null;
     this.glueCatalogSkipArchive = GLUE_CATALOG_SKIP_ARCHIVE_DEFAULT;
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -25,6 +25,7 @@ import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.SerializableSupplier;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.Delete;
@@ -39,7 +40,6 @@ import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 public class S3FileIO implements FileIO {
   private final SerializableSupplier<S3Client> s3;
   private AwsProperties awsProperties;
-
   private transient S3Client client;
 
   public S3FileIO() {

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -25,7 +25,6 @@ import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.SerializableSupplier;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.Delete;

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
@@ -32,7 +32,6 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
-import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
 
 class S3InputStream extends SeekableInputStream {
   private static final Logger LOG = LoggerFactory.getLogger(S3InputStream.class);
@@ -139,11 +138,7 @@ class S3InputStream extends SeekableInputStream {
         .key(location.key())
         .range(String.format("bytes=%s-", pos));
 
-    if (AwsProperties.S3FILEIO_SSE_TYPE_CUSTOM.equals(awsProperties.s3FileIoSseType())) {
-      requestBuilder.sseCustomerAlgorithm(ServerSideEncryption.AES256.name());
-      requestBuilder.sseCustomerKey(awsProperties.s3FileIoSseKey());
-      requestBuilder.sseCustomerKeyMD5(awsProperties.s3FileIoSseMd5());
-    }
+    S3RequestUtil.configureEncryption(awsProperties, requestBuilder);
 
     closeStream();
     stream = s3.getObject(requestBuilder.build(), ResponseTransformer.toInputStream());

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -151,7 +151,7 @@ class S3OutputStream extends PositionOutputStream {
     pos += len;
 
     // switch to multipart upload
-    if (pos >= multiPartSize * multiPartThresholdFactor) {
+    if (multipartUploadId == null && pos >= multiPartSize * multiPartThresholdFactor) {
       initializeMultiPartUpload();
       uploadParts();
     }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -237,9 +237,9 @@ class S3OutputStream extends PositionOutputStream {
             .collect(Collectors.toList());
 
     s3.completeMultipartUpload(CompleteMultipartUploadRequest.builder()
-      .bucket(location.bucket()).key(location.key())
-      .uploadId(multipartUploadId)
-      .multipartUpload(CompletedMultipartUpload.builder().parts(completedParts).build()).build());
+        .bucket(location.bucket()).key(location.key())
+        .uploadId(multipartUploadId)
+        .multipartUpload(CompletedMultipartUpload.builder().parts(completedParts).build()).build());
   }
 
   private void abortUpload() {

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -19,35 +19,70 @@
 
 package org.apache.iceberg.aws.s3;
 
+import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
+import java.io.InputStream;
+import java.io.SequenceInputStream;
+import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.Locale;
 import org.apache.iceberg.aws.AwsProperties;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import org.apache.iceberg.io.PositionOutputStream;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Predicates;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.io.CountingOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompletedMultipartUpload;
+import software.amazon.awssdk.services.s3.model.CompletedPart;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 
 class S3OutputStream extends PositionOutputStream {
   private static final Logger LOG = LoggerFactory.getLogger(S3OutputStream.class);
+
+  static final String MULTIPART_SIZE = "s3fileio.multipart.size";
+  static final String MULTIPART_THRESHOLD_FACTOR = "s3fileio.multipart.threshold";
+
+  static final int MIN_MULTIPART_UPLOAD_SIZE = 5 * 1024 * 1024;
+  static final int DEFAULT_MULTIPART_SIZE = 32 * 1024 * 1024;
+  static final double DEFAULT_MULTIPART_THRESHOLD = 1.5;
 
   private final StackTraceElement[] createStack;
   private final S3Client s3;
   private final S3URI location;
   private final AwsProperties awsProperties;
 
-  private final OutputStream stream;
-  private final File stagingFile;
-  private long pos = 0;
+  private CountingOutputStream stream;
+  private final List<File> stagingFiles = Lists.newArrayList();
+  private File currentStagingFile;
+  private String multipartUploadId;
+  private final Map<File, CompletableFuture<CompletedPart>> multiPartMap = Maps.newHashMap();
+  private final int multiPartSize;
+  private final double multiPartThresholdFactor;
 
+  private long pos = 0;
   private boolean closed = false;
 
   S3OutputStream(S3Client s3, S3URI location) throws IOException {
@@ -60,10 +95,16 @@ class S3OutputStream extends PositionOutputStream {
     this.awsProperties = awsProperties;
 
     createStack = Thread.currentThread().getStackTrace();
-    stagingFile = File.createTempFile("s3fileio-", ".tmp");
-    stream = new BufferedOutputStream(new FileOutputStream(stagingFile));
 
-    stagingFile.deleteOnExit();
+    multiPartSize = Integer.parseInt(properties.getOrDefault(MULTIPART_SIZE, Integer.toString(DEFAULT_MULTIPART_SIZE)));
+    multiPartThresholdFactor = Double.parseDouble(properties.getOrDefault(
+        MULTIPART_THRESHOLD_FACTOR,
+        Double.toString(DEFAULT_MULTIPART_THRESHOLD)));
+
+    Preconditions.checkArgument(multiPartSize * multiPartThresholdFactor > MIN_MULTIPART_UPLOAD_SIZE,
+        "Minimum multipart upload object size must be larger than 5 MB.");
+
+    newStream();
   }
 
   @Override
@@ -78,14 +119,54 @@ class S3OutputStream extends PositionOutputStream {
 
   @Override
   public void write(int b) throws IOException {
+    if (stream.getCount() >= multiPartSize) {
+      newStream();
+      uploadParts();
+    }
+
     stream.write(b);
     pos += 1;
   }
 
   @Override
   public void write(byte[] b, int off, int len) throws IOException {
-    stream.write(b, off, len);
+    int remaining = len;
+    int relativeOffset = off;
+
+    // Write the remainder of the part size to the staging file
+    // and continue to write new staging files if the write is
+    // larger than the part size.
+    while (stream.getCount() + remaining > multiPartSize) {
+      int writeSize = multiPartSize - (int) stream.getCount();
+
+      stream.write(b, relativeOffset, writeSize);
+      remaining -= writeSize;
+      relativeOffset += writeSize;
+
+      newStream();
+      uploadParts();
+    }
+
+    stream.write(b, relativeOffset, remaining);
     pos += len;
+
+    // switch to multipart upload
+    if (pos >= multiPartSize * multiPartThresholdFactor) {
+      initializeMultiPartUpload();
+      uploadParts();
+    }
+  }
+
+  private void newStream() throws IOException {
+    if (stream != null) {
+      stream.close();
+    }
+
+    currentStagingFile = File.createTempFile("s3fileio-", ".tmp");
+    currentStagingFile.deleteOnExit();
+    stagingFiles.add(currentStagingFile);
+
+    stream = new CountingOutputStream(new BufferedOutputStream(new FileOutputStream(currentStagingFile)));
   }
 
   @Override
@@ -96,9 +177,89 @@ class S3OutputStream extends PositionOutputStream {
 
     super.close();
     closed = true;
+    currentStagingFile = null;
 
     try {
       stream.close();
+
+      completeUploads();
+    } finally {
+      stagingFiles.forEach(f -> {
+        if (f.exists() && !f.delete()) {
+          LOG.warn("Could not delete temporary file: {}", f);
+        }
+      });
+    }
+  }
+
+  private void initializeMultiPartUpload() {
+    multipartUploadId = s3.createMultipartUpload(CreateMultipartUploadRequest.builder()
+        .bucket(location.bucket()).key(location.key()).build()).uploadId();
+  }
+
+  private void uploadParts() {
+    // exit if multipart has not been initiated
+    if (multipartUploadId == null) {
+      return;
+    }
+
+    stagingFiles.stream()
+        // do not upload the file currently being written
+        .filter(f -> currentStagingFile == null || !currentStagingFile.equals(f))
+        // do not upload any files that have already been processed
+        .filter(Predicates.not(multiPartMap::containsKey))
+        .forEach(f -> {
+          UploadPartRequest uploadRequest = UploadPartRequest.builder()
+              .bucket(location.bucket())
+              .key(location.key())
+              .uploadId(multipartUploadId)
+              .partNumber(stagingFiles.indexOf(f) + 1)
+              .contentLength(f.length())
+              .build();
+
+          CompletableFuture<CompletedPart> future = CompletableFuture.supplyAsync(
+              () -> {
+                UploadPartResponse response = s3.uploadPart(uploadRequest, RequestBody.fromFile(f));
+                return CompletedPart.builder().eTag(response.eTag()).partNumber(uploadRequest.partNumber()).build();
+              }
+          );
+
+          multiPartMap.put(f, future);
+        });
+  }
+
+  private void completeMultiPartUpload() throws IOException {
+    List<CompletedPart> completedParts = Lists.newArrayList();
+    for (Future<CompletedPart> future : multiPartMap.values()) {
+      try {
+        completedParts.add(future.get());
+      } catch (InterruptedException | ExecutionException e) {
+        abortUpload();
+        throw new IOException("Filed to complete upload for: " + location, e);
+      }
+    }
+
+    CompletableFuture.allOf(multiPartMap.values().toArray(new CompletableFuture[0])).thenRun(() ->
+        s3.completeMultipartUpload(CompleteMultipartUploadRequest.builder()
+          .bucket(location.bucket()).key(location.key())
+          .uploadId(multipartUploadId)
+          .multipartUpload(CompletedMultipartUpload.builder().parts(completedParts).build()).build())
+    );
+  }
+
+  private void abortUpload() {
+    if (multipartUploadId != null) {
+      AbortMultipartUploadResponse response = s3.abortMultipartUpload(AbortMultipartUploadRequest.builder()
+          .bucket(location.bucket()).key(location.key()).uploadId(multipartUploadId).build());
+    }
+  }
+
+  private void completeUploads() throws IOException {
+    if (multipartUploadId == null) {
+      long contentLength = stagingFiles.stream().mapToLong(File::length).sum();
+      InputStream contentStream = new BufferedInputStream(stagingFiles.stream()
+          .map(S3OutputStream::uncheckedInputStream)
+          .reduce(SequenceInputStream::new).orElseGet(() -> new ByteArrayInputStream(new byte[0])));
 
       PutObjectRequest.Builder requestBuilder = PutObjectRequest.builder()
           .bucket(location.bucket())
@@ -128,11 +289,18 @@ class S3OutputStream extends PositionOutputStream {
               "Cannot support given S3 encryption type: " + awsProperties.s3FileIoSseType());
       }
 
-      s3.putObject(requestBuilder.build(), RequestBody.fromFile(stagingFile));
-    } finally {
-      if (!stagingFile.delete()) {
-        LOG.warn("Could not delete temporary file: {}", stagingFile);
-      }
+      s3.putObject(requestBuilder.build(), RequestBody.fromInputStream(contentStream, contentLength));
+    } else {
+      uploadParts();
+      completeMultiPartUpload();
+    }
+  }
+
+  private static InputStream uncheckedInputStream(File file) {
+    try {
+      return new FileInputStream(file);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
     }
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -230,9 +230,11 @@ class S3OutputStream extends PositionOutputStream {
 
   private void completeMultiPartUpload() throws IOException {
     List<CompletedPart> completedParts =
-        multiPartMap.values().stream().map(CompletableFuture::join).collect(Collectors.toList());
-
-    completedParts.sort(Comparator.comparing(CompletedPart::partNumber));
+        multiPartMap.values()
+            .stream()
+            .map(CompletableFuture::join)
+            .sorted(Comparator.comparing(CompletedPart::partNumber))
+            .collect(Collectors.toList());
 
     s3.completeMultipartUpload(CompleteMultipartUploadRequest.builder()
       .bucket(location.bucket()).key(location.key())

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -243,7 +243,7 @@ class S3OutputStream extends PositionOutputStream {
               LOG.warn("Failed to delete staging file: {}", f, e);
             }
 
-            if(thrown != null) {
+            if (thrown != null) {
               LOG.error("Failed to upload part: {}", uploadRequest, thrown);
               abortUpload();
             }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3RequestUtil.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3RequestUtil.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.aws.s3;
+
+import java.util.Locale;
+import org.apache.iceberg.aws.AwsProperties;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+
+public class S3RequestUtil {
+
+  private S3RequestUtil() {
+  }
+
+  static void configureEncryption(AwsProperties awsProperties, PutObjectRequest.Builder requestBuilder) {
+    switch (awsProperties.s3FileIoSseType().toLowerCase(Locale.ENGLISH)) {
+      case AwsProperties.S3FILEIO_SSE_TYPE_NONE:
+        break;
+
+      case AwsProperties.S3FILEIO_SSE_TYPE_KMS:
+        requestBuilder.serverSideEncryption(ServerSideEncryption.AWS_KMS);
+        requestBuilder.ssekmsKeyId(awsProperties.s3FileIoSseKey());
+        break;
+
+      case AwsProperties.S3FILEIO_SSE_TYPE_S3:
+        requestBuilder.serverSideEncryption(ServerSideEncryption.AES256);
+        break;
+
+      case AwsProperties.S3FILEIO_SSE_TYPE_CUSTOM:
+        requestBuilder.sseCustomerAlgorithm(ServerSideEncryption.AES256.name());
+        requestBuilder.sseCustomerKey(awsProperties.s3FileIoSseKey());
+        requestBuilder.sseCustomerKeyMD5(awsProperties.s3FileIoSseMd5());
+        break;
+
+      default:
+        throw new IllegalArgumentException(
+            "Cannot support given S3 encryption type: " + awsProperties.s3FileIoSseType());
+    }
+  }
+
+  static void configureEncryption(AwsProperties awsProperties, CreateMultipartUploadRequest.Builder requestBuilder) {
+    switch (awsProperties.s3FileIoSseType().toLowerCase(Locale.ENGLISH)) {
+      case AwsProperties.S3FILEIO_SSE_TYPE_NONE:
+        break;
+
+      case AwsProperties.S3FILEIO_SSE_TYPE_KMS:
+        requestBuilder.serverSideEncryption(ServerSideEncryption.AWS_KMS);
+        requestBuilder.ssekmsKeyId(awsProperties.s3FileIoSseKey());
+        break;
+
+      case AwsProperties.S3FILEIO_SSE_TYPE_S3:
+        requestBuilder.serverSideEncryption(ServerSideEncryption.AES256);
+        break;
+
+      case AwsProperties.S3FILEIO_SSE_TYPE_CUSTOM:
+        requestBuilder.sseCustomerAlgorithm(ServerSideEncryption.AES256.name());
+        requestBuilder.sseCustomerKey(awsProperties.s3FileIoSseKey());
+        requestBuilder.sseCustomerKeyMD5(awsProperties.s3FileIoSseMd5());
+        break;
+
+      default:
+        throw new IllegalArgumentException(
+            "Cannot support given S3 encryption type: " + awsProperties.s3FileIoSseType());
+    }
+  }
+
+  static void configureEncryption(AwsProperties awsProperties, UploadPartRequest.Builder requestBuilder) {
+    switch (awsProperties.s3FileIoSseType().toLowerCase(Locale.ENGLISH)) {
+      case AwsProperties.S3FILEIO_SSE_TYPE_NONE:
+      case AwsProperties.S3FILEIO_SSE_TYPE_KMS:
+      case AwsProperties.S3FILEIO_SSE_TYPE_S3:
+        break;
+
+      case AwsProperties.S3FILEIO_SSE_TYPE_CUSTOM:
+        requestBuilder.sseCustomerAlgorithm(ServerSideEncryption.AES256.name());
+        requestBuilder.sseCustomerKey(awsProperties.s3FileIoSseKey());
+        requestBuilder.sseCustomerKeyMD5(awsProperties.s3FileIoSseMd5());
+        break;
+
+      default:
+        throw new IllegalArgumentException(
+            "Cannot support given S3 encryption type: " + awsProperties.s3FileIoSseType());
+    }
+  }
+
+  static void configureEncryption(AwsProperties awsProperties, GetObjectRequest.Builder requestBuilder) {
+    switch (awsProperties.s3FileIoSseType().toLowerCase(Locale.ENGLISH)) {
+      case AwsProperties.S3FILEIO_SSE_TYPE_NONE:
+      case AwsProperties.S3FILEIO_SSE_TYPE_KMS:
+      case AwsProperties.S3FILEIO_SSE_TYPE_S3:
+        break;
+
+      case AwsProperties.S3FILEIO_SSE_TYPE_CUSTOM:
+        requestBuilder.sseCustomerAlgorithm(ServerSideEncryption.AES256.name());
+        requestBuilder.sseCustomerKey(awsProperties.s3FileIoSseKey());
+        requestBuilder.sseCustomerKeyMD5(awsProperties.s3FileIoSseMd5());
+        break;
+
+      default:
+        throw new IllegalArgumentException(
+            "Cannot support given S3 encryption type: " + awsProperties.s3FileIoSseType());
+    }
+  }
+}

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/S3OutputStreamTest.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/S3OutputStreamTest.java
@@ -37,7 +37,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.ResponseBytes;
-import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -78,7 +77,8 @@ public class S3OutputStreamTest {
       AwsProperties.S3FILEIO_MULTIPART_SIZE, Integer.toString(5 * 1024 * 1024),
       AwsProperties.S3FILEIO_STAGING_DIRECTORY, tmpDir.toString()));
 
-  public S3OutputStreamTest() throws IOException {}
+  public S3OutputStreamTest() throws IOException {
+  }
 
   @Before
   public void before() {
@@ -88,7 +88,7 @@ public class S3OutputStreamTest {
   @Test
   public void testWrite() {
     // Run tests for both byte and array write paths
-    Stream.of(true, false).forEach((arrayWrite) -> {
+    Stream.of(true, false).forEach(arrayWrite -> {
       // Test small file write (less than multipart threshold)
       writeAndVerify(s3mock, randomURI(), randomData(1024), arrayWrite);
       verify(s3mock, times(1)).putObject((PutObjectRequest) any(), (RequestBody) any());
@@ -140,9 +140,9 @@ public class S3OutputStreamTest {
     stream.close();
   }
 
-  private void writeAndVerify(S3Client s3, S3URI uri, byte [] data, boolean arrayWrite) {
-    try (S3OutputStream stream = new S3OutputStream(s3, uri, properties)) {
-      if(arrayWrite) {
+  private void writeAndVerify(S3Client client, S3URI uri, byte [] data, boolean arrayWrite) {
+    try (S3OutputStream stream = new S3OutputStream(client, uri, properties)) {
+      if (arrayWrite) {
         stream.write(data);
         assertEquals(data.length, stream.getPos());
       } else {

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/S3OutputStreamTest.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/S3OutputStreamTest.java
@@ -133,7 +133,7 @@ public class S3OutputStreamTest {
   @Test
   public void testMultipleClose() throws IOException {
     S3URI uri = new S3URI("s3://bucket/path/to/array-out.dat");
-    S3OutputStream stream = new S3OutputStream(s3, uri);
+    S3OutputStream stream = new S3OutputStream(properties, s3, uri);
     stream.close();
     stream.close();
   }

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/S3OutputStreamTest.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/S3OutputStreamTest.java
@@ -21,121 +21,149 @@ package org.apache.iceberg.aws.s3;
 
 import com.adobe.testing.s3mock.junit4.S3MockRule;
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Random;
+import java.util.UUID;
+import java.util.stream.Stream;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
+
+@RunWith(MockitoJUnitRunner.class)
 public class S3OutputStreamTest {
+  private static final Logger LOG = LoggerFactory.getLogger(S3OutputStreamTest.class);
+  private static final String BUCKET = "test-bucket";
+
   @ClassRule
   public static final S3MockRule S3_MOCK_RULE = S3MockRule.builder().silent().build();
 
   private final S3Client s3 = S3_MOCK_RULE.createS3ClientV2();
+  private final S3Client s3mock = mock(S3Client.class, delegatesTo(s3));
   private final Random random = new Random(1);
-  private final AwsProperties properties = new AwsProperties(ImmutableMap.of(AwsProperties.S3FILEIO_MULTIPART_SIZE,
-      Integer.toString(5 * 1024 * 1024)));
+  private final Path tmpDir = Files.createTempDirectory("s3fileio-test-");
+
+  private final AwsProperties properties = new AwsProperties(ImmutableMap.of(
+      AwsProperties.S3FILEIO_MULTIPART_SIZE, Integer.toString(5 * 1024 * 1024),
+      AwsProperties.S3FILEIO_STAGING_DIRECTORY, tmpDir.toString()));
+
+  public S3OutputStreamTest() throws IOException {}
 
   @Before
   public void before() {
-    s3.createBucket(CreateBucketRequest.builder().bucket("bucket").build());
+    s3.createBucket(CreateBucketRequest.builder().bucket(BUCKET).build());
   }
 
   @Test
-  public void getPos() throws IOException {
+  public void testWrite() {
+    // Run tests for both byte and array write paths
+    Stream.of(true, false).forEach((arrayWrite) -> {
+      // Test small file write (less than multipart threshold)
+      writeAndVerify(s3mock, randomURI(), randomData(1024), arrayWrite);
+      verify(s3mock, times(1)).putObject((PutObjectRequest) any(), (RequestBody) any());
+      reset(s3mock);
 
-    S3URI uri = new S3URI("s3://bucket/path/to/pos.dat");
-    int writeSize = 1024;
+      // Test file larger than part size but less than multipart threshold
+      writeAndVerify(s3mock, randomURI(), randomData(6 * 1024 * 1024), arrayWrite);
+      verify(s3mock, times(1)).putObject((PutObjectRequest) any(), (RequestBody) any());
+      reset(s3mock);
 
-    try (S3OutputStream stream = new S3OutputStream(s3, uri, properties)) {
-      stream.write(new byte[writeSize]);
-      assertEquals(writeSize, stream.getPos());
+      // Test file large enough to trigger multipart upload
+      writeAndVerify(s3mock, randomURI(), randomData(10 * 1024 * 1024), arrayWrite);
+      verify(s3mock, times(2)).uploadPart((UploadPartRequest) any(), (RequestBody) any());
+      reset(s3mock);
+
+      // Test uploading many parts
+      writeAndVerify(s3mock, randomURI(), randomData(22 * 1024 * 1024), arrayWrite);
+      verify(s3mock, times(5)).uploadPart((UploadPartRequest) any(), (RequestBody) any());
+      reset(s3mock);
+    });
+  }
+
+  @Test
+  public void testAbortAfterFailedPartUpload() {
+    doThrow(new RuntimeException()).when(s3mock).uploadPart((UploadPartRequest) any(), (RequestBody) any());
+
+    try (S3OutputStream stream = new S3OutputStream(s3mock, randomURI(), properties)) {
+      stream.write(randomData(10 * 1024 * 1024));
+    } catch (Exception e) {
+      verify(s3mock, atLeastOnce()).abortMultipartUpload((AbortMultipartUploadRequest) any());
     }
   }
 
   @Test
-  public void testWrite() throws IOException {
-    S3URI uri = new S3URI("s3://bucket/path/to/out.dat");
-    int size = 5 * 1024 * 1024;
-    byte [] expected =  new byte[size];
-    random.nextBytes(expected);
+  public void testAbortMultipart() {
+    doThrow(new RuntimeException()).when(s3mock).completeMultipartUpload((CompleteMultipartUploadRequest) any());
 
-    try (S3OutputStream stream = new S3OutputStream(s3, uri, properties)) {
-      for (int i = 0; i < size; i++) {
-        stream.write(expected[i]);
-        assertEquals(i + 1, stream.getPos());
-      }
+    try (S3OutputStream stream = new S3OutputStream(s3mock, randomURI(), properties)) {
+      stream.write(randomData(10 * 1024 * 1024));
+    } catch (Exception e) {
+      verify(s3mock).abortMultipartUpload((AbortMultipartUploadRequest) any());
     }
-
-    byte [] actual = readS3Data(uri);
-
-    assertArrayEquals(expected, actual);
-  }
-
-  @Test
-  public void testWriteArray() throws IOException {
-    S3URI uri = new S3URI("s3://bucket/path/to/array-out.dat");
-    byte [] expected =  new byte[5 * 1024 * 1024];
-    random.nextBytes(expected);
-
-    try (S3OutputStream stream = new S3OutputStream(s3, uri, properties)) {
-      stream.write(expected);
-      assertEquals(expected.length, stream.getPos());
-    }
-
-    byte [] actual = readS3Data(uri);
-
-    assertArrayEquals(expected, actual);
-  }
-
-  @Test
-  public void testMultiPartWriteArray() throws IOException {
-    S3URI uri = new S3URI("s3://bucket/path/to/array-out.dat");
-    byte [] expected =  new byte[10 * 1024 * 1024];
-    random.nextBytes(expected);
-
-    try (S3OutputStream stream = new S3OutputStream(s3, uri, properties)) {
-      stream.write(expected);
-      assertEquals(expected.length, stream.getPos());
-    }
-
-    byte [] actual = readS3Data(uri);
-
-    assertArrayEquals(expected, actual);
-  }
-
-  @Test
-  public void testMultiPartWriteArraySmallFragment() throws IOException {
-    S3URI uri = new S3URI("s3://bucket/path/to/array-out.dat");
-    byte [] expected =  new byte[10 * 1024 * 1024 + 10 * 1024];
-    random.nextBytes(expected);
-
-    try (S3OutputStream stream = new S3OutputStream(s3, uri, properties)) {
-      stream.write(expected);
-      assertEquals(expected.length, stream.getPos());
-    }
-
-    byte [] actual = readS3Data(uri);
-
-    assertArrayEquals(expected, actual);
   }
 
   @Test
   public void testMultipleClose() throws IOException {
-    S3URI uri = new S3URI("s3://bucket/path/to/array-out.dat");
-    S3OutputStream stream = new S3OutputStream(s3, uri, properties);
+    S3OutputStream stream = new S3OutputStream(s3, randomURI(), properties);
     stream.close();
     stream.close();
+  }
+
+  private void writeAndVerify(S3Client s3, S3URI uri, byte [] data, boolean arrayWrite) {
+    try (S3OutputStream stream = new S3OutputStream(s3, uri, properties)) {
+      if(arrayWrite) {
+        stream.write(data);
+        assertEquals(data.length, stream.getPos());
+      } else {
+        for (int i = 0; i < data.length; i++) {
+          stream.write(data[i]);
+          assertEquals(i + 1, stream.getPos());
+        }
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+
+    byte[] actual = readS3Data(uri);
+    assertArrayEquals(data, actual);
+
+    // Verify all staging files are cleaned up
+    try {
+      assertEquals(0, Files.list(tmpDir).count());
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 
   private byte[] readS3Data(S3URI uri) {
@@ -144,5 +172,15 @@ public class S3OutputStreamTest {
         ResponseTransformer.toBytes());
 
     return data.asByteArray();
+  }
+
+  private byte[] randomData(int size) {
+    byte [] result = new byte[size];
+    random.nextBytes(result);
+    return result;
+  }
+
+  private S3URI randomURI() {
+    return new S3URI(String.format("s3://%s/data/%s.dat", BUCKET, UUID.randomUUID()));
   }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/S3OutputStreamTest.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/S3OutputStreamTest.java
@@ -21,8 +21,8 @@ package org.apache.iceberg.aws.s3;
 
 import com.adobe.testing.s3mock.junit4.S3MockRule;
 import java.io.IOException;
-import java.util.Map;
 import java.util.Random;
+import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -34,7 +34,6 @@ import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
-import static org.apache.iceberg.aws.s3.S3OutputStream.MULTIPART_SIZE;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
@@ -44,7 +43,8 @@ public class S3OutputStreamTest {
 
   private final S3Client s3 = S3_MOCK_RULE.createS3ClientV2();
   private final Random random = new Random(1);
-  private final Map<String, String> properties = ImmutableMap.of(MULTIPART_SIZE, Integer.toString(5 * 1024 * 1024));
+  private final AwsProperties properties = new AwsProperties(ImmutableMap.of(AwsProperties.S3FILEIO_MULTIPART_SIZE,
+      Integer.toString(5 * 1024 * 1024)));
 
   @Before
   public void before() {
@@ -57,7 +57,7 @@ public class S3OutputStreamTest {
     S3URI uri = new S3URI("s3://bucket/path/to/pos.dat");
     int writeSize = 1024;
 
-    try (S3OutputStream stream = new S3OutputStream(properties, s3, uri)) {
+    try (S3OutputStream stream = new S3OutputStream(s3, uri, properties)) {
       stream.write(new byte[writeSize]);
       assertEquals(writeSize, stream.getPos());
     }
@@ -70,7 +70,7 @@ public class S3OutputStreamTest {
     byte [] expected =  new byte[size];
     random.nextBytes(expected);
 
-    try (S3OutputStream stream = new S3OutputStream(properties, s3, uri)) {
+    try (S3OutputStream stream = new S3OutputStream(s3, uri, properties)) {
       for (int i = 0; i < size; i++) {
         stream.write(expected[i]);
         assertEquals(i + 1, stream.getPos());
@@ -88,7 +88,7 @@ public class S3OutputStreamTest {
     byte [] expected =  new byte[5 * 1024 * 1024];
     random.nextBytes(expected);
 
-    try (S3OutputStream stream = new S3OutputStream(properties, s3, uri)) {
+    try (S3OutputStream stream = new S3OutputStream(s3, uri, properties)) {
       stream.write(expected);
       assertEquals(expected.length, stream.getPos());
     }
@@ -104,7 +104,7 @@ public class S3OutputStreamTest {
     byte [] expected =  new byte[10 * 1024 * 1024];
     random.nextBytes(expected);
 
-    try (S3OutputStream stream = new S3OutputStream(properties, s3, uri)) {
+    try (S3OutputStream stream = new S3OutputStream(s3, uri, properties)) {
       stream.write(expected);
       assertEquals(expected.length, stream.getPos());
     }
@@ -120,7 +120,7 @@ public class S3OutputStreamTest {
     byte [] expected =  new byte[10 * 1024 * 1024 + 10 * 1024];
     random.nextBytes(expected);
 
-    try (S3OutputStream stream = new S3OutputStream(properties, s3, uri)) {
+    try (S3OutputStream stream = new S3OutputStream(s3, uri, properties)) {
       stream.write(expected);
       assertEquals(expected.length, stream.getPos());
     }
@@ -133,7 +133,7 @@ public class S3OutputStreamTest {
   @Test
   public void testMultipleClose() throws IOException {
     S3URI uri = new S3URI("s3://bucket/path/to/array-out.dat");
-    S3OutputStream stream = new S3OutputStream(properties, s3, uri);
+    S3OutputStream stream = new S3OutputStream(s3, uri, properties);
     stream.close();
     stream.close();
   }

--- a/bundled-guava/src/main/java/org/apache/iceberg/GuavaClasses.java
+++ b/bundled-guava/src/main/java/org/apache/iceberg/GuavaClasses.java
@@ -46,6 +46,7 @@ import com.google.common.collect.Streams;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
+import com.google.common.io.CountingOutputStream;
 import com.google.common.io.Files;
 import com.google.common.primitives.Bytes;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -90,6 +91,7 @@ public class GuavaClasses {
     MoreExecutors.class.getName();
     ThreadFactoryBuilder.class.getName();
     Iterables.class.getName();
+    CountingOutputStream.class.getName();
   }
 
 }

--- a/core/src/main/java/org/apache/iceberg/util/PropertyUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/PropertyUtil.java
@@ -35,6 +35,15 @@ public class PropertyUtil {
     return defaultValue;
   }
 
+  public static double propertyAsDouble(Map<String, String> properties,
+      String property, double defaultValue) {
+    String value = properties.get(property);
+    if (value != null) {
+      return Double.parseDouble(properties.get(property));
+    }
+    return defaultValue;
+  }
+
   public static int propertyAsInt(Map<String, String> properties,
                                   String property, int defaultValue) {
     String value = properties.get(property);


### PR DESCRIPTION
Add progressive upload to S3OutputStream using multipart upload.

A few key changes are:

1. The output stream will switch from single PUT based upload to multipart when the multipart size * threshold is reached.
2. Staging files will be rotated and uploaded async as output written
3. Staging files will be deleted when the upload completes to reduce local disk requirements
4. An attempt will be made to abort the upload upon failure, but this is not guaranteed (Bucket lifecycle rules should be implemented to ensure data is cleaned up.)