### PR TITLE
Spark: Add plans & rules for DELETE

### DIFF
--- a/spark3-extensions/src/main/scala/org/apache/iceberg/spark/extensions/IcebergSparkSessionExtensions.scala
+++ b/spark3-extensions/src/main/scala/org/apache/iceberg/spark/extensions/IcebergSparkSessionExtensions.scala
@@ -20,7 +20,9 @@
 package org.apache.iceberg.spark.extensions
 
 import org.apache.spark.sql.SparkSessionExtensions
+import org.apache.spark.sql.catalyst.analysis.DeleteFromTablePredicateCheck
 import org.apache.spark.sql.catalyst.analysis.ResolveProcedures
+import org.apache.spark.sql.catalyst.optimizer.{OptimizeConditionsInRowLevelOperations, PullupCorrelatedPredicatesInRowLevelOperations, RewriteDelete}
 import org.apache.spark.sql.catalyst.parser.extensions.IcebergSparkSqlExtensionsParser
 import org.apache.spark.sql.execution.datasources.v2.ExtendedDataSourceV2Strategy
 
@@ -29,6 +31,12 @@ class IcebergSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
   override def apply(extensions: SparkSessionExtensions): Unit = {
     extensions.injectParser { case (_, parser) => new IcebergSparkSqlExtensionsParser(parser) }
     extensions.injectResolutionRule { spark => ResolveProcedures(spark) }
+    extensions.injectCheckRule { _ => DeleteFromTablePredicateCheck }
+    // TODO: RewriteDelete should be executed after the operator optimization batch
+    extensions.injectOptimizerRule { _ => OptimizeConditionsInRowLevelOperations }
+    // TODO: PullupCorrelatedPredicates should handle row-level operations
+    extensions.injectOptimizerRule { _ => PullupCorrelatedPredicatesInRowLevelOperations }
+    extensions.injectOptimizerRule { _ => RewriteDelete }
     extensions.injectPlannerStrategy { _ => ExtendedDataSourceV2Strategy }
   }
 }

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/DeleteFromTablePredicateCheck.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/DeleteFromTablePredicateCheck.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.expressions.{Expression, InSubquery, Not}
+import org.apache.spark.sql.catalyst.plans.logical.{DeleteFromTable, LogicalPlan}
+
+object DeleteFromTablePredicateCheck extends (LogicalPlan => Unit) {
+
+  override def apply(plan: LogicalPlan): Unit = {
+    plan foreach {
+      case DeleteFromTable(_, Some(condition)) if hasNullAwarePredicateWithinNot(condition) =>
+        // this limitation is present since SPARK-25154 fix is not yet available
+        // we use Not(EqualsNullSafe(cond, true)) when deciding which records to keep
+        // such conditions are rewritten by Spark as an existential join and currently Spark
+        // does not handle correctly NOT IN subqueries nested into other expressions
+        failAnalysis("Null-aware predicate sub-queries are not currently supported in DELETE")
+
+      case _ => // OK
+    }
+  }
+
+  private def hasNullAwarePredicateWithinNot(cond: Expression): Boolean = {
+    cond.find {
+      case Not(expr) if expr.find(_.isInstanceOf[InSubquery]).isDefined => true
+      case _ => false
+    }.isDefined
+  }
+
+  private def failAnalysis(msg: String): Unit = throw new AnalysisException(msg)
+}

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeConditionsInRowLevelOperations.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeConditionsInRowLevelOperations.scala
@@ -35,12 +35,13 @@ object OptimizeConditionsInRowLevelOperations extends Rule[LogicalPlan] {
       d.copy(condition = Some(optimizedCond))
   }
 
