### PR TITLE
AWS: add ACL support for S3FileIO

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -203,6 +203,7 @@ class S3OutputStream extends PositionOutputStream {
     CreateMultipartUploadRequest.Builder requestBuilder = CreateMultipartUploadRequest.builder()
         .bucket(location.bucket()).key(location.key());
     S3RequestUtil.configureEncryption(awsProperties, requestBuilder);
+    S3RequestUtil.configurePermission(awsProperties, requestBuilder);
 
     multipartUploadId = s3.createMultipartUpload(requestBuilder.build()).uploadId();
   }
@@ -309,6 +310,7 @@ class S3OutputStream extends PositionOutputStream {
           .key(location.key());
 
       S3RequestUtil.configureEncryption(awsProperties, requestBuilder);
+      S3RequestUtil.configurePermission(awsProperties, requestBuilder);
 
       s3.putObject(requestBuilder.build(), RequestBody.fromInputStream(contentStream, contentLength));
     } else {

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3RequestUtil.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3RequestUtil.java
@@ -25,6 +25,7 @@ import org.apache.iceberg.aws.AwsProperties;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Request;
 import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
@@ -96,5 +97,20 @@ public class S3RequestUtil {
         throw new IllegalArgumentException(
             "Cannot support given S3 encryption type: " + awsProperties.s3FileIoSseType());
     }
+  }
+
+  static void configurePermission(AwsProperties awsProperties, PutObjectRequest.Builder requestBuilder) {
+    configurePermission(awsProperties, requestBuilder::acl);
+  }
+
+  static void configurePermission(AwsProperties awsProperties, CreateMultipartUploadRequest.Builder requestBuilder) {
+    configurePermission(awsProperties, requestBuilder::acl);
+  }
+
+  @SuppressWarnings("ReturnValueIgnored")
+  static void configurePermission(
+      AwsProperties awsProperties,
+      Function<ObjectCannedACL, S3Request.Builder> aclSetter) {
+    aclSetter.apply(awsProperties.s3FileIoAcl());
   }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/AwsPropertiesTest.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/AwsPropertiesTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.aws;
+
+import java.util.Map;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.Assert;
+import org.junit.Test;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+
+public class AwsPropertiesTest {
+
+  @Test
+  public void testS3FileIoSseCustom_mustHaveCustomKey() {
+    Map<String, String> map = Maps.newHashMap();
+    map.put(AwsProperties.S3FILEIO_SSE_TYPE, AwsProperties.S3FILEIO_SSE_TYPE_CUSTOM);
+    AssertHelpers.assertThrows("must have key for SSE-C",
+        NullPointerException.class,
+        "Cannot initialize SSE-C S3FileIO with null encryption key",
+        () -> new AwsProperties(map));
+  }
+
+  @Test
+  public void testS3FileIoSseCustom_mustHaveCustomMd5() {
+    Map<String, String> map = Maps.newHashMap();
+    map.put(AwsProperties.S3FILEIO_SSE_TYPE, AwsProperties.S3FILEIO_SSE_TYPE_CUSTOM);
+    map.put(AwsProperties.S3FILEIO_SSE_KEY, "something");
+    AssertHelpers.assertThrows("must have md5 for SSE-C",
+        NullPointerException.class,
+        "Cannot initialize SSE-C S3FileIO with null encryption key MD5",
+        () -> new AwsProperties(map));
+  }
+
+  @Test
+  public void testS3FileIoAcl() {
+    Map<String, String> map = Maps.newHashMap();
+    map.put(AwsProperties.S3FILEIO_ACL, ObjectCannedACL.AUTHENTICATED_READ.toString());
+    AwsProperties properties = new AwsProperties(map);
+    Assert.assertEquals(ObjectCannedACL.AUTHENTICATED_READ, properties.s3FileIoAcl());
+  }
+
+  @Test
+  public void testS3FileIoAcl_unknownType() {
+    Map<String, String> map = Maps.newHashMap();
+    map.put(AwsProperties.S3FILEIO_ACL, "bad-input");
+    AssertHelpers.assertThrows("should not accept bad input",
+        IllegalArgumentException.class,
+        "Cannot support S3 CannedACL bad-input",
+        () -> new AwsProperties(map));
+  }
+
+}


### PR DESCRIPTION
As discussed in #1767 with @danielcweeks and @johnclara, add ACL support for `S3FileIO`