### PR TITLE
[Core] Minor test config value increase for manifest target size in testManifestMergeMinCount

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
@@ -240,9 +240,9 @@ public class TestMergeAppend extends TableTestBase {
     Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
     table.updateProperties().set(TableProperties.MANIFEST_MIN_MERGE_COUNT, "2")
         // Each initial v1/v2 ManifestFile is 5661/6397 bytes respectively. Merging two of the given
-        // manifests make one v1/v2 ManifestFile of 5672/6408 bytes respectively, so 12850 bytes
+        // manifests make one v1/v2 ManifestFile of 5672/6408 bytes respectively, so 15000 bytes
         // limit will give us two bins with three manifest/data files.
-        .set(TableProperties.MANIFEST_TARGET_SIZE_BYTES, "12850")
+        .set(TableProperties.MANIFEST_TARGET_SIZE_BYTES, "15000")
         .commit();
 
     TableMetadata base = readMetadata();


### PR DESCRIPTION
The goal of this patch is to help future proof this test against any future increases in the manifest file size (additional fields, longer or additional doc strings, etc).

This is a follow up to when the value was increased in this PR https://github.com/apache/iceberg/pull/1991, as suggested by @rdblue.

This PR and the original PR are originally related to this issue: https://github.com/apache/iceberg/issues/1954