### PR TITLE
Fix date and timestamp transforms

### DIFF
--- a/api/src/main/java/org/apache/iceberg/transforms/Dates.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Dates.java
@@ -20,7 +20,7 @@
 package org.apache.iceberg.transforms;
 
 import java.time.Instant;
-import java.time.OffsetDateTime;
+import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import org.apache.iceberg.expressions.BoundPredicate;
@@ -36,7 +36,7 @@ enum Dates implements Transform<Integer, Integer> {
   MONTH(ChronoUnit.MONTHS, "month"),
   DAY(ChronoUnit.DAYS, "day");
 
-  private static final OffsetDateTime EPOCH = Instant.ofEpochSecond(0).atOffset(ZoneOffset.UTC);
+  private static final LocalDate EPOCH = Instant.ofEpochSecond(0).atOffset(ZoneOffset.UTC).toLocalDate();
   private final ChronoUnit granularity;
   private final String name;
 
@@ -55,7 +55,15 @@ enum Dates implements Transform<Integer, Integer> {
       return days;
     }
 
-    return (int) granularity.between(EPOCH, EPOCH.plusDays(days));
+    if (days >= 0) {
+      LocalDate date = EPOCH.plusDays(days);
+      return (int) granularity.between(EPOCH, date);
+    } else {
+      // add 1 day to the value to account for the case where there is exactly 1 unit between the date and epoch
+      // because the result will always be decremented.
+      LocalDate date = EPOCH.plusDays(days + 1);
+      return (int) granularity.between(EPOCH, date) - 1;
+    }
   }
 
   @Override
@@ -99,11 +107,24 @@ enum Dates implements Transform<Integer, Integer> {
 
     if (pred.isUnaryPredicate()) {
       return Expressions.predicate(pred.op(), fieldName);
+
     } else if (pred.isLiteralPredicate()) {
-      return ProjectionUtil.truncateInteger(fieldName, pred.asLiteralPredicate(), this);
+      UnboundPredicate<Integer> projected = ProjectionUtil.truncateInteger(fieldName, pred.asLiteralPredicate(), this);
+      if (this != DAY) {
+        return ProjectionUtil.fixInclusiveTimeProjection(projected);
+      }
+
+      return projected;
+
     } else if (pred.isSetPredicate() && pred.op() == Expression.Operation.IN) {
-      return ProjectionUtil.transformSet(fieldName, pred.asSetPredicate(), this);
+      UnboundPredicate<Integer> projected = ProjectionUtil.transformSet(fieldName, pred.asSetPredicate(), this);
+      if (this != DAY) {
+        return ProjectionUtil.fixInclusiveTimeProjection(projected);
+      }
+
+      return projected;
     }
+
     return null;
   }
 
@@ -115,11 +136,25 @@ enum Dates implements Transform<Integer, Integer> {
 
     if (pred.isUnaryPredicate()) {
       return Expressions.predicate(pred.op(), fieldName);
+
     } else if (pred.isLiteralPredicate()) {
-      return ProjectionUtil.truncateIntegerStrict(fieldName, pred.asLiteralPredicate(), this);
+      UnboundPredicate<Integer> projected = ProjectionUtil.truncateIntegerStrict(
+          fieldName, pred.asLiteralPredicate(), this);
+      if (this != DAY) {
+        return ProjectionUtil.fixStrictTimeProjection(projected);
+      }
+
+      return projected;
+
     } else if (pred.isSetPredicate() && pred.op() == Expression.Operation.NOT_IN) {
-      return ProjectionUtil.transformSet(fieldName, pred.asSetPredicate(), this);
+      UnboundPredicate<Integer> projected = ProjectionUtil.transformSet(fieldName, pred.asSetPredicate(), this);
+      if (this != DAY) {
+        return ProjectionUtil.fixStrictTimeProjection(projected);
+      }
+
+      return projected;
     }
+
     return null;
   }
 

--- a/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
@@ -258,6 +258,15 @@ class ProjectionUtil {
         Iterables.transform(predicate.asSetPredicate().literalSet(), transform::apply));
   }
 
