### PR TITLE
AWS: fix Glue bug table type removed after update

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueCatalogTableTest.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueCatalogTableTest.java
@@ -138,6 +138,10 @@ public class GlueCatalogTableTest extends GlueTestBase {
     table.newAppend().appendFile(dataFile).commit();
     table = glueCatalog.loadTable(TableIdentifier.of(namespace, tableName));
     Assert.assertEquals("commit should create a new table version", 1, table.history().size());
+    // check table in Glue
+    GetTableResponse response = glue.getTable(GetTableRequest.builder()
+        .databaseName(namespace).name(tableName).build());
+    Assert.assertEquals("external table type is set after update", "EXTERNAL_TABLE", response.table().tableType());
   }
 
   @Test

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -163,6 +163,7 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
           .skipArchive(awsProperties.glueCatalogSkipArchive())
           .tableInput(TableInput.builder()
               .name(tableName)
+              .tableType(GLUE_EXTERNAL_TABLE_TYPE)
               .parameters(parameters)
               .build())
           .build());


### PR DESCRIPTION
fix bug in `GlueCatalog` that table type is removed after update