### PR TITLE
Spark: Speed up tests for extensions

### DIFF
--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkExtensionsTestBase.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkExtensionsTestBase.java
@@ -48,6 +48,7 @@ public abstract class SparkExtensionsTestBase extends SparkCatalogTestBase {
         .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
         .config("spark.sql.extensions", IcebergSparkSessionExtensions.class.getName())
         .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
+        .config("spark.sql.shuffle.partitions", "4")
         .enableHiveSupport()
         .getOrCreate();
 


### PR DESCRIPTION
There are quite some tests that perform shuffles so it makes sense to reduce the number of shuffle partitions.