### PR TITLE
Build: Add separate CI jobs for javadoc and errorprone/checkstyle

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -21,7 +21,7 @@ name: "Java CI"
 on: [push, pull_request]
 
 jobs:
-  check:
+  run-tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -37,7 +37,7 @@ jobs:
         path: ~/.gradle/caches
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: ${{ runner.os }}-gradle
-    - run: ./gradlew check
+    - run: ./gradlew check -Pquick=true -x javadoc
     - uses: actions/upload-artifact@v2
       if: failure()
       with:
@@ -45,3 +45,20 @@ jobs:
         path: |
           **/build/testlogs
 
+  extra-checks:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - run: ./gradlew build -x test -x javadoc
+
+  build-javadoc:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - run: ./gradlew -Pquick=true javadoc


### PR DESCRIPTION
This is a first step toward breaking the tests up into smaller jobs that can be run in parallel. This creates a job for running errorprone and checkstyle (extra-checks) and a job for javadoc, so that the test jobs don't need to duplicate that work and the analysis feedback is faster because it isn't delayed by testing.