### PR TITLE
Spark: Refactor Spark writes into separate classes

### DIFF
--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchAppend.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchAppend.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.io.FileIO;
+import org.apache.spark.broadcast.Broadcast;
+import org.apache.spark.sql.connector.write.WriterCommitMessage;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+class SparkBatchAppend extends SparkBatchWrite {
+
+  SparkBatchAppend(Table table, Broadcast<FileIO> io, Broadcast<EncryptionManager> encryptionManager,
+                   CaseInsensitiveStringMap options, String applicationId, String wapId,
+                   Schema writeSchema, StructType dsSchema) {
+    super(table, io, encryptionManager, options, applicationId, wapId, writeSchema, dsSchema);
+  }
+
+  @Override
+  public void commit(WriterCommitMessage[] messages) {
+    AppendFiles append = table().newAppend();
+
+    int numFiles = 0;
+    for (DataFile file : files(messages)) {
+      numFiles += 1;
+      append.appendFile(file);
+    }
+
+    commitOperation(append, String.format("append with %d new data files", numFiles));
+  }
+}

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchWrite.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchWrite.java
@@ -24,19 +24,15 @@ import java.util.Arrays;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
-import org.apache.iceberg.OverwriteFiles;
 import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.ReplacePartitions;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.SnapshotUpdate;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.encryption.EncryptionManager;
-import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.io.OutputFileFactory;
@@ -72,16 +68,13 @@ import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
 import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT;
 