+  /**
+   * Fixes an inclusive projection to account for incorrectly transformed values.
+   * <p>
+   * A bug in 0.10.0 and earlier caused negative values to be incorrectly transformed by date and timestamp transforms
+   * to 1 larger than the correct value. For example, day(1969-12-31 10:00:00) produced 0 instead of -1. To read data
+   * written by versions with this bug, this method adjusts the inclusive projection. The current inclusive projection
+   * is correct, so this modifies the "correct" projection when needed. For example, < day(1969-12-31 10:00:00) will
+   * produce <= -1 (= 1969-12-31) and is adjusted to <= 0 (= 1969-01-01) because the incorrect transformed value was 0.
+   */
   static UnboundPredicate<Integer> fixInclusiveTimeProjection(UnboundPredicate<Integer> projected) {
     if (projected == null) {
       return projected;
@@ -320,6 +329,13 @@ class ProjectionUtil {
     }
   }
 
+  /**
+   * Fixes a strict projection to account for incorrectly transformed values.
+   * <p>
+   * A bug in 0.10.0 and earlier caused negative values to be incorrectly transformed by date and timestamp transforms
+   * to 1 larger than the correct value. For example, day(1969-12-31 10:00:00) produced 0 instead of -1. To read data
+   * written by versions with this bug, this method adjusts the strict projection.
+   */
   static UnboundPredicate<Integer> fixStrictTimeProjection(UnboundPredicate<Integer> projected) {
     if (projected == null) {
       return null;

--- a/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
@@ -344,13 +344,7 @@ class ProjectionUtil {
     switch (projected.op()) {
       case LT:
       case LT_EQ:
-        if (projected.literal().value() <= 0) {
-          // LT and LT_EQ cannot be fixed because adjusting the strict projection may include values that were not
-          // written incorrectly. for example, if the correct strict projection is x < 5, adjusting to produce x < 6
-          // cannot guarantee that all values match the original predicate
-          return null;
-        }
-
+        // the correct bound is a correct strict projection for the incorrectly transformed values.
         return projected;
 
       case GT:

--- a/api/src/main/java/org/apache/iceberg/transforms/Timestamps.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Timestamps.java
@@ -54,14 +54,18 @@ enum Timestamps implements Transform<Long, Integer> {
 
     if (timestampMicros >= 0) {
       OffsetDateTime timestamp = Instant
-          .ofEpochSecond(Math.floorDiv(timestampMicros, 1_000_000), Math.floorMod(timestampMicros, 1_000_000))
+          .ofEpochSecond(
+              Math.floorDiv(timestampMicros, 1_000_000),
+              Math.floorMod(timestampMicros, 1_000_000) * 1000)
           .atOffset(ZoneOffset.UTC);
       return (int) granularity.between(EPOCH, timestamp);
     } else {
       // add 1 micro to the value to account for the case where there is exactly 1 unit between the timestamp and epoch
       // because the result will always be decremented.
       OffsetDateTime timestamp = Instant
-          .ofEpochSecond(Math.floorDiv(timestampMicros, 1_000_000), Math.floorMod(timestampMicros + 1, 1_000_000))
+          .ofEpochSecond(
+              Math.floorDiv(timestampMicros, 1_000_000),
+              Math.floorMod(timestampMicros + 1, 1_000_000) * 1000)
           .atOffset(ZoneOffset.UTC);
       return (int) granularity.between(EPOCH, timestamp) - 1;
     }

--- a/api/src/main/java/org/apache/iceberg/transforms/Timestamps.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Timestamps.java
@@ -52,12 +52,19 @@ enum Timestamps implements Transform<Long, Integer> {
       return null;
     }
 
-    // discards fractional seconds, not needed for calculation
-    OffsetDateTime timestamp = Instant
-        .ofEpochSecond(timestampMicros / 1_000_000)
-        .atOffset(ZoneOffset.UTC);
-
-    return (int) granularity.between(EPOCH, timestamp);
+    if (timestampMicros >= 0) {
+      OffsetDateTime timestamp = Instant
+          .ofEpochSecond(Math.floorDiv(timestampMicros, 1_000_000), Math.floorMod(timestampMicros, 1_000_000))
+          .atOffset(ZoneOffset.UTC);
+      return (int) granularity.between(EPOCH, timestamp);
+    } else {
+      // add 1 micro to the value to account for the case where there is exactly 1 unit between the timestamp and epoch
+      // because the result will always be decremented.
+      OffsetDateTime timestamp = Instant
+          .ofEpochSecond(Math.floorDiv(timestampMicros, 1_000_000), Math.floorMod(timestampMicros + 1, 1_000_000))
+          .atOffset(ZoneOffset.UTC);
+      return (int) granularity.between(EPOCH, timestamp) - 1;
+    }
   }
 
   @Override
@@ -101,11 +108,16 @@ enum Timestamps implements Transform<Long, Integer> {
 
     if (pred.isUnaryPredicate()) {
       return Expressions.predicate(pred.op(), fieldName);
+
     } else if (pred.isLiteralPredicate()) {
-      return ProjectionUtil.truncateLong(fieldName, pred.asLiteralPredicate(), this);
+      UnboundPredicate<Integer> projected = ProjectionUtil.truncateLong(fieldName, pred.asLiteralPredicate(), this);
+      return ProjectionUtil.fixInclusiveTimeProjection(projected);
+
     } else if (pred.isSetPredicate() && pred.op() == Expression.Operation.IN) {
-      return ProjectionUtil.transformSet(fieldName, pred.asSetPredicate(), this);
+      UnboundPredicate<Integer> projected = ProjectionUtil.transformSet(fieldName, pred.asSetPredicate(), this);
+      return ProjectionUtil.fixInclusiveTimeProjection(projected);
     }
+
     return null;
   }
 
@@ -117,11 +129,17 @@ enum Timestamps implements Transform<Long, Integer> {
 
     if (pred.isUnaryPredicate()) {
       return Expressions.predicate(pred.op(), fieldName);
+
     } else if (pred.isLiteralPredicate()) {
-      return ProjectionUtil.truncateLongStrict(fieldName, pred.asLiteralPredicate(), this);
+      UnboundPredicate<Integer> projected = ProjectionUtil.truncateLongStrict(
+          fieldName, pred.asLiteralPredicate(), this);
+      return ProjectionUtil.fixStrictTimeProjection(projected);
+
     } else if (pred.isSetPredicate() && pred.op() == Expression.Operation.NOT_IN) {
-      return ProjectionUtil.transformSet(fieldName, pred.asSetPredicate(), this);
+      UnboundPredicate<Integer> projected = ProjectionUtil.transformSet(fieldName, pred.asSetPredicate(), this);
+      return ProjectionUtil.fixStrictTimeProjection(projected);
     }
+
     return null;
   }
 

--- a/api/src/main/java/org/apache/iceberg/transforms/TransformUtil.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/TransformUtil.java
@@ -41,7 +41,8 @@ class TransformUtil {
   }
 
   static String humanMonth(int monthOrdinal) {
-    return String.format("%04d-%02d", EPOCH_YEAR + (monthOrdinal / 12), 1 + (monthOrdinal % 12));
+    return String.format("%04d-%02d",
+        EPOCH_YEAR + Math.floorDiv(monthOrdinal, 12), 1 + Math.floorMod(monthOrdinal, 12));
   }
 
   static String humanDay(int dayOrdinal) {

--- a/api/src/test/java/org/apache/iceberg/expressions/TestStringLiteralConversions.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestStringLiteralConversions.java
@@ -58,6 +58,22 @@ public class TestStringLiteralConversions {
   }
 
   @Test
+  public void testNegativeStringToDateLiteral() {
+    Literal<CharSequence> dateStr = Literal.of("1969-12-30");
+    Literal<Integer> date = dateStr.to(Types.DateType.get());
+
+    // use Avro's date conversion to validate the result
+    Schema avroSchema = LogicalTypes.date().addToSchema(Schema.create(Schema.Type.INT));
+    TimeConversions.DateConversion avroConversion = new TimeConversions.DateConversion();
+    int avroValue = avroConversion.toInt(
+        LocalDate.of(1969, 12, 30),
+        avroSchema, avroSchema.getLogicalType());
+
+    Assert.assertEquals("Date should be -2", -2, (int) date.value());
+    Assert.assertEquals("Date should match", avroValue, (int) date.value());
+  }
+
+  @Test
   public void testStringToTimeLiteral() {
     // use Avro's time conversion to validate the result
     Schema avroSchema = LogicalTypes.timeMicros().addToSchema(Schema.create(Schema.Type.LONG));
@@ -104,6 +120,43 @@ public class TestStringLiteralConversions {
 
     Assert.assertEquals("Timestamp without zone should match UTC",
         avroValue, (long) timestamp.value());
+  }
+
+  @Test
+  public void testNegativeStringToTimestampLiteral() {
+    // use Avro's timestamp conversion to validate the result
+    Schema avroSchema = LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG));
+    TimeConversions.TimestampMicrosConversion avroConversion =
+        new TimeConversions.TimestampMicrosConversion();
+
+    // Timestamp with explicit UTC offset, +00:00
+    Literal<CharSequence> timestampStr = Literal.of("1969-12-31T23:59:58.999999+00:00");
+    Literal<Long> timestamp = timestampStr.to(Types.TimestampType.withZone());
+    long avroValue = avroConversion.toLong(
+        LocalDateTime.of(1969, 12, 31, 23, 59, 58, 999999 * 1_000).toInstant(ZoneOffset.UTC),
+        avroSchema, avroSchema.getLogicalType());
+
+    Assert.assertEquals("Timestamp should match", avroValue, (long) timestamp.value());
+    Assert.assertEquals("Timestamp should be -1_000_001", -1_000_001, (long) timestamp.value());
+
+    // Timestamp without an explicit zone should be UTC (equal to the previous converted value)
+    timestampStr = Literal.of("1969-12-31T23:59:58.999999");
+    timestamp = timestampStr.to(Types.TimestampType.withoutZone());
+
+    Assert.assertEquals("Timestamp without zone should match UTC",
+        avroValue, (long) timestamp.value());
+
+    // Timestamp with an explicit offset should be adjusted to UTC
+    timestampStr = Literal.of("1969-12-31T16:59:58.999999-07:00");
+    timestamp = timestampStr.to(Types.TimestampType.withZone());
+    avroValue = avroConversion.toLong(
+        LocalDateTime.of(1969, 12, 31, 23, 59, 58, 999999 * 1_000).toInstant(ZoneOffset.UTC),
+        avroSchema, avroSchema.getLogicalType());
+
+    Assert.assertEquals("Timestamp without zone should match UTC",
+        avroValue, (long) timestamp.value());
+    Assert.assertEquals("Timestamp without zone should be -1_000_001", -1_000_001, (long) timestamp.value());
+
   }
 
   @Test(expected = DateTimeException.class)

--- a/api/src/test/java/org/apache/iceberg/transforms/TestDates.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestDates.java
@@ -29,22 +29,22 @@ public class TestDates {
   @Test
   public void testDateTransform() {
     Types.DateType type = Types.DateType.get();
-    Literal<Integer> d = Literal.of("2017-12-01").to(type);
+    Literal<Integer> date = Literal.of("2017-12-01").to(type);
     Literal<Integer> pd = Literal.of("1970-01-01").to(type);
     Literal<Integer> nd = Literal.of("1969-12-31").to(type);
 
     Transform<Integer, Integer> years = Transforms.year(type);
-    Assert.assertEquals("Should produce 2017 - 1970 = 47", 47, (int) years.apply(d.value()));
+    Assert.assertEquals("Should produce 2017 - 1970 = 47", 47, (int) years.apply(date.value()));
     Assert.assertEquals("Should produce 1970 - 1970 = 0", 0, (int) years.apply(pd.value()));
     Assert.assertEquals("Should produce 1969 - 1970 = -1", -1, (int) years.apply(nd.value()));
 
     Transform<Integer, Integer> months = Transforms.month(type);
-    Assert.assertEquals("Should produce 47 * 12 + 11 = 575", 575, (int) months.apply(d.value()));
+    Assert.assertEquals("Should produce 47 * 12 + 11 = 575", 575, (int) months.apply(date.value()));
     Assert.assertEquals("Should produce 0 * 12 + 0 = 0", 0, (int) months.apply(pd.value()));
     Assert.assertEquals("Should produce -1", -1, (int) months.apply(nd.value()));
 
     Transform<Integer, Integer> days = Transforms.day(type);
-    Assert.assertEquals("Should produce 17501", 17501, (int) days.apply(d.value()));
+    Assert.assertEquals("Should produce 17501", 17501, (int) days.apply(date.value()));
     Assert.assertEquals("Should produce 0 * 365 + 0 = 0", 0, (int) days.apply(pd.value()));
     Assert.assertEquals("Should produce -1", -1, (int) days.apply(nd.value()));
   }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestDates.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestDates.java
@@ -27,6 +27,29 @@ import org.junit.Test;
 
 public class TestDates {
   @Test
+  public void testDateTransform() {
+    Types.DateType type = Types.DateType.get();
+    Literal<Integer> d = Literal.of("2017-12-01").to(type);
+    Literal<Integer> pd = Literal.of("1970-01-01").to(type);
+    Literal<Integer> nd = Literal.of("1969-12-31").to(type);
+
+    Transform<Integer, Integer> years = Transforms.year(type);
+    Assert.assertEquals("Should produce 2017 - 1970 = 47", 47, (int) years.apply(d.value()));
+    Assert.assertEquals("Should produce 1970 - 1970 = 0", 0, (int) years.apply(pd.value()));
+    Assert.assertEquals("Should produce 1969 - 1970 = -1", -1, (int) years.apply(nd.value()));
+
+    Transform<Integer, Integer> months = Transforms.month(type);
+    Assert.assertEquals("Should produce 47 * 12 + 11 = 575", 575, (int) months.apply(d.value()));
+    Assert.assertEquals("Should produce 0 * 12 + 0 = 0", 0, (int) months.apply(pd.value()));
+    Assert.assertEquals("Should produce -1", -1, (int) months.apply(nd.value()));
+
+    Transform<Integer, Integer> days = Transforms.day(type);
+    Assert.assertEquals("Should produce 17501", 17501, (int) days.apply(d.value()));
+    Assert.assertEquals("Should produce 0 * 365 + 0 = 0", 0, (int) days.apply(pd.value()));
+    Assert.assertEquals("Should produce -1", -1, (int) days.apply(nd.value()));
+  }
+
+  @Test
   public void testDateToHumanString() {
     Types.DateType type = Types.DateType.get();
     Literal<Integer> date = Literal.of("2017-12-01").to(type);
@@ -42,6 +65,78 @@ public class TestDates {
     Transform<Integer, Integer> day = Transforms.day(type);
     Assert.assertEquals("Should produce the correct Human string",
         "2017-12-01", day.toHumanString(day.apply(date.value())));
+  }
+
+  @Test
+  public void testNegativeDateToHumanString() {
+    Types.DateType type = Types.DateType.get();
+    Literal<Integer> date = Literal.of("1969-12-30").to(type);
+
+    Transform<Integer, Integer> year = Transforms.year(type);
+    Assert.assertEquals("Should produce the correct Human string",
+        "1969", year.toHumanString(year.apply(date.value())));
+
+    Transform<Integer, Integer> month = Transforms.month(type);
+    Assert.assertEquals("Should produce the correct Human string",
+        "1969-12", month.toHumanString(month.apply(date.value())));
+
+    Transform<Integer, Integer> day = Transforms.day(type);
+    Assert.assertEquals("Should produce the correct Human string",
+        "1969-12-30", day.toHumanString(day.apply(date.value())));
+  }
+
+  @Test
+  public void testDateToHumanStringLowerBound() {
+    Types.DateType type = Types.DateType.get();
+    Literal<Integer> date = Literal.of("1970-01-01").to(type);
+
+    Transform<Integer, Integer> year = Transforms.year(type);
+    Assert.assertEquals("Should produce the correct Human string",
+        "1970", year.toHumanString(year.apply(date.value())));
+
+    Transform<Integer, Integer> month = Transforms.month(type);
+    Assert.assertEquals("Should produce the correct Human string",
+        "1970-01", month.toHumanString(month.apply(date.value())));
+
+    Transform<Integer, Integer> day = Transforms.day(type);
+    Assert.assertEquals("Should produce the correct Human string",
+        "1970-01-01", day.toHumanString(day.apply(date.value())));
+  }
+
+  @Test
+  public void testNegativeDateToHumanStringLowerBound() {
+    Types.DateType type = Types.DateType.get();
+    Literal<Integer> date = Literal.of("1969-01-01").to(type);
+
+    Transform<Integer, Integer> year = Transforms.year(type);
+    Assert.assertEquals("Should produce the correct Human string",
+        "1969", year.toHumanString(year.apply(date.value())));
+
+    Transform<Integer, Integer> month = Transforms.month(type);
+    Assert.assertEquals("Should produce the correct Human string",
+        "1969-01", month.toHumanString(month.apply(date.value())));
+
+    Transform<Integer, Integer> day = Transforms.day(type);
+    Assert.assertEquals("Should produce the correct Human string",
+        "1969-01-01", day.toHumanString(day.apply(date.value())));
+  }
+
+  @Test
+  public void testNegativeDateToHumanStringUpperBound() {
+    Types.DateType type = Types.DateType.get();
+    Literal<Integer> date = Literal.of("1969-12-31").to(type);
+
+    Transform<Integer, Integer> year = Transforms.year(type);
+    Assert.assertEquals("Should produce the correct Human string",
+        "1969", year.toHumanString(year.apply(date.value())));
+
+    Transform<Integer, Integer> month = Transforms.month(type);
+    Assert.assertEquals("Should produce the correct Human string",
+        "1969-12", month.toHumanString(month.apply(date.value())));
+
+    Transform<Integer, Integer> day = Transforms.day(type);
+    Assert.assertEquals("Should produce the correct Human string",
+        "1969-12-31", day.toHumanString(day.apply(date.value())));
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
@@ -111,9 +111,8 @@ public class TestDatesProjection {
     Integer date = (Integer) Literal.of("1970-01-01").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("date").build();
 
-    // the boundary cannot be projected because fixing strict projection must fix cases where value + 1 = 0
-    assertProjectionStrictValue(spec, lessThan("date", date), Expression.Operation.FALSE);
-    assertProjectionStrictValue(spec, lessThanOrEqual("date", date), Expression.Operation.FALSE);
+    assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT, "1970-01");
+    assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT, "1970-01");
     assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT, "1970-02");
     assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT, "1970-01");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "1970-01");
@@ -166,8 +165,8 @@ public class TestDatesProjection {
     Integer date = (Integer) Literal.of("1969-01-01").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("date").build();
 
-    assertProjectionStrictValue(spec, lessThan("date", date), Expression.Operation.FALSE);
-    assertProjectionStrictValue(spec, lessThanOrEqual("date", date), Expression.Operation.FALSE);
+    assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT, "1969-01");
+    assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT, "1969-01");
     assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT, "1969-02");
     assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT, "1969-01");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_IN, "[1969-01, 1969-02]");
@@ -202,8 +201,8 @@ public class TestDatesProjection {
     Integer date = (Integer) Literal.of("1969-12-31").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("date").build();
 
-    assertProjectionStrictValue(spec, lessThan("date", date), Expression.Operation.FALSE);
-    assertProjectionStrictValue(spec, lessThanOrEqual("date", date), Expression.Operation.FALSE);
+    assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT, "1969-12");
+    assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT, "1970-01");
     assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT, "1970-01");
     assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT, "1970-01");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_IN, "[1969-12, 1970-01]");
