### PR TITLE
Build: Add path config to control github actions

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -18,7 +18,17 @@
 #
 
 name: "Java CI"
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+    - '.github/workflows/python-ci.yml'
+    - 'python/**'
+    - 'site/**'
+  pull_request:
+    paths-ignore:
+    - '.github/workflows/python-ci.yml'
+    - 'python/**'
+    - 'site/**'
 
 jobs:
   check:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -18,27 +18,19 @@
 #
 
 name: "Python CI"
-on: [push, pull_request]
-
-# change detection is based on two references:
-# https://github.community/t/run-job-only-if-folder-changed/118292/2
-# https://carlosbecker.com/posts/git-changed/
+on:
+  push:
+    paths:
+    - '.github/workflows/python-ci.yml'
+    - 'python/**'
+  pull_request:
+    paths:
+    - '.github/workflows/python-ci.yml'
+    - 'python/**'
 
 jobs:
-  detect_changes:
-    runs-on: ubuntu-latest
-    outputs:
-      python_changed: ${{ steps.check.outputs.python_changed }}
-    steps:
-    - uses: actions/checkout@v2
-    - run: git fetch origin ${{ github.base_ref }}
-    - id: check
-      run: git diff HEAD origin/${{ github.base_ref }} --quiet -- python || echo "::set-output name=python_changed::true"
-
   tox:
     runs-on: ubuntu-latest
-    needs: detect_changes
-    if: needs.detect_changes.outputs.python_changed == 'true'
     strategy:
       matrix:
         python: [3.6, 3.7, 3.8]


### PR DESCRIPTION
This updates Java and Python CI actions to run only when certain files are modified. Python matches any file in the `python` folder or its CI config, and Java matches any file except those in the `python` or `site` folders.