### PR TITLE
Hive: Make lock check retries backoff exponentially

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -23,19 +23,16 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
-import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.LockComponent;
 import org.apache.hadoop.hive.metastore.api.LockLevel;
 import org.apache.hadoop.hive.metastore.api.LockRequest;
@@ -48,7 +45,6 @@ import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.iceberg.BaseMetastoreTableOperations;
-import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.common.DynMethods;
@@ -86,12 +82,9 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
       .build();
 
   private static class WaitingForLockException extends RuntimeException {
-    public WaitingForLockException(String message) {
+    WaitingForLockException(String message) {
       super(message);
     }
-//    public WaitingForLockException(String message, Throwable cause) {
-//      super(message, cause);
-//    }
   }
 
   private final HiveClientPool metaClients;

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -111,7 +111,6 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
         conf.getLong(HIVE_LOCK_CHECK_MIN_WAIT_MS, HIVE_LOCK_CHECK_MIN_WAIT_MS_DEFAULT);
     this.lockCheckMaxWaitTime =
         conf.getLong(HIVE_LOCK_CHECK_MAX_WAIT_MS, HIVE_LOCK_CHECK_MAX_WAIT_MS_DEFAULT);
-
   }
 
   @Override

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommitLocks.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommitLocks.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.hive;
+
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.LockResponse;
+import org.apache.hadoop.hive.metastore.api.LockState;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.types.Types;
+import org.apache.thrift.TException;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class TestHiveCommitLocks extends HiveTableBaseTest {
+  HiveTableOperations ops = null;
+  HiveTableOperations spyOps = null;
+  HiveClientPool spyClientPool = null;
+  HiveMetaStoreClient spyClient = null;
+  TableMetadata metadataV1 = null;
+  TableMetadata metadataV2 = null;
+
+  long dummyLockId = 500L;
+  LockResponse waitLockResponse = new LockResponse(dummyLockId, LockState.WAITING);
+  LockResponse acquiredLockResponse = new LockResponse(dummyLockId, LockState.ACQUIRED);
+  LockResponse notAcquiredLockResponse = new LockResponse(dummyLockId, LockState.NOT_ACQUIRED);
+
+  @Before
+  public void before() throws Exception {
+    Table table = catalog.loadTable(TABLE_IDENTIFIER);
+    ops = (HiveTableOperations) ((HasTableOperations) table).operations();
+    String dbName = TABLE_IDENTIFIER.namespace().level(0);
+    String tableName = TABLE_IDENTIFIER.name();
+    Configuration overriddenHiveConf = new Configuration(hiveConf);
+    overriddenHiveConf.setLong("iceberg.hive.lock-timeout-ms", 10 * 1000);
+    overriddenHiveConf.setLong("iceberg.hive.lock-check-min-wait-ms", 50);
+    overriddenHiveConf.setLong("iceberg.hive.lock-check-max-wait-ms", 5 * 1000);
+    overriddenHiveConf.setDouble("iceberg.hive.lock-check-backoff-scale-factor", 3.0);
+
+    metadataV1 = ops.current();
+
+    table.updateSchema()
+        .addColumn("n", Types.IntegerType.get())
+        .commit();
+
+    ops.refresh();
+
+    metadataV2 = ops.current();
+
+    Assert.assertEquals(2, ops.current().schema().columns().size());
+
+    spyClientPool = spy(new HiveClientPool(1, overriddenHiveConf));
+    AtomicReference<HiveMetaStoreClient> spyClientRef = new AtomicReference<>();
+
+    when(spyClientPool.newClient()).thenAnswer(invocation -> {
+      HiveMetaStoreClient client = (HiveMetaStoreClient) invocation.callRealMethod();
+      spyClientRef.set(spy(client));
+      return spyClientRef.get();
+    });
+
+    spyOps = spy(new HiveTableOperations(overriddenHiveConf, spyClientPool, ops.io(), catalog.name(),
+        dbName, tableName));
+    spyClientPool.run(client -> client.isLocalMetaStore()); // To ensure new client is created.
+    Assert.assertNotNull(spyClientRef.get());
+
+    spyClient = spyClientRef.get();
+  }
+
+  @After
+  public void cleanup() {
+    try {
+      spyClientPool.close();
+    } catch (Throwable t) {
+      // Ignore any exception
+    }
+  }
+
+  @Test
+  public void testLockAcquisitionAtFirstTime() throws TException, InterruptedException {
+    doReturn(acquiredLockResponse).when(spyClient).lock(any());
+    doNothing().when(spyOps).doUnlock(eq(dummyLockId));
+
+    spyOps.doCommit(metadataV2, metadataV1);
+
+    Assert.assertEquals(1, spyOps.current().schema().columns().size()); // should be 1 again
+  }
+
+  @Test
+  public void testLockAcquisitionAfterRetries() throws TException, InterruptedException {
+
+    doReturn(waitLockResponse).when(spyClient).lock(any());
+    doReturn(waitLockResponse)
+        .doReturn(waitLockResponse)
+        .doReturn(waitLockResponse)
+        .doReturn(waitLockResponse)
+        .doReturn(acquiredLockResponse)
+        .when(spyClient)
+        .checkLock(eq(dummyLockId));
+    doNothing().when(spyOps).doUnlock(eq(dummyLockId));
+
+    spyOps.doCommit(metadataV2, metadataV1);
+
+    Assert.assertEquals(1, spyOps.current().schema().columns().size()); // should be 1 again
+  }
+
+  @Test
+  public void testLockFailureAtFirstTime() throws TException {
+    doReturn(notAcquiredLockResponse).when(spyClient).lock(any());
+
+    AssertHelpers.assertThrows("Expected an exception",
+        CommitFailedException.class,
+        "Could not acquire the lock on",
+        () -> spyOps.doCommit(metadataV2, metadataV1));
+  }
+
+  @Test
+  public void testLockFailureAfterRetries() throws TException {
+    doReturn(waitLockResponse).when(spyClient).lock(any());
+    doReturn(waitLockResponse)
+        .doReturn(waitLockResponse)
+        .doReturn(waitLockResponse)
+        .doReturn(waitLockResponse)
+        .doReturn(notAcquiredLockResponse)
+        .when(spyClient)
+        .checkLock(eq(dummyLockId));
+
+    AssertHelpers.assertThrows("Expected an exception",
+        CommitFailedException.class,
+        "Could not acquire the lock on",
+        () -> spyOps.doCommit(metadataV2, metadataV1));
+  }
+
+  @Test
+  public void testLockTimeoutAfterRetries() throws TException, InterruptedException {
+    doReturn(waitLockResponse).when(spyClient).lock(any());
+    doReturn(waitLockResponse).when(spyClient).checkLock(eq(dummyLockId));
+
+    AssertHelpers.assertThrows("Expected an exception",
+        CommitFailedException.class,
+        "Timed out after",
+        () -> spyOps.doCommit(metadataV2, metadataV1));
+  }
+
+  @Test
+  public void testPassThroughThriftExceptions() throws TException, InterruptedException {
+    doReturn(waitLockResponse).when(spyClient).lock(any());
+    doReturn(waitLockResponse).doThrow(new TException("Test Thrift Exception"))
+        .when(spyClient).checkLock(eq(dummyLockId));
+
+    AssertHelpers.assertThrows("Expected an exception",
+        RuntimeException.class,
+        "Metastore operation failed for",
+        () -> spyOps.doCommit(metadataV2, metadataV1));
+  }
+}

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -84,7 +84,7 @@ public class TestHiveMetastore {
   private ExecutorService executorService;
   private TServer server;
   private HiveMetaStore.HMSHandler baseHandler;
-  private HiveClientPool clientPool;
+  protected HiveClientPool clientPool; // Exposed for testing.
 
   /**
    * Starts a TestHiveMetastore with the default connection pool size (5).

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -19,6 +19,8 @@
 
 package org.apache.iceberg.hive;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -84,7 +86,7 @@ public class TestHiveMetastore {
   private ExecutorService executorService;
   private TServer server;
   private HiveMetaStore.HMSHandler baseHandler;
-  protected HiveClientPool clientPool; // Exposed for testing.
+  private HiveClientPool clientPool;
 
   /**
    * Starts a TestHiveMetastore with the default connection pool size (5).

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -19,8 +19,6 @@
 
 package org.apache.iceberg.hive;
 
-import com.google.common.annotations.VisibleForTesting;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;

--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -94,10 +94,12 @@ Iceberg tables support table properties to configure table behavior, like the de
 
 The following properties from the Hadoop configuration are used by the Hive Metastore connector.
 
-| Property                           | Default          | Description                                                   |
-| ---------------------------------- | ---------------- | ------------------------------------------------------------- |
-| iceberg.hive.client-pool-size      | 5                | The size of the Hive client pool when tracking tables in HMS  |
-| iceberg.hive.lock-timeout-ms       | 180000 (3 min)   | Maximum time in milliseconds to acquire a lock                |
+| Property                              | Default          | Description                                                                        |
+| ------------------------------------- | ---------------- | ---------------------------------------------------------------------------------- |
+| iceberg.hive.client-pool-size         | 5                | The size of the Hive client pool when tracking tables in HMS                       |
+| iceberg.hive.lock-timeout-ms          | 180000 (3 min)   | Maximum time in milliseconds to acquire a lock                                     |
+| iceberg.hive.lock-check-min-wait-ms   | 50               | Minimum time in milliseconds to check back on the status of lock acquisition       |
+| iceberg.hive.lock-check-max-wait-ms   | 5000             | Maximum time in milliseconds to check back on the status of lock acquisition       |
 
 ## Spark configuration
 

--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -101,6 +101,10 @@ The following properties from the Hadoop configuration are used by the Hive Meta
 | iceberg.hive.lock-check-min-wait-ms   | 50               | Minimum time in milliseconds to check back on the status of lock acquisition       |
 | iceberg.hive.lock-check-max-wait-ms   | 5000             | Maximum time in milliseconds to check back on the status of lock acquisition       |
 
+Note: `iceberg.hive.lock-check-max-wait-ms` should be less than the [transaction timeout](https://cwiki.apache.org/confluence/display/Hive/Configuration+Properties#ConfigurationProperties-hive.txn.timeout) 
+of the Hive Metastore (`hive.txn.timeout` or `metastore.txn.timeout` in the newer versions). Otherwise, the heartbeats on the lock (which happens during the lock checks) would end up expiring in the 
+Hive Metastore before the lock is retried from Iceberg.
+
 ## Spark configuration
 
 ### Catalogs


### PR DESCRIPTION
50 milliseconds (constant) sleep time between "checking lock status" thrashes hive metastore databases when multiple jobs try to commit to the same Iceberg table. This fix allows the frequency of "checking the WAITING lock status" configurable and makes use of Tasks to backoff exponentially.

Every time a check on the lock is made, the HMS performs heartbeats on the lock record and the transaction record. It eventually ends up with the below errors if the number of jobs on the same table grew and commit at the same time. Ability to configure the delay between retries and slowing down retries further exponentially would help. Thanks.

```
MetaException(message:Unable to update transaction database org.postgresql.util.PSQLException: ERROR: could not serialize access due to read/write dependencies among transactions
Detail: Reason code: Canceled on identification as a pivot, during write.
Hint: The transaction might succeed if retried.
```