### PR TITLE
Flink: Support inferring parallelism for batch read.

### DIFF
--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkTableFactory.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkTableFactory.java
@@ -42,7 +42,8 @@ public class FlinkTableFactory implements TableSinkFactory<RowData>, TableSource
     ObjectPath objectPath = context.getObjectIdentifier().toObjectPath();
     TableLoader tableLoader = createTableLoader(objectPath);
     TableSchema tableSchema = TableSchemaUtils.getPhysicalSchema(context.getTable().getSchema());
-    return new IcebergTableSource(tableLoader, tableSchema, context.getTable().getOptions());
+    return new IcebergTableSource(tableLoader, tableSchema, context.getTable().getOptions(),
+        context.getConfiguration());
   }
 
   @Override

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkTableOptions.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkTableOptions.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink;
+
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+public class FlinkTableOptions {
+
+  private FlinkTableOptions() {
+  }
+
+  public static final ConfigOption<Boolean> TABLE_EXEC_ICEBERG_INFER_SOURCE_PARALLELISM =
+      ConfigOptions.key("table.exec.iceberg.infer-source-parallelism").defaultValue(true)
+          .withDescription("If is false, parallelism of source are set by config.\n" +
+              "If is true, source parallelism is inferred according to splits number.\n");
+
+  public static final ConfigOption<Integer> TABLE_EXEC_ICEBERG_INFER_SOURCE_PARALLELISM_MAX =
+      ConfigOptions.key("table.exec.iceberg.infer-source-parallelism.max").defaultValue(100)
+          .withDescription("Sets max infer parallelism for source operator.");
+}

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkTableOptions.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkTableOptions.java
@@ -29,11 +29,15 @@ public class FlinkTableOptions {
   }
 
   public static final ConfigOption<Boolean> TABLE_EXEC_ICEBERG_INFER_SOURCE_PARALLELISM =
-      ConfigOptions.key("table.exec.iceberg.infer-source-parallelism").booleanType().defaultValue(true)
+      ConfigOptions.key("table.exec.iceberg.infer-source-parallelism")
+          .booleanType()
+          .defaultValue(true)
           .withDescription("If is false, parallelism of source are set by config.\n" +
               "If is true, source parallelism is inferred according to splits number.\n");
 
   public static final ConfigOption<Integer> TABLE_EXEC_ICEBERG_INFER_SOURCE_PARALLELISM_MAX =
-      ConfigOptions.key("table.exec.iceberg.infer-source-parallelism.max").intType().defaultValue(100)
+      ConfigOptions.key("table.exec.iceberg.infer-source-parallelism.max")
+          .intType()
+          .defaultValue(100)
           .withDescription("Sets max infer parallelism for source operator.");
 }

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkTableOptions.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkTableOptions.java
@@ -29,11 +29,11 @@ public class FlinkTableOptions {
   }
 
   public static final ConfigOption<Boolean> TABLE_EXEC_ICEBERG_INFER_SOURCE_PARALLELISM =
-      ConfigOptions.key("table.exec.iceberg.infer-source-parallelism").defaultValue(true)
+      ConfigOptions.key("table.exec.iceberg.infer-source-parallelism").booleanType().defaultValue(true)
           .withDescription("If is false, parallelism of source are set by config.\n" +
               "If is true, source parallelism is inferred according to splits number.\n");
 
   public static final ConfigOption<Integer> TABLE_EXEC_ICEBERG_INFER_SOURCE_PARALLELISM_MAX =
-      ConfigOptions.key("table.exec.iceberg.infer-source-parallelism.max").defaultValue(100)
+      ConfigOptions.key("table.exec.iceberg.infer-source-parallelism.max").intType().defaultValue(100)
           .withDescription("Sets max infer parallelism for source operator.");
 }

--- a/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSource.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSource.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.flink;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.TableSchema;
@@ -51,18 +52,20 @@ public class IcebergTableSource
   private final TableLoader loader;
   private final TableSchema schema;
   private final Map<String, String> properties;
