### PR TITLE
Reduce number of calls to fetch table schema from HMS

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -73,10 +73,15 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
   public void configureInputJobProperties(TableDesc tableDesc, Map<String, String> map) {
     Properties props = tableDesc.getProperties();
     Table table = Catalogs.loadTable(conf, props);
+    String schemaJson = SchemaParser.toJson(table.schema());
 
     map.put(InputFormatConfig.TABLE_IDENTIFIER, props.getProperty(Catalogs.NAME));
     map.put(InputFormatConfig.TABLE_LOCATION, table.location());
-    map.put(InputFormatConfig.TABLE_SCHEMA, SchemaParser.toJson(table.schema()));
+    map.put(InputFormatConfig.TABLE_SCHEMA, schemaJson);
+
+    // save schema into table props as well to avoid repeatedly hitting the HMS during serde initializations
+    // this is an exception to the interface documentation, but it's a safe operation to add this property
+    props.put(InputFormatConfig.TABLE_SCHEMA, schemaJson);
   }
 
   @Override


### PR DESCRIPTION
We can reduce the number of HMS calls by caching the table schema in the table properties during query execution. 
In `HiveIcebergSerDe.initialize()`, this results in skipping the HMS calls in all Tez workers as well as during the query optimisation steps. In the `testJoinTable()` unit test, this results in a 40% reduction in schema-related HMS calls (10 -> 6).
@shardulm94 @pvary - could you please take a look when you get the chance? Thanks!