@@ -386,9 +385,8 @@ public class TestDatesProjection {
     Integer date = (Integer) Literal.of("1970-01-01").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("date").build();
 
-    // the boundary cannot be projected because fixing strict projection must fix cases where value + 1 = 0
-    assertProjectionStrictValue(spec, lessThan("date", date), Expression.Operation.FALSE);
-    assertProjectionStrictValue(spec, lessThanOrEqual("date", date), Expression.Operation.FALSE);
+    assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT, "1970");
+    assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT, "1970");
     assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT, "1971");
     assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT, "1970");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "1970");
@@ -423,8 +421,8 @@ public class TestDatesProjection {
     Integer date = (Integer) Literal.of("1969-12-31").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("date").build();
 
-    assertProjectionStrictValue(spec, lessThan("date", date), Expression.Operation.FALSE);
-    assertProjectionStrictValue(spec, lessThanOrEqual("date", date), Expression.Operation.FALSE);
+    assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT, "1969");
+    assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT, "1970");
     assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT, "1970");
     assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT, "1970");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_IN, "[1969, 1970]");

--- a/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
@@ -74,14 +74,14 @@ public class TestDatesProjection {
                                           Expression.Operation expectedOp) {
 
     Expression projection = Projections.strict(spec).project(filter);
-    Assert.assertEquals(projection.op(), expectedOp);
+    Assert.assertEquals(expectedOp, projection.op());
   }
 
   public void assertProjectionInclusiveValue(PartitionSpec spec, UnboundPredicate<?> filter,
                                              Expression.Operation expectedOp) {
 
     Expression projection = Projections.inclusive(spec).project(filter);
-    Assert.assertEquals(projection.op(), expectedOp);
+    Assert.assertEquals(expectedOp, projection.op());
   }
 
   public void assertProjectionInclusive(PartitionSpec spec, UnboundPredicate<?> filter,
@@ -89,7 +89,7 @@ public class TestDatesProjection {
     Expression projection = Projections.inclusive(spec).project(filter);
     UnboundPredicate<?> predicate = assertAndUnwrapUnbound(projection);
 
-    Assert.assertEquals(predicate.op(), expectedOp);
+    Assert.assertEquals(expectedOp, predicate.op());
 
     Assert.assertNotEquals("Inclusive projection never runs for NOT_IN", Expression.Operation.NOT_IN, predicate.op());
 
@@ -125,6 +125,25 @@ public class TestDatesProjection {
   }
 
   @Test
+  public void testNegativeMonthStrictLowerBound() {
+    Integer date = (Integer) Literal.of("1970-01-01").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("date").build();
+
+    // the boundary cannot be projected because fixing strict projection must fix cases where value + 1 = 0
+    assertProjectionStrictValue(spec, lessThan("date", date), Expression.Operation.FALSE);
+    assertProjectionStrictValue(spec, lessThanOrEqual("date", date), Expression.Operation.FALSE);
+    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT, "1970-01");
+    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT, "1969-12");
+    assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "1970-01");
+    assertProjectionStrictValue(spec, equal("date", date), Expression.Operation.FALSE);
+
+    Integer anotherDate = (Integer) Literal.of("1969-12-31").to(TYPE).value();
+    assertProjectionStrict(spec, notIn("date", date, anotherDate),
+        Expression.Operation.NOT_IN, "[1969-12, 1970-01]");
+    assertProjectionStrictValue(spec, in("date", date, anotherDate), Expression.Operation.FALSE);
+  }
+
+  @Test
   public void testMonthStrictUpperBound() {
     Integer date = (Integer) Literal.of("2017-12-31").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("date").build();
@@ -140,6 +159,24 @@ public class TestDatesProjection {
     assertProjectionStrict(spec, notIn("date", anotherDate, date),
         Expression.Operation.NOT_IN, "[2017-01, 2017-12]");
     assertProjectionStrictValue(spec, in("date", anotherDate, date), Expression.Operation.FALSE);
+  }
+
+  @Test
+  public void testNegativeMonthStrictUpperBound() {
+    Integer date = (Integer) Literal.of("1969-12-31").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("date").build();
+
+    assertProjectionStrictValue(spec, lessThan("date", date), Expression.Operation.FALSE);
+    assertProjectionStrictValue(spec, lessThanOrEqual("date", date), Expression.Operation.FALSE);
+    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT, "1969-12");
+    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT, "1969-12");
+    assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_IN, "[1969-12, 1970-01]");
+    assertProjectionStrictValue(spec, equal("date", date), Expression.Operation.FALSE);
+
+    Integer anotherDate = (Integer) Literal.of("1970-01-01").to(TYPE).value();
+    assertProjectionStrict(spec, notIn("date", date, anotherDate),
+        Expression.Operation.NOT_IN, "[1969-12, 1970-01]");
+    assertProjectionStrictValue(spec, in("date", date, anotherDate), Expression.Operation.FALSE);
   }
 
   @Test
