### PR TITLE
Spark: update list array copy behavior in StructInternalRow

### DIFF
--- a/spark/src/main/java/org/apache/iceberg/spark/source/StructInternalRow.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/StructInternalRow.java
@@ -278,7 +278,7 @@ class StructInternalRow extends InternalRow {
             array[pos] = new StructInternalRow(elementType.asStructType(), tuple));
       case LIST:
         return fillArray(values, array -> (BiConsumer<Integer, Collection<?>>) (pos, list) ->
-            array[pos] = collectionToArrayData(elementType.asListType(), list));
+            array[pos] = collectionToArrayData(elementType.asListType().elementType(), list));
       case MAP:
         return fillArray(values, array -> (BiConsumer<Integer, Map<?, ?>>) (pos, map) ->
             array[pos] = mapToMapData(elementType.asMapType(), map));


### PR DESCRIPTION
I noticed this when I was working on avro metrics support #1935, that [this test case](https://github.com/apache/iceberg/pull/1935/files#diff-81688a1556370355eceb1e39ea9babd927c8ae4a2e6b1ae56743548e0ac833f5R259) will fail with cast exception (unable to cast int to collection). Before this change, I think when `elementType` is of type list, this line result in a second call to `collectionToArrayData` with `elementType` as list when it iterates through each element in the list (within `fillArray` L300), and the cast exception occurs when it tries to cast the element's type to collection for applying `setter.accept`. 

I think this would occur when there's a list in a nested structure (e.g. list within map, etc), and I think this doesn't cause problem now since this class is only used for populating metadata tables in spark, and metadata table schema doesn't have such structure. 

Currently there's no direct test coverage on this class so I didn't add test to it; this is indirectly tested by various `TestMergingMetrics` and `TestAvroMetricsBounds` test classes (latter introduced in PR mentioned above) though. 