### PR TITLE
Rename Presto SQL to Trino

### DIFF
--- a/site/docs/trino.md
+++ b/site/docs/trino.md
@@ -15,6 +15,6 @@
  - limitations under the License.
  -->
 
-# Presto
+# Trino (formerly Presto SQL)
 
-The Iceberg connector is available with Presto SQL. It is feature complete and usage details can be found in the [documentation](https://prestosql.io/docs/current/connector/iceberg.html)
+The Iceberg connector is available with Trino. It is feature complete and usage details can be found in the [documentation](https://trino.io/docs/current/connector/iceberg.html)

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -59,7 +59,7 @@ nav:
     - Spark SQL: spark.md
     - Spark Streaming: spark-structured-streaming.md
     - Time Travel: spark#time-travel
-  - Presto: https://prestosql.io/docs/current/connector/iceberg.html
+  - Trino: https://trino.io/docs/current/connector/iceberg.html
   - Flink: flink.md
   - Hive: hive.md
   - API:


### PR DESCRIPTION
PrestoSQL was rebranded as Trino: https://trino.io/blog/2020/12/27/announcing-trino.html