### PR TITLE
AWS: fix errorprone warnings in S3URI

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3URI.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3URI.java
@@ -76,23 +76,21 @@ class S3URI {
   }
 
   /**
-   * S3 bucket name
-   * @return S3 bucket
+   * Returns S3 bucket name.
    */
   public String bucket() {
     return bucket;
   }
 
   /**
-   * S3 object key name
-   * @return S3 key
+   * Returns S3 object key name.
    */
   public String key() {
     return key;
   }
 
-  /*
-   * @return original, unmodified location
+  /**
+   * Returns original, unmodified S3 URI location.
    */
   public String location() {
     return location;

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3URI.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3URI.java
@@ -57,7 +57,7 @@ class S3URI {
     Preconditions.checkNotNull(location, "Location cannot be null.");
 
     this.location = location;
-    String [] schemeSplit = location.split(SCHEME_DELIM);
+    String [] schemeSplit = location.split(SCHEME_DELIM, -1);
     ValidationException.check(schemeSplit.length == 2, "Invalid S3 URI: %s", location);
 
     String scheme = schemeSplit[0];
@@ -70,12 +70,13 @@ class S3URI {
 
     // Strip query and fragment if they exist
     String path = authoritySplit[1];
-    path = path.split(QUERY_DELIM)[0];
-    path = path.split(FRAGMENT_DELIM)[0];
+    path = path.split(QUERY_DELIM, -1)[0];
+    path = path.split(FRAGMENT_DELIM, -1)[0];
     this.key = path;
   }
 
   /**
+   * S3 bucket name
    * @return S3 bucket
    */
   public String bucket() {
@@ -83,6 +84,7 @@ class S3URI {
   }
 
   /**
+   * S3 object key name
    * @return S3 key
    */
   public String key() {


### PR DESCRIPTION
fix errorprone warnings in S3URI：

```
/iceberg/aws/src/main/java/org/apache/iceberg/aws/s3/S3URI.java:60: warning: [StringSplitter] String.split(String) has surprising behavior
    String [] schemeSplit = location.split(SCHEME_DELIM);
                                          ^
    (see https://errorprone.info/bugpattern/StringSplitter)
  Did you mean 'List<String> schemeSplit = Splitter.onPattern(SCHEME_DELIM).splitToList(location);'?
/iceberg/aws/src/main/java/org/apache/iceberg/aws/s3/S3URI.java:73: warning: [StringSplitter] String.split(String) has surprising behavior
    path = path.split(QUERY_DELIM)[0];
                     ^
    (see https://errorprone.info/bugpattern/StringSplitter)
  Did you mean 'path = Iterables.get(Splitter.onPattern(QUERY_DELIM).split(path), 0);'?
/iceberg/aws/src/main/java/org/apache/iceberg/aws/s3/S3URI.java:74: warning: [StringSplitter] String.split(String) has surprising behavior
    path = path.split(FRAGMENT_DELIM)[0];
                     ^
    (see https://errorprone.info/bugpattern/StringSplitter)
  Did you mean 'path = Iterables.get(Splitter.onPattern(FRAGMENT_DELIM).split(path), 0);'?
/iceberg/aws/src/main/java/org/apache/iceberg/aws/s3/S3URI.java:79: warning: [MissingSummary] A summary fragment is required; consider using the value of the @return block as a summary fragment instead.
    * @return S3 bucket
     ^
    (see http://google.github.io/styleguide/javaguide.html#s7.2-summary-fragment)
  Did you mean '*Returns s3 bucket.'?
/iceberg/aws/src/main/java/org/apache/iceberg/aws/s3/S3URI.java:86: warning: [MissingSummary] A summary fragment is required; consider using the value of the @return block as a summary fragment instead.
    * @return S3 key
     ^
    (see http://google.github.io/styleguide/javaguide.html#s7.2-summary-fragment)
  Did you mean '*Returns s3 key.'?
5 warnings
```