### PR TITLE
AWS: cleanup AwsProperties styles

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.aws;
 
 import java.util.Map;
 import org.apache.iceberg.common.DynConstructors;
-import org.apache.iceberg.io.FileIO;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.glue.GlueClient;
@@ -29,12 +28,6 @@ import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.s3.S3Client;
 
 public class AwsClientFactories {
-
-  /**
-   * The implementation class of {@link AwsClientFactory} to customize AWS client configurations.
-   * If set, all AWS clients will be configured by the specified class before initialization.
-   */
-  public static final String CLIENT_FACTORY_CONFIG_KEY = "client.factory";
 
   private static final SdkHttpClient HTTP_CLIENT_DEFAULT = UrlConnectionHttpClient.create();
   private static final DefaultAwsClientFactory AWS_CLIENT_FACTORY_DEFAULT = new DefaultAwsClientFactory();
@@ -47,8 +40,8 @@ public class AwsClientFactories {
   }
 
   public static AwsClientFactory from(Map<String, String> properties) {
-    if (properties.containsKey(CLIENT_FACTORY_CONFIG_KEY)) {
-      return loadClientFactory(properties.get(CLIENT_FACTORY_CONFIG_KEY), properties);
+    if (properties.containsKey(AwsProperties.CLIENT_FACTORY)) {
+      return loadClientFactory(properties.get(AwsProperties.CLIENT_FACTORY), properties);
     } else {
       return defaultFactory();
     }
@@ -57,7 +50,7 @@ public class AwsClientFactories {
   private static AwsClientFactory loadClientFactory(String impl, Map<String, String> properties) {
     DynConstructors.Ctor<AwsClientFactory> ctor;
     try {
-      ctor = DynConstructors.builder(FileIO.class).impl(impl).buildChecked();
+      ctor = DynConstructors.builder(AwsClientFactory.class).impl(impl).buildChecked();
     } catch (NoSuchMethodException e) {
       throw new IllegalArgumentException(String.format(
           "Cannot initialize AwsClientFactory, missing no-arg constructor: %s", impl), e);

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -130,6 +130,13 @@ public class AwsProperties implements Serializable {
    */
   public static final String S3FILEIO_ACL = "s3fileio.acl";
 
+  /**
+   * The implementation class of {@link AwsClientFactory} to customize AWS client configurations.
+   * If set, all AWS clients will be initialized by the specified factory.
+   * If not set, {@link AwsClientFactories#defaultFactory()} is used as default factory.
+   */
+  public static final String CLIENT_FACTORY = "client.factory";
+
   private String s3FileIoSseType;
   private String s3FileIoSseKey;
   private String s3FileIoSseMd5;
@@ -264,7 +271,7 @@ public class AwsProperties implements Serializable {
     this.s3FileIoMultipartThresholdFactor = factor;
   }
 
-  public String getS3fileIoStagingDirectory() {
+  public String s3fileIoStagingDirectory() {
     return s3fileIoStagingDirectory;
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -109,7 +109,7 @@ class S3OutputStream extends PositionOutputStream {
 
     multiPartSize = awsProperties.s3FileIoMultiPartSize();
     multiPartThresholdSize =  (int) (multiPartSize * awsProperties.s3FileIOMultipartThresholdFactor());
-    stagingDirectory = new File(awsProperties.getS3fileIoStagingDirectory());
+    stagingDirectory = new File(awsProperties.s3fileIoStagingDirectory());
 
     newStream();
   }

--- a/aws/src/test/java/org/apache/iceberg/aws/AwsClientFactoriesTest.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/AwsClientFactoriesTest.java
@@ -42,7 +42,7 @@ public class AwsClientFactoriesTest {
   @Test
   public void testLoadCustom() {
     Map<String, String> properties = Maps.newHashMap();
-    properties.put(AwsClientFactories.CLIENT_FACTORY_CONFIG_KEY, CustomFactory.class.getName());
+    properties.put(AwsProperties.CLIENT_FACTORY, CustomFactory.class.getName());
     Assert.assertTrue("should load custom class",
         AwsClientFactories.from(properties) instanceof CustomFactory);
   }


### PR DESCRIPTION
1. remove `get` from get method `getS3fileIoStagingDirectory`
2. move client factory config key to `AwsProperties`, so all configs are in a single place.
3. fix bug in `AwsClientFactories.loadClientFactory`, no error was thrown because of the use of reflection.