+  private final ReadableConfig readableConfig;
   private final int[] projectedFields;
   private final boolean isLimitPushDown;
   private final long limit;
   private final List<org.apache.iceberg.expressions.Expression> filters;
 
   public IcebergTableSource(TableLoader loader, TableSchema schema, Map<String, String> properties) {
-    this(loader, schema, properties, null, false, -1, ImmutableList.of());
+    this(loader, schema, properties, null, false, -1, ImmutableList.of(), null);
   }
 
   private IcebergTableSource(TableLoader loader, TableSchema schema, Map<String, String> properties,
-                             int[] projectedFields, boolean isLimitPushDown, long limit,
-                             List<org.apache.iceberg.expressions.Expression> filters) {
+                             int[] projectedFields, boolean isLimitPushDown,
+                             long limit, List<org.apache.iceberg.expressions.Expression> filters,
+                             ReadableConfig readableConfig) {
     this.loader = loader;
     this.schema = schema;
     this.properties = properties;
@@ -70,6 +73,7 @@ public class IcebergTableSource
     this.isLimitPushDown = isLimitPushDown;
     this.limit = limit;
     this.filters = filters;
+    this.readableConfig = readableConfig;
   }
 
   @Override
@@ -79,13 +83,13 @@ public class IcebergTableSource
 
   @Override
   public TableSource<RowData> projectFields(int[] fields) {
-    return new IcebergTableSource(loader, schema, properties, fields, isLimitPushDown, limit, filters);
+    return new IcebergTableSource(loader, schema, properties, fields, isLimitPushDown, limit, filters, readableConfig);
   }
 
   @Override
   public DataStream<RowData> getDataStream(StreamExecutionEnvironment execEnv) {
     return FlinkSource.forRowData().env(execEnv).tableLoader(loader).project(getProjectedSchema()).limit(limit)
-        .filters(filters).properties(properties).build();
+        .filters(filters).flinkConf(readableConfig).properties(properties).build();
   }
 
   @Override
@@ -146,7 +150,8 @@ public class IcebergTableSource
       FlinkFilters.convert(predicate).ifPresent(expressions::add);
     }
 
-    return new IcebergTableSource(loader, schema, properties, projectedFields, isLimitPushDown, limit, expressions);
+    return new IcebergTableSource(loader, schema, properties, projectedFields, isLimitPushDown, limit, expressions,
+        readableConfig);
   }
 
   @Override

--- a/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSource.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSource.java
@@ -58,8 +58,9 @@ public class IcebergTableSource
   private final long limit;
   private final List<org.apache.iceberg.expressions.Expression> filters;
 
