### PR TITLE
Avro metrics support: create MetricsAwareDatumWriter and some refactors for Avro

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Comparators.java
+++ b/api/src/main/java/org/apache/iceberg/types/Comparators.java
@@ -157,6 +157,10 @@ public class Comparators {
     return UnsignedByteBufComparator.INSTANCE;
   }
 
+  public static Comparator<byte[]> unsignedByteArrays() {
+    return UnsignedByteArrayComparator.INSTANCE;
+  }
+
   public static Comparator<ByteBuffer> signedBytes() {
     return Comparator.naturalOrder();
   }
@@ -269,6 +273,30 @@ public class Comparators {
 
       // if there are no differences, then the shorter seq is first
       return Integer.compare(buf1.remaining(), buf2.remaining());
+    }
+  }
+
+  private static class UnsignedByteArrayComparator implements Comparator<byte[]> {
+    private static final UnsignedByteArrayComparator INSTANCE = new UnsignedByteArrayComparator();
+
+    private UnsignedByteArrayComparator() {
+    }
+
+    @Override
+    public int compare(byte[] array1, byte[] array2) {
+      int len = Math.min(array1.length, array2.length);
+
+      // find the first difference and return
+      for (int i = 0; i < len; i += 1) {
+        // Conversion to int is what Byte.toUnsignedInt would do
+        int cmp = Integer.compare(((int) array1[i]) & 0xff, ((int) array2[i]) & 0xff);
+        if (cmp != 0) {
+          return cmp;
+        }
+      }
+
+      // if there are no differences, then the shorter seq is first
+      return Integer.compare(array1.length, array2.length);
     }
   }
 

--- a/api/src/main/java/org/apache/iceberg/types/Comparators.java
+++ b/api/src/main/java/org/apache/iceberg/types/Comparators.java
@@ -271,7 +271,7 @@ public class Comparators {
         }
       }
 
-      // if there are no differences, then the shorter seq is first
+      // if there are no differences, then the shorter seq is smaller
       return Integer.compare(buf1.remaining(), buf2.remaining());
     }
   }
@@ -295,7 +295,7 @@ public class Comparators {
         }
       }
 
-      // if there are no differences, then the shorter seq is first
+      // if there are no differences, then the shorter seq is smaller
       return Integer.compare(array1.length, array2.length);
     }
   }

--- a/core/src/main/java/org/apache/iceberg/avro/AvroFileAppender.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroFileAppender.java
@@ -27,22 +27,31 @@ import org.apache.avro.file.CodecFactory;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.io.DatumWriter;
 import org.apache.iceberg.Metrics;
