### PR TITLE
Docs: Add redirect from presto/ to trino/

### DIFF
--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -82,3 +82,4 @@ nav:
     - Events: https://www.apache.org/events/current-event.html
 redirects:
   time-travel/index: snapshots/index
+  presto/index: trino/index


### PR DESCRIPTION
Tested locally with `mkdocs serve`.