@@ -161,6 +198,24 @@ public class TestDatesProjection {
   }
 
   @Test
+  public void testNegativeMonthInclusiveLowerBound() {
+    Integer date = (Integer) Literal.of("1970-01-01").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("date").build();
+
+    assertProjectionInclusive(spec, lessThan("date", date), Expression.Operation.LT_EQ, "1970-01");
+    assertProjectionInclusive(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "1970-01");
+    assertProjectionInclusive(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "1970-01");
+    assertProjectionInclusive(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "1970-01");
+    assertProjectionInclusive(spec, equal("date", date), Expression.Operation.EQ, "1970-01");
+    assertProjectionInclusiveValue(spec, notEqual("date", date), Expression.Operation.TRUE);
+
+    Integer anotherDate = (Integer) Literal.of("1969-12-31").to(TYPE).value();
+    assertProjectionInclusive(spec, in("date", date, anotherDate),
+        Expression.Operation.IN, "[1969-12, 1970-01]");
+    assertProjectionInclusiveValue(spec, notIn("date", date, anotherDate), Expression.Operation.TRUE);
+  }
+
+  @Test
   public void testMonthInclusiveUpperBound() {
     Integer date = (Integer) Literal.of("2017-12-31").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("date").build();
@@ -175,6 +230,24 @@ public class TestDatesProjection {
     Integer anotherDate = (Integer) Literal.of("2017-01-01").to(TYPE).value();
     assertProjectionInclusive(spec, in("date", date, anotherDate),
         Expression.Operation.IN, "[2017-01, 2017-12]");
+    assertProjectionInclusiveValue(spec, notIn("date", date, anotherDate), Expression.Operation.TRUE);
+  }
+
+  @Test
+  public void testNegativeMonthInclusiveUpperBound() {
+    Integer date = (Integer) Literal.of("1969-12-31").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("date").build();
+
+    assertProjectionInclusive(spec, lessThan("date", date), Expression.Operation.LT_EQ, "1970-01");
+    assertProjectionInclusive(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "1970-01");
+    assertProjectionInclusive(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "1970-01");
+    assertProjectionInclusive(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "1969-12");
+    assertProjectionInclusive(spec, equal("date", date), Expression.Operation.IN, "[1969-12, 1970-01]");
+    assertProjectionInclusiveValue(spec, notEqual("date", date), Expression.Operation.TRUE);
+
+    Integer anotherDate = (Integer) Literal.of("1969-01-01").to(TYPE).value();
+    assertProjectionInclusive(spec, in("date", date, anotherDate),
+        Expression.Operation.IN, "[1969-01, 1969-02, 1969-12, 1970-01]");
     assertProjectionInclusiveValue(spec, notIn("date", date, anotherDate), Expression.Operation.TRUE);
   }
 
@@ -199,6 +272,26 @@ public class TestDatesProjection {
   }
 
   @Test
+  public void testNegativeDayStrict() {
+    Integer date = (Integer) Literal.of("1969-12-30").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("date").build();
+
+    assertProjectionStrict(spec, lessThan("date", date), Expression.Operation.LT, "1969-12-30");
+    // should be the same date for <=
+    assertProjectionStrict(spec, lessThanOrEqual("date", date), Expression.Operation.LT, "1969-12-31");
+    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT, "1969-12-30");
+    // should be the same date for >=
+    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT, "1969-12-29");
+    assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "1969-12-30");
+    assertProjectionStrictValue(spec, equal("date", date), Expression.Operation.FALSE);
+
+    Integer anotherDate = (Integer) Literal.of("1969-12-28").to(TYPE).value();
+    assertProjectionStrict(spec, notIn("date", date, anotherDate),
+        Expression.Operation.NOT_IN, "[1969-12-28, 1969-12-30]");
+    assertProjectionStrictValue(spec, in("date", date, anotherDate), Expression.Operation.FALSE);
+  }
+
+  @Test
   public void testDayInclusive() {
     Integer date = (Integer) Literal.of("2017-01-01").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("date").build();
@@ -213,6 +306,24 @@ public class TestDatesProjection {
     Integer anotherDate = (Integer) Literal.of("2017-12-31").to(TYPE).value();
     assertProjectionInclusive(spec, in("date", date, anotherDate),
         Expression.Operation.IN, "[2017-01-01, 2017-12-31]");
+    assertProjectionInclusiveValue(spec, notIn("date", date, anotherDate), Expression.Operation.TRUE);
+  }
+
+  @Test
+  public void testNegativeDayInclusive() {
+    Integer date = (Integer) Literal.of("1969-12-30").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("date").build();
+
+    assertProjectionInclusive(spec, lessThan("date", date), Expression.Operation.LT_EQ, "1969-12-29");
+    assertProjectionInclusive(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "1969-12-30");
+    assertProjectionInclusive(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "1969-12-31");
+    assertProjectionInclusive(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "1969-12-30");
+    assertProjectionInclusive(spec, equal("date", date), Expression.Operation.EQ, "1969-12-30");
+    assertProjectionInclusiveValue(spec, notEqual("date", date), Expression.Operation.TRUE);
+
+    Integer anotherDate = (Integer) Literal.of("1969-12-28").to(TYPE).value();
+    assertProjectionInclusive(spec, in("date", date, anotherDate),
+        Expression.Operation.IN, "[1969-12-28, 1969-12-30]");
     assertProjectionInclusiveValue(spec, notIn("date", date, anotherDate), Expression.Operation.TRUE);
   }
 
@@ -235,6 +346,25 @@ public class TestDatesProjection {
   }
 
   @Test
+  public void testNegativeYearStrictLowerBound() {
+    Integer date = (Integer) Literal.of("1970-01-01").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("date").build();
+
+    // the boundary cannot be projected because fixing strict projection must fix cases where value + 1 = 0
+    assertProjectionStrictValue(spec, lessThan("date", date), Expression.Operation.FALSE);
+    assertProjectionStrictValue(spec, lessThanOrEqual("date", date), Expression.Operation.FALSE);
+    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT, "1970");
+    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT, "1969");
+    assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "1970");
+    assertProjectionStrictValue(spec, equal("date", date), Expression.Operation.FALSE);
+
+    Integer anotherDate = (Integer) Literal.of("1969-12-31").to(TYPE).value();
+    assertProjectionStrict(spec, notIn("date", date, anotherDate),
+        Expression.Operation.NOT_IN, "[1969, 1970]");
+    assertProjectionStrictValue(spec, in("date", date, anotherDate), Expression.Operation.FALSE);
+  }
+
+  @Test
   public void testYearStrictUpperBound() {
     Integer date = (Integer) Literal.of("2017-12-31").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("date").build();
@@ -249,6 +379,24 @@ public class TestDatesProjection {
     Integer anotherDate = (Integer) Literal.of("2016-01-01").to(TYPE).value();
     assertProjectionStrict(spec, notIn("date", date, anotherDate),
         Expression.Operation.NOT_IN, "[2016, 2017]");
+    assertProjectionStrictValue(spec, in("date", date, anotherDate), Expression.Operation.FALSE);
+  }
+
+  @Test
+  public void testNegativeYearStrictUpperBound() {
+    Integer date = (Integer) Literal.of("1969-12-31").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("date").build();
+
+    assertProjectionStrictValue(spec, lessThan("date", date), Expression.Operation.FALSE);
+    assertProjectionStrictValue(spec, lessThanOrEqual("date", date), Expression.Operation.FALSE);
+    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT, "1969");
+    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT, "1969");
+    assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_IN, "[1969, 1970]");
+    assertProjectionStrictValue(spec, equal("date", date), Expression.Operation.FALSE);
+
+    Integer anotherDate = (Integer) Literal.of("1970-01-01").to(TYPE).value();
+    assertProjectionStrict(spec, notIn("date", date, anotherDate),
+        Expression.Operation.NOT_IN, "[1969, 1970]");
     assertProjectionStrictValue(spec, in("date", date, anotherDate), Expression.Operation.FALSE);
   }
 