+import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.PositionOutputStream;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 class AvroFileAppender<D> implements FileAppender<D> {
   private PositionOutputStream stream = null;
   private DataFileWriter<D> writer = null;
+  private DatumWriter<?> datumWriter = null;
+  private org.apache.iceberg.Schema icebergSchema;
+  private MetricsConfig metricsConfig;
   private long numRecords = 0L;
+  private boolean isClosed = false;
 
-  AvroFileAppender(Schema schema, OutputFile file,
+  AvroFileAppender(org.apache.iceberg.Schema icebergSchema, Schema schema, OutputFile file,
                    Function<Schema, DatumWriter<?>> createWriterFunc,
                    CodecFactory codec, Map<String, String> metadata,
-                   boolean overwrite) throws IOException {
+                   MetricsConfig metricsConfig, boolean overwrite) throws IOException {
+    this.icebergSchema = icebergSchema;
     this.stream = overwrite ? file.createOrOverwrite() : file.create();
-    this.writer = newAvroWriter(schema, stream, createWriterFunc, codec, metadata);
+    this.datumWriter = createWriterFunc.apply(schema);
+    this.writer = newAvroWriter(schema, stream, datumWriter, codec, metadata);
+    this.metricsConfig = metricsConfig;
   }
 
   @Override
@@ -57,7 +66,10 @@ class AvroFileAppender<D> implements FileAppender<D> {
 
   @Override
   public Metrics metrics() {
-    return new Metrics(numRecords, null, null, null);
+    Preconditions.checkState(isClosed,
+        "Cannot return metrics while appending to an open file.");
+
+    return AvroMetrics.fromWriter(datumWriter, icebergSchema, numRecords, metricsConfig);
   }
 
   @Override
@@ -77,15 +89,16 @@ class AvroFileAppender<D> implements FileAppender<D> {
     if (writer != null) {
       writer.close();
       this.writer = null;
+      isClosed = true;
     }
   }
 
   @SuppressWarnings("unchecked")
   private static <D> DataFileWriter<D> newAvroWriter(
-      Schema schema, PositionOutputStream stream, Function<Schema, DatumWriter<?>> createWriterFunc,
+      Schema schema, PositionOutputStream stream, DatumWriter<?> metricsAwareDatumWriter,
       CodecFactory codec, Map<String, String> metadata) throws IOException {
     DataFileWriter<D> writer = new DataFileWriter<>(
-        (DatumWriter<D>) createWriterFunc.apply(schema));
+        (DatumWriter<D>) metricsAwareDatumWriter);
 
     writer.setCodec(codec);
 

--- a/core/src/main/java/org/apache/iceberg/avro/AvroMetrics.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroMetrics.java
@@ -19,15 +19,19 @@
 
 package org.apache.iceberg.avro;
 
-import java.io.IOException;
-import java.util.stream.Stream;
-import org.apache.avro.io.Encoder;
-import org.apache.iceberg.FieldMetrics;
+import org.apache.avro.io.DatumWriter;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.MetricsConfig;
+import org.apache.iceberg.Schema;
 
-public interface ValueWriter<D> {
-  void write(D datum, Encoder encoder) throws IOException;
+public class AvroMetrics {
 
-  default Stream<FieldMetrics> metrics() {
-    return Stream.empty(); // TODO will populate in following PRs
+  private AvroMetrics() {
+  }
+
+  static Metrics fromWriter(DatumWriter<?> datumWriter, Schema schema, long numRecords,
+                            MetricsConfig inputMetricsConfig) {
+    // TODO will populate in following PRs if datum writer is a MetricsAwareDatumWriter
+    return new Metrics(numRecords, null, null, null);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/avro/GenericAvroWriter.java
+++ b/core/src/main/java/org/apache/iceberg/avro/GenericAvroWriter.java
@@ -21,14 +21,15 @@ package org.apache.iceberg.avro;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Stream;
 import org.apache.avro.LogicalType;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
-import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Encoder;
+import org.apache.iceberg.FieldMetrics;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
-class GenericAvroWriter<T> implements DatumWriter<T> {
+class GenericAvroWriter<T> implements MetricsAwareDatumWriter<T> {
   private ValueWriter<T> writer = null;
 
   GenericAvroWriter(Schema schema) {
@@ -44,6 +45,11 @@ class GenericAvroWriter<T> implements DatumWriter<T> {
   @Override
   public void write(T datum, Encoder out) throws IOException {
     writer.write(datum, out);
+  }
+
+  @Override
+  public Stream<FieldMetrics> metrics() {
+    return writer.metrics();
   }
 
   private static class WriteBuilder extends AvroSchemaVisitor<ValueWriter<?>> {

--- a/core/src/main/java/org/apache/iceberg/avro/MetricsAwareDatumWriter.java
+++ b/core/src/main/java/org/apache/iceberg/avro/MetricsAwareDatumWriter.java
@@ -19,15 +19,17 @@
 
 package org.apache.iceberg.avro;
 
-import java.io.IOException;
 import java.util.stream.Stream;
-import org.apache.avro.io.Encoder;
+import org.apache.avro.io.DatumWriter;
 import org.apache.iceberg.FieldMetrics;
 
-public interface ValueWriter<D> {
-  void write(D datum, Encoder encoder) throws IOException;
+/**
+ * Wrapper writer around {@link DatumWriter} with metrics support.
+ */
+public interface MetricsAwareDatumWriter<D> extends DatumWriter<D> {
 
-  default Stream<FieldMetrics> metrics() {
-    return Stream.empty(); // TODO will populate in following PRs
-  }
+  /**
+   * Returns a stream of {@link FieldMetrics} that this MetricsAwareDatumWriter keeps track of.
+   */
+  Stream<FieldMetrics> metrics();
 }

--- a/core/src/main/java/org/apache/iceberg/data/avro/DataWriter.java
+++ b/core/src/main/java/org/apache/iceberg/data/avro/DataWriter.java
@@ -21,19 +21,21 @@ package org.apache.iceberg.data.avro;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.stream.Stream;
 import org.apache.avro.LogicalType;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
-import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Encoder;
+import org.apache.iceberg.FieldMetrics;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.avro.AvroSchemaVisitor;
 import org.apache.iceberg.avro.LogicalMap;
+import org.apache.iceberg.avro.MetricsAwareDatumWriter;
 import org.apache.iceberg.avro.ValueWriter;
 import org.apache.iceberg.avro.ValueWriters;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
-public class DataWriter<T> implements DatumWriter<T> {
+public class DataWriter<T> implements MetricsAwareDatumWriter<T> {
   private ValueWriter<T> writer = null;
 
   public static <D> DataWriter<D> create(Schema schema) {
@@ -57,6 +59,11 @@ public class DataWriter<T> implements DatumWriter<T> {
 
   protected ValueWriter<?> createStructWriter(List<ValueWriter<?>> fields) {
     return GenericWriters.struct(fields);
+  }
+
+  @Override
+  public Stream<FieldMetrics> metrics() {
+    return writer.metrics();
   }
 
   private class WriteBuilder extends AvroSchemaVisitor<ValueWriter<?>> {

--- a/data/src/main/java/org/apache/iceberg/data/GenericAppenderFactory.java
+++ b/data/src/main/java/org/apache/iceberg/data/GenericAppenderFactory.java
@@ -92,6 +92,7 @@ public class GenericAppenderFactory implements FileAppenderFactory<Record> {
           return Avro.write(outputFile)
               .schema(schema)
               .createWriterFunc(DataWriter::create)
+              .metricsConfig(metricsConfig)
               .setAll(config)
               .overwrite()
               .build();

--- a/flink/src/main/java/org/apache/iceberg/flink/data/FlinkAvroWriter.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/data/FlinkAvroWriter.java
@@ -23,18 +23,20 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
-import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Encoder;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.iceberg.FieldMetrics;
+import org.apache.iceberg.avro.MetricsAwareDatumWriter;
 import org.apache.iceberg.avro.ValueWriter;
 import org.apache.iceberg.avro.ValueWriters;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
-public class FlinkAvroWriter implements DatumWriter<RowData> {
+public class FlinkAvroWriter implements MetricsAwareDatumWriter<RowData> {
   private final RowType rowType;
   private ValueWriter<RowData> writer = null;
 
@@ -52,6 +54,11 @@ public class FlinkAvroWriter implements DatumWriter<RowData> {
   @Override
   public void write(RowData datum, Encoder out) throws IOException {
     writer.write(datum, out);
+  }
+
+  @Override
+  public Stream<FieldMetrics> metrics() {
+    return writer.metrics();
   }
 
   private static class WriteBuilder extends AvroWithFlinkSchemaVisitor<ValueWriter<?>> {

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkAppenderFactory.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkAppenderFactory.java
@@ -102,6 +102,7 @@ public class FlinkAppenderFactory implements FileAppenderFactory<RowData>, Seria
               .createWriterFunc(ignore -> new FlinkAvroWriter(flinkSchema))
               .setAll(props)
               .schema(schema)
+              .metricsConfig(metricsConfig)
               .overwrite()
               .build();
 

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroWriter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroWriter.java
@@ -23,11 +23,13 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.apache.avro.LogicalType;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
-import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Encoder;
+import org.apache.iceberg.FieldMetrics;
+import org.apache.iceberg.avro.MetricsAwareDatumWriter;
 import org.apache.iceberg.avro.ValueWriter;
 import org.apache.iceberg.avro.ValueWriters;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -37,7 +39,7 @@ import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.StructType;
 
-public class SparkAvroWriter implements DatumWriter<InternalRow> {
+public class SparkAvroWriter implements MetricsAwareDatumWriter<InternalRow> {
   private final StructType dsSchema;
   private ValueWriter<InternalRow> writer = null;
 
@@ -55,6 +57,11 @@ public class SparkAvroWriter implements DatumWriter<InternalRow> {
   @Override
   public void write(InternalRow datum, Encoder out) throws IOException {
     writer.write(datum, out);
+  }
+
+  @Override
+  public Stream<FieldMetrics> metrics() {
+    return writer.metrics();
   }
 
   private static class WriteBuilder extends AvroWithSparkSchemaVisitor<ValueWriter<?>> {


### PR DESCRIPTION
This change is a smaller PR broken down from #1935. There is no change in behavior from this PR. It covers the following:
 - add comparator for byte array
 - updated field metrics bound type to allow object to byte buffer translation to occur later
 - add `metrics()` method to `ValueWriter` for Avro, currently default to empty stream
 - create `MetricsAwareDatumWriter` that exposes writer metrics, and replace `DatumWriter` with it in various classes
 - add metrics config to avro writer and builder
 - create a `AvroMetrics` class that resembles current behavior for producing metrics for avro writer