### PR TITLE
Remove sun's jersey

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,8 @@ subprojects {
     all {
       exclude group: 'org.slf4j', module: 'slf4j-log4j12'
       exclude group: 'org.mortbay.jetty'
+      exclude group: 'com.sun.jersey'
+      exclude group: 'com.sun.jersey.contribs'
       exclude group: 'org.pentaho', module: 'pentaho-aggdesigner-algorithm'
 
       resolutionStrategy {


### PR DESCRIPTION
Noticed some weird `java.lang.AbstractMethodError` exceptions while using Iceberg/Hive and REST clients. This completely removes rather old versions of Jersey from all modules so we only have v2 of `javax.ws.rs` in our dependency graph