@@ -271,6 +419,24 @@ public class TestDatesProjection {
   }
 
   @Test
+  public void testNegativeYearInclusiveLowerBound() {
+    Integer date = (Integer) Literal.of("1970-01-01").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("date").build();
+
+    assertProjectionInclusive(spec, lessThan("date", date), Expression.Operation.LT_EQ, "1970");
+    assertProjectionInclusive(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "1970");
+    assertProjectionInclusive(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "1970");
+    assertProjectionInclusive(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "1970");
+    assertProjectionInclusive(spec, equal("date", date), Expression.Operation.EQ, "1970");
+    assertProjectionInclusiveValue(spec, notEqual("date", date), Expression.Operation.TRUE);
+
+    Integer anotherDate = (Integer) Literal.of("1969-12-31").to(TYPE).value();
+    assertProjectionInclusive(spec, in("date", date, anotherDate),
+        Expression.Operation.IN, "[1969, 1970]");
+    assertProjectionInclusiveValue(spec, notIn("date", date, anotherDate), Expression.Operation.TRUE);
+  }
+
+  @Test
   public void testYearInclusiveUpperBound() {
     Integer date = (Integer) Literal.of("2017-12-31").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("date").build();
@@ -285,6 +451,24 @@ public class TestDatesProjection {
     Integer anotherDate = (Integer) Literal.of("2016-01-01").to(TYPE).value();
     assertProjectionInclusive(spec, in("date", date, anotherDate),
         Expression.Operation.IN, "[2016, 2017]");
+    assertProjectionInclusiveValue(spec, notIn("date", date, anotherDate), Expression.Operation.TRUE);
+  }
+
+  @Test
+  public void testNegativeYearInclusiveUpperBound() {
+    Integer date = (Integer) Literal.of("1969-12-31").to(TYPE).value();
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).year("date").build();
+
+    assertProjectionInclusive(spec, lessThan("date", date), Expression.Operation.LT_EQ, "1970");
+    assertProjectionInclusive(spec, lessThanOrEqual("date", date), Expression.Operation.LT_EQ, "1970");
+    assertProjectionInclusive(spec, greaterThan("date", date), Expression.Operation.GT_EQ, "1970");
+    assertProjectionInclusive(spec, greaterThanOrEqual("date", date), Expression.Operation.GT_EQ, "1969");
+    assertProjectionInclusive(spec, equal("date", date), Expression.Operation.IN, "[1969, 1970]");
+    assertProjectionInclusiveValue(spec, notEqual("date", date), Expression.Operation.TRUE);
+
+    Integer anotherDate = (Integer) Literal.of("1969-01-01").to(TYPE).value();
+    assertProjectionInclusive(spec, in("date", date, anotherDate),
+        Expression.Operation.IN, "[1969, 1970]");
     assertProjectionInclusiveValue(spec, notIn("date", date, anotherDate), Expression.Operation.TRUE);
   }
 }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestDatesProjection.java
