### PR TITLE
Parquet - Add a spark session configuration for controlling enabling vectorized reads

### DIFF
--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
@@ -156,10 +156,13 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
     this.io = io;
     this.encryptionManager = encryptionManager;
     this.caseSensitive = caseSensitive;
-
-    this.batchReadsEnabled = options.get("vectorization-enabled").map(Boolean::parseBoolean).orElseGet(() ->
-        PropertyUtil.propertyAsBoolean(table.properties(),
-            TableProperties.PARQUET_VECTORIZATION_ENABLED, TableProperties.PARQUET_VECTORIZATION_ENABLED_DEFAULT));
+    boolean batchReadsSparkSessionConf = SparkSession.active().sparkContext().getConf()
+            .getBoolean("read.parquet.vectorization.enabled", true);
+    boolean batchReadsEnabledTableProp = options.get("vectorization-enabled").map(Boolean::parseBoolean).orElseGet(() ->
+            PropertyUtil.propertyAsBoolean(table.properties(),
+                    TableProperties.PARQUET_VECTORIZATION_ENABLED,
+                    TableProperties.PARQUET_VECTORIZATION_ENABLED_DEFAULT));
+    this.batchReadsEnabled = !batchReadsSparkSessionConf ? false : batchReadsEnabledTableProp;
     this.batchSize = options.get("batch-size").map(Integer::parseInt).orElseGet(() ->
         PropertyUtil.propertyAsInt(table.properties(),
           TableProperties.PARQUET_BATCH_SIZE, TableProperties.PARQUET_BATCH_SIZE_DEFAULT));

--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
@@ -157,7 +157,7 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
     this.encryptionManager = encryptionManager;
     this.caseSensitive = caseSensitive;
     String batchReadsSessionConf = SparkSession.active().conf()
-        .get("spark.iceberg.vectorization.enabled", null);
+        .get("spark.sql.iceberg.vectorization.enabled", null);
     if (batchReadsSessionConf != null) {
       this.batchReadsEnabled = Boolean.valueOf(batchReadsSessionConf);
     } else {

--- a/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -383,7 +383,7 @@ public class Spark3Util {
 
   public static boolean isVectorizationEnabled(Map<String, String> properties, CaseInsensitiveStringMap readOptions) {
     String batchReadsSessionConf = SparkSession.active().conf()
-        .get("spark.iceberg.vectorization.enabled", null);
+        .get("spark.sql.iceberg.vectorization.enabled", null);
     if (batchReadsSessionConf != null) {
       return Boolean.valueOf(batchReadsSessionConf);
     }

--- a/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -382,6 +382,11 @@ public class Spark3Util {
   }
 
   public static boolean isVectorizationEnabled(Map<String, String> properties, CaseInsensitiveStringMap readOptions) {
+    String batchReadsSessionConf = SparkSession.active().conf()
+        .get("spark.iceberg.vectorization.enabled", null);
+    if (batchReadsSessionConf != null) {
+      return Boolean.valueOf(batchReadsSessionConf);
+    }
     return readOptions.getBoolean("vectorization-enabled",
         PropertyUtil.propertyAsBoolean(properties,
             TableProperties.PARQUET_VECTORIZATION_ENABLED, TableProperties.PARQUET_VECTORIZATION_ENABLED_DEFAULT));


### PR DESCRIPTION
Since enabling vectorized reads internally, we have come across a couple of issues listed below that provide motivation for adding a session level control for enabling/disabling vectorized reads:
1) For some pyspark jobs we have noticed that certain libraries like Pandas were not able to handle ColumnarBatch being returned by Iceberg correctly. 
For example in Spark 2.4.4, the below call failed:
```
spark_df.toPandas() 
```
with
```
java.lang.ClassCastException: org.apache.spark.sql.vectorized.ColumnarBatch cannot be cast to org.apache.spark.sql.catalyst.InternalRow
	at org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanExecBase$$anonfun$doExecute$1.apply(DataSourceV2ScanExecBase.scala:71)
	at scala.collection.Iterator$$anon$11.next(Iterator.scala:410)
	at org.apache.spark.sql.execution.SparkPlan$$anonfun$2.apply(SparkPlan.scala:256)
	at org.apache.spark.sql.execution.SparkPlan$$anonfun$2.apply(SparkPlan.scala:247)
	at org.apache.spark.rdd.RDD$$anonfun$mapPartitionsInternal$1$$anonfun$apply$25.apply(RDD.scala:841)
	at org.apache.spark.rdd.RDD$$anonfun$mapPartitionsInternal$1$$anonfun$apply$25.apply(RDD.scala:841)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:329)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:293)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:123)
	at org.apache.spark.executor.Executor$TaskRunner$$anonfun$10.apply(Executor.scala:414)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1361)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:420)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
Till the problem is fixed, having a session level property provides a reasonable workaround to disable vectorized reads in such jobs. 

2. For some tables with really large columns, storing batches in Arrow buffers exceeds the 2GB limit. While Arrow has introduced various Large*Vector buffer classes, unfortunately, using them regresses performance. For ex - replacing VarCharVector with LargeVarCharVector regressed performance by more than 30% for String columns. Considering this limitation, a couple of possible workarounds are to either reduce the batch size significantly or to disable vectorized reads via table properties altogether. For jobs that are not projecting these large columns, it doesn't make sense to penalize their read times by doing the above two changes. For jobs that are projecting these large columns, they could simply disable vectorization by setting the `spark.iceberg.vectorization.enabled` property to `false`.