### PR TITLE
Rename fanout configs

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -129,8 +129,8 @@ public class TableProperties {
   public static final String WRITE_TARGET_FILE_SIZE_BYTES = "write.target-file-size-bytes";
   public static final long WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT = Long.MAX_VALUE;
 
-  public static final String WRITE_PARTITIONED_FANOUT_ENABLED = "write.partitioned.fanout.enabled";
-  public static final boolean WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT = false;
+  public static final String SPARK_WRITE_PARTITIONED_FANOUT_ENABLED = "write.spark.partitioned.fanout.enabled";
+  public static final boolean SPARK_WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT = false;
 
   public static final String SNAPSHOT_ID_INHERITANCE_ENABLED = "compatibility.snapshot-id-inheritance.enabled";
   public static final boolean SNAPSHOT_ID_INHERITANCE_ENABLED_DEFAULT = false;

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -129,7 +129,7 @@ public class TableProperties {
   public static final String WRITE_TARGET_FILE_SIZE_BYTES = "write.target-file-size-bytes";
   public static final long WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT = Long.MAX_VALUE;
 
-  public static final String SPARK_WRITE_PARTITIONED_FANOUT_ENABLED = "write.spark.partitioned.fanout.enabled";
+  public static final String SPARK_WRITE_PARTITIONED_FANOUT_ENABLED = "write.spark.fanout.enabled";
   public static final boolean SPARK_WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT = false;
 
   public static final String SNAPSHOT_ID_INHERITANCE_ENABLED = "compatibility.snapshot-id-inheritance.enabled";

--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -68,7 +68,7 @@ Iceberg tables support table properties to configure table behavior, like the de
 | write.summary.partition-limit      | 0                  | Includes partition-level summary stats in snapshot summaries if the changed partition count is less than this limit |
 | write.metadata.delete-after-commit.enabled | false      | Controls whether to delete the oldest version metadata files after commit |
 | write.metadata.previous-versions-max       | 100        | The max number of previous version metadata files to keep before deleting after commit |
-| write.partitioned.fanout.enabled       | false        | Enables Partitioned-Fanout-Writer writes |
+| write.spark.partitioned.fanout.enabled       | false        | Enables Partitioned-Fanout-Writer writes |
 
 ### Table behavior properties
 
@@ -156,5 +156,5 @@ df.write
 | target-file-size-bytes | As per table property      | Overrides this table's write.target-file-size-bytes          |
 | check-nullability      | true                       | Sets the nullable check on fields                            |
 | snapshot-property._custom-key_    | null            | Adds an entry with custom-key and corresponding value in the snapshot summary  |
-| partitioned.fanout.enabled       | false        | Overrides this table's write.partitioned.fanout.enabled  |
+| fanout-enabled       | false        | Overrides this table's write.spark.partitioned.fanout.enabled  |
 

--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -68,7 +68,7 @@ Iceberg tables support table properties to configure table behavior, like the de
 | write.summary.partition-limit      | 0                  | Includes partition-level summary stats in snapshot summaries if the changed partition count is less than this limit |
 | write.metadata.delete-after-commit.enabled | false      | Controls whether to delete the oldest version metadata files after commit |
 | write.metadata.previous-versions-max       | 100        | The max number of previous version metadata files to keep before deleting after commit |
-| write.spark.partitioned.fanout.enabled       | false        | Enables Partitioned-Fanout-Writer writes |
+| write.spark.fanout.enabled       | false        | Enables Partitioned-Fanout-Writer writes in Spark |
 
 ### Table behavior properties
 
@@ -156,5 +156,5 @@ df.write
 | target-file-size-bytes | As per table property      | Overrides this table's write.target-file-size-bytes          |
 | check-nullability      | true                       | Sets the nullable check on fields                            |
 | snapshot-property._custom-key_    | null            | Adds an entry with custom-key and corresponding value in the snapshot summary  |
-| fanout-enabled       | false        | Overrides this table's write.spark.partitioned.fanout.enabled  |
+| fanout-enabled       | false        | Overrides this table's write.spark.fanout.enabled  |
 

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
@@ -14,6 +14,10 @@
 
 package org.apache.iceberg.spark;
 
+/**
+ * Spark DF write options
+ */
 public class SparkWriteOptions {
+    // Overrides table property write.spark.partitioned.fanout.enabled(default: false)
     public static final String FANOUT_ENABLED = "fanout-enabled";
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
@@ -27,6 +27,6 @@ public class SparkWriteOptions {
   private SparkWriteOptions() {
   }
 
-  // Overrides table property write.spark.partitioned.fanout.enabled(default: false)
+  // Overrides table property write.spark.fanout.enabled(default: false)
   public static final String FANOUT_ENABLED = "fanout-enabled";
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.spark;
+
+public class SparkWriteOptions {
+    public static final String FANOUT_ENABLED = "fanout-enabled";
+}

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
@@ -1,15 +1,20 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.iceberg.spark;
@@ -18,6 +23,10 @@ package org.apache.iceberg.spark;
  * Spark DF write options
  */
 public class SparkWriteOptions {
-    // Overrides table property write.spark.partitioned.fanout.enabled(default: false)
-    public static final String FANOUT_ENABLED = "fanout-enabled";
+
+  private SparkWriteOptions() {
+  }
+
+  // Overrides table property write.spark.partitioned.fanout.enabled(default: false)
+  public static final String FANOUT_ENABLED = "fanout-enabled";
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/source/RowDataRewriter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/RowDataRewriter.java
@@ -108,8 +108,8 @@ public class RowDataRewriter implements Serializable {
       writer = new UnpartitionedWriter<>(spec, format, appenderFactory, fileFactory, io.value(),
           Long.MAX_VALUE);
     } else if (PropertyUtil.propertyAsBoolean(properties,
-        TableProperties.WRITE_PARTITIONED_FANOUT_ENABLED,
-        TableProperties.WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT)) {
+        TableProperties.SPARK_WRITE_PARTITIONED_FANOUT_ENABLED,
+        TableProperties.SPARK_WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT)) {
       writer = new SparkPartitionedFanoutWriter(
           spec, format, appenderFactory, fileFactory, io.value(), Long.MAX_VALUE, schema,
           structType);

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.SparkWriteOptions;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
@@ -49,7 +50,7 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import static org.apache.iceberg.TableProperties.WRITE_PARTITIONED_FANOUT_ENABLED;
+import static org.apache.iceberg.TableProperties.SPARK_WRITE_PARTITIONED_FANOUT_ENABLED;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 
 @RunWith(Parameterized.class)
@@ -67,7 +68,7 @@ public abstract class TestSparkDataWrite {
 
   @Parameterized.Parameters(name = "format = {0}")
   public static Object[] parameters() {
-    return new Object[] { "parquet", "avro", "orc" };
+    return new Object[] { "parquet", "avro", "orc"};
   }
 
   @BeforeClass
@@ -502,7 +503,7 @@ public abstract class TestSparkDataWrite {
             .save(location.toString());
         break;
       case TABLE:
-        table.updateProperties().set(WRITE_PARTITIONED_FANOUT_ENABLED, "true").commit();
+        table.updateProperties().set(SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, "true").commit();
         df.select("id", "data").write()
             .format("iceberg")
             .option("write-format", format.toString())
@@ -516,7 +517,7 @@ public abstract class TestSparkDataWrite {
             .option("write-format", format.toString())
             .mode("append")
             .option("target-file-size-bytes", 4) // ~4 bytes; low enough to trigger
-            .option("partitioned.fanout.enabled", true)
+            .option(SparkWriteOptions.FANOUT_ENABLED, true)
             .save(location.toString());
         break;
       default:

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
@@ -68,7 +68,7 @@ public abstract class TestSparkDataWrite {
 
   @Parameterized.Parameters(name = "format = {0}")
   public static Object[] parameters() {
-    return new Object[] { "parquet", "avro", "orc"};
+    return new Object[] { "parquet", "avro", "orc" };
   }
 
   @BeforeClass

--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Writer.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Writer.java
@@ -42,6 +42,7 @@ import org.apache.iceberg.io.UnpartitionedWriter;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.SparkWriteOptions;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 import org.apache.spark.broadcast.Broadcast;
@@ -65,8 +66,8 @@ import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS;
 import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
-import static org.apache.iceberg.TableProperties.WRITE_PARTITIONED_FANOUT_ENABLED;
-import static org.apache.iceberg.TableProperties.WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT;
+import static org.apache.iceberg.TableProperties.SPARK_WRITE_PARTITIONED_FANOUT_ENABLED;
+import static org.apache.iceberg.TableProperties.SPARK_WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT;
 import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT;
 
@@ -118,8 +119,8 @@ class Writer implements DataSourceWriter {
     this.targetFileSize = options.getLong("target-file-size-bytes", tableTargetFileSize);
 
     boolean tablePartitionedFanoutEnabled = PropertyUtil.propertyAsBoolean(
-        table.properties(), WRITE_PARTITIONED_FANOUT_ENABLED, WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT);
-    this.partitionedFanoutEnabled = options.getBoolean("partitioned.fanout.enabled", tablePartitionedFanoutEnabled);
+        table.properties(), SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, SPARK_WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT);
+    this.partitionedFanoutEnabled = options.getBoolean(SparkWriteOptions.FANOUT_ENABLED, tablePartitionedFanoutEnabled);
   }
 
   private FileFormat getFileFormat(Map<String, String> tableProperties, DataSourceOptions options) {

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -46,6 +46,7 @@ import org.apache.iceberg.io.UnpartitionedWriter;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.SparkWriteOptions;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 import org.apache.spark.broadcast.Broadcast;
@@ -72,8 +73,8 @@ import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS;
 import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
-import static org.apache.iceberg.TableProperties.WRITE_PARTITIONED_FANOUT_ENABLED;
-import static org.apache.iceberg.TableProperties.WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT;
+import static org.apache.iceberg.TableProperties.SPARK_WRITE_PARTITIONED_FANOUT_ENABLED;
+import static org.apache.iceberg.TableProperties.SPARK_WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT;
 import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT;
 
@@ -118,9 +119,9 @@ class SparkWrite {
     this.targetFileSize = writeInfo.options().getLong("target-file-size-bytes", tableTargetFileSize);
 
     boolean tablePartitionedFanoutEnabled = PropertyUtil.propertyAsBoolean(
-        table.properties(), WRITE_PARTITIONED_FANOUT_ENABLED, WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT);
+        table.properties(), SPARK_WRITE_PARTITIONED_FANOUT_ENABLED, SPARK_WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT);
     this.partitionedFanoutEnabled = writeInfo.options()
-        .getBoolean("partitioned.fanout.enabled", tablePartitionedFanoutEnabled);
+        .getBoolean(SparkWriteOptions.FANOUT_ENABLED, tablePartitionedFanoutEnabled);
   }
 
   BatchWrite asBatchAppend() {


### PR DESCRIPTION
Renaming the fanout configs.
1. Renamed DF write option from `partitioned.fanout.enabled` to `fanout-enabled`(similar to other Spark options)
2. Renamed TableProperty `write.partitioned.fanout.enabled` to `write.spark.partitioned.fanout.enabled`, as it applies to only Spark.