### PR TITLE
Add support for converting avro schemas containing timestamps without the adjust-to-utc annotations

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -107,10 +107,15 @@ public class AvroSchemaUtil {
 
   public static boolean isTimestamptz(Schema schema) {
     LogicalType logicalType = schema.getLogicalType();
-    if (logicalType != null && logicalType instanceof LogicalTypes.TimestampMicros) {
+    if (logicalType instanceof LogicalTypes.TimestampMillis || logicalType instanceof LogicalTypes.TimestampMicros){
       // timestamptz is adjusted to UTC
       Object value = schema.getObjectProp(ADJUST_TO_UTC_PROP);
-      if (value instanceof Boolean) {
+
+      if(value == null){
+        // not all avro timestamp logical types will have the adjust_to_utc prop, default to not timestamptz
+        return false;
+      }
+      else if (value instanceof Boolean) {
         return (Boolean) value;
       } else if (value instanceof String) {
         return Boolean.parseBoolean((String) value);

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -112,7 +112,7 @@ public class AvroSchemaUtil {
       Object value = schema.getObjectProp(ADJUST_TO_UTC_PROP);
 
       if (value == null) {
-        // not all avro timestamp logical types will have the adjust_to_utc prop, default to not timestamptz
+        // not all avro timestamp logical types will have the adjust_to_utc prop, default to timestamp without timezone
         return false;
       } else if (value instanceof Boolean) {
         return (Boolean) value;

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -107,15 +107,14 @@ public class AvroSchemaUtil {
 
   public static boolean isTimestamptz(Schema schema) {
     LogicalType logicalType = schema.getLogicalType();
-    if (logicalType instanceof LogicalTypes.TimestampMillis || logicalType instanceof LogicalTypes.TimestampMicros){
+    if (logicalType instanceof LogicalTypes.TimestampMillis || logicalType instanceof LogicalTypes.TimestampMicros) {
       // timestamptz is adjusted to UTC
       Object value = schema.getObjectProp(ADJUST_TO_UTC_PROP);
 
-      if(value == null){
+      if (value == null) {
         // not all avro timestamp logical types will have the adjust_to_utc prop, default to not timestamptz
         return false;
-      }
-      else if (value instanceof Boolean) {
+      } else if (value instanceof Boolean) {
         return (Boolean) value;
       } else if (value instanceof String) {
         return Boolean.parseBoolean((String) value);

--- a/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
+++ b/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
@@ -181,12 +181,9 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
       } else if (
           logical instanceof LogicalTypes.TimestampMillis ||
           logical instanceof LogicalTypes.TimestampMicros) {
-        Object adjustToUTC = primitive.getObjectProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP);
-        Preconditions.checkArgument(adjustToUTC instanceof Boolean,
-            "Invalid value for adjust-to-utc: %s", adjustToUTC);
-        if ((Boolean) adjustToUTC) {
+        if(AvroSchemaUtil.isTimestamptz(primitive)){
           return Types.TimestampType.withZone();
-        } else {
+        }else{
           return Types.TimestampType.withoutZone();
         }
 

--- a/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
+++ b/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
@@ -181,9 +181,9 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
       } else if (
           logical instanceof LogicalTypes.TimestampMillis ||
           logical instanceof LogicalTypes.TimestampMicros) {
-        if(AvroSchemaUtil.isTimestamptz(primitive)){
+        if (AvroSchemaUtil.isTimestamptz(primitive)) {
           return Types.TimestampType.withZone();
-        }else{
+        } else {
           return Types.TimestampType.withoutZone();
         }
 

--- a/core/src/test/java/org/apache/iceberg/avro/TestSchemaConversions.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestSchemaConversions.java
@@ -86,6 +86,16 @@ public class TestSchemaConversions {
     }
   }
 
+  @Test
+  public void testAvroToIcebergTimestampTypeWithoutAdjustToUTC() {
+    // Not included in the primitives test because there is not a way to round trip the avro<->iceberg conversion
+    // This is because iceberg types can only can encode adjust-to-utc=true|false but not a missing adjust-to-utc
+    Type expectedIcebergType = Types.TimestampType.withoutZone();
+    Schema avroType = LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG));
+
+    Assert.assertEquals(expectedIcebergType, AvroSchemaUtil.convert(avroType));
+  }
+
   private Schema addAdjustToUtc(Schema schema, boolean adjustToUTC) {
     schema.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, adjustToUTC);
     return schema;


### PR DESCRIPTION
Currently trying to convert avro schemas to iceberg schemas fails for avro schemas containing timestamps but without the `adjust-to-utc` annotations. 

```
val icebergSchema = AvroSchemaUtil.toIceberg(avroSchema)
Exception in thread "main" java.lang.IllegalArgumentException: Invalid value for adjust-to-utc: null
	at org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkArgument(Preconditions.java:217)
	at org.apache.iceberg.avro.SchemaToType.primitive(SchemaToType.java:185)
```

The [avro spec](https://avro.apache.org/docs/current/spec.html#Timestamp+%28microsecond+precision%29) says the `timestamp-millis` and `timestamp-micros` types represent an instant on the global timeline, and this aligns with the [timestamp iceberg type](https://iceberg.apache.org/spec/#schemas-and-data-types). Thus, if `adjust-to-utc` is not configured then instead of failing we default to the `timestamp` iceberg type. 

Slack thread for context: 
https://the-asf.slack.com/archives/CF01LKV9S/p1605902467354000

Note:  I did not add support for the new avro types (`local-timestamp-millis/micros`) in this PR, but that would be a good next pass. 