@@ -114,8 +114,8 @@ public class TestDatesProjection {
     // the boundary cannot be projected because fixing strict projection must fix cases where value + 1 = 0
     assertProjectionStrictValue(spec, lessThan("date", date), Expression.Operation.FALSE);
     assertProjectionStrictValue(spec, lessThanOrEqual("date", date), Expression.Operation.FALSE);
-    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT, "1970-01");
-    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT, "1969-12");
+    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT, "1970-02");
+    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT, "1970-01");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "1970-01");
     assertProjectionStrictValue(spec, equal("date", date), Expression.Operation.FALSE);
 
@@ -168,8 +168,8 @@ public class TestDatesProjection {
 
     assertProjectionStrictValue(spec, lessThan("date", date), Expression.Operation.FALSE);
     assertProjectionStrictValue(spec, lessThanOrEqual("date", date), Expression.Operation.FALSE);
-    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT, "1969-01");
-    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT, "1968-12");
+    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT, "1969-02");
+    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT, "1969-01");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_IN, "[1969-01, 1969-02]");
     assertProjectionStrictValue(spec, equal("date", date), Expression.Operation.FALSE);
 
@@ -204,8 +204,8 @@ public class TestDatesProjection {
 
     assertProjectionStrictValue(spec, lessThan("date", date), Expression.Operation.FALSE);
     assertProjectionStrictValue(spec, lessThanOrEqual("date", date), Expression.Operation.FALSE);
-    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT, "1969-12");
-    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT, "1969-12");
+    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT, "1970-01");
+    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT, "1970-01");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_IN, "[1969-12, 1970-01]");
     assertProjectionStrictValue(spec, equal("date", date), Expression.Operation.FALSE);
 
@@ -389,8 +389,8 @@ public class TestDatesProjection {
     // the boundary cannot be projected because fixing strict projection must fix cases where value + 1 = 0
     assertProjectionStrictValue(spec, lessThan("date", date), Expression.Operation.FALSE);
     assertProjectionStrictValue(spec, lessThanOrEqual("date", date), Expression.Operation.FALSE);
-    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT, "1970");
-    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT, "1969");
+    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT, "1971");
+    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT, "1970");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_EQ, "1970");
     assertProjectionStrictValue(spec, equal("date", date), Expression.Operation.FALSE);
 
