### PR TITLE
Spark: Add newInternalRow to BaseProcedure

### DIFF
--- a/spark3/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
@@ -25,7 +25,9 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.catalyst.parser.ParseException;
 import org.apache.spark.sql.catalyst.parser.ParserInterface;
 import org.apache.spark.sql.connector.catalog.Identifier;
@@ -98,6 +100,10 @@ abstract class BaseProcedure implements Procedure {
     CacheManager cacheManager = spark.sharedState().cacheManager();
     DataSourceV2Relation relation = DataSourceV2Relation.create(table, Option.apply(tableCatalog), Option.apply(ident));
     cacheManager.recacheByPlan(spark, relation);
+  }
+
+  protected InternalRow newInternalRow(Object... values) {
+    return new GenericInternalRow(values);
   }
 
   protected abstract static class Builder<T extends BaseProcedure> implements ProcedureBuilder {

--- a/spark3/src/main/java/org/apache/iceberg/spark/procedures/CherrypickSnapshotProcedure.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/procedures/CherrypickSnapshotProcedure.java
@@ -22,7 +22,6 @@ package org.apache.iceberg.spark.procedures;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
@@ -79,11 +78,7 @@ class CherrypickSnapshotProcedure extends BaseProcedure {
 
       Snapshot currentSnapshot = table.currentSnapshot();
 
-      Object[] outputValues = new Object[OUTPUT_TYPE.size()];
-      outputValues[0] = snapshotId;
-      outputValues[1] = currentSnapshot.snapshotId();
-      GenericInternalRow outputRow = new GenericInternalRow(outputValues);
-
+      InternalRow outputRow = newInternalRow(snapshotId, currentSnapshot.snapshotId());
       return new InternalRow[]{outputRow};
     });
   }

--- a/spark3/src/main/java/org/apache/iceberg/spark/procedures/RollbackToSnapshotProcedure.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/procedures/RollbackToSnapshotProcedure.java
@@ -22,7 +22,6 @@ package org.apache.iceberg.spark.procedures;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
@@ -82,11 +81,7 @@ class RollbackToSnapshotProcedure extends BaseProcedure {
           .rollbackTo(snapshotId)
           .commit();
 
-      Object[] outputValues = new Object[OUTPUT_TYPE.size()];
-      outputValues[0] = previousSnapshot.snapshotId();
-      outputValues[1] = snapshotId;
-      GenericInternalRow outputRow = new GenericInternalRow(outputValues);
-
+      InternalRow outputRow = newInternalRow(previousSnapshot.snapshotId(), snapshotId);
       return new InternalRow[]{outputRow};
     });
   }

--- a/spark3/src/main/java/org/apache/iceberg/spark/procedures/RollbackToTimestampProcedure.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/procedures/RollbackToTimestampProcedure.java
@@ -22,7 +22,6 @@ package org.apache.iceberg.spark.procedures;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
@@ -86,11 +85,7 @@ class RollbackToTimestampProcedure extends BaseProcedure {
 
       Snapshot currentSnapshot = table.currentSnapshot();
 
-      Object[] outputValues = new Object[OUTPUT_TYPE.size()];
-      outputValues[0] = previousSnapshot.snapshotId();
-      outputValues[1] = currentSnapshot.snapshotId();
-      GenericInternalRow outputRow = new GenericInternalRow(outputValues);
-
+      InternalRow outputRow = newInternalRow(previousSnapshot.snapshotId(), currentSnapshot.snapshotId());
       return new InternalRow[]{outputRow};
     });
   }

--- a/spark3/src/main/java/org/apache/iceberg/spark/procedures/SetCurrentSnapshotProcedure.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/procedures/SetCurrentSnapshotProcedure.java
@@ -22,7 +22,6 @@ package org.apache.iceberg.spark.procedures;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
 import org.apache.spark.sql.types.DataTypes;
@@ -83,11 +82,7 @@ class SetCurrentSnapshotProcedure extends BaseProcedure {
           .setCurrentSnapshot(snapshotId)
           .commit();
 
-      Object[] outputValues = new Object[OUTPUT_TYPE.size()];
-      outputValues[0] = previousSnapshotId;
-      outputValues[1] = snapshotId;
-      GenericInternalRow outputRow = new GenericInternalRow(outputValues);
-
+      InternalRow outputRow = newInternalRow(previousSnapshotId, snapshotId);
       return new InternalRow[]{outputRow};
     });
   }


### PR DESCRIPTION
This PR adds `newInternalRow` to `BaseProcedure` to unify construction of `InternalRow`s in procedures.