### PR TITLE
Add delta writer classes

### DIFF
--- a/core/src/main/java/org/apache/iceberg/deletes/EqualityDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/EqualityDeleteWriter.java
@@ -61,6 +61,10 @@ public class EqualityDeleteWriter<T> implements Closeable {
     appender.add(row);
   }
 
+  public long length() {
+    return appender.length();
+  }
+
   @Override
   public void close() throws IOException {
     if (deleteFile == null) {

--- a/core/src/main/java/org/apache/iceberg/io/DataWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/DataWriter.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.io;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.encryption.EncryptionKeyMetadata;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+public class DataWriter<T> implements Closeable {
+  private final FileAppender<T> appender;
+  private final FileFormat format;
+  private final String location;
+  private final PartitionSpec spec;
+  private final StructLike partition;
+  private final ByteBuffer keyMetadata;
+  private DataFile dataFile = null;
+
+  public DataWriter(FileAppender<T> appender, FileFormat format, String location,
+                    PartitionSpec spec, StructLike partition, EncryptionKeyMetadata keyMetadata) {
+    this.appender = appender;
+    this.format = format;
+    this.location = location;
+    this.spec = spec;
+    this.partition = partition;
+    this.keyMetadata = keyMetadata != null ? keyMetadata.buffer() : null;
+  }
+
+  public void addAll(Iterable<T> rows) {
+    appender.addAll(rows);
+  }
+
+  public void add(T row) {
+    appender.add(row);
+  }
+
+  public long length() {
+    return appender.length();
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (dataFile == null) {
+      appender.close();
+      this.dataFile = DataFiles.builder(spec)
+          .withFormat(format)
+          .withPath(location)
+          .withPartition(partition)
+          .withEncryptionKeyMetadata(keyMetadata)
+          .withFileSizeInBytes(appender.length())
+          .withMetrics(appender.metrics())
+          .withSplitOffsets(appender.splitOffsets())
+          .build();
+    }
+  }
+
+  public DataFile toDataFile() {
+    Preconditions.checkState(dataFile != null, "Cannot create data file from unclosed writer");
+    return dataFile;
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/io/FileAppenderFactory.java
+++ b/core/src/main/java/org/apache/iceberg/io/FileAppenderFactory.java
@@ -20,6 +20,10 @@
 package org.apache.iceberg.io;
 
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.deletes.EqualityDeleteWriter;
+import org.apache.iceberg.deletes.PositionDeleteWriter;
+import org.apache.iceberg.encryption.EncryptedOutputFile;
 
 /**
  * Factory to create a new {@link FileAppender} to write records.
@@ -36,4 +40,34 @@ public interface FileAppenderFactory<T> {
    * @return a newly created {@link FileAppender}
    */
   FileAppender<T> newAppender(OutputFile outputFile, FileFormat fileFormat);
+
+  /**
+   * Create a new {@link DataWriter}.
+   *
+   * @param outputFile an OutputFile used to create an output stream.
+   * @param format a file format
+   * @param partition a tuple of partition values
+   * @return a newly created {@link DataWriter} for rows
+   */
+  DataWriter<T> newDataWriter(EncryptedOutputFile outputFile, FileFormat format, StructLike partition);
+
+  /**
+   * Create a new {@link EqualityDeleteWriter}.
+   *
+   * @param outputFile an OutputFile used to create an output stream.
+   * @param format a file format
+   * @param partition a tuple of partition values
+   * @return a newly created {@link EqualityDeleteWriter} for equality deletes
+   */
+  EqualityDeleteWriter<T> newEqDeleteWriter(EncryptedOutputFile outputFile, FileFormat format, StructLike partition);
+
+  /**
+   * Create a new {@link PositionDeleteWriter}.
+   *
+   * @param outputFile an OutputFile used to create an output stream.
+   * @param format a file format
+   * @param partition a tuple of partition values
+   * @return a newly created {@link EqualityDeleteWriter} for position deletes
+   */
+  PositionDeleteWriter<T> newPosDeleteWriter(EncryptedOutputFile outputFile, FileFormat format, StructLike partition);
 }

--- a/core/src/main/java/org/apache/iceberg/io/UnpartitionedDeltaWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/UnpartitionedDeltaWriter.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.io;
+
+import java.io.IOException;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+
+public class UnpartitionedDeltaWriter<T> extends BaseTaskWriter<T> {
+
+  private final RollingFileWriter currentWriter;
+  private final RollingEqDeleteWriter currentEqDeletes;
+
+  public UnpartitionedDeltaWriter(PartitionSpec spec, FileFormat format, FileAppenderFactory<T> appenderFactory,
+                                  OutputFileFactory fileFactory, FileIO io, long targetFileSize) {
+    super(spec, format, appenderFactory, fileFactory, io, targetFileSize);
+    currentWriter = new RollingFileWriter(null);
+    currentEqDeletes = new RollingEqDeleteWriter(null);
+  }
+
+  @Override
+  public void write(T record) throws IOException {
+    currentWriter.add(record);
+  }
+
+  public void delete(T record) throws IOException {
+    currentEqDeletes.delete(record);
+  }
+
+  @Override
+  public void close() throws IOException {
+    currentWriter.close();
+    currentEqDeletes.close();
+  }
+}


### PR DESCRIPTION
This is a draft of how we can extend the current writer classes to handle deltas and file rolling.

* Adds `DataWriter` like `EqualityDeleteWriter` and `PositionDeleteWriter`
* Adds methods to `FileAppenderFactory` to create writers; it may be cleaner to move these to a separate `WriterFactory`
* Adds a rolling writer implementation for equality deletes to `BaseTaskWriter`
* Abstracts rolling writer logic into a base class
* Adds an example `UnpartitionedDeltaWriter`

These changes are incomplete, so this probably doesn't work yet. This would still need a real task writer implementation and additional arguments passed to create the `FileAppenderFactory`.