### PR TITLE
Spark: Support multipart identifier arguments for procedures

### DIFF
--- a/spark3-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
+++ b/spark3-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
@@ -76,6 +76,7 @@ callArgument
 
 expression
     : constant
+    | multipartIdentifier
     ;
 
 constant

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
@@ -130,6 +130,27 @@ public class TestCallStatementParser {
   }
 
   @Test
+  public void testCallWithPositionalMultipartIdentifier() throws ParseException {
+    CallStatement call = (CallStatement) parser.parsePlan("CALL cat.system.func(prod.`a.b`.table)");
+    Assert.assertEquals(ImmutableList.of("cat", "system", "func"), JavaConverters.seqAsJavaList(call.name()));
+
+    Assert.assertEquals(1, call.args().size());
+
+    checkArg(call, 0, new String[] { "prod", "a.b", "table" }, DataTypes.createArrayType(DataTypes.StringType));
+  }
+
+  @Test
+  public void testCallWithNamedMultipartIdentifier() throws ParseException {
+    CallStatement call = (CallStatement) parser.parsePlan("CALL cat.system.func(source_table => prod.`a.b`.table)");
+    Assert.assertEquals(ImmutableList.of("cat", "system", "func"), JavaConverters.seqAsJavaList(call.name()));
+
+    Assert.assertEquals(1, call.args().size());
+
+    checkArg(call, 0, "source_table",
+        new String[] { "prod", "a.b", "table" }, DataTypes.createArrayType(DataTypes.StringType));
+  }
+
+  @Test
   public void testCallParseError() {
     AssertHelpers.assertThrows("Should fail with a sensible parse error", ParseException.class,
         "missing '(' at 'radish'",


### PR DESCRIPTION
This allows Spark stored procedures to accept multipart identifiers as `array<string>`. This avoids some awkward cases when identifying tables:

* Using separate namespace and table name arguments
* Always requiring namespace argument because table is required
* Parsing namespace into a multipart identifier inside of procedure implementations
* Limited options for including a catalog in an identifier (catalog, namespace, table vs namespace, table, optional catalog)