### PR TITLE
add missing metrics config to ORC appenders

### DIFF
--- a/data/src/main/java/org/apache/iceberg/data/GenericAppenderFactory.java
+++ b/data/src/main/java/org/apache/iceberg/data/GenericAppenderFactory.java
@@ -110,6 +110,7 @@ public class GenericAppenderFactory implements FileAppenderFactory<Record> {
               .schema(schema)
               .createWriterFunc(GenericOrcWriter::buildWriter)
               .setAll(config)
+              .metricsConfig(metricsConfig)
               .overwrite()
               .build();
 

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkAppenderFactory.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkAppenderFactory.java
@@ -109,6 +109,7 @@ public class FlinkAppenderFactory implements FileAppenderFactory<RowData>, Seria
           return ORC.write(outputFile)
               .createWriterFunc((iSchema, typDesc) -> FlinkOrcWriter.buildWriter(flinkSchema, iSchema))
               .setAll(props)
+              .metricsConfig(metricsConfig)
               .schema(schema)
               .overwrite()
               .build();


### PR DESCRIPTION
Looks like we didn't plug in the metrics config for generating ORC file appenders in Flink and Generic appender factory as we do in Parquet