### PR TITLE
Add ExceptionUtil.runSafely

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/ExceptionUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/ExceptionUtil.java
@@ -19,7 +19,11 @@
 
 package org.apache.iceberg.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class ExceptionUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(ExceptionUtil.class);
 
   private ExceptionUtil() {
   }
@@ -35,5 +39,97 @@ public class ExceptionUtil {
       throw (E) exception;
     }
     throw new RuntimeException(exception);
+  }
+
+  interface Block<R, E1 extends Exception, E2 extends Exception, E3 extends Exception> {
+    R run() throws E1, E2, E3;
+  }
+
+  interface CatchBlock {
+    void run(Throwable failure) throws Exception;
+  }
+
+  interface FinallyBlock {
+    void run() throws Exception;
+  }
+
+  public static <R> R runSafely(
+      Block<R, RuntimeException, RuntimeException, RuntimeException> block,
+      CatchBlock catchBlock,
+      FinallyBlock finallyBlock) {
+    return runSafely(block, catchBlock, finallyBlock,
+        RuntimeException.class, RuntimeException.class, RuntimeException.class);
+  }
+
+  public static <R, E1 extends Exception> R runSafely(
+      Block<R, E1, RuntimeException, RuntimeException> block,
+      CatchBlock catchBlock,
+      FinallyBlock finallyBlock,
+      Class<? extends E1> e1Class) throws E1 {
+    return runSafely(block, catchBlock, finallyBlock, e1Class, RuntimeException.class, RuntimeException.class);
+  }
+
+  public static <R, E1 extends Exception, E2 extends Exception> R runSafely(
+      Block<R, E1, E2, RuntimeException> block,
+      CatchBlock catchBlock,
+      FinallyBlock finallyBlock,
+      Class<? extends E1> e1Class,
+      Class<? extends E2> e2Class) throws E1, E2 {
+    return runSafely(block, catchBlock, finallyBlock, e1Class, e2Class, RuntimeException.class);
+  }
+
+  public static <R, E1 extends Exception, E2 extends Exception, E3 extends Exception> R runSafely(
+      Block<R, E1, E2, E3> block,
+      CatchBlock catchBlock,
+      FinallyBlock finallyBlock,
+      Class<? extends E1> e1Class,
+      Class<? extends E2> e2Class,
+      Class<? extends E3> e3Class) throws E1, E2, E3 {
+    Throwable failure = null;
+    try {
+      return block.run();
+
+    } catch (Throwable t) {
+      failure = t;
+
+      if (catchBlock != null) {
+        try {
+          catchBlock.run(failure);
+        } catch (Exception e) {
+          LOG.warn("Suppressing failure in catch block", e);
+          failure.addSuppressed(e);
+        }
+      }
+
+      tryThrowAs(failure, e1Class);
+      tryThrowAs(failure, e2Class);
+      tryThrowAs(failure, e3Class);
+      tryThrowAs(failure, RuntimeException.class);
+      throw new RuntimeException("Unknown throwable", failure);
+
+    } finally {
+      if (finallyBlock != null) {
+        try {
+          finallyBlock.run();
+        } catch (Exception e) {
+          LOG.warn("Suppressing failure in finally block", e);
+          if (failure != null) {
+            failure.addSuppressed(e);
+          } else {
+            tryThrowAs(e, e1Class);
+            tryThrowAs(e, e2Class);
+            tryThrowAs(e, e3Class);
+            tryThrowAs(e, RuntimeException.class);
+            throw new RuntimeException("Unknown exception in finally block", failure);
+          }
+        }
+      }
+    }
+  }
+
+  private static <E extends Exception> void tryThrowAs(Throwable failure, Class<E> excClass) throws E {
+    if (excClass.isInstance(failure)) {
+      throw excClass.cast(failure);
+    }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/util/ExceptionUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/ExceptionUtil.java
@@ -85,11 +85,12 @@ public class ExceptionUtil {
       Class<? extends E1> e1Class,
       Class<? extends E2> e2Class,
       Class<? extends E3> e3Class) throws E1, E2, E3 {
-    Exception failure = null;
+
+    Throwable failure = null;
     try {
       return block.run();
 
-    } catch (Exception t) {
+    } catch (Throwable t) {
       failure = t;
 
       if (catchBlock != null) {

--- a/core/src/main/java/org/apache/iceberg/util/ExceptionUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/ExceptionUtil.java
@@ -85,11 +85,11 @@ public class ExceptionUtil {
       Class<? extends E1> e1Class,
       Class<? extends E2> e2Class,
       Class<? extends E3> e3Class) throws E1, E2, E3 {
-    Throwable failure = null;
+    Exception failure = null;
     try {
       return block.run();
 
-    } catch (Throwable t) {
+    } catch (Exception t) {
       failure = t;
 
       if (catchBlock != null) {

--- a/core/src/test/java/org/apache/iceberg/util/TestExceptionUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestExceptionUtil.java
@@ -35,7 +35,7 @@ public class TestExceptionUtil {
 
   @Test
   public void testRunSafely() {
-    CustomCheckedException exc = new CustomCheckedException("test");
+     CustomCheckedException exc = new CustomCheckedException("test");
     try {
       ExceptionUtil.runSafely(() -> {
         throw exc;

--- a/core/src/test/java/org/apache/iceberg/util/TestExceptionUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestExceptionUtil.java
@@ -35,15 +35,16 @@ public class TestExceptionUtil {
 
   @Test
   public void testRunSafely() {
-     CustomCheckedException exc = new CustomCheckedException("test");
+    CustomCheckedException exc = new CustomCheckedException("test");
     try {
       ExceptionUtil.runSafely(() -> {
-        throw exc;
-      }, (e) -> {
-        throw new Exception("test catch suppression");
-      }, () -> {
-        throw new RuntimeException("test finally suppression");
-      }, CustomCheckedException.class);
+            throw exc;
+          }, e -> {
+            throw new Exception("test catch suppression");
+          }, () -> {
+            throw new RuntimeException("test finally suppression");
+          }, CustomCheckedException.class
+      );
 
       Assert.fail("Should have thrown CustomCheckedException");
 

--- a/core/src/test/java/org/apache/iceberg/util/TestExceptionUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestExceptionUtil.java
@@ -69,7 +69,7 @@ public class TestExceptionUtil {
   public void testRunSafelyTwoExceptions() {
     CustomCheckedException exc = new CustomCheckedException("test");
     try {
-      ExceptionUtil.runSafely(() -> {
+      ExceptionUtil.runSafely((ExceptionUtil.Block<Void, CustomCheckedException, IOException, RuntimeException>) () -> {
             throw exc;
           }, e -> {
             throw new Exception("test catch suppression");
@@ -103,7 +103,8 @@ public class TestExceptionUtil {
   public void testRunSafelyThreeExceptions() {
     CustomCheckedException exc = new CustomCheckedException("test");
     try {
-      ExceptionUtil.runSafely(() -> {
+      ExceptionUtil.runSafely((ExceptionUtil.Block<Void, CustomCheckedException, IOException, ClassNotFoundException>)
+          () -> {
             throw exc;
           }, e -> {
             throw new Exception("test catch suppression");

--- a/core/src/test/java/org/apache/iceberg/util/TestExceptionUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestExceptionUtil.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestExceptionUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(TestExceptionUtil.class);
+
+  private static class CustomCheckedException extends Exception {
+    private CustomCheckedException(String message) {
+      super(message);
+    }
+  }
+
+  @Test
+  public void testRunSafely() {
+    CustomCheckedException exc = new CustomCheckedException("test");
+    try {
+      ExceptionUtil.runSafely(() -> {
+        throw exc;
+      }, (e) -> {
+        throw new Exception("test catch suppression");
+      }, () -> {
+        throw new RuntimeException("test finally suppression");
+      }, CustomCheckedException.class);
+
+      Assert.fail("Should have thrown CustomCheckedException");
+
+    } catch (CustomCheckedException e) {
+      LOG.info("Final exception", e);
+      Assert.assertEquals("Should throw correct exception instance", exc, e);
+      Assert.assertEquals("Should not alter exception message", "test", e.getMessage());
+      Assert.assertEquals("Should have 2 suppressed exceptions", 2, e.getSuppressed().length);
+
+      Throwable throwSuppressed = e.getSuppressed()[0];
+      Assert.assertTrue("Should be a CustomCheckedException", throwSuppressed instanceof Exception);
+      Assert.assertEquals("Should have correct message", "test catch suppression", throwSuppressed.getMessage());
+
+      Throwable finallySuppressed = e.getSuppressed()[1];
+      Assert.assertTrue("Should be a CustomCheckedException", finallySuppressed instanceof RuntimeException);
+      Assert.assertEquals("Should have correct message", "test finally suppression", finallySuppressed.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
This adds a utility method that accepts blocks as lambdas and correctly handles exceptions. Catch and finally blocks are always run and any exceptions thrown in those blocks are added to the main block's exception as suppressed exceptions. If the main block does not throw an exception, but finally does then the finally exception is thrown.

This currently supports up to 3 checked exception classes.