### PR TITLE
Flink: Add PartitionedDeltaTaskWriter and UnpartitionedDeltaTaskWriter to write both insert and equality-deletes

### DIFF
--- a/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java
@@ -64,6 +64,10 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
     this.targetFileSize = targetFileSize;
   }
 
+  protected PartitionSpec spec() {
+    return spec;
+  }
+
   @Override
   public void abort() throws IOException {
     close();

--- a/flink/src/main/java/org/apache/iceberg/flink/RowDataWrapper.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/RowDataWrapper.java
@@ -53,16 +53,6 @@ public class RowDataWrapper implements StructLike {
     }
   }
 
-  private RowDataWrapper(RowDataWrapper toCopy) {
-    this.types = toCopy.types;
-    this.getters = toCopy.getters;
-    this.rowData = toCopy.rowData;
-  }
-
-  public RowDataWrapper copy() {
-    return new RowDataWrapper(this);
-  }
-
   public RowDataWrapper wrap(RowData data) {
     this.rowData = data;
     return this;

--- a/flink/src/main/java/org/apache/iceberg/flink/RowDataWrapper.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/RowDataWrapper.java
@@ -53,6 +53,16 @@ public class RowDataWrapper implements StructLike {
     }
   }
 
+  private RowDataWrapper(RowDataWrapper toCopy) {
+    this.types = toCopy.types;
+    this.getters = toCopy.getters;
+    this.rowData = toCopy.rowData;
+  }
+
+  public RowDataWrapper copy() {
+    return new RowDataWrapper(this);
+  }
+
   public RowDataWrapper wrap(RowData data) {
     this.rowData = data;
     return this;

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/BaseDeltaTaskWriter.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/BaseDeltaTaskWriter.java
@@ -69,11 +69,6 @@ abstract class BaseDeltaTaskWriter extends BaseTaskWriter<RowData> {
 
     switch (row.getRowKind()) {
       case INSERT:
-        // INSERT is actually an UPSERT, which will overwrite the existing row.
-        writer.delete(row);
-        writer.write(row);
-        break;
-
       case UPDATE_AFTER:
         writer.write(row);
         break;

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/BaseDeltaTaskWriter.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/BaseDeltaTaskWriter.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.sink;
+
+import java.io.IOException;
+import java.util.List;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionKey;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.flink.RowDataWrapper;
+import org.apache.iceberg.io.BaseTaskWriter;
+import org.apache.iceberg.io.FileAppenderFactory;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.OutputFileFactory;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.TypeUtil;
+
+abstract class BaseDeltaTaskWriter extends BaseTaskWriter<RowData> {
+
+  private final Schema schema;
+  private final Schema deleteSchema;
+  private final RowDataWrapper wrapper;
+
+  BaseDeltaTaskWriter(PartitionSpec spec,
+                      FileFormat format,
+                      FileAppenderFactory<RowData> appenderFactory,
+                      OutputFileFactory fileFactory,
+                      FileIO io,
+                      long targetFileSize,
+                      Schema schema,
+                      RowType flinkSchema,
+                      List<Integer> equalityFieldIds) {
+    super(spec, format, appenderFactory, fileFactory, io, targetFileSize);
+    this.schema = schema;
+    this.deleteSchema = TypeUtil.select(schema, Sets.newHashSet(equalityFieldIds));
+    this.wrapper = new RowDataWrapper(flinkSchema, schema.asStruct());
+  }
+
+  abstract RowDataDeltaWriter route(RowData row);
+
+  RowDataWrapper wrapper() {
+    return wrapper;
+  }
+
+  @Override
+  public void write(RowData row) throws IOException {
+    RowDataDeltaWriter writer = route(row);
+
+    switch (row.getRowKind()) {
+      case INSERT:
+        // INSERT is actually an UPSERT, which will overwrite the existing row.
+        writer.delete(row);
+        writer.write(row);
+        break;
+
+      case UPDATE_AFTER:
+        writer.write(row);
+        break;
+
+      case DELETE:
+      case UPDATE_BEFORE:
+        writer.delete(row);
+        break;
+
+      default:
+        throw new UnsupportedOperationException("Unknown row kind: " + row.getRowKind());
+    }
+  }
+
+  protected class RowDataDeltaWriter extends BaseEqualityDeltaWriter {
+    RowDataDeltaWriter(PartitionKey partition) {
+      super(partition, schema, deleteSchema);
+    }
+
+    @Override
+    protected StructLike asStructLike(RowData data) {
+      return wrapper.wrap(data);
+    }
+  }
+}

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -224,7 +224,8 @@ public class FlinkSink {
     FileFormat fileFormat = getFileFormat(props);
 
     TaskWriterFactory<RowData> taskWriterFactory = new RowDataTaskWriterFactory(table.schema(), flinkSchema,
-        table.spec(), table.locationProvider(), table.io(), table.encryption(), targetFileSize, fileFormat, props);
+        table.spec(), table.locationProvider(), table.io(), table.encryption(), targetFileSize, fileFormat, props,
+        null);
 
     return new IcebergStreamWriter<>(table.name(), taskWriterFactory);
   }

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/PartitionedDeltaWriter.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/PartitionedDeltaWriter.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.sink;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionKey;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.io.FileAppenderFactory;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.OutputFileFactory;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.Tasks;
+
+class PartitionedDeltaWriter extends BaseDeltaTaskWriter {
+
+  private final PartitionKey partitionKey;
+
+  private final Map<PartitionKey, RowDataDeltaWriter> writers = Maps.newHashMap();
+
+  PartitionedDeltaWriter(PartitionSpec spec,
+                         FileFormat format,
+                         FileAppenderFactory<RowData> appenderFactory,
+                         OutputFileFactory fileFactory,
+                         FileIO io,
+                         long targetFileSize,
+                         Schema schema,
+                         RowType flinkSchema,
+                         List<Integer> equalityFieldIds) {
+    super(spec, format, appenderFactory, fileFactory, io, targetFileSize, schema, flinkSchema, equalityFieldIds);
+    this.partitionKey = new PartitionKey(spec, schema);
+  }
+
+  @Override
+  RowDataDeltaWriter route(RowData row) {
+    partitionKey.partition(wrapper().wrap(row));
+
+    RowDataDeltaWriter writer = writers.get(partitionKey);
+    if (writer == null) {
+      // NOTICE: we need to copy a new partition key here, in case of messing up the keys in writers.
+      PartitionKey copiedKey = partitionKey.copy();
+      writer = new RowDataDeltaWriter(copiedKey);
+      writers.put(copiedKey, writer);
+    }
+
+    return writer;
+  }
+
+  @Override
+  public void close() {
+    try {
+      Tasks.foreach(writers.values())
+          .throwFailureWhenFinished()
+          .noRetry()
+          .run(RowDataDeltaWriter::close, IOException.class);
+
+      writers.clear();
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to close equality delta writer", e);
+    }
+  }
+}

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/RowDataTaskWriterFactory.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/RowDataTaskWriterFactory.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.flink.sink;
 
+import java.util.List;
 import java.util.Map;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
@@ -36,6 +37,7 @@ import org.apache.iceberg.io.PartitionedFanoutWriter;
 import org.apache.iceberg.io.TaskWriter;
 import org.apache.iceberg.io.UnpartitionedWriter;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.ArrayUtil;
 
 public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
   private final Schema schema;
@@ -46,6 +48,7 @@ public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
   private final EncryptionManager encryptionManager;
   private final long targetFileSizeBytes;
   private final FileFormat format;
+  private final List<Integer> equalityFieldIds;
   private final FileAppenderFactory<RowData> appenderFactory;
 
   private transient OutputFileFactory outputFileFactory;
@@ -58,7 +61,8 @@ public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
                                   EncryptionManager encryptionManager,
                                   long targetFileSizeBytes,
                                   FileFormat format,
-                                  Map<String, String> tableProperties) {
+                                  Map<String, String> tableProperties,
+                                  List<Integer> equalityFieldIds) {
     this.schema = schema;
     this.flinkSchema = flinkSchema;
     this.spec = spec;
@@ -67,7 +71,15 @@ public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
     this.encryptionManager = encryptionManager;
     this.targetFileSizeBytes = targetFileSizeBytes;
     this.format = format;
-    this.appenderFactory = new FlinkAppenderFactory(schema, flinkSchema, tableProperties, spec);
+    this.equalityFieldIds = equalityFieldIds;
+
+    if (equalityFieldIds == null || equalityFieldIds.isEmpty()) {
+      this.appenderFactory = new FlinkAppenderFactory(schema, flinkSchema, tableProperties, spec);
+    } else {
+      // TODO provide the ability to customize the equality-delete row schema.
+      this.appenderFactory = new FlinkAppenderFactory(schema, flinkSchema, tableProperties, spec,
+          ArrayUtil.toIntArray(equalityFieldIds), schema, null);
+    }
   }
 
   @Override
@@ -80,11 +92,23 @@ public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
     Preconditions.checkNotNull(outputFileFactory,
         "The outputFileFactory shouldn't be null if we have invoked the initialize().");
 
-    if (spec.fields().isEmpty()) {
-      return new UnpartitionedWriter<>(spec, format, appenderFactory, outputFileFactory, io, targetFileSizeBytes);
+    if (equalityFieldIds == null || equalityFieldIds.isEmpty()) {
+      // Initialize a task writer to write INSERT only.
+      if (spec.isUnpartitioned()) {
+        return new UnpartitionedWriter<>(spec, format, appenderFactory, outputFileFactory, io, targetFileSizeBytes);
+      } else {
+        return new RowDataPartitionedFanoutWriter(spec, format, appenderFactory, outputFileFactory,
+            io, targetFileSizeBytes, schema, flinkSchema);
+      }
     } else {
-      return new RowDataPartitionedFanoutWriter(spec, format, appenderFactory, outputFileFactory,
-          io, targetFileSizeBytes, schema, flinkSchema);
+      // Initialize a task writer to write both INSERT and equality DELETE.
+      if (spec.isUnpartitioned()) {
+        return new UnpartitionedDeltaWriter(spec, format, appenderFactory, outputFileFactory, io,
+            targetFileSizeBytes, schema, flinkSchema, equalityFieldIds);
+      } else {
+        return new PartitionedDeltaWriter(spec, format, appenderFactory, outputFileFactory, io,
+            targetFileSizeBytes, schema, flinkSchema, equalityFieldIds);
+      }
     }
   }
 

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/UnpartitionedDeltaWriter.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/UnpartitionedDeltaWriter.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.sink;
+
+import java.io.IOException;
+import java.util.List;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.io.FileAppenderFactory;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.OutputFileFactory;
+
+class UnpartitionedDeltaWriter extends BaseDeltaTaskWriter {
+  private final RowDataDeltaWriter writer;
+
+  UnpartitionedDeltaWriter(PartitionSpec spec,
+                           FileFormat format,
+                           FileAppenderFactory<RowData> appenderFactory,
+                           OutputFileFactory fileFactory,
+                           FileIO io,
+                           long targetFileSize,
+                           Schema schema,
+                           RowType flinkSchema,
+                           List<Integer> equalityFieldIds) {
+    super(spec, format, appenderFactory, fileFactory, io, targetFileSize, schema, flinkSchema, equalityFieldIds);
+    this.writer = new RowDataDeltaWriter(null);
+  }
+
+  @Override
+  RowDataDeltaWriter route(RowData row) {
+    return writer;
+  }
+
+  @Override
+  public void close() throws IOException {
+    writer.close();
+  }
+}

--- a/flink/src/main/java/org/apache/iceberg/flink/source/RowDataRewriter.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/source/RowDataRewriter.java
@@ -80,7 +80,8 @@ public class RowDataRewriter {
         encryptionManager,
         Long.MAX_VALUE,
         format,
-        table.properties());
+        table.properties(),
+        null);
   }
 
   public List<DataFile> rewriteDataForTasks(DataStream<CombinedScanTask> dataStream, int parallelism) {

--- a/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.RowKind;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.DataFile;
@@ -92,6 +93,22 @@ public class SimpleDataUtil {
 
   public static RowData createRowData(Integer id, String data) {
     return GenericRowData.of(id, StringData.fromString(data));
+  }
+
+  public static RowData createInsert(Integer id, String data) {
+    return GenericRowData.ofKind(RowKind.INSERT, id, StringData.fromString(data));
+  }
+
+  public static RowData createDelete(Integer id, String data) {
+    return GenericRowData.ofKind(RowKind.DELETE, id, StringData.fromString(data));
+  }
+
+  public static RowData createUpdateBefore(Integer id, String data) {
+    return GenericRowData.ofKind(RowKind.UPDATE_BEFORE, id, StringData.fromString(data));
+  }
+
+  public static RowData createUpdateAfter(Integer id, String data) {
+    return GenericRowData.ofKind(RowKind.UPDATE_AFTER, id, StringData.fromString(data));
   }
 
   public static DataFile writeFile(Schema schema, PartitionSpec spec, Configuration conf,

--- a/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
@@ -1,0 +1,339 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.sink;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import org.apache.flink.table.data.RowData;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.RowDelta;
+import org.apache.iceberg.TableTestBase;
+import org.apache.iceberg.data.IcebergGenerics;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.TaskWriter;
+import org.apache.iceberg.io.WriteResult;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.StructLikeSet;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.apache.iceberg.flink.SimpleDataUtil.createDelete;
+import static org.apache.iceberg.flink.SimpleDataUtil.createInsert;
+import static org.apache.iceberg.flink.SimpleDataUtil.createRecord;
+import static org.apache.iceberg.flink.SimpleDataUtil.createUpdateAfter;
+import static org.apache.iceberg.flink.SimpleDataUtil.createUpdateBefore;
+
+@RunWith(Parameterized.class)
+public class TestDeltaTaskWriter extends TableTestBase {
+  private static final int FORMAT_V2 = 2;
+
+  private final FileFormat format;
+
+  @Parameterized.Parameters(name = "FileFormat = {0}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+        {"avro"},
+        {"parquet"}
+    };
+  }
+
+  public TestDeltaTaskWriter(String fileFormat) {
+    super(FORMAT_V2);
+    this.format = FileFormat.valueOf(fileFormat.toUpperCase(Locale.ENGLISH));
+  }
+
+  @Before
+  public void setupTable() throws IOException {
+    this.tableDir = temp.newFolder();
+    Assert.assertTrue(tableDir.delete()); // created by table create
+
+    this.metadataDir = new File(tableDir, "metadata");
+  }
+
+  private void initTable(boolean partitioned) {
+    if (partitioned) {
+      this.table = create(SCHEMA, PartitionSpec.builderFor(SCHEMA).identity("data").build());
+    } else {
+      this.table = create(SCHEMA, PartitionSpec.unpartitioned());
+    }
+
+    table.updateProperties()
+        .defaultFormat(format)
+        .commit();
+  }
+
+  private int idFieldId() {
+    return table.schema().findField("id").fieldId();
+  }
+
+  private int dataFieldId() {
+    return table.schema().findField("data").fieldId();
+  }
+
+  private void testCdcEvents(boolean partitioned) throws IOException {
+    List<Integer> equalityFieldIds = Lists.newArrayList(idFieldId());
+    TaskWriterFactory<RowData> taskWriterFactory = createTaskWriterFactory(equalityFieldIds);
+    taskWriterFactory.initialize(1, 1);
+
+    // Start the 1th transaction.
+    TaskWriter<RowData> writer = taskWriterFactory.create();
+
+    writer.write(createInsert(1, "aaa"));
+    writer.write(createInsert(2, "bbb"));
+    writer.write(createInsert(3, "ccc"));
+
+    // Update <2, 'bbb'> to <2, 'ddd'>
+    writer.write(createUpdateBefore(2, "bbb"));
+    writer.write(createUpdateAfter(2, "ddd"));
+
+    // Update <1, 'aaa'> to <1, 'eee'>
+    writer.write(createUpdateBefore(1, "aaa"));
+    writer.write(createUpdateAfter(1, "eee"));
+
+    // Insert <4, 'fff'>
+    writer.write(createInsert(4, "fff"));
+    // Insert <5, 'ggg'>
+    writer.write(createInsert(5, "ggg"));
+
+    // Delete <3, 'ccc'>
+    writer.write(createDelete(3, "ccc"));
+
+    WriteResult result = writer.complete();
+    Assert.assertEquals(partitioned ? 7 : 1, result.dataFiles().length);
+    Assert.assertEquals(partitioned ? 8 : 2, result.deleteFiles().length);
+    commitTransaction(result);
+
+    Assert.assertEquals("Should have expected records.", expectedRowSet(
+        createRecord(1, "eee"),
+        createRecord(2, "ddd"),
+        createRecord(4, "fff"),
+        createRecord(5, "ggg")
+    ), actualRowSet("*"));
+
+    // Start the 2nd transaction.
+    writer = taskWriterFactory.create();
+
+    // Update <2, 'ddd'> to <6, 'hhh'> - (Update both key and value)
+    writer.write(createUpdateBefore(2, "ddd"));
+    writer.write(createUpdateAfter(6, "hhh"));
+
+    // Update <5, 'ggg'> to <5, 'iii'>
+    writer.write(createUpdateBefore(5, "ggg"));
+    writer.write(createUpdateAfter(5, "iii"));
+
+    // Delete <4, 'fff'>
+    writer.write(createDelete(4, "fff"));
+
+    result = writer.complete();
+    Assert.assertEquals(partitioned ? 2 : 1, result.dataFiles().length);
+    Assert.assertEquals(partitioned ? 3 : 1, result.deleteFiles().length);
+    commitTransaction(result);
+
+    Assert.assertEquals("Should have expected records", expectedRowSet(
+        createRecord(1, "eee"),
+        createRecord(5, "iii"),
+        createRecord(6, "hhh")
+    ), actualRowSet("*"));
+  }
+
+  @Test
+  public void testUnpartitioned() throws IOException {
+    initTable(false);
+    testCdcEvents(false);
+  }
+
+  @Test
+  public void testPartitioned() throws IOException {
+    initTable(true);
+    testCdcEvents(true);
+  }
+
+  private void testWritePureEqDeletes(boolean partitioned) throws IOException {
+    initTable(partitioned);
+    List<Integer> equalityFieldIds = Lists.newArrayList(idFieldId());
+    TaskWriterFactory<RowData> taskWriterFactory = createTaskWriterFactory(equalityFieldIds);
+    taskWriterFactory.initialize(1, 1);
+
+    TaskWriter<RowData> writer = taskWriterFactory.create();
+    writer.write(createDelete(1, "aaa"));
+    writer.write(createDelete(2, "bbb"));
+    writer.write(createDelete(3, "ccc"));
+
+    WriteResult result = writer.complete();
+    Assert.assertEquals(0, result.dataFiles().length);
+    Assert.assertEquals(partitioned ? 3 : 1, result.deleteFiles().length);
+    commitTransaction(result);
+
+    Assert.assertEquals("Should have no record", expectedRowSet(), actualRowSet("*"));
+  }
+
+  @Test
+  public void testUnpartitionedPureEqDeletes() throws IOException {
+    testWritePureEqDeletes(false);
+  }
+
+  @Test
+  public void testPartitionedPureEqDeletes() throws IOException {
+    testWritePureEqDeletes(true);
+  }
+
+  private void testAbort(boolean partitioned) throws IOException {
+    initTable(partitioned);
+    List<Integer> equalityFieldIds = Lists.newArrayList(idFieldId());
+    TaskWriterFactory<RowData> taskWriterFactory = createTaskWriterFactory(equalityFieldIds);
+    taskWriterFactory.initialize(1, 1);
+
+    TaskWriter<RowData> writer = taskWriterFactory.create();
+    writer.write(createUpdateBefore(1, "aaa"));
+    writer.write(createUpdateAfter(1, "bbb"));
+
+    writer.write(createUpdateBefore(2, "aaa"));
+    writer.write(createUpdateAfter(2, "bbb"));
+
+    // Assert the current data/delete file count.
+    List<Path> files = Files.walk(Paths.get(tableDir.getPath(), "data"))
+        .filter(p -> p.toFile().isFile())
+        .filter(p -> !p.toString().endsWith(".crc"))
+        .collect(Collectors.toList());
+    Assert.assertEquals("Should have expected file count, but files are: " + files, partitioned ? 4 : 2, files.size());
+
+    writer.abort();
+    for (Path file : files) {
+      Assert.assertFalse(Files.exists(file));
+    }
+  }
+
+  @Test
+  public void testUnpartitionedAbort() throws IOException {
+    testAbort(false);
+  }
+
+  @Test
+  public void testPartitionedAbort() throws IOException {
+    testAbort(true);
+  }
+
+  @Test
+  public void testPartitionedTableWithDataAsKey() throws IOException {
+    initTable(true);
+    List<Integer> equalityFieldIds = Lists.newArrayList(dataFieldId());
+    TaskWriterFactory<RowData> taskWriterFactory = createTaskWriterFactory(equalityFieldIds);
+    taskWriterFactory.initialize(1, 1);
+
+    // Start the 1th transaction.
+    TaskWriter<RowData> writer = taskWriterFactory.create();
+    writer.write(createInsert(1, "aaa"));
+    writer.write(createInsert(2, "aaa"));
+    writer.write(createInsert(3, "bbb"));
+    writer.write(createInsert(4, "ccc"));
+
+    WriteResult result = writer.complete();
+    Assert.assertEquals(3, result.dataFiles().length);
+    Assert.assertEquals(4, result.deleteFiles().length);
+    commitTransaction(result);
+
+    Assert.assertEquals("Should have expected records", expectedRowSet(
+        createRecord(2, "aaa"),
+        createRecord(3, "bbb"),
+        createRecord(4, "ccc")
+    ), actualRowSet("*"));
+
+    // Start the 2nd transaction.
+    writer = taskWriterFactory.create();
+    writer.write(createInsert(5, "aaa"));
+    writer.write(createInsert(6, "bbb"));
+    writer.write(createDelete(7, "ccc"));
+
+    result = writer.complete();
+    Assert.assertEquals(2, result.dataFiles().length);
+    Assert.assertEquals(3, result.deleteFiles().length);
+    commitTransaction(result);
+
+    Assert.assertEquals("Should have expected records", expectedRowSet(
+        createRecord(5, "aaa"),
+        createRecord(6, "bbb")
+    ), actualRowSet("*"));
+  }
+
+  @Test
+  public void testPartitionedTableWithDataAndIdAsKey() throws IOException {
+    initTable(true);
+    List<Integer> equalityFieldIds = Lists.newArrayList(dataFieldId(), idFieldId());
+    TaskWriterFactory<RowData> taskWriterFactory = createTaskWriterFactory(equalityFieldIds);
+    taskWriterFactory.initialize(1, 1);
+
+    TaskWriter<RowData> writer = taskWriterFactory.create();
+    writer.write(createInsert(1, "aaa"));
+    writer.write(createInsert(2, "aaa"));
+
+    WriteResult result = writer.complete();
+    Assert.assertEquals(1, result.dataFiles().length);
+    Assert.assertEquals(1, result.deleteFiles().length);
+    Assert.assertEquals(FileContent.EQUALITY_DELETES, result.deleteFiles()[0].content());
+    commitTransaction(result);
+
+    Assert.assertEquals("Should have expected records", expectedRowSet(
+        createRecord(1, "aaa"),
+        createRecord(2, "aaa")
+    ), actualRowSet("*"));
+  }
+
+  private void commitTransaction(WriteResult result) {
+    RowDelta rowDelta = table.newRowDelta();
+    Arrays.stream(result.dataFiles()).forEach(rowDelta::addRows);
+    Arrays.stream(result.deleteFiles()).forEach(rowDelta::addDeletes);
+    rowDelta.commit();
+  }
+
+  private StructLikeSet expectedRowSet(Record... records) {
+    StructLikeSet set = StructLikeSet.create(table.schema().asStruct());
+    Collections.addAll(set, records);
+    return set;
+  }
+
+  private StructLikeSet actualRowSet(String... columns) throws IOException {
+    StructLikeSet set = StructLikeSet.create(table.schema().asStruct());
+    try (CloseableIterable<Record> reader = IcebergGenerics.read(table).select(columns).build()) {
+      reader.forEach(set::add);
+    }
+    return set;
+  }
+
+  private TaskWriterFactory<RowData> createTaskWriterFactory(List<Integer> equalityFieldIds) {
+    return new RowDataTaskWriterFactory(table.schema(), FlinkSchemaUtil.convert(table.schema()),
+        table.spec(), table.locationProvider(), table.io(), table.encryption(), 128 * 1024 * 1024,
+        format, table.properties(), equalityFieldIds);
+  }
+}

--- a/flink/src/test/java/org/apache/iceberg/flink/sink/TestTaskWriters.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/sink/TestTaskWriters.java
@@ -239,7 +239,7 @@ public class TestTaskWriters {
     TaskWriterFactory<RowData> taskWriterFactory = new RowDataTaskWriterFactory(table.schema(),
         (RowType) SimpleDataUtil.FLINK_SCHEMA.toRowDataType().getLogicalType(), table.spec(),
         table.locationProvider(), table.io(), table.encryption(),
-        targetFileSize, format, table.properties());
+        targetFileSize, format, table.properties(), null);
     taskWriterFactory.initialize(1, 1);
     return taskWriterFactory.create();
   }


### PR DESCRIPTION
Introduced an new flink  delta task writer to write cdc events into iceberg table,  this PR is currently built on top of PR https://github.com/apache/iceberg/pull/1888.