### PR TITLE
Fix Resolving of SparkSession Table's Metadata Tables

### DIFF
--- a/spark/src/main/java/org/apache/iceberg/actions/BaseSparkAction.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/BaseSparkAction.java
@@ -133,7 +133,7 @@ abstract class BaseSparkAction<R> implements Action<R> {
                                                            MetadataTableType type) {
     DataFrameReader dataFrameReader = spark.read().format("iceberg");
     if (tableName.startsWith("spark_catalog")) {
-      // Do to the design of Spark, we cannot pass multi-element namespaces to the session catalog.
+      // Due to the design of Spark, we cannot pass multi-element namespaces to the session catalog.
       // We also don't know whether the Catalog is Hive or Hadoop Based so we can't just load one way or the other.
       // Instead we will try to load the metadata table in the hive manner first, then fall back and try the
       // hadoop location method if that fails
@@ -157,7 +157,7 @@ abstract class BaseSparkAction<R> implements Action<R> {
     }
     // Try catalog based name based resolution
     try {
-      loadMetadataTableFromCatalog(spark, tableName, tableLocation, type);
+      return loadMetadataTableFromCatalog(spark, tableName, tableLocation, type);
     } catch (Exception e) {
       if (!(e instanceof ParseException || e instanceof AnalysisException)) {
         // Rethrow unexpected exceptions

--- a/spark/src/main/java/org/apache/iceberg/actions/BaseSparkAction.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/BaseSparkAction.java
@@ -157,7 +157,7 @@ abstract class BaseSparkAction<R> implements Action<R> {
     }
     try {
       // Try DSV2 catalog based name based resolution
-      if (!spark.version().startsWith("2")) {
+      if (spark.version().startsWith("3")) {
         return loadCatalogMetadataTable(spark, tableName, type);
       }
     } catch (Exception e) {

--- a/spark/src/main/java/org/apache/iceberg/actions/BaseSparkAction.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/BaseSparkAction.java
@@ -137,7 +137,7 @@ abstract class BaseSparkAction<R> implements Action<R> {
 
   private static Dataset<Row> loadCatalogMetadataTable(SparkSession spark, String tableName, MetadataTableType type) {
     Preconditions.checkArgument(!LOAD_CATALOG.isNoop(), "Cannot find Spark3Util class but Spark3 is in use");
-    return LOAD_CATALOG.invoke(spark, tableName, type);
+    return LOAD_CATALOG.asStatic().invoke(spark, tableName, type);
   }
 
   protected static Dataset<Row> loadMetadataTable(SparkSession spark, String tableName, String tableLocation,

--- a/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -582,11 +582,10 @@ public class Spark3Util {
       CatalogAndIdentifier catalogAndIdentifier = catalogAndIdentifier(spark, name);
       if (catalogAndIdentifier.catalog instanceof BaseCatalog) {
         BaseCatalog catalog = (BaseCatalog) catalogAndIdentifier.catalog;
-        Identifier baseIdent = catalogAndIdentifier.identifier;
-        Identifier metaIdent = Identifier.of(ArrayUtils.add(baseIdent.namespace(), baseIdent.name()), type.name());
-        Table metaTable = catalog.loadTable(metaIdent);
-        return Dataset
-            .ofRows(spark, DataSourceV2Relation.create(metaTable, Some.apply(catalog), Some.apply(metaIdent)));
+        Identifier baseId = catalogAndIdentifier.identifier;
+        Identifier metaId = Identifier.of(ArrayUtils.add(baseId.namespace(), baseId.name()), type.name());
+        Table metaTable = catalog.loadTable(metaId);
+        return Dataset.ofRows(spark, DataSourceV2Relation.create(metaTable, Some.apply(catalog), Some.apply(metaId)));
       }
     } catch (NoSuchTableException | ParseException e) {
       // Could not find table

--- a/spark3/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction3.java
+++ b/spark3/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction3.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.actions;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -28,9 +27,6 @@ import org.apache.iceberg.spark.SparkCatalog;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.SparkSessionCatalog;
 import org.apache.iceberg.spark.source.SparkTable;
-import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
-import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
-import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.expressions.Transform;
 import org.junit.Assert;

--- a/spark3/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction3.java
+++ b/spark3/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction3.java
@@ -26,7 +26,9 @@ import java.util.Map;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.SparkCatalog;
 import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.spark.SparkSessionCatalog;
 import org.apache.iceberg.spark.source.SparkTable;
+import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
 import org.apache.spark.sql.connector.catalog.Identifier;
@@ -61,7 +63,7 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
   }
 
   @Test
-  public void testSparkCatalogHadoopTable() throws TableAlreadyExistsException, NoSuchTableException, IOException {
+  public void testSparkCatalogNamedHadoopTable() throws TableAlreadyExistsException, NoSuchTableException, IOException {
     spark.conf().set("spark.sql.catalog.hadoop", "org.apache.iceberg.spark.SparkCatalog");
     spark.conf().set("spark.sql.catalog.hadoop.type", "hadoop");
     spark.conf().set("spark.sql.catalog.hadoop.warehouse", tableLocation);
@@ -86,7 +88,7 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
   }
 
   @Test
-  public void testSparkCatalogHiveTable() throws TableAlreadyExistsException, NoSuchTableException, IOException {
+  public void testSparkCatalogNamedHiveTable() throws TableAlreadyExistsException, NoSuchTableException, IOException {
     spark.conf().set("spark.sql.catalog.hive", "org.apache.iceberg.spark.SparkCatalog");
     spark.conf().set("spark.sql.catalog.hive.type", "hadoop");
     spark.conf().set("spark.sql.catalog.hive.warehouse", tableLocation);
@@ -100,6 +102,58 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
     SparkTable table = cat.loadTable(id);
 
     spark.sql("INSERT INTO hive.default.table VALUES (1,1,1)");
+
+    String location = table.table().location().replaceFirst("file:", "");
+    new File(location + "/data/trashfile").createNewFile();
+
+    List<String> results = Actions.forTable(table.table()).removeOrphanFiles()
+        .olderThan(System.currentTimeMillis() + 1000).execute();
+    Assert.assertTrue("trash file should be removed",
+        results.contains("file:" + location + "/data/trashfile"));
+  }
+
+  @Test
+  public void testSparkSessionCatalogHadoopTable()
+      throws TableAlreadyExistsException, NoSuchTableException, IOException, NoSuchNamespaceException {
+    spark.conf().set("spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkSessionCatalog");
+    spark.conf().set("spark.sql.catalog.spark_catalog.type", "hadoop");
+    spark.conf().set("spark.sql.catalog.spark_catalog.warehouse", tableLocation);
+    SparkSessionCatalog cat = (SparkSessionCatalog) spark.sessionState().catalogManager().v2SessionCatalog();
+
+    String[] database = {"default"};
+    Identifier id = Identifier.of(database, "table");
+    Map<String, String> options = Maps.newHashMap();
+    Transform[] transforms = {};
+    cat.createTable(id, SparkSchemaUtil.convert(SCHEMA), transforms, options);
+    SparkTable table = (SparkTable) cat.loadTable(id);
+
+    spark.sql("INSERT INTO default.table VALUES (1,1,1)");
+
+    String location = table.table().location().replaceFirst("file:", "");
+    new File(location + "/data/trashfile").createNewFile();
+
+    List<String> results = Actions.forTable(table.table()).removeOrphanFiles()
+        .olderThan(System.currentTimeMillis() + 1000).execute();
+    Assert.assertTrue("trash file should be removed",
+        results.contains("file:" + location + "/data/trashfile"));
+  }
+
+  @Test
+  public void testSparkSessionCatalogHiveTable()
+      throws TableAlreadyExistsException, NoSuchTableException, IOException, NoSuchNamespaceException {
+    spark.conf().set("spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkSessionCatalog");
+    spark.conf().set("spark.sql.catalog.spark_catalog.type", "hive");
+    SparkSessionCatalog cat = (SparkSessionCatalog) spark.sessionState().catalogManager().v2SessionCatalog();
+
+    String[] database = {"default"};
+    Identifier id = Identifier.of(database, "sessioncattest");
+    Map<String, String> options = Maps.newHashMap();
+    Transform[] transforms = {};
+    cat.dropTable(id);
+    cat.createTable(id, SparkSchemaUtil.convert(SCHEMA), transforms, options);
+    SparkTable table = (SparkTable) cat.loadTable(id);
+
+    spark.sql("INSERT INTO default.sessioncattest VALUES (1,1,1)");
 
     String location = table.table().location().replaceFirst("file:", "");
     new File(location + "/data/trashfile").createNewFile();

--- a/spark3/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction3.java
+++ b/spark3/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction3.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 
 public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
   @Test
-  public void testSparkCatalogTable() throws TableAlreadyExistsException, NoSuchTableException, IOException {
+  public void testSparkCatalogTable() throws Exception {
     spark.conf().set("spark.sql.catalog.mycat", "org.apache.iceberg.spark.SparkCatalog");
     spark.conf().set("spark.sql.catalog.mycat.type", "hadoop");
     spark.conf().set("spark.sql.catalog.mycat.warehouse", tableLocation);
@@ -63,7 +63,7 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
   }
 
   @Test
-  public void testSparkCatalogNamedHadoopTable() throws TableAlreadyExistsException, NoSuchTableException, IOException {
+  public void testSparkCatalogNamedHadoopTable() throws Exception {
     spark.conf().set("spark.sql.catalog.hadoop", "org.apache.iceberg.spark.SparkCatalog");
     spark.conf().set("spark.sql.catalog.hadoop.type", "hadoop");
     spark.conf().set("spark.sql.catalog.hadoop.warehouse", tableLocation);
@@ -88,7 +88,7 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
   }
 
   @Test
-  public void testSparkCatalogNamedHiveTable() throws TableAlreadyExistsException, NoSuchTableException, IOException {
+  public void testSparkCatalogNamedHiveTable() throws Exception {
     spark.conf().set("spark.sql.catalog.hive", "org.apache.iceberg.spark.SparkCatalog");
     spark.conf().set("spark.sql.catalog.hive.type", "hadoop");
     spark.conf().set("spark.sql.catalog.hive.warehouse", tableLocation);
@@ -113,8 +113,7 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
   }
 
   @Test
-  public void testSparkSessionCatalogHadoopTable()
-      throws TableAlreadyExistsException, NoSuchTableException, IOException, NoSuchNamespaceException {
+  public void testSparkSessionCatalogHadoopTable() throws Exception {
     spark.conf().set("spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkSessionCatalog");
     spark.conf().set("spark.sql.catalog.spark_catalog.type", "hadoop");
     spark.conf().set("spark.sql.catalog.spark_catalog.warehouse", tableLocation);
@@ -139,8 +138,7 @@ public class TestRemoveOrphanFilesAction3 extends TestRemoveOrphanFilesAction {
   }
 
   @Test
-  public void testSparkSessionCatalogHiveTable()
-      throws TableAlreadyExistsException, NoSuchTableException, IOException, NoSuchNamespaceException {
+  public void testSparkSessionCatalogHiveTable() throws Exception {
     spark.conf().set("spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkSessionCatalog");
     spark.conf().set("spark.sql.catalog.spark_catalog.type", "hive");
     SparkSessionCatalog cat = (SparkSessionCatalog) spark.sessionState().catalogManager().v2SessionCatalog();


### PR DESCRIPTION
Do to an issue within Spark's Resolution rules we cannot acces a table in the session
catalog with a multipart identifier. Because we also cannot determine whether the underlying
Iceberg table is Hadoop or Hive based we also cannot know the right method for reading the
table. To work around this for now we attempt to first load the table as a HiveTable, if
the table isn't found we fall back and attempt to load it as a Hadoop table.