### PR TITLE
Revert "AWS: support S3 strong consistency (#1863)"

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/S3FileIOTest.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/S3FileIOTest.java
@@ -29,11 +29,9 @@ import java.util.Base64;
 import java.util.UUID;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.aws.AwsClientUtil;
 import org.apache.iceberg.aws.AwsIntegTestUtil;
 import org.apache.iceberg.aws.AwsProperties;
-import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.junit.AfterClass;
@@ -90,39 +88,6 @@ public class S3FileIOTest {
   public void before() {
     objectKey = String.format("%s/%s", prefix, UUID.randomUUID().toString());
     objectUri = String.format("s3://%s/%s", bucketName, objectKey);
-  }
-
-  @Test
-  public void testExists_noFile() {
-    S3FileIO s3FileIO = new S3FileIO(AwsClientUtil::defaultS3Client);
-    InputFile file = s3FileIO.newInputFile(objectUri);
-    Assert.assertFalse("file should not exist", file.exists());
-    AssertHelpers.assertThrows("get length should throw exception",
-        NotFoundException.class,
-        String.format("Cannot retrieve file length because file %s does not exist", objectUri),
-        file::getLength);
-  }
-
-  @Test
-  public void testExists_wrongFileSamePrefix() {
-    s3.putObject(PutObjectRequest.builder().bucket(bucketName).key(objectKey + "suffix").build(),
-        RequestBody.fromBytes(contentBytes));
-    S3FileIO s3FileIO = new S3FileIO(AwsClientUtil::defaultS3Client);
-    InputFile file = s3FileIO.newInputFile(objectUri);
-    Assert.assertFalse("file should not exist", file.exists());
-  }
-
-  @Test
-  public void testExists_multipleFilesSamePrefix() {
-    s3.putObject(PutObjectRequest.builder().bucket(bucketName).key(objectKey).build(),
-        RequestBody.fromBytes(contentBytes));
-    s3.putObject(PutObjectRequest.builder().bucket(bucketName).key(objectKey + "suffix").build(),
-        RequestBody.fromBytes(new byte[1024 * 1024]));
-    S3FileIO s3FileIO = new S3FileIO(AwsClientUtil::defaultS3Client);
-    InputFile file = s3FileIO.newInputFile(objectUri);
-    Assert.assertTrue("file should exist", file.exists());
-    Assert.assertEquals("List results are always returned in UTF-8 binary order",
-        contentBytes.length, file.getLength());
   }
 
   @Test

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/BaseS3File.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/BaseS3File.java
@@ -22,16 +22,15 @@ package org.apache.iceberg.aws.s3;
 import org.apache.iceberg.aws.AwsProperties;
 import software.amazon.awssdk.http.HttpStatusCode;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
-import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
-import software.amazon.awssdk.services.s3.model.S3Object;
 
 abstract class BaseS3File {
   private final S3Client client;
   private final S3URI uri;
   private final AwsProperties awsProperties;
-  private S3Object metadata;
+  private HeadObjectResponse metadata;
 
   BaseS3File(S3Client client, S3URI uri) {
     this(client, uri, new AwsProperties());
@@ -76,24 +75,13 @@ abstract class BaseS3File {
     }
   }
 
-  protected S3Object getObjectMetadata() throws S3Exception {
+  protected HeadObjectResponse getObjectMetadata() throws S3Exception {
     if (metadata == null) {
-      ListObjectsV2Response response = client().listObjectsV2(ListObjectsV2Request.builder()
+      HeadObjectRequest.Builder requestBuilder = HeadObjectRequest.builder()
           .bucket(uri().bucket())
-          .prefix(uri().key())
-          .maxKeys(1)
-          .build());
-
-      if (!response.hasContents()) {
-        metadata = null;
-      } else {
-        S3Object s3Object = response.contents().get(0);
-        if (uri().key().equals(s3Object.key())) {
-          metadata = s3Object;
-        } else {
-          metadata = null;
-        }
-      }
+          .key(uri().key());
+      S3RequestUtil.configureEncryption(awsProperties, requestBuilder);
+      metadata = client().headObject(requestBuilder.build());
     }
 
     return metadata;

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputFile.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputFile.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.aws.s3;
 
 import org.apache.iceberg.aws.AwsProperties;
-import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.SeekableInputStream;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -41,11 +40,7 @@ public class S3InputFile extends BaseS3File implements InputFile {
    */
   @Override
   public long getLength() {
-    if (!exists()) {
-      throw new NotFoundException("Cannot retrieve file length because file %s does not exist", uri());
-    }
-
-    return getObjectMetadata().size();
+    return getObjectMetadata().contentLength();
   }
 
   @Override

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3RequestUtil.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3RequestUtil.java
@@ -24,6 +24,7 @@ import java.util.function.Function;
 import org.apache.iceberg.aws.AwsProperties;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Request;
@@ -55,6 +56,11 @@ public class S3RequestUtil {
   }
 
   static void configureEncryption(AwsProperties awsProperties, GetObjectRequest.Builder requestBuilder) {
+    configureEncryption(awsProperties, NULL_SSE_SETTER, NULL_STRING_SETTER,
+        requestBuilder::sseCustomerAlgorithm, requestBuilder::sseCustomerKey, requestBuilder::sseCustomerKeyMD5);
+  }
+
+  static void configureEncryption(AwsProperties awsProperties, HeadObjectRequest.Builder requestBuilder) {
     configureEncryption(awsProperties, NULL_SSE_SETTER, NULL_STRING_SETTER,
         requestBuilder::sseCustomerAlgorithm, requestBuilder::sseCustomerKey, requestBuilder::sseCustomerKeyMD5);
   }

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/S3FileIOTest.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/S3FileIOTest.java
@@ -26,20 +26,16 @@ import java.io.OutputStream;
 import java.util.Random;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.SerializationUtils;
-import org.apache.iceberg.AssertHelpers;
-import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.util.SerializableSupplier;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
-import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -68,10 +64,6 @@ public class S3FileIOTest {
 
     InputFile in = s3FileIO.newInputFile(location);
     assertFalse(in.exists());
-    AssertHelpers.assertThrows("get length should throw exception",
-        NotFoundException.class,
-        "Cannot retrieve file length because file s3://bucket/path/to/file.txt does not exist",
-        in::getLength);
 
     OutputFile out = s3FileIO.newOutputFile(location);
     try (OutputStream os = out.createOrOverwrite()) {
@@ -90,31 +82,6 @@ public class S3FileIOTest {
     s3FileIO.deleteFile(in);
 
     assertFalse(s3FileIO.newInputFile(location).exists());
-  }
-
-  @Test
-  public void testExists_wrongFileWithSamePrefix() {
-    String location = "s3://bucket/file.txt";
-    byte [] data = new byte[1024 * 1024];
-    random.nextBytes(data);
-    s3.get().putObject(PutObjectRequest.builder().bucket("bucket").key("file.txt.dup").build(),
-        RequestBody.fromBytes(data));
-    InputFile in = s3FileIO.newInputFile(location);
-    assertFalse("file should not exist", in.exists());
-  }
-
-  @Test
-  public void testExists_multipleFilesSamePrefix() {
-    String location = "s3://bucket/file.txt";
-    byte [] data = new byte[1024 * 1024];
-    random.nextBytes(data);
-    s3.get().putObject(PutObjectRequest.builder().bucket("bucket").key("file.txt.dup").build(),
-        RequestBody.fromBytes(new byte[1024 * 1024 * 2]));
-    s3.get().putObject(PutObjectRequest.builder().bucket("bucket").key("file.txt").build(),
-        RequestBody.fromBytes(data));
-    InputFile in = s3FileIO.newInputFile(location);
-    assertTrue("file should exist", in.exists());
-    assertEquals("List results are always returned in UTF-8 binary order", data.length, in.getLength());
   }
 
   @Test


### PR DESCRIPTION
This reverts commit c882ac9249229078bf89caf48de688c399e858f9.

@jackye1995 I wanted to propose reverting #1863 and going back to the HEAD operation for `exists()` and `contentLength()` FileIO operations.  There was some discussion on the dev list and apparently there's some level of confirmation that negative caching with HEAD operations is covered (and possibly strong consistency?) in the recent announcement around S3 consistency.

Iceberg isn't using this operation for consistency and the major concern I have is that the LIST operation cost appears to be 10X (or more) than the HEAD operation, which could really add up depending on usage.

I just wanted to put this up for discussion and see if there's any real advantage at this point to using LIST.  

(cc @giovannifumarola, @kbendick, @massdosage  and @rdblue since you were all on the original thread)