### PR TITLE
Use supplied sort order in HadoopTables replace transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,4 @@ Iceberg's Spark integration is compatible with Spark 2.4 and Spark 3.0 using the
 | master branch   | spark-runtime | spark3-runtime |
 | 0.9.0           | spark-runtime | spark3-runtime |
 | 0.8.0           | spark-runtime |                |
+

--- a/README.md
+++ b/README.md
@@ -85,4 +85,3 @@ Iceberg's Spark integration is compatible with Spark 2.4 and Spark 3.0 using the
 | master branch   | spark-runtime | spark3-runtime |
 | 0.9.0           | spark-runtime | spark3-runtime |
 | 0.8.0           | spark-runtime |                |
-

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTables.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTables.java
@@ -339,9 +339,9 @@ public class HadoopTables implements Tables, Configurable {
       Map<String, String> properties = propertiesBuilder.build();
       TableMetadata metadata;
       if (ops.current() != null) {
-        metadata = ops.current().buildReplacement(schema, spec, SortOrder.unsorted(), location, properties);
+        metadata = ops.current().buildReplacement(schema, spec, sortOrder, location, properties);
       } else {
-        metadata = tableMetadata(schema, spec, null, properties, location);
+        metadata = tableMetadata(schema, spec, sortOrder, properties, location);
       }
 
       if (orCreate) {


### PR DESCRIPTION
fix issue in #1843 which failed to pick up correct sort order when executing transactions from `HadoopTables`

Thanks @openinx !