### PR TITLE
Add Atomic Write support for Hadoop Tables

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -67,6 +67,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
  * is not supported yet.
  *
  * Note: The HadoopCatalog requires that the underlying file system supports atomic rename.
+ *       atomic write can also be used (instead of atomic rename) - this is configured on a per-scheme basis.
  */
 public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, SupportsNamespaces {
 

--- a/core/src/main/java/org/apache/iceberg/hadoop/Util.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/Util.java
@@ -51,6 +51,15 @@ public class Util {
     }
   }
 
+  public static boolean shouldUseAtomicWrite(Path path, Configuration conf) {
+    String scheme = path.toUri().getScheme();
+    String fullConfigName = String.join(".",
+            ConfigProperties.USE_ATOMIC_WRITE_PREFIX,
+            scheme,
+            ConfigProperties.USE_ATOMIC_WRITE_SUFFIX);
+    return conf.getBoolean(fullConfigName, false);
+  }
+
   public static String[] blockLocations(CombinedScanTask task, Configuration conf) {
     Set<String> locationSets = Sets.newHashSet();
     for (FileScanTask f : task.files()) {

--- a/core/src/test/java/org/apache/iceberg/hadoop/HadoopTableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/HadoopTableTestBase.java
@@ -71,8 +71,6 @@ public class HadoopTableTestBase {
       .bucket("data", 16)
       .build();
 
-  static final HadoopTables TABLES = new HadoopTables(new Configuration());
-
   static final DataFile FILE_A = DataFiles.builder(SPEC)
       .withPath("/path/to/data-a.parquet")
       .withFileSizeInBytes(0)
@@ -101,6 +99,8 @@ public class HadoopTableTestBase {
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
 
+  final HadoopTables tables = new HadoopTables(new Configuration());
+
   File tableDir = null;
   String tableLocation = null;
   File metadataDir = null;
@@ -115,7 +115,7 @@ public class HadoopTableTestBase {
     this.tableLocation = tableDir.toURI().toString();
     this.metadataDir = new File(tableDir, "metadata");
     this.versionHintFile = new File(metadataDir, "version-hint.text");
-    this.table = TABLES.create(SCHEMA, SPEC, tableLocation);
+    this.table = tables.create(SCHEMA, SPEC, tableLocation);
   }
 
   List<File> listManifestFiles() {

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
@@ -452,7 +452,7 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
   public void testVersionHintFileErrorWithFile() throws Exception {
     addVersionsToTable(table);
 
-    HadoopTableOperations tableOperations = (HadoopTableOperations) TABLES.newTableOps(tableLocation);
+    HadoopTableOperations tableOperations = (HadoopTableOperations) tables.newTableOps(tableLocation);
 
     long secondSnapshotId = table.currentSnapshot().snapshotId();
 
@@ -465,7 +465,7 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
 
     // Check the result of the findVersion(), and load the table and check the current snapshotId
     Assert.assertEquals(1, tableOperations.findVersion());
-    Assert.assertEquals(secondSnapshotId, TABLES.load(tableLocation).currentSnapshot().snapshotId());
+    Assert.assertEquals(secondSnapshotId, tables.load(tableLocation).currentSnapshot().snapshotId());
 
     // Write newer data to confirm that we are writing the correct file
     io.deleteFile(versionHintFile.getPath());
@@ -475,7 +475,7 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
 
     // Check the result of the findVersion(), and load the table and check the current snapshotId
     Assert.assertEquals(3, tableOperations.findVersion());
-    Assert.assertEquals(secondSnapshotId, TABLES.load(tableLocation).currentSnapshot().snapshotId());
+    Assert.assertEquals(secondSnapshotId, tables.load(tableLocation).currentSnapshot().snapshotId());
 
     // Write an empty version hint file
     io.deleteFile(versionHintFile.getPath());
@@ -483,21 +483,21 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
 
     // Check the result of the findVersion(), and load the table and check the current snapshotId
     Assert.assertEquals(3, tableOperations.findVersion());
-    Assert.assertEquals(secondSnapshotId, TABLES.load(tableLocation).currentSnapshot().snapshotId());
+    Assert.assertEquals(secondSnapshotId, tables.load(tableLocation).currentSnapshot().snapshotId());
 
     // Just delete the file
     io.deleteFile(versionHintFile.getPath());
 
     // Check the result of the versionHint(), and load the table and check the current snapshotId
     Assert.assertEquals(3, tableOperations.findVersion());
-    Assert.assertEquals(secondSnapshotId, TABLES.load(tableLocation).currentSnapshot().snapshotId());
+    Assert.assertEquals(secondSnapshotId, tables.load(tableLocation).currentSnapshot().snapshotId());
   }
 
   @Test
   public void testVersionHintFileMissingMetadata() throws Exception {
     addVersionsToTable(table);
 
-    HadoopTableOperations tableOperations = (HadoopTableOperations) TABLES.newTableOps(tableLocation);
+    HadoopTableOperations tableOperations = (HadoopTableOperations) tables.newTableOps(tableLocation);
 
     long secondSnapshotId = table.currentSnapshot().snapshotId();
 
@@ -510,7 +510,7 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
 
     // Check the result of the findVersion(), and load the table and check the current snapshotId
     Assert.assertEquals(3, tableOperations.findVersion());
-    Assert.assertEquals(secondSnapshotId, TABLES.load(tableLocation).currentSnapshot().snapshotId());
+    Assert.assertEquals(secondSnapshotId, tables.load(tableLocation).currentSnapshot().snapshotId());
 
     // Remove all the version files, and see if we can recover. Hint... not :)
     io.deleteFile(tableOperations.getMetadataFile(2).toString());
@@ -522,7 +522,7 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
         "Should not be able to find the table",
         NoSuchTableException.class,
         "Table does not exist",
-        () -> TABLES.load(tableLocation));
+        () -> tables.load(tableLocation));
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommitsAtomicRename.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommitsAtomicRename.java
@@ -19,12 +19,27 @@
 
 package org.apache.iceberg.hadoop;
 
-public class ConfigProperties {
+import java.io.IOException;
+import org.apache.hadoop.fs.FileSystem;
+import org.junit.Test;
 
-  private ConfigProperties() {
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TestHadoopCommitsAtomicRename extends TestHadoopCommitsBase {
+
+  @Test
+  public void testRenameReturnFalse() throws Exception {
+    FileSystem mockFs = mock(FileSystem.class);
+    when(mockFs.rename(any(), any())).thenReturn(false);
+    testCommitWithFileSystem(mockFs, false);
   }
 
-  public static final String ENGINE_HIVE_ENABLED = "iceberg.engine.hive.enabled";
-  public static final String USE_ATOMIC_WRITE_PREFIX = "iceberg.engine.hadoop";
-  public static final String USE_ATOMIC_WRITE_SUFFIX = "atomic.write";
+  @Test
+  public void testRenameThrow() throws Exception {
+    FileSystem mockFs = mock(FileSystem.class);
+    when(mockFs.rename(any(), any())).thenThrow(new IOException("test injected"));
+    testCommitWithFileSystem(mockFs, false);
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommitsAtomicWrite.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommitsAtomicWrite.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.hadoop;
+
+
+import java.io.IOException;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.junit.Test;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TestHadoopCommitsAtomicWrite extends TestHadoopCommitsBase {
+
+  public TestHadoopCommitsAtomicWrite() {
+    tables.getConf().set("iceberg.engine.hadoop.file.atomic.write", "true");
+  }
+
+  @Test
+  public void testAtomicWriteThrow() throws Exception {
+    FileSystem mockFs = mock(FileSystem.class);
+    when(mockFs.rename(any(), any())).thenThrow(new AssertionError("rename should not have been called!"));
+    FSDataOutputStream mockFSDataOutputStream = mock(FSDataOutputStream.class);
+    // on the first close we throw the IOException, then we stop throwing.
+    // the reason is that the write is surrounded in a try-with-resource, so after the first
+    // exception is thrown, close() will be called again - if we throw again there, the same exception will be
+    // suppressed on itself, and we'll get "self-suppression not permitted"
+    doThrow(new IOException("test injected")).doNothing().when(mockFSDataOutputStream).close();
+    when(mockFs.create(any(), anyBoolean())).thenReturn(mockFSDataOutputStream);
+    testCommitWithFileSystem(mockFs, true);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestStaticTable.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestStaticTable.java
@@ -31,11 +31,11 @@ import org.junit.Test;
 public class TestStaticTable extends HadoopTableTestBase {
 
   private Table getStaticTable() {
-    return TABLES.load(((HasTableOperations) table).operations().current().metadataFileLocation());
+    return tables.load(((HasTableOperations) table).operations().current().metadataFileLocation());
   }
 
   private Table getStaticTable(MetadataTableType type) {
-    return TABLES.load(((HasTableOperations) table).operations().current().metadataFileLocation() + "#" + type);
+    return tables.load(((HasTableOperations) table).operations().current().metadataFileLocation() + "#" + type);
   }
 
   @Test

--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -96,6 +96,13 @@ The following properties from the Hadoop configuration are used by the Hive Meta
 | iceberg.hive.client-pool-size      | 5                | The size of the Hive client pool when tracking tables in HMS  |
 | iceberg.hive.lock-timeout-ms       | 180000 (3 min)   | Maximum time in milliseconds to acquire a lock                |
 
+The following properties from the Hadoop configuration are used by Hadoop Tables
+
+| Property                                      | Default  | Description                                                            |
+| --------------------------------------------- | -------- | ---------------------------------------------------------------------- |
+| iceberg.engine.hadoop.`SCHEME`.atomic.write   | false    | Controls whether atomic write will be used instead of atomic rename. `SCHEME` is the scheme used, e.g. `{hdfs, cos}`    |
+
+
 ## Spark configuration
 
 ### Catalogs


### PR DESCRIPTION
This PR introduces support for File Systems with Atomic Write guarantees in Hadoop Tables.
until now, hadoop tables required Atomic Rename from the underlying FS, now they can also be configured to use Atomic Write.
when using Atomic Write, the final metadata file will be (atomically) written instead of using a tempfile and atomically renaming it (this is till used when atomic rename, which remains the default, is used).

To enable the use of Atomic Write, (and assuming this guarantee is indeed supplied by the FS), a new config param is added.
`iceberg.engine,hadoop.<SCHEME>.atomic.write` (defaults to `false`) where `SCHEME` is the FS scheme (e.g., `{file, hdfs, cos}`.

closes #1655 