### PR TITLE
Add support for timestamp with local zone in Hive3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -561,6 +561,7 @@ if (jdkVersion == '8') {
     test {
       exclude '**/TestIcebergDateObjectInspector.class'
       exclude '**/TestIcebergTimestampObjectInspector.class'
+      exclude '**/TestIcebergTimestampWithZoneObjectInspector.class'
     }
 
     dependencies {

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaConverter.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaConverter.java
@@ -99,6 +99,10 @@ class HiveSchemaConverter {
           case INTERVAL_YEAR_MONTH:
           case INTERVAL_DAY_TIME:
           default:
+            // special case for Timestamp with Local TZ which is only available in Hive3
+            if ("TIMESTAMPLOCALTZ".equals(((PrimitiveTypeInfo) typeInfo).getPrimitiveCategory().name())) {
+              return Types.TimestampType.withZone();
+            }
             throw new IllegalArgumentException("Unsupported Hive type (" +
                 ((PrimitiveTypeInfo) typeInfo).getPrimitiveCategory() +
                 ") for Iceberg tables.");

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaConverter.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaConverter.java
@@ -100,7 +100,7 @@ class HiveSchemaConverter {
           case INTERVAL_DAY_TIME:
           default:
             // special case for Timestamp with Local TZ which is only available in Hive3
-            if ("TIMESTAMPLOCALTZ".equals(((PrimitiveTypeInfo) typeInfo).getPrimitiveCategory().name())) {
+            if ("TIMESTAMPLOCALTZ".equalsIgnoreCase(((PrimitiveTypeInfo) typeInfo).getPrimitiveCategory().name())) {
               return Types.TimestampType.withZone();
             }
             throw new IllegalArgumentException("Unsupported Hive type (" +

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaUtil.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaUtil.java
@@ -108,6 +108,10 @@ public final class HiveSchemaUtil {
       case TIME:
         return "string";
       case TIMESTAMP:
+        Types.TimestampType timestampType = (Types.TimestampType) type;
+        if (MetastoreUtil.hive3PresentOnClasspath() && timestampType.shouldAdjustToUTC()) {
+          return "timestamp with local time zone";
+        }
         return "timestamp";
       case STRING:
       case UUID:

--- a/hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampObjectInspectorHive3.java
+++ b/hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampObjectInspectorHive3.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectIn
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 
 public class IcebergTimestampObjectInspectorHive3 extends AbstractPrimitiveJavaObjectInspector
-    implements TimestampObjectInspector {
+    implements TimestampObjectInspector, WriteObjectInspector {
 
   private static final IcebergTimestampObjectInspectorHive3 INSTANCE = new IcebergTimestampObjectInspectorHive3();
 
@@ -38,6 +38,12 @@ public class IcebergTimestampObjectInspectorHive3 extends AbstractPrimitiveJavaO
 
   private IcebergTimestampObjectInspectorHive3() {
     super(TypeInfoFactory.timestampTypeInfo);
+  }
+
+  @Override
+  public LocalDateTime convert(Object o) {
+    return o == null ? null : LocalDateTime.ofEpochSecond(
+        ((TimestampWritableV2) o).getTimestamp().toEpochSecond(), 0, ZoneOffset.UTC);
   }
 
   @Override

--- a/hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampObjectInspectorHive3.java
+++ b/hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampObjectInspectorHive3.java
@@ -42,8 +42,11 @@ public class IcebergTimestampObjectInspectorHive3 extends AbstractPrimitiveJavaO
 
   @Override
   public LocalDateTime convert(Object o) {
-    return o == null ? null : LocalDateTime.ofEpochSecond(
-        ((TimestampWritableV2) o).getTimestamp().toEpochSecond(), 0, ZoneOffset.UTC);
+    if (o == null) {
+      return null;
+    }
+    Timestamp timestamp = ((TimestampWritableV2) o).getTimestamp();
+    return LocalDateTime.ofEpochSecond(timestamp.toEpochSecond(), timestamp.getNanos(), ZoneOffset.UTC);
   }
 
   @Override

--- a/hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampObjectInspectorHive3.java
+++ b/hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampObjectInspectorHive3.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.mr.hive.serde.objectinspector;
 
 import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import org.apache.hadoop.hive.common.type.Timestamp;
 import org.apache.hadoop.hive.serde2.io.TimestampWritableV2;
@@ -28,42 +27,25 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.AbstractPrimitive
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 
-public abstract class IcebergTimestampObjectInspectorHive3 extends AbstractPrimitiveJavaObjectInspector
+public class IcebergTimestampObjectInspectorHive3 extends AbstractPrimitiveJavaObjectInspector
     implements TimestampObjectInspector {
 
-  private static final IcebergTimestampObjectInspectorHive3 INSTANCE_WITH_ZONE =
-      new IcebergTimestampObjectInspectorHive3() {
-        @Override
-        LocalDateTime toLocalDateTime(Object o) {
-          return ((OffsetDateTime) o).toLocalDateTime();
-        }
-      };
+  private static final IcebergTimestampObjectInspectorHive3 INSTANCE = new IcebergTimestampObjectInspectorHive3();
 
-  private static final IcebergTimestampObjectInspectorHive3 INSTANCE_WITHOUT_ZONE =
-      new IcebergTimestampObjectInspectorHive3() {
-        @Override
-        LocalDateTime toLocalDateTime(Object o) {
-          return (LocalDateTime) o;
-        }
-      };
-
-  public static IcebergTimestampObjectInspectorHive3 get(boolean adjustToUTC) {
-    return adjustToUTC ? INSTANCE_WITH_ZONE : INSTANCE_WITHOUT_ZONE;
+  public static IcebergTimestampObjectInspectorHive3 get() {
+    return INSTANCE;
   }
 
   private IcebergTimestampObjectInspectorHive3() {
     super(TypeInfoFactory.timestampTypeInfo);
   }
 
-
-  abstract LocalDateTime toLocalDateTime(Object object);
-
   @Override
   public Timestamp getPrimitiveJavaObject(Object o) {
     if (o == null) {
       return null;
     }
-    LocalDateTime time = toLocalDateTime(o);
+    LocalDateTime time = (LocalDateTime) o;
     Timestamp timestamp = Timestamp.ofEpochMilli(time.toInstant(ZoneOffset.UTC).toEpochMilli());
     timestamp.setNanos(time.getNano());
     return timestamp;
@@ -86,8 +68,6 @@ public abstract class IcebergTimestampObjectInspectorHive3 extends AbstractPrimi
       Timestamp copy = new Timestamp(ts);
       copy.setNanos(ts.getNanos());
       return copy;
-    } else if (o instanceof OffsetDateTime) {
-      return OffsetDateTime.of(((OffsetDateTime) o).toLocalDateTime(), ((OffsetDateTime) o).getOffset());
     } else if (o instanceof LocalDateTime) {
       return LocalDateTime.of(((LocalDateTime) o).toLocalDate(), ((LocalDateTime) o).toLocalTime());
     } else {

--- a/hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampWithZoneObjectInspectorHive3.java
+++ b/hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampWithZoneObjectInspectorHive3.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampLocalTZO
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 
 public class IcebergTimestampWithZoneObjectInspectorHive3 extends AbstractPrimitiveJavaObjectInspector
-    implements TimestampLocalTZObjectInspector {
+    implements TimestampLocalTZObjectInspector, WriteObjectInspector {
 
   private static final IcebergTimestampWithZoneObjectInspectorHive3 INSTANCE =
       new IcebergTimestampWithZoneObjectInspectorHive3();
@@ -40,6 +40,15 @@ public class IcebergTimestampWithZoneObjectInspectorHive3 extends AbstractPrimit
 
   private IcebergTimestampWithZoneObjectInspectorHive3() {
     super(TypeInfoFactory.timestampLocalTZTypeInfo);
+  }
+
+  @Override
+  public OffsetDateTime convert(Object o) {
+    if (o == null) {
+      return null;
+    }
+    ZonedDateTime zdt = ((TimestampLocalTZWritable) o).getTimestampTZ().getZonedDateTime();
+    return OffsetDateTime.of(zdt.toLocalDateTime(), zdt.getOffset());
   }
 
   @Override

--- a/hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampWithZoneObjectInspectorHive3.java
+++ b/hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampWithZoneObjectInspectorHive3.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.mr.hive.serde.objectinspector;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import org.apache.hadoop.hive.common.type.TimestampTZ;
+import org.apache.hadoop.hive.serde2.io.TimestampLocalTZWritable;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.AbstractPrimitiveJavaObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampLocalTZObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+
+public class IcebergTimestampWithZoneObjectInspectorHive3 extends AbstractPrimitiveJavaObjectInspector
+    implements TimestampLocalTZObjectInspector {
+
+  private static final IcebergTimestampWithZoneObjectInspectorHive3 INSTANCE =
+      new IcebergTimestampWithZoneObjectInspectorHive3();
+
+  public static IcebergTimestampWithZoneObjectInspectorHive3 get() {
+    return INSTANCE;
+  }
+
+  private IcebergTimestampWithZoneObjectInspectorHive3() {
+    super(TypeInfoFactory.timestampLocalTZTypeInfo);
+  }
+
+  @Override
+  public TimestampTZ getPrimitiveJavaObject(Object o) {
+    if (o == null) {
+      return null;
+    }
+    OffsetDateTime odt = (OffsetDateTime) o;
+    ZonedDateTime zdt = odt.atZoneSameInstant(ZoneOffset.UTC);
+    return new TimestampTZ(zdt);
+  }
+
+  @Override
+  public TimestampLocalTZWritable getPrimitiveWritableObject(Object o) {
+    TimestampTZ tsTz = getPrimitiveJavaObject(o);
+    return tsTz == null ? null : new TimestampLocalTZWritable(tsTz);
+  }
+
+  @Override
+  public Object copyObject(Object o) {
+    if (o instanceof TimestampTZ) {
+      TimestampTZ ts = (TimestampTZ) o;
+      return new TimestampTZ(ts.getZonedDateTime());
+    } else if (o instanceof OffsetDateTime) {
+      OffsetDateTime odt = (OffsetDateTime) o;
+      return OffsetDateTime.of(odt.toLocalDateTime(), odt.getOffset());
+    } else {
+      return o;
+    }
+  }
+}

--- a/hive3/src/test/java/org/apache/iceberg/mr/hive/TestHiveSchemaUtilHive3.java
+++ b/hive3/src/test/java/org/apache/iceberg/mr/hive/TestHiveSchemaUtilHive3.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.mr.hive;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.serde.serdeConstants;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.hive.TestHiveSchemaUtil;
+import org.apache.iceberg.types.Types;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+
+public class TestHiveSchemaUtilHive3 extends TestHiveSchemaUtil {
+
+  @Override
+  protected List<FieldSchema> getSupportedFieldSchemas() {
+    List<FieldSchema> fields = new ArrayList<>();
+    fields.add(new FieldSchema("c_float", serdeConstants.FLOAT_TYPE_NAME, ""));
+    fields.add(new FieldSchema("c_double", serdeConstants.DOUBLE_TYPE_NAME, ""));
+    fields.add(new FieldSchema("c_boolean", serdeConstants.BOOLEAN_TYPE_NAME, ""));
+    fields.add(new FieldSchema("c_int", serdeConstants.INT_TYPE_NAME, ""));
+    fields.add(new FieldSchema("c_long", serdeConstants.BIGINT_TYPE_NAME, ""));
+    fields.add(new FieldSchema("c_binary", serdeConstants.BINARY_TYPE_NAME, ""));
+    fields.add(new FieldSchema("c_string", serdeConstants.STRING_TYPE_NAME, ""));
+    fields.add(new FieldSchema("c_timestamp", serdeConstants.TIMESTAMP_TYPE_NAME, ""));
+    // timestamp local tz only present in Hive3
+    fields.add(new FieldSchema("c_timestamptz", serdeConstants.TIMESTAMPLOCALTZ_TYPE_NAME, ""));
+    fields.add(new FieldSchema("c_date", serdeConstants.DATE_TYPE_NAME, ""));
+    fields.add(new FieldSchema("c_decimal", serdeConstants.DECIMAL_TYPE_NAME + "(38,10)", ""));
+    return fields;
+  }
+
+  @Override
+  protected Schema getSchemaWithSupportedTypes() {
+    return new Schema(
+        optional(0, "c_float", Types.FloatType.get()),
+        optional(1, "c_double", Types.DoubleType.get()),
+        optional(2, "c_boolean", Types.BooleanType.get()),
+        optional(3, "c_int", Types.IntegerType.get()),
+        optional(4, "c_long", Types.LongType.get()),
+        optional(5, "c_binary", Types.BinaryType.get()),
+        optional(6, "c_string", Types.StringType.get()),
+        optional(7, "c_timestamp", Types.TimestampType.withoutZone()),
+        // timestamp local tz only present in Hive3
+        optional(8, "c_timestamptz", Types.TimestampType.withZone()),
+        optional(9, "c_date", Types.DateType.get()),
+        optional(10, "c_decimal", Types.DecimalType.of(38, 10)));
+  }
+}

--- a/hive3/src/test/java/org/apache/iceberg/mr/hive/TestHiveSchemaUtilHive3.java
+++ b/hive3/src/test/java/org/apache/iceberg/mr/hive/TestHiveSchemaUtilHive3.java
@@ -19,12 +19,12 @@
 
 package org.apache.iceberg.mr.hive;
 
-import java.util.ArrayList;
 import java.util.List;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.hive.TestHiveSchemaUtil;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
@@ -33,36 +33,18 @@ public class TestHiveSchemaUtilHive3 extends TestHiveSchemaUtil {
 
   @Override
   protected List<FieldSchema> getSupportedFieldSchemas() {
-    List<FieldSchema> fields = new ArrayList<>();
-    fields.add(new FieldSchema("c_float", serdeConstants.FLOAT_TYPE_NAME, ""));
-    fields.add(new FieldSchema("c_double", serdeConstants.DOUBLE_TYPE_NAME, ""));
-    fields.add(new FieldSchema("c_boolean", serdeConstants.BOOLEAN_TYPE_NAME, ""));
-    fields.add(new FieldSchema("c_int", serdeConstants.INT_TYPE_NAME, ""));
-    fields.add(new FieldSchema("c_long", serdeConstants.BIGINT_TYPE_NAME, ""));
-    fields.add(new FieldSchema("c_binary", serdeConstants.BINARY_TYPE_NAME, ""));
-    fields.add(new FieldSchema("c_string", serdeConstants.STRING_TYPE_NAME, ""));
-    fields.add(new FieldSchema("c_timestamp", serdeConstants.TIMESTAMP_TYPE_NAME, ""));
+    List<FieldSchema> fields = Lists.newArrayList(super.getSupportedFieldSchemas());
     // timestamp local tz only present in Hive3
     fields.add(new FieldSchema("c_timestamptz", serdeConstants.TIMESTAMPLOCALTZ_TYPE_NAME, ""));
-    fields.add(new FieldSchema("c_date", serdeConstants.DATE_TYPE_NAME, ""));
-    fields.add(new FieldSchema("c_decimal", serdeConstants.DECIMAL_TYPE_NAME + "(38,10)", ""));
     return fields;
   }
 
   @Override
   protected Schema getSchemaWithSupportedTypes() {
-    return new Schema(
-        optional(0, "c_float", Types.FloatType.get()),
-        optional(1, "c_double", Types.DoubleType.get()),
-        optional(2, "c_boolean", Types.BooleanType.get()),
-        optional(3, "c_int", Types.IntegerType.get()),
-        optional(4, "c_long", Types.LongType.get()),
-        optional(5, "c_binary", Types.BinaryType.get()),
-        optional(6, "c_string", Types.StringType.get()),
-        optional(7, "c_timestamp", Types.TimestampType.withoutZone()),
-        // timestamp local tz only present in Hive3
-        optional(8, "c_timestamptz", Types.TimestampType.withZone()),
-        optional(9, "c_date", Types.DateType.get()),
-        optional(10, "c_decimal", Types.DecimalType.of(38, 10)));
+    Schema schema = super.getSchemaWithSupportedTypes();
+    List<Types.NestedField> columns = Lists.newArrayList(schema.columns());
+    // timestamp local tz only present in Hive3
+    columns.add(optional(columns.size(), "c_timestamptz", Types.TimestampType.withZone()));
+    return new Schema(columns);
   }
 }

--- a/hive3/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampObjectInspectorHive3.java
+++ b/hive3/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampObjectInspectorHive3.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.hive.common.type.Timestamp;
 import org.apache.hadoop.hive.serde2.io.TimestampWritableV2;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.junit.Assert;
 import org.junit.Test;
@@ -35,7 +34,7 @@ public class TestIcebergTimestampObjectInspectorHive3 {
 
   @Test
   public void testIcebergTimestampObjectInspector() {
-    TimestampObjectInspector oi = IcebergTimestampObjectInspectorHive3.get();
+    IcebergTimestampObjectInspectorHive3 oi = IcebergTimestampObjectInspectorHive3.get();
 
     Assert.assertEquals(ObjectInspector.Category.PRIMITIVE, oi.getCategory());
     Assert.assertEquals(PrimitiveObjectInspector.PrimitiveCategory.TIMESTAMP, oi.getPrimitiveCategory());
@@ -49,6 +48,7 @@ public class TestIcebergTimestampObjectInspectorHive3 {
     Assert.assertNull(oi.copyObject(null));
     Assert.assertNull(oi.getPrimitiveJavaObject(null));
     Assert.assertNull(oi.getPrimitiveWritableObject(null));
+    Assert.assertNull(oi.convert(null));
 
     long epochMilli = 1601471970000L;
     LocalDateTime local = LocalDateTime.ofInstant(Instant.ofEpochMilli(epochMilli), ZoneId.of("UTC"));
@@ -63,6 +63,8 @@ public class TestIcebergTimestampObjectInspectorHive3 {
     Assert.assertNotSame(ts, copy);
 
     Assert.assertFalse(oi.preferWritable());
+
+    Assert.assertEquals(local, oi.convert(new TimestampWritableV2(ts)));
   }
 
 }

--- a/hive3/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampObjectInspectorHive3.java
+++ b/hive3/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampObjectInspectorHive3.java
@@ -21,9 +21,7 @@ package org.apache.iceberg.mr.hive.serde.objectinspector;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import org.apache.hadoop.hive.common.type.Timestamp;
 import org.apache.hadoop.hive.serde2.io.TimestampWritableV2;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
@@ -37,7 +35,7 @@ public class TestIcebergTimestampObjectInspectorHive3 {
 
   @Test
   public void testIcebergTimestampObjectInspector() {
-    TimestampObjectInspector oi = IcebergTimestampObjectInspectorHive3.get(false);
+    TimestampObjectInspector oi = IcebergTimestampObjectInspectorHive3.get();
 
     Assert.assertEquals(ObjectInspector.Category.PRIMITIVE, oi.getCategory());
     Assert.assertEquals(PrimitiveObjectInspector.PrimitiveCategory.TIMESTAMP, oi.getPrimitiveCategory());
@@ -58,39 +56,6 @@ public class TestIcebergTimestampObjectInspectorHive3 {
 
     Assert.assertEquals(ts, oi.getPrimitiveJavaObject(local));
     Assert.assertEquals(new TimestampWritableV2(ts), oi.getPrimitiveWritableObject(local));
-
-    Timestamp copy = (Timestamp) oi.copyObject(ts);
-
-    Assert.assertEquals(ts, copy);
-    Assert.assertNotSame(ts, copy);
-
-    Assert.assertFalse(oi.preferWritable());
-  }
-
-  @Test
-  public void testIcebergTimestampObjectInspectorWithUTCAdjustment() {
-    TimestampObjectInspector oi = IcebergTimestampObjectInspectorHive3.get(true);
-
-    Assert.assertEquals(ObjectInspector.Category.PRIMITIVE, oi.getCategory());
-    Assert.assertEquals(PrimitiveObjectInspector.PrimitiveCategory.TIMESTAMP, oi.getPrimitiveCategory());
-
-    Assert.assertEquals(TypeInfoFactory.timestampTypeInfo, oi.getTypeInfo());
-    Assert.assertEquals(TypeInfoFactory.timestampTypeInfo.getTypeName(), oi.getTypeName());
-
-    Assert.assertEquals(Timestamp.class, oi.getJavaPrimitiveClass());
-    Assert.assertEquals(TimestampWritableV2.class, oi.getPrimitiveWritableClass());
-
-    Assert.assertNull(oi.copyObject(null));
-    Assert.assertNull(oi.getPrimitiveJavaObject(null));
-    Assert.assertNull(oi.getPrimitiveWritableObject(null));
-
-    long epochMilli = 1601471970000L;
-    LocalDateTime local = LocalDateTime.ofInstant(Instant.ofEpochMilli(epochMilli), ZoneId.of("UTC"));
-    OffsetDateTime offsetDateTime = OffsetDateTime.of(local, ZoneOffset.ofHours(4));
-    Timestamp ts = Timestamp.ofEpochMilli(epochMilli);
-
-    Assert.assertEquals(ts, oi.getPrimitiveJavaObject(offsetDateTime));
-    Assert.assertEquals(new TimestampWritableV2(ts), oi.getPrimitiveWritableObject(offsetDateTime));
 
     Timestamp copy = (Timestamp) oi.copyObject(ts);
 

--- a/hive3/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampObjectInspectorHive3.java
+++ b/hive3/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampObjectInspectorHive3.java
@@ -51,8 +51,9 @@ public class TestIcebergTimestampObjectInspectorHive3 {
     Assert.assertNull(oi.convert(null));
 
     long epochMilli = 1601471970000L;
-    LocalDateTime local = LocalDateTime.ofInstant(Instant.ofEpochMilli(epochMilli), ZoneId.of("UTC"));
+    LocalDateTime local = LocalDateTime.ofInstant(Instant.ofEpochMilli(epochMilli), ZoneId.of("UTC")).plusNanos(34000);
     Timestamp ts = Timestamp.ofEpochMilli(epochMilli);
+    ts.setNanos(34000);
 
     Assert.assertEquals(ts, oi.getPrimitiveJavaObject(local));
     Assert.assertEquals(new TimestampWritableV2(ts), oi.getPrimitiveWritableObject(local));

--- a/hive3/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspectorHive3.java
+++ b/hive3/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspectorHive3.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.hive.common.type.TimestampTZ;
 import org.apache.hadoop.hive.serde2.io.TimestampLocalTZWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampLocalTZObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.junit.Assert;
 import org.junit.Test;
@@ -36,7 +35,7 @@ public class TestIcebergTimestampWithZoneObjectInspectorHive3 {
 
   @Test
   public void testIcebergTimestampLocalTZObjectInspector() {
-    TimestampLocalTZObjectInspector oi = IcebergTimestampWithZoneObjectInspectorHive3.get();
+    IcebergTimestampWithZoneObjectInspectorHive3 oi = IcebergTimestampWithZoneObjectInspectorHive3.get();
 
     Assert.assertEquals(ObjectInspector.Category.PRIMITIVE, oi.getCategory());
     Assert.assertEquals(PrimitiveObjectInspector.PrimitiveCategory.TIMESTAMPLOCALTZ, oi.getPrimitiveCategory());
@@ -50,6 +49,7 @@ public class TestIcebergTimestampWithZoneObjectInspectorHive3 {
     Assert.assertNull(oi.copyObject(null));
     Assert.assertNull(oi.getPrimitiveJavaObject(null));
     Assert.assertNull(oi.getPrimitiveWritableObject(null));
+    Assert.assertNull(oi.convert(null));
 
     LocalDateTime dateTimeAtUTC = LocalDateTime.of(2020, 12, 10, 15, 55, 20, 0);
     OffsetDateTime offsetDateTime = OffsetDateTime.of(dateTimeAtUTC.plusHours(4), ZoneOffset.ofHours(4));
@@ -69,6 +69,8 @@ public class TestIcebergTimestampWithZoneObjectInspectorHive3 {
     Assert.assertNotSame(ts, copy);
 
     Assert.assertFalse(oi.preferWritable());
+
+    Assert.assertEquals(OffsetDateTime.of(dateTimeAtUTC, ZoneOffset.UTC), oi.convert(new TimestampLocalTZWritable(ts)));
   }
 
 }

--- a/hive3/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspectorHive3.java
+++ b/hive3/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspectorHive3.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.mr.hive.serde.objectinspector;
 
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import org.apache.hadoop.hive.common.type.TimestampTZ;
 import org.apache.hadoop.hive.serde2.io.TimestampLocalTZWritable;
@@ -50,11 +51,15 @@ public class TestIcebergTimestampWithZoneObjectInspectorHive3 {
     Assert.assertNull(oi.getPrimitiveJavaObject(null));
     Assert.assertNull(oi.getPrimitiveWritableObject(null));
 
-    long epochSeconds = 1601471970L;
-    OffsetDateTime offsetDateTime = OffsetDateTime.of(
-        LocalDateTime.ofEpochSecond(epochSeconds, 0, ZoneOffset.UTC), ZoneOffset.ofHours(4));
-    TimestampTZ ts = new TimestampTZ(offsetDateTime.toZonedDateTime());
+    LocalDateTime dateTimeAtUTC = LocalDateTime.of(2020, 12, 10, 15, 55, 20, 0);
+    OffsetDateTime offsetDateTime = OffsetDateTime.of(dateTimeAtUTC.plusHours(4), ZoneOffset.ofHours(4));
+    TimestampTZ ts = new TimestampTZ(dateTimeAtUTC.atZone(ZoneId.of("UTC")));
 
+    Assert.assertEquals(ts, oi.getPrimitiveJavaObject(offsetDateTime));
+    Assert.assertEquals(new TimestampLocalTZWritable(ts), oi.getPrimitiveWritableObject(offsetDateTime));
+
+    // try with another offset as well
+    offsetDateTime = OffsetDateTime.of(dateTimeAtUTC.plusHours(11), ZoneOffset.ofHours(11));
     Assert.assertEquals(ts, oi.getPrimitiveJavaObject(offsetDateTime));
     Assert.assertEquals(new TimestampLocalTZWritable(ts), oi.getPrimitiveWritableObject(offsetDateTime));
 

--- a/hive3/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspectorHive3.java
+++ b/hive3/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspectorHive3.java
@@ -1,15 +1,20 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.iceberg.mr.hive.serde.objectinspector;
@@ -28,37 +33,37 @@ import org.junit.Test;
 
 public class TestIcebergTimestampWithZoneObjectInspectorHive3 {
 
-    @Test
-    public void testIcebergTimestampLocalTZObjectInspector() {
-        TimestampLocalTZObjectInspector oi = IcebergTimestampWithZoneObjectInspectorHive3.get();
+  @Test
+  public void testIcebergTimestampLocalTZObjectInspector() {
+    TimestampLocalTZObjectInspector oi = IcebergTimestampWithZoneObjectInspectorHive3.get();
 
-        Assert.assertEquals(ObjectInspector.Category.PRIMITIVE, oi.getCategory());
-        Assert.assertEquals(PrimitiveObjectInspector.PrimitiveCategory.TIMESTAMPLOCALTZ, oi.getPrimitiveCategory());
+    Assert.assertEquals(ObjectInspector.Category.PRIMITIVE, oi.getCategory());
+    Assert.assertEquals(PrimitiveObjectInspector.PrimitiveCategory.TIMESTAMPLOCALTZ, oi.getPrimitiveCategory());
 
-        Assert.assertEquals(TypeInfoFactory.timestampLocalTZTypeInfo, oi.getTypeInfo());
-        Assert.assertEquals(TypeInfoFactory.timestampLocalTZTypeInfo.getTypeName(), oi.getTypeName());
+    Assert.assertEquals(TypeInfoFactory.timestampLocalTZTypeInfo, oi.getTypeInfo());
+    Assert.assertEquals(TypeInfoFactory.timestampLocalTZTypeInfo.getTypeName(), oi.getTypeName());
 
-        Assert.assertEquals(TimestampTZ.class, oi.getJavaPrimitiveClass());
-        Assert.assertEquals(TimestampLocalTZWritable.class, oi.getPrimitiveWritableClass());
+    Assert.assertEquals(TimestampTZ.class, oi.getJavaPrimitiveClass());
+    Assert.assertEquals(TimestampLocalTZWritable.class, oi.getPrimitiveWritableClass());
 
-        Assert.assertNull(oi.copyObject(null));
-        Assert.assertNull(oi.getPrimitiveJavaObject(null));
-        Assert.assertNull(oi.getPrimitiveWritableObject(null));
+    Assert.assertNull(oi.copyObject(null));
+    Assert.assertNull(oi.getPrimitiveJavaObject(null));
+    Assert.assertNull(oi.getPrimitiveWritableObject(null));
 
-        long epochSeconds = 1601471970L;
-        OffsetDateTime offsetDateTime = OffsetDateTime.of(
-            LocalDateTime.ofEpochSecond(epochSeconds, 0, ZoneOffset.UTC), ZoneOffset.ofHours(4));
-        TimestampTZ ts = new TimestampTZ(offsetDateTime.toZonedDateTime());
+    long epochSeconds = 1601471970L;
+    OffsetDateTime offsetDateTime = OffsetDateTime.of(
+        LocalDateTime.ofEpochSecond(epochSeconds, 0, ZoneOffset.UTC), ZoneOffset.ofHours(4));
+    TimestampTZ ts = new TimestampTZ(offsetDateTime.toZonedDateTime());
 
-        Assert.assertEquals(ts, oi.getPrimitiveJavaObject(offsetDateTime));
-        Assert.assertEquals(new TimestampLocalTZWritable(ts), oi.getPrimitiveWritableObject(offsetDateTime));
+    Assert.assertEquals(ts, oi.getPrimitiveJavaObject(offsetDateTime));
+    Assert.assertEquals(new TimestampLocalTZWritable(ts), oi.getPrimitiveWritableObject(offsetDateTime));
 
-        TimestampTZ copy = (TimestampTZ) oi.copyObject(ts);
+    TimestampTZ copy = (TimestampTZ) oi.copyObject(ts);
 
-        Assert.assertEquals(ts, copy);
-        Assert.assertNotSame(ts, copy);
+    Assert.assertEquals(ts, copy);
+    Assert.assertNotSame(ts, copy);
 
-        Assert.assertFalse(oi.preferWritable());
-    }
+    Assert.assertFalse(oi.preferWritable());
+  }
 
 }

--- a/hive3/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspectorHive3.java
+++ b/hive3/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspectorHive3.java
@@ -51,7 +51,7 @@ public class TestIcebergTimestampWithZoneObjectInspectorHive3 {
     Assert.assertNull(oi.getPrimitiveWritableObject(null));
     Assert.assertNull(oi.convert(null));
 
-    LocalDateTime dateTimeAtUTC = LocalDateTime.of(2020, 12, 10, 15, 55, 20, 0);
+    LocalDateTime dateTimeAtUTC = LocalDateTime.of(2020, 12, 10, 15, 55, 20, 30000);
     OffsetDateTime offsetDateTime = OffsetDateTime.of(dateTimeAtUTC.plusHours(4), ZoneOffset.ofHours(4));
     TimestampTZ ts = new TimestampTZ(dateTimeAtUTC.atZone(ZoneId.of("UTC")));
 

--- a/hive3/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspectorHive3.java
+++ b/hive3/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspectorHive3.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.serde.objectinspector;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.apache.hadoop.hive.common.type.TimestampTZ;
+import org.apache.hadoop.hive.serde2.io.TimestampLocalTZWritable;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampLocalTZObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestIcebergTimestampWithZoneObjectInspectorHive3 {
+
+    @Test
+    public void testIcebergTimestampLocalTZObjectInspector() {
+        TimestampLocalTZObjectInspector oi = IcebergTimestampWithZoneObjectInspectorHive3.get();
+
+        Assert.assertEquals(ObjectInspector.Category.PRIMITIVE, oi.getCategory());
+        Assert.assertEquals(PrimitiveObjectInspector.PrimitiveCategory.TIMESTAMPLOCALTZ, oi.getPrimitiveCategory());
+
+        Assert.assertEquals(TypeInfoFactory.timestampLocalTZTypeInfo, oi.getTypeInfo());
+        Assert.assertEquals(TypeInfoFactory.timestampLocalTZTypeInfo.getTypeName(), oi.getTypeName());
+
+        Assert.assertEquals(TimestampTZ.class, oi.getJavaPrimitiveClass());
+        Assert.assertEquals(TimestampLocalTZWritable.class, oi.getPrimitiveWritableClass());
+
+        Assert.assertNull(oi.copyObject(null));
+        Assert.assertNull(oi.getPrimitiveJavaObject(null));
+        Assert.assertNull(oi.getPrimitiveWritableObject(null));
+
+        long epochSeconds = 1601471970L;
+        OffsetDateTime offsetDateTime = OffsetDateTime.of(
+            LocalDateTime.ofEpochSecond(epochSeconds, 0, ZoneOffset.UTC), ZoneOffset.ofHours(4));
+        TimestampTZ ts = new TimestampTZ(offsetDateTime.toZonedDateTime());
+
+        Assert.assertEquals(ts, oi.getPrimitiveJavaObject(offsetDateTime));
+        Assert.assertEquals(new TimestampLocalTZWritable(ts), oi.getPrimitiveWritableObject(offsetDateTime));
+
+        TimestampTZ copy = (TimestampTZ) oi.copyObject(ts);
+
+        Assert.assertEquals(ts, copy);
+        Assert.assertNotSame(ts, copy);
+
+        Assert.assertFalse(oi.preferWritable());
+    }
+
+}

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergObjectInspector.java
@@ -50,15 +50,19 @@ public final class IcebergObjectInspector extends TypeUtil.SchemaVisitor<ObjectI
           "org.apache.iceberg.mr.hive.serde.objectinspector.IcebergTimestampObjectInspectorHive3" :
           "org.apache.iceberg.mr.hive.serde.objectinspector.IcebergTimestampObjectInspector";
 
+  private static final String TIMESTAMPTZ_INSPECTOR_CLASS = MetastoreUtil.hive3PresentOnClasspath() ?
+          "org.apache.iceberg.mr.hive.serde.objectinspector.IcebergTimestampWithZoneObjectInspectorHive3" :
+          "org.apache.iceberg.mr.hive.serde.objectinspector.IcebergTimestampWithZoneObjectInspector";
+
   private static final ObjectInspector TIMESTAMP_INSPECTOR = DynMethods.builder("get")
-          .impl(TIMESTAMP_INSPECTOR_CLASS, boolean.class)
+          .impl(TIMESTAMP_INSPECTOR_CLASS)
           .buildStatic()
-          .invoke(false);
+          .invoke();
 
   private static final ObjectInspector TIMESTAMP_INSPECTOR_WITH_TZ = DynMethods.builder("get")
-          .impl(TIMESTAMP_INSPECTOR_CLASS, boolean.class)
+          .impl(TIMESTAMPTZ_INSPECTOR_CLASS)
           .buildStatic()
-          .invoke(true);
+          .invoke();
 
   public static ObjectInspector create(@Nullable Schema schema) {
     if (schema == null) {

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampObjectInspector.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectIn
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 
 public class IcebergTimestampObjectInspector extends AbstractPrimitiveJavaObjectInspector
-   implements TimestampObjectInspector, WriteObjectInspector {
+    implements TimestampObjectInspector, WriteObjectInspector {
 
   private static final IcebergTimestampObjectInspector INSTANCE = new IcebergTimestampObjectInspector();
 

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampWithZoneObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampWithZoneObjectInspector.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectIn
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 
 public class IcebergTimestampWithZoneObjectInspector extends AbstractPrimitiveJavaObjectInspector
-  implements TimestampObjectInspector, WriteObjectInspector {
+    implements TimestampObjectInspector, WriteObjectInspector {
 
   private static final IcebergTimestampWithZoneObjectInspector INSTANCE = new IcebergTimestampWithZoneObjectInspector();
 

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampWithZoneObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampWithZoneObjectInspector.java
@@ -21,7 +21,7 @@ package org.apache.iceberg.mr.hive.serde.objectinspector;
 
 import java.sql.Timestamp;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import org.apache.hadoop.hive.serde2.io.TimestampWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.AbstractPrimitiveJavaObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectInspector;
@@ -43,7 +43,7 @@ public class IcebergTimestampWithZoneObjectInspector extends AbstractPrimitiveJa
   @Override
   public OffsetDateTime convert(Object o) {
     return o == null ? null :
-            OffsetDateTime.ofInstant(((TimestampWritable) o).getTimestamp().toInstant(), ZoneId.of("UTC"));
+        OffsetDateTime.of(((TimestampWritable) o).getTimestamp().toLocalDateTime(), ZoneOffset.UTC);
   }
 
   @Override

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampWithZoneObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampWithZoneObjectInspector.java
@@ -20,28 +20,28 @@
 package org.apache.iceberg.mr.hive.serde.objectinspector;
 
 import java.sql.Timestamp;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import org.apache.hadoop.hive.serde2.io.TimestampWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.AbstractPrimitiveJavaObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 
-public class IcebergTimestampObjectInspector extends AbstractPrimitiveJavaObjectInspector
+public class IcebergTimestampWithZoneObjectInspector extends AbstractPrimitiveJavaObjectInspector
                                                       implements TimestampObjectInspector {
 
-  private static final IcebergTimestampObjectInspector INSTANCE = new IcebergTimestampObjectInspector();
+  private static final IcebergTimestampWithZoneObjectInspector INSTANCE = new IcebergTimestampWithZoneObjectInspector();
 
-  public static IcebergTimestampObjectInspector get() {
+  public static IcebergTimestampWithZoneObjectInspector get() {
     return INSTANCE;
   }
 
-  private IcebergTimestampObjectInspector() {
+  private IcebergTimestampWithZoneObjectInspector() {
     super(TypeInfoFactory.timestampTypeInfo);
   }
 
   @Override
   public Timestamp getPrimitiveJavaObject(Object o) {
-    return o == null ? null : Timestamp.valueOf((LocalDateTime) o);
+    return o == null ? null : Timestamp.valueOf(((OffsetDateTime) o).toLocalDateTime());
   }
 
   @Override
@@ -57,11 +57,12 @@ public class IcebergTimestampObjectInspector extends AbstractPrimitiveJavaObject
       Timestamp copy = new Timestamp(ts.getTime());
       copy.setNanos(ts.getNanos());
       return copy;
-    } else if (o instanceof LocalDateTime) {
-      LocalDateTime ldt = (LocalDateTime) o;
-      return LocalDateTime.of(ldt.toLocalDate(), ldt.toLocalTime());
+    } else if (o instanceof OffsetDateTime) {
+      OffsetDateTime odt = (OffsetDateTime) o;
+      return OffsetDateTime.of(odt.toLocalDateTime(), odt.getOffset());
     } else {
       return o;
     }
   }
+
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergObjectInspector.java
@@ -154,10 +154,10 @@ public class TestIcebergObjectInspector {
     Assert.assertEquals("timestamp_field", timestampField.getFieldName());
     Assert.assertEquals("timestamp comment", timestampField.getFieldComment());
     if (MetastoreUtil.hive3PresentOnClasspath()) {
-      Assert.assertTrue(timestampField.getFieldObjectInspector().getClass().getName()
-              .startsWith("org.apache.iceberg.mr.hive.serde.objectinspector.IcebergTimestampObjectInspectorHive3"));
+      Assert.assertEquals("IcebergTimestampObjectInspectorHive3",
+          timestampField.getFieldObjectInspector().getClass().getSimpleName());
     } else {
-      Assert.assertEquals(IcebergTimestampObjectInspector.get(false), timestampField.getFieldObjectInspector());
+      Assert.assertEquals(IcebergTimestampObjectInspector.get(), timestampField.getFieldObjectInspector());
     }
 
     // timestamp with tz
@@ -166,10 +166,10 @@ public class TestIcebergObjectInspector {
     Assert.assertEquals("timestamptz_field", timestampTzField.getFieldName());
     Assert.assertEquals("timestamptz comment", timestampTzField.getFieldComment());
     if (MetastoreUtil.hive3PresentOnClasspath()) {
-      Assert.assertTrue(timestampTzField.getFieldObjectInspector().getClass().getName()
-              .startsWith("org.apache.iceberg.mr.hive.serde.objectinspector.IcebergTimestampObjectInspectorHive3"));
+      Assert.assertEquals("IcebergTimestampWithZoneObjectInspectorHive3",
+          timestampTzField.getFieldObjectInspector().getClass().getSimpleName());
     } else {
-      Assert.assertEquals(IcebergTimestampObjectInspector.get(true), timestampTzField.getFieldObjectInspector());
+      Assert.assertEquals(IcebergTimestampWithZoneObjectInspector.get(), timestampTzField.getFieldObjectInspector());
     }
 
     // UUID

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampObjectInspector.java
@@ -33,7 +33,7 @@ public class TestIcebergTimestampObjectInspector {
 
   @Test
   public void testIcebergTimestampObjectInspector() {
-    TimestampObjectInspector oi = IcebergTimestampObjectInspector.get(false);
+    TimestampObjectInspector oi = IcebergTimestampObjectInspector.get();
 
     Assert.assertEquals(ObjectInspector.Category.PRIMITIVE, oi.getCategory());
     Assert.assertEquals(PrimitiveObjectInspector.PrimitiveCategory.TIMESTAMP, oi.getPrimitiveCategory());

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampObjectInspector.java
@@ -24,7 +24,6 @@ import java.time.LocalDateTime;
 import org.apache.hadoop.hive.serde2.io.TimestampWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.junit.Assert;
 import org.junit.Test;
@@ -33,7 +32,7 @@ public class TestIcebergTimestampObjectInspector {
 
   @Test
   public void testIcebergTimestampObjectInspector() {
-    TimestampObjectInspector oi = IcebergTimestampObjectInspector.get();
+    IcebergTimestampObjectInspector oi = IcebergTimestampObjectInspector.get();
 
     Assert.assertEquals(ObjectInspector.Category.PRIMITIVE, oi.getCategory());
     Assert.assertEquals(PrimitiveObjectInspector.PrimitiveCategory.TIMESTAMP, oi.getPrimitiveCategory());
@@ -47,6 +46,7 @@ public class TestIcebergTimestampObjectInspector {
     Assert.assertNull(oi.copyObject(null));
     Assert.assertNull(oi.getPrimitiveJavaObject(null));
     Assert.assertNull(oi.getPrimitiveWritableObject(null));
+    Assert.assertNull(oi.convert(null));
 
     LocalDateTime local = LocalDateTime.of(2020, 1, 1, 0, 0);
     Timestamp ts = Timestamp.valueOf("2020-01-01 00:00:00");
@@ -60,6 +60,8 @@ public class TestIcebergTimestampObjectInspector {
     Assert.assertNotSame(ts, copy);
 
     Assert.assertFalse(oi.preferWritable());
+
+    Assert.assertEquals(local, oi.convert(new TimestampWritable(ts)));
   }
 
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampObjectInspector.java
@@ -48,8 +48,8 @@ public class TestIcebergTimestampObjectInspector {
     Assert.assertNull(oi.getPrimitiveWritableObject(null));
     Assert.assertNull(oi.convert(null));
 
-    LocalDateTime local = LocalDateTime.of(2020, 1, 1, 0, 0);
-    Timestamp ts = Timestamp.valueOf("2020-01-01 00:00:00");
+    LocalDateTime local = LocalDateTime.of(2020, 1, 1, 12, 55, 30, 5560000);
+    Timestamp ts = Timestamp.valueOf(local);
 
     Assert.assertEquals(ts, oi.getPrimitiveJavaObject(local));
     Assert.assertEquals(new TimestampWritable(ts), oi.getPrimitiveWritableObject(local));

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspector.java
@@ -1,15 +1,20 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.iceberg.mr.hive.serde.objectinspector;
@@ -28,36 +33,36 @@ import org.junit.Test;
 
 public class TestIcebergTimestampWithZoneObjectInspector {
 
-    @Test
-    public void testIcebergTimestampObjectInspectorWithUTCAdjustment() {
-        TimestampObjectInspector oi = IcebergTimestampWithZoneObjectInspector.get();
+  @Test
+  public void testIcebergTimestampObjectInspectorWithUTCAdjustment() {
+    TimestampObjectInspector oi = IcebergTimestampWithZoneObjectInspector.get();
 
-        Assert.assertEquals(ObjectInspector.Category.PRIMITIVE, oi.getCategory());
-        Assert.assertEquals(PrimitiveObjectInspector.PrimitiveCategory.TIMESTAMP, oi.getPrimitiveCategory());
+    Assert.assertEquals(ObjectInspector.Category.PRIMITIVE, oi.getCategory());
+    Assert.assertEquals(PrimitiveObjectInspector.PrimitiveCategory.TIMESTAMP, oi.getPrimitiveCategory());
 
-        Assert.assertEquals(TypeInfoFactory.timestampTypeInfo, oi.getTypeInfo());
-        Assert.assertEquals(TypeInfoFactory.timestampTypeInfo.getTypeName(), oi.getTypeName());
+    Assert.assertEquals(TypeInfoFactory.timestampTypeInfo, oi.getTypeInfo());
+    Assert.assertEquals(TypeInfoFactory.timestampTypeInfo.getTypeName(), oi.getTypeName());
 
-        Assert.assertEquals(Timestamp.class, oi.getJavaPrimitiveClass());
-        Assert.assertEquals(TimestampWritable.class, oi.getPrimitiveWritableClass());
+    Assert.assertEquals(Timestamp.class, oi.getJavaPrimitiveClass());
+    Assert.assertEquals(TimestampWritable.class, oi.getPrimitiveWritableClass());
 
-        Assert.assertNull(oi.copyObject(null));
-        Assert.assertNull(oi.getPrimitiveJavaObject(null));
-        Assert.assertNull(oi.getPrimitiveWritableObject(null));
+    Assert.assertNull(oi.copyObject(null));
+    Assert.assertNull(oi.getPrimitiveJavaObject(null));
+    Assert.assertNull(oi.getPrimitiveWritableObject(null));
 
-        LocalDateTime local = LocalDateTime.of(2020, 1, 1, 0, 0);
-        OffsetDateTime offsetDateTime = OffsetDateTime.of(local, ZoneOffset.ofHours(-5));
-        Timestamp ts = Timestamp.valueOf(offsetDateTime.toLocalDateTime());
+    LocalDateTime local = LocalDateTime.of(2020, 1, 1, 0, 0);
+    OffsetDateTime offsetDateTime = OffsetDateTime.of(local, ZoneOffset.ofHours(-5));
+    Timestamp ts = Timestamp.valueOf(offsetDateTime.toLocalDateTime());
 
-        Assert.assertEquals(ts, oi.getPrimitiveJavaObject(offsetDateTime));
-        Assert.assertEquals(new TimestampWritable(ts), oi.getPrimitiveWritableObject(offsetDateTime));
+    Assert.assertEquals(ts, oi.getPrimitiveJavaObject(offsetDateTime));
+    Assert.assertEquals(new TimestampWritable(ts), oi.getPrimitiveWritableObject(offsetDateTime));
 
-        Timestamp copy = (Timestamp) oi.copyObject(ts);
+    Timestamp copy = (Timestamp) oi.copyObject(ts);
 
-        Assert.assertEquals(ts, copy);
-        Assert.assertNotSame(ts, copy);
+    Assert.assertEquals(ts, copy);
+    Assert.assertNotSame(ts, copy);
 
-        Assert.assertFalse(oi.preferWritable());
-    }
+    Assert.assertFalse(oi.preferWritable());
+  }
 
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspector.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.serde.objectinspector;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.apache.hadoop.hive.serde2.io.TimestampWritable;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestIcebergTimestampWithZoneObjectInspector {
+
+    @Test
+    public void testIcebergTimestampObjectInspectorWithUTCAdjustment() {
+        TimestampObjectInspector oi = IcebergTimestampWithZoneObjectInspector.get();
+
+        Assert.assertEquals(ObjectInspector.Category.PRIMITIVE, oi.getCategory());
+        Assert.assertEquals(PrimitiveObjectInspector.PrimitiveCategory.TIMESTAMP, oi.getPrimitiveCategory());
+
+        Assert.assertEquals(TypeInfoFactory.timestampTypeInfo, oi.getTypeInfo());
+        Assert.assertEquals(TypeInfoFactory.timestampTypeInfo.getTypeName(), oi.getTypeName());
+
+        Assert.assertEquals(Timestamp.class, oi.getJavaPrimitiveClass());
+        Assert.assertEquals(TimestampWritable.class, oi.getPrimitiveWritableClass());
+
+        Assert.assertNull(oi.copyObject(null));
+        Assert.assertNull(oi.getPrimitiveJavaObject(null));
+        Assert.assertNull(oi.getPrimitiveWritableObject(null));
+
+        LocalDateTime local = LocalDateTime.of(2020, 1, 1, 0, 0);
+        OffsetDateTime offsetDateTime = OffsetDateTime.of(local, ZoneOffset.ofHours(-5));
+        Timestamp ts = Timestamp.valueOf(offsetDateTime.toLocalDateTime());
+
+        Assert.assertEquals(ts, oi.getPrimitiveJavaObject(offsetDateTime));
+        Assert.assertEquals(new TimestampWritable(ts), oi.getPrimitiveWritableObject(offsetDateTime));
+
+        Timestamp copy = (Timestamp) oi.copyObject(ts);
+
+        Assert.assertEquals(ts, copy);
+        Assert.assertNotSame(ts, copy);
+
+        Assert.assertFalse(oi.preferWritable());
+    }
+
+}

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspector.java
@@ -50,7 +50,7 @@ public class TestIcebergTimestampWithZoneObjectInspector {
     Assert.assertNull(oi.getPrimitiveWritableObject(null));
     Assert.assertNull(oi.convert(null));
 
-    LocalDateTime local = LocalDateTime.of(2020, 1, 1, 0, 0);
+    LocalDateTime local = LocalDateTime.of(2020, 1, 1, 16, 45, 33, 456000);
     OffsetDateTime offsetDateTime = OffsetDateTime.of(local, ZoneOffset.ofHours(-5));
     Timestamp ts = Timestamp.valueOf(offsetDateTime.toLocalDateTime());
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspector.java
@@ -26,7 +26,6 @@ import java.time.ZoneOffset;
 import org.apache.hadoop.hive.serde2.io.TimestampWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.junit.Assert;
 import org.junit.Test;
@@ -35,7 +34,7 @@ public class TestIcebergTimestampWithZoneObjectInspector {
 
   @Test
   public void testIcebergTimestampObjectInspectorWithUTCAdjustment() {
-    TimestampObjectInspector oi = IcebergTimestampWithZoneObjectInspector.get();
+    IcebergTimestampWithZoneObjectInspector oi = IcebergTimestampWithZoneObjectInspector.get();
 
     Assert.assertEquals(ObjectInspector.Category.PRIMITIVE, oi.getCategory());
     Assert.assertEquals(PrimitiveObjectInspector.PrimitiveCategory.TIMESTAMP, oi.getPrimitiveCategory());
@@ -49,6 +48,7 @@ public class TestIcebergTimestampWithZoneObjectInspector {
     Assert.assertNull(oi.copyObject(null));
     Assert.assertNull(oi.getPrimitiveJavaObject(null));
     Assert.assertNull(oi.getPrimitiveWritableObject(null));
+    Assert.assertNull(oi.convert(null));
 
     LocalDateTime local = LocalDateTime.of(2020, 1, 1, 0, 0);
     OffsetDateTime offsetDateTime = OffsetDateTime.of(local, ZoneOffset.ofHours(-5));
@@ -63,6 +63,8 @@ public class TestIcebergTimestampWithZoneObjectInspector {
     Assert.assertNotSame(ts, copy);
 
     Assert.assertFalse(oi.preferWritable());
+
+    Assert.assertEquals(OffsetDateTime.of(local, ZoneOffset.UTC), oi.convert(new TimestampWritable(ts)));
   }
 
 }


### PR DESCRIPTION
- Break up `TimestampObjectInspector` classes into two separate classes for (i) normal timestamps and (ii) timestamps with zone (instead of using inner classes)
- For Hive3, take advantage of its TimestampWithLocalTimeZone type (which Hive2 doesn't have) instead of just converting timestampTz into normal timestamps