### PR TITLE
Spark: Add RemoveOrphanFilesProcedure

### DIFF
--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkExtensionsTestBase.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkExtensionsTestBase.java
@@ -44,6 +44,7 @@ public abstract class SparkExtensionsTestBase extends SparkCatalogTestBase {
 
     SparkTestBase.spark = SparkSession.builder()
         .master("local[2]")
+        .config("spark.testing", "true")
         .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
         .config("spark.sql.extensions", IcebergSparkSessionExtensions.class.getName())
         .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.extensions;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.spark.sql.AnalysisException;
+import org.apache.spark.sql.catalyst.analysis.NoSuchProcedureException;
+import org.junit.After;
+import org.junit.Test;
+
+public class TestRemoveOrphanFilesProcedure extends SparkExtensionsTestBase {
+
+  public TestRemoveOrphanFilesProcedure(String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
+  }
+
+  @After
+  public void removeTable() {
+    if (catalogName.equals("spark_catalog")) {
+      // Spark will drop the table using v1 without cleaning the table location
+      validationCatalog.dropTable(tableIdent);
+    } else {
+      sql("DROP TABLE IF EXISTS %s", tableName);
+    }
+  }
+
+  @Test
+  public void testRemoveOrphanFilesInEmptyTable() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    List<Object[]> output = sql(
+        "CALL %s.system.remove_orphan_files('%s', '%s')",
+        catalogName, tableIdent.namespace(), tableIdent.name());
+    assertEquals("Procedure output must match", ImmutableList.of(), output);
+
+    assertEquals("Should have no rows",
+        ImmutableList.of(),
+        sql("SELECT * FROM %s", tableName));
+  }
+
+  @Test
+  public void testRemoveOrphanFilesWithTooShortInterval() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    AssertHelpers.assertThrows("Should reject too short interval",
+        IllegalArgumentException.class, "Cannot remove orphan files with an interval less than",
+        () -> sql("CALL %s.system.remove_orphan_files('%s', '%s', TIMESTAMP '%s')",
+            catalogName, tableIdent.namespace(), tableIdent.name(), LocalDateTime.now()));
+
+    List<Object[]> output = sql(
+        "CALL %s.system.remove_orphan_files(" +
+            "namespace => '%s'," +
+            "table => '%s'," +
+            "older_than => TIMESTAMP '%s'," +
+            "validate_interval => false)",
+        catalogName, tableIdent.namespace(), tableIdent.name(), LocalDateTime.now());
+    assertEquals("Procedure output must match", ImmutableList.of(), output);
+  }
+
+  @Test
+  public void testInvalidRemoveOrphanFilesCases() {
+    AssertHelpers.assertThrows("Should not allow mixed args",
+        AnalysisException.class, "Named and positional arguments cannot be mixed",
+        () -> sql("CALL %s.system.remove_orphan_files('n', table => 't')", catalogName));
+
+    AssertHelpers.assertThrows("Should not resolve procedures in arbitrary namespaces",
+        NoSuchProcedureException.class, "not found",
+        () -> sql("CALL %s.custom.remove_orphan_files('n', 't')", catalogName));
+
+    AssertHelpers.assertThrows("Should reject calls without all required args",
+        AnalysisException.class, "Missing required parameters",
+        () -> sql("CALL %s.system.remove_orphan_files('n')", catalogName));
+
+    AssertHelpers.assertThrows("Should reject calls with invalid arg types",
+        RuntimeException.class, "Couldn't parse identifier",
+        () -> sql("CALL %s.system.remove_orphan_files('n', 2.2)", catalogName));
+
+    AssertHelpers.assertThrows("Should reject empty namespace",
+        IllegalArgumentException.class, "Namespace cannot be empty",
+        () -> sql("CALL %s.system.remove_orphan_files('', 't')", catalogName));
+
+    AssertHelpers.assertThrows("Should reject empty table name",
+        IllegalArgumentException.class, "Table name cannot be empty",
+        () -> sql("CALL %s.system.remove_orphan_files('n', '')", catalogName));
+  }
+}

