### PR TITLE
Avro metrics support

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Comparators.java
+++ b/api/src/main/java/org/apache/iceberg/types/Comparators.java
@@ -157,6 +157,10 @@ public class Comparators {
     return UnsignedByteBufComparator.INSTANCE;
   }
 
+  public static Comparator<byte[]> unsignedByteArray() {
+    return UnsignedByteArrayComparator.INSTANCE;
+  }
+
   public static Comparator<ByteBuffer> signedBytes() {
     return Comparator.naturalOrder();
   }
@@ -269,6 +273,30 @@ public class Comparators {
 
       // if there are no differences, then the shorter seq is first
       return Integer.compare(buf1.remaining(), buf2.remaining());
+    }
+  }
+
+  private static class UnsignedByteArrayComparator implements Comparator<byte[]> {
+    private static final UnsignedByteArrayComparator INSTANCE = new UnsignedByteArrayComparator();
+
+    private UnsignedByteArrayComparator() {
+    }
+
+    @Override
+    public int compare(byte[] array1, byte[] array2) {
+      int len = Math.min(array1.length, array2.length);
+
+      // find the first difference and return
+      for (int i = 0; i < len; i += 1) {
+        // Conversion to int is what Byte.toUnsignedInt would do
+        int cmp = Integer.compare(((int) array1[i]) & 0xff, ((int) array2[i]) & 0xff);
+        if (cmp != 0) {
+          return cmp;
+        }
+      }
+
+      // if there are no differences, then the shorter seq is first
+      return Integer.compare(array1.length, array2.length);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/FieldMetrics.java
+++ b/core/src/main/java/org/apache/iceberg/FieldMetrics.java
@@ -20,8 +20,6 @@
 package org.apache.iceberg;
 
 
-import java.nio.ByteBuffer;
-
 /**
  * Iceberg internally tracked field level metrics.
  */
@@ -30,15 +28,15 @@ public class FieldMetrics {
   private final long valueCount;
   private final long nullValueCount;
   private final long nanValueCount;
-  private final ByteBuffer lowerBound;
-  private final ByteBuffer upperBound;
+  private final Object lowerBound;
+  private final Object upperBound;
 
   public FieldMetrics(int id,
                       long valueCount,
                       long nullValueCount,
                       long nanValueCount,
-                      ByteBuffer lowerBound,
-                      ByteBuffer upperBound) {
+                      Object lowerBound,
+                      Object upperBound) {
     this.id = id;
     this.valueCount = valueCount;
     this.nullValueCount = nullValueCount;
@@ -78,14 +76,14 @@ public class FieldMetrics {
   /**
    * Returns the lower bound value of this field.
    */
-  public ByteBuffer lowerBound() {
+  public Object lowerBound() {
     return lowerBound;
   }
 
   /**
    * Returns the upper bound value of this field.
    */
-  public ByteBuffer upperBound() {
+  public Object upperBound() {
     return upperBound;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/avro/AvroMetrics.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroMetrics.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.avro;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.iceberg.FieldMetrics;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.MetricsConfig;
+import org.apache.iceberg.MetricsModes;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.expressions.Literal;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.util.BinaryUtil;
+import org.apache.iceberg.util.UnicodeUtil;
+
+public class AvroMetrics {
+
+  private AvroMetrics() {
+  }
+
+  static Metrics fromWriter(MetricsAwareDatumWriter<?> datumWriter, Schema schema, long numRecords,
+                            MetricsConfig inputMetricsConfig) {
+    MetricsConfig metricsConfig;
+    if (inputMetricsConfig == null) {
+      metricsConfig = MetricsConfig.getDefault();
+    } else {
+      metricsConfig = inputMetricsConfig;
+    }
+
+    Map<Integer, Long> valueCounts = new HashMap<>();
+    Map<Integer, Long> nullValueCounts = new HashMap<>();
+    Map<Integer, Long> nanValueCounts = new HashMap<>();
+    Map<Integer, ByteBuffer> lowerBounds = new HashMap<>();
+    Map<Integer, ByteBuffer> upperBounds = new HashMap<>();
+
+    datumWriter.metrics().forEach(metrics -> {
+      String columnName = schema.findColumnName(metrics.id());
+      MetricsModes.MetricsMode metricsMode = metricsConfig.columnMode(columnName);
+      if (metricsMode == MetricsModes.None.get()) {
+        return;
+      }
+
+      valueCounts.put(metrics.id(), metrics.valueCount());
+      nullValueCounts.put(metrics.id(), metrics.nullValueCount());
+      Type type = schema.findType(metrics.id());
+
+      if (type.typeId() == Type.TypeID.FLOAT || type.typeId() == Type.TypeID.DOUBLE) {
+        nanValueCounts.put(metrics.id(), metrics.nanValueCount());
+      }
+
+      if (metricsMode == MetricsModes.Counts.get()) {
+        return;
+      }
+
+      updateLowerBound(metrics, type, metricsMode).ifPresent(lowerBound -> lowerBounds.put(metrics.id(), lowerBound));
+      updateUpperBound(metrics, type, metricsMode).ifPresent(upperBound -> upperBounds.put(metrics.id(), upperBound));
+    });
+
+    return new Metrics(numRecords, null,
+        valueCounts, nullValueCounts, nanValueCounts, lowerBounds, upperBounds);
+  }
+
+  private static Optional<ByteBuffer> updateLowerBound(FieldMetrics metrics, Type type,
+                                                       MetricsModes.MetricsMode metricsMode) {
+    if (metrics.lowerBound() == null) {
+      return Optional.empty();
+    }
+
+    Object lowerBound = metrics.lowerBound();
+    if (metricsMode instanceof MetricsModes.Truncate) {
+      MetricsModes.Truncate truncateMode = (MetricsModes.Truncate) metricsMode;
+      int truncateLength = truncateMode.length();
+      switch (type.typeId()) {
+        case STRING:
+          lowerBound = UnicodeUtil.truncateStringMin(
+              Literal.of((CharSequence) metrics.lowerBound()), truncateLength).value();
+          break;
+        case FIXED:
+        case BINARY:
+          lowerBound = BinaryUtil.truncateBinaryMin(
+              Literal.of((ByteBuffer) metrics.lowerBound()), truncateLength).value();
+          break;
+        default:
+          break;
+      }
+    }
+
+    return Optional.ofNullable(Conversions.toByteBuffer(type, lowerBound));
+  }
+
+  private static Optional<ByteBuffer> updateUpperBound(FieldMetrics metrics, Type type,
+                                                 MetricsModes.MetricsMode metricsMode) {
+    if (metrics.upperBound() == null) {
+      return Optional.empty();
+    }
+
+    Object upperBound = null;
+    if (metricsMode instanceof MetricsModes.Truncate) {
+      MetricsModes.Truncate truncateMode = (MetricsModes.Truncate) metricsMode;
+      int truncateLength = truncateMode.length();
+      switch (type.typeId()) {
+        case STRING:
+          upperBound = Optional.ofNullable(
+              UnicodeUtil.truncateStringMax(Literal.of((CharSequence) metrics.upperBound()), truncateLength))
+              .map(Literal::value)
+              .orElse(null);
+          break;
+        case FIXED:
+        case BINARY:
+          upperBound = Optional.ofNullable(
+              BinaryUtil.truncateBinaryMax(Literal.of((ByteBuffer) metrics.upperBound()), truncateLength))
+              .map(Literal::value)
+              .orElse(null);
+          break;
+        default:
+          break;
+      }
+    }
+
+    if (upperBound == null) {
+      upperBound = metrics.upperBound();
+    }
+
+    return Optional.ofNullable(Conversions.toByteBuffer(type, upperBound));
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/avro/MetricsAwareDatumWriter.java
+++ b/core/src/main/java/org/apache/iceberg/avro/MetricsAwareDatumWriter.java
@@ -19,13 +19,17 @@
 
 package org.apache.iceberg.avro;
 
-import java.io.IOException;
 import java.util.stream.Stream;
-import org.apache.avro.io.Encoder;
+import org.apache.avro.io.DatumWriter;
 import org.apache.iceberg.FieldMetrics;
 
-public interface ValueWriter<D> {
-  void write(D datum, Encoder encoder) throws IOException;
+/**
+ * Wrapper writer around {@link DatumWriter} with metrics support.
+ */
+public interface MetricsAwareDatumWriter<D> extends DatumWriter<D> {
 
+  /**
+   * Returns a stream of {@link FieldMetrics} that this MetricsAwareDatumWriter keeps track of.
+   */
   Stream<FieldMetrics> metrics();
 }

--- a/core/src/main/java/org/apache/iceberg/avro/ValueWriters.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ValueWriters.java
@@ -24,18 +24,28 @@ import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
+import org.apache.iceberg.FieldMetrics;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.DecimalUtil;
+import org.apache.iceberg.util.NaNUtil;
 
 public class ValueWriters {
   private ValueWriters() {
@@ -45,68 +55,68 @@ public class ValueWriters {
     return NullWriter.INSTANCE;
   }
 
-  public static ValueWriter<Boolean> booleans() {
-    return BooleanWriter.INSTANCE;
+  public static ValueWriter<Boolean> booleans(int id) {
+    return new BooleanWriter(id);
   }
 
-  public static ValueWriter<Byte> tinyints() {
-    return ByteToIntegerWriter.INSTANCE;
+  public static ValueWriter<Byte> tinyints(int id) {
+    return new ByteToIntegerWriter(id);
   }
 
-  public static ValueWriter<Short> shorts() {
-    return ShortToIntegerWriter.INSTANCE;
+  public static ValueWriter<Short> shorts(int id) {
+    return new ShortToIntegerWriter(id);
   }
 
-  public static ValueWriter<Integer> ints() {
-    return IntegerWriter.INSTANCE;
+  public static ValueWriter<Integer> ints(int id) {
+    return new IntegerWriter(id);
   }
 
-  public static ValueWriter<Long> longs() {
-    return LongWriter.INSTANCE;
+  public static ValueWriter<Long> longs(int id) {
+    return new LongWriter(id);
   }
 
-  public static ValueWriter<Float> floats() {
-    return FloatWriter.INSTANCE;
+  public static ValueWriter<Float> floats(int id) {
+    return new FloatWriter(id);
   }
 
-  public static ValueWriter<Double> doubles() {
-    return DoubleWriter.INSTANCE;
+  public static ValueWriter<Double> doubles(int id) {
+    return new DoubleWriter(id);
   }
 
-  public static ValueWriter<Object> strings() {
-    return StringWriter.INSTANCE;
+  public static ValueWriter<CharSequence> strings(int id) {
+    return new StringWriter(id);
   }
 
-  public static ValueWriter<Utf8> utf8s() {
-    return Utf8Writer.INSTANCE;
+  public static ValueWriter<Utf8> utf8s(int id) {
+    return new Utf8Writer(id);
   }
 
-  public static ValueWriter<UUID> uuids() {
-    return UUIDWriter.INSTANCE;
+  public static ValueWriter<UUID> uuids(int id) {
+    return new UUIDWriter(id);
   }
 
-  public static ValueWriter<byte[]> fixed(int length) {
-    return new FixedWriter(length);
+  public static ValueWriter<byte[]> fixed(int id, int length) {
+    return new FixedWriter(id, length);
   }
 
-  public static ValueWriter<GenericData.Fixed> genericFixed(int length) {
-    return new GenericFixedWriter(length);
+  public static ValueWriter<GenericData.Fixed> genericFixed(int id, int length) {
+    return new GenericFixedWriter(id, length);
   }
 
-  public static ValueWriter<byte[]> bytes() {
-    return BytesWriter.INSTANCE;
+  public static ValueWriter<byte[]> bytes(int id) {
+    return new BytesWriter(id);
   }
 
-  public static ValueWriter<ByteBuffer> byteBuffers() {
-    return ByteBufferWriter.INSTANCE;
+  public static ValueWriter<ByteBuffer> byteBuffers(int id) {
+    return new ByteBufferWriter(id);
   }
 
-  public static ValueWriter<BigDecimal> decimal(int precision, int scale) {
-    return new DecimalWriter(precision, scale);
+  public static ValueWriter<BigDecimal> decimal(int id, int precision, int scale) {
+    return new DecimalWriter(id, precision, scale);
   }
 
-  public static <T> ValueWriter<T> option(int nullIndex, ValueWriter<T> writer) {
-    return new OptionWriter<>(nullIndex, writer);
+  public static <T> ValueWriter<T> option(int nullIndex, ValueWriter<T> writer, Schema.Type type) {
+    return new OptionWriter<>(nullIndex, writer, type);
   }
 
   public static <T> ValueWriter<Collection<T>> array(ValueWriter<T> elementWriter) {
@@ -127,6 +137,11 @@ public class ValueWriters {
     return new RecordWriter(writers);
   }
 
+  /**
+   * NullWriter is created as a placeholder so that when building writers from schema,
+   * visitor could use the existence of NullWriter for input verification when constructing optional fields.
+   * The actual writing of null values is handled by {@link OptionWriter}.
+   */
   private static class NullWriter implements ValueWriter<Void> {
     private static final NullWriter INSTANCE = new NullWriter();
 
@@ -135,109 +150,106 @@ public class ValueWriters {
 
     @Override
     public void write(Void ignored, Encoder encoder) throws IOException {
-      encoder.writeNull();
-    }
-  }
-
-  private static class BooleanWriter implements ValueWriter<Boolean> {
-    private static final BooleanWriter INSTANCE = new BooleanWriter();
-
-    private BooleanWriter() {
+      throw new IllegalStateException("[BUG] NullWriter shouldn't be used for writing nulls for Avro");
     }
 
     @Override
-    public void write(Boolean bool, Encoder encoder) throws IOException {
+    public Stream<FieldMetrics> metrics() {
+      throw new IllegalStateException("[BUG] NullWriter shouldn't be used for writing nulls for Avro");
+    }
+  }
+
+  private static class BooleanWriter extends ComparableWriter<Boolean> {
+    private BooleanWriter(int id) {
+      super(id);
+    }
+
+    @Override
+    protected void writeVal(Boolean bool, Encoder encoder) throws IOException {
       encoder.writeBoolean(bool);
     }
   }
 
-  private static class ByteToIntegerWriter implements ValueWriter<Byte> {
-    private static final ByteToIntegerWriter INSTANCE = new ByteToIntegerWriter();
-
-    private ByteToIntegerWriter() {
+  private static class ByteToIntegerWriter extends MetricsAwareTransformWriter<Byte, Integer> {
+    private ByteToIntegerWriter(int id) {
+      super(id, Integer::compareTo, Byte::intValue);
     }
 
     @Override
-    public void write(Byte b, Encoder encoder) throws IOException {
-      encoder.writeInt(b.intValue());
+    protected void writeVal(Integer intVal, Encoder encoder) throws IOException {
+      encoder.writeInt(intVal);
     }
   }
 
-  private static class ShortToIntegerWriter implements ValueWriter<Short> {
-    private static final ShortToIntegerWriter INSTANCE = new ShortToIntegerWriter();
-
-    private ShortToIntegerWriter() {
+  private static class ShortToIntegerWriter extends MetricsAwareTransformWriter<Short, Integer> {
+    private ShortToIntegerWriter(int id) {
+      super(id, Integer::compareTo, Short::intValue);
     }
 
     @Override
-    public void write(Short s, Encoder encoder) throws IOException {
-      encoder.writeInt(s.intValue());
+    protected void writeVal(Integer intValue, Encoder encoder) throws IOException {
+      encoder.writeInt(intValue);
     }
   }
 
-  private static class IntegerWriter implements ValueWriter<Integer> {
-    private static final IntegerWriter INSTANCE = new IntegerWriter();
-
-    private IntegerWriter() {
+  private static class IntegerWriter extends ComparableWriter<Integer> {
+    private IntegerWriter(int id) {
+      super(id);
     }
 
     @Override
-    public void write(Integer i, Encoder encoder) throws IOException {
+    protected void writeVal(Integer i, Encoder encoder) throws IOException {
       encoder.writeInt(i);
     }
   }
 
-  private static class LongWriter implements ValueWriter<Long> {
-    private static final LongWriter INSTANCE = new LongWriter();
-
-    private LongWriter() {
+  private static class LongWriter extends ComparableWriter<Long> {
+    private LongWriter(int id) {
+      super(id);
     }
 
     @Override
-    public void write(Long l, Encoder encoder) throws IOException {
+    protected void writeVal(Long l, Encoder encoder) throws IOException {
       encoder.writeLong(l);
     }
   }
 
-  private static class FloatWriter implements ValueWriter<Float> {
-    private static final FloatWriter INSTANCE = new FloatWriter();
-
-    private FloatWriter() {
+  private static class FloatWriter extends FloatingPointWriter<Float> {
+    private FloatWriter(int id) {
+      super(id);
     }
 
     @Override
-    public void write(Float f, Encoder encoder) throws IOException {
+    protected void writeVal(Float f, Encoder encoder) throws IOException {
       encoder.writeFloat(f);
     }
   }
 
-  private static class DoubleWriter implements ValueWriter<Double> {
-    private static final DoubleWriter INSTANCE = new DoubleWriter();
-
-    private DoubleWriter() {
+  private static class DoubleWriter extends FloatingPointWriter<Double> {
+    private DoubleWriter(int id) {
+      super(id);
     }
 
     @Override
-    public void write(Double d, Encoder encoder) throws IOException {
+    protected void writeVal(Double d, Encoder encoder) throws IOException {
       encoder.writeDouble(d);
     }
   }
 
-  private static class StringWriter implements ValueWriter<Object> {
-    private static final StringWriter INSTANCE = new StringWriter();
-
-    private StringWriter() {
+  private static class StringWriter extends MetricsAwareWriter<CharSequence> {
+    private StringWriter(int id) {
+      super(id, Comparators.charSequences());
     }
 
     @Override
-    public void write(Object s, Encoder encoder) throws IOException {
+    public void write(CharSequence s, Encoder encoder) throws IOException {
       // use getBytes because it may return the backing byte array if available.
       // otherwise, it copies to a new byte array, which is still cheaper than Avro
       // calling toString, which incurs encoding costs
       if (s instanceof Utf8) {
-        encoder.writeString((Utf8) s);
+        super.write(s, encoder);
       } else if (s instanceof String) {
-        encoder.writeString(new Utf8((String) s));
+        super.write(new Utf8((String) s), encoder);
       } else if (s == null) {
         throw new IllegalArgumentException("Cannot write null to required string column");
       } else {
@@ -245,35 +257,38 @@ public class ValueWriters {
             "Cannot write unknown string type: " + s.getClass().getName() + ": " + s.toString());
       }
     }
+
+    @Override
+    protected void writeVal(CharSequence s, Encoder encoder) throws IOException {
+      encoder.writeString((Utf8) s);
+    }
   }
 
-  private static class Utf8Writer implements ValueWriter<Utf8> {
-    private static final Utf8Writer INSTANCE = new Utf8Writer();
-
-    private Utf8Writer() {
+  private static class Utf8Writer extends ComparableWriter<Utf8> {
+    private Utf8Writer(int id) {
+      super(id);
     }
 
     @Override
-    public void write(Utf8 s, Encoder encoder) throws IOException {
+    protected void writeVal(Utf8 s, Encoder encoder) throws IOException {
       encoder.writeString(s);
     }
   }
 
-  private static class UUIDWriter implements ValueWriter<UUID> {
+  private static class UUIDWriter extends MetricsAwareWriter<UUID> {
     private static final ThreadLocal<ByteBuffer> BUFFER = ThreadLocal.withInitial(() -> {
       ByteBuffer buffer = ByteBuffer.allocate(16);
       buffer.order(ByteOrder.BIG_ENDIAN);
       return buffer;
     });
 
-    private static final UUIDWriter INSTANCE = new UUIDWriter();
-
-    private UUIDWriter() {
+    private UUIDWriter(int id) {
+      super(id, Comparators.forType(Types.UUIDType.get()));
     }
 
     @Override
     @SuppressWarnings("ByteBufferBackingArray")
-    public void write(UUID uuid, Encoder encoder) throws IOException {
+    protected void writeVal(UUID uuid, Encoder encoder) throws IOException {
       // TODO: direct conversion from string to byte buffer
       ByteBuffer buffer = BUFFER.get();
       buffer.rewind();
@@ -283,73 +298,80 @@ public class ValueWriters {
     }
   }
 
-  private static class FixedWriter implements ValueWriter<byte[]> {
+  private static class FixedWriter extends MetricsAwareByteArrayWriter {
     private final int length;
 
-    private FixedWriter(int length) {
+    private FixedWriter(int id, int length) {
+      super(id);
       this.length = length;
     }
 
     @Override
-    public void write(byte[] bytes, Encoder encoder) throws IOException {
+    protected void writeVal(byte[] bytes, Encoder encoder) throws IOException {
       Preconditions.checkArgument(bytes.length == length,
           "Cannot write byte array of length %s as fixed[%s]", bytes.length, length);
       encoder.writeFixed(bytes);
     }
   }
 
-  private static class GenericFixedWriter implements ValueWriter<GenericData.Fixed> {
+  private static class GenericFixedWriter extends ComparableWriter<GenericData.Fixed> {
     private final int length;
 
-    private GenericFixedWriter(int length) {
+    private GenericFixedWriter(int id, int length) {
+      super(id);
       this.length = length;
     }
 
     @Override
-    public void write(GenericData.Fixed datum, Encoder encoder) throws IOException {
+    protected void writeVal(GenericData.Fixed datum, Encoder encoder) throws IOException {
       Preconditions.checkArgument(datum.bytes().length == length,
           "Cannot write byte array of length %s as fixed[%s]", datum.bytes().length, length);
       encoder.writeFixed(datum.bytes());
     }
+
+    @Override
+    public Stream<FieldMetrics> metrics() {
+      // convert min/max to byte buffer to allow upper/lower bound truncation when gathering metrics.
+      return metrics(fixed -> ByteBuffer.wrap(fixed.bytes()));
+    }
   }
 
-  private static class BytesWriter implements ValueWriter<byte[]> {
-    private static final BytesWriter INSTANCE = new BytesWriter();
-
-    private BytesWriter() {
+  private static class BytesWriter extends MetricsAwareByteArrayWriter {
+    private BytesWriter(int id) {
+      super(id);
     }
 
     @Override
-    public void write(byte[] bytes, Encoder encoder) throws IOException {
+    protected void writeVal(byte[] bytes, Encoder encoder) throws IOException {
       encoder.writeBytes(bytes);
     }
   }
 
-  private static class ByteBufferWriter implements ValueWriter<ByteBuffer> {
-    private static final ByteBufferWriter INSTANCE = new ByteBufferWriter();
-
-    private ByteBufferWriter() {
+  private static class ByteBufferWriter extends MetricsAwareWriter<ByteBuffer> {
+    private ByteBufferWriter(int id) {
+      super(id, Comparators.unsignedBytes());
     }
 
     @Override
-    public void write(ByteBuffer bytes, Encoder encoder) throws IOException {
+    protected void writeVal(ByteBuffer bytes, Encoder encoder) throws IOException {
       encoder.writeBytes(bytes);
     }
   }
 
-  private static class DecimalWriter implements ValueWriter<BigDecimal> {
+  private static class DecimalWriter extends ComparableWriter<BigDecimal> {
     private final int precision;
     private final int scale;
     private final ThreadLocal<byte[]> bytes;
 
-    private DecimalWriter(int precision, int scale) {
+    private DecimalWriter(int id, int precision, int scale) {
+      super(id);
       this.precision = precision;
       this.scale = scale;
       this.bytes = ThreadLocal.withInitial(() -> new byte[TypeUtil.decimalRequiredBytes(precision)]);
     }
 
     @Override
-    public void write(BigDecimal decimal, Encoder encoder) throws IOException {
+    protected void writeVal(BigDecimal decimal, Encoder encoder) throws IOException {
       encoder.writeFixed(DecimalUtil.toReusedFixLengthBytes(precision, scale, decimal, bytes.get()));
     }
   }
@@ -358,8 +380,10 @@ public class ValueWriters {
     private final int nullIndex;
     private final int valueIndex;
     private final ValueWriter<T> valueWriter;
+    private final Schema.Type type;
+    private long nullValueCount;
 
-    private OptionWriter(int nullIndex, ValueWriter<T> valueWriter) {
+    private OptionWriter(int nullIndex, ValueWriter<T> valueWriter, Schema.Type type) {
       this.nullIndex = nullIndex;
       if (nullIndex == 0) {
         this.valueIndex = 1;
@@ -369,16 +393,41 @@ public class ValueWriters {
         throw new IllegalArgumentException("Invalid option index: " + nullIndex);
       }
       this.valueWriter = valueWriter;
+      this.type = type;
+      this.nullValueCount = 0;
     }
 
     @Override
     public void write(T option, Encoder encoder) throws IOException {
       if (option == null) {
         encoder.writeIndex(nullIndex);
+        nullValueCount++;
       } else {
         encoder.writeIndex(valueIndex);
         valueWriter.write(option, encoder);
       }
+    }
+
+    @Override
+    public Stream<FieldMetrics> metrics() {
+      if (AvroSchemaUtil.isMetricSupportedType(type)) {
+        return mergeNullCountIntoMetric();
+      } else {
+        return valueWriter.metrics();
+      }
+    }
+
+    private Stream<FieldMetrics> mergeNullCountIntoMetric() {
+      List<FieldMetrics> fieldMetricsFromWriter = valueWriter.metrics().collect(Collectors.toList());
+      Preconditions.checkState(fieldMetricsFromWriter.size() == 1,
+          "Optional field for type % shouldn't vend more than one field metrics", type);
+
+      FieldMetrics metrics = fieldMetricsFromWriter.get(0);
+      return Stream.of(
+          new FieldMetrics(metrics.id(),
+              metrics.valueCount() + nullValueCount, nullValueCount,
+              metrics.nanValueCount(), metrics.lowerBound(), metrics.upperBound())
+      );
     }
   }
 
@@ -401,6 +450,11 @@ public class ValueWriters {
         elementWriter.write(iter.next(), encoder);
       }
       encoder.writeArrayEnd();
+    }
+
+    @Override
+    public Stream<FieldMetrics> metrics() {
+      return elementWriter.metrics();
     }
   }
 
@@ -428,6 +482,11 @@ public class ValueWriters {
       }
       encoder.writeArrayEnd();
     }
+
+    @Override
+    public Stream<FieldMetrics> metrics() {
+      return Stream.concat(keyWriter.metrics(), valueWriter.metrics());
+    }
   }
 
   private static class MapWriter<K, V> implements ValueWriter<Map<K, V>> {
@@ -454,6 +513,11 @@ public class ValueWriters {
       }
       encoder.writeMapEnd();
     }
+
+    @Override
+    public Stream<FieldMetrics> metrics() {
+      return Stream.concat(keyWriter.metrics(), valueWriter.metrics());
+    }
   }
 
   public abstract static class StructWriter<S> implements ValueWriter<S> {
@@ -479,6 +543,11 @@ public class ValueWriters {
         writers[i].write(get(row, i), encoder);
       }
     }
+
+    @Override
+    public Stream<FieldMetrics> metrics() {
+      return Arrays.stream(writers).flatMap(ValueWriter::metrics);
+    }
   }
 
   private static class RecordWriter extends StructWriter<IndexedRecord> {
@@ -492,4 +561,153 @@ public class ValueWriters {
       return struct.get(pos);
     }
   }
+
+  private abstract static class FloatingPointWriter<T extends Comparable<T>>
+      extends ComparableWriter<T> {
+    private long nanValueCount;
+
+    FloatingPointWriter(int id) {
+      super(id);
+    }
+
+    @Override
+    public void write(T datum, Encoder encoder) throws IOException {
+      valueCount++;
+
+      if (datum == null) {
+        nullValueCount++;
+      } else if (NaNUtil.isNaN(datum)) {
+        nanValueCount++;
+      } else {
+        if (max == null || datum.compareTo(max) > 0) {
+          this.max = datum;
+        }
+        if (min == null || datum.compareTo(min) < 0) {
+          this.min = datum;
+        }
+      }
+
+      writeVal(datum, encoder);
+    }
+
+    @Override
+    public Stream<FieldMetrics> metrics() {
+      return Stream.of(new FieldMetrics(id, valueCount, nullValueCount, nanValueCount, min, max));
+    }
+  }
+
+  public abstract static class MetricsAwareStringWriter<T extends Comparable<T>> extends ComparableWriter<T> {
+    public MetricsAwareStringWriter(int id) {
+      super(id);
+    }
+
+    @Override
+    public Stream<FieldMetrics> metrics() {
+      // convert min/max to string to allow upper/lower bound truncation when gathering metrics,
+      // as in different implementations there's no guarantee that input to string writer will be char sequence
+      return metrics(Object::toString);
+    }
+  }
+
+  private abstract static class MetricsAwareByteArrayWriter extends MetricsAwareWriter<byte[]> {
+    MetricsAwareByteArrayWriter(int id) {
+      super(id, Comparators.unsignedByteArray());
+    }
+
+    @Override
+    public Stream<FieldMetrics> metrics() {
+      // convert min/max to byte buffer to allow upper/lower bound truncation when gathering metrics.
+      return metrics(ByteBuffer::wrap);
+    }
+  }
+
+  public abstract static class ComparableWriter<T extends Comparable<T>> extends MetricsAwareWriter<T> {
+    public ComparableWriter(int id) {
+      super(id, Comparable::compareTo);
+    }
+  }
+
+  /**
+   * A value writer wrapper that keeps track of column statistics (metrics) during writing.
+   *
+   * @param <T> Input type
+   */
+  public abstract static class MetricsAwareWriter<T> extends MetricsAwareTransformWriter<T, T> {
+    public MetricsAwareWriter(int id, Comparator<T> comparator) {
+      super(id, comparator, Function.identity());
+    }
+
+    /**
+     * Helper class to transform the input type when collecting metrics.
+     * The transform function converts the stats information from the specific type that the underlying writer
+     * understands to a more general type that could be transformed to binary following iceberg single-value
+     * serialization spec.
+     *
+     * @param func tranformation function
+     * @return a stream of field metrics with bounds converted by the given transformation
+     */
+    protected Stream<FieldMetrics> metrics(Function<T, ?> func) {
+      return Stream.of(new FieldMetrics(id, valueCount, nullValueCount, 0,
+          updateBound(min, func), updateBound(max, func)));
+    }
+
+    private <T3, T4> T4 updateBound(T3 bound, Function<T3, T4> func) {
+      return bound == null ? null : func.apply(bound);
+    }
+  }
+
+  /**
+   * A value writer wrapper that keeps track of column statistics (metrics) during writing, and accepts a
+   * transformation in its constructor.
+   * The transformation will apply to the input data to produce the type that the underlying writer accepts.
+   * Stats will also be tracked with the type after transformation.
+   *
+   * @param <T1> Input type
+   * @param <T2> Type after transformation
+   */
+  @SuppressWarnings("checkstyle:VisibilityModifier")
+  public abstract static class MetricsAwareTransformWriter<T1, T2> implements ValueWriter<T1> {
+    protected final int id;
+    protected long valueCount;
+    protected long nullValueCount;
+    protected T2 max;
+    protected T2 min;
+    protected final Function<T1, T2> transformation;
+
+    private final Comparator<T2> comparator;
+
+    public MetricsAwareTransformWriter(int id, Comparator<T2> comparator, Function<T1, T2> func) {
+      this.id = id;
+      this.comparator = comparator;
+      this.transformation = func;
+    }
+
+    @Override
+    public void write(T1 datum, Encoder encoder) throws IOException {
+      valueCount++;
+      if (datum == null) {
+        nullValueCount++;
+        writeVal(null, encoder);
+
+      } else {
+        T2 transformedDatum = transformation.apply(datum);
+        if (max == null || comparator.compare(transformedDatum, max) > 0) {
+          max = transformedDatum;
+        }
+        if (min == null || comparator.compare(transformedDatum, min) < 0) {
+          min = transformedDatum;
+        }
+        writeVal(transformedDatum, encoder);
+
+      }
+    }
+
+    protected abstract void writeVal(T2 datum, Encoder encoder) throws IOException;
+
+    @Override
+    public Stream<FieldMetrics> metrics() {
+      return Stream.of(new FieldMetrics(id, valueCount, nullValueCount, 0, min, max));
+    }
+  }
+
 }

--- a/data/src/test/java/org/apache/iceberg/TestMergingMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/TestMergingMetrics.java
@@ -90,7 +90,7 @@ public abstract class TestMergingMetrics<T> {
 
   @Parameterized.Parameters(name = "fileFormat = {0}")
   public static Object[] parameters() {
-    return new Object[] {FileFormat.PARQUET };
+    return new Object[] {FileFormat.PARQUET, FileFormat.AVRO};
   }
 
   public TestMergingMetrics(FileFormat fileFormat) {

--- a/data/src/test/java/org/apache/iceberg/avro/TestAvroMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/avro/TestAvroMetrics.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.avro;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.MetricsConfig;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.TestMetrics;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.avro.DataWriter;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+public class TestAvroMetrics extends TestMetrics {
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  @Override
+  public FileFormat fileFormat() {
+    return FileFormat.AVRO;
+  }
+
+  @Override
+  public Metrics getMetrics(Schema schema, MetricsConfig metricsConfig, Record... records) throws IOException {
+    return getMetrics(schema, createOutputFile(), ImmutableMap.of(), metricsConfig, records);
+  }
+
+  @Override
+  public Metrics getMetrics(Schema schema, Record... records) throws IOException {
+    return getMetrics(schema, MetricsConfig.getDefault(), records);
+  }
+
+  private Metrics getMetrics(Schema schema, OutputFile file, Map<String, String> properties,
+                             MetricsConfig metricsConfig, Record... records) throws IOException {
+    FileAppender<Record> writer = Avro.write(file)
+        .schema(schema)
+        .setAll(properties)
+        .createWriterFunc(DataWriter::create)
+        .metricsConfig(metricsConfig)
+        .build();
+    try (FileAppender<Record> appender = writer) {
+      appender.addAll(Lists.newArrayList(records));
+    }
+    return writer.metrics();
+  }
+
+  @Override
+  protected Metrics getMetricsForRecordsWithSmallRowGroups(Schema schema, OutputFile outputFile, Record... records) {
+    throw new UnsupportedOperationException("supportsSmallRowGroups = " + supportsSmallRowGroups());
+  }
+
+
+  @Override
+  public int splitCount(InputFile inputFile) throws IOException {
+    return 0;
+  }
+
+  @Override
+  protected OutputFile createOutputFile() throws IOException {
+    File tmpFolder = temp.newFolder("avro");
+    String filename = UUID.randomUUID().toString();
+    return Files.localOutput(new File(tmpFolder, FileFormat.AVRO.addExtension(filename)));
+  }
+}

--- a/data/src/test/java/org/apache/iceberg/avro/TestAvroMetricsBounds.java
+++ b/data/src/test/java/org/apache/iceberg/avro/TestAvroMetricsBounds.java
@@ -1,0 +1,346 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.avro;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.DateTimeUtil;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+
+public abstract class TestAvroMetricsBounds {
+  // all supported types, except for UUID which is on deprecation path: see https://github.com/apache/iceberg/pull/1611
+  protected static final Types.NestedField INT_FIELD = optional(1, "id", Types.IntegerType.get());
+  protected static final Types.NestedField STRING_FIELD = optional(2, "string", Types.StringType.get());
+  protected static final Types.NestedField FLOAT_FIELD = optional(3, "float", Types.FloatType.get());
+  protected static final Types.NestedField DOUBLE_FIELD = optional(4, "double", Types.DoubleType.get());
+  protected static final Types.NestedField DECIMAL_FIELD = optional(5, "decimal", Types.DecimalType.of(5, 3));
+  protected static final Types.NestedField FIXED_FIELD = optional(6, "fixed", Types.FixedType.ofLength(4));
+  protected static final Types.NestedField BINARY_FIELD = optional(7, "binary", Types.BinaryType.get());
+  protected static final Types.NestedField LONG_FIELD = optional(8, "long", Types.LongType.get());
+  protected static final Types.NestedField BOOLEAN_FIELD = optional(9, "boolean", Types.BooleanType.get());
+  protected static final Types.NestedField DATE_FIELD = optional(10, "date", Types.DateType.get());
+  protected static final Types.NestedField TIME_FIELD = optional(11, "time", Types.TimeType.get());
+  protected static final Types.NestedField TIMESTAMPZ_FIELD = optional(12, "timestampz",
+      Types.TimestampType.withZone());
+  protected static final Types.NestedField TIMESTAMP_FIELD = optional(13, "timestamp",
+      Types.TimestampType.withoutZone());
+
+  protected static final Map<Types.NestedField, Schema> SINGLE_FIELD_SCHEMA_MAP = populateSingleFieldSchemaMap();
+
+  private static Map<Types.NestedField, Schema> populateSingleFieldSchemaMap() {
+    Set<Types.NestedField> allTypes = new HashSet<>();
+    allTypes.add(INT_FIELD);
+    allTypes.add(STRING_FIELD);
+    allTypes.add(FLOAT_FIELD);
+    allTypes.add(DOUBLE_FIELD);
+    allTypes.add(DECIMAL_FIELD);
+    allTypes.add(FIXED_FIELD);
+    allTypes.add(BINARY_FIELD);
+    allTypes.add(LONG_FIELD);
+    allTypes.add(BOOLEAN_FIELD);
+    allTypes.add(DATE_FIELD);
+    allTypes.add(TIME_FIELD);
+    allTypes.add(TIMESTAMPZ_FIELD);
+    allTypes.add(TIMESTAMP_FIELD);
+    return allTypes.stream().collect(Collectors.toMap(Function.identity(), Schema::new));
+  }
+
+  protected Metrics writeAndGetMetrics(Types.NestedField field, Record... records) throws IOException {
+    return writeAndGetMetrics(SINGLE_FIELD_SCHEMA_MAP.get(field), records);
+  }
+
+  protected abstract Metrics writeAndGetMetrics(Schema schema, Record... records) throws IOException;
+
+  protected boolean supportTimeWithoutZoneField() {
+    return true;
+  }
+
+  protected boolean supportTimeField() {
+    return true;
+  }
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  @Test
+  public void testIntFieldBound() throws IOException {
+    Metrics metrics = writeAndGetMetrics(INT_FIELD,
+        createRecord(INT_FIELD, 3),
+        createRecord(INT_FIELD, 8),
+        createRecord(INT_FIELD, -1),
+        createRecord(INT_FIELD, 0));
+    assertBounds(INT_FIELD, -1, 8, metrics);
+  }
+
+  @Test
+  public void testStringFieldBound() throws IOException {
+    Metrics metrics = writeAndGetMetrics(STRING_FIELD,
+        createRecord(STRING_FIELD, "aaa"),
+        createRecord(STRING_FIELD, "aab"),
+        createRecord(STRING_FIELD, "az"),
+        createRecord(STRING_FIELD, "a"));
+    assertBounds(STRING_FIELD, CharBuffer.wrap("a"), CharBuffer.wrap("az"), metrics);
+  }
+
+  @Test
+  public void testFloatFieldBound() throws IOException {
+    Metrics metrics = writeAndGetMetrics(FLOAT_FIELD,
+        createRecord(FLOAT_FIELD, 3.2F),
+        createRecord(FLOAT_FIELD, 8.9F),
+        createRecord(FLOAT_FIELD, -1.1F),
+        createRecord(FLOAT_FIELD, Float.NaN),
+        createRecord(FLOAT_FIELD, 0F));
+    assertBounds(FLOAT_FIELD, -1.1F, 8.9F, metrics);
+  }
+
+  @Test
+  public void testDoubleFieldBound() throws IOException {
+    Metrics metrics = writeAndGetMetrics(DOUBLE_FIELD,
+        createRecord(DOUBLE_FIELD, 3.2D),
+        createRecord(DOUBLE_FIELD, 8.9D),
+        createRecord(DOUBLE_FIELD, -1.1D),
+        createRecord(DOUBLE_FIELD, Double.NaN),
+        createRecord(DOUBLE_FIELD, 0D));
+    assertBounds(DOUBLE_FIELD, -1.1D, 8.9D, metrics);
+  }
+
+  @Test
+  public void testDecimalFieldBound() throws IOException {
+    Metrics metrics = writeAndGetMetrics(DECIMAL_FIELD,
+        createRecord(DECIMAL_FIELD, new BigDecimal("3.599")),
+        createRecord(DECIMAL_FIELD, new BigDecimal("3.600")),
+        createRecord(DECIMAL_FIELD, new BigDecimal("-25.613")),
+        createRecord(DECIMAL_FIELD, new BigDecimal("-25.614")));
+    assertBounds(DECIMAL_FIELD, new BigDecimal("-25.614"), new BigDecimal("3.600"), metrics);
+  }
+
+  @Test
+  public void testFixedFieldBound() throws IOException {
+    Metrics metrics = writeAndGetMetrics(FIXED_FIELD,
+        createRecord(FIXED_FIELD, bytes("abcd")),
+        createRecord(FIXED_FIELD, bytes("abcz")),
+        createRecord(FIXED_FIELD, bytes("abce")),
+        createRecord(FIXED_FIELD, bytes("aacd")));
+    assertBounds(FIXED_FIELD, byteBuffer("aacd"), byteBuffer("abcz"), metrics);
+  }
+
+  @Test
+  public void testBinaryFieldBound() throws IOException {
+    Metrics metrics = writeAndGetMetrics(BINARY_FIELD,
+        createRecord(BINARY_FIELD, ByteBuffer.wrap(new byte[] { 0x0A, 0x01})),
+        createRecord(BINARY_FIELD, ByteBuffer.wrap(new byte[] { 0x01, 0x0A, 0x0B })),
+        createRecord(BINARY_FIELD, ByteBuffer.wrap(new byte[] { 0x10 })),
+        createRecord(BINARY_FIELD, ByteBuffer.wrap(new byte[] { 0x10, 0x01 })));
+    assertBounds(BINARY_FIELD,
+        ByteBuffer.wrap(new byte[] { 0x01, 0x0A, 0x0B }),
+        ByteBuffer.wrap(new byte[] { 0x10, 0x01 }),
+        metrics);
+  }
+
+  @Test
+  public void testLongFieldBound() throws IOException {
+    Metrics metrics = writeAndGetMetrics(LONG_FIELD,
+        createRecord(LONG_FIELD, 52L),
+        createRecord(LONG_FIELD, 8L),
+        createRecord(LONG_FIELD, -1L),
+        createRecord(LONG_FIELD, 0L));
+    assertBounds(LONG_FIELD, -1L, 52L, metrics);
+  }
+
+  @Test
+  public void testBooleanFieldBound() throws IOException {
+    Metrics metrics = writeAndGetMetrics(BOOLEAN_FIELD,
+        createRecord(BOOLEAN_FIELD, false),
+        createRecord(BOOLEAN_FIELD, false),
+        createRecord(BOOLEAN_FIELD, false),
+        createRecord(BOOLEAN_FIELD, true));
+    assertBounds(BOOLEAN_FIELD, false, true, metrics);
+  }
+
+  @Test
+  public void testDateFieldBound() throws IOException {
+    Metrics metrics = writeAndGetMetrics(DATE_FIELD,
+        createRecord(DATE_FIELD, DateTimeUtil.dateFromDays(-1)),
+        createRecord(DATE_FIELD, DateTimeUtil.dateFromDays(32)),
+        createRecord(DATE_FIELD, DateTimeUtil.dateFromDays(0)),
+        createRecord(DATE_FIELD, DateTimeUtil.dateFromDays(1276)));
+    assertBounds(DATE_FIELD, -1, 1276, metrics);
+  }
+
+  @Test
+  public void testDateTimeBound() throws IOException {
+    Assume.assumeTrue("Skip test for engine that do not support time field", supportTimeField());
+
+    Metrics metrics = writeAndGetMetrics(TIME_FIELD,
+        createRecord(TIME_FIELD, DateTimeUtil.timeFromMicros(3000L)),
+        createRecord(TIME_FIELD, DateTimeUtil.timeFromMicros(80000000000L)),
+        createRecord(TIME_FIELD, DateTimeUtil.timeFromMicros(0L)),
+        createRecord(TIME_FIELD, DateTimeUtil.timeFromMicros(27000L)));
+    assertBounds(TIME_FIELD, 0L, 80000000000L, metrics);
+  }
+
+  @Test
+  public void testDateTimestampBound() throws IOException {
+    Assume.assumeTrue("Skip test for engine that do not support timestamp without time zone field",
+        supportTimeWithoutZoneField());
+    Metrics metrics = writeAndGetMetrics(TIMESTAMP_FIELD,
+        createRecord(TIMESTAMP_FIELD, DateTimeUtil.timestampFromMicros(3000L)),
+        createRecord(TIMESTAMP_FIELD, DateTimeUtil.timestampFromMicros(80000000000L)),
+        createRecord(TIMESTAMP_FIELD, DateTimeUtil.timestampFromMicros(-1L)),
+        createRecord(TIMESTAMP_FIELD, DateTimeUtil.timestampFromMicros(3000L)));
+    assertBounds(TIMESTAMP_FIELD, -1L, 80000000000L, metrics);
+  }
+
+  @Test
+  public void testDateTimestampWithZoneBound() throws IOException {
+    Metrics metrics = writeAndGetMetrics(TIMESTAMPZ_FIELD,
+        createRecord(TIMESTAMPZ_FIELD, DateTimeUtil.timestamptzFromMicros(3000L)),
+        createRecord(TIMESTAMPZ_FIELD, DateTimeUtil.timestamptzFromMicros(80000000000L)),
+        createRecord(TIMESTAMPZ_FIELD, DateTimeUtil.timestamptzFromMicros(-1L)),
+        createRecord(TIMESTAMPZ_FIELD, DateTimeUtil.timestamptzFromMicros(3000L)));
+    assertBounds(TIMESTAMPZ_FIELD, -1L, 80000000000L, metrics);
+  }
+
+  @Test
+  public void testArrayBound() throws IOException {
+    Types.NestedField listType = optional(1, "list",
+        Types.ListType.ofRequired(2, Types.IntegerType.get()));
+    Schema schema = new Schema(listType);
+    Metrics metrics = writeAndGetMetrics(schema,
+        createRecord(schema, "list", ImmutableList.of(3, 2, 1)),
+        createRecord(schema, "list", ImmutableList.of(6, 4, 5)),
+        createRecord(schema, "list", ImmutableList.of(8, 9, 7)));
+
+    assertNullBounds(1, metrics);
+    assertBounds(2, Types.IntegerType.get(), 1, 9, metrics);
+  }
+
+  @Test
+  public void testMapBound() throws IOException {
+    Types.NestedField mapField = optional(1, "map",
+        Types.MapType.ofOptional(2, 3, Types.StringType.get(),
+            Types.ListType.ofRequired(4, Types.IntegerType.get())));
+    Schema schema = new Schema(mapField);
+    Metrics metrics = writeAndGetMetrics(schema,
+        createRecord(schema, "map", ImmutableMap.of("az", ImmutableList.of(3, 2, 1))),
+        createRecord(schema, "map", ImmutableMap.of("aaaaa", ImmutableList.of(6, 4, 5))),
+        createRecord(schema, "map", ImmutableMap.of("ab", ImmutableList.of(8, 9, 7))));
+
+    assertNullBounds(1, metrics);
+    assertBounds(2, Types.StringType.get(), CharBuffer.wrap("aaaaa"), CharBuffer.wrap("az"), metrics);
+    assertNullBounds(3, metrics);
+    assertBounds(4, Types.IntegerType.get(), 1, 9, metrics);
+  }
+
+  @Test
+  public void testStructBound() throws IOException {
+    Types.StructType leafField = Types.StructType.of(
+        optional(2, "string", Types.StringType.get()),
+        optional(3, "list", Types.ListType.ofRequired(4, Types.IntegerType.get())));
+    Types.NestedField structField = optional(1, "struct", leafField);
+
+    Schema schema = new Schema(structField);
+
+    Record leafStruct1 = GenericRecord.create(leafField);
+    leafStruct1.setField("string", "az");
+    leafStruct1.setField("list", ImmutableList.of(3, 2, 1));
+
+    Record leafStruct2 = GenericRecord.create(leafField);
+    leafStruct2.setField("string", "aaaaa");
+    leafStruct2.setField("list", ImmutableList.of(6, 5, 4));
+
+    Record leafStruct3 = GenericRecord.create(leafField);
+    leafStruct3.setField("string", "ab");
+    leafStruct3.setField("list", ImmutableList.of(8, 9, 7));
+
+    Metrics metrics = writeAndGetMetrics(schema,
+        createRecord(schema, "struct", leafStruct1),
+        createRecord(schema, "struct", leafStruct2),
+        createRecord(schema, "struct", leafStruct3));
+
+    assertNullBounds(1, metrics);
+    assertBounds(2, Types.StringType.get(), CharBuffer.wrap("aaaaa"), CharBuffer.wrap("az"), metrics);
+    assertNullBounds(3, metrics);
+    assertBounds(4, Types.IntegerType.get(), 1, 9, metrics);
+  }
+
+  private ByteBuffer byteBuffer(String str) {
+    return ByteBuffer.wrap(bytes(str));
+  }
+
+  private byte[] bytes(String str) {
+    return str.getBytes(StandardCharsets.UTF_8);
+  }
+
+  private Record createRecord(Types.NestedField field, Object value) {
+    return createRecord(SINGLE_FIELD_SCHEMA_MAP.get(field), field.name(), value);
+  }
+
+  private Record createRecord(Schema schema, String name, Object value) {
+    Record record = GenericRecord.create(schema);
+    record.setField(name, value);
+    return record;
+
+  }
+
+  private <T> void assertBounds(Types.NestedField field, T lowerBound, T upperBound, Metrics metrics) {
+    assertBounds(field.fieldId(), field.type(), lowerBound, upperBound, metrics);
+  }
+
+  private <T> void assertBounds(int fieldId, Type type, T lowerBound, T upperBound, Metrics metrics) {
+    Map<Integer, ByteBuffer> lowerBounds = metrics.lowerBounds();
+    Map<Integer, ByteBuffer> upperBounds = metrics.upperBounds();
+
+    Assert.assertEquals(
+        lowerBound,
+        lowerBounds.containsKey(fieldId) ? Conversions.fromByteBuffer(type, lowerBounds.get(fieldId)) : null);
+    Assert.assertEquals(
+        upperBound,
+        upperBounds.containsKey(fieldId) ? Conversions.fromByteBuffer(type, upperBounds.get(fieldId)) : null);
+  }
+
+  private void assertNullBounds(int fieldId, Metrics metrics) {
+    Assert.assertNull(metrics.lowerBounds().get(fieldId));
+    Assert.assertNull(metrics.upperBounds().get(fieldId));
+  }
+}

--- a/data/src/test/java/org/apache/iceberg/avro/TestGenericAvroAppenderMetricsBounds.java
+++ b/data/src/test/java/org/apache/iceberg/avro/TestGenericAvroAppenderMetricsBounds.java
@@ -20,12 +20,24 @@
 package org.apache.iceberg.avro;
 
 import java.io.IOException;
-import java.util.stream.Stream;
-import org.apache.avro.io.Encoder;
-import org.apache.iceberg.FieldMetrics;
+import java.util.Arrays;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericAppenderFactory;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.io.FileAppender;
 
-public interface ValueWriter<D> {
-  void write(D datum, Encoder encoder) throws IOException;
+public class TestGenericAvroAppenderMetricsBounds extends TestAvroMetricsBounds {
 
-  Stream<FieldMetrics> metrics();
+  @Override
+  protected Metrics writeAndGetMetrics(Schema schema, Record... records) throws IOException {
+    FileAppender<Record> appender = new GenericAppenderFactory(schema).newAppender(
+        org.apache.iceberg.Files.localOutput(temp.newFile()), FileFormat.AVRO);
+    try (FileAppender<Record> fileAppender = appender) {
+      Arrays.stream(records).forEach(fileAppender::add);
+    }
+    return appender.metrics();
+  }
+
 }

--- a/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkAvroMetricsBounds.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkAvroMetricsBounds.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source;
+
+import java.io.IOException;
+import java.util.Arrays;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.avro.TestAvroMetricsBounds;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.RowDataConverter;
+import org.apache.iceberg.flink.sink.FlinkAppenderFactory;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+
+public class TestFlinkAvroMetricsBounds extends TestAvroMetricsBounds {
+
+  @Override
+  protected Metrics writeAndGetMetrics(Schema schema, Record... records) throws IOException {
+    RowType flinkSchema = FlinkSchemaUtil.convert(schema);
+
+    FileAppender<RowData> appender =
+        new FlinkAppenderFactory(schema, flinkSchema, ImmutableMap.of(), PartitionSpec.unpartitioned())
+            .newAppender(org.apache.iceberg.Files.localOutput(temp.newFile()), FileFormat.AVRO);
+    try (FileAppender<RowData> fileAppender = appender) {
+      Arrays.stream(records).map(r -> RowDataConverter.convert(schema, r)).forEach(fileAppender::add);
+    }
+
+    return appender.metrics();
+  }
+}

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroWriter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroWriter.java
@@ -23,11 +23,14 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.apache.avro.LogicalType;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
-import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Encoder;
+import org.apache.iceberg.FieldMetrics;
+import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.avro.MetricsAwareDatumWriter;
 import org.apache.iceberg.avro.ValueWriter;
 import org.apache.iceberg.avro.ValueWriters;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -37,7 +40,7 @@ import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.StructType;
 
-public class SparkAvroWriter implements DatumWriter<InternalRow> {
+public class SparkAvroWriter implements MetricsAwareDatumWriter<InternalRow> {
   private final StructType dsSchema;
   private ValueWriter<InternalRow> writer = null;
 
@@ -57,6 +60,11 @@ public class SparkAvroWriter implements DatumWriter<InternalRow> {
     writer.write(datum, out);
   }
 
+  @Override
+  public Stream<FieldMetrics> metrics() {
+    return writer.metrics();
+  }
+
   private static class WriteBuilder extends AvroWithSparkSchemaVisitor<ValueWriter<?>> {
     @Override
     public ValueWriter<?> record(DataType struct, Schema record, List<String> names, List<ValueWriter<?>> fields) {
@@ -71,9 +79,9 @@ public class SparkAvroWriter implements DatumWriter<InternalRow> {
       Preconditions.checkArgument(options.size() == 2,
           "Cannot create writer for non-option union: %s", union);
       if (union.getTypes().get(0).getType() == Schema.Type.NULL) {
-        return ValueWriters.option(0, options.get(1));
+        return ValueWriters.option(0, options.get(1), union.getTypes().get(1).getType());
       } else {
-        return ValueWriters.option(1, options.get(0));
+        return ValueWriters.option(1, options.get(0), union.getTypes().get(0).getType());
       }
     }
 
@@ -84,7 +92,9 @@ public class SparkAvroWriter implements DatumWriter<InternalRow> {
 
     @Override
     public ValueWriter<?> map(DataType sMap, Schema map, ValueWriter<?> valueReader) {
-      return SparkValueWriters.map(SparkValueWriters.strings(), mapKeyType(sMap), valueReader, mapValueType(sMap));
+      return SparkValueWriters.map(
+          SparkValueWriters.strings(AvroSchemaUtil.getKeyId(map)), mapKeyType(sMap),
+          valueReader, mapValueType(sMap));
     }
 
     @Override
@@ -94,23 +104,25 @@ public class SparkAvroWriter implements DatumWriter<InternalRow> {
 
     @Override
     public ValueWriter<?> primitive(DataType type, Schema primitive) {
+      int fieldId = AvroSchemaUtil.fieldId(primitive, parentSchema(), this::lastFieldName);
+
       LogicalType logicalType = primitive.getLogicalType();
       if (logicalType != null) {
         switch (logicalType.getName()) {
           case "date":
             // Spark uses the same representation
-            return ValueWriters.ints();
+            return ValueWriters.ints(fieldId);
 
           case "timestamp-micros":
             // Spark uses the same representation
-            return ValueWriters.longs();
+            return ValueWriters.longs(fieldId);
 
           case "decimal":
             LogicalTypes.Decimal decimal = (LogicalTypes.Decimal) logicalType;
-            return SparkValueWriters.decimal(decimal.getPrecision(), decimal.getScale());
+            return SparkValueWriters.decimal(fieldId, decimal.getPrecision(), decimal.getScale());
 
           case "uuid":
-            return ValueWriters.uuids();
+            return ValueWriters.uuids(fieldId);
 
           default:
             throw new IllegalArgumentException("Unsupported logical type: " + logicalType);
@@ -121,26 +133,26 @@ public class SparkAvroWriter implements DatumWriter<InternalRow> {
         case NULL:
           return ValueWriters.nulls();
         case BOOLEAN:
-          return ValueWriters.booleans();
+          return ValueWriters.booleans(fieldId);
         case INT:
           if (type instanceof ByteType) {
-            return ValueWriters.tinyints();
+            return ValueWriters.tinyints(fieldId);
           } else if (type instanceof ShortType) {
-            return ValueWriters.shorts();
+            return ValueWriters.shorts(fieldId);
           }
-          return ValueWriters.ints();
+          return ValueWriters.ints(fieldId);
         case LONG:
-          return ValueWriters.longs();
+          return ValueWriters.longs(fieldId);
         case FLOAT:
-          return ValueWriters.floats();
+          return ValueWriters.floats(fieldId);
         case DOUBLE:
-          return ValueWriters.doubles();
+          return ValueWriters.doubles(fieldId);
         case STRING:
-          return SparkValueWriters.strings();
+          return SparkValueWriters.strings(fieldId);
         case FIXED:
-          return ValueWriters.fixed(primitive.getFixedSize());
+          return ValueWriters.fixed(fieldId, primitive.getFixedSize());
         case BYTES:
-          return ValueWriters.bytes();
+          return ValueWriters.bytes(fieldId);
         default:
           throw new IllegalArgumentException("Unsupported type: " + primitive);
       }

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkAvroMetricsBounds.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkAvroMetricsBounds.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.avro.TestAvroMetricsBounds;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.spark.sql.catalyst.InternalRow;
+
+public class TestSparkAvroMetricsBounds extends TestAvroMetricsBounds  {
+
+  @Override
+  protected boolean supportTimeWithoutZoneField() {
+    return false;
+  }
+
+  @Override
+  protected boolean supportTimeField() {
+    return false;
+  }
+
+  @Override
+  protected Metrics writeAndGetMetrics(Schema schema, Record... records) throws IOException {
+    FileAppender<InternalRow> appender =
+        new SparkAppenderFactory(new HashMap<>(), schema, SparkSchemaUtil.convert(schema)).newAppender(
+            org.apache.iceberg.Files.localOutput(temp.newFile()), FileFormat.AVRO);
+    try (FileAppender<InternalRow> fileAppender = appender) {
+      Arrays.stream(records).map(r -> new StructInternalRow(schema.asStruct()).setStruct(r)).forEach(fileAppender::add);
+    }
+
+    return appender.metrics();
+  }
+}


### PR DESCRIPTION
This change adds metrics support for Avro, including NaN counter support. Wanted to send out the entire change to gather high level feedback. 

I'm starting to break down this to smaller PRs for readability, and will post follow up PRs once the early ones get some feedback. Here's the current list:
 - #1946 : introduced the `MetricsAwareDatumWriter` interface and some refactoring/addition, no change to the current behavior. 
 - #1963: track metrics in Avro value writers