-  public IcebergTableSource(TableLoader loader, TableSchema schema, Map<String, String> properties) {
-    this(loader, schema, properties, null, false, -1, ImmutableList.of(), null);
+  public IcebergTableSource(TableLoader loader, TableSchema schema, Map<String, String> properties,
+                            ReadableConfig readableConfig) {
+    this(loader, schema, properties, null, false, -1, ImmutableList.of(), readableConfig);
   }
 
   private IcebergTableSource(TableLoader loader, TableSchema schema, Map<String, String> properties,
@@ -140,7 +141,7 @@ public class IcebergTableSource
 
   @Override
   public TableSource<RowData> applyLimit(long newLimit) {
-    return new IcebergTableSource(loader, schema, properties, projectedFields, true, newLimit, filters);
+    return new IcebergTableSource(loader, schema, properties, projectedFields, true, newLimit, filters, readableConfig);
   }
 
   @Override

--- a/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSource.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSource.java
@@ -89,8 +89,15 @@ public class IcebergTableSource
 
   @Override
   public DataStream<RowData> getDataStream(StreamExecutionEnvironment execEnv) {
-    return FlinkSource.forRowData().env(execEnv).tableLoader(loader).project(getProjectedSchema()).limit(limit)
-        .filters(filters).flinkConf(readableConfig).properties(properties).build();
+    return FlinkSource.forRowData()
+        .env(execEnv)
+        .tableLoader(loader)
+        .project(getProjectedSchema())
+        .limit(limit)
+        .filters(filters)
+        .flinkConf(readableConfig)
+        .properties(properties)
+        .build();
   }
 
   @Override

--- a/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSource.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSource.java
@@ -52,11 +52,11 @@ public class IcebergTableSource
   private final TableLoader loader;
   private final TableSchema schema;
   private final Map<String, String> properties;
-  private final ReadableConfig readableConfig;
   private final int[] projectedFields;
   private final boolean isLimitPushDown;
   private final long limit;
   private final List<org.apache.iceberg.expressions.Expression> filters;
+  private final ReadableConfig readableConfig;
 
   public IcebergTableSource(TableLoader loader, TableSchema schema, Map<String, String> properties,
                             ReadableConfig readableConfig) {
@@ -92,11 +92,11 @@ public class IcebergTableSource
     return FlinkSource.forRowData()
         .env(execEnv)
         .tableLoader(loader)
+        .properties(properties)
         .project(getProjectedSchema())
         .limit(limit)
         .filters(filters)
         .flinkConf(readableConfig)
-        .properties(properties)
         .build();
   }
 

--- a/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSource.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSource.java
@@ -24,6 +24,7 @@ import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -73,7 +74,7 @@ public class FlinkSource {
     private Table table;
     private TableLoader tableLoader;
     private TableSchema projectedSchema;
-    private ReadableConfig readableConfig;
+    private ReadableConfig readableConfig = new Configuration();
     private final ScanContext.Builder contextBuilder = ScanContext.builder();
 
     public Builder tableLoader(TableLoader newLoader) {
@@ -222,8 +223,8 @@ public class FlinkSource {
     int inferParallelism(FlinkInputFormat format, ScanContext context) {
       int parallelism = readableConfig.get(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM);
       if (readableConfig.get(FlinkTableOptions.TABLE_EXEC_ICEBERG_INFER_SOURCE_PARALLELISM)) {
-        int maxInterParallelism = readableConfig.get(FlinkTableOptions.TABLE_EXEC_ICEBERG_INFER_SOURCE_PARALLELISM_MAX);
-        Preconditions.checkState(maxInterParallelism >= 1,
+        int maxInferParallelism = readableConfig.get(FlinkTableOptions.TABLE_EXEC_ICEBERG_INFER_SOURCE_PARALLELISM_MAX);
+        Preconditions.checkState(maxInferParallelism >= 1,
             FlinkTableOptions.TABLE_EXEC_ICEBERG_INFER_SOURCE_PARALLELISM_MAX.key() + " cannot be less than 1");
         int splitNum;
         try {
@@ -233,7 +234,7 @@ public class FlinkSource {
           throw new UncheckedIOException("Failed to create iceberg input splits for table: " + table, e);
         }
 
-        parallelism = Math.min(splitNum, maxInterParallelism);
+        parallelism = Math.min(splitNum, maxInferParallelism);
       }
 
       if (context.limit() > 0) {

--- a/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSource.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSource.java
@@ -47,11 +47,11 @@ public class FlinkSource {
   }
 
   /**
-   * Initialize a {@link Builder} to read the data from iceberg table. Equivalent to {@link TableScan}. See more options
-   * in {@link ScanContext}.
+   * Initialize a {@link Builder} to read the data from iceberg table. Equivalent to {@link TableScan}.
+   * See more options in {@link ScanContext}.
    * <p>
-   * The Source can be read static data in bounded mode. It can also continuously check the arrival of new data and read
-   * records incrementally.
+   * The Source can be read static data in bounded mode. It can also continuously check the arrival of new data and
+   * read records incrementally.
    * <ul>
    *   <li>Without startSnapshotId: Bounded</li>
    *   <li>With startSnapshotId and with endSnapshotId: Bounded</li>

--- a/flink/src/test/java/org/apache/iceberg/flink/FlinkTestBase.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/FlinkTestBase.java
@@ -62,10 +62,15 @@ public abstract class FlinkTestBase extends AbstractTestBase {
     if (tEnv == null) {
       synchronized (this) {
         if (tEnv == null) {
-          this.tEnv = TableEnvironment.create(EnvironmentSettings
+          EnvironmentSettings settings = EnvironmentSettings
               .newInstance()
               .useBlinkPlanner()
-              .inBatchMode().build());
+              .inBatchMode()
+              .build();
+
+          TableEnvironment env = TableEnvironment.create(settings);
+          env.getConfig().getConfiguration().set(FlinkTableOptions.TABLE_EXEC_ICEBERG_INFER_SOURCE_PARALLELISM, false);
+          tEnv = env;
         }
       }
     }

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSource.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSource.java
@@ -729,7 +729,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
     org.apache.iceberg.Table table = validationCatalog.loadTable(TableIdentifier.of(icebergNamespace, TABLE_NAME));
     Stream<FileScanTask> stream = StreamSupport.stream(table.newScan().planFiles().spliterator(), false);
     Optional<FileScanTask> fileScanTaskOptional = stream.max(Comparator.comparing(FileScanTask::length));
-    Assert.assertTrue(fileScanTaskOptional.isPresent());
+    Assert.assertTrue("Conversion should succeed", fileScanTaskOptional.isPresent());
     long maxFileLen = fileScanTaskOptional.get().length();
     sql("ALTER TABLE %s SET ('read.split.open-file-cost'='1', 'read.split.target-size'='%s')", TABLE_NAME, maxFileLen);
 
@@ -752,7 +752,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
     ExecNode execNode =
         planner.translateToExecNodePlan(JavaScalaConversionUtil.toScala(Collections.singletonList(relNode))).get(0);
     Transformation transformation = execNode.translateToPlan(planner);
-    Assert.assertEquals(expected, transformation.getParallelism());
+    Assert.assertEquals("Should get the expected parallelism", expected, transformation.getParallelism());
   }
 
   private RelNode toRelNode(Table table) {

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSource.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSource.java
@@ -47,6 +47,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
   private int scanEventCount = 0;
   private ScanEvent lastScanEvent = null;
 
+
   public TestFlinkTableSource() {
     // register a scan event listener to validate pushdown
     Listeners.register(event -> {
@@ -121,7 +122,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
     String sql = String.format("SELECT * FROM %s ", TABLE_NAME);
     String explain = getTableEnv().explainSql(sql);
     Assert.assertFalse("Explain should not contain FilterPushDown", explain.contains(expectedFilterPushDownExplain));
-    Assert.assertEquals("Should not push down a filter", Expressions.alwaysTrue(), lastScanEvent.filter());
+    Assert.assertNull("Should not push down a filter", lastScanEvent);
   }
 
   @Test
@@ -136,10 +137,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
     Assert.assertEquals("Should have 1 record", 1, result.size());
     Assert.assertArrayEquals("Should produce the expected record", expectRecord, result.get(0));
 
-    // Because we add infer parallelism, all data files will be scanned first.
-    // Flink will call FlinkInputFormat#createInputSplits method to scan the data files,
-    // plus the operation to get the execution plan, so there are three scan event.
-    Assert.assertEquals("Should create 3 scans", 3, scanEventCount);
+    Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
   }
 
@@ -167,7 +165,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
     Assert.assertEquals("Should have 1 record", 1, resultLeft.size());
     Assert.assertArrayEquals("Should produce the expected record", expectRecord, resultLeft.get(0));
 
-    Assert.assertEquals("Should create 3 scans", 3, scanEventCount);
+    Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
   }
 
@@ -185,7 +183,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
     expectedNE.add(new Object[] {2, "b", 20.0});
     expectedNE.add(new Object[] {3, null, 30.0});
     Assert.assertArrayEquals("Should produce the expected record", expectedNE.toArray(), resultNE.toArray());
-    Assert.assertEquals("Should create 3 scans", 3, scanEventCount);
+    Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
   }
 
@@ -213,7 +211,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
     Assert.assertEquals("Should have 1 record", 1, resultAnd.size());
     Assert.assertArrayEquals("Should produce the expected record", expectRecord, resultAnd.get(0));
 
-    Assert.assertEquals("Should create 3 scans", 3, scanEventCount);
+    Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     String expected = "(ref(name=\"id\") == 1 and ref(name=\"data\") == \"iceberg\")";
     Assert.assertEquals("Should contain the push down filter", expected, lastScanEvent.filter().toString());
   }
@@ -233,7 +231,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
     expectedOR.add(new Object[] {2, "b", 20.0});
     Assert.assertArrayEquals("Should produce the expected record", expectedOR.toArray(), resultOr.toArray());
 
-    Assert.assertEquals("Should create 3 scans", 3, scanEventCount);
+    Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
   }
 
@@ -252,7 +250,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
     expectedGT.add(new Object[] {3, null, 30.0});
     Assert.assertArrayEquals("Should produce the expected record", expectedGT.toArray(), resultGT.toArray());
 
-    Assert.assertEquals("Should create 3 scans", 3, scanEventCount);
+    Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
   }
 
@@ -282,7 +280,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
     expectedGT.add(new Object[] {2, "b", 20.0});
     Assert.assertArrayEquals("Should produce the expected record", expectedGT.toArray(), resultGT.toArray());
 
-    Assert.assertEquals("Should create 3 scans", 3, scanEventCount);
+    Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
   }
 
@@ -301,7 +299,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
     expectedGTE.add(new Object[] {3, null, 30.0});
     Assert.assertArrayEquals("Should produce the expected record", expectedGTE.toArray(), resultGTE.toArray());
 
-    Assert.assertEquals("Should create 3 scans", 3, scanEventCount);
+    Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
   }
 
@@ -331,7 +329,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
     expectedGTE.add(new Object[] {2, "b", 20.0});
     Assert.assertArrayEquals("Should produce the expected record", expectedGTE.toArray(), resultGTE.toArray());
 
-    Assert.assertEquals("Should create 3 scans", 3, scanEventCount);
+    Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
   }
 
@@ -347,7 +345,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
     Assert.assertEquals("Should have 1 record", 1, resultLT.size());
     Assert.assertArrayEquals("Should produce the expected record", expectRecord, resultLT.get(0));
 
-    Assert.assertEquals("Should create 3 scans", 3, scanEventCount);
+    Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
   }
 
@@ -374,7 +372,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
     Assert.assertEquals("Should have 1 record", 1, resultLT.size());
     Assert.assertArrayEquals("Should produce the expected record", expectRecord, resultLT.get(0));
 
-    Assert.assertEquals("Should create 3 scans", 3, scanEventCount);
+    Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
   }
 
@@ -390,7 +388,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
     Assert.assertEquals("Should have 1 record", 1, resultLTE.size());
     Assert.assertArrayEquals("Should produce the expected record", expectRecord, resultLTE.get(0));
 
-    Assert.assertEquals("Should create 3 scans", 3, scanEventCount);
+    Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
   }
 
@@ -417,7 +415,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
     Assert.assertEquals("Should have 1 record", 1, resultLTE.size());
     Assert.assertArrayEquals("Should produce the expected record", expectRecord, resultLTE.get(0));
 
-    Assert.assertEquals("Should create 3 scans", 3, scanEventCount);
+    Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
   }
 
@@ -434,7 +432,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
     expectedIN.add(new Object[] {1, "iceberg", 10.0});
     expectedIN.add(new Object[] {2, "b", 20.0});
     Assert.assertArrayEquals("Should produce the expected record", expectedIN.toArray(), resultIN.toArray());
-    Assert.assertEquals("Should create 3 scans", 3, scanEventCount);
+    Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
   }
 
@@ -463,7 +461,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
     List<Object[]> resultNotIn = sql(sqlNotIn);
     Assert.assertEquals("Should have 1 record", 1, resultNotIn.size());
     Assert.assertArrayEquals("Should produce the expected record", expectRecord, resultNotIn.get(0));
-    Assert.assertEquals("Should create 3 scans", 3, scanEventCount);
+    Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     String expectedScan = "(ref(name=\"id\") != 3 and ref(name=\"id\") != 2)";
     Assert.assertEquals("Should contain the push down filter", expectedScan, lastScanEvent.filter().toString());
   }
@@ -494,7 +492,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
     expected.add(new Object[] {2, "b", 20.0});
     Assert.assertArrayEquals("Should produce the expected record", expected.toArray(), resultNotNull.toArray());
 
-    Assert.assertEquals("Should create 3 scans", 3, scanEventCount);
+    Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
   }
 
@@ -510,7 +508,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
     Assert.assertEquals("Should have 1 record", 1, resultNull.size());
     Assert.assertArrayEquals("Should produce the expected record", expectRecord, resultNull.get(0));
 
-    Assert.assertEquals("Should create 3 scans", 3, scanEventCount);
+    Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
   }
 
@@ -526,7 +524,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
     Assert.assertEquals("Should have 1 record", 1, resultNot.size());
     Assert.assertArrayEquals("Should produce the expected record", expectRecord, resultNot.get(0));
 
-    Assert.assertEquals("Should create 3 scans", 3, scanEventCount);
+    Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     expectedFilter = "(ref(name=\"id\") != 1 and ref(name=\"id\") != 2)";
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
   }
@@ -546,7 +544,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
     expectedBetween.add(new Object[] {2, "b", 20.0});
     Assert.assertArrayEquals("Should produce the expected record", expectedBetween.toArray(), resultBetween.toArray());
 
-    Assert.assertEquals("Should create 3 scans", 3, scanEventCount);
+    Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     String expected = "(ref(name=\"id\") >= 1 and ref(name=\"id\") <= 2)";
     Assert.assertEquals("Should contain the push down filter", expected, lastScanEvent.filter().toString());
   }
@@ -563,7 +561,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
     Assert.assertEquals("Should have 1 record", 1, resultNotBetween.size());
     Assert.assertArrayEquals("Should produce the expected record", expectRecord, resultNotBetween.get(0));
 
-    Assert.assertEquals("Should create 3 scans", 3, scanEventCount);
+    Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
   }
 
@@ -579,7 +577,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
     List<Object[]> resultLike = sql(sqlLike);
     Assert.assertEquals("Should have 1 record", 1, resultLike.size());
     Assert.assertArrayEquals("The like result should produce the expected record", expectRecord, resultLike.get(0));
-    Assert.assertEquals("Should create 3 scans", 3, scanEventCount);
+    Assert.assertEquals("Should create only one scan", 1, scanEventCount);
     Assert.assertEquals("Should contain the push down filter", expectedFilter, lastScanEvent.filter().toString());
   }
 
@@ -654,7 +652,7 @@ public class TestFlinkTableSource extends FlinkTestBase {
     String explain2Literal = getTableEnv().explainSql(sql2Literal);
     Assert.assertFalse("Explain should not contain FilterPushDown",
         explain2Literal.contains(expectedFilterPushDownExplain));
-    Assert.assertEquals("Should not push down a filter", Expressions.alwaysTrue(), lastScanEvent.filter());
+    Assert.assertNull("Should not push down a filter", lastScanEvent);
   }
 
   /**

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSource.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSource.java
@@ -19,10 +19,12 @@
 
 package org.apache.iceberg.flink;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import org.apache.calcite.rel.RelNode;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.table.api.SqlParserException;
@@ -33,8 +35,6 @@ import org.apache.flink.table.api.internal.TableImpl;
 import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.iceberg.AssertHelpers;
-import org.apache.iceberg.DataFile;
-import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
@@ -47,16 +47,17 @@ import org.apache.iceberg.events.Listeners;
 import org.apache.iceberg.events.ScanEvent;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
 
 public class TestFlinkTableSource extends FlinkTestBase {
 
@@ -713,67 +714,31 @@ public class TestFlinkTableSource extends FlinkTestBase {
   }
 
   @Test
-  public void testParallelismOptimize() throws IOException {
-    Assume.assumeFalse("ORC does not support getting length when file is opening", format.equals(FileFormat.ORC));
-    String tableName = "test_parallelism_optimize";
-
-    long filesize = 20000L;
-    long maxFileLen = 0L;
-    sql("CREATE TABLE %s (id INT, data VARCHAR)" +
-        " WITH (" +
-        "'write.format.default'='%s'," +
-        "'read.split.open-file-cost'='1'" +
-        ")", tableName, format.name());
+  public void testParallelismOptimize() {
+    sql("INSERT INTO %s  VALUES (1,'hello')", TABLE_NAME);
+    sql("INSERT INTO %s  VALUES (2,'iceberg')", TABLE_NAME);
 
     TableEnvironment tenv = getTableEnv();
 
     // empty table ,parallelism at least 1
-    Table tableEmpty = tenv.sqlQuery(String.format("SELECT * FROM %s", tableName));
+    Table tableEmpty = tenv.sqlQuery(String.format("SELECT * FROM %s", TABLE_NAME));
     testParallelismSettingTranslateAndAssert(1, tableEmpty, tenv);
 
-    org.apache.iceberg.Table table = validationCatalog.loadTable(TableIdentifier.of(icebergNamespace, tableName));
-    Schema schema = table.schema();
+    // make sure to generate 2 CombinedScanTasks
+    org.apache.iceberg.Table table = validationCatalog.loadTable(TableIdentifier.of(icebergNamespace, TABLE_NAME));
+    Stream<FileScanTask> stream = StreamSupport.stream(table.newScan().planFiles().spliterator(), false);
+    Optional<FileScanTask> fileScanTaskOptional =  stream.max(Comparator.comparing(FileScanTask::length));
+    Assert.assertTrue(fileScanTaskOptional.isPresent());
+    long maxFileLen = fileScanTaskOptional.get().length();
+    sql("ALTER TABLE %s SET ('read.split.open-file-cost'='1', 'read.split.target-size'='%s')", TABLE_NAME, maxFileLen);
 
-    // Generate 2 datafile of the specified size to ensure that 2 CombinedScanTasks are obtained
-    GenericAppenderFactory genericAppenderFactory = new GenericAppenderFactory(schema);
-    for (int i = 0; i < 2; i++) {
-      File file = temp.newFile();
-      int count = 0;
-      try (FileAppender<Record> fileAppender = genericAppenderFactory.newAppender(Files.localOutput(file), format)) {
-        for (; fileAppender.length() < filesize; count++) {
-          Record record = RECORD.copy();
-          record.setField("id", count);
-          record.setField("data", "hello,iceberg");
-          fileAppender.add(record);
-        }
-      }
-
-      DataFile dataFile = DataFiles.builder(table.spec())
-          .withPath(file.getAbsolutePath())
-          .withFileSizeInBytes(file.length())
-          .withFormat(format)
-          .withRecordCount(count)
-          .build();
-
-      maxFileLen = Math.max(file.length(), maxFileLen);
-      table.newAppend().appendFile(dataFile).commit();
-    }
-
-    table.refresh();
-
-    Transaction transaction = table.newTransaction();
-    transaction.updateProperties().set(TableProperties.SPLIT_SIZE, String.valueOf(maxFileLen)).commit();
-    transaction.commitTransaction();
-
-    // 2 split ,the parallelism is  2
-    Table tableSelect = tenv.sqlQuery(String.format("SELECT * FROM %s", tableName));
+    // 2 splits ,the parallelism is  2
+    Table tableSelect = tenv.sqlQuery(String.format("SELECT * FROM %s", TABLE_NAME));
     testParallelismSettingTranslateAndAssert(2, tableSelect, tenv);
 
-    // 2 split  and limit is 1 ,the parallelism is  1
-    Table tableLimit = tenv.sqlQuery(String.format("SELECT * FROM %s LIMIT 1", tableName));
+    // 2 splits  and limit is 1 ,the parallelism is  1
+    Table tableLimit = tenv.sqlQuery(String.format("SELECT * FROM %s LIMIT 1", TABLE_NAME));
     testParallelismSettingTranslateAndAssert(1, tableLimit, tenv);
-
-    sql("DROP TABLE IF EXISTS %s.%s", flinkDatabase, tableName);
   }
 
   private void testParallelismSettingTranslateAndAssert(int expected, Table table, TableEnvironment tEnv) {

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSource.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSource.java
@@ -34,6 +34,7 @@ import org.apache.flink.table.api.internal.TableEnvironmentImpl;
 import org.apache.flink.table.api.internal.TableImpl;
 import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Files;
@@ -748,7 +749,8 @@ public class TestFlinkTableSource extends FlinkTestBase {
   private void testParallelismSettingTranslateAndAssert(int expected, Table table, TableEnvironment tEnv) {
     PlannerBase planner = (PlannerBase) ((TableEnvironmentImpl) tEnv).getPlanner();
     RelNode relNode = planner.optimize(toRelNode(table));
-    ExecNode execNode = planner.translateToExecNodePlan(toScala(Collections.singletonList(relNode))).get(0);
+    ExecNode execNode =
+        planner.translateToExecNodePlan(JavaScalaConversionUtil.toScala(Collections.singletonList(relNode))).get(0);
     Transformation transformation = execNode.translateToPlan(planner);
     Assert.assertEquals(expected, transformation.getParallelism());
   }


### PR DESCRIPTION
When using flink to query the iceberg table, the parallelism is the default parallelism of flink, but the number of datafiles on  iceberg table is different. The user do not know how much parallelism should be used, and setting a too large parallelism will cause  resource waste, setting the parallelism too small will cause the query to be slow, so we can add  parallelism infer.

The function is enabled by default. the parallelism is equal to the number of read splits. Of course, the user can manually turn off the infer function. In order to prevent too many datafiles from causing excessive parallelism, we also set a max infer parallelism.  When the infer parallelism exceeds the setting, use the max  parallelism.

  In addition, we also need to compare with the limit in the `select` query statement to get a more appropriate parallelism in the case of limit pushdown, for example we have a sql  `select * from table limit 1`, and finally we infer the parallelism is 10, but we  only one parallel  is needed , besause we only need one data .