### PR TITLE
Core: Improve the utility StructLikeSet.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/StructLikeSet.java
+++ b/core/src/main/java/org/apache/iceberg/util/StructLikeSet.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.util;
 
+import java.util.AbstractSet;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Objects;
@@ -29,7 +30,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
 
-public class StructLikeSet implements Set<StructLike> {
+public class StructLikeSet extends AbstractSet<StructLike> implements Set<StructLike> {
   public static StructLikeSet create(Types.StructType type) {
     return new StructLikeSet(type);
   }
@@ -104,7 +105,7 @@ public class StructLikeSet implements Set<StructLike> {
 
   @Override
   public boolean remove(Object obj) {
-    if (obj instanceof CharSequence) {
+    if (obj instanceof StructLike) {
       StructLikeWrapper wrapper = wrappers.get();
       boolean result = wrapperSet.remove(wrapper.set((StructLike) obj));
       wrapper.set(null); // don't hold a reference to the value


### PR DESCRIPTION
When I prepare the patch for flink cdc write flow (https://github.com/apache/iceberg/pull/1663/files),  I found the `StructLikeSet` had the following issues: 

1.  It does not provide several common methods, such as `toString()`, `equals`, `hashCode`  etc.   It's useful for testing.  So I make it extend the `AbstractSet`. 

2. In the `remove` method,  we did the instanceof incorrectly. 