### PR TITLE
Core: Implement NaN counts in ORC

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestMetrics.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetrics.java
@@ -628,9 +628,7 @@ public abstract class TestMetrics {
     Map<Integer, Long> nanValueCounts = metrics.nanValueCounts();
     Assert.assertEquals(valueCount, valueCounts.get(fieldId));
     Assert.assertEquals(nullValueCount, nullValueCounts.get(fieldId));
-    if (fileFormat() != FileFormat.ORC) {
-      Assert.assertEquals(nanValueCount, nanValueCounts.get(fieldId));
-    }
+    Assert.assertEquals(nanValueCount, nanValueCounts.get(fieldId));
   }
 
   protected <T> void assertBounds(int fieldId, Type type, T lowerBound, T upperBound, Metrics metrics) {

--- a/data/src/test/java/org/apache/iceberg/TestMergingMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/TestMergingMetrics.java
@@ -90,7 +90,7 @@ public abstract class TestMergingMetrics<T> {
 
   @Parameterized.Parameters(name = "fileFormat = {0}")
   public static Object[] parameters() {
-    return new Object[] {FileFormat.PARQUET };
+    return new Object[] { FileFormat.PARQUET, FileFormat.ORC };
   }
 
   public TestMergingMetrics(FileFormat fileFormat) {

--- a/data/src/test/java/org/apache/iceberg/parquet/TestGenericMergingMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/parquet/TestGenericMergingMetrics.java
@@ -17,10 +17,12 @@
  * under the License.
  */
 
-package org.apache.iceberg;
+package org.apache.iceberg.parquet;
 
 import java.io.IOException;
 import java.util.List;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.TestMergingMetrics;
 import org.apache.iceberg.data.GenericAppenderFactory;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.io.FileAppender;

--- a/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORCSchemaUtil.java
@@ -387,7 +387,7 @@ public final class ORCSchemaUtil {
         .map(Integer::parseInt);
   }
 
-  static int fieldId(TypeDescription orcType) {
+  public static int fieldId(TypeDescription orcType) {
     String idStr = orcType.getAttributeValue(ICEBERG_ID_ATTRIBUTE);
     Preconditions.checkNotNull(idStr, "Missing expected '%s' property", ICEBERG_ID_ATTRIBUTE);
     return Integer.parseInt(idStr);

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcFileAppender.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcFileAppender.java
@@ -94,7 +94,7 @@ class OrcFileAppender<D> implements FileAppender<D> {
   public Metrics metrics() {
     Preconditions.checkState(isClosed,
         "Cannot return metrics while appending to an open file.");
-    return OrcMetrics.fromWriter(writer, metricsConfig);
+    return OrcMetrics.fromWriter(writer, valueWriter.metrics(), metricsConfig);
   }
 
   @Override

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcRowWriter.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcRowWriter.java
@@ -41,5 +41,7 @@ public interface OrcRowWriter<T> {
   /**
    * Returns a stream of {@link FieldMetrics} that this OrcRowWriter keeps track of.
    */
-  Stream<FieldMetrics> metrics();
+  default Stream<FieldMetrics> metrics() {
+    return Stream.empty();
+  }
 }

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcRowWriter.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcRowWriter.java
@@ -20,6 +20,8 @@
 package org.apache.iceberg.orc;
 
 import java.io.IOException;
+import java.util.stream.Stream;
+import org.apache.iceberg.FieldMetrics;
 import org.apache.orc.storage.ql.exec.vector.VectorizedRowBatch;
 
 /**
@@ -35,4 +37,9 @@ public interface OrcRowWriter<T> {
    * @throws IOException if there's any IO error while writing the data value.
    */
   void write(T row, VectorizedRowBatch output) throws IOException;
+
+  /**
+   * Returns a stream of {@link FieldMetrics} that this OrcRowWriter keeps track of.
+   */
+  Stream<FieldMetrics> metrics();
 }

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcValueWriter.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcValueWriter.java
@@ -19,6 +19,8 @@
 
 package org.apache.iceberg.orc;
 
+import java.util.stream.Stream;
+import org.apache.iceberg.FieldMetrics;
 import org.apache.orc.storage.ql.exec.vector.ColumnVector;
 
 public interface OrcValueWriter<T> {
@@ -43,4 +45,11 @@ public interface OrcValueWriter<T> {
   }
 
   void nonNullWrite(int rowId, T data, ColumnVector output);
+
+  /**
+   * Returns a stream of {@link FieldMetrics} that this OrcValueWriter keeps track of.
+   */
+  default Stream<FieldMetrics> metrics() {
+    return Stream.empty();
+  }
 }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueWriter.java
@@ -33,10 +33,6 @@ public interface ParquetValueWriter<T> {
 
   /**
    * Returns a stream of {@link FieldMetrics} that this ParquetValueWriter keeps track of.
-   * <p>
-   * Since Parquet keeps track of most metrics in its footer, for now ParquetValueWriter only keeps track of NaN
-   * counter, and only return non-empty stream if the writer writes double or float values either by itself or
-   * transitively.
    */
   default Stream<FieldMetrics> metrics() {
     return Stream.empty();

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueWriter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueWriter.java
@@ -19,6 +19,8 @@
 
 package org.apache.iceberg.spark.data;
 
+import java.util.stream.Stream;
+import org.apache.iceberg.FieldMetrics;
 import org.apache.orc.storage.ql.exec.vector.ColumnVector;
 import org.apache.spark.sql.catalyst.expressions.SpecializedGetters;
 
@@ -43,4 +45,15 @@ interface SparkOrcValueWriter {
   }
 
   void nonNullWrite(int rowId, int column, SpecializedGetters data, ColumnVector output);
+
+  /**
+   * Returns a stream of {@link FieldMetrics} that this SparkOrcValueWriter keeps track of.
+   * <p>
+   * Since ORC keeps track of most metrics via column statistics, for now SparkOrcValueWriter only keeps track of NaN
+   * counters, and only return non-empty stream if the writer writes double or float values either by itself or
+   * transitively.
+   */
+  default Stream<FieldMetrics> metrics() {
+    return Stream.empty();
+  }
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcWriter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcWriter.java
@@ -106,9 +106,9 @@ public class SparkOrcWriter implements OrcRowWriter<InternalRow> {
         case LONG:
           return SparkOrcValueWriters.longs();
         case FLOAT:
-          return SparkOrcValueWriters.floats(getFieldId(primitive));
+          return SparkOrcValueWriters.floats(ORCSchemaUtil.fieldId(primitive));
         case DOUBLE:
-          return SparkOrcValueWriters.doubles(getFieldId(primitive));
+          return SparkOrcValueWriters.doubles(ORCSchemaUtil.fieldId(primitive));
         case BINARY:
           return SparkOrcValueWriters.byteArrays();
         case STRING:
@@ -122,10 +122,6 @@ public class SparkOrcWriter implements OrcRowWriter<InternalRow> {
         default:
           throw new IllegalArgumentException("Unhandled type " + primitive);
       }
-    }
-
-    private int getFieldId(TypeDescription typeDescription) {
-      return ORCSchemaUtil.fieldId(typeDescription);
     }
   }
 

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcWriter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcWriter.java
@@ -20,7 +20,10 @@
 package org.apache.iceberg.spark.data;
 
 import java.util.List;
+import java.util.stream.Stream;
+import org.apache.iceberg.FieldMetrics;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.orc.ORCSchemaUtil;
 import org.apache.iceberg.orc.OrcRowWriter;
 import org.apache.iceberg.orc.OrcSchemaWithTypeVisitor;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -61,6 +64,11 @@ public class SparkOrcWriter implements OrcRowWriter<InternalRow> {
     }
   }
 
+  @Override
+  public Stream<FieldMetrics> metrics() {
+    return writer.metrics();
+  }
+
   private static class WriteBuilder extends OrcSchemaWithTypeVisitor<SparkOrcValueWriter> {
     private WriteBuilder() {
     }
@@ -98,9 +106,9 @@ public class SparkOrcWriter implements OrcRowWriter<InternalRow> {
         case LONG:
           return SparkOrcValueWriters.longs();
         case FLOAT:
-          return SparkOrcValueWriters.floats();
+          return SparkOrcValueWriters.floats(getFieldId(primitive));
         case DOUBLE:
-          return SparkOrcValueWriters.doubles();
+          return SparkOrcValueWriters.doubles(getFieldId(primitive));
         case BINARY:
           return SparkOrcValueWriters.byteArrays();
         case STRING:
@@ -114,6 +122,10 @@ public class SparkOrcWriter implements OrcRowWriter<InternalRow> {
         default:
           throw new IllegalArgumentException("Unhandled type " + primitive);
       }
+    }
+
+    private int getFieldId(TypeDescription typeDescription) {
+      return ORCSchemaUtil.fieldId(typeDescription);
     }
   }
 
@@ -136,5 +148,11 @@ public class SparkOrcWriter implements OrcRowWriter<InternalRow> {
         writers.get(c).write(rowId, c, value, cv.fields[c]);
       }
     }
+
+    @Override
+    public Stream<FieldMetrics> metrics() {
+      return writers.stream().flatMap(SparkOrcValueWriter::metrics);
+    }
+
   }
 }


### PR DESCRIPTION
- Similar to #1641 
- Renamed a few classes to be shared between Parquet and ORC
- Also noticed an issue where the Spark implementation of `TestMergingMetrics ` didn't handle `Date`/`Timestamp` types as expected: they don't have matching type in `StructInternalRow.get` and the logic default the value to null, and this didn't trigger issue earlier since in the test case they were declared as optional fields. ORC Spark writer handles null values differently and revealed this problem. 

Edit: To reduce the size of this PR I separated some of the changes to #1829, and will rebase this on top of #1829 once that is merged. This PR still contains some of the changes in #1829 to ensure the code can compile and tests can run. 