### PR TITLE
Alternative dynamic loading for Actions

### DIFF
--- a/spark/src/main/java/org/apache/iceberg/actions/ActionsFactoryMethods.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/ActionsFactoryMethods.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.actions;
+
+import org.apache.iceberg.Table;
+
+interface ActionsFactoryMethods {
+  Actions forTable(Table table);
+}

--- a/spark2/src/main/java/org/apache/iceberg/actions/Spark2Actions.java
+++ b/spark2/src/main/java/org/apache/iceberg/actions/Spark2Actions.java
@@ -22,8 +22,19 @@ package org.apache.iceberg.actions;
 import org.apache.iceberg.Table;
 import org.apache.spark.sql.SparkSession;
 
-class SparkActions extends Actions {
-  protected SparkActions(SparkSession spark, Table table) {
-    super(spark, table);
+class Spark2Actions implements ActionsFactoryMethods {
+  private final SparkSession spark;
+
+  public Spark2Actions() {
+    this(SparkSession.active());
+  }
+
+  public Spark2Actions(SparkSession spark) {
+    this.spark = spark;
+  }
+
+  @Override
+  public Actions forTable(Table table) {
+    return new Actions(spark, table);
   }
 }

--- a/spark3/src/main/java/org/apache/iceberg/actions/SparkActions.java
+++ b/spark3/src/main/java/org/apache/iceberg/actions/SparkActions.java
@@ -22,8 +22,19 @@ package org.apache.iceberg.actions;
 import org.apache.iceberg.Table;
 import org.apache.spark.sql.SparkSession;
 
-class SparkActions extends Actions {
-  protected SparkActions(SparkSession spark, Table table) {
-    super(spark, table);
+class Spark3Actions implements ActionsFactoryMethods {
+  private final SparkSession spark;
+
+  public Spark3Actions() {
+    this(SparkSession.active());
+  }
+
+  public Spark3Actions(SparkSession spark) {
+    this.spark = spark;
+  }
+
+  @Override
+  public Actions forTable(Table table) {
+    return new Actions(spark, table);
   }
 }


### PR DESCRIPTION
This is to demonstrate one option for sharing static methods in `Actions` with different implementations to allow Spark 2 and 3 to use different logic. No need to review this right now.