### PR TITLE
Spark: Fix resolution of procedures with expressions

### DIFF
--- a/spark3-extensions/src/main/scala/org/apache/iceberg/spark/extensions/IcebergSparkSessionExtensions.scala
+++ b/spark3-extensions/src/main/scala/org/apache/iceberg/spark/extensions/IcebergSparkSessionExtensions.scala
@@ -20,8 +20,7 @@
 package org.apache.iceberg.spark.extensions
 
 import org.apache.spark.sql.SparkSessionExtensions
-import org.apache.spark.sql.catalyst.analysis.DeleteFromTablePredicateCheck
-import org.apache.spark.sql.catalyst.analysis.ResolveProcedures
+import org.apache.spark.sql.catalyst.analysis.{DeleteFromTablePredicateCheck, ProcedureArgumentCoercion, ResolveProcedures}
 import org.apache.spark.sql.catalyst.optimizer.{OptimizeConditionsInRowLevelOperations, PullupCorrelatedPredicatesInRowLevelOperations, RewriteDelete}
 import org.apache.spark.sql.catalyst.parser.extensions.IcebergSparkSqlExtensionsParser
 import org.apache.spark.sql.execution.datasources.v2.ExtendedDataSourceV2Strategy
@@ -31,6 +30,7 @@ class IcebergSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
   override def apply(extensions: SparkSessionExtensions): Unit = {
     extensions.injectParser { case (_, parser) => new IcebergSparkSqlExtensionsParser(parser) }
     extensions.injectResolutionRule { spark => ResolveProcedures(spark) }
+    extensions.injectResolutionRule { _ => ProcedureArgumentCoercion }
     extensions.injectCheckRule { _ => DeleteFromTablePredicateCheck }
     // TODO: RewriteDelete should be executed after the operator optimization batch
     extensions.injectOptimizerRule { _ => OptimizeConditionsInRowLevelOperations }

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/ProcedureArgumentCoercion.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/ProcedureArgumentCoercion.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.expressions.Cast
+import org.apache.spark.sql.catalyst.plans.logical.{Call, LogicalPlan}
+import org.apache.spark.sql.catalyst.rules.Rule
+
+object ProcedureArgumentCoercion extends Rule[LogicalPlan] {
+  override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
+    case c @ Call(procedure, args) if c.resolved =>
+      val params = procedure.parameters
+
+      val newArgs = args.zipWithIndex.map { case (arg, index) =>
+        val param = params(index)
+        val paramType = param.dataType
+        val argType = arg.dataType
+
+        if (paramType != argType && !Cast.canUpCast(argType, paramType)) {
+          throw new AnalysisException(
+            s"Wrong arg type for ${param.name}: cannot cast $argType to $paramType")
+        }
+
+        if (paramType != argType) {
+          Cast(arg, paramType)
+        } else {
+          arg
+        }
+      }
+
+      if (newArgs != args) {
+        c.copy(args = newArgs)
+      } else {
+        c
+      }
+  }
+}

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveProcedures.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveProcedures.scala
@@ -79,19 +79,7 @@ case class ResolveProcedures(spark: SparkSession) extends Rule[LogicalPlan] with
 
     nameToArgMap.foreach { case (name, arg) =>
       val position = nameToPositionMap(name)
-      val param = params(position)
-      val paramType = param.dataType
-      val argType = arg.expr.dataType
-
-      if (paramType != argType && !Cast.canUpCast(argType, paramType)) {
-        throw new AnalysisException(s"Wrong arg type for ${param.name}: expected $paramType but got $argType")
-      }
-
-      if (paramType != argType) {
-        argExprs(position) = Cast(arg.expr, paramType)
-      } else {
-        argExprs(position) = arg.expr
-      }
+      argExprs(position) = arg.expr
     }
 
     // assign nulls to optional params that were not set

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCherrypickSnapshotProcedure.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCherrypickSnapshotProcedure.java
@@ -174,7 +174,7 @@ public class TestCherrypickSnapshotProcedure extends SparkExtensionsTestBase {
         () -> sql("CALL %s.system.cherrypick_snapshot('n', 't')", catalogName));
 
     AssertHelpers.assertThrows("Should reject calls with invalid arg types",
-        AnalysisException.class, "Wrong arg type for snapshot_id: expected LongType",
+        AnalysisException.class, "Wrong arg type for snapshot_id: cannot cast",
         () -> sql("CALL %s.system.cherrypick_snapshot('n', 't', 2.2)", catalogName));
 
     AssertHelpers.assertThrows("Should reject empty namespace",

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToSnapshotProcedure.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToSnapshotProcedure.java
@@ -258,7 +258,7 @@ public class TestRollbackToSnapshotProcedure extends SparkExtensionsTestBase {
         () -> sql("CALL %s.system.rollback_to_snapshot(table => 't', snapshot_id => 1L)", catalogName));
 
     AssertHelpers.assertThrows("Should reject calls with invalid arg types",
-        AnalysisException.class, "Wrong arg type for snapshot_id: expected LongType",
+        AnalysisException.class, "Wrong arg type for snapshot_id: cannot cast",
         () -> sql("CALL %s.system.rollback_to_snapshot('n', 't', 2.2)", catalogName));
 
     AssertHelpers.assertThrows("Should reject empty namespace",

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToTimestampProcedure.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRollbackToTimestampProcedure.java
@@ -266,7 +266,7 @@ public class TestRollbackToTimestampProcedure extends SparkExtensionsTestBase {
         () -> sql("CALL %s.system.rollback_to_timestamp('n', 't', %s, 1L)", catalogName, timestamp));
 
     AssertHelpers.assertThrows("Should reject calls with invalid arg types",
-        AnalysisException.class, "Wrong arg type for timestamp: expected TimestampType",
+        AnalysisException.class, "Wrong arg type for timestamp: cannot cast",
         () -> sql("CALL %s.system.rollback_to_timestamp('n', 't', 2.2)", catalogName));
 
     AssertHelpers.assertThrows("Should reject empty namespace",

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSetCurrentSnapshotProcedure.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSetCurrentSnapshotProcedure.java
@@ -211,7 +211,7 @@ public class TestSetCurrentSnapshotProcedure extends SparkExtensionsTestBase {
         () -> sql("CALL %s.system.set_current_snapshot(table => 't', snapshot_id => 1L)", catalogName));
 
     AssertHelpers.assertThrows("Should reject calls with invalid arg types",
-        AnalysisException.class, "Wrong arg type for snapshot_id: expected LongType",
+        AnalysisException.class, "Wrong arg type for snapshot_id: cannot cast",
         () -> sql("CALL %s.system.set_current_snapshot('n', 't', 2.2)", catalogName));
 
     AssertHelpers.assertThrows("Should reject empty namespace",


### PR DESCRIPTION
This PR fixes the resolution of procedures that contain expressions as arguments.