### PR TITLE
Spark: Add table properties to control MERGE mode and isolation level

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -158,4 +158,10 @@ public class TableProperties {
 
   public static final String UPDATE_MODE = "write.update.mode";
   public static final String UPDATE_MODE_DEFAULT = "copy-on-write";
+
+  public static final String MERGE_ISOLATION_LEVEL = "write.merge.isolation-level";
+  public static final String MERGE_ISOLATION_LEVEL_DEFAULT = "serializable";
+
+  public static final String MERGE_MODE = "write.merge.mode";
+  public static final String MERGE_MODE_DEFAULT = "copy-on-write";
 }

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkMergeBuilder.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkMergeBuilder.java
@@ -33,6 +33,8 @@ import org.apache.spark.sql.connector.write.WriteBuilder;
 
 import static org.apache.iceberg.TableProperties.DELETE_ISOLATION_LEVEL;
 import static org.apache.iceberg.TableProperties.DELETE_ISOLATION_LEVEL_DEFAULT;
+import static org.apache.iceberg.TableProperties.MERGE_ISOLATION_LEVEL;
+import static org.apache.iceberg.TableProperties.MERGE_ISOLATION_LEVEL_DEFAULT;
 import static org.apache.iceberg.TableProperties.UPDATE_ISOLATION_LEVEL;
 import static org.apache.iceberg.TableProperties.UPDATE_ISOLATION_LEVEL_DEFAULT;
 
@@ -61,6 +63,8 @@ class SparkMergeBuilder implements MergeBuilder {
       isolationLevelAsString = props.getOrDefault(DELETE_ISOLATION_LEVEL, DELETE_ISOLATION_LEVEL_DEFAULT);
     } else if (operation.equalsIgnoreCase("update")) {
       isolationLevelAsString = props.getOrDefault(UPDATE_ISOLATION_LEVEL, UPDATE_ISOLATION_LEVEL_DEFAULT);
+    } else if (operation.equalsIgnoreCase("merge")) {
+      isolationLevelAsString = props.getOrDefault(MERGE_ISOLATION_LEVEL, MERGE_ISOLATION_LEVEL_DEFAULT);
     } else {
       throw new IllegalArgumentException("Unsupported operation: " + operation);
     }

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -53,6 +53,8 @@ import org.slf4j.LoggerFactory;
 
 import static org.apache.iceberg.TableProperties.DELETE_MODE;
 import static org.apache.iceberg.TableProperties.DELETE_MODE_DEFAULT;
+import static org.apache.iceberg.TableProperties.MERGE_MODE;
+import static org.apache.iceberg.TableProperties.MERGE_MODE_DEFAULT;
 import static org.apache.iceberg.TableProperties.UPDATE_MODE;
 import static org.apache.iceberg.TableProperties.UPDATE_MODE_DEFAULT;
 
@@ -182,6 +184,8 @@ public class SparkTable implements org.apache.spark.sql.connector.catalog.Table,
       return props.getOrDefault(DELETE_MODE, DELETE_MODE_DEFAULT);
     } else if (operation.equalsIgnoreCase("update")) {
       return props.getOrDefault(UPDATE_MODE, UPDATE_MODE_DEFAULT);
+    } else if (operation.equalsIgnoreCase("merge")) {
+      return props.getOrDefault(MERGE_MODE, MERGE_MODE_DEFAULT);
     } else {
       throw new IllegalArgumentException("Unsupported operation: " + operation);
     }


### PR DESCRIPTION
This PR adds table properties to control MERGE mode and isolation level.