### PR TITLE
Avro: Schema conversions should preserve field docs

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
+++ b/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
@@ -79,7 +79,6 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
   }
 
   @Override
-  // TODO(kbendick) - Capture top level record doc comment?
   public Type record(Schema record, List<String> names, List<Type> fieldTypes) {
     List<Schema.Field> fields = record.getFields();
     List<Types.NestedField> newFields = Lists.newArrayListWithExpectedSize(fields.size());

--- a/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
+++ b/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
@@ -79,6 +79,7 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
   }
 
   @Override
+  // TODO(kbendick) - Capture top level record doc comment?
   public Type record(Schema record, List<String> names, List<Type> fieldTypes) {
     List<Schema.Field> fields = record.getFields();
     List<Types.NestedField> newFields = Lists.newArrayListWithExpectedSize(fields.size());
@@ -93,9 +94,9 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
       int fieldId = getId(field);
 
       if (AvroSchemaUtil.isOptionSchema(field.schema())) {
-        newFields.add(Types.NestedField.optional(fieldId, field.name(), fieldType));
+        newFields.add(Types.NestedField.optional(fieldId, field.name(), fieldType, field.doc()));
       } else {
-        newFields.add(Types.NestedField.required(fieldId, field.name(), fieldType));
+        newFields.add(Types.NestedField.required(fieldId, field.name(), fieldType, field.doc()));
       }
     }
 

--- a/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
+++ b/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
@@ -111,7 +111,6 @@ class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
       fields.add(field);
     }
 
-    // TODO(kbendick) - Capture top level doc when creating the record
     recordSchema = Schema.createRecord(recordName, null, null, false, fields);
 
     results.put(struct, recordSchema);

--- a/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
+++ b/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
@@ -102,7 +102,7 @@ class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
       boolean isValidFieldName = AvroSchemaUtil.validAvroName(origFieldName);
       String fieldName =  isValidFieldName ? origFieldName : AvroSchemaUtil.sanitize(origFieldName);
       Schema.Field field = new Schema.Field(
-          fieldName, fieldSchemas.get(i), null,
+          fieldName, fieldSchemas.get(i), structField.doc(),
           structField.isOptional() ? JsonProperties.NULL_VALUE : null);
       if (!isValidFieldName) {
         field.addProp(AvroSchemaUtil.ICEBERG_FIELD_NAME_PROP, origFieldName);
@@ -111,6 +111,7 @@ class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
       fields.add(field);
     }
 
+    // TODO(kbendick) - Capture top level doc when creating the record
     recordSchema = Schema.createRecord(recordName, null, null, false, fields);
 
     results.put(struct, recordSchema);

--- a/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
@@ -239,8 +239,10 @@ public class TestMergeAppend extends TableTestBase {
   public void testManifestMergeMinCount() throws IOException {
     Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
     table.updateProperties().set(TableProperties.MANIFEST_MIN_MERGE_COUNT, "2")
-        // each manifest file is 5227 bytes, so 12000 bytes limit will give us 2 bins with 3 manifest/data files.
-        .set(TableProperties.MANIFEST_TARGET_SIZE_BYTES, "12000")
+        // Each initial v1/v2 ManifestFile is 5661/6397 bytes respectively. Merging two of the given
+        // manifests make one v1/v2 ManifestFile of 5672/6408 bytes respectively, so 12850 bytes
+        // limit will give us two bins with three manifest/data files.
+        .set(TableProperties.MANIFEST_TARGET_SIZE_BYTES, "12850")
         .commit();
 
     TableMetadata base = readMetadata();

--- a/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
@@ -42,7 +42,7 @@ public abstract class AvroDataTest {
 
   protected static final StructType SUPPORTED_PRIMITIVES = StructType.of(
       required(100, "id", LongType.get()),
-      optional(101, "data", Types.StringType.get()),
+      optional(101, "data", Types.StringType.get(), "optional blob field"),
       required(102, "b", Types.BooleanType.get()),
       optional(103, "i", Types.IntegerType.get()),
       required(104, "l", LongType.get()),

--- a/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/AvroDataTest.java
@@ -42,7 +42,7 @@ public abstract class AvroDataTest {
 
   protected static final StructType SUPPORTED_PRIMITIVES = StructType.of(
       required(100, "id", LongType.get()),
-      optional(101, "data", Types.StringType.get(), "optional blob field"),
+      optional(101, "data", Types.StringType.get()),
       required(102, "b", Types.BooleanType.get()),
       optional(103, "i", Types.IntegerType.get()),
       required(104, "l", LongType.get()),


### PR DESCRIPTION
This addresses issue https://github.com/apache/iceberg/issues/1954