### PR TITLE
Core: update record_count behavior, include in manifest reader

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -60,7 +60,7 @@ abstract class BaseFile<F>
   private String filePath = null;
   private FileFormat format = null;
   private PartitionData partitionData = null;
-  private long recordCount = -1L;
+  private Long recordCount = null;
   private long fileSizeInBytes = -1L;
 
   // optional fields

--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -60,7 +60,7 @@ abstract class BaseFile<F>
   private String filePath = null;
   private FileFormat format = null;
   private PartitionData partitionData = null;
-  private Long recordCount = null;
+  private long recordCount = -1L;
   private long fileSizeInBytes = -1L;
 
   // optional fields

--- a/core/src/main/java/org/apache/iceberg/ManifestGroup.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestGroup.java
@@ -164,7 +164,7 @@ class ManifestGroup {
 
     boolean dropStats = ManifestReader.dropStats(dataFilter, columns);
     if (!deleteFiles.isEmpty()) {
-      select(Lists.newArrayList(ManifestReader.withStatsColumns(columns)));
+      select(ManifestReader.withStatsColumns(columns));
     }
 
     Iterable<CloseableIterable<FileScanTask>> tasks = entries((manifest, entries) -> {

--- a/core/src/main/java/org/apache/iceberg/ManifestGroup.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestGroup.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import org.apache.iceberg.expressions.Evaluator;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
@@ -39,7 +38,6 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ParallelIterable;
 
@@ -166,7 +164,7 @@ class ManifestGroup {
 
     boolean dropStats = ManifestReader.dropStats(dataFilter, columns);
     if (!deleteFiles.isEmpty()) {
-      select(Streams.concat(columns.stream(), ManifestReader.STATS_COLUMNS.stream()).collect(Collectors.toList()));
+      select(Lists.newArrayList(ManifestReader.withStatsColumns(columns)));
     }
 
     Iterable<CloseableIterable<FileScanTask>> tasks = entries((manifest, entries) -> {

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -38,6 +38,7 @@ import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
@@ -53,7 +54,7 @@ public class ManifestReader<F extends ContentFile<F>>
     extends CloseableGroup implements CloseableIterable<F> {
   static final ImmutableList<String> ALL_COLUMNS = ImmutableList.of("*");
 
-  private static final Set<String> STATS_COLUMNS = Sets.newHashSet(
+  private static final Set<String> STATS_COLUMNS = ImmutableSet.of(
       "value_counts", "null_value_counts", "nan_value_counts", "lower_bounds", "upper_bounds", "record_count");
 
   protected enum FileType {

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -53,8 +53,6 @@ public class ManifestReader<F extends ContentFile<F>>
     extends CloseableGroup implements CloseableIterable<F> {
   static final ImmutableList<String> ALL_COLUMNS = ImmutableList.of("*");
 
-  // the difference between the two stats set below is to support ContentFile.copyWithoutStats(), which
-  // still keeps record count.
   private static final Set<String> STATS_COLUMNS = Sets.newHashSet(
       "value_counts", "null_value_counts", "nan_value_counts", "lower_bounds", "upper_bounds", "record_count");
 
@@ -285,7 +283,9 @@ public class ManifestReader<F extends ContentFile<F>>
 
   static boolean dropStats(Expression rowFilter, Collection<String> columns) {
     // Make sure we only drop all stats if we had projected all stats
-    // We do not drop stats even if we had partially added some stats columns
+    // We do not drop stats even if we had partially added some stats columns, except for record_count column.
+    // Since we don't want to keep stats map which could be huge in size just because we select record_count, which
+    // is a primitive type.
     if (rowFilter != Expressions.alwaysTrue() && columns != null &&
         !columns.containsAll(ManifestReader.ALL_COLUMNS)) {
       Set<String> interaction = Sets.intersection(Sets.newHashSet(columns), STATS_COLUMNS);

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -82,7 +82,7 @@ public class ManifestReader<F extends ContentFile<F>>
   private Expression partFilter = alwaysTrue();
   private Expression rowFilter = alwaysTrue();
   private Schema fileProjection = null;
-  private List<String> columns = null;
+  private Collection<String> columns = null;
   private boolean caseSensitive = true;
 
   // lazily initialized
@@ -137,7 +137,7 @@ public class ManifestReader<F extends ContentFile<F>>
     return spec;
   }
 
-  public ManifestReader<F> select(List<String> newColumns) {
+  public ManifestReader<F> select(Collection<String> newColumns) {
     Preconditions.checkState(fileProjection == null,
         "Cannot select columns using both select(String...) and project(Schema)");
     this.columns = newColumns;
@@ -288,15 +288,15 @@ public class ManifestReader<F extends ContentFile<F>>
     // is a primitive type.
     if (rowFilter != Expressions.alwaysTrue() && columns != null &&
         !columns.containsAll(ManifestReader.ALL_COLUMNS)) {
-      Set<String> interaction = Sets.intersection(Sets.newHashSet(columns), STATS_COLUMNS);
-      return interaction.isEmpty() || interaction.equals(Sets.newHashSet("record_count"));
+      Set<String> intersection = Sets.intersection(Sets.newHashSet(columns), STATS_COLUMNS);
+      return intersection.isEmpty() || intersection.equals(Sets.newHashSet("record_count"));
     }
     return false;
   }
 
-  static List<String> withStatsColumns(List<String> columns) {
+  static List<String> withStatsColumns(Collection<String> columns) {
     if (columns.containsAll(ManifestReader.ALL_COLUMNS)) {
-      return columns;
+      return Lists.newArrayList(columns);
     } else {
       List<String> projectColumns = Lists.newArrayList(columns);
       projectColumns.addAll(STATS_COLUMNS); // order doesn't matter

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -88,7 +88,7 @@ public class ManifestReader<F extends ContentFile<F>>
   private Expression partFilter = alwaysTrue();
   private Expression rowFilter = alwaysTrue();
   private Schema fileProjection = null;
-  private Collection<String> columns = null;
+  private List<String> columns = null;
   private boolean caseSensitive = true;
 
   // lazily initialized
@@ -143,7 +143,7 @@ public class ManifestReader<F extends ContentFile<F>>
     return spec;
   }
 
-  public ManifestReader<F> select(Collection<String> newColumns) {
+  public ManifestReader<F> select(List<String> newColumns) {
     Preconditions.checkState(fileProjection == null,
         "Cannot select columns using both select(String...) and project(Schema)");
     this.columns = newColumns;
@@ -296,7 +296,7 @@ public class ManifestReader<F extends ContentFile<F>>
         Sets.intersection(Sets.newHashSet(columns), STATS_COLUMNS).isEmpty();
   }
 
-  static Collection<String> withStatsColumns(Collection<String> columns) {
+  static List<String> withStatsColumns(List<String> columns) {
     if (columns.containsAll(ManifestReader.ALL_COLUMNS)) {
       return columns;
     } else {

--- a/core/src/test/java/org/apache/iceberg/TestManifestReaderStats.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReaderStats.java
@@ -158,9 +158,9 @@ public class TestManifestReaderStats extends TableTestBase {
       Assert.assertNull(dataFile.columnSizes());
       Assert.assertNull(dataFile.valueCounts());
       Assert.assertNull(dataFile.nullValueCounts());
-      Assert.assertNull(dataFile.nanValueCounts());
       Assert.assertNull(dataFile.lowerBounds());
       Assert.assertNull(dataFile.upperBounds());
+      Assert.assertNull(dataFile.nanValueCounts());
       assertNullRecordCount(dataFile);
     }
   }
@@ -203,9 +203,9 @@ public class TestManifestReaderStats extends TableTestBase {
     Assert.assertNull(dataFile.columnSizes());
     Assert.assertNull(dataFile.valueCounts());
     Assert.assertNull(dataFile.nullValueCounts());
-    Assert.assertNull(dataFile.nanValueCounts());
     Assert.assertNull(dataFile.lowerBounds());
     Assert.assertNull(dataFile.upperBounds());
+    Assert.assertNull(dataFile.nanValueCounts());
 
     Assert.assertEquals(FILE_PATH, dataFile.path()); // always select file path in all test cases
   }

--- a/core/src/test/java/org/apache/iceberg/TestManifestReaderStats.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReaderStats.java
@@ -24,8 +24,8 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
@@ -88,7 +88,7 @@ public class TestManifestReaderStats extends TableTestBase {
   public void testReadEntriesWithFilterAndSelectIncludesFullStats() throws IOException {
     ManifestFile manifest = writeManifest(1000L, FILE);
     try (ManifestReader<DataFile> reader = ManifestFiles.read(manifest, FILE_IO)
-        .select(ImmutableSet.of("file_path"))
+        .select(ImmutableList.of("file_path"))
         .filterRows(Expressions.equal("id", 3))) {
       CloseableIterable<ManifestEntry<DataFile>> entries = reader.entries();
       ManifestEntry<DataFile> entry = entries.iterator().next();
@@ -100,7 +100,7 @@ public class TestManifestReaderStats extends TableTestBase {
   public void testReadIteratorWithFilterAndSelectDropsStats() throws IOException {
     ManifestFile manifest = writeManifest(1000L, FILE);
     try (ManifestReader<DataFile> reader = ManifestFiles.read(manifest, FILE_IO)
-        .select(ImmutableSet.of("file_path"))
+        .select(ImmutableList.of("file_path"))
         .filterRows(Expressions.equal("id", 3))) {
       DataFile entry = reader.iterator().next();
       assertStatsDropped(entry);
@@ -110,7 +110,7 @@ public class TestManifestReaderStats extends TableTestBase {
   public void testReadIteratorWithFilterAndSelectStatsIncludesFullStats() throws IOException {
     ManifestFile manifest = writeManifest(1000L, FILE);
     try (ManifestReader<DataFile> reader = ManifestFiles.read(manifest, FILE_IO)
-        .select(ImmutableSet.of("file_path", "value_counts"))
+        .select(ImmutableList.of("file_path", "value_counts"))
         .filterRows(Expressions.equal("id", 3))) {
       DataFile entry = reader.iterator().next();
       assertFullStats(entry);
@@ -121,7 +121,7 @@ public class TestManifestReaderStats extends TableTestBase {
   public void testReadEntriesWithSelectNotIncludeFullStats() throws IOException {
     ManifestFile manifest = writeManifest(1000L, FILE);
     try (ManifestReader<DataFile> reader = ManifestFiles.read(manifest, FILE_IO)
-        .select(ImmutableSet.of("file_path"))) {
+        .select(ImmutableList.of("file_path"))) {
       CloseableIterable<ManifestEntry<DataFile>> entries = reader.entries();
       ManifestEntry<DataFile> entry = entries.iterator().next();
       assertNoStats(entry.file());
@@ -131,7 +131,7 @@ public class TestManifestReaderStats extends TableTestBase {
   public void testReadEntriesWithSelectCertainStatNotIncludeFullStats() throws IOException {
     ManifestFile manifest = writeManifest(1000L, FILE);
     try (ManifestReader<DataFile> reader = ManifestFiles.read(manifest, FILE_IO)
-        .select(ImmutableSet.of("file_path", "value_counts"))) {
+        .select(ImmutableList.of("file_path", "value_counts"))) {
       DataFile dataFile = reader.iterator().next();
 
       Assert.assertEquals(-1, dataFile.recordCount());

--- a/core/src/test/java/org/apache/iceberg/TestManifestReaderStats.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReaderStats.java
@@ -116,6 +116,18 @@ public class TestManifestReaderStats extends TableTestBase {
       assertStatsDropped(entry);
     }
   }
+
+  @Test
+  public void testReadIteratorWithFilterAndSelectRecordCountDropsStats() throws IOException {
+    ManifestFile manifest = writeManifest(1000L, FILE);
+    try (ManifestReader<DataFile> reader = ManifestFiles.read(manifest, FILE_IO)
+        .select(ImmutableList.of("file_path", "record_count"))
+        .filterRows(Expressions.equal("id", 3))) {
+      DataFile entry = reader.iterator().next();
+      assertStatsDropped(entry);
+    }
+  }
+
   @Test
   public void testReadIteratorWithFilterAndSelectStatsIncludesFullStats() throws IOException {
     ManifestFile manifest = writeManifest(1000L, FILE);
@@ -124,6 +136,9 @@ public class TestManifestReaderStats extends TableTestBase {
         .filterRows(Expressions.equal("id", 3))) {
       DataFile entry = reader.iterator().next();
       assertFullStats(entry);
+
+      // explicitly call copyWithoutStats and ensure record count will not be dropped
+      assertStatsDropped(entry.copyWithoutStats());
     }
   }
 


### PR DESCRIPTION
- Please see [this comment](https://github.com/apache/iceberg/pull/1803#discussion_r528061128_) for the reason to have this change
- Please note that this changes the behavior of `recordCount` in `BaseFile`; originally if `BaseFile` was created by avro schema reflection without populating `recordCount`, calling `recordCount()` will throw NPE because its return type is primitive. I'm currently following the same style as `fileSizeInBytes` to return -1 when it is not populated. 
- One implication of this is that the NPE problem described in the original comment will no longer exist, instead metrics evaluators will not filter out anything. 
- Alternatively I can refrain from changing this and accept that `data.recordCount()` could throw NPE in tests, or change the return type of `recordCount()` to be `Long`; I don't really have a strong preference so suggestions are welcome!