### PR TITLE
Spark: Add RewriteManifestsProcedure

### DIFF
--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteManifestsProcedure.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.extensions;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.spark.sql.AnalysisException;
+import org.apache.spark.sql.catalyst.analysis.NoSuchProcedureException;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.iceberg.TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED;
+
+public class TestRewriteManifestsProcedure extends SparkExtensionsTestBase {
+
+  public TestRewriteManifestsProcedure(String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
+  }
+
+  @After
+  public void removeTable() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @Test
+  public void testRewriteManifestsInEmptyTable() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+    List<Object[]> output = sql(
+        "CALL %s.system.rewrite_manifests('%s', '%s')",
+        catalogName, tableIdent.namespace(), tableIdent.name());
+    assertEquals("Procedure output must match",
+        ImmutableList.of(row(0, 0)),
+        output);
+  }
+
+  @Test
+  public void testRewriteLargeManifests() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg PARTITIONED BY (data)", tableName);
+    sql("INSERT INTO TABLE %s VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Assert.assertEquals("Must have 1 manifest", 1, table.currentSnapshot().allManifests().size());
+
+    sql("ALTER TABLE %s SET TBLPROPERTIES ('commit.manifest.target-size-bytes' '1')", tableName);
+
+    List<Object[]> output = sql(
+        "CALL %s.system.rewrite_manifests('%s', '%s')",
+        catalogName, tableIdent.namespace(), tableIdent.name());
+    assertEquals("Procedure output must match",
+        ImmutableList.of(row(1, 4)),
+        output);
+
+    table.refresh();
+
+    Assert.assertEquals("Must have 4 manifests", 4, table.currentSnapshot().allManifests().size());
+  }
+
+  @Test
+  public void testRewriteSmallManifestsWithSnapshotIdInheritance() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg PARTITIONED BY (data)", tableName);
+
+    sql("ALTER TABLE %s SET TBLPROPERTIES ('%s' '%s')", tableName, SNAPSHOT_ID_INHERITANCE_ENABLED, "true");
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (3, 'c')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (4, 'd')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Assert.assertEquals("Must have 4 manifest", 4, table.currentSnapshot().allManifests().size());
+
+    List<Object[]> output = sql(
+        "CALL %s.system.rewrite_manifests(table => '%s', namespace => '%s')",
+        catalogName, tableIdent.name(), tableIdent.namespace());
+    assertEquals("Procedure output must match",
+        ImmutableList.of(row(4, 1)),
+        output);
+
+    table.refresh();
+
+    Assert.assertEquals("Must have 1 manifests", 1, table.currentSnapshot().allManifests().size());
+  }
+
+  @Test
+  public void testRewriteSmallManifestsWithoutCaching() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg PARTITIONED BY (data)", tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Assert.assertEquals("Must have 2 manifest", 2, table.currentSnapshot().allManifests().size());
+
+    List<Object[]> output = sql(
+        "CALL %s.system.rewrite_manifests(use_caching => false, namespace => '%s', table => '%s')",
+        catalogName, tableIdent.namespace(), tableIdent.name());
+    assertEquals("Procedure output must match",
+        ImmutableList.of(row(2, 1)),
+        output);
+
+    table.refresh();
+
+    Assert.assertEquals("Must have 1 manifests", 1, table.currentSnapshot().allManifests().size());
+  }
+
+  @Test
+  public void testInvalidRewriteManifestsCases() {
+    AssertHelpers.assertThrows("Should not allow mixed args",
+        AnalysisException.class, "Named and positional arguments cannot be mixed",
+        () -> sql("CALL %s.system.rewrite_manifests('n', table => 't')", catalogName));
+
+    AssertHelpers.assertThrows("Should not resolve procedures in arbitrary namespaces",
+        NoSuchProcedureException.class, "not found",
+        () -> sql("CALL %s.custom.rewrite_manifests('n', 't')", catalogName));
+
+    AssertHelpers.assertThrows("Should reject calls without all required args",
+        AnalysisException.class, "Missing required parameters",
+        () -> sql("CALL %s.system.rewrite_manifests('n')", catalogName));
+
+    AssertHelpers.assertThrows("Should reject calls with invalid arg types",
+        RuntimeException.class, "Couldn't parse identifier",
+        () -> sql("CALL %s.system.rewrite_manifests('n', 2.2)", catalogName));
+
+    AssertHelpers.assertThrows("Should reject empty namespace",
+        IllegalArgumentException.class, "Namespace cannot be empty",
+        () -> sql("CALL %s.system.rewrite_manifests('', 't')", catalogName));
+
+    AssertHelpers.assertThrows("Should reject empty table name",
+        IllegalArgumentException.class, "Table name cannot be empty",
+        () -> sql("CALL %s.system.rewrite_manifests('n', '')", catalogName));
+  }
+}

