### PR TITLE
Spark: Add WRITE ORDERED BY command to set table order

### DIFF
--- a/spark3-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
+++ b/spark3-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
@@ -69,11 +69,21 @@ statement
     : CALL multipartIdentifier '(' (callArgument (',' callArgument)*)? ')'                  #call
     | ALTER TABLE multipartIdentifier ADD PARTITION FIELD transform (AS name=identifier)?   #addPartitionField
     | ALTER TABLE multipartIdentifier DROP PARTITION FIELD transform                        #dropPartitionField
+    | ALTER TABLE multipartIdentifier WRITE ORDERED BY order                                #setTableOrder
     ;
 
 callArgument
     : expression                    #positionalArgument
     | identifier '=>' expression    #namedArgument
+    ;
+
+order
+    : fields+=orderField (',' fields+=orderField)*
+    | '(' fields+=orderField (',' fields+=orderField)* ')'
+    ;
+
+orderField
+    : transform direction=(ASC | DESC)? (NULLS nullOrder=(FIRST | LAST))?
     ;
 
 transform
@@ -134,7 +144,7 @@ quotedIdentifier
     ;
 
 nonReserved
-    : ADD | ALTER | AS | CALL | DROP | FIELD | PARTITION | TABLE
+    : ADD | ALTER | AS | ASC | BY | CALL | DESC | DROP | FIELD | FIRST | LAST | NULLS | ORDERED | PARTITION | TABLE | WRITE
     | TRUE | FALSE
     | MAP
     ;
@@ -142,11 +152,19 @@ nonReserved
 ADD: 'ADD';
 ALTER: 'ALTER';
 AS: 'AS';
+ASC: 'ASC';
+BY: 'BY';
 CALL: 'CALL';
+DESC: 'DESC';
 DROP: 'DROP';
 FIELD: 'FIELD';
+FIRST: 'FIRST';
+LAST: 'LAST';
+NULLS: 'NULLS';
+ORDERED: 'ORDERED';
 PARTITION: 'PARTITION';
 TABLE: 'TABLE';
