### PR TITLE
Change ManifestList to an immutable list from linked list

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestLists.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestLists.java
@@ -27,7 +27,7 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 
 class ManifestLists {
   private ManifestLists() {
@@ -43,7 +43,7 @@ class ManifestLists {
         .reuseContainers(false)
         .build()) {
 
-      return Lists.newLinkedList(files);
+      return ImmutableList.copyOf(files);
 
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Cannot read manifest list file: %s", manifestList.location());

--- a/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -146,7 +147,7 @@ public class TestRewriteManifests extends TableTestBase {
         .clusterBy(file -> file.path())
         .commit();
 
-    List<ManifestFile> manifests = table.currentSnapshot().allManifests();
+    List<ManifestFile> manifests = new ArrayList(table.currentSnapshot().allManifests());
     Assert.assertEquals(2, manifests.size());
     manifests.sort(Comparator.comparing(ManifestFile::path));
 
@@ -279,7 +280,7 @@ public class TestRewriteManifests extends TableTestBase {
     when(rewriteManifests.getManifestTargetSizeBytes()).thenReturn(1L);
     rewriteManifests.clusterBy(file -> "file").commit();
 
-    List<ManifestFile> manifests = table.currentSnapshot().allManifests();
+    List<ManifestFile> manifests = new ArrayList(table.currentSnapshot().allManifests());
     Assert.assertEquals(2, manifests.size());
     manifests.sort(Comparator.comparing(ManifestFile::path));
 


### PR DESCRIPTION
From https://github.com/apache/iceberg/issues/1812

Trying to match with: https://github.com/apache/iceberg/blob/master/core/src/main/java/org/apache/iceberg/BaseSnapshot.java#L131

Not sure if this is worth the risk of changing. A couple of our tables have some really large manifest lists and I was wondering if the micro benchmark shows anything noticable