### PR TITLE
Docs: Fix typos in api.md 

### DIFF
--- a/site/docs/api.md
+++ b/site/docs/api.md
@@ -21,11 +21,11 @@
 
 The main purpose of the Iceberg API is to manage table metadata, like schema, partition spec, metadata, and data files that store table data.
 
-Table metadata and operations are accessed through the `Table` interface. This interface will return table information, 
+Table metadata and operations are accessed through the `Table` interface. This interface will return table information.
 
 ### Table metadata
 
-The [`Table` interface](./javadoc/master/index.html?org/apache/iceberg/Table.html) provides access table metadata:
+The [`Table` interface](./javadoc/master/index.html?org/apache/iceberg/Table.html) provides access to the table metadata:
 
 * `schema` returns the current table [schema](./schemas.md)
 * `spec` returns the current table partition spec
@@ -95,7 +95,7 @@ Available operations to update a table are:
 * `newRewrite` -- used to rewrite data files; will replace existing files with new versions
 * `newTransaction` -- create a new table-level transaction
 * `rewriteManifests` -- rewrite manifest data by clustering files, for faster scan planning
-* `rollback` -- roll the table state back by pointing current to a specific snapshot
+* `rollback` -- rollback the table state to a specific snapshot
 
 ### Transactions
 
@@ -103,7 +103,7 @@ Transactions are used to commit multiple table changes in a single atomic operat
 
 For example, deleting and appending a file in the same transaction:
 ```java
-Transaction t = table.newTrasaction();
+Transaction t = table.newTransaction();
 
 // commit operations to the transaction
 t.newDelete().deleteFromRowFilter(filter).commit();
@@ -188,7 +188,7 @@ Constant expressions are:
 
 When created, expressions are unbound. Before an expression is used, it will be bound to a data type to find the field ID the expression name represents, and to convert predicate literals.
 
-For example, before using the expression `lessThan("x", 10)`, Iceberg needs to determine which column `"x"` refers to and convert `10` to that colunn's data type.
+For example, before using the expression `lessThan("x", 10)`, Iceberg needs to determine which column `"x"` refers to and convert `10` to that column's data type.
 
 If the expression could be bound to the type `struct<1 x: long, 2 y: long>` or to `struct<11 x: int, 12 y: int>`.
 


### PR DESCRIPTION
- Fix typos and minor wording change in api.md