+WRITE: 'WRITE';
 
 TRUE: 'TRUE';
 FALSE: 'FALSE';

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
@@ -103,9 +103,11 @@ class IcebergSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserI
 
   private def isIcebergCommand(sqlText: String): Boolean = {
     val normalized = sqlText.toLowerCase(Locale.ROOT).trim()
-    normalized.startsWith("call") ||
-        (normalized.startsWith("alter table") && (
-            normalized.contains("add partition field") || normalized.contains("drop partition field")))
+    normalized.startsWith("call") || (
+        normalized.startsWith("alter table") && (
+            normalized.contains("add partition field") ||
+            normalized.contains("drop partition field") ||
+            normalized.contains("write ordered by")))
   }
 
   protected def parse[T](command: String)(toResult: IcebergSqlExtensionsParser => T): T = {

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/SetWriteOrder.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/SetWriteOrder.scala
@@ -31,7 +31,7 @@ case class SetWriteOrder(
 
   override def output: Seq[Attribute] = Nil
 
-  override def simpleString: String = {
+  override def simpleString(maxFields: Int): String = {
     val order = sortOrder.map {
       case (term, direction, nullOrder) => s"$term $direction $nullOrder"
     }.mkString(", ")

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/SetWriteOrder.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/SetWriteOrder.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.iceberg.NullOrder
+import org.apache.iceberg.SortDirection
+import org.apache.iceberg.expressions.Term
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+case class SetWriteOrder(
+    table: Seq[String],
+    sortOrder: Array[(Term, SortDirection, NullOrder)]) extends Command {
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  override def output: Seq[Attribute] = Nil
+
+  override def simpleString: String = {
+    val order = sortOrder.map {
+      case (term, direction, nullOrder) => s"$term $direction $nullOrder"
+    }.mkString(", ")
+    s"SetWriteOrder ${table.quoted} $order"
+  }
+}

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Strategy.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Strategy.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.catalyst.plans.logical.DropPartitionField
 import org.apache.spark.sql.catalyst.plans.logical.DynamicFileFilter
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.logical.ReplaceData
+import org.apache.spark.sql.catalyst.plans.logical.SetWriteOrder
 import org.apache.spark.sql.connector.catalog.Identifier
 import org.apache.spark.sql.connector.catalog.TableCatalog
 import org.apache.spark.sql.execution.ProjectExec
@@ -51,6 +52,9 @@ case class ExtendedDataSourceV2Strategy(spark: SparkSession) extends Strategy {
 
     case DropPartitionField(IcebergCatalogAndIdentifier(catalog, ident), transform) =>
       DropPartitionFieldExec(catalog, ident, transform) :: Nil
+
+    case SetWriteOrder(IcebergCatalogAndIdentifier(catalog, ident), writeOrder) =>
+      SetWriteOrderExec(catalog, ident, writeOrder) :: Nil
 
     case DynamicFileFilter(scanRelation, fileFilterPlan) =>
       // we don't use planLater here as we need ExtendedBatchScanExec, not BatchScanExec

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/SetWriteOrderExec.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/SetWriteOrderExec.scala
@@ -55,7 +55,7 @@ case class SetWriteOrderExec(
     Nil
   }
 
-  override def simpleString: String = {
+  override def simpleString(maxFields: Int): String = {
     val order = sortOrder.map {
       case (term, direction, nullOrder) => s"$term $direction $nullOrder"
     }.mkString(", ")

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/SetWriteOrderExec.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/SetWriteOrderExec.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.iceberg.NullOrder
+import org.apache.iceberg.SortDirection
+import org.apache.iceberg.expressions.Term
+import org.apache.iceberg.spark.source.SparkTable
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.connector.catalog.TableCatalog
+
+case class SetWriteOrderExec(
+    catalog: TableCatalog,
+    ident: Identifier,
+    sortOrder: Array[(Term, SortDirection, NullOrder)]) extends V2CommandExec {
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override protected def run(): Seq[InternalRow] = {
+    catalog.loadTable(ident) match {
+      case iceberg: SparkTable =>
+        val orderBuilder = iceberg.table.replaceSortOrder()
+        sortOrder.foreach {
+          case (term, SortDirection.ASC, nullOrder) =>
+            orderBuilder.asc(term, nullOrder)
+          case (term, SortDirection.DESC, nullOrder) =>
+            orderBuilder.desc(term, nullOrder)
+        }
+        orderBuilder.commit()
+
+      case table =>
+        throw new UnsupportedOperationException(s"Cannot set write order of non-Iceberg table: $table")
+    }
+
+    Nil
+  }
+
+  override def simpleString: String = {
+    val order = sortOrder.map {
+      case (term, direction, nullOrder) => s"$term $direction $nullOrder"
+    }.mkString(", ")
+    s"SetWriteOrder ${catalog.name}.${ident.quoted} $order"
+  }
+}

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSetWriteOrder.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSetWriteOrder.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.extensions;
+
+import java.util.Map;
+import org.apache.iceberg.NullOrder;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.Table;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.iceberg.expressions.Expressions.bucket;
+
+public class TestSetWriteOrder extends SparkExtensionsTestBase {
+  public TestSetWriteOrder(String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
+  }
+
+  @After
+  public void removeTable() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @Test
+  public void testSetWriteOrderByColumn() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg", tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+    Assert.assertTrue("Table should start unsorted", table.sortOrder().isUnsorted());
+
+    sql("ALTER TABLE %s WRITE ORDERED BY category, id", tableName);
+
+    table.refresh();
+
+    SortOrder expected = SortOrder.builderFor(table.schema())
+        .withOrderId(1)
+        .asc("category", NullOrder.NULLS_FIRST)
+        .asc("id", NullOrder.NULLS_FIRST)
+        .build();
+
+    Assert.assertEquals("Should have expected order", expected, table.sortOrder());
+  }
+
+  @Test
+  public void testSetWriteOrderByColumnWithDirection() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg", tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+    Assert.assertTrue("Table should start unsorted", table.sortOrder().isUnsorted());
+
+    sql("ALTER TABLE %s WRITE ORDERED BY category ASC, id DESC", tableName);
+
+    table.refresh();
+
+    SortOrder expected = SortOrder.builderFor(table.schema())
+        .withOrderId(1)
+        .asc("category", NullOrder.NULLS_FIRST)
+        .desc("id", NullOrder.NULLS_LAST)
+        .build();
+
+    Assert.assertEquals("Should have expected order", expected, table.sortOrder());
+  }
+
+  @Test
+  public void testSetWriteOrderByColumnWithDirectionAndNullOrder() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg", tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+    Assert.assertTrue("Table should start unsorted", table.sortOrder().isUnsorted());
+
+    sql("ALTER TABLE %s WRITE ORDERED BY category ASC NULLS LAST, id DESC NULLS FIRST", tableName);
+
+    table.refresh();
+
+    SortOrder expected = SortOrder.builderFor(table.schema())
+        .withOrderId(1)
+        .asc("category", NullOrder.NULLS_LAST)
+        .desc("id", NullOrder.NULLS_FIRST)
+        .build();
+
+    Assert.assertEquals("Should have expected order", expected, table.sortOrder());
+  }
+
+  @Test
+  public void testSetWriteOrderByTransform() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, category string, ts timestamp, data string) USING iceberg", tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+    Assert.assertTrue("Table should start unsorted", table.sortOrder().isUnsorted());
+
+    sql("ALTER TABLE %s WRITE ORDERED BY category DESC, bucket(16, id), id", tableName);
+
+    table.refresh();
+
+    SortOrder expected = SortOrder.builderFor(table.schema())
+        .withOrderId(1)
+        .desc("category")
+        .asc(bucket("id", 16))
+        .asc("id")
+        .build();
+
+    Assert.assertEquals("Should have expected order", expected, table.sortOrder());
+  }
+}


### PR DESCRIPTION
This adds `ALTER TABLE ... WRITE ORDERED BY ...` to set the table order in Spark.