-class SparkBatchWrite implements BatchWrite {
+abstract class SparkBatchWrite implements BatchWrite {
   private static final Logger LOG = LoggerFactory.getLogger(SparkBatchWrite.class);
 
   private final Table table;
   private final FileFormat format;
   private final Broadcast<FileIO> io;
   private final Broadcast<EncryptionManager> encryptionManager;
-  private final boolean overwriteDynamic;
-  private final boolean overwriteByFilter;
-  private final Expression overwriteExpr;
   private final String applicationId;
   private final String wapId;
   private final long targetFileSize;
@@ -90,16 +83,12 @@ class SparkBatchWrite implements BatchWrite {
   private final Map<String, String> extraSnapshotMetadata;
 
   SparkBatchWrite(Table table, Broadcast<FileIO> io, Broadcast<EncryptionManager> encryptionManager,
-                  CaseInsensitiveStringMap options, boolean overwriteDynamic, boolean overwriteByFilter,
-                  Expression overwriteExpr, String applicationId, String wapId, Schema writeSchema,
-                  StructType dsSchema) {
+                  CaseInsensitiveStringMap options, String applicationId, String wapId,
+                  Schema writeSchema, StructType dsSchema) {
     this.table = table;
     this.format = getFileFormat(table.properties(), options);
     this.io = io;
     this.encryptionManager = encryptionManager;
-    this.overwriteDynamic = overwriteDynamic;
-    this.overwriteByFilter = overwriteByFilter;
-    this.overwriteExpr = overwriteExpr;
     this.applicationId = applicationId;
     this.wapId = wapId;
     this.writeSchema = writeSchema;
@@ -136,19 +125,8 @@ class SparkBatchWrite implements BatchWrite {
         writeSchema, dsSchema);
   }
 
-  @Override
-  public void commit(WriterCommitMessage[] messages) {
-    if (overwriteDynamic) {
-      replacePartitions(messages);
-    } else if (overwriteByFilter) {
-      overwrite(messages);
-    } else {
-      append(messages);
-    }
-  }
-
-  protected void commitOperation(SnapshotUpdate<?> operation, int numFiles, String description) {
-    LOG.info("Committing {} with {} files to table {}", description, numFiles, table);
+  protected void commitOperation(SnapshotUpdate<?> operation, String description) {
+    LOG.info("Committing {} to table {}", description, table);
     if (applicationId != null) {
       operation.set("spark.app.id", applicationId);
     }
@@ -168,43 +146,6 @@ class SparkBatchWrite implements BatchWrite {
     operation.commit(); // abort is automatically called if this fails
     long duration = System.currentTimeMillis() - start;
     LOG.info("Committed in {} ms", duration);
-  }
-
-  private void append(WriterCommitMessage[] messages) {
-    AppendFiles append = table.newAppend();
-
-    int numFiles = 0;
-    for (DataFile file : files(messages)) {
-      numFiles += 1;
-      append.appendFile(file);
-    }
-
-    commitOperation(append, numFiles, "append");
-  }
-
-  private void replacePartitions(WriterCommitMessage[] messages) {
-    ReplacePartitions dynamicOverwrite = table.newReplacePartitions();
-
-    int numFiles = 0;
-    for (DataFile file : files(messages)) {
-      numFiles += 1;
-      dynamicOverwrite.addFile(file);
-    }
-
-    commitOperation(dynamicOverwrite, numFiles, "dynamic partition overwrite");
-  }
-
-  private void overwrite(WriterCommitMessage[] messages) {
-    OverwriteFiles overwriteFiles = table.newOverwrite();
-    overwriteFiles.overwriteByRowFilter(overwriteExpr);
-
-    int numFiles = 0;
-    for (DataFile file : files(messages)) {
-      numFiles += 1;
-      overwriteFiles.addFile(file);
-    }
-
-    commitOperation(overwriteFiles, numFiles, "overwrite by filter");
   }
 
   @Override

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkDynamicOverwrite.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkDynamicOverwrite.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.ReplacePartitions;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.io.FileIO;
+import org.apache.spark.broadcast.Broadcast;
+import org.apache.spark.sql.connector.write.WriterCommitMessage;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+class SparkDynamicOverwrite extends SparkBatchWrite {
+
+  SparkDynamicOverwrite(Table table, Broadcast<FileIO> io, Broadcast<EncryptionManager> encryptionManager,
+                        CaseInsensitiveStringMap options, String applicationId, String wapId,
+                        Schema writeSchema, StructType dsSchema) {
+    super(table, io, encryptionManager, options, applicationId, wapId, writeSchema, dsSchema);
+  }
+
+  @Override
+  public void commit(WriterCommitMessage[] messages) {
+    ReplacePartitions dynamicOverwrite = table().newReplacePartitions();
+
+    int numFiles = 0;
+    for (DataFile file : files(messages)) {
+      numFiles += 1;
+      dynamicOverwrite.addFile(file);
+    }
+
+    commitOperation(dynamicOverwrite, String.format("dynamic partition overwrite with %d new data files", numFiles));
+  }
+}

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkOverwriteByFilter.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkOverwriteByFilter.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.OverwriteFiles;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.io.FileIO;
+import org.apache.spark.broadcast.Broadcast;
+import org.apache.spark.sql.connector.write.WriterCommitMessage;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+class SparkOverwriteByFilter extends SparkBatchWrite {
+
+  private final Expression overwriteExpr;
+
+  SparkOverwriteByFilter(Table table, Broadcast<FileIO> io, Broadcast<EncryptionManager> encryptionManager,
+                         CaseInsensitiveStringMap options, String applicationId, String wapId,
+                         Schema writeSchema, StructType dsSchema, Expression overwriteExpr) {
+    super(table, io, encryptionManager, options, applicationId, wapId, writeSchema, dsSchema);
+    this.overwriteExpr = overwriteExpr;
+  }
+
+  @Override
+  public void commit(WriterCommitMessage[] messages) {
+    OverwriteFiles overwriteFiles = table().newOverwrite();
+    overwriteFiles.overwriteByRowFilter(overwriteExpr);
+
+    int numFiles = 0;
+    for (DataFile file : files(messages)) {
+      numFiles += 1;
+      overwriteFiles.addFile(file);
+    }
+
+    String commitMsg = String.format("overwrite by filter %s with %d new data files", overwriteExpr, numFiles);
+    commitOperation(overwriteFiles, commitMsg);
+  }
+}

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkStreamingWrite.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkStreamingWrite.java
@@ -40,7 +40,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SparkStreamingWrite extends SparkBatchWrite implements StreamingWrite {
+class SparkStreamingWrite extends SparkBatchWrite implements StreamingWrite {
 
   private static final Logger LOG = LoggerFactory.getLogger(SparkStreamingWrite.class);
   private static final String QUERY_ID_PROPERTY = "spark.sql.streaming.queryId";
@@ -52,9 +52,7 @@ public class SparkStreamingWrite extends SparkBatchWrite implements StreamingWri
   SparkStreamingWrite(Table table, Broadcast<FileIO> io, Broadcast<EncryptionManager> encryptionManager,
                       CaseInsensitiveStringMap options, boolean truncateBatches, String queryId,
                       String applicationId, String wapId, Schema writeSchema, StructType dsSchema) {
-    super(
-        table, io, encryptionManager, options, false, truncateBatches, Expressions.alwaysTrue(), applicationId, wapId,
-        writeSchema, dsSchema);
+    super(table, io, encryptionManager, options, applicationId, wapId, writeSchema, dsSchema);
     this.truncateBatches = truncateBatches;
     this.queryId = queryId;
   }
@@ -84,7 +82,7 @@ public class SparkStreamingWrite extends SparkBatchWrite implements StreamingWri
         overwriteFiles.addFile(file);
         numFiles++;
       }
-      commit(overwriteFiles, epochId, numFiles, "streaming complete overwrite");
+      commit(overwriteFiles, epochId, String.format("streaming complete overwrite with %d new data files", numFiles));
     } else {
       AppendFiles append = table().newFastAppend();
       int numFiles = 0;
@@ -92,14 +90,19 @@ public class SparkStreamingWrite extends SparkBatchWrite implements StreamingWri
         append.appendFile(file);
         numFiles++;
       }
-      commit(append, epochId, numFiles, "streaming append");
+      commit(append, epochId, String.format("streaming append with %d new data files", numFiles));
     }
   }
 
-  private <T> void commit(SnapshotUpdate<T> snapshotUpdate, long epochId, int numFiles, String description) {
+  private <T> void commit(SnapshotUpdate<T> snapshotUpdate, long epochId, String description) {
     snapshotUpdate.set(QUERY_ID_PROPERTY, queryId);
     snapshotUpdate.set(EPOCH_ID_PROPERTY, Long.toString(epochId));
-    commitOperation(snapshotUpdate, numFiles, description);
+    commitOperation(snapshotUpdate, description);
+  }
+
+  @Override
+  public void commit(WriterCommitMessage[] messages) {
+    throw new UnsupportedOperationException("Streaming writes don't support batch writes");
   }
 
   @Override

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
@@ -113,9 +113,18 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
     Broadcast<FileIO> io = lazySparkContext().broadcast(SparkUtil.serializableFileIO(table));
     Broadcast<EncryptionManager> encryptionManager = lazySparkContext().broadcast(table.encryption());
 
-    return new SparkBatchWrite(
-        table, io, encryptionManager, options, overwriteDynamic, overwriteByFilter, overwriteExpr, appId, wapId,
-        writeSchema, dsSchema);
+    if (overwriteByFilter) {
+      return new SparkOverwriteByFilter(
+          table, io, encryptionManager, options, appId, wapId, writeSchema, dsSchema, overwriteExpr);
+    }
+
+    if (overwriteDynamic) {
+      return new SparkDynamicOverwrite(
+          table, io, encryptionManager, options, appId, wapId, writeSchema, dsSchema);
+    }
+
+    return new SparkBatchAppend(
+        table, io, encryptionManager, options, appId, wapId, writeSchema, dsSchema);
   }
 
   @Override


### PR DESCRIPTION
This PR refactors our Spark writes into separate classes so that we can add more writes with other commit functions.