### PR TITLE
Flink: add limit pushdown for IcebergTableSource

### DIFF
--- a/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSource.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSource.java
@@ -45,8 +45,8 @@ public class IcebergTableSource
   private final TableSchema schema;
   private final Map<String, String> properties;
   private final int[] projectedFields;
-  private boolean isLimitPushDown = false;
-  private long limit = -1L;
+  private final boolean isLimitPushDown;
+  private final long limit;
 
   public IcebergTableSource(TableLoader loader, TableSchema schema, Map<String, String> properties) {
     this(loader, schema, properties, null, false, -1);
@@ -109,7 +109,7 @@ public class IcebergTableSource
     }
 
     if (isLimitPushDown) {
-      explain += String.format(", LimitPushDown %s, Limit %d", isLimitPushDown, limit);
+      explain += String.format(", LimitPushDown : %d", limit);
     }
 
     return TableConnectorUtils.generateRuntimeName(getClass(), getTableSchema().getFieldNames()) + explain;

--- a/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSource.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSource.java
@@ -36,25 +36,30 @@ import org.apache.iceberg.flink.source.FlinkSource;
 
 /**
  * Flink Iceberg table source.
- * TODO: Implement {@link FilterableTableSource} and {@link LimitableTableSource}.
+ * TODO: Implement {@link FilterableTableSource}
  */
-public class IcebergTableSource implements StreamTableSource<RowData>, ProjectableTableSource<RowData> {
+public class IcebergTableSource
+    implements StreamTableSource<RowData>, ProjectableTableSource<RowData>, LimitableTableSource<RowData> {
 
   private final TableLoader loader;
   private final TableSchema schema;
   private final Map<String, String> properties;
   private final int[] projectedFields;
+  private boolean isLimitPushDown = false;
+  private long limit = -1L;
 
   public IcebergTableSource(TableLoader loader, TableSchema schema, Map<String, String> properties) {
-    this(loader, schema, properties, null);
+    this(loader, schema, properties, null, false, -1);
   }
 
   private IcebergTableSource(TableLoader loader, TableSchema schema, Map<String, String> properties,
-                             int[] projectedFields) {
+                             int[] projectedFields, boolean isLimitPushDown, long limit) {
     this.loader = loader;
     this.schema = schema;
     this.properties = properties;
     this.projectedFields = projectedFields;
+    this.isLimitPushDown = isLimitPushDown;
+    this.limit = limit;
   }
 
   @Override
@@ -64,12 +69,12 @@ public class IcebergTableSource implements StreamTableSource<RowData>, Projectab
 
   @Override
   public TableSource<RowData> projectFields(int[] fields) {
-    return new IcebergTableSource(loader, schema, properties, fields);
+    return new IcebergTableSource(loader, schema, properties, fields, isLimitPushDown, limit);
   }
 
   @Override
   public DataStream<RowData> getDataStream(StreamExecutionEnvironment execEnv) {
-    return FlinkSource.forRowData().env(execEnv).tableLoader(loader).project(getProjectedSchema())
+    return FlinkSource.forRowData().env(execEnv).tableLoader(loader).project(getProjectedSchema()).limit(limit)
         .properties(properties).build();
   }
 
@@ -102,6 +107,21 @@ public class IcebergTableSource implements StreamTableSource<RowData>, Projectab
     if (projectedFields != null) {
       explain += ", ProjectedFields: " + Arrays.toString(projectedFields);
     }
+
+    if (isLimitPushDown) {
+      explain += String.format(", LimitPushDown %s, Limit %d", isLimitPushDown, limit);
+    }
+
     return TableConnectorUtils.generateRuntimeName(getClass(), getTableSchema().getFieldNames()) + explain;
+  }
+
+  @Override
+  public boolean isLimitPushedDown() {
+    return isLimitPushDown;
+  }
+
+  @Override
+  public TableSource<RowData> applyLimit(long newLimit) {
+    return new IcebergTableSource(loader, schema, properties, projectedFields, true, newLimit);
   }
 }

--- a/flink/src/main/java/org/apache/iceberg/flink/source/FlinkInputFormat.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/source/FlinkInputFormat.java
@@ -49,7 +49,6 @@ public class FlinkInputFormat extends RichInputFormat<RowData, FlinkInputSplit> 
 
   private transient RowDataIterator iterator;
   private transient long currentReadCount = 0L;
