### PR TITLE
Hive: fix hiveCatalog create/write table and hive client read no data

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -270,7 +270,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
       parameters.put(ConfigProperties.ENGINE_HIVE_ENABLED, "TRUE");
     } else {
       parameters.remove(hive_metastoreConstants.META_TABLE_STORAGE);
-      parameters.remove(ConfigProperties.ENGINE_HIVE_ENABLED);
+      parameters.put(ConfigProperties.ENGINE_HIVE_ENABLED, "FALSE");
     }
 
     tbl.setParameters(parameters);

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -270,7 +270,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
       parameters.put(ConfigProperties.ENGINE_HIVE_ENABLED, "TRUE");
     } else {
       parameters.remove(hive_metastoreConstants.META_TABLE_STORAGE);
-      parameters.put(ConfigProperties.ENGINE_HIVE_ENABLED, "FALSE");
+      parameters.remove(ConfigProperties.ENGINE_HIVE_ENABLED);
     }
 
     tbl.setParameters(parameters);

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
@@ -405,14 +405,14 @@ public class HiveTableTest extends HiveTableBaseTest {
           hmsTable.getSd().getInputFormat());
       Assert.assertEquals("org.apache.iceberg.mr.hive.HiveIcebergOutputFormat",
           hmsTable.getSd().getOutputFormat());
-      Assert.assertEquals(true, hmsTable.getParameters().get(ConfigProperties.ENGINE_HIVE_ENABLED));
+      Assert.assertEquals("TRUE", hmsTable.getParameters().get(ConfigProperties.ENGINE_HIVE_ENABLED));
     } else {
       Assert.assertNull(hmsTable.getParameters().get(hive_metastoreConstants.META_TABLE_STORAGE));
       Assert.assertEquals("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
           hmsTable.getSd().getSerdeInfo().getSerializationLib());
       Assert.assertEquals("org.apache.hadoop.mapred.FileInputFormat", hmsTable.getSd().getInputFormat());
       Assert.assertEquals("org.apache.hadoop.mapred.FileOutputFormat", hmsTable.getSd().getOutputFormat());
-      Assert.assertEquals(false, hmsTable.getParameters().get(ConfigProperties.ENGINE_HIVE_ENABLED));
+      Assert.assertEquals("FALSE", hmsTable.getParameters().get(ConfigProperties.ENGINE_HIVE_ENABLED));
     }
   }
 }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
@@ -405,14 +405,16 @@ public class HiveTableTest extends HiveTableBaseTest {
           hmsTable.getSd().getInputFormat());
       Assert.assertEquals("org.apache.iceberg.mr.hive.HiveIcebergOutputFormat",
           hmsTable.getSd().getOutputFormat());
-      Assert.assertEquals("TRUE", hmsTable.getParameters().get(ConfigProperties.ENGINE_HIVE_ENABLED));
+      Assert.assertEquals("TRUE",
+          hmsTable.getParameters().getOrDefault(ConfigProperties.ENGINE_HIVE_ENABLED, "FALSE"));
     } else {
       Assert.assertNull(hmsTable.getParameters().get(hive_metastoreConstants.META_TABLE_STORAGE));
       Assert.assertEquals("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
           hmsTable.getSd().getSerdeInfo().getSerializationLib());
       Assert.assertEquals("org.apache.hadoop.mapred.FileInputFormat", hmsTable.getSd().getInputFormat());
       Assert.assertEquals("org.apache.hadoop.mapred.FileOutputFormat", hmsTable.getSd().getOutputFormat());
-      Assert.assertEquals("FALSE", hmsTable.getParameters().get(ConfigProperties.ENGINE_HIVE_ENABLED));
+      Assert.assertEquals("FALSE",
+          hmsTable.getParameters().getOrDefault(ConfigProperties.ENGINE_HIVE_ENABLED, "FALSE"));
     }
   }
 }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
@@ -405,12 +405,14 @@ public class HiveTableTest extends HiveTableBaseTest {
           hmsTable.getSd().getInputFormat());
       Assert.assertEquals("org.apache.iceberg.mr.hive.HiveIcebergOutputFormat",
           hmsTable.getSd().getOutputFormat());