@@ -425,8 +425,8 @@ public class TestDatesProjection {
 
     assertProjectionStrictValue(spec, lessThan("date", date), Expression.Operation.FALSE);
     assertProjectionStrictValue(spec, lessThanOrEqual("date", date), Expression.Operation.FALSE);
-    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT, "1969");
-    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT, "1969");
+    assertProjectionStrict(spec, greaterThan("date", date), Expression.Operation.GT, "1970");
+    assertProjectionStrict(spec, greaterThanOrEqual("date", date), Expression.Operation.GT, "1970");
     assertProjectionStrict(spec, notEqual("date", date), Expression.Operation.NOT_IN, "[1969, 1970]");
     assertProjectionStrictValue(spec, equal("date", date), Expression.Operation.FALSE);
 

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTimestamps.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTimestamps.java
@@ -27,6 +27,34 @@ import org.junit.Test;
 
 public class TestTimestamps {
   @Test
+  public void testTimestampTransform() {
+    Types.TimestampType type = Types.TimestampType.withoutZone();
+    Literal<Long> ts = Literal.of("2017-12-01T10:12:55.038194").to(type);
+    Literal<Long> pts = Literal.of("1970-01-01T00:00:01.000001").to(type);
+    Literal<Long> nts = Literal.of("1969-12-31T23:59:58.999999").to(type);
+
+    Transform<Long, Integer> years = Transforms.year(type);
+    Assert.assertEquals("Should produce 2017 - 1970 = 47", 47, (int) years.apply(ts.value()));
+    Assert.assertEquals("Should produce 1970 - 1970 = 0", 0, (int) years.apply(pts.value()));
+    Assert.assertEquals("Should produce 1969 - 1970 = -1", -1, (int) years.apply(nts.value()));
+
+    Transform<Long, Integer> months = Transforms.month(type);
+    Assert.assertEquals("Should produce 47 * 12 + 11 = 575", 575, (int) months.apply(ts.value()));
+    Assert.assertEquals("Should produce 0 * 12 + 0 = 0", 0, (int) months.apply(pts.value()));
+    Assert.assertEquals("Should produce -1", -1, (int) months.apply(nts.value()));
+
+    Transform<Long, Integer> days = Transforms.day(type);
+    Assert.assertEquals("Should produce 17501", 17501, (int) days.apply(ts.value()));
+    Assert.assertEquals("Should produce 0 * 365 + 0 = 0", 0, (int) days.apply(pts.value()));
+    Assert.assertEquals("Should produce -1", -1, (int) days.apply(nts.value()));
+
+    Transform<Long, Integer> hours = Transforms.hour(type);
+    Assert.assertEquals("Should produce 17501 * 24 + 10", 420034, (int) hours.apply(ts.value()));
+    Assert.assertEquals("Should produce 0 * 24 + 0 = 0", 0, (int) hours.apply(pts.value()));
+    Assert.assertEquals("Should produce -1", -1, (int) hours.apply(nts.value()));
+  }
+
+  @Test
   public void testTimestampWithoutZoneToHumanString() {
     Types.TimestampType type = Types.TimestampType.withoutZone();
     Literal<Long> date = Literal.of("2017-12-01T10:12:55.038194").to(type);
@@ -46,6 +74,72 @@ public class TestTimestamps {
     Transform<Long, Integer> hour = Transforms.hour(type);
     Assert.assertEquals("Should produce the correct Human string",
         "2017-12-01-10", hour.toHumanString(hour.apply(date.value())));
+  }
+
+  @Test
+  public void testNegativeTimestampWithoutZoneToHumanString() {
+    Types.TimestampType type = Types.TimestampType.withoutZone();
+    Literal<Long> date = Literal.of("1969-12-30T10:12:55.038194").to(type);
+
+    Transform<Long, Integer> year = Transforms.year(type);
+    Assert.assertEquals("Should produce the correct Human string",
+        "1969", year.toHumanString(year.apply(date.value())));
+
+    Transform<Long, Integer> month = Transforms.month(type);
+    Assert.assertEquals("Should produce the correct Human string",
+        "1969-12", month.toHumanString(month.apply(date.value())));
+
+    Transform<Long, Integer> day = Transforms.day(type);
+    Assert.assertEquals("Should produce the correct Human string",
+        "1969-12-30", day.toHumanString(day.apply(date.value())));
+
+    Transform<Long, Integer> hour = Transforms.hour(type);
+    Assert.assertEquals("Should produce the correct Human string",
+        "1969-12-30-10", hour.toHumanString(hour.apply(date.value())));
+  }
+
+  @Test
+  public void testNegativeTimestampWithoutZoneToHumanStringLowerBound() {
+    Types.TimestampType type = Types.TimestampType.withoutZone();
+    Literal<Long> date = Literal.of("1969-12-30T00:00:00.000000").to(type);
+
+    Transform<Long, Integer> year = Transforms.year(type);
+    Assert.assertEquals("Should produce the correct Human string",
+        "1969", year.toHumanString(year.apply(date.value())));
+
+    Transform<Long, Integer> month = Transforms.month(type);
+    Assert.assertEquals("Should produce the correct Human string",
+        "1969-12", month.toHumanString(month.apply(date.value())));
+
+    Transform<Long, Integer> day = Transforms.day(type);
+    Assert.assertEquals("Should produce the correct Human string",
+        "1969-12-30", day.toHumanString(day.apply(date.value())));
+
+    Transform<Long, Integer> hour = Transforms.hour(type);
+    Assert.assertEquals("Should produce the correct Human string",
+        "1969-12-30-00", hour.toHumanString(hour.apply(date.value())));
+  }
+
+  @Test
+  public void testNegativeTimestampWithoutZoneToHumanStringUpperBound() {
+    Types.TimestampType type = Types.TimestampType.withoutZone();
+    Literal<Long> date = Literal.of("1969-12-31T23:59:59.999999").to(type);
+
+    Transform<Long, Integer> year = Transforms.year(type);
+    Assert.assertEquals("Should produce the correct Human string",
+        "1969", year.toHumanString(year.apply(date.value())));
+
+    Transform<Long, Integer> month = Transforms.month(type);
+    Assert.assertEquals("Should produce the correct Human string",
+        "1969-12", month.toHumanString(month.apply(date.value())));
+
+    Transform<Long, Integer> day = Transforms.day(type);
+    Assert.assertEquals("Should produce the correct Human string",
+        "1969-12-31", day.toHumanString(day.apply(date.value())));
+
+    Transform<Long, Integer> hour = Transforms.hour(type);
+    Assert.assertEquals("Should produce the correct Human string",
+        "1969-12-31-23", hour.toHumanString(hour.apply(date.value())));
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
@@ -111,9 +111,8 @@ public class TestTimestampsProjection {
     Long date = (long) Literal.of("1970-01-01T00:00:00.00000").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("timestamp").build();
 
-    // the boundary cannot be projected because fixing strict projection must fix cases where value + 1 = 0
-    assertProjectionStrictValue(spec, lessThan("timestamp", date), Expression.Operation.FALSE);
-    assertProjectionStrictValue(spec, lessThanOrEqual("timestamp", date), Expression.Operation.FALSE);
+    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT, "1970-01-01");
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT, "1970-01-01");
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT, "1970-01-02");
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT, "1970-01-01");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "1970-01-01");
@@ -166,8 +165,8 @@ public class TestTimestampsProjection {
     Long date = (long) Literal.of("1969-01-01T00:00:00.00000").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("timestamp").build();
 
-    assertProjectionStrictValue(spec, lessThan("timestamp", date), Expression.Operation.FALSE);
-    assertProjectionStrictValue(spec, lessThanOrEqual("timestamp", date), Expression.Operation.FALSE);
+    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT, "1969-01");
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT, "1969-01");
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT, "1969-02");
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT, "1969-01");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_IN, "[1969-01, 1969-02]");
@@ -202,8 +201,8 @@ public class TestTimestampsProjection {
     Long date = (long) Literal.of("1969-12-31T23:59:59.999999").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).month("timestamp").build();
 
