### PR TITLE
Remove duplicate Arrow dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -756,7 +756,6 @@ project(':iceberg-spark') {
     compile project(':iceberg-parquet')
     compile project(':iceberg-arrow')
     compile project(':iceberg-hive-metastore')
-    compile project(':iceberg-arrow')
 
     compileOnly "org.apache.avro:avro"
     compileOnly("org.apache.spark:spark-hive_2.11") {


### PR DESCRIPTION
Small one. While working on a Beam sink, I've noticed that the Arrow dependency was referenced twice. It is also reference two lines above.