+      Assert.assertEquals(true, hmsTable.getParameters().get(ConfigProperties.ENGINE_HIVE_ENABLED));
     } else {
       Assert.assertNull(hmsTable.getParameters().get(hive_metastoreConstants.META_TABLE_STORAGE));
       Assert.assertEquals("org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
           hmsTable.getSd().getSerdeInfo().getSerializationLib());
       Assert.assertEquals("org.apache.hadoop.mapred.FileInputFormat", hmsTable.getSd().getInputFormat());
       Assert.assertEquals("org.apache.hadoop.mapred.FileOutputFormat", hmsTable.getSd().getOutputFormat());
+      Assert.assertEquals(false, hmsTable.getParameters().get(ConfigProperties.ENGINE_HIVE_ENABLED));
     }
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandlerBaseTest.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandlerBaseTest.java
@@ -364,10 +364,12 @@ public abstract class HiveIcebergStorageHandlerBaseTest {
       Assert.assertTrue(hmsParams.get(BaseMetastoreTableOperations.METADATA_LOCATION_PROP)
           .startsWith(icebergTable.location()));
       hmsParams.remove(BaseMetastoreTableOperations.METADATA_LOCATION_PROP);
+      Assert.assertEquals(7, hmsParams.size());
+    } else {
+      Assert.assertEquals(6, hmsParams.size());
     }
 
     // General metadata checks
-    Assert.assertEquals(7, hmsParams.size());
     Assert.assertEquals("test", hmsParams.get("dummy"));
     Assert.assertEquals("TRUE", hmsParams.get(InputFormatConfig.EXTERNAL_TABLE_PURGE));
     Assert.assertEquals("TRUE", hmsParams.get("EXTERNAL"));

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandlerBaseTest.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandlerBaseTest.java
@@ -445,7 +445,7 @@ public abstract class HiveIcebergStorageHandlerBaseTest {
     if (Catalogs.hiveCatalog(shell.getHiveConf())) {
       Assert.assertEquals(7, hmsParams.size());
     } else {
-      Assert.assertEquals(6, hmsParams.size());
+      Assert.assertEquals(5, hmsParams.size());
     }
   }
 
@@ -476,7 +476,7 @@ public abstract class HiveIcebergStorageHandlerBaseTest {
     if (Catalogs.hiveCatalog(shell.getHiveConf())) {
       Assert.assertEquals(7, hmsParams.size());
     } else {
-      Assert.assertEquals(6, hmsParams.size());
+      Assert.assertEquals(5, hmsParams.size());
     }
   }
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandlerBaseTest.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandlerBaseTest.java
@@ -367,7 +367,7 @@ public abstract class HiveIcebergStorageHandlerBaseTest {
     }
 
     // General metadata checks
-    Assert.assertEquals(6, hmsParams.size());
+    Assert.assertEquals(7, hmsParams.size());
     Assert.assertEquals("test", hmsParams.get("dummy"));
     Assert.assertEquals("TRUE", hmsParams.get(InputFormatConfig.EXTERNAL_TABLE_PURGE));
     Assert.assertEquals("TRUE", hmsParams.get("EXTERNAL"));
@@ -443,9 +443,9 @@ public abstract class HiveIcebergStorageHandlerBaseTest {
     Assert.assertNull(hmsParams.get(InputFormatConfig.PARTITION_SPEC));
 
     if (Catalogs.hiveCatalog(shell.getHiveConf())) {
-      Assert.assertEquals(6, hmsParams.size());
+      Assert.assertEquals(7, hmsParams.size());
     } else {
-      Assert.assertEquals(5, hmsParams.size());
+      Assert.assertEquals(6, hmsParams.size());
     }
   }
 
@@ -474,9 +474,9 @@ public abstract class HiveIcebergStorageHandlerBaseTest {
     // Just check that the PartitionSpec is not set in the metadata
     Assert.assertNull(hmsParams.get(InputFormatConfig.PARTITION_SPEC));
     if (Catalogs.hiveCatalog(shell.getHiveConf())) {
-      Assert.assertEquals(6, hmsParams.size());
+      Assert.assertEquals(7, hmsParams.size());
     } else {
-      Assert.assertEquals(5, hmsParams.size());
+      Assert.assertEquals(6, hmsParams.size());
     }
   }
 


### PR DESCRIPTION
Here I tried to make a PR for #1831 , and the way I adopted is as follows.

Save the value of `iceberg.engine.hive.enabled` to hive metastore, rather than  the value of `engine.hive.enabled` in the table property.

@pvary If you have time, I hope you can help to review it.