-  private def optimizeCondition(condition: Expression, targetTable: LogicalPlan): Expression = {
+  private def optimizeCondition(cond: Expression, table: LogicalPlan): Expression = {
     val optimizer = SparkSession.active.sessionState.optimizer
-    optimizer.execute(Filter(condition, targetTable)) match {
+    optimizer.execute(Filter(cond, table)) match {
       case Filter(optimizedCondition, _) => optimizedCondition
       case _: LocalRelation => Literal.FalseLiteral
       case _: DataSourceV2ScanRelation => Literal.TrueLiteral
+      case _ => cond
     }
   }
 }

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeConditionsInRowLevelOperations.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/OptimizeConditionsInRowLevelOperations.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.{Expression, Literal, SubqueryExpression}
+import org.apache.spark.sql.catalyst.plans.logical.{DeleteFromTable, Filter, LocalRelation, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
+
+// we have to optimize expressions used in delete/update before we can rewrite row-level operations
+// otherwise, we will have to deal with redundant casts and will not detect noop deletes
+// it is a temp solution since we cannot inject rewrite of row-level ops after operator optimizations
+object OptimizeConditionsInRowLevelOperations extends Rule[LogicalPlan] {
+  override def apply(plan: LogicalPlan): LogicalPlan = plan transform {
+    case d @ DeleteFromTable(table, cond) if !SubqueryExpression.hasSubquery(cond.getOrElse(Literal.TrueLiteral)) =>
+      val optimizedCond = optimizeCondition(cond.getOrElse(Literal.TrueLiteral), table)
+      d.copy(condition = Some(optimizedCond))
+  }
+
+  private def optimizeCondition(condition: Expression, targetTable: LogicalPlan): Expression = {
+    val optimizer = SparkSession.active.sessionState.optimizer
+    optimizer.execute(Filter(condition, targetTable)) match {
+      case Filter(optimizedCondition, _) => optimizedCondition
+      case _: LocalRelation => Literal.FalseLiteral
+      case _: DataSourceV2ScanRelation => Literal.TrueLiteral
+    }
+  }
+}

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PullupCorrelatedPredicatesInRowLevelOperations.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/PullupCorrelatedPredicatesInRowLevelOperations.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.expressions.SubqueryExpression
+import org.apache.spark.sql.catalyst.plans.logical.{DeleteFromTable, Filter, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.Rule
+
+// a temp solution until PullupCorrelatedPredicates handles row-level operations in Spark
+object PullupCorrelatedPredicatesInRowLevelOperations extends Rule[LogicalPlan] {
+  override def apply(plan: LogicalPlan): LogicalPlan = plan transform {
+    case d @ DeleteFromTable(table, Some(cond)) if SubqueryExpression.hasSubquery(cond) =>
+      // Spark pulls up correlated predicates only for UnaryNodes
+      // DeleteFromTable does not extend UnaryNode so it is ignored in that rule
+      // We have this workaround until it is fixed in Spark
+      val filter = Filter(cond, table)
+      val transformedFilter = PullupCorrelatedPredicates.apply(filter)
+      val transformedCond = transformedFilter.asInstanceOf[Filter].condition
+      d.copy(condition = Some(transformedCond))
+  }
+}

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDelete.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDelete.scala
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import java.util.UUID
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.{sources, AnalysisException}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Ascending, Attribute, AttributeReference, EqualNullSafe, Expression, InputFileName, Literal, Not, PredicateHelper, SortOrder, SubqueryExpression}
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, DeleteFromTable, DynamicFileFilter, Filter, LogicalPlan, Project, RepartitionByExpression, ReplaceData, Sort}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.connector.catalog.Table
+import org.apache.spark.sql.connector.iceberg.catalog.ExtendedSupportsDelete
+import org.apache.spark.sql.connector.iceberg.read.SupportsFileFilter
+import org.apache.spark.sql.connector.iceberg.write.MergeBuilder
+import org.apache.spark.sql.connector.write.{LogicalWriteInfo, LogicalWriteInfoImpl}
+import org.apache.spark.sql.execution.datasources.DataSourceStrategy
+import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, DataSourceV2ScanRelation, PushDownUtils}
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.types.{BooleanType, StructType}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+// TODO: should be part of early scan push down after the delete condition is optimized
+object RewriteDelete extends Rule[LogicalPlan] with PredicateHelper with Logging {
+
+  import org.apache.spark.sql.execution.datasources.v2.ExtendedDataSourceV2Implicits._
+
+  private val FILE_NAME_COL = "_file"
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
+    // don't rewrite deletes that can be answered by passing filters to deleteWhere in SupportsDelete
+    case d @ DeleteFromTable(r: DataSourceV2Relation, Some(cond)) if isDeleteWhereCase(r, cond) =>
+      d
+
+    // rewrite all operations that require reading the table to delete records
+    case DeleteFromTable(r: DataSourceV2Relation, Some(cond)) =>
+      // TODO: do a switch based on whether we get BatchWrite or DeltaBatchWrite
+      val writeInfo = newWriteInfo(r.schema)
+      val mergeBuilder = r.table.asMergeable.newMergeBuilder(writeInfo)
+
+      val scanPlan = buildScanPlan(r.table, r.output, mergeBuilder, cond)
+
+      val remainingRowFilter = Not(EqualNullSafe(cond, Literal(true, BooleanType)))
+      val remainingRowsPlan = Filter(remainingRowFilter, scanPlan)
+
+      val batchWrite = mergeBuilder.asWriteBuilder.buildForBatch()
+      val writePlan = buildWritePlan(remainingRowsPlan, r.output)
+      ReplaceData(r, batchWrite, writePlan)
+  }
+
+  private def buildScanPlan(
+      table: Table,
+      output: Seq[AttributeReference],
+      mergeBuilder: MergeBuilder,
+      cond: Expression): LogicalPlan = {
+
+    val scanBuilder = mergeBuilder.asScanBuilder
+
+    val predicates = splitConjunctivePredicates(cond)
+    val normalizedPredicates = DataSourceStrategy.normalizeExprs(predicates, output)
+    PushDownUtils.pushFilters(scanBuilder, normalizedPredicates)
+
+    val scan = scanBuilder.build()
+    val scanRelation = DataSourceV2ScanRelation(table, scan, output)
+
+    val scanPlan = scan match {
+      case _: SupportsFileFilter =>
+        val matchingFilePlan = buildFileFilterPlan(cond, scanRelation)
+        val dynamicFileFilter = DynamicFileFilter(scanRelation, matchingFilePlan)
+        dynamicFileFilter
+      case _ =>
+        scanRelation
+    }
+
+    // include file name so that we can group data back
+    val fileNameExpr = Alias(InputFileName(), FILE_NAME_COL)()
+    Project(scanPlan.output :+ fileNameExpr, scanPlan)
+  }
+
+  private def buildWritePlan(
+      remainingRowsPlan: LogicalPlan,
+      output: Seq[AttributeReference]): LogicalPlan = {
+
+    // TODO: sort by _pos to keep the original ordering of rows
+    // TODO: consider setting a file size limit
+
+    val fileNameCol = findOutputAttr(remainingRowsPlan, FILE_NAME_COL)
+    val numShufflePartitions = SQLConf.get.numShufflePartitions
+    val repartition = RepartitionByExpression(Seq(fileNameCol), remainingRowsPlan, numShufflePartitions)
+    val sort = Sort(Seq(SortOrder(fileNameCol, Ascending)), global = false, repartition)
+    Project(output, sort)
+  }
+
+  private def isDeleteWhereCase(relation: DataSourceV2Relation, cond: Expression): Boolean = {
+    relation.table match {
+      case t: ExtendedSupportsDelete if !SubqueryExpression.hasSubquery(cond) =>
+        val predicates = splitConjunctivePredicates(cond)
+        val normalizedPredicates = DataSourceStrategy.normalizeExprs(predicates, relation.output)
+        val dataSourceFilters = toDataSourceFilters(normalizedPredicates)
+        val allPredicatesTranslated = normalizedPredicates.size == dataSourceFilters.length
+        allPredicatesTranslated && t.canDeleteWhere(dataSourceFilters)
+      case _ => false
+    }
+  }
+
+  private def toDataSourceFilters(predicates: Seq[Expression]): Array[sources.Filter] = {
+    predicates.flatMap { p =>
+      val translatedFilter = DataSourceStrategy.translateFilter(p, supportNestedPredicatePushdown = true)
+      if (translatedFilter.isEmpty) {
+        logWarning(s"Cannot translate expression to source filter: $p")
+      }
+      translatedFilter
+    }.toArray
+  }
+
+  private def newWriteInfo(schema: StructType): LogicalWriteInfo = {
+    val uuid = UUID.randomUUID()
+    LogicalWriteInfoImpl(queryId = uuid.toString, schema, CaseInsensitiveStringMap.empty)
+  }
+
+  private def buildFileFilterPlan(cond: Expression, scanRelation: DataSourceV2ScanRelation): LogicalPlan = {
+    val fileNameExpr = Alias(InputFileName(), FILE_NAME_COL)()
+    val fileNameProjection = Project(scanRelation.output :+ fileNameExpr, scanRelation)
+    val matchingFilter = Filter(cond, fileNameProjection)
+    val fileAttr = findOutputAttr(matchingFilter, FILE_NAME_COL)
+    val agg = Aggregate(Seq(fileAttr), Seq(fileAttr), matchingFilter)
+    Project(Seq(findOutputAttr(agg, FILE_NAME_COL)), agg)
+  }
+
+  private def findOutputAttr(plan: LogicalPlan, attrName: String): Attribute = {
+    val resolver = SQLConf.get.resolver
+    plan.output.find(attr => resolver(attr.name, attrName)).getOrElse {
+      throw new AnalysisException(s"Cannot find $attrName in ${plan.output}")
+    }
+  }
+}

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/DynamicFileFilter.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/DynamicFileFilter.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet}
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
+
+// TODO: fix stats (ignore the fact it is a binary node and report only scanRelation stats)
+case class DynamicFileFilter(
+    scanRelation: DataSourceV2ScanRelation,
+    fileFilterPlan: LogicalPlan) extends BinaryNode {
+
+  @transient
+  override lazy val references: AttributeSet = AttributeSet(fileFilterPlan.output)
+
+  override def left: LogicalPlan = scanRelation
+  override def right: LogicalPlan = fileFilterPlan
+  override def output: Seq[Attribute] = scanRelation.output
+}

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ReplaceData.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ReplaceData.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.analysis.NamedRelation
+import org.apache.spark.sql.connector.write.BatchWrite
+
+case class ReplaceData(
+    table: NamedRelation,
+    write: BatchWrite,
+    query: LogicalPlan) extends V2WriteCommand

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DynamicFileFilterExec.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DynamicFileFilterExec.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import collection.JavaConverters._
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, SortOrder}
+import org.apache.spark.sql.catalyst.plans.physical
+import org.apache.spark.sql.connector.iceberg.read.SupportsFileFilter
+import org.apache.spark.sql.execution.{BinaryExecNode, SparkPlan}
+import org.apache.spark.sql.vectorized.ColumnarBatch
+
+case class DynamicFileFilterExec(scanExec: ExtendedBatchScanExec, fileFilterExec: SparkPlan) extends BinaryExecNode {
+
+  @transient
+  override lazy val references: AttributeSet = AttributeSet(fileFilterExec.output)
+
+  override def left: SparkPlan = scanExec
+  override def right: SparkPlan = fileFilterExec
+  override def output: Seq[Attribute] = scanExec.output
+  override def outputPartitioning: physical.Partitioning = scanExec.outputPartitioning
+  override def outputOrdering: Seq[SortOrder] = scanExec.outputOrdering
+  override def supportsColumnar: Boolean = scanExec.supportsColumnar
+
+  override protected def doExecute(): RDD[InternalRow] = scanExec.execute()
+  override protected def doExecuteColumnar(): RDD[ColumnarBatch] = scanExec.executeColumnar()
+
+  override protected def doPrepare(): Unit = {
+    scanExec.scan match {
+      case s: SupportsFileFilter =>
+        val rows = fileFilterExec.executeCollect()
+        val matchedFileLocations = rows.map(_.getString(0))
+        s.filterFiles(matchedFileLocations.toSet.asJava)
+      case _ => // do nothing
+    }
+  }
+}

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedBatchScanExec.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedBatchScanExec.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.AttributeReference
+import org.apache.spark.sql.catalyst.plans.QueryPlan
+import org.apache.spark.sql.connector.read.{InputPartition, PartitionReaderFactory, Scan}
+
+// The only reason we need this class and cannot reuse BatchScanExec is because
+// BatchScanExec caches input partitions and we cannot apply file filtering before execution
+// Spark calls supportsColumnar during physical planning which, in turn, triggers split planning
+// We must ensure the result is not cached so that we can push down file filters later
+// The only difference compared to BatchScanExec is that we are using def instead of lazy val for splits
+case class ExtendedBatchScanExec(
+    output: Seq[AttributeReference],
+    @transient scan: Scan) extends DataSourceV2ScanExecBase {
+
+  @transient private lazy val batch = scan.toBatch
+
+  // TODO: unify the equal/hashCode implementation for all data source v2 query plans.
+  override def equals(other: Any): Boolean = other match {
+    case other: ExtendedBatchScanExec => this.batch == other.batch
+    case _ => false
+  }
+
+  override def hashCode(): Int = batch.hashCode()
+
+  override def partitions: Seq[InputPartition] = batch.planInputPartitions()
+
+  override lazy val readerFactory: PartitionReaderFactory = batch.createReaderFactory()
+
+  override def inputRDD: RDD[InternalRow] = {
+    new DataSourceRDD(sparkContext, partitions, readerFactory, supportsColumnar)
+  }
+
+  override def doCanonicalize(): ExtendedBatchScanExec = {
+    this.copy(output = output.map(QueryPlan.normalizeExpressions(_, output)))
+  }
+}

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Implicits.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Implicits.scala
@@ -31,7 +31,7 @@ object ExtendedDataSourceV2Implicits {
         case support: SupportsMerge =>
           support
         case _ =>
-          throw new AnalysisException(s"Table does not support row level operations: ${table.name}")
+          throw new AnalysisException(s"Table does not support updates and deletes: ${table.name}")
       }
     }
   }

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Implicits.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Implicits.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.connector.catalog.Table
+import org.apache.spark.sql.connector.iceberg.catalog.SupportsMerge
+
+// must be merged with DataSourceV2Implicits in Spark
+object ExtendedDataSourceV2Implicits {
+  implicit class TableHelper(table: Table) {
+    def asMergeable: SupportsMerge = {
+      table match {
+        case support: SupportsMerge =>
+          support
+        case _ =>
+          throw new AnalysisException(s"Table does not support row level operations: ${table.name}")
+      }
+    }
+  }
+}

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Strategy.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Strategy.scala
@@ -22,8 +22,8 @@ package org.apache.spark.sql.execution.datasources.v2
 import org.apache.spark.sql.Strategy
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Expression, GenericInternalRow}
-import org.apache.spark.sql.catalyst.plans.logical.{Call, LogicalPlan}
-import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.catalyst.plans.logical.{Call, DynamicFileFilter, LogicalPlan, ReplaceData}
+import org.apache.spark.sql.execution.{ProjectExec, SparkPlan}
 
 object ExtendedDataSourceV2Strategy extends Strategy {
 
@@ -31,6 +31,18 @@ object ExtendedDataSourceV2Strategy extends Strategy {
     case c @ Call(procedure, args) =>
       val input = buildInternalRow(args)
       CallExec(c.output, procedure, input) :: Nil
+    case DynamicFileFilter(scanRelation, fileFilterPlan) =>
+      // we don't use planLater here as we need ExtendedBatchScanExec, not BatchScanExec
+      val scanExec = ExtendedBatchScanExec(scanRelation.output, scanRelation.scan)
+      val dynamicFileFilter = DynamicFileFilterExec(scanExec, planLater(fileFilterPlan))
+      if (scanExec.supportsColumnar) {
+        dynamicFileFilter :: Nil
+      } else {
+        // add a projection to ensure we have UnsafeRows required by some operations
+        ProjectExec(scanRelation.output, dynamicFileFilter) :: Nil
+      }
+    case ReplaceData(_, batchWrite, query) =>
+      ReplaceDataExec(batchWrite, planLater(query)) :: Nil
     case _ => Nil
   }
 

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ReplaceDataExec.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ReplaceDataExec.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.connector.write.BatchWrite
+import org.apache.spark.sql.execution.SparkPlan
+
+case class ReplaceDataExec(batchWrite: BatchWrite, query: SparkPlan) extends V2TableWriteExec {
+
+  override protected def run(): Seq[InternalRow] = {
+    // calling prepare() ensures we execute DynamicFileFilter if present
+    prepare()
+    writeWithV2(batchWrite)
+  }
+}


### PR DESCRIPTION
This PR adds the core logic for executing DELETE statements in Spark.