### PR TITLE
Fix update partition spec with only rename changes

### DIFF
--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -181,8 +181,8 @@ public class PartitionSpec implements Serializable {
   }
 
   /**
-   * Returns true if this spec is equivalent to the other, with field names and partition field ids ignored.
-   * That is, if both specs have the same number of fields, field order, source columns, and transforms.
+   * Returns true if this spec is equivalent to the other, with partition field ids ignored.
+   * That is, if both specs have the same number of fields, field order, field name, source columns, and transforms.
    *
    * @param other another PartitionSpec
    * @return true if the specs have the same fields, source columns, and transforms.
@@ -200,7 +200,8 @@ public class PartitionSpec implements Serializable {
       PartitionField thisField = fields[i];
       PartitionField thatField = other.fields[i];
       if (thisField.sourceId() != thatField.sourceId() ||
-          !thisField.transform().toString().equals(thatField.transform().toString())) {
+          !thisField.transform().toString().equals(thatField.transform().toString()) ||
+          !thisField.name().equals(thatField.name())) {
         return false;
       }
     }

--- a/core/src/test/java/org/apache/iceberg/TestTableUpdatePartitionSpec.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableUpdatePartitionSpec.java
@@ -140,19 +140,21 @@ public class TestTableUpdatePartitionSpec extends TableTestBase {
 
     Assert.assertEquals("should match evolved spec", evolvedSpec, table.spec());
     Assert.assertEquals(1002, table.spec().lastAssignedFieldId());
+  }
 
+  @Test
+  public void testRenameOnlyEvolution() {
     table.updateSpec()
-        .renameField("id_bucket_8", "id_partition")
+        .renameField("data_bucket", "data_partition")
         .commit();
 
-    evolvedSpec = PartitionSpec.builderFor(table.schema())
-        .withSpecId(3)
-        .bucket("data", 16, "data_bucket")
-        .bucket("id", 8, "id_partition")
-        .truncate("id", 4, "id_trunc_4")
+    PartitionSpec evolvedSpec = PartitionSpec.builderFor(table.schema())
+        .withSpecId(1)
+        .bucket("data", 16, "data_partition")
         .build();
+
     Assert.assertEquals("should match evolved spec", evolvedSpec, table.spec());
-    Assert.assertEquals(1002, table.spec().lastAssignedFieldId());
+    Assert.assertEquals(1000, table.spec().lastAssignedFieldId());
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestTableUpdatePartitionSpec.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableUpdatePartitionSpec.java
@@ -140,6 +140,19 @@ public class TestTableUpdatePartitionSpec extends TableTestBase {
 
     Assert.assertEquals("should match evolved spec", evolvedSpec, table.spec());
     Assert.assertEquals(1002, table.spec().lastAssignedFieldId());
+
+    table.updateSpec()
+        .renameField("id_bucket_8", "id_partition")
+        .commit();
+
+    evolvedSpec = PartitionSpec.builderFor(table.schema())
+        .withSpecId(3)
+        .bucket("data", 16, "data_bucket")
+        .bucket("id", 8, "id_partition")
+        .truncate("id", 4, "id_trunc_4")
+        .build();
+    Assert.assertEquals("should match evolved spec", evolvedSpec, table.spec());
+    Assert.assertEquals(1002, table.spec().lastAssignedFieldId());
   }
 
   @Test


### PR DESCRIPTION
 Fix update partition spec with only rename changes by treating the new spec as incompatible one.
