### PR TITLE
Add Table.replaceSortOrder operation

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ReplaceSortOrder.java
+++ b/api/src/main/java/org/apache/iceberg/ReplaceSortOrder.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+/**
+ * API for replacing table sort order with a newly created order.
+ * <p>
+ * The table sort order is used to sort incoming records in engines that can request an ordering.
+ * <p>
+ * Apply returns the new sort order for validation.
+ * <p>
+ * When committing, these changes will be applied to the current table metadata. Commit conflicts
+ * will be resolved by applying the pending changes to the new table metadata.
+ */
+public interface ReplaceSortOrder extends PendingUpdate<SortOrder>, SortOrderBuilder<ReplaceSortOrder> {
+}

--- a/api/src/main/java/org/apache/iceberg/SortOrder.java
+++ b/api/src/main/java/org/apache/iceberg/SortOrder.java
@@ -184,7 +184,7 @@ public class SortOrder implements Serializable {
    * <p>
    * Call {@link #builderFor(Schema)} to create a new builder.
    */
-  public static class Builder {
+  public static class Builder implements SortOrderBuilder<Builder> {
     private final Schema schema;
     private final List<SortField> fields = Lists.newArrayList();
     // default ID to 1 as 0 is reserved for unsorted order
@@ -195,34 +195,24 @@ public class SortOrder implements Serializable {
       this.schema = schema;
     }
 
-    public Builder asc(String name) {
-      return asc(name, NullOrder.NULLS_FIRST);
-    }
-
-    public Builder asc(String name, NullOrder nullOrder) {
-      return addSortField(Expressions.ref(name), SortDirection.ASC, nullOrder);
-    }
-
-    public Builder asc(Term term) {
-      return asc(term, NullOrder.NULLS_FIRST);
-    }
-
+    /**
+     * Add an expression term to the sort, ascending with the given null order.
+     *
+     * @param term an expression term
+     * @param nullOrder a null order (first or last)
+     * @return this for method chaining
+     */
     public Builder asc(Term term, NullOrder nullOrder) {
       return addSortField(term, SortDirection.ASC, nullOrder);
     }
 
-    public Builder desc(String name) {
-      return desc(name, NullOrder.NULLS_LAST);
-    }
-
-    public Builder desc(String name, NullOrder nullOrder) {
-      return addSortField(Expressions.ref(name), SortDirection.DESC, nullOrder);
-    }
-
-    public Builder desc(Term term) {
-      return desc(term, NullOrder.NULLS_LAST);
-    }
-
+    /**
+     * Add an expression term to the sort, ascending with the given null order.
+     *
+     * @param term an expression term
+     * @param nullOrder a null order (first or last)
+     * @return this for method chaining
+     */
     public Builder desc(Term term, NullOrder nullOrder) {
       return addSortField(term, SortDirection.DESC, nullOrder);
     }

--- a/api/src/main/java/org/apache/iceberg/SortOrderBuilder.java
+++ b/api/src/main/java/org/apache/iceberg/SortOrderBuilder.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.Term;
+
+/**
+ * Methods for building a sort order.
+ */
+public interface SortOrderBuilder<R> {
+
+  /**
+   * Add a field to the sort by field name, ascending with nulls first.
+   *
+   * @param name a field name
+   * @return this for method chaining
+   */
+  default R asc(String name) {
+    return asc(Expressions.ref(name), NullOrder.NULLS_FIRST);
+  }
+
+  /**
+   * Add a field to the sort by field name, ascending with the given null order.
+   *
+   * @param name a field name
+   * @param nullOrder a null order (first or last)
+   * @return this for method chaining
+   */
+  default R asc(String name, NullOrder nullOrder) {
+    return asc(Expressions.ref(name), nullOrder);
+  }
+
+  /**
+   * Add an expression term to the sort, ascending with nulls first.
+   *
+   * @param term an expression term
+   * @return this for method chaining
+   */
+  default R asc(Term term) {
+    return asc(term, NullOrder.NULLS_FIRST);
+  }
+
+  /**
+   * Add an expression term to the sort, ascending with the given null order.
+   *
+   * @param term an expression term
+   * @param nullOrder a null order (first or last)
+   * @return this for method chaining
+   */
+  R asc(Term term, NullOrder nullOrder);
+
+  /**
+   * Add a field to the sort by field name, ascending with nulls first.
+   *
+   * @param name a field name
+   * @return this for method chaining
+   */
+  default R desc(String name) {
+    return desc(Expressions.ref(name), NullOrder.NULLS_LAST);
+  }
+
+  /**
+   * Add a field to the sort by field name, ascending with the given null order.
+   *
+   * @param name a field name
+   * @param nullOrder a null order (first or last)
+   * @return this for method chaining
+   */
+  default R desc(String name, NullOrder nullOrder) {
+    return desc(Expressions.ref(name), nullOrder);
+  }
+
+  /**
+   * Add an expression term to the sort, ascending with nulls first.
+   *
+   * @param term an expression term
+   * @return this for method chaining
+   */
+  default R desc(Term term) {
+    return desc(term, NullOrder.NULLS_LAST);
+  }
+
+  /**
+   * Add an expression term to the sort, ascending with the given null order.
+   *
+   * @param term an expression term
+   * @param nullOrder a null order (first or last)
+   * @return this for method chaining
+   */
+  R desc(Term term, NullOrder nullOrder);
+}

--- a/api/src/main/java/org/apache/iceberg/Table.java
+++ b/api/src/main/java/org/apache/iceberg/Table.java
@@ -146,6 +146,13 @@ public interface Table {
   UpdateProperties updateProperties();
 
   /**
+   * Create a new {@link ReplaceSortOrder} to set the table sort order and commit the change.
+   *
+   * @return a new {@link ReplaceSortOrder}
+   */
+  ReplaceSortOrder replaceSortOrder();
+
+  /**
    * Create a new {@link UpdateLocation} to update table location and commit the changes.
    *
    * @return a new {@link UpdateLocation}

--- a/api/src/main/java/org/apache/iceberg/Transaction.java
+++ b/api/src/main/java/org/apache/iceberg/Transaction.java
@@ -48,6 +48,13 @@ public interface Transaction {
   UpdateProperties updateProperties();
 
   /**
+   * Create a new {@link ReplaceSortOrder} to set a table sort order and commit the change.
+   *
+   * @return a new {@link ReplaceSortOrder}
+   */
+  ReplaceSortOrder replaceSortOrder();
+
+  /**
    * Create a new {@link UpdateLocation} to update table location.
    *
    * @return a new {@link UpdateLocation}

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -113,6 +113,11 @@ abstract class BaseMetadataTable implements Table {
   }
 
   @Override
+  public ReplaceSortOrder replaceSortOrder() {
+    throw new UnsupportedOperationException("Cannot update the sort order of a metadata table");
+  }
+
+  @Override
   public UpdateLocation updateLocation() {
     throw new UnsupportedOperationException("Cannot update the location of a metadata table");
   }

--- a/core/src/main/java/org/apache/iceberg/BaseReplaceSortOrder.java
+++ b/core/src/main/java/org/apache/iceberg/BaseReplaceSortOrder.java
@@ -32,12 +32,12 @@ import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES_DEFAULT;
 import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS;
 import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT;
 
-public class ReplaceOrder implements ReplaceSortOrder {
+public class BaseReplaceSortOrder implements ReplaceSortOrder {
   private final TableOperations ops;
   private final SortOrder.Builder builder;
   private TableMetadata base;
 
-  ReplaceOrder(TableOperations ops) {
+  BaseReplaceSortOrder(TableOperations ops) {
     this.ops = ops;
     this.base = ops.current();
     this.builder = SortOrder.builderFor(base.schema());

--- a/core/src/main/java/org/apache/iceberg/BaseTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTable.java
@@ -125,6 +125,11 @@ public class BaseTable implements Table, HasTableOperations {
   }
 
   @Override
+  public ReplaceSortOrder replaceSortOrder() {
+    return new ReplaceOrder(ops);
+  }
+
+  @Override
   public UpdateLocation updateLocation() {
     return new SetLocation(ops);
   }

--- a/core/src/main/java/org/apache/iceberg/BaseTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTable.java
@@ -126,7 +126,7 @@ public class BaseTable implements Table, HasTableOperations {
 
   @Override
   public ReplaceSortOrder replaceSortOrder() {
-    return new ReplaceOrder(ops);
+    return new BaseReplaceSortOrder(ops);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -111,6 +111,14 @@ class BaseTransaction implements Transaction {
   }
 
   @Override
+  public ReplaceSortOrder replaceSortOrder() {
+    checkLastOperationCommitted("ReplaceSortOrder");
+    ReplaceSortOrder replaceSortOrder = new ReplaceOrder(transactionOps);
+    updates.add(replaceSortOrder);
+    return replaceSortOrder;
+  }
+
+  @Override
   public UpdateLocation updateLocation() {
     checkLastOperationCommitted("UpdateLocation");
     UpdateLocation setLocation = new SetLocation(transactionOps);
@@ -562,6 +570,11 @@ class BaseTransaction implements Transaction {
     @Override
     public UpdateProperties updateProperties() {
       return BaseTransaction.this.updateProperties();
+    }
+
+    @Override
+    public ReplaceSortOrder replaceSortOrder() {
+      return BaseTransaction.this.replaceSortOrder();
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -113,7 +113,7 @@ class BaseTransaction implements Transaction {
   @Override
   public ReplaceSortOrder replaceSortOrder() {
     checkLastOperationCommitted("ReplaceSortOrder");
-    ReplaceSortOrder replaceSortOrder = new ReplaceOrder(transactionOps);
+    ReplaceSortOrder replaceSortOrder = new BaseReplaceSortOrder(transactionOps);
     updates.add(replaceSortOrder);
     return replaceSortOrder;
   }

--- a/core/src/main/java/org/apache/iceberg/CommitCallbackTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/CommitCallbackTransaction.java
@@ -48,6 +48,11 @@ class CommitCallbackTransaction implements Transaction {
   }
 
   @Override
+  public ReplaceSortOrder replaceSortOrder() {
+    return wrapped.replaceSortOrder();
+  }
+
+  @Override
   public UpdateLocation updateLocation() {
     return wrapped.updateLocation();
   }

--- a/core/src/main/java/org/apache/iceberg/ReplaceOrder.java
+++ b/core/src/main/java/org/apache/iceberg/ReplaceOrder.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.expressions.Term;
+import org.apache.iceberg.util.Tasks;
+
+import static org.apache.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS;
+import static org.apache.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS_DEFAULT;
+import static org.apache.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS;
+import static org.apache.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS_DEFAULT;
+import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
+import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES_DEFAULT;
+import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS;
+import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT;
+
+public class ReplaceOrder implements ReplaceSortOrder {
+  private final TableOperations ops;
+  private final SortOrder.Builder builder;
+  private TableMetadata base;
+
+  ReplaceOrder(TableOperations ops) {
+    this.ops = ops;
+    this.base = ops.current();
+    this.builder = SortOrder.builderFor(base.schema());
+  }
+
+  @Override
+  public SortOrder apply() {
+    return builder.build();
+  }
+
+  @Override
+  public void commit() {
+    Tasks.foreach(ops)
+        .retry(base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
+        .exponentialBackoff(
+            base.propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+            base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+            base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
+            2.0 /* exponential */)
+        .onlyRetryOn(CommitFailedException.class)
+        .run(taskOps -> {
+          this.base = ops.refresh();
+          SortOrder newOrder = apply();
+          TableMetadata updated = base.replaceSortOrder(newOrder);
+          taskOps.commit(base, updated);
+        });
+  }
+
+  @Override
+  public ReplaceSortOrder asc(Term term, NullOrder nullOrder) {
+    builder.asc(term, nullOrder);
+    return this;
+  }
+
+  @Override
+  public ReplaceSortOrder desc(Term term, NullOrder nullOrder) {
+    builder.desc(term, nullOrder);
+    return this;
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -491,7 +491,7 @@ public class TableMetadata implements Serializable {
         currentSnapshotId, snapshots, snapshotLog, addPreviousFile(file, lastUpdatedMillis));
   }
 
-  public TableMetadata updateSortOrder(SortOrder newOrder) {
+  public TableMetadata replaceSortOrder(SortOrder newOrder) {
     SortOrder.checkCompatibility(newOrder, schema);
 
     // determine the next order id

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -541,7 +541,7 @@ public class TestTableMetadata {
     TableMetadata meta = TableMetadata.newTableMetadata(
         schema, PartitionSpec.unpartitioned(), null, ImmutableMap.of());
     Assert.assertTrue("Should default to unsorted order", meta.sortOrder().isUnsorted());
-    Assert.assertSame("Should detect identical unsorted order", meta, meta.updateSortOrder(SortOrder.unsorted()));
+    Assert.assertSame("Should detect identical unsorted order", meta, meta.replaceSortOrder(SortOrder.unsorted()));
   }
 
   @Test
@@ -566,15 +566,15 @@ public class TestTableMetadata {
     // build an equivalent order with the correct schema
     SortOrder newOrder = SortOrder.builderFor(sortedByX.schema()).asc("x").build();
 
-    TableMetadata alsoSortedByX = sortedByX.updateSortOrder(newOrder);
+    TableMetadata alsoSortedByX = sortedByX.replaceSortOrder(newOrder);
     Assert.assertSame("Should detect current sortOrder and not update", alsoSortedByX, sortedByX);
 
-    TableMetadata unsorted = alsoSortedByX.updateSortOrder(SortOrder.unsorted());
+    TableMetadata unsorted = alsoSortedByX.replaceSortOrder(SortOrder.unsorted());
     Assert.assertEquals("Should have 2 sort orders", 2, unsorted.sortOrders().size());
     Assert.assertEquals("Should use orderId 0", 0, unsorted.sortOrder().orderId());
     Assert.assertTrue("Should be unsorted", unsorted.sortOrder().isUnsorted());
 
-    TableMetadata sortedByXDesc = unsorted.updateSortOrder(SortOrder.builderFor(unsorted.schema()).desc("x").build());
+    TableMetadata sortedByXDesc = unsorted.replaceSortOrder(SortOrder.builderFor(unsorted.schema()).desc("x").build());
     Assert.assertEquals("Should have 3 sort orders", 3, sortedByXDesc.sortOrders().size());
     Assert.assertEquals("Should use orderId 2", 2, sortedByXDesc.sortOrder().orderId());
     Assert.assertEquals("Should be sorted by one field", 1, sortedByXDesc.sortOrder().fields().size());


### PR DESCRIPTION
This adds a table API operation to replace the sort order with a newly constructed order, and abstracts the configuration methods into an API shared between `SortOrder.Builder` and `ReplaceSortOrder`.