### PR TITLE
[WIP]SQL extension: expire snapshot

### DIFF
--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveProcedures.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveProcedures.scala
@@ -50,7 +50,8 @@ case class ResolveProcedures(spark: SparkSession) extends Rule[LogicalPlan] with
 
     // optional params should be at the end
     procedure.parameters.sliding(2).foreach {
-      case Array(previousParam, currentParam) if previousParam.required && !currentParam.required =>
+          // Optional arg must be behind the required arg.
+      case Array(previousParam, currentParam) if !previousParam.required && currentParam.required =>
         throw new AnalysisException("Optional parameters must be after required ones")
       case _ =>
     }

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotProcedure.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotProcedure.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.extensions;
+
+import com.google.common.collect.Lists;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestExpireSnapshotProcedure extends SparkExtensionsTestBase {
+  public TestExpireSnapshotProcedure(
+      String catalogName,
+      String implementation,
+      Map<String, String> config) {
+    super(catalogName, implementation, config);
+  }
+
+  @After
+  public void removeTables() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @Test
+  public void testExpireSnapshotUsingPostionArgs() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+    long firstSnapshotTimestamp = System.currentTimeMillis();
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    table.refresh();
+    Assert.assertEquals(2, Lists.newArrayList(table.snapshots()).size());
+    Snapshot secondSnapshot = table.currentSnapshot();
+
+    // without the retained last num arg
+    List<Object[]> output = sql(
+        "CALL %s.system.expire_snapshot('%s', '%s', TIMESTAMP '%s')",
+        catalogName, tableIdent.namespace(), tableIdent.name(), new Timestamp(firstSnapshotTimestamp).toString());
+    table.refresh();
+    assertEquals(
+        "Procedure output must match",
+        ImmutableList.of(row(null, firstSnapshotTimestamp)),
+        output);
+    Assert.assertEquals(1, Lists.newArrayList(table.snapshots()).size());
+    Assert.assertEquals(secondSnapshot.snapshotId(), Lists.newArrayList(table.snapshots()).get(0).snapshotId());
+
+    //with the retained last num arg
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    table.refresh();
+    Snapshot tailSnapshot = table.currentSnapshot();
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    table.refresh();
+    Assert.assertEquals(4, Lists.newArrayList(table.snapshots()).size());
+    Snapshot headSnapshot = table.currentSnapshot();
+    long currentTimeStamp = System.currentTimeMillis();
+    int retainedLastNum = 3;
+    output = sql(
+        "CALL %s.system.expire_snapshot('%s', '%s', TIMESTAMP '%s', %d)",
+        catalogName,
+        tableIdent.namespace(),
+        tableIdent.name(),
+        new Timestamp(currentTimeStamp).toString(),
+        retainedLastNum);
+    table.refresh();
+    assertEquals(
+        "Procedure output must match",
+        ImmutableList.of(row(retainedLastNum, currentTimeStamp)),
+        output);
+    Assert.assertEquals(3, Lists.newArrayList(table.snapshots()).size());
+    Assert.assertEquals(tailSnapshot.snapshotId(), Lists.newArrayList(table.snapshots()).get(0).snapshotId());
+    Assert.assertEquals(headSnapshot.snapshotId(), Lists.newArrayList(table.snapshots()).get(2).snapshotId());
+  }
+
+  @Test
+  public void testExpireSnapshotUsingNameArgs() {
+
+  }
+
+  @Test
+  public void testExpireSnapshotWithInvalidRetainLastNum() {
+
+  }
+}

