### PR TITLE
Partition Stats file schema for Iceberg tables

### DIFF
--- a/api/src/main/java/org/apache/iceberg/PartitionStatsFile.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionStatsFile.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import org.apache.iceberg.types.Types;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+public interface PartitionStatsFile {
+  Types.NestedField PARTITION_SPEC_ID = required(600, "partition_spec_id", Types.IntegerType.get(),
+      "partition spec used for row entry");
+  Types.NestedField FILE_COUNT = required(602, "file_count", Types.IntegerType.get(),
+      "Number of data files in this partition");
+  Types.NestedField ROW_COUNT = required(603, "row_count", Types.LongType.get(),
+      "Number of row count in this partition");
+  int PARTITION_ID = 601;
+  String PARTITION_NAME = "partition";
+  String PARTITION_DOC = "Partition data tuple, schema based on the partition spec";
+
+  static Types.StructType getType(Types.StructType partitionType) {
+    return Types.StructType.of(
+        PARTITION_SPEC_ID,
+        required(PARTITION_ID, PARTITION_NAME, partitionType, PARTITION_DOC),
+        FILE_COUNT,
+        ROW_COUNT
+    );
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/Snapshot.java
+++ b/api/src/main/java/org/apache/iceberg/Snapshot.java
@@ -126,4 +126,11 @@ public interface Snapshot extends Serializable {
    * @return the location of the manifest list for this Snapshot
    */
   String manifestListLocation();
+
+  /**
+   * Return the location of partition stats file, or null if doesn't exist.
+   *
+   * @return the location of Partition stats file for this Snapshot
+   */
+  String partitionStatsLocation();
 }

--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -43,6 +43,7 @@ class BaseSnapshot implements Snapshot {
   private final String manifestListLocation;
   private final String operation;
   private final Map<String, String> summary;
+  private final String partitionStatsLocation;
 
   // lazily initialized
   private transient List<ManifestFile> allManifests = null;
@@ -69,7 +70,7 @@ class BaseSnapshot implements Snapshot {
                long timestampMillis,
                String operation,
                Map<String, String> summary,
-               String manifestList) {
+               String manifestList, String partitionStatsLocation) {
     this.io = io;
     this.sequenceNumber = sequenceNumber;
     this.snapshotId = snapshotId;
@@ -78,6 +79,7 @@ class BaseSnapshot implements Snapshot {
     this.operation = operation;
     this.summary = summary;
     this.manifestListLocation = manifestList;
+    this.partitionStatsLocation = partitionStatsLocation;
   }
 
   BaseSnapshot(FileIO io,
@@ -87,7 +89,7 @@ class BaseSnapshot implements Snapshot {
                String operation,
                Map<String, String> summary,
                List<ManifestFile> dataManifests) {
-    this(io, INITIAL_SEQUENCE_NUMBER, snapshotId, parentId, timestampMillis, operation, summary, null);
+    this(io, INITIAL_SEQUENCE_NUMBER, snapshotId, parentId, timestampMillis, operation, summary, null, null);
     this.allManifests = dataManifests;
   }
 
@@ -180,6 +182,11 @@ class BaseSnapshot implements Snapshot {
     return manifestListLocation;
   }
 
+  @Override
+  public String partitionStatsLocation() {
+    return partitionStatsLocation;
+  }
+
   private void cacheChanges() {
     ImmutableList.Builder<DataFile> adds = ImmutableList.builder();
     ImmutableList.Builder<DataFile> deletes = ImmutableList.builder();
@@ -219,6 +226,7 @@ class BaseSnapshot implements Snapshot {
         .add("operation", operation)
         .add("summary", summary)
         .add("manifest-list", manifestListLocation)
+        .add("partition-stats", partitionStatsLocation)
         .toString();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/GenericPartitionStatsFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericPartitionStatsFile.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import org.apache.avro.Schema;
+import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Types;
+
+public class GenericPartitionStatsFile implements PartitionStatsFile {
+  private int partitionSpecId;
+  private PartitionData partitionData;
+  private int fileCount;
+  private Long rowCount;
+
+  /**
+   * @param partitionSpecId defines {@link PartitionSpec} used for this partition data
+   * @param partitionData   {@link PartitionData} tuple. schema of this is define by partitionSpecId
+   * @param fileCount       Total Number of data file count in this partition
+   * @param rowCount        Total Number of rows in table in this partition.
+   *                        <p>
+   *                        PS : 1. In PartitionStats file ParitionSpec-PartitionData will be key. 2. When partition
+   *                        evolution happens, new entries in Partition stats table will use new spec. This will help in
+   *                        query planning to get more accurate stats.
+   */
+
+  public GenericPartitionStatsFile(int partitionSpecId, PartitionData partitionData, int fileCount, Long rowCount) {
+    this.partitionSpecId = partitionSpecId;
+    this.partitionData = partitionData;
+    this.fileCount = fileCount;
+    this.rowCount = rowCount;
+  }
+
+  public int getPartitionSpecId() {
+    return partitionSpecId;
+  }
+
+  public PartitionData getPartitionData() {
+    return partitionData;
+  }
+
+  public int getFileCount() {
+    return fileCount;
+  }
+
+  public Long getRowCount() {
+    return rowCount;
+  }
+
+  public Schema getAvroSchema(Types.StructType partitionStruct) {
+    return AvroSchemaUtil.convert(PartitionStatsFile.getType(partitionStruct),
+        ImmutableMap.of(partitionStruct, PartitionData.class.getName()));
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/SnapshotParser.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotParser.java
@@ -142,7 +142,8 @@ public class SnapshotParser {
     if (node.has(MANIFEST_LIST)) {
       // the manifest list is stored in a manifest list file
       String manifestList = JsonUtil.getString(MANIFEST_LIST, node);
-      return new BaseSnapshot(io, sequenceNumber, snapshotId, parentId, timestamp, operation, summary, manifestList);
+      return new BaseSnapshot(io, sequenceNumber, snapshotId, parentId, timestamp, operation, summary, manifestList,
+          null);
 
     } else {
       // fall back to an embedded manifest list. pass in the manifest's InputFile so length can be

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -187,7 +187,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
 
       return new BaseSnapshot(ops.io(),
           sequenceNumber, snapshotId(), parentSnapshotId, System.currentTimeMillis(), operation(), summary(base),
-          manifestList.location());
+          manifestList.location(), null);
 
     } else {
       return new BaseSnapshot(ops.io(),

--- a/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
@@ -35,7 +35,8 @@ public class SnapshotsTable extends BaseMetadataTable {
       Types.NestedField.optional(4, "operation", Types.StringType.get()),
       Types.NestedField.optional(5, "manifest_list", Types.StringType.get()),
       Types.NestedField.optional(6, "summary",
-          Types.MapType.ofRequired(7, 8, Types.StringType.get(), Types.StringType.get()))
+          Types.MapType.ofRequired(7, 8, Types.StringType.get(), Types.StringType.get())),
+      Types.NestedField.optional(9, "partition_stats", Types.StringType.get())
   );
 
   private final TableOperations ops;
@@ -98,7 +99,8 @@ public class SnapshotsTable extends BaseMetadataTable {
         snap.parentId(),
         snap.operation(),
         snap.manifestListLocation(),
-        snap.summary()
+        snap.summary(),
+        snap.partitionStatsLocation()
     );
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
@@ -102,7 +102,7 @@ public class TestSnapshotJson {
     }
 
     Snapshot expected = new BaseSnapshot(
-        ops.io(), id, 34, parentId, System.currentTimeMillis(), null, null, localInput(manifestList).location());
+        ops.io(), id, 34, parentId, System.currentTimeMillis(), null, null, localInput(manifestList).location(), null);
     Snapshot inMemory = new BaseSnapshot(
         ops.io(), id, parentId, expected.timestampMillis(), null, null, manifests);
 

--- a/spark3/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
@@ -103,7 +103,7 @@ public class TestSelect extends SparkCatalogTestBase {
         "spark_catalog".equals(catalogName));
 
     assertEquals("Snapshot metadata table",
-        ImmutableList.of(row(ANY, ANY, null, "append", ANY, ANY)),
+        ImmutableList.of(row(ANY, ANY, null, "append", ANY, ANY, ANY)),
         sql("SELECT * FROM %s.snapshots", tableName));
   }
 }


### PR DESCRIPTION
This is not full PR but This PR explains schema for partition stats file. 
Mainly see following classes : 
PartitionStatsFile.java
BaseSnapshot.java
GenericPartitionStatsFile.java

- Within each snapshot we will have "partitionStatsfileLocation" points to partition stats file location for this snapshot.
- Schema of partitionstatsfile : 
        1.   partition_spec_id (int): This is the partition-spec-id for the partition
        2.   partition: This is a list of values for each partition column. PartitionData tuple based on partition specification.
        3.   file_count (int): Number of data files in this partition
        4.   row_count(long): Number of rows in table in this partition
        
issue : https://github.com/apache/iceberg/issues/1832        
        