### PR TITLE
AWS: Glue catalog lock interface

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
@@ -68,11 +68,13 @@ public class GlueTestBase {
     String testBucketPath = "s3://" + testBucketName + "/" + testPathPrefix;
     S3FileIO fileIO = new S3FileIO(clientFactory::s3);
     glueCatalog = new GlueCatalog();
-    glueCatalog.initialize(catalogName, testBucketPath, new AwsProperties(), glue, fileIO);
+    glueCatalog.initialize(catalogName, testBucketPath, new AwsProperties(), glue,
+            LockManagers.defaultLockManager(), fileIO);
     AwsProperties properties = new AwsProperties();
     properties.setGlueCatalogSkipArchive(true);
     glueCatalogWithSkip = new GlueCatalog();
-    glueCatalogWithSkip.initialize(catalogName, testBucketPath, properties, glue, fileIO);
+    glueCatalogWithSkip.initialize(catalogName, testBucketPath, properties, glue,
+            LockManagers.defaultLockManager(), fileIO);
   }
 
   @AfterClass

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/S3FileIOTest.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/S3FileIOTest.java
@@ -36,7 +36,6 @@ import org.apache.iceberg.aws.AwsIntegTestUtil;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -202,8 +201,7 @@ public class S3FileIOTest {
 
   @Test
   public void testClientFactorySerialization() throws Exception {
-    S3FileIO fileIO = new S3FileIO();
-    fileIO.initialize(Maps.newHashMap());
+    S3FileIO fileIO = new S3FileIO(clientFactory::s3);
     write(fileIO);
     byte [] data = SerializationUtils.serialize(fileIO);
     S3FileIO fileIO2 = SerializationUtils.deserialize(data);

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/LockManager.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/LockManager.java
@@ -38,9 +38,9 @@ interface LockManager extends AutoCloseable {
    * Release a lock
    * @param entityId ID of the entity to lock
    * @param ownerId ID of the owner if the lock
-   * @throws IllegalArgumentException if lock entity not found or trying to unlock with a wrong owner ID
+   * @return if the lock for the entity of the owner is released
    */
-  void release(String entityId, String ownerId);
+  boolean release(String entityId, String ownerId);
 
   /**
    * Initialize lock manager from catalog properties.

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/LockManager.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/LockManager.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.aws.glue;
+
+import java.util.Map;
+
+/**
+ * An interface for locking, used to ensure Glue catalog commit isolation.
+ */
+interface LockManager extends AutoCloseable {
+
+  /**
+   * Try to acquire a lock
+   * @param entityId ID of the entity to lock
+   * @param ownerId ID of the owner if the lock
+   * @return if the lock for the entity is acquired by the owner
+   */
+  boolean acquire(String entityId, String ownerId);
+
+  /**
+   * Release a lock
+   * @param entityId ID of the entity to lock
+   * @param ownerId ID of the owner if the lock
+   * @throws IllegalArgumentException if lock entity not found or trying to unlock with a wrong owner ID
+   */
+  void release(String entityId, String ownerId);
+
+  /**
+   * Initialize lock manager from catalog properties.
+   * @param properties catalog properties
+   */
+  void initialize(Map<String, String> properties);
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/LockManagers.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/LockManagers.java
@@ -71,7 +71,7 @@ class LockManagers {
     return lockManager;
   }
 
-  abstract static class LockManagerBase implements LockManager {
+  abstract static class BaseLockManager implements LockManager {
 
     private static volatile ScheduledExecutorService scheduler;
 
@@ -133,7 +133,7 @@ class LockManagers {
    * This implementation should only be used for testing,
    * or if the caller only needs locking within the same JVM during table commits.
    */
-  static class InMemoryLockManager extends LockManagerBase {
+  static class InMemoryLockManager extends BaseLockManager {
 
     private static final Map<String, DefaultLockContent> LOCKS = Maps.newConcurrentMap();
     private static final Map<String, ScheduledFuture<?>> HEARTBEATS = Maps.newHashMap();

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/LockManagers.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/LockManagers.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.aws.glue;
+
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.common.DynConstructors;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.PropertyUtil;
+import org.apache.iceberg.util.Tasks;
+
+class LockManagers {
+
+  private static final LockManager LOCK_MANAGER_DEFAULT = new InMemoryLockManager(Maps.newHashMap());
+
+  private LockManagers() {
+  }
+
+  public static LockManager defaultLockManager() {
+    return LOCK_MANAGER_DEFAULT;
+  }
+
+  public static LockManager from(Map<String, String> properties) {
+    if (properties.containsKey(CatalogProperties.LOCK_IMPL)) {
+      return loadLockManager(properties.get(CatalogProperties.LOCK_IMPL), properties);
+    } else {
+      return defaultLockManager();
+    }
+  }
+
+  private static LockManager loadLockManager(String impl, Map<String, String> properties) {
+    DynConstructors.Ctor<LockManager> ctor;
+    try {
+      ctor = DynConstructors.builder(LockManager.class).hiddenImpl(impl).buildChecked();
+    } catch (NoSuchMethodException e) {
+      throw new IllegalArgumentException(String.format(
+          "Cannot initialize LockManager, missing no-arg constructor: %s", impl), e);
+    }
+
+    LockManager lockManager;
+    try {
+      lockManager = ctor.newInstance();
+    } catch (ClassCastException e) {
+      throw new IllegalArgumentException(
+          String.format("Cannot initialize LockManager, %s does not implement LockManager.", impl), e);
+    }
+
+    lockManager.initialize(properties);
+    return lockManager;
+  }
+
+  abstract static class LockManagerBase implements LockManager {
+
+    private static volatile ScheduledExecutorService scheduler;
+
+    private long acquireTimeoutMs;
+    private long acquireIntervalMs;
+    private long heartbeatIntervalMs;
+    private long heartbeatTimeoutMs;
+    private int heartbeatThreads;
+
+    public long heartbeatTimeoutMs() {
+      return heartbeatTimeoutMs;
+    }
+
+    public long heartbeatIntervalMs() {
+      return heartbeatIntervalMs;
+    }
+
+    public long acquireIntervalMs() {
+      return acquireIntervalMs;
+    }
+
+    public long acquireTimeoutMs() {
+      return acquireTimeoutMs;
+    }
+
+    public int heartbeatThreads() {
+      return heartbeatThreads;
+    }
+
+    @SuppressWarnings("StaticGuardedByInstance")
+    public ScheduledExecutorService scheduler() {
+      if (scheduler == null) {
+        synchronized (this) {
+          if (scheduler == null) {
+            scheduler = Executors.newScheduledThreadPool(heartbeatThreads);
+          }
+        }
+      }
+      return scheduler;
+    }
+
+    @Override
+    public void initialize(Map<String, String> properties) {
+      this.acquireTimeoutMs = PropertyUtil.propertyAsLong(properties,
+          CatalogProperties.LOCK_ACQUIRE_TIMEOUT_MS, CatalogProperties.LOCK_ACQUIRE_TIMEOUT_MS_DEFAULT);
+      this.acquireIntervalMs = PropertyUtil.propertyAsLong(properties,
+          CatalogProperties.LOCK_ACQUIRE_INTERVAL_MS, CatalogProperties.LOCK_ACQUIRE_INTERVAL_MS_DEFAULT);
+      this.heartbeatIntervalMs = PropertyUtil.propertyAsLong(properties,
+          CatalogProperties.LOCK_HEARTBEAT_INTERVAL_MS, CatalogProperties.LOCK_HEARTBEAT_INTERVAL_MS_DEFAULT);
+      this.heartbeatTimeoutMs = PropertyUtil.propertyAsLong(properties,
+          CatalogProperties.LOCK_HEARTBEAT_TIMEOUT_MS, CatalogProperties.LOCK_HEARTBEAT_TIMEOUT_MS_DEFAULT);
+      this.heartbeatThreads = PropertyUtil.propertyAsInt(properties,
+          CatalogProperties.LOCK_HEARTBEAT_THREADS, CatalogProperties.LOCK_HEARTBEAT_THREADS_DEFAULT);
+    }
+  }
+
+  /**
+   * Implementation of {@link LockManager} that uses an in-memory concurrent map for locking.
+   * This implementation should only be used for testing,
+   * or if the caller only needs locking within the same JVM during table commits.
+   */
+  static class InMemoryLockManager extends LockManagerBase {
+
+    private static final Map<String, DefaultLockContent> LOCKS = Maps.newConcurrentMap();
+    private static final Map<String, ScheduledFuture<?>> HEARTBEATS = Maps.newHashMap();
+
+    InMemoryLockManager(Map<String, String> properties) {
+      initialize(properties);
+    }
+
+    @VisibleForTesting
+    void acquireOnce(String entityId, String ownerId) {
+      DefaultLockContent content = LOCKS.get(entityId);
+      if (content != null && content.expireMs() > System.currentTimeMillis()) {
+        throw new IllegalStateException(String.format("Lock for %s currently held by %s, expiration: %s",
+            entityId, content.ownerId(), content.expireMs()));
+      }
+
+      long expiration = System.currentTimeMillis() + heartbeatTimeoutMs();
+      boolean succeed;
+      if (content == null) {
+        DefaultLockContent previous = LOCKS.putIfAbsent(
+            entityId, new DefaultLockContent(ownerId, expiration));
+        succeed = previous == null;
+      } else {
+        succeed = LOCKS.replace(entityId, content, new DefaultLockContent(ownerId, expiration));
+      }
+
+      if (succeed) {
+        // cleanup old heartbeat
+        if (HEARTBEATS.containsKey(entityId)) {
+          HEARTBEATS.remove(entityId).cancel(false);
+        }
+
+        HEARTBEATS.put(entityId, scheduler().scheduleAtFixedRate(() -> {
+          DefaultLockContent lastContent = LOCKS.get(entityId);
+          try {
+            long newExpiration = System.currentTimeMillis() + heartbeatTimeoutMs();
+            LOCKS.replace(entityId, lastContent, new DefaultLockContent(ownerId, newExpiration));
+          } catch (NullPointerException e) {
+            throw new RuntimeException("Cannot heartbeat to a deleted lock " + entityId, e);
+          }
+
+        }, 0, heartbeatIntervalMs(), TimeUnit.MILLISECONDS));
+
+      } else {
+        throw new IllegalStateException("Unable to acquire lock " + entityId);
+      }
+    }
+
+    @Override
+    public boolean acquire(String entityId, String ownerId) {
+      try {
+        Tasks.foreach(entityId)
+            .retry(Integer.MAX_VALUE - 1)
+            .onlyRetryOn(IllegalStateException.class)
+            .throwFailureWhenFinished()
+            .exponentialBackoff(acquireIntervalMs(), acquireIntervalMs(), acquireTimeoutMs(), 1)
+            .run(id -> acquireOnce(id, ownerId));
+        return true;
+      } catch (IllegalStateException e) {
+        return false;
+      }
+    }
+
+    @Override
+    public void release(String entityId, String ownerId) {
+      DefaultLockContent currentContent = LOCKS.get(entityId);
+      if (currentContent == null) {
+        throw new IllegalArgumentException("Cannot find lock for entity " + entityId);
+      }
+
+      if (!currentContent.ownerId().equals(ownerId)) {
+        throw new IllegalArgumentException(String.format(
+            "Cannot unlock %s by %s, current owner: %s", entityId, ownerId, currentContent.ownerId()));
+      }
+      HEARTBEATS.remove(entityId).cancel(false);
+      LOCKS.remove(entityId);
+    }
+
+    @Override
+    public void close() {
+      HEARTBEATS.values().forEach(future -> future.cancel(false));
+      HEARTBEATS.clear();
+      LOCKS.clear();
+    }
+  }
+
+  private static class DefaultLockContent {
+    private final String ownerId;
+    private final long expireMs;
+
+    DefaultLockContent(String ownerId, long expireMs) {
+      this.ownerId = ownerId;
+      this.expireMs = expireMs;
+    }
+
+    public long expireMs() {
+      return expireMs;
+    }
+
+    public String ownerId() {
+      return ownerId;
+    }
+
+  }
+}

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/GlueCatalogTest.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/GlueCatalogTest.java
@@ -70,7 +70,8 @@ public class GlueCatalogTest {
   public void before() {
     glue = Mockito.mock(GlueClient.class);
     glueCatalog = new GlueCatalog();
-    glueCatalog.initialize(CATALOG_NAME, WAREHOUSE_PATH, new AwsProperties(), glue, null);
+    glueCatalog.initialize(CATALOG_NAME, WAREHOUSE_PATH, new AwsProperties(), glue,
+        LockManagers.defaultLockManager(), null);
   }
 
   @Test
@@ -80,14 +81,16 @@ public class GlueCatalogTest {
         "Cannot initialize GlueCatalog because warehousePath must not be null",
         () -> {
             GlueCatalog catalog = new GlueCatalog();
-            catalog.initialize(CATALOG_NAME, null, new AwsProperties(), glue, null);
+            catalog.initialize(CATALOG_NAME, null, new AwsProperties(), glue,
+                LockManagers.defaultLockManager(), null);
         });
   }
 
   @Test
   public void constructor_warehousePathWithEndSlash() {
     GlueCatalog catalogWithSlash = new GlueCatalog();
-    catalogWithSlash.initialize(CATALOG_NAME, WAREHOUSE_PATH + "/", new AwsProperties(), glue, null);
+    catalogWithSlash.initialize(
+        CATALOG_NAME, WAREHOUSE_PATH + "/", new AwsProperties(), glue, LockManagers.defaultLockManager(), null);
     Mockito.doReturn(GetDatabaseResponse.builder()
         .database(Database.builder().name("db").build()).build())
         .when(glue).getDatabase(Mockito.any(GetDatabaseRequest.class));

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/InMemoryLockManagerTest.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/InMemoryLockManagerTest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.aws.glue;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class InMemoryLockManagerTest {
+
+  private LockManagers.InMemoryLockManager lockManager;
+  private String lockEntityId;
+  private String ownerId;
+
+  @Before
+  public void before() {
+    lockEntityId = UUID.randomUUID().toString();
+    ownerId = UUID.randomUUID().toString();
+    lockManager = new LockManagers.InMemoryLockManager(Maps.newHashMap());
+  }
+
+  @After
+  public void after() {
+    lockManager.close();
+  }
+
+  @Test
+  public void testAcquireOnce_singleProcess() {
+    lockManager.acquireOnce(lockEntityId, ownerId);
+  }
+
+  @Test
+  public void testAcquireOnce_multiProcess() {
+    List<Boolean> results = IntStream.range(0, 10).parallel()
+        .mapToObj(i -> {
+          try {
+            lockManager.acquireOnce(lockEntityId, ownerId);
+            return true;
+          } catch (IllegalStateException e) {
+            return false;
+          }
+        })
+        .collect(Collectors.toList());
+    Assert.assertEquals(
+        "only 1 thread should have acquired the lock",
+        1, results.stream().filter(s -> s).count());
+  }
+
+  @Test
+  public void testReleaseAndAcquire() {
+    Assert.assertTrue(lockManager.acquire(lockEntityId, ownerId));
+    lockManager.release(lockEntityId, ownerId);
+    Assert.assertTrue(lockManager.acquire(lockEntityId, ownerId));
+  }
+
+  @Test
+  public void testReleaseWithWrongOwner() {
+    Assert.assertTrue(lockManager.acquire(lockEntityId, ownerId));
+    AssertHelpers.assertThrows("should throw exception if ownerId is wrong",
+        IllegalArgumentException.class,
+        "current owner",
+        () -> lockManager.release(lockEntityId, UUID.randomUUID().toString()));
+  }
+
+  @Test
+  public void testAcquire_singleProcess() throws Exception {
+    Assert.assertTrue(lockManager.acquire(lockEntityId, ownerId));
+    String oldOwner = ownerId;
+
+    CompletableFuture.supplyAsync(() -> {
+      try {
+        Thread.sleep(5000);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+      lockManager.release(lockEntityId, oldOwner);
+      return null;
+    });
+
+    ownerId = UUID.randomUUID().toString();
+    long start = System.currentTimeMillis();
+    Assert.assertTrue(lockManager.acquire(lockEntityId, ownerId));
+    Assert.assertTrue("should succeed after 5 seconds",
+        System.currentTimeMillis() - start >= 5000);
+  }
+
+  @Test
+  public void testAcquire_multiProcess_allSucceed() {
+    lockManager.initialize(ImmutableMap.of(
+        CatalogProperties.LOCK_ACQUIRE_INTERVAL_MS, "500"
+    ));
+    long start = System.currentTimeMillis();
+    List<Boolean> results = IntStream.range(0, 10).parallel()
+        .mapToObj(i -> {
+          String owner = UUID.randomUUID().toString();
+          boolean succeeded = lockManager.acquire(lockEntityId, owner);
+          if (succeeded) {
+            try {
+              Thread.sleep(1000);
+            } catch (InterruptedException e) {
+              throw new RuntimeException(e);
+            }
+            lockManager.release(lockEntityId, owner);
+          }
+          return succeeded;
+        })
+        .collect(Collectors.toList());
+    Assert.assertEquals("all lock acquire should succeed sequentially",
+        10, results.stream().filter(s -> s).count());
+    Assert.assertTrue("must take more than 10 seconds", System.currentTimeMillis() - start >= 10000);
+  }
+
+  @Test
+  public void testAcquire_multiProcess_onlyOneSucceed() {
+    lockManager.initialize(ImmutableMap.of(
+        CatalogProperties.LOCK_ACQUIRE_TIMEOUT_MS, "10000"
+    ));
+
+    List<Boolean> results = IntStream.range(0, 10).parallel()
+        .mapToObj(i -> lockManager.acquire(lockEntityId, ownerId))
+        .collect(Collectors.toList());
+    Assert.assertEquals("only 1 thread should have acquired the lock",
+        1, results.stream().filter(s -> s).count());
+  }
+}

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/LockManagersTest.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/LockManagersTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.aws.glue;
+
+import java.util.Map;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LockManagersTest {
+
+  @Test
+  public void testLoadDefaultLockManager() {
+    Assert.assertTrue(LockManagers.defaultLockManager() instanceof LockManagers.InMemoryLockManager);
+  }
+
+  @Test
+  public void testLoadCustomLockManager() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(CatalogProperties.LOCK_IMPL, CustomLockManager.class.getName());
+    Assert.assertTrue(LockManagers.from(properties) instanceof CustomLockManager);
+  }
+
+  static class CustomLockManager implements LockManager {
+
+    @Override
+    public boolean acquire(String entityId, String ownerId) {
+      return false;
+    }
+
+    @Override
+    public void release(String entityId, String ownerId) {
+
+    }
+
+    @Override
+    public void close() throws Exception {
+
+    }
+
+    @Override
+    public void initialize(Map<String, String> properties) {
+
+    }
+  }
+}

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/LockManagersTest.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/LockManagersTest.java
@@ -47,8 +47,8 @@ public class LockManagersTest {
     }
 
     @Override
-    public void release(String entityId, String ownerId) {
-
+    public boolean release(String entityId, String ownerId) {
+      return false;
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -19,6 +19,8 @@
 
 package org.apache.iceberg;
 
+import java.util.concurrent.TimeUnit;
+
 public class CatalogProperties {
 
   private CatalogProperties() {
@@ -31,4 +33,24 @@ public class CatalogProperties {
   public static final String HIVE_URI = "uri";
   public static final String HIVE_CLIENT_POOL_SIZE = "clients";
   public static final int HIVE_CLIENT_POOL_SIZE_DEFAULT = 2;
+
+  public static final String LOCK_IMPL = "lock.impl";
+
+  public static final String LOCK_HEARTBEAT_INTERVAL_MS = "lock.heartbeat-interval-ms";
+  public static final long LOCK_HEARTBEAT_INTERVAL_MS_DEFAULT = TimeUnit.SECONDS.toMillis(3);
+
+  public static final String LOCK_HEARTBEAT_TIMEOUT_MS = "lock.heartbeat-timeout-ms";
+  public static final long LOCK_HEARTBEAT_TIMEOUT_MS_DEFAULT = TimeUnit.SECONDS.toMillis(15);
+
+  public static final String LOCK_HEARTBEAT_THREADS = "lock.heartbeat-threads";
+  public static final int LOCK_HEARTBEAT_THREADS_DEFAULT = 4;
+
+  public static final String LOCK_ACQUIRE_INTERVAL_MS = "lock.acquire-interval-ms";
+  public static final long LOCK_ACQUIRE_INTERVAL_MS_DEFAULT = TimeUnit.SECONDS.toMillis(5);
+
+  public static final String LOCK_ACQUIRE_TIMEOUT_MS = "lock.acquire-timeout-ms";
+  public static final long LOCK_ACQUIRE_TIMEOUT_MS_DEFAULT = TimeUnit.MINUTES.toMillis(3);
+
+  public static final String LOCK_TABLE = "lock.table";
+
 }


### PR DESCRIPTION
Allow Glue catalog to use an external DynamoDB table to enforce serializable isolation during commit.