### PR TITLE
API for supporting a TransactionalCatalog to enable multi-table transactions

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Table.java
+++ b/api/src/main/java/org/apache/iceberg/Table.java
@@ -41,6 +41,13 @@ public interface Table {
 
   /**
    * Refresh the current table metadata.
+   *
+   * <p>If this table is associated with a TransactionalCatalog, this refresh will be bounded by
+   * the visibility that the {@code IsolationLevel} of that transaction exposes. For example, if
+   * we are in a context of {@code READ_COMMITTED}, this refresh will update to the latest state
+   * of the table. However, in the case of {@code SERIALIZABLE} where this table hasn't mutated
+   * within this transaction, calling refresh will have no impact as the isolation level
+   * constrains all observations to within the transactional snapshot.
    */
   void refresh();
 

--- a/api/src/main/java/org/apache/iceberg/Transaction.java
+++ b/api/src/main/java/org/apache/iceberg/Transaction.java
@@ -133,7 +133,7 @@ public interface Transaction {
   /**
    * Apply the pending changes from all actions and commit.
    *
-   * <p>If this a nested transaction within a {@link TransactionalCatalog}, this will only
+   * <p>If this is a nested transaction within a {@link TransactionalCatalog}, this will only
    * validate that the transaction can still apply. The changes are not completed until the
    * the commit is called on the {@link TransactionalCatalog}.
    *

--- a/api/src/main/java/org/apache/iceberg/Transaction.java
+++ b/api/src/main/java/org/apache/iceberg/Transaction.java
@@ -133,6 +133,10 @@ public interface Transaction {
   /**
    * Apply the pending changes from all actions and commit.
    *
+   * <p>If this a nested transaction within a {@link TransactionalCatalog}, this will only
+   * validate that the transaction can still apply. The changes are not completed until the
+   * the commit is called on the {@link TransactionalCatalog}.
+   *
    * @throws ValidationException If any update cannot be applied to the current table metadata.
    * @throws CommitFailedException If the updates cannot be committed due to conflicts.
    */

--- a/api/src/main/java/org/apache/iceberg/catalog/SupportsCatalogTransactions.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/SupportsCatalogTransactions.java
@@ -93,7 +93,7 @@ public interface SupportsCatalogTransactions {
   }
 
   /**
-   * Start a new transaction and return a {@TransactionalCatalog} that supports
+   * Start a new transaction and return a {@link TransactionalCatalog} that supports
    * cross table operations. If a {@link Catalog} supports {@link OPTIMISTIC}
    * locking mode, this will use that mode. If it only supports {@link PESSIMISTIC},
    * it will use that mode with default values for lock times.

--- a/api/src/main/java/org/apache/iceberg/catalog/SupportsCatalogTransactions.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/SupportsCatalogTransactions.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.catalog;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Catalog methods for working with catalog-level transactions.
+ *
+ * <p>Catalog implementations are not required to support catalog-level transactional state.
+ * If they do, they may support one or more {@code IsolationLevel}s and one or more
+ * {@code LockingMode}s.
+ */
+public interface SupportsCatalogTransactions {
+
+  /**
+   * The level of isolation for a transaction.
+   */
+  enum IsolationLevel {
+
+    /**
+     * Only read committed data. Reading the same table multiple times
+     * may result in different committed reads for each read.
+     */
+    READ_COMMITTED,
+
+    /**
+     * Only read committed data. Reading the same table multiple times will
+     * result in the same view of those tables.
+     */
+    REPEATED_READ,
+
+    /**
+     * Only read committed data. A commit will only succeed if there have
+     * been no changes to data read during the course of the transaction
+     * prior to the commit operation.
+     */
+    SERIALIZABLE;
+  }
+
+  /**
+   * The type of locking mode used by the transaction.
+   */
+  enum LockingMode {
+
+    /**
+     * Pessimistically lock tables. In this situation, each table being worked on will grab a lock.
+     * This mode will typically result in a better chance for transactions to complete at the cost
+     * of throughput and resource consumption.
+     */
+    PESSIMISTIC,
+
+    /**
+     * Run the transaction with an optimistic behavior. This assumes that most operations will not
+     * conflict. It typically increases concurrency and throughput while reducing resource
+     * consumption.
+     */
+    OPTIMISTIC;
+  }
+
+  /**
+   * Get the list of {@link LockingMode}s this Catalog supports.
+   * @return A set of locking modes supported.
+   */
+  default Set<LockingMode> lockingModes() {
+    return Collections.emptySet();
+  }
+
+  /**
+   * Get the list of {@link IsolationLevel}s this Catalog supports.
+   * @return A set of locking modes supported.
+   */
+  default Set<IsolationLevel> isolationLevels() {
+    return Collections.emptySet();
+  }
+
+  /**
+   * Start a new transaction and return a {@TransactionalCatalog} that supports
+   * cross table operations. If a {@link Catalog} supports {@link OPTIMISTIC}
+   * locking mode, this will use that mode. If it only supports {@link PESSIMISTIC},
+   * it will use that mode with default values for lock times.
+   *
+   * @param isolationLevel The {@link IsolationLevel} to use for the transaction.
+   * @return A Catalog with an open transaction.
+   * @throws IllegalArgumentException If the IsolationLevel is not supported.
+   */
+  TransactionalCatalog createTransaction(IsolationLevel isolationLevel);
+
+  /**
+   * Start a new transaction that holds locks for the life of the transaction.
+   *
+   * <p>If supported, this type of transaction allows a much higher likelihood of
+   * transaction completion but can also result in more failures, lower concurrency
+   * and deadlocks.
+   *
+   * @param isolationLevel The {@link IsolationLevel} to use for the transaction.
+   * @param lockWaitInMillis How long to wait in milliseconds when grabbing a pessimistic lock.
+   * @param maxTimeMillis The maximum amount of time the transaction is allowed to be open.
+   * @param tables An optional list of tables that should be locked immediately for this
+   *        transaction. Note that this can include tables that exist and tables that do not
+   *        exist as this transaction may be adding new tables and want to grab pessimistic locks
+   *        for those operations.
+   *
+   * @return A Catalog with an open transaction.
+   *
+   * @throws IllegalArgumentException If the IsolationLevel is not supported. Also throws if
+   *         {@code lockWaitInMillis} or {@code maxTimeMillis} are not within supported limits
+   *         (check specific {@link Catalog} documentation for any limits).
+   * @throws CommitFailedException If the list of {@code tables} cannot be locked.
+   * @throws ValidationException If the set of tables names includes tables names that are not
+   *         valid.
+   */
+  TransactionalCatalog createLockingTransaction(
+      IsolationLevel isolationLevel,
+      long lockWaitInMillis,
+      long maxTimeMillis,
+      TableIdentifier...tables);
+
+}

--- a/api/src/main/java/org/apache/iceberg/catalog/SupportsCatalogTransactions.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/SupportsCatalogTransactions.java
@@ -60,12 +60,12 @@ public interface SupportsCatalogTransactions {
     READ_COMMITTED,
 
     /**
-     * Reading the same table multiple times will result in the same view of that table.
-     * Different tables may come from different snapshots. A commit can be completed as
-     * long as any tables changed externally do not conflict with any writes within this
-     * transaction.
+     * Reading the same table multiple times within the same transaction will result in
+     * the same version of that table. Different tables may come from different snapshots.
+     * A commit can be completed as long as any tables changed externally do not conflict
+     * with any writes within this transaction.
      */
-    REPEATED_READ,
+    REPEATABLE_READ,
 
     /**
      * A commit will only succeed if there have been no meaningful changes to data read during
@@ -74,8 +74,9 @@ public interface SupportsCatalogTransactions {
      * consistent for all tables to a single point in time (or single snapshot of the database).
      * Additionally, it implies additional requirements around the successful completion of a
      * write. In order for a write to complete, any entities read during this transaction are also
-     * blocked from changing (via another transaction) post-read in ways that would influence the
-     * writes of this operation. This is also sometimes called snapshot isolation.
+     * disallowed from changing (via another transaction) post-read in ways that would influence the
+     * writes of this operation. This isolation level encompasses all the standard guarantees of
+     * snapshot isolation.
      */
     SERIALIZABLE;
 

--- a/api/src/main/java/org/apache/iceberg/catalog/TransactionalCatalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/TransactionalCatalog.java
@@ -48,6 +48,10 @@ import org.apache.iceberg.exceptions.CommitFailedException;
  * <p>Nested transactions such as creating a new table may fail. Those failures alone do
  * not necessarily result in a failure of the catalog-level transaction.
  *
+ * <p>Implementations of {@code TransactionalCatalog} are responsible for monitoring all
+ * table level operations that are spawned from this catalog and ensure that all nested
+ * transactions that are completed successfully are either exposed atomically or not.
+ *
  */
 public interface TransactionalCatalog extends Catalog, AutoCloseable {
 

--- a/api/src/main/java/org/apache/iceberg/catalog/TransactionalCatalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/TransactionalCatalog.java
@@ -45,8 +45,8 @@ import org.apache.iceberg.exceptions.CommitFailedException;
  * <p>When one of the items above occurs, the transaction is no longer valid. Further use
  * of the transaction will result in a {@link IllegalStateException} being thrown.
  *
- * <p>Nested transactions such creating a new table may fail within a transaction. Those
- * failures alone do not necessarily result in a failure of the Catalog-level transaction.
+ * <p>Nested transactions such as creating a new table may fail. Those failures alone do
+ * not necessarily result in a failure of the catalog-level transaction.
  *
  */
 public interface TransactionalCatalog extends Catalog, AutoCloseable {

--- a/api/src/main/java/org/apache/iceberg/catalog/TransactionalCatalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/TransactionalCatalog.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.catalog;
+
+import org.apache.iceberg.catalog.SupportsCatalogTransactions.IsolationLevel;
+import org.apache.iceberg.catalog.SupportsCatalogTransactions.LockingMode;
+import org.apache.iceberg.exceptions.CommitFailedException;
+
+/**
+ * A {@link Catalog} that applies all mutations within a single transaction.
+ *
+ * <p>A TransactionalCatalog can spawn child transactions for multiple operations on different
+ * tables. All operations will be done within the context of a single Catalog-level transaction
+ * and they will either all be successful or all fail.
+ *
+ * <p>A TransactionalCatalog is initially active upon creation and will remain so until one of
+ * the following terminal actions occurs:
+ * <ul>
+ * <li>{@link rollback} is called.
+ * <li>{@link commit} is called.
+ * <li>The transaction expires while using Pessimistic {@link LockingMode}.
+ * <li>The transaction is terminated externally (for example, when a locking arbitrator
+ *     determines a deadlock between two transactions has occurred).
+ * <li>The underlying implementation determines that the transaction can no longer complete
+ *     successfully.
+ * </ul>
+ *
+ * <p>When one of the items above occurs, the transaction is no longer valid. Further use
+ * of the transaction will result in a {@link IllegalStateException} being thrown.
+ *
+ * <p>Nested transactions such creating a new table may fail within a transaction. Those
+ * failures alone do not necessarily result in a failure of the Catalog-level transaction.
+ *
+ */
+public interface TransactionalCatalog extends Catalog, AutoCloseable {
+
+  /**
+   * An internal identifier associated with this transaction.
+   * @return An internal identifier.
+   */
+  String transactionId();
+
+  /**
+   * Return the current {@code IsolationLevel} for this transaction.
+   * @return The IsolationLevel for this transaction.
+   */
+  IsolationLevel isolationLevel();
+
+  /**
+   * Return the {@link LockingMode} for this transaction.
+   * @return The LockingMode for this transaction.
+   */
+  LockingMode lockingMode();
+
+  /**
+   * Whether the current transaction is still active/open.
+   * @return True until a terminal action occurs.
+   */
+  boolean active();
+
+  /**
+   * Aborts the set of operations here and makes this TransactionalCatalog inoperable.
+   *
+   * <p>Once called, no further operations can be done against this catalog. If any
+   * operations are attempted, {$link IllegalStateException} will be thrown.
+   */
+  void rollback();
+
+  /**
+   * Commit the pending changes from all nested transactions against the Catalog.
+   *
+   * <p>Once called, no further operations can be done against this catalog. If any
+   * operations are attempted, {$link IllegalStateException} will be thrown.
+   *
+   * @throws CommitFailedException If the updates cannot be committed due to conflicts.
+   */
+  void commit();
+
+  /**
+   * A shortcut for {@link commit} that allows users to use this catalog in try-with-resources
+   * block.
+   *
+   * @throws CommitFailedException If the updates cannot be committed due to conflicts.
+   */
+  default void close() {
+    commit();
+  }
+
+}

--- a/api/src/main/java/org/apache/iceberg/catalog/TransactionalCatalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/TransactionalCatalog.java
@@ -79,7 +79,7 @@ public interface TransactionalCatalog extends Catalog, AutoCloseable {
    * Aborts the set of operations here and makes this TransactionalCatalog inoperable.
    *
    * <p>Once called, no further operations can be done against this catalog. If any
-   * operations are attempted, {$link IllegalStateException} will be thrown.
+   * operations are attempted, {@link IllegalStateException} will be thrown.
    */
   void rollback();
 
@@ -87,7 +87,7 @@ public interface TransactionalCatalog extends Catalog, AutoCloseable {
    * Commit the pending changes from all nested transactions against the Catalog.
    *
    * <p>Once called, no further operations can be done against this catalog. If any
-   * operations are attempted, {$link IllegalStateException} will be thrown.
+   * operations are attempted, {@link IllegalStateException} will be thrown.
    *
    * @throws CommitFailedException If the updates cannot be committed due to conflicts.
    */
@@ -99,6 +99,7 @@ public interface TransactionalCatalog extends Catalog, AutoCloseable {
    *
    * @throws CommitFailedException If the updates cannot be committed due to conflicts.
    */
+  @Override
   default void close() {
     commit();
   }

--- a/api/src/main/java/org/apache/iceberg/catalog/TransactionalCatalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/TransactionalCatalog.java
@@ -114,9 +114,6 @@ public interface TransactionalCatalog extends Catalog, AutoCloseable {
    * the close will only close any remaining open resources associated with the transaction.
    */
   @Override
-  default void close() {
-    commit();
-    close();
-  }
+  void close();
 
 }


### PR DESCRIPTION
Introduce a new SupportsCatalogTransactions marker interface that can be added to a top-level Catalog. This
then allows the creation of a "TransactionalCatalog" that looks like a normal catalog but supports catalog-level
transactions using commit/rollback.

This closes #1647