### PR TITLE
AWS: add more S3FileIO tests, cleanup related codebase

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/S3MultipartUploadTest.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/S3MultipartUploadTest.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.aws.s3;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Random;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import org.apache.iceberg.aws.AwsClientUtil;
+import org.apache.iceberg.aws.AwsIntegTestUtil;
+import org.apache.iceberg.aws.AwsProperties;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.PositionOutputStream;
+import org.apache.iceberg.io.SeekableInputStream;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import software.amazon.awssdk.services.s3.S3Client;
+
+/**
+ * Long-running tests to ensure multipart upload logic is resilient
+ */
+public class S3MultipartUploadTest {
+
+  private final Random random = new Random(1);
+  private static S3Client s3;
+  private static String bucketName;
+  private static String prefix;
+  private String objectUri;
+
+  @BeforeClass
+  public static void beforeClass() {
+    s3 = AwsClientUtil.defaultS3Client();
+    bucketName = AwsIntegTestUtil.testBucketName();
+    prefix = UUID.randomUUID().toString();
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    AwsIntegTestUtil.cleanS3Bucket(s3, bucketName, prefix);
+  }
+
+  @Before
+  public void before() {
+    String objectKey = String.format("%s/%s", prefix, UUID.randomUUID().toString());
+    objectUri = String.format("s3://%s/%s", bucketName, objectKey);
+  }
+
+  @Test
+  public void testManyParts_writeWithInt() throws IOException {
+    AwsProperties properties = new AwsProperties();
+    properties.setS3FileIoMultiPartSize(AwsProperties.S3FILEIO_MULTIPART_SIZE_MIN);
+    S3FileIO io = new S3FileIO(() -> s3, properties);
+    PositionOutputStream outputStream = io.newOutputFile(objectUri).create();
+    for (int i = 0; i < 100; i++) {
+      for (int j = 0; j < AwsProperties.S3FILEIO_MULTIPART_SIZE_MIN; j++) {
+        outputStream.write(random.nextInt());
+      }
+    }
+    outputStream.close();
+    Assert.assertEquals(100 * (long) AwsProperties.S3FILEIO_MULTIPART_SIZE_MIN,
+        io.newInputFile(objectUri).getLength());
+  }
+
+  @Test
+  public void testManyParts_writeWithBytes() throws IOException {
+    AwsProperties properties = new AwsProperties();
+    properties.setS3FileIoMultiPartSize(AwsProperties.S3FILEIO_MULTIPART_SIZE_MIN);
+    S3FileIO io = new S3FileIO(() -> s3, properties);
+    PositionOutputStream outputStream = io.newOutputFile(objectUri).create();
+    byte[] bytes = new byte[AwsProperties.S3FILEIO_MULTIPART_SIZE_MIN];
+    for (int i = 0; i < 100; i++) {
+      random.nextBytes(bytes);
+      outputStream.write(bytes);
+    }
+    outputStream.close();
+    Assert.assertEquals(100 * (long) AwsProperties.S3FILEIO_MULTIPART_SIZE_MIN,
+        io.newInputFile(objectUri).getLength());
+  }
+
+  @Test
+  public void testContents_writeWithInt() throws IOException {
+    AwsProperties properties = new AwsProperties();
+    properties.setS3FileIoMultiPartSize(AwsProperties.S3FILEIO_MULTIPART_SIZE_MIN);
+    S3FileIO io = new S3FileIO(() -> s3, properties);
+    PositionOutputStream outputStream = io.newOutputFile(objectUri).create();
+    for (int i = 0; i < 10; i++) {
+      for (int j = 0; j < AwsProperties.S3FILEIO_MULTIPART_SIZE_MIN; j++) {
+        outputStream.write(6);
+      }
+    }
+    outputStream.close();
+    SeekableInputStream inputStream = io.newInputFile(objectUri).newStream();
+    int cur;
+    while ((cur = inputStream.read()) != -1) {
+      Assert.assertEquals(6, cur);
+    }
+    inputStream.close();
+  }
+
+  @Test
+  public void testContents_writeWithBytes() throws IOException {
+    AwsProperties properties = new AwsProperties();
+    properties.setS3FileIoMultiPartSize(AwsProperties.S3FILEIO_MULTIPART_SIZE_MIN);
+    S3FileIO io = new S3FileIO(() -> s3, properties);
+    PositionOutputStream outputStream = io.newOutputFile(objectUri).create();
+    byte[] bytes = new byte[AwsProperties.S3FILEIO_MULTIPART_SIZE_MIN];
+    for (int i = 0; i < AwsProperties.S3FILEIO_MULTIPART_SIZE_MIN; i++) {
+      bytes[i] = 6;
+    }
+    for (int i = 0; i < 10; i++) {
+      outputStream.write(bytes);
+    }
+    outputStream.close();
+    SeekableInputStream inputStream = io.newInputFile(objectUri).newStream();
+    int cur;
+    while ((cur = inputStream.read()) != -1) {
+      Assert.assertEquals(6, cur);
+    }
+    inputStream.close();
+  }
+
+  @Test
+  public void testUploadRemainder() throws IOException {
+    AwsProperties properties = new AwsProperties();
+    properties.setS3FileIoMultiPartSize(AwsProperties.S3FILEIO_MULTIPART_SIZE_MIN);
+    properties.setS3FileIoMultipartThresholdFactor(1);
+    S3FileIO io = new S3FileIO(() -> s3, properties);
+    PositionOutputStream outputStream = io.newOutputFile(objectUri).create();
+    long length = 3 * AwsProperties.S3FILEIO_MULTIPART_SIZE_MIN + 2 * 1024 * 1024;
+    for (int i = 0; i < length; i++) {
+      outputStream.write(random.nextInt());
+    }
+    outputStream.close();
+    Assert.assertEquals(length, io.newInputFile(objectUri).getLength());
+  }
+
+  @Test
+  public void testParallelUpload() throws IOException {
+    AwsProperties properties = new AwsProperties();
+    properties.setS3FileIoMultiPartSize(AwsProperties.S3FILEIO_MULTIPART_SIZE_MIN);
+    properties.setS3FileIoMultipartUploadThreads(16);
+    S3FileIO io = new S3FileIO(() -> s3, properties);
+    IntStream.range(0, 16).parallel().forEach(d -> {
+      byte[] bytes = new byte[AwsProperties.S3FILEIO_MULTIPART_SIZE_MIN];
+      for (int i = 0; i < AwsProperties.S3FILEIO_MULTIPART_SIZE_MIN; i++) {
+        bytes[i] = (byte) d;
+      }
+      PositionOutputStream outputStream = io.newOutputFile(objectUri + "_" + d).create();
+      try {
+        for (int i = 0; i < 3; i++) {
+          outputStream.write(bytes);
+        }
+        outputStream.close();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    for (int i = 0; i < 16; i++) {
+      String fileUri = objectUri + "_" + i;
+      InputFile inputFile = io.newInputFile(fileUri);
+      Assert.assertEquals(3 * (long) AwsProperties.S3FILEIO_MULTIPART_SIZE_MIN, inputFile.getLength());
+      int cur;
+      InputStream stream = inputFile.newStream();
+      while ((cur = stream.read()) != -1) {
+        Assert.assertEquals(i, cur);
+      }
+      stream.close();
+    }
+  }
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -33,8 +33,10 @@ import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 
 /**
  * FileIO implementation backed by S3.
+ * <p>
  * Locations used must follow the conventions for S3 URIs (e.g. s3://bucket/path...).
- * See {@link S3URI#VALID_SCHEMES} for the list of supported S3 URI schemes.
+ * URIs with schemes s3a, s3n, https are also treated as s3 file paths.
+ * Using this FileIO with other schemes will result in {@link org.apache.iceberg.exceptions.ValidationException}.
  */
 public class S3FileIO implements FileIO {
   private final SerializableSupplier<S3Client> s3;

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -85,6 +85,7 @@ class S3OutputStream extends PositionOutputStream {
   private long pos = 0;
   private boolean closed = false;
 
+  @SuppressWarnings({"StaticAssignmentInConstructor", "StaticGuardedByInstance"})
   S3OutputStream(S3Client s3, S3URI location, AwsProperties awsProperties) throws IOException {
     if (executorService == null) {
       synchronized (this) {

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3RequestUtil.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3RequestUtil.java
@@ -30,6 +30,7 @@ import software.amazon.awssdk.services.s3.model.S3Request;
 import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 
+@SuppressWarnings("UnnecessaryLambda")
 public class S3RequestUtil {
 
   private static final Function<ServerSideEncryption, S3Request.Builder> NULL_SSE_SETTER = sse -> null;

--- a/aws/src/test/java/org/apache/iceberg/aws/AwsPropertiesTest.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/AwsPropertiesTest.java
@@ -67,4 +67,34 @@ public class AwsPropertiesTest {
         () -> new AwsProperties(map));
   }
 
+  @Test
+  public void testS3MultipartSizeTooSmall() {
+    Map<String, String> map = Maps.newHashMap();
+    map.put(AwsProperties.S3FILEIO_MULTIPART_SIZE, "1");
+    AssertHelpers.assertThrows("should not accept small part size",
+        IllegalArgumentException.class,
+        "Minimum multipart upload object size must be larger than 5 MB",
+        () -> new AwsProperties(map));
+  }
+
+  @Test
+  public void testS3MultipartSizeTooLarge() {
+    Map<String, String> map = Maps.newHashMap();
+    map.put(AwsProperties.S3FILEIO_MULTIPART_SIZE, "5368709120"); // 5GB
+    AssertHelpers.assertThrows("should not accept too big part size",
+        IllegalArgumentException.class,
+        "Input malformed or exceeded maximum multipart upload size 5GB",
+        () -> new AwsProperties(map));
+  }
+
+  @Test
+  public void testS3MultipartThresholdFactorLessThanOne() {
+    Map<String, String> map = Maps.newHashMap();
+    map.put(AwsProperties.S3FILEIO_MULTIPART_THRESHOLD_FACTOR, "0.9");
+    AssertHelpers.assertThrows("should not accept factor less than 1",
+        IllegalArgumentException.class,
+        "Multipart threshold factor must be >= to 1.0",
+        () -> new AwsProperties(map));
+  }
+
 }


### PR DESCRIPTION
@danielcweeks made the following updates to `S3FileIO` related code:
1. added integration tests that verifies upload behaviors against S3
2. updated variable names and documentations in `AwsProperties` to be consistent with others, added corresponding tests
3. fixed invalid reference to private variable `S3URI#VALID_SCHEMES` in doc of `S3FileIO`
4. muted errorprone warnings:

```
/iceberg/aws/src/main/java/org/apache/iceberg/aws/s3/S3RequestUtil.java:35: warning: [UnnecessaryLambda] Returning a lambda from a helper method or saving it in a constant is unnecessary; prefer to implement the functional interface method directly and use a method reference instead.
  private static final Function<ServerSideEncryption, S3Request.Builder> NULL_SSE_SETTER = sse -> null;
                                                                         ^
    (see https://errorprone.info/bugpattern/UnnecessaryLambda)
  Did you mean 'private static  S3Request.Builder nullSseSetter(ServerSideEncryption sse){return null;}'?
/iceberg/aws/src/main/java/org/apache/iceberg/aws/s3/S3RequestUtil.java:36: warning: [UnnecessaryLambda] Returning a lambda from a helper method or saving it in a constant is unnecessary; prefer to implement the functional interface method directly and use a method reference instead.
  private static final Function<String, S3Request.Builder> NULL_STRING_SETTER = s -> null;
                                                           ^
    (see https://errorprone.info/bugpattern/UnnecessaryLambda)
  Did you mean 'private static  S3Request.Builder nullStringSetter(String s){return null;}'?
/iceberg/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java:92: warning: [StaticAssignmentInConstructor] This assignment is to a static field. Mutating static state from a constructor is highly error-prone.
          executorService = MoreExecutors.getExitingExecutorService(
                          ^
    (see https://errorprone.info/bugpattern/StaticAssignmentInConstructor)
/iceberg/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java:92: warning: [StaticGuardedByInstance] Write to static variable should not be guarded by instance lock 'this'
          executorService = MoreExecutors.getExitingExecutorService(
          ^
    (see https://errorprone.info/bugpattern/StaticGuardedByInstance)
4 warnings
```