### PR TITLE
Core: add sort order id to content file

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ContentFile.java
+++ b/api/src/main/java/org/apache/iceberg/ContentFile.java
@@ -124,6 +124,14 @@ public interface ContentFile<F> {
    */
   List<Integer> equalityFieldIds();
 
+  /**
+   * Returns the sort order id of this file, which describes how the file is ordered.
+   * This information will be useful for merging data and equality delete files more efficiently
+   * when they share the same sort order id.
+   */
+  default Integer sortOrderId() {
+    return null;
+  }
 
   /**
    * Copies this file. Manifest readers can reuse file instances; use
@@ -142,12 +150,4 @@ public interface ContentFile<F> {
    */
   F copyWithoutStats();
 
-  /**
-   * Returns the sort order id of this file, which describes how the file is ordered.
-   * This information will be useful for merging data and equality delete files more efficiently
-   * when they share the same sort order id.
-   */
-  default Integer sortOrderId() {
-    return null;
-  }
 }

--- a/api/src/main/java/org/apache/iceberg/ContentFile.java
+++ b/api/src/main/java/org/apache/iceberg/ContentFile.java
@@ -141,4 +141,13 @@ public interface ContentFile<F> {
    *         null value counts, or nan value counts
    */
   F copyWithoutStats();
+
+  /**
+   * Returns the sort order id of this file, which describes how the file is ordered.
+   * This information will be useful for merging data and equality delete files more efficiently
+   * when they share the same sort order id.
+   */
+  default Integer sortOrderId() {
+    return null;
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/DataFile.java
+++ b/api/src/main/java/org/apache/iceberg/DataFile.java
@@ -61,11 +61,12 @@ public interface DataFile extends ContentFile<DataFile> {
       "Splittable offsets");
   Types.NestedField EQUALITY_IDS = optional(135, "equality_ids", ListType.ofRequired(136, IntegerType.get()),
       "Equality comparison field IDs");
+  Types.NestedField SORT_ORDER_ID = optional(140, "sort_order_id", IntegerType.get(), "Sort order ID");
 
   int PARTITION_ID = 102;
   String PARTITION_NAME = "partition";
   String PARTITION_DOC = "Partition data tuple, schema based on the partition spec";
-  // NEXT ID TO ASSIGN: 140
+  // NEXT ID TO ASSIGN: 141
 
   static StructType getType(StructType partitionType) {
     // IDs start at 100 to leave room for changes to ManifestEntry
@@ -84,7 +85,8 @@ public interface DataFile extends ContentFile<DataFile> {
         UPPER_BOUNDS,
         KEY_METADATA,
         SPLIT_OFFSETS,
-        EQUALITY_IDS
+        EQUALITY_IDS,
+        SORT_ORDER_ID
     );
   }
 

--- a/core/src/main/java/org/apache/iceberg/DataFiles.java
+++ b/core/src/main/java/org/apache/iceberg/DataFiles.java
@@ -271,8 +271,10 @@ public class DataFiles {
       return withEncryptionKeyMetadata(newKeyMetadata.buffer());
     }
 
-    public Builder withSortOrderId(int newSortOrderId) {
-      this.sortOrderId = newSortOrderId;
+    public Builder withSortOrder(SortOrder newSortOrder) {
+      if (newSortOrder != null) {
+        this.sortOrderId = newSortOrder.orderId();
+      }
       return this;
     }
 

--- a/core/src/main/java/org/apache/iceberg/DataFiles.java
+++ b/core/src/main/java/org/apache/iceberg/DataFiles.java
@@ -121,6 +121,7 @@ public class DataFiles {
     private FileFormat format = null;
     private long recordCount = -1L;
     private long fileSizeInBytes = -1L;
+    private int sortOrderId = SortOrder.unsorted().orderId();
 
     // optional fields
     private Map<Integer, Long> columnSizes = null;
@@ -154,6 +155,7 @@ public class DataFiles {
       this.lowerBounds = null;
       this.upperBounds = null;
       this.splitOffsets = null;
+      this.sortOrderId = SortOrder.unsorted().orderId();
     }
 
     public Builder copy(DataFile toCopy) {
@@ -174,6 +176,7 @@ public class DataFiles {
       this.keyMetadata = toCopy.keyMetadata() == null ? null
           : ByteBuffers.copy(toCopy.keyMetadata());
       this.splitOffsets = toCopy.splitOffsets() == null ? null : copyList(toCopy.splitOffsets());
+      this.sortOrderId = toCopy.sortOrderId();
       return this;
     }
 
@@ -268,6 +271,11 @@ public class DataFiles {
       return withEncryptionKeyMetadata(newKeyMetadata.buffer());
     }
 
+    public Builder withSortOrderId(int newSortOrderId) {
+      this.sortOrderId = newSortOrderId;
+      return this;
+    }
+
     public DataFile build() {
       Preconditions.checkArgument(filePath != null, "File path is required");
       if (format == null) {
@@ -281,7 +289,7 @@ public class DataFiles {
           specId, filePath, format, isPartitioned ? partitionData.copy() : null,
           fileSizeInBytes, new Metrics(
               recordCount, columnSizes, valueCounts, nullValueCounts, nanValueCounts, lowerBounds, upperBounds),
-          keyMetadata, splitOffsets);
+          keyMetadata, splitOffsets, sortOrderId);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/FileMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/FileMetadata.java
@@ -200,8 +200,10 @@ public class FileMetadata {
       return withEncryptionKeyMetadata(newKeyMetadata.buffer());
     }
 
-    public Builder withSortOrderId(int newSortOrderId) {
-      this.sortOrderId = newSortOrderId;
+    public Builder withSortOrder(SortOrder newSortOrder) {
+      if (newSortOrder != null) {
+        this.sortOrderId = newSortOrder.orderId();
+      }
       return this;
     }
 

--- a/core/src/main/java/org/apache/iceberg/FileMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/FileMetadata.java
@@ -58,6 +58,7 @@ public class FileMetadata {
     private Map<Integer, ByteBuffer> lowerBounds = null;
     private Map<Integer, ByteBuffer> upperBounds = null;
     private ByteBuffer keyMetadata = null;
+    private Integer sortOrderId = null;
 
     Builder(PartitionSpec spec) {
       this.spec = spec;
@@ -80,6 +81,7 @@ public class FileMetadata {
       this.nanValueCounts = null;
       this.lowerBounds = null;
       this.upperBounds = null;
+      this.sortOrderId = null;
     }
 
     public Builder copy(DeleteFile toCopy) {
@@ -100,6 +102,7 @@ public class FileMetadata {
       this.upperBounds = toCopy.upperBounds();
       this.keyMetadata = toCopy.keyMetadata() == null ? null
           : ByteBuffers.copy(toCopy.keyMetadata());
+      this.sortOrderId = toCopy.sortOrderId();
       return this;
     }
 
@@ -197,6 +200,11 @@ public class FileMetadata {
       return withEncryptionKeyMetadata(newKeyMetadata.buffer());
     }
 
+    public Builder withSortOrderId(int newSortOrderId) {
+      this.sortOrderId = newSortOrderId;
+      return this;
+    }
+
     public DeleteFile build() {
       Preconditions.checkArgument(filePath != null, "File path is required");
       if (format == null) {
@@ -207,11 +215,25 @@ public class FileMetadata {
       Preconditions.checkArgument(fileSizeInBytes >= 0, "File size is required");
       Preconditions.checkArgument(recordCount >= 0, "Record count is required");
 
+      switch (content) {
+        case POSITION_DELETES:
+          Preconditions.checkArgument(sortOrderId == null,
+              "Position delete file should not have sort order");
+          break;
+        case EQUALITY_DELETES:
+          if (sortOrderId == null) {
+            sortOrderId = SortOrder.unsorted().orderId();
+          }
+          break;
+        default:
+          throw new IllegalStateException("Unknown content type " + content);
+      }
+
       return new GenericDeleteFile(
           specId, content, filePath, format, isPartitioned ? DataFiles.copy(spec, partitionData) : null,
           fileSizeInBytes, new Metrics(
           recordCount, columnSizes, valueCounts, nullValueCounts, nanValueCounts, lowerBounds, upperBounds),
-          equalityFieldIds, keyMetadata);
+          equalityFieldIds, sortOrderId, keyMetadata);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/GenericDataFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDataFile.java
@@ -36,10 +36,10 @@ class GenericDataFile extends BaseFile<DataFile> implements DataFile {
 
   GenericDataFile(int specId, String filePath, FileFormat format, PartitionData partition,
                   long fileSizeInBytes, Metrics metrics,
-                  ByteBuffer keyMetadata, List<Long> splitOffsets) {
+                  ByteBuffer keyMetadata, List<Long> splitOffsets, Integer sortOrderId) {
     super(specId, FileContent.DATA, filePath, format, partition, fileSizeInBytes, metrics.recordCount(),
         metrics.columnSizes(), metrics.valueCounts(), metrics.nullValueCounts(), metrics.nanValueCounts(),
-        metrics.lowerBounds(), metrics.upperBounds(), splitOffsets, null, keyMetadata);
+        metrics.lowerBounds(), metrics.upperBounds(), splitOffsets, null, sortOrderId, keyMetadata);
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/GenericDeleteFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDeleteFile.java
@@ -35,10 +35,11 @@ class GenericDeleteFile extends BaseFile<DeleteFile> implements DeleteFile {
   }
 
   GenericDeleteFile(int specId, FileContent content, String filePath, FileFormat format, PartitionData partition,
-                    long fileSizeInBytes, Metrics metrics, int[] equalityFieldIds, ByteBuffer keyMetadata) {
+                    long fileSizeInBytes, Metrics metrics, int[] equalityFieldIds,
+                    Integer sortOrderId, ByteBuffer keyMetadata) {
     super(specId, content, filePath, format, partition, fileSizeInBytes, metrics.recordCount(),
         metrics.columnSizes(), metrics.valueCounts(), metrics.nullValueCounts(), metrics.nanValueCounts(),
-        metrics.lowerBounds(), metrics.upperBounds(), null, equalityFieldIds, keyMetadata);
+        metrics.lowerBounds(), metrics.upperBounds(), null, equalityFieldIds, sortOrderId, keyMetadata);
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/V1Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V1Metadata.java
@@ -214,7 +214,8 @@ class V1Metadata {
         DataFile.LOWER_BOUNDS,
         DataFile.UPPER_BOUNDS,
         DataFile.KEY_METADATA,
-        DataFile.SPLIT_OFFSETS
+        DataFile.SPLIT_OFFSETS,
+        DataFile.SORT_ORDER_ID
     );
   }
 
@@ -353,6 +354,8 @@ class V1Metadata {
           return wrapped.keyMetadata();
         case 13:
           return wrapped.splitOffsets();
+        case 14:
+          return wrapped.sortOrderId();
       }
       throw new IllegalArgumentException("Unknown field ordinal: " + pos);
     }
@@ -445,6 +448,11 @@ class V1Metadata {
     @Override
     public List<Long> splitOffsets() {
       return wrapped.splitOffsets();
+    }
+
+    @Override
+    public Integer sortOrderId() {
+      return wrapped.sortOrderId();
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/V2Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V2Metadata.java
@@ -255,7 +255,8 @@ class V2Metadata {
         DataFile.UPPER_BOUNDS,
         DataFile.KEY_METADATA,
         DataFile.SPLIT_OFFSETS,
-        DataFile.EQUALITY_IDS
+        DataFile.EQUALITY_IDS,
+        DataFile.SORT_ORDER_ID
     );
   }
 
@@ -409,6 +410,8 @@ class V2Metadata {
           return wrapped.splitOffsets();
         case 14:
           return wrapped.equalityFieldIds();
+        case 15:
+          return wrapped.sortOrderId();
       }
       throw new IllegalArgumentException("Unknown field ordinal: " + pos);
     }
@@ -501,6 +504,11 @@ class V2Metadata {
     @Override
     public List<Integer> equalityFieldIds() {
       return wrapped.equalityFieldIds();
+    }
+
+    @Override
+    public Integer sortOrderId() {
+      return wrapped.sortOrderId();
     }
 
     @Override

--- a/core/src/test/java/org/apache/iceberg/TestManifestWriterVersions.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestWriterVersions.java
@@ -68,15 +68,16 @@ public class TestManifestWriterVersions {
       ImmutableMap.of(1, Conversions.toByteBuffer(Types.IntegerType.get(), 1)),  // lower bounds
       ImmutableMap.of(1, Conversions.toByteBuffer(Types.IntegerType.get(), 1))); // upper bounds
   private static final List<Long> OFFSETS = ImmutableList.of(4L);
+  private static final Integer SORT_ORDER_ID = 2;
 
   private static final DataFile DATA_FILE = new GenericDataFile(
-      0, PATH, FORMAT, PARTITION, 150972L, METRICS, null, OFFSETS);
+      0, PATH, FORMAT, PARTITION, 150972L, METRICS, null, OFFSETS, SORT_ORDER_ID);
 
   private static final List<Integer> EQUALITY_IDS = ImmutableList.of(1);
   private static final int[] EQUALITY_ID_ARR = new int[] { 1 };
 
   private static final DeleteFile DELETE_FILE = new GenericDeleteFile(
-      0, FileContent.EQUALITY_DELETES, PATH, FORMAT, PARTITION, 22905L, METRICS, EQUALITY_ID_ARR, null);
+      0, FileContent.EQUALITY_DELETES, PATH, FORMAT, PARTITION, 22905L, METRICS, EQUALITY_ID_ARR, SORT_ORDER_ID, null);
 
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
@@ -201,6 +202,7 @@ public class TestManifestWriterVersions {
     Assert.assertEquals("NaN value counts", METRICS.nanValueCounts(), dataFile.nanValueCounts());
     Assert.assertEquals("Lower bounds", METRICS.lowerBounds(), dataFile.lowerBounds());
     Assert.assertEquals("Upper bounds", METRICS.upperBounds(), dataFile.upperBounds());
+    Assert.assertEquals("Sort order id", SORT_ORDER_ID, dataFile.sortOrderId());
     if (dataFile.content() == FileContent.EQUALITY_DELETES) {
       Assert.assertEquals(EQUALITY_IDS, dataFile.equalityFieldIds());
     } else {

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkDataFile.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkDataFile.java
@@ -47,6 +47,7 @@ public class SparkDataFile implements DataFile {
   private final int upperBoundsPosition;
   private final int keyMetadataPosition;
   private final int splitOffsetsPosition;
+  private final int sortOrderIdPosition;
   private final Type lowerBoundsType;
   private final Type upperBoundsType;
   private final Type keyMetadataType;
@@ -79,6 +80,7 @@ public class SparkDataFile implements DataFile {
     upperBoundsPosition = positions.get("upper_bounds");
     keyMetadataPosition = positions.get("key_metadata");
     splitOffsetsPosition = positions.get("split_offsets");
+    sortOrderIdPosition = positions.get("sort_order_id");
   }
 
   public SparkDataFile wrap(Row row) {
@@ -175,6 +177,11 @@ public class SparkDataFile implements DataFile {
   @Override
   public List<Long> splitOffsets() {
     return wrapped.isNullAt(splitOffsetsPosition) ? null : wrapped.getList(splitOffsetsPosition);
+  }
+
+  @Override
+  public Integer sortOrderId() {
+    return wrapped.getAs(sortOrderIdPosition);
   }
 
   private int fieldPosition(String name, StructType sparkType) {

--- a/spark/src/test/java/org/apache/iceberg/TestDataFileSerialization.java
+++ b/spark/src/test/java/org/apache/iceberg/TestDataFileSerialization.java
@@ -93,6 +93,7 @@ public class TestDataFileSerialization {
           5L, null, VALUE_COUNTS, NULL_VALUE_COUNTS, NAN_VALUE_COUNTS, LOWER_BOUNDS, UPPER_BOUNDS))
       .withSplitOffsets(ImmutableList.of(4L))
       .withEncryptionKeyMetadata(ByteBuffer.allocate(4).putInt(34))
+      .withSortOrderId(1)
       .build();
 
   @Rule

--- a/spark/src/test/java/org/apache/iceberg/TestDataFileSerialization.java
+++ b/spark/src/test/java/org/apache/iceberg/TestDataFileSerialization.java
@@ -93,7 +93,7 @@ public class TestDataFileSerialization {
           5L, null, VALUE_COUNTS, NULL_VALUE_COUNTS, NAN_VALUE_COUNTS, LOWER_BOUNDS, UPPER_BOUNDS))
       .withSplitOffsets(ImmutableList.of(4L))
       .withEncryptionKeyMetadata(ByteBuffer.allocate(4).putInt(34))
-      .withSortOrderId(1)
+      .withSortOrder(SortOrder.unsorted())
       .build();
 
   @Rule

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
@@ -198,6 +198,7 @@ public abstract class TestSparkDataFile {
     Assert.assertEquals("Upper bounds must match", expected.upperBounds(), actual.upperBounds());
     Assert.assertEquals("Key metadata must match", expected.keyMetadata(), actual.keyMetadata());
     Assert.assertEquals("Split offsets must match", expected.splitOffsets(), actual.splitOffsets());
+    Assert.assertEquals("Sort order id must match", expected.sortOrderId(), actual.sortOrderId());
 
     checkStructLike(expected.partition(), actual.partition());
   }


### PR DESCRIPTION
This change adds sort_order_id to content file, and allow read and write of this attribute in manifest entry. The logic of populating sort order id in writers from table attribute is not included here and will be the main focus for the next PR, as doing so will likely requires a lot of signature changes. 

**Questions**
- Not sure if sort order should be nullable by default or  0 (from`unsorted_order`): decided as nullable for now, as I think positional delete files shouldn't have sort order (since they should be sorted by file_path and position per spec)
- Do we want only sort order id, or actual sort order struct? Id itself is good for comparison but when merging data/delete files I think we do need the actual sort order struct. Without including it in manifest entries, I think we may need to do an additional lookup of the table to fetch it, which could slow down the query. 
- For the next PR, do we assume the table's current sort order id is the authoritative place to get sort order information when adding a new file?  I wonder if engine is ever possible/allowed to override the default sort order to unsorted and pass it back to data/delete writer. 
 