--- a/spark3/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotProcedure.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotProcedure.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.procedures;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.catalyst.util.DateTimeUtils;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+public class ExpireSnapshotProcedure extends BaseProcedure {
+
+  private static final ProcedureParameter[] PARAMETERS = new ProcedureParameter[] {
+      ProcedureParameter.required("namespace", DataTypes.StringType),
+      ProcedureParameter.required("table", DataTypes.StringType),
+      ProcedureParameter.required("older_than", DataTypes.TimestampType),
+      ProcedureParameter.optional("retain_last", DataTypes.IntegerType)
+  };
+
+
+  private static final StructField[] OUTPUT_FIELDS = new StructField[] {
+      new StructField("retain_last_num", DataTypes.IntegerType, true, Metadata.empty()),
+      new StructField("expire_timestamp", DataTypes.TimestampType, true, Metadata.empty())
+  };
+
+  private static final StructType OUTPUT_TYPE = new StructType(OUTPUT_FIELDS);
+
+  public static SparkProcedures.ProcedureBuilder builder() {
+    return new Builder<ExpireSnapshotProcedure>() {
+      @Override
+      protected ExpireSnapshotProcedure doBuild() {
+        return new ExpireSnapshotProcedure(tableCatalog());
+      }
+    };
+  }
+
+  private ExpireSnapshotProcedure(TableCatalog tableCatalog) {
+    super(tableCatalog);
+  }
+
+  @Override
+  public InternalRow[] call(InternalRow input) {
+    String namespace = input.getString(0);
+    String tableName = input.getString(1);
+    Long timestamp = DateTimeUtils.toMillis(input.getLong(2));
+    Integer retainLastNum = input.isNullAt(3) ? null : input.getInt(3);
+
+    return modifyIcebergTable(namespace, tableName, table -> {
+      if (retainLastNum == null) {
+        table.expireSnapshots()
+            .expireOlderThan(timestamp)
+            .commit();
+      } else {
+        table.expireSnapshots()
+            .expireOlderThan(timestamp)
+            .retainLast(retainLastNum)
+            .commit();
+      }
+      Object[] outputValues = new Object[OUTPUT_TYPE.size()];
+      outputValues[0] = retainLastNum;
+      outputValues[1] = timestamp;
+      GenericInternalRow outputRow = new GenericInternalRow(outputValues);
+      return new InternalRow[]{outputRow};
+    });
+  }
+
+  @Override
+  public ProcedureParameter[] parameters() {
+    return PARAMETERS;
+  }
+
+  @Override
+  public StructType outputType() {
+    return OUTPUT_TYPE;
+  }
+
+  @Override
+  public String description() {
+    return "ExpireSnapshotProcedure";
+  }
+}

--- a/spark3/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotProcedure.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotProcedure.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.spark.procedures;
 
+import java.sql.Timestamp;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.catalyst.util.DateTimeUtils;
@@ -41,7 +42,7 @@ public class ExpireSnapshotProcedure extends BaseProcedure {
 
   private static final StructField[] OUTPUT_FIELDS = new StructField[] {
       new StructField("retain_last_num", DataTypes.IntegerType, true, Metadata.empty()),
-      new StructField("expire_timestamp", DataTypes.TimestampType, true, Metadata.empty())
+      new StructField("expire_timestamp", DataTypes.LongType, true, Metadata.empty())
   };
 
   private static final StructType OUTPUT_TYPE = new StructType(OUTPUT_FIELDS);

--- a/spark3/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
@@ -45,6 +45,7 @@ public class SparkProcedures {
     mapBuilder.put("rollback_to_timestamp", RollbackToTimestampProcedure::builder);
     mapBuilder.put("set_current_snapshot", SetCurrentSnapshotProcedure::builder);
     mapBuilder.put("cherrypick_snapshot", CherrypickSnapshotProcedure::builder);
+    mapBuilder.put("expire_snapshot", ExpireSnapshotProcedure::builder);
     return mapBuilder.build();
   }
 


### PR DESCRIPTION
support the expire snapshot and some sql test
syntax:

```
CALL catalog.schema.expire_snapshots(
  namespace  => 'namespace_name' 
  table => 'table_name',
  older_than => timestamp,  
  retain_last => number
)

The namespace/table/older_than is required.
The retain_last is optional.
```

issue: [#1597](https://github.com/apache/iceberg/issues/1597)

