### PR TITLE
API: move NaN validation from Expressions to Literals

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -26,7 +26,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Types;
-import org.apache.iceberg.util.NaNUtil;
 
 /**
  * Factory methods for creating {@link Expression expressions}.
@@ -141,62 +140,50 @@ public class Expressions {
   }
 
   public static <T> UnboundPredicate<T> lessThan(String name, T value) {
-    validateInput("lessThan", value);
     return new UnboundPredicate<>(Expression.Operation.LT, ref(name), value);
   }
 
   public static <T> UnboundPredicate<T> lessThan(UnboundTerm<T> expr, T value) {
-    validateInput("lessThan", value);
     return new UnboundPredicate<>(Expression.Operation.LT, expr, value);
   }
 
   public static <T> UnboundPredicate<T> lessThanOrEqual(String name, T value) {
-    validateInput("lessThanOrEqual", value);
     return new UnboundPredicate<>(Expression.Operation.LT_EQ, ref(name), value);
   }
 
   public static <T> UnboundPredicate<T> lessThanOrEqual(UnboundTerm<T> expr, T value) {
-    validateInput("lessThanOrEqual", value);
     return new UnboundPredicate<>(Expression.Operation.LT_EQ, expr, value);
   }
 
   public static <T> UnboundPredicate<T> greaterThan(String name, T value) {
-    validateInput("greaterThan", value);
     return new UnboundPredicate<>(Expression.Operation.GT, ref(name), value);
   }
 
   public static <T> UnboundPredicate<T> greaterThan(UnboundTerm<T> expr, T value) {
-    validateInput("greaterThan", value);
     return new UnboundPredicate<>(Expression.Operation.GT, expr, value);
   }
 
   public static <T> UnboundPredicate<T> greaterThanOrEqual(String name, T value) {
-    validateInput("greaterThanOrEqual", value);
     return new UnboundPredicate<>(Expression.Operation.GT_EQ, ref(name), value);
   }
 
   public static <T> UnboundPredicate<T> greaterThanOrEqual(UnboundTerm<T> expr, T value) {
-    validateInput("greaterThanOrEqual", value);
     return new UnboundPredicate<>(Expression.Operation.GT_EQ, expr, value);
   }
 
   public static <T> UnboundPredicate<T> equal(String name, T value) {
-    validateInput("equal", value);
     return new UnboundPredicate<>(Expression.Operation.EQ, ref(name), value);
   }
 
   public static <T> UnboundPredicate<T> equal(UnboundTerm<T> expr, T value) {
-    validateInput("equal", value);
     return new UnboundPredicate<>(Expression.Operation.EQ, expr, value);
   }
 
   public static <T> UnboundPredicate<T> notEqual(String name, T value) {
-    validateInput("notEqual", value);
     return new UnboundPredicate<>(Expression.Operation.NOT_EQ, ref(name), value);
   }
 
   public static <T> UnboundPredicate<T> notEqual(UnboundTerm<T> expr, T value) {
-    validateInput("notEqual", value);
     return new UnboundPredicate<>(Expression.Operation.NOT_EQ, expr, value);
   }
 
@@ -245,7 +232,6 @@ public class Expressions {
   }
 
   public static <T> UnboundPredicate<T> predicate(Operation op, String name, T value) {
-    validateInput(op.toString(), value);
     return predicate(op, name, Literals.from(value));
   }
 
@@ -257,7 +243,6 @@ public class Expressions {
   }
 
   public static <T> UnboundPredicate<T> predicate(Operation op, String name, Iterable<T> values) {
-    validateInput(op.toString(), values);
     return predicate(op, ref(name), values);
   }
 
@@ -269,17 +254,7 @@ public class Expressions {
   }
 
   private static <T> UnboundPredicate<T> predicate(Operation op, UnboundTerm<T> expr, Iterable<T> values) {
-    validateInput(op.toString(), values);
     return new UnboundPredicate<>(op, expr, values);
-  }
-
-  private static <T> void validateInput(String op, T value) {
-    Preconditions.checkArgument(!NaNUtil.isNaN(value), String.format("Cannot create %s predicate with NaN", op));
-  }
-
-  private static <T> void validateInput(String op, Iterable<T> values) {
-    Preconditions.checkArgument(Lists.newArrayList(values).stream().noneMatch(NaNUtil::isNaN),
-        String.format("Cannot create %s predicate with NaN", op));
   }
 
   public static True alwaysTrue() {

--- a/api/src/main/java/org/apache/iceberg/expressions/Literals.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Literals.java
@@ -39,6 +39,7 @@ import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.NaNUtil;
 
 class Literals {
   private Literals() {
@@ -57,6 +58,7 @@ class Literals {
   @SuppressWarnings("unchecked")
   static <T> Literal<T> from(T value) {
     Preconditions.checkNotNull(value, "Cannot create expression literal from null");
+    Preconditions.checkArgument(!NaNUtil.isNaN(value), "Cannot expression literal from NaN");
 
     if (value instanceof Boolean) {
       return (Literal<T>) new Literals.BooleanLiteral((Boolean) value);

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionHelpers.java
@@ -194,36 +194,36 @@ public class TestExpressionHelpers {
 
   @Test
   public void testInvalidateNaNInput() {
-    assertInvalidateNaNThrows("lessThan", () -> lessThan("a", Double.NaN));
-    assertInvalidateNaNThrows("lessThan", () -> lessThan(self("a"), Double.NaN));
+    assertInvalidateNaNThrows(() -> lessThan("a", Double.NaN));
+    assertInvalidateNaNThrows(() -> lessThan(self("a"), Double.NaN));
 
-    assertInvalidateNaNThrows("lessThanOrEqual", () -> lessThanOrEqual("a", Double.NaN));
-    assertInvalidateNaNThrows("lessThanOrEqual", () -> lessThanOrEqual(self("a"), Double.NaN));
+    assertInvalidateNaNThrows(() -> lessThanOrEqual("a", Double.NaN));
+    assertInvalidateNaNThrows(() -> lessThanOrEqual(self("a"), Double.NaN));
 
-    assertInvalidateNaNThrows("greaterThan", () -> greaterThan("a", Double.NaN));
-    assertInvalidateNaNThrows("greaterThan", () -> greaterThan(self("a"), Double.NaN));
+    assertInvalidateNaNThrows(() -> greaterThan("a", Double.NaN));
+    assertInvalidateNaNThrows(() -> greaterThan(self("a"), Double.NaN));
 
-    assertInvalidateNaNThrows("greaterThanOrEqual", () -> greaterThanOrEqual("a", Double.NaN));
-    assertInvalidateNaNThrows("greaterThanOrEqual", () -> greaterThanOrEqual(self("a"), Double.NaN));
+    assertInvalidateNaNThrows(() -> greaterThanOrEqual("a", Double.NaN));
+    assertInvalidateNaNThrows(() -> greaterThanOrEqual(self("a"), Double.NaN));
 
-    assertInvalidateNaNThrows("equal", () -> equal("a", Double.NaN));
-    assertInvalidateNaNThrows("equal", () -> equal(self("a"), Double.NaN));
+    assertInvalidateNaNThrows(() -> equal("a", Double.NaN));
+    assertInvalidateNaNThrows(() -> equal(self("a"), Double.NaN));
 
-    assertInvalidateNaNThrows("notEqual", () -> notEqual("a", Double.NaN));
-    assertInvalidateNaNThrows("notEqual", () -> notEqual(self("a"), Double.NaN));
+    assertInvalidateNaNThrows(() -> notEqual("a", Double.NaN));
+    assertInvalidateNaNThrows(() -> notEqual(self("a"), Double.NaN));
 
-    assertInvalidateNaNThrows("IN", () -> in("a", 1.0D, 2.0D, Double.NaN));
-    assertInvalidateNaNThrows("IN", () -> in(self("a"), 1.0D, 2.0D, Double.NaN));
+    assertInvalidateNaNThrows(() -> in("a", 1.0D, 2.0D, Double.NaN));
+    assertInvalidateNaNThrows(() -> in(self("a"), 1.0D, 2.0D, Double.NaN));
 
-    assertInvalidateNaNThrows("NOT_IN", () -> notIn("a", 1.0D, 2.0D, Double.NaN));
-    assertInvalidateNaNThrows("NOT_IN", () -> notIn(self("a"), 1.0D, 2.0D, Double.NaN));
+    assertInvalidateNaNThrows(() -> notIn("a", 1.0D, 2.0D, Double.NaN));
+    assertInvalidateNaNThrows(() -> notIn(self("a"), 1.0D, 2.0D, Double.NaN));
 
-    assertInvalidateNaNThrows("EQ", () -> predicate(Expression.Operation.EQ, "a", Double.NaN));
+    assertInvalidateNaNThrows(() -> predicate(Expression.Operation.EQ, "a", Double.NaN));
   }
 
-  private void assertInvalidateNaNThrows(String operation, Callable<UnboundPredicate<Double>> callable) {
+  private void assertInvalidateNaNThrows(Callable<UnboundPredicate<Double>> callable) {
     AssertHelpers.assertThrows("Should invalidate NaN input",
-        IllegalArgumentException.class, String.format("Cannot create %s predicate with NaN", operation),
+        IllegalArgumentException.class, "Cannot expression literal from NaN",
         callable);
   }
 


### PR DESCRIPTION
Follow up item from #1747 to clean up `Expressions` a bit. No behavior change. 