### PR TITLE
[iceberg-1746] Implement spark fanout writer

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -129,6 +129,9 @@ public class TableProperties {
   public static final String WRITE_TARGET_FILE_SIZE_BYTES = "write.target-file-size-bytes";
   public static final long WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT = Long.MAX_VALUE;
 
+  public static final String WRITE_PARTITIONED_FANOUT_ENABLED = "write.partitioned.fanout.enabled";
+  public static final boolean WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT = false;
+
   public static final String SNAPSHOT_ID_INHERITANCE_ENABLED = "compatibility.snapshot-id-inheritance.enabled";
   public static final boolean SNAPSHOT_ID_INHERITANCE_ENABLED_DEFAULT = false;
 

--- a/core/src/main/java/org/apache/iceberg/io/PartitionedFanoutWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/PartitionedFanoutWriter.java
@@ -17,23 +17,19 @@
  * under the License.
  */
 
-package org.apache.iceberg.flink.sink;
+package org.apache.iceberg.io;
 
 import java.io.IOException;
 import java.util.Map;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.PartitionSpec;
-import org.apache.iceberg.io.BaseTaskWriter;
-import org.apache.iceberg.io.FileAppenderFactory;
-import org.apache.iceberg.io.FileIO;
-import org.apache.iceberg.io.OutputFileFactory;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
-abstract class PartitionedFanoutWriter<T> extends BaseTaskWriter<T> {
+public abstract class PartitionedFanoutWriter<T> extends BaseTaskWriter<T> {
   private final Map<PartitionKey, RollingFileWriter> writers = Maps.newHashMap();
 
-  PartitionedFanoutWriter(PartitionSpec spec, FileFormat format, FileAppenderFactory<T> appenderFactory,
+  protected PartitionedFanoutWriter(PartitionSpec spec, FileFormat format, FileAppenderFactory<T> appenderFactory,
                           OutputFileFactory fileFactory, FileIO io, long targetFileSize) {
     super(spec, format, appenderFactory, fileFactory, io, targetFileSize);
   }

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/RowDataTaskWriterFactory.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/RowDataTaskWriterFactory.java
@@ -42,6 +42,7 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.OutputFileFactory;
+import org.apache.iceberg.io.PartitionedFanoutWriter;
 import org.apache.iceberg.io.TaskWriter;
 import org.apache.iceberg.io.UnpartitionedWriter;
 import org.apache.iceberg.orc.ORC;

--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -68,6 +68,7 @@ Iceberg tables support table properties to configure table behavior, like the de
 | write.summary.partition-limit      | 0                  | Includes partition-level summary stats in snapshot summaries if the changed partition count is less than this limit |
 | write.metadata.delete-after-commit.enabled | false      | Controls whether to delete the oldest version metadata files after commit |
 | write.metadata.previous-versions-max       | 100        | The max number of previous version metadata files to keep before deleting after commit |
+| write.partitioned.fanout.writer       | false        | Enables Partitioned-Fanout-Writer writes |
 
 ### Table behavior properties
 
@@ -155,4 +156,5 @@ df.write
 | target-file-size-bytes | As per table property      | Overrides this table's write.target-file-size-bytes          |
 | check-nullability      | true                       | Sets the nullable check on fields                            |
 | snapshot-property._custom-key_    | null            | Adds an entry with custom-key and corresponding value in the snapshot summary  |
+| partitioned.fanout.enabled       | Table write.partitioned.fanout.enabled        | Overrides this table's write.partitioned.fanout.enabled  |
 

--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -156,5 +156,5 @@ df.write
 | target-file-size-bytes | As per table property      | Overrides this table's write.target-file-size-bytes          |
 | check-nullability      | true                       | Sets the nullable check on fields                            |
 | snapshot-property._custom-key_    | null            | Adds an entry with custom-key and corresponding value in the snapshot summary  |
-| partitioned.fanout.enabled       | Table write.partitioned.fanout.enabled        | Overrides this table's write.partitioned.fanout.enabled  |
+| partitioned.fanout.enabled       | false        | Overrides this table's write.partitioned.fanout.enabled  |
 

--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -68,7 +68,7 @@ Iceberg tables support table properties to configure table behavior, like the de
 | write.summary.partition-limit      | 0                  | Includes partition-level summary stats in snapshot summaries if the changed partition count is less than this limit |
 | write.metadata.delete-after-commit.enabled | false      | Controls whether to delete the oldest version metadata files after commit |
 | write.metadata.previous-versions-max       | 100        | The max number of previous version metadata files to keep before deleting after commit |
-| write.partitioned.fanout.writer       | false        | Enables Partitioned-Fanout-Writer writes |
+| write.partitioned.fanout.enabled       | false        | Enables Partitioned-Fanout-Writer writes |
 
 ### Table behavior properties
 

--- a/spark/src/main/java/org/apache/iceberg/spark/source/RowDataRewriter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/RowDataRewriter.java
@@ -105,17 +105,18 @@ public class RowDataRewriter implements Serializable {
 
     TaskWriter<InternalRow> writer;
     if (spec.fields().isEmpty()) {
-      writer = new UnpartitionedWriter<>(spec, format, appenderFactory, fileFactory, io.value(), Long.MAX_VALUE);
+      writer = new UnpartitionedWriter<>(spec, format, appenderFactory, fileFactory, io.value(),
+          Long.MAX_VALUE);
+    } else if (PropertyUtil.propertyAsBoolean(properties,
+        TableProperties.WRITE_PARTITIONED_FANOUT_ENABLED,
+        TableProperties.WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT)) {
+      writer = new SparkPartitionedFanoutWriter(
+          spec, format, appenderFactory, fileFactory, io.value(), Long.MAX_VALUE, schema,
+          structType);
     } else {
-      if (PropertyUtil.propertyAsBoolean(properties,
-          TableProperties.WRITE_PARTITIONED_FANOUT_ENABLED,
-          TableProperties.WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT)) {
-        writer = new SparkPartitionedFanoutWriter(
-            spec, format, appenderFactory, fileFactory, io.value(), Long.MAX_VALUE, schema, structType);
-      } else {
-        writer = new SparkPartitionedWriter(spec, format, appenderFactory, fileFactory, io.value(), Long.MAX_VALUE,
-            schema, structType);
-      }
+      writer = new SparkPartitionedWriter(
+          spec, format, appenderFactory, fileFactory, io.value(), Long.MAX_VALUE, schema,
+          structType);
     }
 
     try {

--- a/spark/src/main/java/org/apache/iceberg/spark/source/RowDataRewriter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/RowDataRewriter.java
@@ -110,12 +110,10 @@ public class RowDataRewriter implements Serializable {
       if (PropertyUtil.propertyAsBoolean(properties,
           TableProperties.WRITE_PARTITIONED_FANOUT_ENABLED,
           TableProperties.WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT)) {
-        writer = new SparkPartitionedFanoutWriter(spec, format, appenderFactory, fileFactory, io.value(),
-            Long.MAX_VALUE,
-            schema, structType);
+        writer = new SparkPartitionedFanoutWriter(
+            spec, format, appenderFactory, fileFactory, io.value(), Long.MAX_VALUE, schema, structType);
       } else {
-        writer = new SparkPartitionedWriter(spec, format, appenderFactory, fileFactory, io.value(),
-            Long.MAX_VALUE,
+        writer = new SparkPartitionedWriter(spec, format, appenderFactory, fileFactory, io.value(), Long.MAX_VALUE,
             schema, structType);
       }
     }

--- a/spark/src/main/java/org/apache/iceberg/spark/source/SparkPartitionedFanoutWriter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/SparkPartitionedFanoutWriter.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionKey;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.io.FileAppenderFactory;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.OutputFileFactory;
+import org.apache.iceberg.io.PartitionedFanoutWriter;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.StructType;
+
+public class SparkPartitionedFanoutWriter extends PartitionedFanoutWriter<InternalRow> {
+  private final PartitionKey partitionKey;
+  private final InternalRowWrapper internalRowWrapper;
+
+  public SparkPartitionedFanoutWriter(PartitionSpec spec, FileFormat format,
+                                FileAppenderFactory<InternalRow> appenderFactory,
+                                OutputFileFactory fileFactory, FileIO io, long targetFileSize,
+                                Schema schema, StructType sparkSchema) {
+    super(spec, format, appenderFactory, fileFactory, io, targetFileSize);
+    this.partitionKey = new PartitionKey(spec, schema);
+    this.internalRowWrapper = new InternalRowWrapper(sparkSchema);
+  }
+
+  @Override
+  protected PartitionKey partition(InternalRow row) {
+    partitionKey.partition(internalRowWrapper.wrap(row));
+    return partitionKey;
+  }
+}

--- a/spark/src/main/java/org/apache/iceberg/spark/source/SparkPartitionedFanoutWriter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/SparkPartitionedFanoutWriter.java
@@ -35,9 +35,9 @@ public class SparkPartitionedFanoutWriter extends PartitionedFanoutWriter<Intern
   private final InternalRowWrapper internalRowWrapper;
 
   public SparkPartitionedFanoutWriter(PartitionSpec spec, FileFormat format,
-                                FileAppenderFactory<InternalRow> appenderFactory,
-                                OutputFileFactory fileFactory, FileIO io, long targetFileSize,
-                                Schema schema, StructType sparkSchema) {
+      FileAppenderFactory<InternalRow> appenderFactory,
+      OutputFileFactory fileFactory, FileIO io, long targetFileSize,
+      Schema schema, StructType sparkSchema) {
     super(spec, format, appenderFactory, fileFactory, io, targetFileSize);
     this.partitionKey = new PartitionKey(spec, schema);
     this.internalRowWrapper = new InternalRowWrapper(sparkSchema);

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
@@ -49,6 +49,7 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import static org.apache.iceberg.TableProperties.WRITE_PARTITIONED_FANOUT_ENABLED;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 
 @RunWith(Parameterized.class)
@@ -333,6 +334,58 @@ public abstract class TestSparkDataWrite {
     HadoopTables tables = new HadoopTables(CONF);
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("data").build();
     Table table = tables.create(SCHEMA, spec, location.toString());
+
+    List<SimpleRecord> expected = Lists.newArrayListWithCapacity(8000);
+    for (int i = 0; i < 2000; i++) {
+      expected.add(new SimpleRecord(i, "a"));
+      expected.add(new SimpleRecord(i, "b"));
+      expected.add(new SimpleRecord(i, "c"));
+      expected.add(new SimpleRecord(i, "d"));
+    }
+
+    Dataset<Row> df = spark.createDataFrame(expected, SimpleRecord.class);
+
+    df.select("id", "data").sort("data").write()
+        .format("iceberg")
+        .option("write-format", format.toString())
+        .mode("append")
+        .option("target-file-size-bytes", 4) // ~4 bytes; low enough to trigger
+        .save(location.toString());
+
+    table.refresh();
+
+    Dataset<Row> result = spark.read()
+        .format("iceberg")
+        .load(location.toString());
+
+    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+    Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
+    Assert.assertEquals("Result rows should match", expected, actual);
+
+    List<DataFile> files = Lists.newArrayList();
+    for (ManifestFile manifest : table.currentSnapshot().allManifests()) {
+      for (DataFile file : ManifestFiles.read(manifest, table.io())) {
+        files.add(file);
+      }
+    }
+    // TODO: ORC file now not support target file size
+    if (!format.equals(FileFormat.ORC)) {
+      Assert.assertEquals("Should have 8 DataFiles", 8, files.size());
+      Assert.assertTrue("All DataFiles contain 1000 rows", files.stream().allMatch(d -> d.recordCount() == 1000));
+    }
+  }
+
+  @Test
+  public void testPartitionedFanoutCreateWithTargetFileSizeViaOption() throws IOException {
+    File parent = temp.newFolder(format.toString());
+    File location = new File(parent, "test");
+
+    HadoopTables tables = new HadoopTables(CONF);
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("data").build();
+    Table table = tables.create(SCHEMA, spec, location.toString());
+    table.updateProperties()
+        .set(WRITE_PARTITIONED_FANOUT_ENABLED, "true")
+        .commit();
 
     List<SimpleRecord> expected = Lists.newArrayListWithCapacity(8000);
     for (int i = 0; i < 2000; i++) {

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
@@ -54,6 +54,7 @@ import static org.apache.iceberg.types.Types.NestedField.optional;
 
 @RunWith(Parameterized.class)
 public abstract class TestSparkDataWrite {
+
   private static final Configuration CONF = new Configuration();
   private final FileFormat format;
   private static SparkSession spark = null;
@@ -67,7 +68,7 @@ public abstract class TestSparkDataWrite {
 
   @Parameterized.Parameters(name = "format = {0}")
   public static Object[] parameters() {
-    return new Object[] { "parquet", "avro", "orc" };
+    return new Object[]{"parquet", "avro", "orc"};
   }
 
   @BeforeClass
@@ -115,7 +116,8 @@ public abstract class TestSparkDataWrite {
         .format("iceberg")
         .load(location.toString());
 
-    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class))
+        .collectAsList();
     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
     Assert.assertEquals("Result rows should match", expected, actual);
     for (ManifestFile manifest : table.currentSnapshot().allManifests()) {
@@ -181,7 +183,8 @@ public abstract class TestSparkDataWrite {
         .format("iceberg")
         .load(location.toString());
 
-    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class))
+        .collectAsList();
     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
     Assert.assertEquals("Result rows should match", expected, actual);
   }
@@ -231,7 +234,8 @@ public abstract class TestSparkDataWrite {
         .format("iceberg")
         .load(location.toString());
 
-    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class))
+        .collectAsList();
     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
     Assert.assertEquals("Result rows should match", expected, actual);
   }
@@ -272,7 +276,8 @@ public abstract class TestSparkDataWrite {
         .format("iceberg")
         .load(location.toString());
 
-    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class))
+        .collectAsList();
     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
     Assert.assertEquals("Result rows should match", expected, actual);
   }
@@ -309,7 +314,8 @@ public abstract class TestSparkDataWrite {
         .format("iceberg")
         .load(location.toString());
 
-    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class))
+        .collectAsList();
     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
     Assert.assertEquals("Result rows should match", expected, actual);
 
@@ -322,18 +328,24 @@ public abstract class TestSparkDataWrite {
     // TODO: ORC file now not support target file size
     if (!format.equals(FileFormat.ORC)) {
       Assert.assertEquals("Should have 4 DataFiles", 4, files.size());
-      Assert.assertTrue("All DataFiles contain 1000 rows", files.stream().allMatch(d -> d.recordCount() == 1000));
+      Assert.assertTrue("All DataFiles contain 1000 rows",
+          files.stream().allMatch(d -> d.recordCount() == 1000));
     }
   }
 
   @Test
   public void testPartitionedCreateWithTargetFileSizeViaOption() throws IOException {
-    partitionedCreateWithTargetFileSizeViaOption(false);
+    partitionedCreateWithTargetFileSizeViaOption(IcebergOptionsType.NONE);
   }
 
   @Test
   public void testPartitionedFanoutCreateWithTargetFileSizeViaOption() throws IOException {
-    partitionedCreateWithTargetFileSizeViaOption(true);
+    partitionedCreateWithTargetFileSizeViaOption(IcebergOptionsType.TABLE);
+  }
+
+  @Test
+  public void testPartitionedFanoutCreateWithTargetFileSizeViaOption2() throws IOException {
+    partitionedCreateWithTargetFileSizeViaOption(IcebergOptionsType.JOB);
   }
 
   @Test
@@ -369,7 +381,8 @@ public abstract class TestSparkDataWrite {
         .format("iceberg")
         .load(location.toString());
 
-    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class))
+        .collectAsList();
     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
     Assert.assertEquals("Result rows should match", expected, actual);
   }
@@ -412,7 +425,8 @@ public abstract class TestSparkDataWrite {
         .format("iceberg")
         .load(location.toString());
 
-    List<ThreeColumnRecord> actual = result.orderBy("c1").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
+    List<ThreeColumnRecord> actual = result.orderBy("c1").as(Encoders.bean(ThreeColumnRecord.class))
+        .collectAsList();
     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
     Assert.assertEquals("Result rows should match", expected, actual);
   }
@@ -446,7 +460,8 @@ public abstract class TestSparkDataWrite {
         .where("id = 1");
     query.createOrReplaceTempView("tmp");
 
-    List<SimpleRecord> actual1 = spark.table("tmp").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+    List<SimpleRecord> actual1 = spark.table("tmp").as(Encoders.bean(SimpleRecord.class))
+        .collectAsList();
     List<SimpleRecord> expected1 = Lists.newArrayList(
         new SimpleRecord(1, "a")
     );
@@ -459,7 +474,8 @@ public abstract class TestSparkDataWrite {
         .mode("append")
         .save(location.toString());
 
-    List<SimpleRecord> actual2 = spark.table("tmp").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+    List<SimpleRecord> actual2 = spark.table("tmp").as(Encoders.bean(SimpleRecord.class))
+        .collectAsList();
     List<SimpleRecord> expected2 = Lists.newArrayList(
         new SimpleRecord(1, "a"),
         new SimpleRecord(1, "a")
@@ -468,18 +484,14 @@ public abstract class TestSparkDataWrite {
     Assert.assertEquals("Result rows should match", expected2, actual2);
   }
 
-  public void partitionedCreateWithTargetFileSizeViaOption(boolean fanoutEnable) throws IOException {
+  public void partitionedCreateWithTargetFileSizeViaOption(IcebergOptionsType option)
+      throws IOException {
     File parent = temp.newFolder(format.toString());
     File location = new File(parent, "test");
 
     HadoopTables tables = new HadoopTables(CONF);
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("data").build();
     Table table = tables.create(SCHEMA, spec, location.toString());
-    if (fanoutEnable) {
-      table.updateProperties()
-          .set(WRITE_PARTITIONED_FANOUT_ENABLED, "true")
-          .commit();
-    }
 
     List<SimpleRecord> expected = Lists.newArrayListWithCapacity(8000);
     for (int i = 0; i < 2000; i++) {
@@ -491,20 +503,35 @@ public abstract class TestSparkDataWrite {
 
     Dataset<Row> df = spark.createDataFrame(expected, SimpleRecord.class);
 
-    if (!fanoutEnable) {
-      df.select("id", "data").sort("data").write()
-          .format("iceberg")
-          .option("write-format", format.toString())
-          .mode("append")
-          .option("target-file-size-bytes", 4) // ~4 bytes; low enough to trigger
-          .save(location.toString());
-    } else {
-      df.select("id", "data").write()
-          .format("iceberg")
-          .option("write-format", format.toString())
-          .mode("append")
-          .option("target-file-size-bytes", 4) // ~4 bytes; low enough to trigger
-          .save(location.toString());
+    switch (option) {
+      case NONE:
+        df.select("id", "data").sort("data").write()
+            .format("iceberg")
+            .option("write-format", format.toString())
+            .mode("append")
+            .option("target-file-size-bytes", 4) // ~4 bytes; low enough to trigger
+            .save(location.toString());
+        break;
+      case TABLE:
+        table.updateProperties().set(WRITE_PARTITIONED_FANOUT_ENABLED, "true").commit();
+        df.select("id", "data").write()
+            .format("iceberg")
+            .option("write-format", format.toString())
+            .mode("append")
+            .option("target-file-size-bytes", 4) // ~4 bytes; low enough to trigger
+            .save(location.toString());
+        break;
+      case JOB:
+        df.select("id", "data").write()
+            .format("iceberg")
+            .option("write-format", format.toString())
+            .mode("append")
+            .option("target-file-size-bytes", 4) // ~4 bytes; low enough to trigger
+            .option("partitioned.fanout.enabled", true)
+            .save(location.toString());
+        break;
+      default:
+        break;
     }
 
     table.refresh();
@@ -513,7 +540,8 @@ public abstract class TestSparkDataWrite {
         .format("iceberg")
         .load(location.toString());
 
-    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class))
+        .collectAsList();
     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
     Assert.assertEquals("Result rows should match", expected, actual);
 
@@ -526,7 +554,14 @@ public abstract class TestSparkDataWrite {
     // TODO: ORC file now not support target file size
     if (!format.equals(FileFormat.ORC)) {
       Assert.assertEquals("Should have 8 DataFiles", 8, files.size());
-      Assert.assertTrue("All DataFiles contain 1000 rows", files.stream().allMatch(d -> d.recordCount() == 1000));
+      Assert.assertTrue("All DataFiles contain 1000 rows",
+          files.stream().allMatch(d -> d.recordCount() == 1000));
     }
+  }
+
+  public enum IcebergOptionsType {
+    NONE,
+    TABLE,
+    JOB
   }
 }

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
@@ -54,7 +54,6 @@ import static org.apache.iceberg.types.Types.NestedField.optional;
 
 @RunWith(Parameterized.class)
 public abstract class TestSparkDataWrite {
-
   private static final Configuration CONF = new Configuration();
   private final FileFormat format;
   private static SparkSession spark = null;
@@ -68,7 +67,7 @@ public abstract class TestSparkDataWrite {
 
   @Parameterized.Parameters(name = "format = {0}")
   public static Object[] parameters() {
-    return new Object[]{"parquet", "avro", "orc"};
+    return new Object[] { "parquet", "avro", "orc" };
   }
 
   @BeforeClass
@@ -116,8 +115,7 @@ public abstract class TestSparkDataWrite {
         .format("iceberg")
         .load(location.toString());
 
-    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class))
-        .collectAsList();
+    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
     Assert.assertEquals("Result rows should match", expected, actual);
     for (ManifestFile manifest : table.currentSnapshot().allManifests()) {
@@ -183,8 +181,7 @@ public abstract class TestSparkDataWrite {
         .format("iceberg")
         .load(location.toString());
 
-    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class))
-        .collectAsList();
+    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
     Assert.assertEquals("Result rows should match", expected, actual);
   }
@@ -234,8 +231,7 @@ public abstract class TestSparkDataWrite {
         .format("iceberg")
         .load(location.toString());
 
-    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class))
-        .collectAsList();
+    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
     Assert.assertEquals("Result rows should match", expected, actual);
   }
@@ -276,8 +272,7 @@ public abstract class TestSparkDataWrite {
         .format("iceberg")
         .load(location.toString());
 
-    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class))
-        .collectAsList();
+    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
     Assert.assertEquals("Result rows should match", expected, actual);
   }
@@ -314,8 +309,7 @@ public abstract class TestSparkDataWrite {
         .format("iceberg")
         .load(location.toString());
 
-    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class))
-        .collectAsList();
+    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
     Assert.assertEquals("Result rows should match", expected, actual);
 
@@ -328,8 +322,7 @@ public abstract class TestSparkDataWrite {
     // TODO: ORC file now not support target file size
     if (!format.equals(FileFormat.ORC)) {
       Assert.assertEquals("Should have 4 DataFiles", 4, files.size());
-      Assert.assertTrue("All DataFiles contain 1000 rows",
-          files.stream().allMatch(d -> d.recordCount() == 1000));
+      Assert.assertTrue("All DataFiles contain 1000 rows", files.stream().allMatch(d -> d.recordCount() == 1000));
     }
   }
 
@@ -381,8 +374,7 @@ public abstract class TestSparkDataWrite {
         .format("iceberg")
         .load(location.toString());
 
-    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class))
-        .collectAsList();
+    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
     Assert.assertEquals("Result rows should match", expected, actual);
   }
@@ -425,8 +417,7 @@ public abstract class TestSparkDataWrite {
         .format("iceberg")
         .load(location.toString());
 
-    List<ThreeColumnRecord> actual = result.orderBy("c1").as(Encoders.bean(ThreeColumnRecord.class))
-        .collectAsList();
+    List<ThreeColumnRecord> actual = result.orderBy("c1").as(Encoders.bean(ThreeColumnRecord.class)).collectAsList();
     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
     Assert.assertEquals("Result rows should match", expected, actual);
   }
@@ -460,8 +451,7 @@ public abstract class TestSparkDataWrite {
         .where("id = 1");
     query.createOrReplaceTempView("tmp");
 
-    List<SimpleRecord> actual1 = spark.table("tmp").as(Encoders.bean(SimpleRecord.class))
-        .collectAsList();
+    List<SimpleRecord> actual1 = spark.table("tmp").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     List<SimpleRecord> expected1 = Lists.newArrayList(
         new SimpleRecord(1, "a")
     );
@@ -474,8 +464,7 @@ public abstract class TestSparkDataWrite {
         .mode("append")
         .save(location.toString());
 
-    List<SimpleRecord> actual2 = spark.table("tmp").as(Encoders.bean(SimpleRecord.class))
-        .collectAsList();
+    List<SimpleRecord> actual2 = spark.table("tmp").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     List<SimpleRecord> expected2 = Lists.newArrayList(
         new SimpleRecord(1, "a"),
         new SimpleRecord(1, "a")
@@ -540,8 +529,7 @@ public abstract class TestSparkDataWrite {
         .format("iceberg")
         .load(location.toString());
 
-    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class))
-        .collectAsList();
+    List<SimpleRecord> actual = result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
     Assert.assertEquals("Number of rows should match", expected.size(), actual.size());
     Assert.assertEquals("Result rows should match", expected, actual);
 
@@ -554,8 +542,7 @@ public abstract class TestSparkDataWrite {
     // TODO: ORC file now not support target file size
     if (!format.equals(FileFormat.ORC)) {
       Assert.assertEquals("Should have 8 DataFiles", 8, files.size());
-      Assert.assertTrue("All DataFiles contain 1000 rows",
-          files.stream().allMatch(d -> d.recordCount() == 1000));
+      Assert.assertTrue("All DataFiles contain 1000 rows", files.stream().allMatch(d -> d.recordCount() == 1000));
     }
   }
 

--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Writer.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Writer.java
@@ -279,14 +279,12 @@ class Writer implements DataSourceWriter {
 
       if (spec.fields().isEmpty()) {
         return new Unpartitioned24Writer(spec, format, appenderFactory, fileFactory, io.value(), targetFileSize);
+      } else if (partitionedFanoutEnabled) {
+        return new PartitionedFanout24Writer(spec, format, appenderFactory, fileFactory, io.value(), targetFileSize,
+            writeSchema, dsSchema);
       } else {
-        if (partitionedFanoutEnabled) {
-          return new PartitionedFanout24Writer(spec, format, appenderFactory, fileFactory, io.value(),
-              targetFileSize, writeSchema, dsSchema);
-        } else {
-          return new Partitioned24Writer(spec, format, appenderFactory, fileFactory, io.value(),
-              targetFileSize, writeSchema, dsSchema);
-        }
+        return new Partitioned24Writer(spec, format, appenderFactory, fileFactory, io.value(), targetFileSize,
+            writeSchema, dsSchema);
       }
     }
   }
@@ -326,9 +324,9 @@ class Writer implements DataSourceWriter {
       implements DataWriter<InternalRow> {
 
     PartitionedFanout24Writer(PartitionSpec spec, FileFormat format,
-        SparkAppenderFactory appenderFactory,
-        OutputFileFactory fileFactory, FileIO fileIo, long targetFileSize,
-        Schema schema, StructType sparkSchema) {
+                              SparkAppenderFactory appenderFactory,
+                              OutputFileFactory fileFactory, FileIO fileIo, long targetFileSize,
+                              Schema schema, StructType sparkSchema) {
       super(spec, format, appenderFactory, fileFactory, fileIo, targetFileSize, schema,
           sparkSchema);
     }

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -429,16 +429,12 @@ class SparkWrite {
       SparkAppenderFactory appenderFactory = new SparkAppenderFactory(properties, writeSchema, dsSchema);
       if (spec.fields().isEmpty()) {
         return new Unpartitioned3Writer(spec, format, appenderFactory, fileFactory, io.value(), targetFileSize);
+      } else if (partitionedFanoutEnabled) {
+        return new PartitionedFanout3Writer(
+            spec, format, appenderFactory, fileFactory, io.value(), targetFileSize, writeSchema, dsSchema);
       } else {
-        if (partitionedFanoutEnabled) {
-          return new PartitionedFanout3Writer(
-              spec, format, appenderFactory, fileFactory, io.value(), targetFileSize, writeSchema,
-              dsSchema);
-        } else {
-          return new Partitioned3Writer(
-              spec, format, appenderFactory, fileFactory, io.value(), targetFileSize, writeSchema,
-              dsSchema);
-        }
+        return new Partitioned3Writer(
+            spec, format, appenderFactory, fileFactory, io.value(), targetFileSize, writeSchema, dsSchema);
       }
     }
   }
@@ -476,8 +472,8 @@ class SparkWrite {
   private static class PartitionedFanout3Writer extends SparkPartitionedFanoutWriter
       implements DataWriter<InternalRow> {
     PartitionedFanout3Writer(PartitionSpec spec, FileFormat format, SparkAppenderFactory appenderFactory,
-        OutputFileFactory fileFactory, FileIO io, long targetFileSize,
-        Schema schema, StructType sparkSchema) {
+                             OutputFileFactory fileFactory, FileIO io, long targetFileSize,
+                             Schema schema, StructType sparkSchema) {
       super(spec, format, appenderFactory, fileFactory, io, targetFileSize, schema, sparkSchema);
     }
 


### PR DESCRIPTION
Changes involved in this PR:
1. Move the `PartitionedFanoutWriter` of flink to `core/src/main/java/org/apache/iceberg/io` package.
2. Implement immobile writers for spark2 and spark3 modules respectively.
3. User can turn it on according to the parameter `write.partitioned.fanout.enabled= true` in the setting table. The default is false and can also set spark option `partitioned.fanout.enabled` to override it.