### PR TITLE
Flink:  Add unit test to write CDC events by SQL.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -72,14 +72,14 @@ public class TableMetadata implements Serializable {
                                                SortOrder sortOrder,
                                                String location,
                                                Map<String, String> properties) {
-    return newTableMetadata(schema, spec, sortOrder, location, properties, DEFAULT_TABLE_FORMAT_VERSION);
+    return newTableMetadata(schema, spec, sortOrder, location, properties, formatVersion(properties));
   }
 
   public static TableMetadata newTableMetadata(Schema schema,
                                                PartitionSpec spec,
                                                String location,
                                                Map<String, String> properties) {
-    return newTableMetadata(schema, spec, SortOrder.unsorted(), location, properties, DEFAULT_TABLE_FORMAT_VERSION);
+    return newTableMetadata(schema, spec, SortOrder.unsorted(), location, properties, formatVersion(properties));
   }
 
   static TableMetadata newTableMetadata(Schema schema,
@@ -844,5 +844,11 @@ public class TableMetadata implements Serializable {
       builder.put(sortOrder.orderId(), sortOrder);
     }
     return builder.build();
+  }
+
+  private static int formatVersion(Map<String, String> properties) {
+    return PropertyUtil.propertyAsInt(properties,
+        TableProperties.FORMAT_VERSION,
+        TableProperties.DEFAULT_FORMAT_VERSION);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -72,14 +72,14 @@ public class TableMetadata implements Serializable {
                                                SortOrder sortOrder,
                                                String location,
                                                Map<String, String> properties) {
-    return newTableMetadata(schema, spec, sortOrder, location, properties, formatVersion(properties));
+    return newTableMetadata(schema, spec, sortOrder, location, properties, DEFAULT_TABLE_FORMAT_VERSION);
   }
 
   public static TableMetadata newTableMetadata(Schema schema,
                                                PartitionSpec spec,
                                                String location,
                                                Map<String, String> properties) {
-    return newTableMetadata(schema, spec, SortOrder.unsorted(), location, properties, formatVersion(properties));
+    return newTableMetadata(schema, spec, SortOrder.unsorted(), location, properties, DEFAULT_TABLE_FORMAT_VERSION);
   }
 
   static TableMetadata newTableMetadata(Schema schema,
@@ -844,11 +844,5 @@ public class TableMetadata implements Serializable {
       builder.put(sortOrder.orderId(), sortOrder);
     }
     return builder.build();
-  }
-
-  private static int formatVersion(Map<String, String> properties) {
-    return PropertyUtil.propertyAsInt(properties,
-        TableProperties.FORMAT_VERSION,
-        TableProperties.DEFAULT_FORMAT_VERSION);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -161,7 +161,4 @@ public class TableProperties {
 
   public static final String EQUALITY_FIELD_COLUMNS = "equality.field.columns";
   public static final String DEFAULT_EQUALITY_FIELD_COLUMNS = null;
-
-  public static final String FORMAT_VERSION = "format.version";
-  public static final int DEFAULT_FORMAT_VERSION = 1;
 }

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -161,4 +161,7 @@ public class TableProperties {
 
   public static final String EQUALITY_FIELD_COLUMNS = "equality.field.columns";
   public static final String DEFAULT_EQUALITY_FIELD_COLUMNS = null;
+
+  public static final String FORMAT_VERSION = "format.version";
+  public static final int DEFAULT_FORMAT_VERSION = 1;
 }

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -158,4 +158,7 @@ public class TableProperties {
 
   public static final String UPDATE_MODE = "write.update.mode";
   public static final String UPDATE_MODE_DEFAULT = "copy-on-write";
+
+  public static final String EQUALITY_FIELD_COLUMNS = "equality.field.columns";
+  public static final String DEFAULT_EQUALITY_FIELD_COLUMNS = null;
 }

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -73,7 +73,9 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -367,8 +369,7 @@ public class FlinkCatalog extends AbstractCatalog {
     // Set the equality field columns.
     List<String> equalityFieldColumns = toEqualityColumns(table.getSchema());
     if (!equalityFieldColumns.isEmpty()) {
-      properties.put(TableProperties.EQUALITY_FIELD_COLUMNS,
-          org.apache.commons.lang.StringUtils.join(equalityFieldColumns, ","));
+      properties.put(TableProperties.EQUALITY_FIELD_COLUMNS, Joiner.on(',').join(equalityFieldColumns));
     }
 
     String location = null;
@@ -542,8 +543,8 @@ public class FlinkCatalog extends AbstractCatalog {
     String concatColumns = PropertyUtil.propertyAsString(table.properties(),
         TableProperties.EQUALITY_FIELD_COLUMNS,
         TableProperties.DEFAULT_EQUALITY_FIELD_COLUMNS);
-    String[] columns = org.apache.commons.lang3.StringUtils.split(concatColumns, ",");
-    if (columns != null && columns.length > 0) {
+    String[] columns = Splitter.on(',').splitToList(concatColumns).toArray(new String[0]);
+    if (columns.length > 0) {
       builder.primaryKey(columns);
     }
 

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -21,9 +21,11 @@ package org.apache.iceberg.flink.sink;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
@@ -41,6 +43,7 @@ import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.TableLoader;
 import org.apache.iceberg.io.WriteResult;
@@ -200,6 +203,15 @@ public class FlinkSink {
 
       // Find out the equality field id list based on the user-provided equality field column names.
       List<Integer> equalityFieldIds = Lists.newArrayList();
+      if (equalityFieldColumns == null) {
+        String concatColumns = PropertyUtil.propertyAsString(table.properties(),
+            TableProperties.EQUALITY_FIELD_COLUMNS,
+            TableProperties.DEFAULT_EQUALITY_FIELD_COLUMNS);
+        String[] columns = StringUtils.split(concatColumns, ",");
+        if (columns != null && columns.length > 0) {
+          equalityFieldColumns = Arrays.asList(columns);
+        }
+      }
       if (equalityFieldColumns != null && equalityFieldColumns.size() > 0) {
         for (String column : equalityFieldColumns) {
           org.apache.iceberg.types.Types.NestedField field = table.schema().findField(column);

--- a/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
@@ -224,8 +224,17 @@ public class SimpleDataUtil {
 
   public static StructLikeSet actualRowSet(Table table, String... columns) throws IOException {
     table.refresh();
+    return actualRowSet(table, table.currentSnapshot().snapshotId(), columns);
+  }
+
+  public static StructLikeSet actualRowSet(Table table, long snapshotId, String... columns) throws IOException {
+    table.refresh();
     StructLikeSet set = StructLikeSet.create(table.schema().asStruct());
-    try (CloseableIterable<Record> reader = IcebergGenerics.read(table).select(columns).build()) {
+    try (CloseableIterable<Record> reader = IcebergGenerics
+        .read(table)
+        .useSnapshot(snapshotId)
+        .select(columns)
+        .build()) {
       reader.forEach(set::add);
     }
     return set;

--- a/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -96,6 +97,21 @@ public class SimpleDataUtil {
     record.setField("id", id);
     record.setField("data", data);
     return record;
+  }
+
+  private static final Map<String, RowKind> ROW_KIND_MAP = ImmutableMap.of(
+      "+I", RowKind.INSERT,
+      "-D", RowKind.DELETE,
+      "-U", RowKind.UPDATE_BEFORE,
+      "+U", RowKind.UPDATE_AFTER);
+
+  public static Row createRow(String rowKind, int id, String data) {
+    RowKind kind = ROW_KIND_MAP.get(rowKind);
+    if (kind == null) {
+      throw new IllegalArgumentException("Unknown row kind: " + rowKind);
+    }
+
+    return Row.ofKind(kind, id, data);
   }
 
   public static RowData createRowData(Integer id, String data) {

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
@@ -20,12 +20,8 @@
 package org.apache.iceberg.flink;
 
 import java.util.List;
-import org.apache.flink.streaming.api.TimeCharacteristic;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Expressions;
 import org.apache.flink.table.api.TableEnvironment;
-import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -71,19 +67,7 @@ public class TestFlinkTableSink extends FlinkCatalogTestBase {
   protected TableEnvironment getTableEnv() {
     if (tEnv == null) {
       synchronized (this) {
-        EnvironmentSettings.Builder settingsBuilder = EnvironmentSettings
-            .newInstance()
-            .useBlinkPlanner();
-        if (isStreamingJob) {
-          settingsBuilder.inStreamingMode();
-          StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-          env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
-          env.enableCheckpointing(400);
-          tEnv = StreamTableEnvironment.create(env, settingsBuilder.build());
-        } else {
-          settingsBuilder.inBatchMode();
-          tEnv = TableEnvironment.create(settingsBuilder.build());
-        }
+        tEnv = createTableEnv(isStreamingJob);
       }
     }
     return tEnv;

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSinkV2.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSinkV2.java
@@ -22,6 +22,8 @@ package org.apache.iceberg.flink;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -36,6 +38,7 @@ import org.apache.flink.table.data.util.DataFormatConverters;
 import org.apache.flink.table.runtime.typeutils.RowDataTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.Row;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -43,6 +46,7 @@ import org.apache.iceberg.data.Record;
 import org.apache.iceberg.flink.source.BoundedTestSource;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.StructLikeSet;
 import org.junit.After;
 import org.junit.Assert;
@@ -54,27 +58,35 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class TestFlinkTableSinkV2 extends FlinkCatalogTestBase {
   private static final String TABLE_NAME_V2 = "test_table_v2";
+  private static final int ROW_ID_POS = 0;
+  private static final int ROW_DATA_POS = 1;
+
+  private final boolean partitioned;
 
   private final StreamExecutionEnvironment env;
 
   private StreamTableEnvironment tEnv;
   private Map<String, String> tableProps;
 
-  @Parameterized.Parameters(name = "catalogName={0}, format={1}")
+  @Parameterized.Parameters(name = "CatalogName={0}, Format={1}, Partitioned={2}")
   public static Iterable<Object[]> parameters() {
     return ImmutableList.of(
-        new Object[] {"testhive", "avro"},
-        new Object[] {"testhive", "parquet"},
-        new Object[] {"testhadoop", "avro"},
-        new Object[] {"testhadoop", "parquet"}
+        new Object[] {"testhive", "avro", true},
+        new Object[] {"testhive", "avro", false},
+        new Object[] {"testhive", "parquet", true},
+        new Object[] {"testhive", "parquet", false},
+        new Object[] {"testhadoop", "avro", true},
+        new Object[] {"testhadoop", "avro", false},
+        new Object[] {"testhadoop", "parquet", true},
+        new Object[] {"testhadoop", "parquet", false}
     );
   }
 
-  public TestFlinkTableSinkV2(String catalogName, String format) {
+  public TestFlinkTableSinkV2(String catalogName, String format, Boolean partitioned) {
     super(catalogName, new String[0]);
+    this.partitioned = partitioned;
 
-    this.env = StreamExecutionEnvironment.getExecutionEnvironment()
-        .enableCheckpointing(400);
+    this.env = StreamExecutionEnvironment.getExecutionEnvironment().enableCheckpointing(400);
     env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 
     this.tableProps = ImmutableMap.of(TableProperties.DEFAULT_FILE_FORMAT, format, TableProperties.FORMAT_VERSION, "2");
@@ -111,6 +123,147 @@ public class TestFlinkTableSinkV2 extends FlinkCatalogTestBase {
     super.clean();
   }
 
+  @Test
+  public void testSqlChangeLogOnIdKey() throws Exception {
+    List<List<Row>> inputRowsPerCheckpoint = ImmutableList.of(
+        ImmutableList.of(
+            row("+I", 1, "aaa"),
+            row("-D", 1, "aaa"),
+            row("+I", 1, "bbb"),
+            row("+I", 2, "aaa"),
+            row("-D", 2, "aaa"),
+            row("+I", 2, "bbb")
+        ),
+        ImmutableList.of(
+            row("-U", 2, "bbb"),
+            row("+U", 2, "ccc"),
+            row("-D", 2, "ccc"),
+            row("+I", 2, "ddd")
+        ),
+        ImmutableList.of(
+            row("-D", 1, "bbb"),
+            row("+I", 1, "ccc"),
+            row("-D", 1, "ccc"),
+            row("+I", 1, "ddd")
+        )
+    );
+
+    List<List<Record>> expectedRecordsPerCheckpoint = ImmutableList.of(
+        ImmutableList.of(record(1, "bbb"), record(2, "bbb")),
+        ImmutableList.of(record(1, "bbb"), record(2, "ddd")),
+        ImmutableList.of(record(1, "ddd"), record(2, "ddd"))
+    );
+
+    testSqlChangeLog(ImmutableList.of("id"), row -> Row.of(row.getField(ROW_ID_POS)), inputRowsPerCheckpoint,
+        expectedRecordsPerCheckpoint);
+  }
+
+  @Test
+  public void testChangeLogOnDataKey() throws Exception {
+    List<List<Row>> elementsPerCheckpoint = ImmutableList.of(
+        ImmutableList.of(
+            row("+I", 1, "aaa"),
+            row("-D", 1, "aaa"),
+            row("+I", 2, "bbb"),
+            row("+I", 1, "bbb"),
+            row("+I", 2, "aaa")
+        ),
+        ImmutableList.of(
+            row("-U", 2, "aaa"),
+            row("+U", 1, "ccc"),
+            row("+I", 1, "aaa")
+        ),
+        ImmutableList.of(
+            row("-D", 1, "bbb"),
+            row("+I", 2, "aaa"),
+            row("+I", 2, "ccc")
+        )
+    );
+
+    List<List<Record>> expectedRecords = ImmutableList.of(
+        ImmutableList.of(record(1, "bbb"), record(2, "aaa")),
+        ImmutableList.of(record(1, "aaa"), record(1, "bbb"), record(1, "ccc")),
+        ImmutableList.of(record(1, "aaa"), record(1, "ccc"), record(2, "aaa"), record(2, "ccc"))
+    );
+
+    testSqlChangeLog(ImmutableList.of("data"), row -> Row.of(row.getField(ROW_DATA_POS)), elementsPerCheckpoint,
+        expectedRecords);
+  }
+
+  @Test
+  public void testChangeLogOnIdDataKey() throws Exception {
+    List<List<Row>> elementsPerCheckpoint = ImmutableList.of(
+        ImmutableList.of(
+            row("+I", 1, "aaa"),
+            row("-D", 1, "aaa"),
+            row("+I", 2, "bbb"),
+            row("+I", 1, "bbb"),
+            row("+I", 2, "aaa")
+        ),
+        ImmutableList.of(
+            row("-U", 2, "aaa"),
+            row("+U", 1, "ccc"),
+            row("+I", 1, "aaa")
+        ),
+        ImmutableList.of(
+            row("-D", 1, "bbb"),
+            row("+I", 2, "aaa")
+        )
+    );
+
+    List<List<Record>> expectedRecords = ImmutableList.of(
+        ImmutableList.of(record(1, "bbb"), record(2, "aaa"), record(2, "bbb")),
+        ImmutableList.of(record(1, "aaa"), record(1, "bbb"), record(1, "ccc"), record(2, "bbb")),
+        ImmutableList.of(record(1, "aaa"), record(1, "ccc"), record(2, "aaa"), record(2, "bbb"))
+    );
+
+    testSqlChangeLog(ImmutableList.of("data", "id"),
+        row -> Row.of(row.getField(ROW_ID_POS), row.getField(ROW_DATA_POS)),
+        elementsPerCheckpoint, expectedRecords);
+  }
+
+  @Test
+  public void testPureInsertOnIdKey() throws Exception {
+    List<List<Row>> elementsPerCheckpoint = ImmutableList.of(
+        ImmutableList.of(
+            row("+I", 1, "aaa"),
+            row("+I", 2, "bbb")
+        ),
+        ImmutableList.of(
+            row("+I", 3, "ccc"),
+            row("+I", 4, "ddd")
+        ),
+        ImmutableList.of(
+            row("+I", 5, "eee"),
+            row("+I", 6, "fff")
+        )
+    );
+
+    List<List<Record>> expectedRecords = ImmutableList.of(
+        ImmutableList.of(
+            record(1, "aaa"),
+            record(2, "bbb")
+        ),
+        ImmutableList.of(
+            record(1, "aaa"),
+            record(2, "bbb"),
+            record(3, "ccc"),
+            record(4, "ddd")
+        ),
+        ImmutableList.of(
+            record(1, "aaa"),
+            record(2, "bbb"),
+            record(3, "ccc"),
+            record(4, "ddd"),
+            record(5, "eee"),
+            record(6, "fff")
+        )
+    );
+
+    testSqlChangeLog(ImmutableList.of("data"), row -> Row.of(row.getField(ROW_DATA_POS)), elementsPerCheckpoint,
+        expectedRecords);
+  }
+
   private static Row row(String rowKind, int id, String data) {
     return SimpleDataUtil.createRow(rowKind, id, data);
   }
@@ -119,50 +272,62 @@ public class TestFlinkTableSinkV2 extends FlinkCatalogTestBase {
     return SimpleDataUtil.createRecord(id, data);
   }
 
-  @Test
-  public void testCase() throws Exception {
-    sql("CREATE TABLE %s (id INT, data VARCHAR, PRIMARY KEY(id) NOT ENFORCED) WITH %s",
-        TABLE_NAME_V2, toWithClause(tableProps));
-    Table table = validationCatalog.loadTable(TableIdentifier.of(icebergNamespace, TABLE_NAME_V2));
+  private void testSqlChangeLog(List<String> equalityColumns,
+                                KeySelector<Row, Row> keySelector,
+                                List<List<Row>> inputRowsPerCheckpoint,
+                                List<List<Record>> expectedRecordsPerCheckpoint) throws Exception {
+    String partitionByCause = partitioned ? "PARTITIONED BY (data)" : "";
+    sql("CREATE TABLE %s (id INT, data VARCHAR, PRIMARY KEY(%s) NOT ENFORCED) %s WITH %s",
+        TABLE_NAME_V2,
+        StringUtils.join(equalityColumns, ","),
+        partitionByCause,
+        toWithClause(tableProps));
 
     TableSchema flinkSchema = TableSchema.builder()
         .field("id", DataTypes.INT().notNull())
         .field("data", DataTypes.STRING().notNull())
-        .primaryKey("id")
+        .primaryKey(equalityColumns.toArray(new String[0]))
         .build();
     RowType rowType = (RowType) flinkSchema.toRowDataType().getLogicalType();
+    DataFormatConverters.RowConverter mapper = new DataFormatConverters.RowConverter(flinkSchema.getFieldDataTypes());
 
-    DataStream<RowData> inputStream = env.addSource(new BoundedTestSource<>(
-            row("+I", 1, "aaa"),
-            row("-D", 1, "aaa"),
-            row("+I", 1, "bbb"),
-            row("+I", 2, "bbb"),
-            row("-U", 2, "bbb"),
-            row("+U", 2, "ccc")
-        ),
-        new RowTypeInfo(flinkSchema.getFieldTypes()))
-        .keyBy(row -> row.getField(0))
-        .map(new DataFormatConverters.RowConverter(flinkSchema.getFieldDataTypes())::toInternal,
-            RowDataTypeInfo.of(rowType));
+    DataStream<RowData> inputStream =
+        env.addSource(new BoundedTestSource<>(inputRowsPerCheckpoint), new RowTypeInfo(flinkSchema.getFieldTypes()))
+            .keyBy(keySelector) // Shuffle by key so that different version of same key could be in the correct order.
+            .map(mapper::toInternal, RowDataTypeInfo.of(rowType));
 
     tEnv.createTemporaryView("source_change_logs", tEnv.fromDataStream(inputStream));
 
     sql("INSERT INTO %s SELECT * FROM source_change_logs", TABLE_NAME_V2);
 
-    List<Record> expectedRecords = ImmutableList.of(
-        record(1, "bbb"),
-        record(2, "ccc")
-    );
+    Table table = validationCatalog.loadTable(TableIdentifier.of(icebergNamespace, TABLE_NAME_V2));
+    List<Snapshot> snapshots = findValidSnapshots(table);
+    int expectedSnapshotNum = expectedRecordsPerCheckpoint.size();
+    Assert.assertEquals("Should have the expected snapshot number", expectedSnapshotNum, snapshots.size());
 
-    Assert.assertEquals("Should have the expected records", expectedRowSet(table, expectedRecords),
-        actualRowSet(table, "*"));
+    for (int i = 0; i < expectedSnapshotNum; i++) {
+      long snapshotId = snapshots.get(i).snapshotId();
+      List<Record> expectedRecords = expectedRecordsPerCheckpoint.get(i);
+      Assert.assertEquals("Should have the expected records for the checkpoint#" + i,
+          expectedRowSet(table, expectedRecords), actualRowSet(table, snapshotId, "*"));
+    }
+  }
+
+  private List<Snapshot> findValidSnapshots(Table table) {
+    List<Snapshot> validSnapshots = Lists.newArrayList();
+    for (Snapshot snapshot : table.snapshots()) {
+      if (snapshot.allManifests().stream().anyMatch(m -> snapshot.snapshotId() == m.snapshotId())) {
+        validSnapshots.add(snapshot);
+      }
+    }
+    return validSnapshots;
   }
 
   private static StructLikeSet expectedRowSet(Table table, List<Record> records) {
     return SimpleDataUtil.expectedRowSet(table, records.toArray(new Record[0]));
   }
 
-  private static StructLikeSet actualRowSet(Table table, String... columns) throws IOException {
-    return SimpleDataUtil.actualRowSet(table, columns);
+  private static StructLikeSet actualRowSet(Table table, long snapshotId, String... columns) throws IOException {
+    return SimpleDataUtil.actualRowSet(table, snapshotId, columns);
   }
 }

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSinkV2.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSinkV2.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.util.DataFormatConverters;
+import org.apache.flink.table.runtime.typeutils.RowDataTypeInfo;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.Row;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.flink.source.BoundedTestSource;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.util.StructLikeSet;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestFlinkTableSinkV2 extends FlinkCatalogTestBase {
+  private static final String TABLE_NAME_V2 = "test_table_v2";
+
+  private final StreamExecutionEnvironment env;
+
+  private StreamTableEnvironment tEnv;
+  private Map<String, String> tableProps;
+
+  @Parameterized.Parameters(name = "catalogName={0}, format={1}")
+  public static Iterable<Object[]> parameters() {
+    return ImmutableList.of(
+        new Object[] {"testhive", "avro"},
+        new Object[] {"testhive", "parquet"},
+        new Object[] {"testhadoop", "avro"},
+        new Object[] {"testhadoop", "parquet"}
+    );
+  }
+
+  public TestFlinkTableSinkV2(String catalogName, String format) {
+    super(catalogName, new String[0]);
+
+    this.env = StreamExecutionEnvironment.getExecutionEnvironment()
+        .enableCheckpointing(400);
+    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+
+    this.tableProps = ImmutableMap.of(TableProperties.DEFAULT_FILE_FORMAT, format, TableProperties.FORMAT_VERSION, "2");
+  }
+
+  @Override
+  protected TableEnvironment getTableEnv() {
+    if (tEnv == null) {
+      synchronized (this) {
+        if (tEnv == null) {
+          tEnv = StreamTableEnvironment.create(env, EnvironmentSettings
+              .newInstance()
+              .useBlinkPlanner()
+              .inStreamingMode()
+              .build());
+        }
+      }
+    }
+    return tEnv;
+  }
+
+  @Before
+  public void before() {
+    super.before();
+    sql("CREATE DATABASE %s", flinkDatabase);
+    sql("USE CATALOG %s", catalogName);
+    sql("USE %s", DATABASE);
+  }
+
+  @After
+  public void clean() {
+    sql("DROP TABLE IF EXISTS %s.%s", flinkDatabase, TABLE_NAME_V2);
+    sql("DROP DATABASE IF EXISTS %s", flinkDatabase);
+    super.clean();
+  }
+
+  private static Row row(String rowKind, int id, String data) {
+    return SimpleDataUtil.createRow(rowKind, id, data);
+  }
+
+  private Record record(int id, String data) {
+    return SimpleDataUtil.createRecord(id, data);
+  }
+
+  @Test
+  public void testCase() throws Exception {
+    sql("CREATE TABLE %s (id INT, data VARCHAR, PRIMARY KEY(id) NOT ENFORCED) WITH %s",
+        TABLE_NAME_V2, toWithClause(tableProps));
+    Table table = validationCatalog.loadTable(TableIdentifier.of(icebergNamespace, TABLE_NAME_V2));
+
+    TableSchema flinkSchema = TableSchema.builder()
+        .field("id", DataTypes.INT().notNull())
+        .field("data", DataTypes.STRING().notNull())
+        .primaryKey("id")
+        .build();
+    RowType rowType = (RowType) flinkSchema.toRowDataType().getLogicalType();
+
+    DataStream<RowData> inputStream = env.addSource(new BoundedTestSource<>(
+            row("+I", 1, "aaa"),
+            row("-D", 1, "aaa"),
+            row("+I", 1, "bbb"),
+            row("+I", 2, "bbb"),
+            row("-U", 2, "bbb"),
+            row("+U", 2, "ccc")
+        ),
+        new RowTypeInfo(flinkSchema.getFieldTypes()))
+        .keyBy(row -> row.getField(0))
+        .map(new DataFormatConverters.RowConverter(flinkSchema.getFieldDataTypes())::toInternal,
+            RowDataTypeInfo.of(rowType));
+
+    tEnv.createTemporaryView("source_change_logs", tEnv.fromDataStream(inputStream));
+
+    sql("INSERT INTO %s SELECT * FROM source_change_logs", TABLE_NAME_V2);
+
+    List<Record> expectedRecords = ImmutableList.of(
+        record(1, "bbb"),
+        record(2, "ccc")
+    );
+
+    Assert.assertEquals("Should have the expected records", expectedRowSet(table, expectedRecords),
+        actualRowSet(table, "*"));
+  }
+
+  private static StructLikeSet expectedRowSet(Table table, List<Record> records) {
+    return SimpleDataUtil.expectedRowSet(table, records.toArray(new Record[0]));
+  }
+
+  private static StructLikeSet actualRowSet(Table table, String... columns) throws IOException {
+    return SimpleDataUtil.actualRowSet(table, columns);
+  }
+}

--- a/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
@@ -23,28 +23,23 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.types.Row;
-import org.apache.flink.types.RowKind;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableTestBase;
-import org.apache.iceberg.data.IcebergGenerics;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.flink.SimpleDataUtil;
 import org.apache.iceberg.flink.TestTableLoader;
 import org.apache.iceberg.flink.source.BoundedTestSource;
-import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.StructLikeSet;
 import org.junit.Assert;
@@ -304,14 +299,6 @@ public class TestFlinkIcebergSinkV2 extends TableTestBase {
   }
 
   private StructLikeSet actualRowSet(long snapshotId, String... columns) throws IOException {
-    table.refresh();
-    StructLikeSet set = StructLikeSet.create(table.schema().asStruct());
-    try (CloseableIterable<Record> reader = IcebergGenerics.read(table)
-        .useSnapshot(snapshotId)
-        .select(columns)
-        .build()) {
-      reader.forEach(set::add);
-    }
-    return set;
+    return SimpleDataUtil.actualRowSet(table, snapshotId, columns);
   }
 }

--- a/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
@@ -59,12 +59,6 @@ public class TestFlinkIcebergSinkV2 extends TableTestBase {
   private static final TypeInformation<Row> ROW_TYPE_INFO =
       new RowTypeInfo(SimpleDataUtil.FLINK_SCHEMA.getFieldTypes());
 
-  private static final Map<String, RowKind> ROW_KIND_MAP = ImmutableMap.of(
-      "+I", RowKind.INSERT,
-      "-D", RowKind.DELETE,
-      "-U", RowKind.UPDATE_BEFORE,
-      "+U", RowKind.UPDATE_AFTER);
-
   private static final int ROW_ID_POS = 0;
   private static final int ROW_DATA_POS = 1;
 
@@ -164,12 +158,7 @@ public class TestFlinkIcebergSinkV2 extends TableTestBase {
   }
 
   private Row row(String rowKind, int id, String data) {
-    RowKind kind = ROW_KIND_MAP.get(rowKind);
-    if (kind == null) {
-      throw new IllegalArgumentException("Unknown row kind: " + rowKind);
-    }
-
-    return Row.ofKind(kind, id, data);
+    return SimpleDataUtil.createRow(rowKind, id, data);
   }
 
   private Record record(int id, String data) {


### PR DESCRIPTION
To verify that flink sql could write cdc/upsert events to iceberg table correctly,  I made few changes to let it work: 

1.  Mapping the flink `CREATE TABLE` DDL's primary key to iceberg's equality field columns, that means when creating a flink table with primary key,  it will create an iceberg table with the `equality.field.columns` properties indicating which columns are  equality columns.   Apache Flink does not support altering primary key in DDL,  so we don't support alter equality field columns in SQL, will need to use the iceberg java API to accomplish schema evolution. 

2.  I exposed the iceberg format v2 to end users in this patch because I found that the iceberg catalog has no way to share the `TableTestBase`.   It's not the correct time to expose format v2, so I will try to find another way to make the unit tests work. 

3. Provide a basic unit test to verify the sql job work,  it will need more work to add more unit tests,  still in-progress.