### PR TITLE
Update IcebergTimestampWithZoneObjectInspector to fix test failures

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampWithZoneObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampWithZoneObjectInspector.java
@@ -43,12 +43,12 @@ public class IcebergTimestampWithZoneObjectInspector extends AbstractPrimitiveJa
   @Override
   public OffsetDateTime convert(Object o) {
     return o == null ? null :
-        OffsetDateTime.of(((TimestampWritable) o).getTimestamp().toLocalDateTime(), ZoneOffset.UTC);
+        OffsetDateTime.ofInstant(((TimestampWritable) o).getTimestamp().toInstant(), ZoneOffset.UTC);
   }
 
   @Override
   public Timestamp getPrimitiveJavaObject(Object o) {
-    return o == null ? null : Timestamp.valueOf(((OffsetDateTime) o).toLocalDateTime());
+    return o == null ? null : Timestamp.from(((OffsetDateTime) o).toInstant());
   }
 
   @Override
@@ -66,7 +66,7 @@ public class IcebergTimestampWithZoneObjectInspector extends AbstractPrimitiveJa
       return copy;
     } else if (o instanceof OffsetDateTime) {
       OffsetDateTime odt = (OffsetDateTime) o;
-      return OffsetDateTime.of(odt.toLocalDateTime(), odt.getOffset());
+      return OffsetDateTime.ofInstant(odt.toInstant(), odt.getOffset());
     } else {
       return o;
     }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspector.java
@@ -52,7 +52,7 @@ public class TestIcebergTimestampWithZoneObjectInspector {
 
     LocalDateTime local = LocalDateTime.of(2020, 1, 1, 16, 45, 33, 456000);
     OffsetDateTime offsetDateTime = OffsetDateTime.of(local, ZoneOffset.ofHours(-5));
-    Timestamp ts = Timestamp.valueOf(offsetDateTime.toLocalDateTime());
+    Timestamp ts = Timestamp.from(offsetDateTime.toInstant());
 
     Assert.assertEquals(ts, oi.getPrimitiveJavaObject(offsetDateTime));
     Assert.assertEquals(new TimestampWritable(ts), oi.getPrimitiveWritableObject(offsetDateTime));
@@ -64,7 +64,11 @@ public class TestIcebergTimestampWithZoneObjectInspector {
 
     Assert.assertFalse(oi.preferWritable());
 
-    Assert.assertEquals(OffsetDateTime.of(local, ZoneOffset.UTC), oi.convert(new TimestampWritable(ts)));
+    Assert.assertEquals(OffsetDateTime.ofInstant(local.toInstant(ZoneOffset.ofHours(-5)), ZoneOffset.UTC),
+            oi.convert(new TimestampWritable(ts)));
+
+    Assert.assertEquals(offsetDateTime.withOffsetSameInstant(ZoneOffset.UTC),
+            oi.convert(new TimestampWritable(Timestamp.from(offsetDateTime.toInstant()))));
   }
 
 }


### PR DESCRIPTION
For https://github.com/apache/iceberg/issues/1964, update IcebergTimestampWithZoneObjectInspector to fix test failures in local build.