--- a/spark3/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.procedures;
+
+import org.apache.iceberg.actions.Actions;
+import org.apache.iceberg.actions.RewriteManifestsAction;
+import org.apache.iceberg.actions.RewriteManifestsActionResult;
+import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+class RewriteManifestsProcedure extends BaseProcedure {
+
+  private static final ProcedureParameter[] PARAMETERS = new ProcedureParameter[]{
+      ProcedureParameter.required("namespace", DataTypes.StringType),
+      ProcedureParameter.required("table", DataTypes.StringType),
+      ProcedureParameter.optional("use_caching", DataTypes.BooleanType)
+  };
+
+  // counts are not nullable since the action result is never null
+  private static final StructType OUTPUT_TYPE = new StructType(new StructField[]{
+      new StructField("num_rewritten_manifests", DataTypes.IntegerType, false, Metadata.empty()),
+      new StructField("num_added_manifests", DataTypes.IntegerType, false, Metadata.empty())
+  });
+
+  public static ProcedureBuilder builder() {
+    return new BaseProcedure.Builder<RewriteManifestsProcedure>() {
+      @Override
+      protected RewriteManifestsProcedure doBuild() {
+        return new RewriteManifestsProcedure(tableCatalog());
+      }
+    };
+  }
+
+  private RewriteManifestsProcedure(TableCatalog tableCatalog) {
+    super(tableCatalog);
+  }
+
+  @Override
+  public ProcedureParameter[] parameters() {
+    return PARAMETERS;
+  }
+
+  @Override
+  public StructType outputType() {
+    return OUTPUT_TYPE;
+  }
+
+  @Override
+  public InternalRow[] call(InternalRow args) {
+    String namespace = args.getString(0);
+    String tableName = args.getString(1);
+    Boolean useCaching = args.isNullAt(2) ? null : args.getBoolean(2);
+
+    return modifyIcebergTable(namespace, tableName, table -> {
+      Actions actions = Actions.forTable(table);
+
+      RewriteManifestsAction action = actions.rewriteManifests();
+
+      if (useCaching != null) {
+        action.useCaching(useCaching);
+      }
+
+      RewriteManifestsActionResult result = action.execute();
+
+      int numRewrittenManifests = result.deletedManifests().size();
+      int numAddedManifests = result.addedManifests().size();
+      InternalRow outputRow = newInternalRow(numRewrittenManifests, numAddedManifests);
+      return new InternalRow[]{outputRow};
+    });
+  }
+
+  @Override
+  public String description() {
+    return "RewriteManifestsProcedure";
+  }
+}

--- a/spark3/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/procedures/RewriteManifestsProcedure.java
@@ -31,6 +31,9 @@ import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
+/**
+ * A procedure that rewrites manifests in a table.
+ */
 class RewriteManifestsProcedure extends BaseProcedure {
 
   private static final ProcedureParameter[] PARAMETERS = new ProcedureParameter[]{

--- a/spark3/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
@@ -45,6 +45,7 @@ public class SparkProcedures {
     mapBuilder.put("rollback_to_timestamp", RollbackToTimestampProcedure::builder);
     mapBuilder.put("set_current_snapshot", SetCurrentSnapshotProcedure::builder);
     mapBuilder.put("cherrypick_snapshot", CherrypickSnapshotProcedure::builder);
+    mapBuilder.put("rewrite_manifests", RewriteManifestsProcedure::builder);
     return mapBuilder.build();
   }
 


### PR DESCRIPTION
This PR adds a procedure to rewrite manifests.

This is a temporary solution that rewrites all metadata until we figure out how to determine the clustering ratio of metadata. 