-    assertProjectionStrictValue(spec, lessThan("timestamp", date), Expression.Operation.FALSE);
-    assertProjectionStrictValue(spec, lessThanOrEqual("timestamp", date), Expression.Operation.FALSE);
+    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT, "1969-12");
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT, "1970-01");
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT, "1970-01");
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT, "1970-01");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_IN, "[1969-12, 1970-01]");
@@ -310,8 +309,8 @@ public class TestTimestampsProjection {
     Long date = (long) Literal.of("1969-01-01T00:00:00.00000").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("timestamp").build();
 
-    assertProjectionStrictValue(spec, lessThan("timestamp", date), Expression.Operation.FALSE);
-    assertProjectionStrictValue(spec, lessThanOrEqual("timestamp", date), Expression.Operation.FALSE);
+    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT, "1969-01-01");
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT, "1969-01-01");
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT, "1969-01-02");
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT, "1969-01-01");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_IN, "[1969-01-01, 1969-01-02]");
@@ -346,8 +345,8 @@ public class TestTimestampsProjection {
     Long date = (long) Literal.of("1969-12-31T23:59:59.999999").to(TYPE).value();
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).day("timestamp").build();
 
-    assertProjectionStrictValue(spec, lessThan("timestamp", date), Expression.Operation.FALSE);
-    assertProjectionStrictValue(spec, lessThanOrEqual("timestamp", date), Expression.Operation.FALSE);
+    assertProjectionStrict(spec, lessThan("timestamp", date), Expression.Operation.LT, "1969-12-31");
+    assertProjectionStrict(spec, lessThanOrEqual("timestamp", date), Expression.Operation.LT, "1970-01-01");
     assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT, "1970-01-01");
     assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT, "1970-01-01");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_IN, "[1969-12-31, 1970-01-01]");

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
@@ -74,14 +74,14 @@ public class TestTimestampsProjection {
                                           Expression.Operation expectedOp) {
 
     Expression projection = Projections.strict(spec).project(filter);
-    Assert.assertEquals(projection.op(), expectedOp);
+    Assert.assertEquals(expectedOp, projection.op());
   }
 
   public void assertProjectionInclusiveValue(PartitionSpec spec, UnboundPredicate<?> filter,
                                              Expression.Operation expectedOp) {
 
     Expression projection = Projections.inclusive(spec).project(filter);
-    Assert.assertEquals(projection.op(), expectedOp);
+    Assert.assertEquals(expectedOp, projection.op());
   }
 
   public void assertProjectionInclusive(PartitionSpec spec, UnboundPredicate<?> filter,
@@ -89,7 +89,7 @@ public class TestTimestampsProjection {
     Expression projection = Projections.inclusive(spec).project(filter);
     UnboundPredicate<?> predicate = assertAndUnwrapUnbound(projection);
 
-    Assert.assertEquals(predicate.op(), expectedOp);
+    Assert.assertEquals(expectedOp, predicate.op());
 
     Assert.assertNotEquals("Inclusive projection never runs for NOT_IN", Expression.Operation.NOT_IN, predicate.op());
 

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTimestampsProjection.java
@@ -114,8 +114,8 @@ public class TestTimestampsProjection {
     // the boundary cannot be projected because fixing strict projection must fix cases where value + 1 = 0
     assertProjectionStrictValue(spec, lessThan("timestamp", date), Expression.Operation.FALSE);
     assertProjectionStrictValue(spec, lessThanOrEqual("timestamp", date), Expression.Operation.FALSE);
-    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT, "1970-01-01");
-    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT, "1969-12-31");
+    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT, "1970-01-02");
+    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT, "1970-01-01");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_EQ, "1970-01-01");
     assertProjectionStrictValue(spec, equal("timestamp", date), Expression.Operation.FALSE);
 
@@ -168,8 +168,8 @@ public class TestTimestampsProjection {
 
     assertProjectionStrictValue(spec, lessThan("timestamp", date), Expression.Operation.FALSE);
     assertProjectionStrictValue(spec, lessThanOrEqual("timestamp", date), Expression.Operation.FALSE);
-    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT, "1969-01");
-    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT, "1968-12");
+    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT, "1969-02");
+    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT, "1969-01");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_IN, "[1969-01, 1969-02]");
     assertProjectionStrictValue(spec, equal("timestamp", date), Expression.Operation.FALSE);
 
@@ -204,8 +204,8 @@ public class TestTimestampsProjection {
 
     assertProjectionStrictValue(spec, lessThan("timestamp", date), Expression.Operation.FALSE);
     assertProjectionStrictValue(spec, lessThanOrEqual("timestamp", date), Expression.Operation.FALSE);
-    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT, "1969-12");
-    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT, "1969-12");
+    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT, "1970-01");
+    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT, "1970-01");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_IN, "[1969-12, 1970-01]");
     assertProjectionStrictValue(spec, equal("timestamp", date), Expression.Operation.FALSE);
 
@@ -312,8 +312,8 @@ public class TestTimestampsProjection {
 
     assertProjectionStrictValue(spec, lessThan("timestamp", date), Expression.Operation.FALSE);
     assertProjectionStrictValue(spec, lessThanOrEqual("timestamp", date), Expression.Operation.FALSE);
-    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT, "1969-01-01");
-    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT, "1968-12-31");
+    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT, "1969-01-02");
+    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT, "1969-01-01");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_IN, "[1969-01-01, 1969-01-02]");
     assertProjectionStrictValue(spec, equal("timestamp", date), Expression.Operation.FALSE);
 
@@ -348,8 +348,8 @@ public class TestTimestampsProjection {
 
     assertProjectionStrictValue(spec, lessThan("timestamp", date), Expression.Operation.FALSE);
     assertProjectionStrictValue(spec, lessThanOrEqual("timestamp", date), Expression.Operation.FALSE);
-    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT, "1969-12-31");
-    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT, "1969-12-31");
+    assertProjectionStrict(spec, greaterThan("timestamp", date), Expression.Operation.GT, "1970-01-01");
+    assertProjectionStrict(spec, greaterThanOrEqual("timestamp", date), Expression.Operation.GT, "1970-01-01");
     assertProjectionStrict(spec, notEqual("timestamp", date), Expression.Operation.NOT_IN, "[1969-12-31, 1970-01-01]");
     assertProjectionStrictValue(spec, equal("timestamp", date), Expression.Operation.FALSE);
 


### PR DESCRIPTION
This fixes incorrect values produced by date and time transforms and adds tests.

This also updates date and timestamp transform projection methods to include incorrectly transformed values.

Fixes #1680.