### PR TITLE
AWS: support S3 strong consistency

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/S3FileIOTest.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/S3FileIOTest.java
@@ -29,9 +29,11 @@ import java.util.Base64;
 import java.util.UUID;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
+import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.aws.AwsClientUtil;
 import org.apache.iceberg.aws.AwsIntegTestUtil;
 import org.apache.iceberg.aws.AwsProperties;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.junit.AfterClass;
@@ -95,6 +97,10 @@ public class S3FileIOTest {
     S3FileIO s3FileIO = new S3FileIO(AwsClientUtil::defaultS3Client);
     InputFile file = s3FileIO.newInputFile(objectUri);
     Assert.assertFalse("file should not exist", file.exists());
+    AssertHelpers.assertThrows("get length should throw exception",
+        NotFoundException.class,
+        String.format("Cannot retrieve file length because file %s does not exist", objectUri),
+        file::getLength);
   }
 
   @Test

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/S3FileIOTest.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/S3FileIOTest.java
@@ -91,6 +91,26 @@ public class S3FileIOTest {
   }
 
   @Test
+  public void testExists_noFile() {
+    S3FileIO s3FileIO = new S3FileIO(AwsClientUtil::defaultS3Client);
+    InputFile file = s3FileIO.newInputFile(objectUri);
+    Assert.assertFalse("file should not exist", file.exists());
+  }
+
+  @Test
+  public void testExists_multipleFilesSamePrefix() {
+    s3.putObject(PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
+        RequestBody.fromBytes(contentBytes));
+    s3.putObject(PutObjectRequest.builder().bucket(bucketName).key(objectKey + "suffix").build(),
+        RequestBody.fromBytes(new byte[1024 * 1024]));
+    S3FileIO s3FileIO = new S3FileIO(AwsClientUtil::defaultS3Client);
+    InputFile file = s3FileIO.newInputFile(objectUri);
+    Assert.assertTrue("file should exist", file.exists());
+    Assert.assertEquals("List results are always returned in UTF-8 binary order",
+        contentBytes.length, file.getLength());
+  }
+
+  @Test
   public void testNewInputStream() throws Exception {
     s3.putObject(PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
         RequestBody.fromBytes(contentBytes));

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/S3FileIOTest.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/S3FileIOTest.java
@@ -98,6 +98,15 @@ public class S3FileIOTest {
   }
 
   @Test
+  public void testExists_wrongFileSamePrefix() {
+    s3.putObject(PutObjectRequest.builder().bucket(bucketName).key(objectKey + "suffix").build(),
+        RequestBody.fromBytes(contentBytes));
+    S3FileIO s3FileIO = new S3FileIO(AwsClientUtil::defaultS3Client);
+    InputFile file = s3FileIO.newInputFile(objectUri);
+    Assert.assertFalse("file should not exist", file.exists());
+  }
+
+  @Test
   public void testExists_multipleFilesSamePrefix() {
     s3.putObject(PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
         RequestBody.fromBytes(contentBytes));

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/BaseS3File.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/BaseS3File.java
@@ -24,6 +24,7 @@ import software.amazon.awssdk.http.HttpStatusCode;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
 abstract class BaseS3File {
@@ -77,6 +78,12 @@ abstract class BaseS3File {
 
   protected HeadObjectResponse getObjectMetadata() throws S3Exception {
     if (metadata == null) {
+      // list object to force strong consistency
+      client().listObjectsV2(ListObjectsV2Request.builder()
+          .bucket(uri().bucket())
+          .prefix(uri().key())
+          .build());
+
       HeadObjectRequest.Builder requestBuilder = HeadObjectRequest.builder()
           .bucket(uri().bucket())
           .key(uri().key());

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/BaseS3File.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/BaseS3File.java
@@ -83,7 +83,17 @@ abstract class BaseS3File {
           .prefix(uri().key())
           .maxKeys(1)
           .build());
-      metadata = response.hasContents() ? response.contents().get(0) : null;
+
+      if (!response.hasContents()) {
+        metadata = null;
+      } else {
+        S3Object s3Object = response.contents().get(0);
+        if (uri().key().equals(s3Object.key())) {
+          metadata = s3Object;
+        } else {
+          metadata = null;
+        }
+      }
     }
 
     return metadata;

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputFile.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputFile.java
@@ -40,7 +40,7 @@ public class S3InputFile extends BaseS3File implements InputFile {
    */
   @Override
   public long getLength() {
-    return getObjectMetadata().contentLength();
+    return getObjectMetadata().size();
   }
 
   @Override

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputFile.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputFile.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.aws.s3;
 
 import org.apache.iceberg.aws.AwsProperties;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.SeekableInputStream;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -40,6 +41,10 @@ public class S3InputFile extends BaseS3File implements InputFile {
    */
   @Override
   public long getLength() {
+    if (!exists()) {
+      throw new NotFoundException("Cannot retrieve file length because file %s does not exist", uri());
+    }
+
     return getObjectMetadata().size();
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3RequestUtil.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3RequestUtil.java
@@ -24,7 +24,6 @@ import java.util.function.Function;
 import org.apache.iceberg.aws.AwsProperties;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
-import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Request;
@@ -55,11 +54,6 @@ public class S3RequestUtil {
   }
 
   static void configureEncryption(AwsProperties awsProperties, GetObjectRequest.Builder requestBuilder) {
-    configureEncryption(awsProperties, NULL_SSE_SETTER, NULL_STRING_SETTER,
-        requestBuilder::sseCustomerAlgorithm, requestBuilder::sseCustomerKey, requestBuilder::sseCustomerKeyMD5);
-  }
-
-  static void configureEncryption(AwsProperties awsProperties, HeadObjectRequest.Builder requestBuilder) {
     configureEncryption(awsProperties, NULL_SSE_SETTER, NULL_STRING_SETTER,
         requestBuilder::sseCustomerAlgorithm, requestBuilder::sseCustomerKey, requestBuilder::sseCustomerKeyMD5);
   }

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/S3FileIOTest.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/S3FileIOTest.java
@@ -26,6 +26,8 @@ import java.io.OutputStream;
 import java.util.Random;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.SerializationUtils;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.util.SerializableSupplier;
@@ -66,6 +68,10 @@ public class S3FileIOTest {
 
     InputFile in = s3FileIO.newInputFile(location);
     assertFalse(in.exists());
+    AssertHelpers.assertThrows("get length should throw exception",
+        NotFoundException.class,
+        "Cannot retrieve file length because file s3://bucket/path/to/file.txt does not exist",
+        in::getLength);
 
     OutputFile out = s3FileIO.newOutputFile(location);
     try (OutputStream os = out.createOrOverwrite()) {


### PR DESCRIPTION
AWS released S3 strong consistency, and now all LIST and GET are strongly consistent. So we can use a LIST to force strong consistency before performing a HEAD for `exists()` check.

More details: https://aws.amazon.com/blogs/aws/amazon-s3-update-strong-read-after-write-consistency/