### PR TITLE
#1855 : When we fail to parse a "CALL" command provide a better error message

### DIFF
--- a/spark3-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
+++ b/spark3-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
@@ -67,7 +67,6 @@ singleStatement
 
 statement
     : CALL multipartIdentifier '(' (callArgument (',' callArgument)*)? ')'   #call
-    | .*?                                                                    #nonIcebergCommand
     ;
 
 callArgument

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
@@ -94,7 +94,7 @@ class IcebergSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserI
    */
   override def parsePlan(sqlText: String): LogicalPlan = {
     val sqlTextAfterSubstitution = substitutor.substitute(sqlText)
-    if (sqlTextAfterSubstitution.toLowerCase(Locale.ROOT).stripLeading().startsWith("call")) {
+    if (sqlTextAfterSubstitution.toLowerCase(Locale.ROOT).trim().startsWith("call")) {
       parse(sqlTextAfterSubstitution) { parser => astBuilder.visit(parser.singleStatement()) }.asInstanceOf[LogicalPlan]
     } else {
       delegate.parsePlan(sqlText)

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
@@ -163,9 +163,9 @@ case object IcebergSqlExtensionsPostProcessor extends IcebergSqlExtensionsBaseLi
   }
 
   private def replaceTokenByIdentifier(
-                                        ctx: ParserRuleContext,
-                                        stripMargins: Int)(
-                                        f: CommonToken => CommonToken = identity): Unit = {
+      ctx: ParserRuleContext,
+      stripMargins: Int)(
+      f: CommonToken => CommonToken = identity): Unit = {
     val parent = ctx.getParent
     parent.removeLastChild()
     val token = ctx.getChild(0).getPayload.asInstanceOf[Token]

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
@@ -47,9 +47,6 @@ class IcebergSqlExtensionsAstBuilder(delegate: ParserInterface) extends IcebergS
     NamedArgument(name, expr)
   }
 
-  // return null for any statement we cannot handle so it can be parsed with the main Spark parser
-  override def visitNonIcebergCommand(ctx: NonIcebergCommandContext): LogicalPlan = null
-
   override def visitSingleStatement(ctx: SingleStatementContext): LogicalPlan = withOrigin(ctx) {
     visit(ctx.statement).asInstanceOf[LogicalPlan]
   }

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.spark.extensions;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.Instant;
+import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.expressions.Expression;
@@ -126,6 +127,13 @@ public class TestCallStatementParser {
     Assert.assertEquals(1, call.args().size());
 
     checkArg(call, 0, "value", DataTypes.StringType);
+  }
+
+  @Test
+  public void testCallParseError() {
+    AssertHelpers.assertThrows("Should fail with a sensible parse error", ParseException.class,
+        "missing '(' at 'radish'",
+        () -> parser.parsePlan("CALL cat.system radish kebab"));
   }
 
   private void checkArg(CallStatement call, int index, Object expectedValue, DataType expectedType) {


### PR DESCRIPTION
Previously we would always delegate to the Spark parser, even when a
CALL request could not be parsed. This leads to confusing errors which
would state that "CALL" was not a good first token. This change has us
only using the custom parser for "CALL" commands and delegating for
everything else.

Fixes #1855