-  private transient long limit;
 
   FlinkInputFormat(TableLoader tableLoader, Schema tableSchema, FileIO io, EncryptionManager encryption,
                    ScanContext context) {
@@ -95,12 +94,11 @@ public class FlinkInputFormat extends RichInputFormat<RowData, FlinkInputSplit> 
     this.iterator = new RowDataIterator(
         split.getTask(), io, encryption, tableSchema, context.projectedSchema(), context.nameMapping(),
         context.caseSensitive());
-    this.limit = context.limit();
   }
 
   @Override
   public boolean reachedEnd() {
-    if (limit > 0 && currentReadCount >= limit) {
+    if (context.limit() > 0 && currentReadCount >= context.limit()) {
       return true;
     } else {
       return !iterator.hasNext();

--- a/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSource.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSource.java
@@ -70,6 +70,7 @@ public class FlinkSource {
     private Table table;
     private TableLoader tableLoader;
     private TableSchema projectedSchema;
+    private long limit;
     private ScanContext context = new ScanContext();
 
     private RowDataTypeInfo rowTypeInfo;
@@ -96,6 +97,11 @@ public class FlinkSource {
 
     public Builder project(TableSchema schema) {
       this.projectedSchema = schema;
+      return this;
+    }
+
+    public Builder limit(long newLimit) {
+      this.limit = newLimit;
       return this;
     }
 
@@ -179,6 +185,8 @@ public class FlinkSource {
 
       context = context.project(projectedSchema == null ? icebergSchema :
           FlinkSchemaUtil.convert(icebergSchema, projectedSchema));
+
+      context = context.limit(limit);
 
       return new FlinkInputFormat(tableLoader, icebergSchema, io, encryption, context);
     }

--- a/flink/src/main/java/org/apache/iceberg/flink/source/ScanContext.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/source/ScanContext.java
@@ -61,8 +61,6 @@ class ScanContext implements Serializable {
   private static final ConfigOption<Long> SPLIT_FILE_OPEN_COST =
       ConfigOptions.key("split-file-open-cost").longType().defaultValue(null);
 
-  private static final ConfigOption<Long> LIMIT = ConfigOptions.key("limit").longType().defaultValue(-1L);
-
   private final boolean caseSensitive;
   private final Long snapshotId;
   private final Long startSnapshotId;
@@ -88,7 +86,7 @@ class ScanContext implements Serializable {
     this.nameMapping = null;
     this.projectedSchema = null;
     this.filterExpressions = null;
-    this.limit = -1L;
+    this.limit = null;
   }
 
   private ScanContext(boolean caseSensitive, Long snapshotId, Long startSnapshotId, Long endSnapshotId,

--- a/flink/src/main/java/org/apache/iceberg/flink/source/ScanContext.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/source/ScanContext.java
@@ -61,6 +61,8 @@ class ScanContext implements Serializable {
   private static final ConfigOption<Long> SPLIT_FILE_OPEN_COST =
       ConfigOptions.key("split-file-open-cost").longType().defaultValue(null);
 
+  private static final ConfigOption<Long> LIMIT = ConfigOptions.key("limit").longType().defaultValue(-1L);
+
   private final boolean caseSensitive;
   private final Long snapshotId;
   private final Long startSnapshotId;
@@ -72,6 +74,7 @@ class ScanContext implements Serializable {
   private final String nameMapping;
   private final Schema projectedSchema;
   private final List<Expression> filterExpressions;
+  private final Long limit;
 
   ScanContext() {
     this.caseSensitive = CASE_SENSITIVE.defaultValue();
@@ -85,11 +88,12 @@ class ScanContext implements Serializable {
     this.nameMapping = null;
     this.projectedSchema = null;
     this.filterExpressions = null;
+    this.limit = -1L;
   }
 
   private ScanContext(boolean caseSensitive, Long snapshotId, Long startSnapshotId, Long endSnapshotId,
       Long asOfTimestamp, Long splitSize, Integer splitLookback, Long splitOpenFileCost,
-      String nameMapping, Schema projectedSchema, List<Expression> filterExpressions) {
+      String nameMapping, Schema projectedSchema, List<Expression> filterExpressions, Long limit) {
     this.caseSensitive = caseSensitive;
     this.snapshotId = snapshotId;
     this.startSnapshotId = startSnapshotId;
@@ -101,6 +105,7 @@ class ScanContext implements Serializable {
     this.nameMapping = nameMapping;
     this.projectedSchema = projectedSchema;
     this.filterExpressions = filterExpressions;
+    this.limit = limit;
   }
 
   ScanContext fromProperties(Map<String, String> properties) {
@@ -108,7 +113,8 @@ class ScanContext implements Serializable {
     properties.forEach(config::setString);
     return new ScanContext(config.get(CASE_SENSITIVE), config.get(SNAPSHOT_ID), config.get(START_SNAPSHOT_ID),
         config.get(END_SNAPSHOT_ID), config.get(AS_OF_TIMESTAMP), config.get(SPLIT_SIZE), config.get(SPLIT_LOOKBACK),
-        config.get(SPLIT_FILE_OPEN_COST), properties.get(DEFAULT_NAME_MAPPING), projectedSchema, filterExpressions);
+        config.get(SPLIT_FILE_OPEN_COST), properties.get(DEFAULT_NAME_MAPPING), projectedSchema, filterExpressions,
+        limit);
   }
 
   boolean caseSensitive() {
@@ -117,7 +123,7 @@ class ScanContext implements Serializable {
 
   ScanContext setCaseSensitive(boolean isCaseSensitive) {
     return new ScanContext(isCaseSensitive, snapshotId, startSnapshotId, endSnapshotId, asOfTimestamp, splitSize,
-        splitLookback, splitOpenFileCost, nameMapping, projectedSchema, filterExpressions);
+        splitLookback, splitOpenFileCost, nameMapping, projectedSchema, filterExpressions, limit);
   }
 
   Long snapshotId() {
@@ -126,7 +132,7 @@ class ScanContext implements Serializable {
 
   ScanContext useSnapshotId(Long scanSnapshotId) {
     return new ScanContext(caseSensitive, scanSnapshotId, startSnapshotId, endSnapshotId, asOfTimestamp, splitSize,
-        splitLookback, splitOpenFileCost, nameMapping, projectedSchema, filterExpressions);
+        splitLookback, splitOpenFileCost, nameMapping, projectedSchema, filterExpressions, limit);
   }
 
   Long startSnapshotId() {
@@ -135,7 +141,7 @@ class ScanContext implements Serializable {
 
   ScanContext startSnapshotId(Long id) {
     return new ScanContext(caseSensitive, snapshotId, id, endSnapshotId, asOfTimestamp, splitSize, splitLookback,
-        splitOpenFileCost, nameMapping, projectedSchema, filterExpressions);
+        splitOpenFileCost, nameMapping, projectedSchema, filterExpressions, limit);
   }
 
   Long endSnapshotId() {
@@ -144,7 +150,7 @@ class ScanContext implements Serializable {
 
   ScanContext endSnapshotId(Long id) {
     return new ScanContext(caseSensitive, snapshotId, startSnapshotId, id, asOfTimestamp, splitSize, splitLookback,
-        splitOpenFileCost, nameMapping, projectedSchema, filterExpressions);
+        splitOpenFileCost, nameMapping, projectedSchema, filterExpressions, limit);
   }
 
   Long asOfTimestamp() {
@@ -153,7 +159,7 @@ class ScanContext implements Serializable {
 
   ScanContext asOfTimestamp(Long timestamp) {
     return new ScanContext(caseSensitive, snapshotId, startSnapshotId, endSnapshotId, timestamp, splitSize,
-        splitLookback, splitOpenFileCost, nameMapping, projectedSchema, filterExpressions);
+        splitLookback, splitOpenFileCost, nameMapping, projectedSchema, filterExpressions, limit);
   }
 
   Long splitSize() {
@@ -162,7 +168,7 @@ class ScanContext implements Serializable {
 
   ScanContext splitSize(Long size) {
     return new ScanContext(caseSensitive, snapshotId, startSnapshotId, endSnapshotId, asOfTimestamp, size,
-        splitLookback, splitOpenFileCost, nameMapping, projectedSchema, filterExpressions);
+        splitLookback, splitOpenFileCost, nameMapping, projectedSchema, filterExpressions, limit);
   }
 
   Integer splitLookback() {
@@ -171,7 +177,7 @@ class ScanContext implements Serializable {
 
   ScanContext splitLookback(Integer lookback) {
     return new ScanContext(caseSensitive, snapshotId, startSnapshotId, endSnapshotId, asOfTimestamp, splitSize,
-        lookback, splitOpenFileCost, nameMapping, projectedSchema, filterExpressions);
+        lookback, splitOpenFileCost, nameMapping, projectedSchema, filterExpressions, limit);
   }
 
   Long splitOpenFileCost() {
@@ -180,7 +186,7 @@ class ScanContext implements Serializable {
 
   ScanContext splitOpenFileCost(Long fileCost) {
     return new ScanContext(caseSensitive, snapshotId, startSnapshotId, endSnapshotId, asOfTimestamp, splitSize,
-        splitLookback, fileCost, nameMapping, projectedSchema, filterExpressions);
+        splitLookback, fileCost, nameMapping, projectedSchema, filterExpressions, limit);
   }
 
   String nameMapping() {
@@ -189,7 +195,7 @@ class ScanContext implements Serializable {
 
   ScanContext nameMapping(String mapping) {
     return new ScanContext(caseSensitive, snapshotId, startSnapshotId, endSnapshotId, asOfTimestamp, splitSize,
-        splitLookback, splitOpenFileCost, mapping, projectedSchema, filterExpressions);
+        splitLookback, splitOpenFileCost, mapping, projectedSchema, filterExpressions, limit);
   }
 
   Schema projectedSchema() {
@@ -198,7 +204,7 @@ class ScanContext implements Serializable {
 
   ScanContext project(Schema schema) {
     return new ScanContext(caseSensitive, snapshotId, startSnapshotId, endSnapshotId, asOfTimestamp, splitSize,
-        splitLookback, splitOpenFileCost, nameMapping, schema, filterExpressions);
+        splitLookback, splitOpenFileCost, nameMapping, schema, filterExpressions, limit);
   }
 
   List<Expression> filterExpressions() {
@@ -207,6 +213,15 @@ class ScanContext implements Serializable {
 
   ScanContext filterRows(List<Expression> filters) {
     return new ScanContext(caseSensitive, snapshotId, startSnapshotId, endSnapshotId, asOfTimestamp, splitSize,
-        splitLookback, splitOpenFileCost, nameMapping, projectedSchema, filters);
+        splitLookback, splitOpenFileCost, nameMapping, projectedSchema, filters, limit);
+  }
+
+  long limit() {
+    return limit;
+  }
+
+  ScanContext limit(Long newLimit) {
+    return new ScanContext(caseSensitive, snapshotId, startSnapshotId, endSnapshotId, asOfTimestamp, splitSize,
+        splitLookback, splitOpenFileCost, nameMapping, projectedSchema, filterExpressions, newLimit);
   }
 }

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSource.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSource.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink;
+
+
+import java.util.List;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public class TestFlinkTableSource extends FlinkCatalogTestBase {
+  private static final String TABLE_NAME = "test_table";
+
+  private final FileFormat format;
+
+  @Parameterized.Parameters(name = "catalogName={0}, baseNamespace={1}, format={2}")
+  public static Iterable<Object[]> parameters() {
+    List<Object[]> parameters = Lists.newArrayList();
+    for (FileFormat format : new FileFormat[] {FileFormat.ORC, FileFormat.AVRO, FileFormat.PARQUET}) {
+      for (Object[] catalogParams : FlinkCatalogTestBase.parameters()) {
+        String catalogName = (String) catalogParams[0];
+        String[] baseNamespace = (String[]) catalogParams[1];
+        parameters.add(new Object[] {catalogName, baseNamespace, format});
+      }
+    }
+    return parameters;
+  }
+
+  public TestFlinkTableSource(String catalogName, String[] baseNamespace, FileFormat format) {
+    super(catalogName, baseNamespace);
+    this.format = format;
+  }
+
+  @Before
+  public void before() {
+    super.before();
+    sql("CREATE DATABASE %s", flinkDatabase);
+    sql("USE CATALOG %s", catalogName);
+    sql("USE %s", DATABASE);
+    sql("CREATE TABLE %s (id INT, data VARCHAR) with ('write.format.default'='%s')", TABLE_NAME, format.name());
+  }
+
+  @After
+  public void clean() {
+    sql("DROP TABLE IF EXISTS %s.%s", flinkDatabase, TABLE_NAME);
+    sql("DROP DATABASE IF EXISTS %s", flinkDatabase);
+    super.clean();
+  }
+
+  @Test
+  public void testLimitPushDown() {
+    sql("INSERT INTO %s  VALUES (1,'a'),(2,'b')", TABLE_NAME);
+
+    String querySql = String.format("SELECT * FROM %s LIMIT 1", TABLE_NAME);
+    String explain = getTableEnv().explainSql(querySql);
+    String expectedExplain = "LimitPushDown true, Limit 1";
+    assertTrue("explain should contains LimitPushDown", explain.contains(expectedExplain));
+
+    List<Object[]> result = sql(querySql);
+    Assert.assertEquals("should have 1 record", 1, result.size());
+    Assert.assertArrayEquals("Should produce the expected records", result.get(0), new Object[] {1, "a"});
+  }
+}


### PR DESCRIPTION
related to #1816 

now the source implement the interface `LimitableTableSource`,
after flink 1.12 ,implement the `SupportsLimitPushDown`