--- a/spark3/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.procedures;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.iceberg.actions.Actions;
+import org.apache.iceberg.actions.RemoveOrphanFilesAction;
+import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.util.DateTimeUtils;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.types.UTF8String;
+
+/**
+ * A procedure that removes orphan files in a table.
+ *
+ * @see Actions#removeOrphanFiles()
+ */
+public class RemoveOrphanFilesProcedure extends BaseProcedure {
+
+  private static final ProcedureParameter[] PARAMETERS = new ProcedureParameter[]{
+      ProcedureParameter.required("namespace", DataTypes.StringType),
+      ProcedureParameter.required("table", DataTypes.StringType),
+      ProcedureParameter.optional("older_than", DataTypes.TimestampType),
+      ProcedureParameter.optional("location", DataTypes.StringType),
+      ProcedureParameter.optional("dry_run", DataTypes.BooleanType),
+      ProcedureParameter.optional("validate_interval", DataTypes.BooleanType)
+  };
+
+  private static final StructType OUTPUT_TYPE = new StructType(new StructField[]{
+      new StructField("orphan_file_location", DataTypes.StringType, false, Metadata.empty())
+  });
+
+  public static ProcedureBuilder builder() {
+    return new BaseProcedure.Builder<RemoveOrphanFilesProcedure>() {
+      @Override
+      protected RemoveOrphanFilesProcedure doBuild() {
+        return new RemoveOrphanFilesProcedure(tableCatalog());
+      }
+    };
+  }
+
+  private RemoveOrphanFilesProcedure(TableCatalog catalog) {
+    super(catalog);
+  }
+
+  @Override
+  public ProcedureParameter[] parameters() {
+    return PARAMETERS;
+  }
+
+  @Override
+  public StructType outputType() {
+    return OUTPUT_TYPE;
+  }
+
+  @Override
+  public InternalRow[] call(InternalRow args) {
+    String namespace = args.getString(0);
+    String tableName = args.getString(1);
+    Long olderThanMillis = args.isNullAt(2) ? null : DateTimeUtils.toMillis(args.getLong(2));
+    String location = args.isNullAt(3) ? null : args.getString(3);
+    boolean dryRun = !args.isNullAt(4) && args.getBoolean(4);
+    boolean validateInterval = args.isNullAt(5) || args.getBoolean(5);
+
+    return withIcebergTable(namespace, tableName, table -> {
+      Actions actions = Actions.forTable(table);
+
+      RemoveOrphanFilesAction action = actions.removeOrphanFiles();
+
+      if (olderThanMillis != null) {
+        if (validateInterval) {
+          validateInterval(olderThanMillis);
+        }
+        action.olderThan(olderThanMillis);
+      }
+
+      if (location != null) {
+        action.location(location);
+      }
+
+      if (dryRun) {
+        action.deleteWith(file -> { });
+      }
+
+      List<String> orphanFileLocations = action.execute();
+
+      InternalRow[] outputRows = new InternalRow[orphanFileLocations.size()];
+      for (int index = 0; index < orphanFileLocations.size(); index++) {
+        String fileLocation = orphanFileLocations.get(index);
+        outputRows[index] = newInternalRow(UTF8String.fromString(fileLocation));
+      }
+      return outputRows;
+    });
+  }
+
+  private void validateInterval(long olderThanMillis) {
+    long intervalMillis = System.currentTimeMillis() - olderThanMillis;
+    if (intervalMillis < TimeUnit.DAYS.toMillis(1)) {
+      throw new IllegalArgumentException(
+          "Cannot remove orphan files with an interval less than 24 hours. Executing this " +
+          "procedure with a short interval may corrupt the table if other operations are happening " +
+          "at the same time. If you are absolutely confident that no concurrent operations will be " +
+          "affected by removing orphan files with such a short interval, you can call this procedure " +
+          "with 'validate_interval' as false.");
+    }
+  }
+
+  @Override
+  public String description() {
+    return "RemoveOrphanFilesProcedure";
+  }
+}

--- a/spark3/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
@@ -46,6 +46,7 @@ public class SparkProcedures {
     mapBuilder.put("set_current_snapshot", SetCurrentSnapshotProcedure::builder);
     mapBuilder.put("cherrypick_snapshot", CherrypickSnapshotProcedure::builder);
     mapBuilder.put("rewrite_manifests", RewriteManifestsProcedure::builder);
+    mapBuilder.put("remove_orphan_files", RemoveOrphanFilesProcedure::builder);
     return mapBuilder.build();
   }
 


### PR DESCRIPTION
This PR adds a stored procedure for removing orphan files.

This change was originally authored by @liukun4515 against my internal fork before we got the stored procedures in. I kept @liukun4515 as the lead author and added more changes based on the current API for stored procedures.

Tests to be done.