### PR TITLE
Core: Add RollingEqDeleteWriter.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/deletes/EqualityDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/EqualityDeleteWriter.java
@@ -61,6 +61,10 @@ public class EqualityDeleteWriter<T> implements Closeable {
     appender.add(row);
   }
 
+  public long length() {
+    return appender.length();
+  }
+
   @Override
   public void close() throws IOException {
     if (deleteFile == null) {

--- a/core/src/main/java/org/apache/iceberg/io/PartitionedFanoutWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/PartitionedFanoutWriter.java
@@ -55,7 +55,7 @@ public abstract class PartitionedFanoutWriter<T> extends BaseTaskWriter<T> {
       writers.put(copiedKey, writer);
     }
 
-    writer.add(row);
+    writer.write(row);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/io/PartitionedWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/PartitionedWriter.java
@@ -73,7 +73,7 @@ public abstract class PartitionedWriter<T> extends BaseTaskWriter<T> {
       currentWriter = new RollingFileWriter(currentKey);
     }
 
-    currentWriter.add(row);
+    currentWriter.write(row);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/io/TaskWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/TaskWriter.java
@@ -21,6 +21,8 @@ package org.apache.iceberg.io;
 
 import java.io.Closeable;
 import java.io.IOException;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 /**
  * The writer interface could accept records and provide the generated data files.
@@ -40,6 +42,19 @@ public interface TaskWriter<T> extends Closeable {
    * @throws IOException if any IO error happen.
    */
   void abort() throws IOException;
+
+  /**
+   * Close the writer and get the completed data files, it requires that the task writer would produce data files only.
+   *
+   * @return the completed data files of this task writer.
+   */
+  default DataFile[] dataFiles() throws IOException {
+    WriteResult result = complete();
+    Preconditions.checkArgument(result.deleteFiles() == null || result.deleteFiles().length == 0,
+        "Should have no delete files in this write result.");
+
+    return result.dataFiles();
+  }
 
   /**
    * Close the writer and get the completed data and delete files.

--- a/core/src/main/java/org/apache/iceberg/io/TaskWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/TaskWriter.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.io;
 
 import java.io.Closeable;
 import java.io.IOException;
-import org.apache.iceberg.DataFile;
 
 /**
  * The writer interface could accept records and provide the generated data files.
@@ -43,9 +42,9 @@ public interface TaskWriter<T> extends Closeable {
   void abort() throws IOException;
 
   /**
-   * Close the writer and get the completed data files.
+   * Close the writer and get the completed data and delete files.
    *
-   * @return the completed data files of this task writer.
+   * @return the completed data and delete files of this task writer.
    */
-  DataFile[] complete() throws IOException;
+  WriteResult complete() throws IOException;
 }

--- a/core/src/main/java/org/apache/iceberg/io/UnpartitionedWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/UnpartitionedWriter.java
@@ -35,7 +35,7 @@ public class UnpartitionedWriter<T> extends BaseTaskWriter<T> {
 
   @Override
   public void write(T record) throws IOException {
-    currentWriter.add(record);
+    currentWriter.write(record);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/io/WriteResult.java
+++ b/core/src/main/java/org/apache/iceberg/io/WriteResult.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+public class WriteResult implements Serializable {
+  private DataFile[] dataFiles;
+  private DeleteFile[] deleteFiles;
+
+  private WriteResult(List<DataFile> dataFiles, List<DeleteFile> deleteFiles) {
+    this.dataFiles = dataFiles.toArray(new DataFile[0]);
+    this.deleteFiles = deleteFiles.toArray(new DeleteFile[0]);
+  }
+
+  public DataFile[] dataFiles() {
+    return dataFiles;
+  }
+
+  public DeleteFile[] deleteFiles() {
+    return deleteFiles;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private final List<DataFile> dataFiles;
+    private final List<DeleteFile> deleteFiles;
+
+    private Builder() {
+      this.dataFiles = Lists.newArrayList();
+      this.deleteFiles = Lists.newArrayList();
+    }
+
+    public Builder add(WriteResult result) {
+      addDataFiles(result.dataFiles);
+      addDeleteFiles(result.deleteFiles);
+
+      return this;
+    }
+
+    public Builder addDataFiles(DataFile... files) {
+      Collections.addAll(dataFiles, files);
+      return this;
+    }
+
+    public Builder addDataFiles(List<DataFile> files) {
+      dataFiles.addAll(files);
+      return this;
+    }
+
+    public Builder addDeleteFiles(DeleteFile... files) {
+      Collections.addAll(deleteFiles, files);
+      return this;
+    }
+
+    public Builder addDeleteFiles(List<DeleteFile> files) {
+      deleteFiles.addAll(files);
+      return this;
+    }
+
+    public WriteResult build() {
+      return new WriteResult(dataFiles, deleteFiles);
+    }
+  }
+}

--- a/data/src/test/java/org/apache/iceberg/io/TestBaseTaskWriter.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestBaseTaskWriter.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.RowDelta;
+import org.apache.iceberg.TableTestBase;
+import org.apache.iceberg.data.GenericAppenderFactory;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.IcebergGenerics;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.StructLikeSet;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestBaseTaskWriter extends TableTestBase {
+  private static final int FORMAT_V2 = 2;
+
+  private final FileFormat format;
+  private final GenericRecord gRecord = GenericRecord.create(SCHEMA);
+
+  private OutputFileFactory fileFactory = null;
+  private FileAppenderFactory<Record> appenderFactory = null;
+
+  @Parameterized.Parameters(name = "FileFormat = {0}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+        {"avro"},
+        {"parquet"}
+    };
+  }
+
+  public TestBaseTaskWriter(String fileFormat) {
+    super(FORMAT_V2);
+    this.format = FileFormat.valueOf(fileFormat.toUpperCase(Locale.ENGLISH));
+  }
+
+  @Before
+  public void setupTable() throws IOException {
+    this.tableDir = temp.newFolder();
+    Assert.assertTrue(tableDir.delete()); // created by table create
+
+    this.metadataDir = new File(tableDir, "metadata");
+
+    this.table = create(SCHEMA, PartitionSpec.unpartitioned());
+    this.fileFactory = new OutputFileFactory(table.spec(), format, table.locationProvider(), table.io(),
+        table.encryption(), 1, 1);
+
+    int firstFieldId = table.schema().findField("id").fieldId();
+    int secondFieldId = table.schema().findField("data").fieldId();
+    this.appenderFactory = new GenericAppenderFactory(table.schema(), table.spec(),
+        new int[] {firstFieldId, secondFieldId}, table.schema(), null);
+
+    table.updateProperties()
+        .defaultFormat(format)
+        .commit();
+  }
+
+  private Record createRecord(Integer id, String data) {
+    return gRecord.copy("id", id, "data", data);
+  }
+
+  @Test
+  public void testWriteZeroRecord() throws IOException {
+    try (TestTaskWriter writer = createTaskWriter(128 * 1024 * 1024)) {
+      writer.close();
+
+      WriteResult result = writer.complete();
+      Assert.assertEquals(0, result.dataFiles().length);
+      Assert.assertEquals(0, result.deleteFiles().length);
+
+      writer.close();
+      result = writer.complete();
+      Assert.assertEquals(0, result.dataFiles().length);
+      Assert.assertEquals(0, result.deleteFiles().length);
+    }
+  }
+
+  @Test
+  public void testAbort() throws IOException {
+    List<Record> records = Lists.newArrayList();
+    for (int i = 0; i < 2000; i++) {
+      records.add(createRecord(i, "aaa"));
+    }
+
+    WriteResult result;
+    try (TestTaskWriter taskWriter = createTaskWriter(4)) {
+      for (Record record : records) {
+        taskWriter.write(record);
+        taskWriter.delete(record);
+      }
+
+      // Close the current opened files.
+      taskWriter.close();
+
+      // Assert the current data file count.
+      List<Path> files = Files.list(Paths.get(tableDir.getPath(), "data"))
+          .filter(p -> !p.toString().endsWith(".crc"))
+          .collect(Collectors.toList());
+      Assert.assertEquals("Should have 4 files but the files are: " + files, 4, files.size());
+
+      // Abort to clean all delete files and data files.
+      taskWriter.abort();
+
+      // Complete again to get all results.
+      result = taskWriter.complete();
+    }
+    Assert.assertEquals(2, result.deleteFiles().length);
+    Assert.assertEquals(2, result.dataFiles().length);
+
+    for (DeleteFile deleteFile : result.deleteFiles()) {
+      Assert.assertFalse(Files.exists(Paths.get(deleteFile.path().toString())));
+    }
+    for (DataFile dataFile : result.dataFiles()) {
+      Assert.assertFalse(Files.exists(Paths.get(dataFile.path().toString())));
+    }
+  }
+
+  @Test
+  public void testRollIfExceedTargetFileSize() throws IOException {
+    List<Record> records = Lists.newArrayListWithCapacity(8000);
+    for (int i = 0; i < 2000; i++) {
+      records.add(createRecord(i, "aaa"));
+      records.add(createRecord(i, "bbb"));
+      records.add(createRecord(i, "ccc"));
+      records.add(createRecord(i, "ddd"));
+    }
+
+    WriteResult result;
+    try (TaskWriter<Record> taskWriter = createTaskWriter(4)) {
+      for (Record record : records) {
+        taskWriter.write(record);
+      }
+
+      result = taskWriter.complete();
+      Assert.assertEquals(8, result.dataFiles().length);
+      Assert.assertEquals(0, result.deleteFiles().length);
+    }
+
+    RowDelta rowDelta = table.newRowDelta();
+    Arrays.stream(result.dataFiles()).forEach(rowDelta::addRows);
+    rowDelta.commit();
+
+    List<Record> expected = Lists.newArrayList();
+    try (TestTaskWriter taskWriter = createTaskWriter(3)) {
+      for (Record record : records) {
+        // ex: UPSERT <0, 'aaa'> to <0, 'AAA'>
+        taskWriter.delete(record);
+
+        int id = record.get(0, Integer.class);
+        String data = record.get(1, String.class);
+        Record newRecord = createRecord(id, data.toUpperCase());
+        expected.add(newRecord);
+        taskWriter.write(newRecord);
+      }
+
+      result = taskWriter.complete();
+      Assert.assertEquals(8, result.dataFiles().length);
+      Assert.assertEquals(8, result.deleteFiles().length);
+    }
+
+    rowDelta = table.newRowDelta();
+    Arrays.stream(result.dataFiles()).forEach(rowDelta::addRows);
+    Arrays.stream(result.deleteFiles()).forEach(rowDelta::addDeletes);
+    rowDelta.commit();
+
+    Assert.assertEquals("Should have expected records", expectedRowSet(expected), actualRowSet("*"));
+  }
+
+  private StructLikeSet expectedRowSet(Iterable<Record> records) {
+    StructLikeSet set = StructLikeSet.create(table.schema().asStruct());
+    records.forEach(set::add);
+    return set;
+  }
+
+  private StructLikeSet actualRowSet(String... columns) throws IOException {
+    StructLikeSet set = StructLikeSet.create(table.schema().asStruct());
+    try (CloseableIterable<Record> reader = IcebergGenerics.read(table).select(columns).build()) {
+      reader.forEach(set::add);
+    }
+    return set;
+  }
+
+  private TestTaskWriter createTaskWriter(long targetFileSize) {
+    return new TestTaskWriter(table.spec(), format, appenderFactory, fileFactory, table.io(), targetFileSize);
+  }
+
+  private static class TestTaskWriter extends BaseTaskWriter<Record> {
+
+    private RollingFileWriter dataWriter;
+    private RollingEqDeleteWriter deleteWriter;
+
+    private TestTaskWriter(PartitionSpec spec, FileFormat format,
+                           FileAppenderFactory<Record> appenderFactory,
+                           OutputFileFactory fileFactory, FileIO io,
+                           long targetFileSize) {
+      super(spec, format, appenderFactory, fileFactory, io, targetFileSize);
+      this.dataWriter = new RollingFileWriter(null);
+      this.deleteWriter = new RollingEqDeleteWriter(null);
+    }
+
+    @Override
+    public void write(Record row) throws IOException {
+      dataWriter.write(row);
+    }
+
+    void delete(Record row) throws IOException {
+      deleteWriter.write(row);
+    }
+
+    @Override
+    public void close() throws IOException {
+      if (dataWriter != null) {
+        dataWriter.close();
+      }
+      if (deleteWriter != null) {
+        deleteWriter.close();
+      }
+    }
+  }
+}

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriter.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriter.java
@@ -62,7 +62,7 @@ class IcebergStreamWriter<T> extends AbstractStreamOperator<DataFile>
   @Override
   public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
     // close all open files and emit files to downstream committer operator
-    for (DataFile dataFile : writer.complete()) {
+    for (DataFile dataFile : writer.complete().dataFiles()) {
       emit(dataFile);
     }
 
@@ -87,7 +87,7 @@ class IcebergStreamWriter<T> extends AbstractStreamOperator<DataFile>
   public void endInput() throws IOException {
     // For bounded stream, it may don't enable the checkpoint mechanism so we'd better to emit the remaining
     // data files to downstream before closing the writer so that we won't miss any of them.
-    for (DataFile dataFile : writer.complete()) {
+    for (DataFile dataFile : writer.complete().dataFiles()) {
       emit(dataFile);
     }
   }

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriter.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergStreamWriter.java
@@ -62,7 +62,7 @@ class IcebergStreamWriter<T> extends AbstractStreamOperator<DataFile>
   @Override
   public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
     // close all open files and emit files to downstream committer operator
-    for (DataFile dataFile : writer.complete().dataFiles()) {
+    for (DataFile dataFile : writer.dataFiles()) {
       emit(dataFile);
     }
 
@@ -87,7 +87,7 @@ class IcebergStreamWriter<T> extends AbstractStreamOperator<DataFile>
   public void endInput() throws IOException {
     // For bounded stream, it may don't enable the checkpoint mechanism so we'd better to emit the remaining
     // data files to downstream before closing the writer so that we won't miss any of them.
-    for (DataFile dataFile : writer.complete().dataFiles()) {
+    for (DataFile dataFile : writer.dataFiles()) {
       emit(dataFile);
     }
   }

--- a/flink/src/main/java/org/apache/iceberg/flink/source/RowDataRewriter.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/source/RowDataRewriter.java
@@ -131,7 +131,7 @@ public class RowDataRewriter {
           RowData rowData = iterator.next();
           writer.write(rowData);
         }
-        return Lists.newArrayList(writer.complete());
+        return Lists.newArrayList(writer.complete().dataFiles());
       } catch (Throwable originalThrowable) {
         try {
           LOG.error("Aborting commit for  (subTaskId {}, attemptId {})", subTaskId, attemptId);

--- a/flink/src/main/java/org/apache/iceberg/flink/source/RowDataRewriter.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/source/RowDataRewriter.java
@@ -131,7 +131,7 @@ public class RowDataRewriter {
           RowData rowData = iterator.next();
           writer.write(rowData);
         }
-        return Lists.newArrayList(writer.complete().dataFiles());
+        return Lists.newArrayList(writer.dataFiles());
       } catch (Throwable originalThrowable) {
         try {
           LOG.error("Aborting commit for  (subTaskId {}, attemptId {})", subTaskId, attemptId);

--- a/flink/src/test/java/org/apache/iceberg/flink/sink/TestTaskWriters.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/sink/TestTaskWriters.java
@@ -94,13 +94,13 @@ public class TestTaskWriters {
     try (TaskWriter<RowData> taskWriter = createTaskWriter(TARGET_FILE_SIZE)) {
       taskWriter.close();
 
-      DataFile[] dataFiles = taskWriter.complete();
+      DataFile[] dataFiles = taskWriter.complete().dataFiles();
       Assert.assertNotNull(dataFiles);
       Assert.assertEquals(0, dataFiles.length);
 
       // Close again.
       taskWriter.close();
-      dataFiles = taskWriter.complete();
+      dataFiles = taskWriter.complete().dataFiles();
       Assert.assertNotNull(dataFiles);
       Assert.assertEquals(0, dataFiles.length);
     }
@@ -115,7 +115,7 @@ public class TestTaskWriters {
       taskWriter.close(); // The second close
 
       int expectedFiles = partitioned ? 2 : 1;
-      DataFile[] dataFiles = taskWriter.complete();
+      DataFile[] dataFiles = taskWriter.complete().dataFiles();
       Assert.assertEquals(expectedFiles, dataFiles.length);
 
       FileSystem fs = FileSystem.get(CONF);
@@ -132,7 +132,7 @@ public class TestTaskWriters {
       taskWriter.write(SimpleDataUtil.createRowData(2, "world"));
 
       taskWriter.abort();
-      DataFile[] dataFiles = taskWriter.complete();
+      DataFile[] dataFiles = taskWriter.complete().dataFiles();
 
       int expectedFiles = partitioned ? 2 : 1;
       Assert.assertEquals(expectedFiles, dataFiles.length);
@@ -152,11 +152,11 @@ public class TestTaskWriters {
       taskWriter.write(SimpleDataUtil.createRowData(3, "c"));
       taskWriter.write(SimpleDataUtil.createRowData(4, "d"));
 
-      DataFile[] dataFiles = taskWriter.complete();
+      DataFile[] dataFiles = taskWriter.complete().dataFiles();
       int expectedFiles = partitioned ? 4 : 1;
       Assert.assertEquals(expectedFiles, dataFiles.length);
 
-      dataFiles = taskWriter.complete();
+      dataFiles = taskWriter.complete().dataFiles();
       Assert.assertEquals(expectedFiles, dataFiles.length);
 
       FileSystem fs = FileSystem.get(CONF);
@@ -200,7 +200,7 @@ public class TestTaskWriters {
         taskWriter.write(row);
       }
 
-      DataFile[] dataFiles = taskWriter.complete();
+      DataFile[] dataFiles = taskWriter.complete().dataFiles();
       Assert.assertEquals(8, dataFiles.length);
 
       AppendFiles appendFiles = table.newAppend();
@@ -223,7 +223,7 @@ public class TestTaskWriters {
       }
 
       taskWriter.close();
-      DataFile[] dataFiles = taskWriter.complete();
+      DataFile[] dataFiles = taskWriter.complete().dataFiles();
       AppendFiles appendFiles = table.newAppend();
       for (DataFile dataFile : dataFiles) {
         appendFiles.appendFile(dataFile);

--- a/flink/src/test/java/org/apache/iceberg/flink/sink/TestTaskWriters.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/sink/TestTaskWriters.java
@@ -94,13 +94,13 @@ public class TestTaskWriters {
     try (TaskWriter<RowData> taskWriter = createTaskWriter(TARGET_FILE_SIZE)) {
       taskWriter.close();
 
-      DataFile[] dataFiles = taskWriter.complete().dataFiles();
+      DataFile[] dataFiles = taskWriter.dataFiles();
       Assert.assertNotNull(dataFiles);
       Assert.assertEquals(0, dataFiles.length);
 
       // Close again.
       taskWriter.close();
-      dataFiles = taskWriter.complete().dataFiles();
+      dataFiles = taskWriter.dataFiles();
       Assert.assertNotNull(dataFiles);
       Assert.assertEquals(0, dataFiles.length);
     }
@@ -115,7 +115,7 @@ public class TestTaskWriters {
       taskWriter.close(); // The second close
 
       int expectedFiles = partitioned ? 2 : 1;
-      DataFile[] dataFiles = taskWriter.complete().dataFiles();
+      DataFile[] dataFiles = taskWriter.dataFiles();
       Assert.assertEquals(expectedFiles, dataFiles.length);
 
       FileSystem fs = FileSystem.get(CONF);
@@ -132,7 +132,7 @@ public class TestTaskWriters {
       taskWriter.write(SimpleDataUtil.createRowData(2, "world"));
 
       taskWriter.abort();
-      DataFile[] dataFiles = taskWriter.complete().dataFiles();
+      DataFile[] dataFiles = taskWriter.dataFiles();
 
       int expectedFiles = partitioned ? 2 : 1;
       Assert.assertEquals(expectedFiles, dataFiles.length);
@@ -152,11 +152,11 @@ public class TestTaskWriters {
       taskWriter.write(SimpleDataUtil.createRowData(3, "c"));
       taskWriter.write(SimpleDataUtil.createRowData(4, "d"));
 
-      DataFile[] dataFiles = taskWriter.complete().dataFiles();
+      DataFile[] dataFiles = taskWriter.dataFiles();
       int expectedFiles = partitioned ? 4 : 1;
       Assert.assertEquals(expectedFiles, dataFiles.length);
 
-      dataFiles = taskWriter.complete().dataFiles();
+      dataFiles = taskWriter.dataFiles();
       Assert.assertEquals(expectedFiles, dataFiles.length);
 
       FileSystem fs = FileSystem.get(CONF);
@@ -200,7 +200,7 @@ public class TestTaskWriters {
         taskWriter.write(row);
       }
 
-      DataFile[] dataFiles = taskWriter.complete().dataFiles();
+      DataFile[] dataFiles = taskWriter.dataFiles();
       Assert.assertEquals(8, dataFiles.length);
 
       AppendFiles appendFiles = table.newAppend();
@@ -223,7 +223,7 @@ public class TestTaskWriters {
       }
 
       taskWriter.close();
-      DataFile[] dataFiles = taskWriter.complete().dataFiles();
+      DataFile[] dataFiles = taskWriter.dataFiles();
       AppendFiles appendFiles = table.newAppend();
       for (DataFile dataFile : dataFiles) {
         appendFiles.appendFile(dataFile);

--- a/spark/src/main/java/org/apache/iceberg/spark/source/RowDataRewriter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/RowDataRewriter.java
@@ -129,7 +129,7 @@ public class RowDataRewriter implements Serializable {
       dataReader = null;
 
       writer.close();
-      return Lists.newArrayList(writer.complete());
+      return Lists.newArrayList(writer.complete().dataFiles());
 
     } catch (Throwable originalThrowable) {
       try {

--- a/spark/src/main/java/org/apache/iceberg/spark/source/RowDataRewriter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/RowDataRewriter.java
@@ -129,7 +129,7 @@ public class RowDataRewriter implements Serializable {
       dataReader = null;
 
       writer.close();
-      return Lists.newArrayList(writer.complete().dataFiles());
+      return Lists.newArrayList(writer.dataFiles());
 
     } catch (Throwable originalThrowable) {
       try {

--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Writer.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Writer.java
@@ -300,7 +300,7 @@ class Writer implements DataSourceWriter {
     public WriterCommitMessage commit() throws IOException {
       close();
 
-      return new TaskCommit(complete().dataFiles());
+      return new TaskCommit(dataFiles());
     }
   }
 
@@ -316,7 +316,7 @@ class Writer implements DataSourceWriter {
     public WriterCommitMessage commit() throws IOException {
       close();
 
-      return new TaskCommit(complete().dataFiles());
+      return new TaskCommit(dataFiles());
     }
   }
 
@@ -335,7 +335,7 @@ class Writer implements DataSourceWriter {
     public WriterCommitMessage commit() throws IOException {
       close();
 
-      return new TaskCommit(complete().dataFiles());
+      return new TaskCommit(dataFiles());
     }
   }
 }

--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Writer.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Writer.java
@@ -300,7 +300,7 @@ class Writer implements DataSourceWriter {
     public WriterCommitMessage commit() throws IOException {
       close();
 
-      return new TaskCommit(complete());
+      return new TaskCommit(complete().dataFiles());
     }
   }
 
@@ -316,7 +316,7 @@ class Writer implements DataSourceWriter {
     public WriterCommitMessage commit() throws IOException {
       close();
 
-      return new TaskCommit(complete());
+      return new TaskCommit(complete().dataFiles());
     }
   }
 
@@ -335,7 +335,7 @@ class Writer implements DataSourceWriter {
     public WriterCommitMessage commit() throws IOException {
       close();
 
-      return new TaskCommit(complete());
+      return new TaskCommit(complete().dataFiles());
     }
   }
 }

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -450,7 +450,7 @@ class SparkWrite {
     public WriterCommitMessage commit() throws IOException {
       this.close();
 
-      return new TaskCommit(complete());
+      return new TaskCommit(complete().dataFiles());
     }
   }
 
@@ -465,7 +465,7 @@ class SparkWrite {
     public WriterCommitMessage commit() throws IOException {
       this.close();
 
-      return new TaskCommit(complete());
+      return new TaskCommit(complete().dataFiles());
     }
   }
 
@@ -481,7 +481,7 @@ class SparkWrite {
     public WriterCommitMessage commit() throws IOException {
       this.close();
 
-      return new TaskCommit(complete());
+      return new TaskCommit(complete().dataFiles());
     }
   }
 }

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -450,7 +450,7 @@ class SparkWrite {
     public WriterCommitMessage commit() throws IOException {
       this.close();
 
-      return new TaskCommit(complete().dataFiles());
+      return new TaskCommit(dataFiles());
     }
   }
 
@@ -465,7 +465,7 @@ class SparkWrite {
     public WriterCommitMessage commit() throws IOException {
       this.close();
 
-      return new TaskCommit(complete().dataFiles());
+      return new TaskCommit(dataFiles());
     }
   }
 
@@ -481,7 +481,7 @@ class SparkWrite {
     public WriterCommitMessage commit() throws IOException {
       this.close();
 
-      return new TaskCommit(complete().dataFiles());
+      return new TaskCommit(dataFiles());
     }
   }
 }


### PR DESCRIPTION
This is a sub-PR for this issue: https://github.com/apache/iceberg/pull/1818/files#diff-fc9a9fd84d24c607fd85e053b08a559f56dd2dd2a46f1341c528e7a0269f873cR183.   It's mainly used for abstracting the BaseRollingWriter.  We've provided the `RollingFileWriter` to write data records and `RollingEqDeleteWriter` to write equality-delete records in this patch, and provide complete unit tests to cover those.