### PR TITLE
Core: Add primary key spec.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/PrimaryKey.java
+++ b/api/src/main/java/org/apache/iceberg/PrimaryKey.java
@@ -30,6 +30,9 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 
+/**
+ * A primary key that defines which columns will be unique in this table.
+ */
 public class PrimaryKey implements Serializable {
 
   private static final PrimaryKey NON_PRIMARY_KEY = new PrimaryKey(null, 0, false, ImmutableList.of());
@@ -48,18 +51,30 @@ public class PrimaryKey implements Serializable {
     this.sourceIds = sourceIds.toArray(new Integer[0]);
   }
 
+  /**
+   * Returns the {@link Schema} for this primary key.
+   */
   public Schema schema() {
     return schema;
   }
 
+  /**
+   * Returns this ID of this primary key.
+   */
   public int keyId() {
     return keyId;
   }
 
+  /**
+   * Returns true if the uniqueness should be guaranteed when writing iceberg table.
+   */
   public boolean enforceUniqueness() {
     return enforceUniqueness;
   }
 
+  /**
+   * Returns the list of source field ids for this primary key.
+   */
   public List<Integer> sourceIds() {
     if (sourceIdList == null) {
       synchronized (this) {
@@ -71,16 +86,28 @@ public class PrimaryKey implements Serializable {
     return sourceIdList;
   }
 
+  /**
+   * Returns true if the primary key has no column.
+   */
   public boolean isNonPrimaryKey() {
     return sourceIds.length == 0;
   }
 
+  /**
+   * Returns a dummy primary key that has no column.
+   */
   public static PrimaryKey nonPrimaryKey() {
     return NON_PRIMARY_KEY;
   }
 
+  /**
+   * Checks whether this primary key is equivalent to another primary key while ignoring the primary key id.
+   *
+   * @param other a different primary key.
+   * @return true if this key is equivalent to the given key.
+   */
   public boolean samePrimaryKey(PrimaryKey other) {
-    return Arrays.equals(sourceIds, other.sourceIds);
+    return Arrays.equals(sourceIds, other.sourceIds) && enforceUniqueness == other.enforceUniqueness;
   }
 
   @Override
@@ -120,10 +147,20 @@ public class PrimaryKey implements Serializable {
         .toString();
   }
 
+  /**
+   * Creates a new {@link Builder primary key builder} for the given {@link Schema}.
+   *
+   * @param schema a schema
+   * @return a primary key builder for the given schema.
+   */
   public static Builder builderFor(Schema schema) {
     return new Builder(schema);
   }
 
+  /**
+   * A builder to create valid {@link PrimaryKey primary keys}. Call {@link #builderFor(Schema)} to create a new
+   * builder.
+   */
   public static class Builder {
     private final Schema schema;
     private final List<Integer> sourceIds = Lists.newArrayList();

--- a/api/src/main/java/org/apache/iceberg/PrimaryKey.java
+++ b/api/src/main/java/org/apache/iceberg/PrimaryKey.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+
+public class PrimaryKey implements Serializable {
+
+  private static final PrimaryKey NON_PRIMARY_KEY = new PrimaryKey(null, 0, false, ImmutableList.of());
+
+  private final Schema schema;
+  private final int keyId;
+  private final boolean enforceUniqueness;
+  private final Integer[] fieldIds;
+
+  private transient volatile List<Integer> fieldIdList;
+
+  private PrimaryKey(Schema schema, int keyId, boolean enforceUniqueness, List<Integer> fields) {
+    this.schema = schema;
+    this.keyId = keyId;
+    this.enforceUniqueness = enforceUniqueness;
+    this.fieldIds = fields.toArray(new Integer[0]);
+  }
+
+  public Schema schema() {
+    return schema;
+  }
+
+  public int keyId() {
+    return keyId;
+  }
+
+  public boolean enforceUniqueness() {
+    return enforceUniqueness;
+  }
+
+  public List<Integer> fieldIds() {
+    if (fieldIdList == null) {
+      synchronized (this) {
+        if (fieldIdList == null) {
+          this.fieldIdList = ImmutableList.copyOf(fieldIds);
+        }
+      }
+    }
+    return fieldIdList;
+  }
+
+  public boolean isNonPrimaryKey() {
+    return fieldIds.length == 0;
+  }
+
+  public static PrimaryKey nonPrimaryKey() {
+    return NON_PRIMARY_KEY;
+  }
+
+  public boolean samePrimaryKey(PrimaryKey other) {
+    return Arrays.equals(fieldIds, other.fieldIds);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    } else if (!(other instanceof PrimaryKey)) {
+      return false;
+    }
+
+    PrimaryKey that = (PrimaryKey) other;
+    if (this.keyId != that.keyId) {
+      return false;
+    }
+
+    if (this.enforceUniqueness != that.enforceUniqueness) {
+      return false;
+    }
+
+    return Arrays.equals(fieldIds, that.fieldIds);
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = 31 * keyId;
+    hash = hash + (enforceUniqueness ? 1 : 0);
+    hash += Arrays.hashCode(fieldIds);
+    return hash;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("keyId", keyId)
+        .add("enforceUniqueness", enforceUniqueness)
+        .add("fields", fieldIds())
+        .toString();
+  }
+
+  public static Builder builderFor(Schema schema) {
+    return new Builder(schema);
+  }
+
+  public static class Builder {
+    private final Schema schema;
+    private final List<Integer> fieldIds = Lists.newArrayList();
+
+    private int keyId = 0;
+    private boolean enforceUniqueness = false;
+
+    private Builder(Schema schema) {
+      this.schema = schema;
+    }
+
+    public Builder withKeyId(int newKeyId) {
+      this.keyId = newKeyId;
+      return this;
+    }
+
+    public Builder withEnforceUniqueness(boolean enable) {
+      this.enforceUniqueness = enable;
+      return this;
+    }
+
+    public Builder addFieldId(int sourceId) {
+      Types.NestedField column = schema.findField(sourceId);
+      Preconditions.checkNotNull(column, "Cannot find source column: %s", sourceId);
+      Preconditions.checkArgument(column.isRequired(), "Cannot add optional source field to primary key: %s", sourceId);
+
+      Type sourceType = column.type();
+      ValidationException.check(sourceType.isPrimitiveType(), "Cannot add non-primitive field: %s", sourceType);
+
+      fieldIds.add(sourceId);
+      return this;
+    }
+
+    public PrimaryKey build() {
+      return new PrimaryKey(schema, keyId, enforceUniqueness, fieldIds);
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/PrimaryKey.java
+++ b/api/src/main/java/org/apache/iceberg/PrimaryKey.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Objects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -132,10 +133,7 @@ public class PrimaryKey implements Serializable {
 
   @Override
   public int hashCode() {
-    int hash = 31 * keyId;
-    hash = hash + (enforceUniqueness ? 1 : 0);
-    hash += Arrays.hashCode(sourceIds);
-    return hash;
+    return Objects.hashCode(keyId, enforceUniqueness ? 1 : 0, Arrays.hashCode(sourceIds));
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/PrimaryKey.java
+++ b/api/src/main/java/org/apache/iceberg/PrimaryKey.java
@@ -128,15 +128,15 @@ public class PrimaryKey implements Serializable {
     private final Schema schema;
     private final List<Integer> fieldIds = Lists.newArrayList();
 
-    private int keyId = 0;
+    private int primaryKeyId = 0;
     private boolean enforceUniqueness = false;
 
     private Builder(Schema schema) {
       this.schema = schema;
     }
 
-    public Builder withKeyId(int newKeyId) {
-      this.keyId = newKeyId;
+    public Builder withPrimaryKeyId(int newPrimaryKeyId) {
+      this.primaryKeyId = newPrimaryKeyId;
       return this;
     }
 
@@ -158,7 +158,7 @@ public class PrimaryKey implements Serializable {
     }
 
     public PrimaryKey build() {
-      return new PrimaryKey(schema, keyId, enforceUniqueness, fieldIds);
+      return new PrimaryKey(schema, primaryKeyId, enforceUniqueness, fieldIds);
     }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/Table.java
+++ b/api/src/main/java/org/apache/iceberg/Table.java
@@ -89,6 +89,20 @@ public interface Table {
   Map<Integer, SortOrder> sortOrders();
 
   /**
+   * Return the {@link PrimaryKey primary key} for this table.
+   *
+   * @return this table's primary key.
+   */
+  PrimaryKey primaryKey();
+
+  /**
+   * Return a map of primary key IDs to {@link PrimaryKey primary keys} for this table.
+   *
+   * @return this table's primary keys map.
+   */
+  Map<Integer, PrimaryKey> primaryKeys();
+
+  /**
    * Return a map of string properties for this table.
    *
    * @return this table's properties map

--- a/api/src/main/java/org/apache/iceberg/Tables.java
+++ b/api/src/main/java/org/apache/iceberg/Tables.java
@@ -38,12 +38,13 @@ public interface Tables {
   }
 
   default Table create(Schema schema, PartitionSpec spec, Map<String, String> properties, String tableIdentifier) {
-    return create(schema, spec, SortOrder.unsorted(), properties, tableIdentifier);
+    return create(schema, spec, SortOrder.unsorted(), PrimaryKey.nonPrimaryKey(), properties, tableIdentifier);
   }
 
   default Table create(Schema schema,
                        PartitionSpec spec,
                        SortOrder order,
+                       PrimaryKey primaryKey,
                        Map<String, String> properties,
                        String tableIdentifier) {
     throw new UnsupportedOperationException(this.getClass().getName() + " does not implement create with a sort order");

--- a/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.catalog;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.PrimaryKey;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
@@ -359,6 +360,14 @@ public interface Catalog {
      * @return this for method chaining
      */
     TableBuilder withSortOrder(SortOrder sortOrder);
+
+    /**
+     * Sets a primary key for this table.
+     *
+     * @param primaryKey a primary key
+     * @return this for method chaining
+     */
+    TableBuilder withPrimaryKey(PrimaryKey primaryKey);
 
     /**
      * Sets a location for the table.

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 abstract class BaseMetadataTable implements Table {
   private final PartitionSpec spec = PartitionSpec.unpartitioned();
   private final SortOrder sortOrder = SortOrder.unsorted();
+  private final PrimaryKey primaryKey = PrimaryKey.nonPrimaryKey();
 
   abstract Table table();
 
@@ -75,6 +76,16 @@ abstract class BaseMetadataTable implements Table {
   @Override
   public Map<Integer, SortOrder> sortOrders() {
     return ImmutableMap.of(sortOrder.orderId(), sortOrder);
+  }
+
+  @Override
+  public PrimaryKey primaryKey() {
+    return primaryKey;
+  }
+
+  @Override
+  public Map<Integer, PrimaryKey> primaryKeys() {
+    return ImmutableMap.of(primaryKey.keyId(), primaryKey);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTable.java
@@ -85,6 +85,16 @@ public class BaseTable implements Table, HasTableOperations {
   }
 
   @Override
+  public PrimaryKey primaryKey() {
+    return ops.current().primaryKey();
+  }
+
+  @Override
+  public Map<Integer, PrimaryKey> primaryKeys() {
+    return ops.current().primaryKeysById();
+  }
+
+  @Override
   public Map<String, String> properties() {
     return ops.current().properties();
   }

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -541,6 +541,16 @@ class BaseTransaction implements Transaction {
     }
 
     @Override
+    public PrimaryKey primaryKey() {
+      return current.primaryKey();
+    }
+
+    @Override
+    public Map<Integer, PrimaryKey> primaryKeys() {
+      return current.primaryKeysById();
+    }
+
+    @Override
     public Map<String, String> properties() {
       return current.properties();
     }

--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -187,6 +187,12 @@ public class CachingCatalog implements Catalog {
     }
 
     @Override
+    public TableBuilder withPrimaryKey(PrimaryKey primaryKey) {
+      innerBuilder.withPrimaryKey(primaryKey);
+      return this;
+    }
+
+    @Override
     public TableBuilder withLocation(String location) {
       innerBuilder.withLocation(location);
       return this;

--- a/core/src/main/java/org/apache/iceberg/PrimaryKeyParser.java
+++ b/core/src/main/java/org/apache/iceberg/PrimaryKeyParser.java
@@ -68,7 +68,7 @@ public class PrimaryKeyParser {
     int primaryKeyId = JsonUtil.getInt(PRIMARY_KEY_ID, json);
     boolean enforceUniqueness = JsonUtil.getBool(ENFORCE_UNIQUENESS, json);
     PrimaryKey.Builder builder = PrimaryKey.builderFor(schema)
-        .withKeyId(primaryKeyId)
+        .withPrimaryKeyId(primaryKeyId)
         .withEnforceUniqueness(enforceUniqueness);
     buildFromJsonFields(builder, json.get(FIELDS));
     return builder.build();

--- a/core/src/main/java/org/apache/iceberg/PrimaryKeyParser.java
+++ b/core/src/main/java/org/apache/iceberg/PrimaryKeyParser.java
@@ -105,9 +105,7 @@ public class PrimaryKeyParser {
       JsonNode element = elements.next();
       Preconditions.checkArgument(element.isObject(), "Cannot parse primary key field, not an object: %s", element);
 
-      int fieldId = JsonUtil.getInt(SOURCE_ID, element);
-
-      builder.addField(fieldId);
+      builder.addField(JsonUtil.getInt(SOURCE_ID, element));
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/PrimaryKeyParser.java
+++ b/core/src/main/java/org/apache/iceberg/PrimaryKeyParser.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Iterator;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.JsonUtil;
+
+public class PrimaryKeyParser {
+  private static final String PRIMARY_KEY_ID = "primary-key-id";
+  private static final String ENFORCE_UNIQUENESS = "enforce-uniqueness";
+  private static final String FIELDS = "fields";
+  private static final String SOURCE_ID = "source-id";
+
+  private PrimaryKeyParser() {
+  }
+
+  public static void toJson(PrimaryKey primaryKey, JsonGenerator generator) throws IOException {
+    generator.writeStartObject();
+    generator.writeNumberField(PRIMARY_KEY_ID, primaryKey.keyId());
+    generator.writeBooleanField(ENFORCE_UNIQUENESS, primaryKey.enforceUniqueness());
+    generator.writeFieldName(FIELDS);
+    toJsonFields(primaryKey, generator);
+    generator.writeEndObject();
+  }
+
+  private static void toJsonFields(PrimaryKey primaryKey, JsonGenerator generator) throws IOException {
+    generator.writeStartArray();
+    for (Integer fieldId : primaryKey.fieldIds()) {
+      generator.writeStartObject();
+      generator.writeNumberField(SOURCE_ID, fieldId);
+      generator.writeEndObject();
+    }
+    generator.writeEndArray();
+  }
+
+  public static PrimaryKey fromJson(Schema schema, String json) {
+    try {
+      return fromJson(schema, JsonUtil.mapper().readValue(json, JsonNode.class));
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  public static PrimaryKey fromJson(Schema schema, JsonNode json) {
+    Preconditions.checkArgument(json.isObject(), "Cannot parse primary key from non-object: %s", json);
+    int primaryKeyId = JsonUtil.getInt(PRIMARY_KEY_ID, json);
+    boolean enforceUniqueness = JsonUtil.getBool(ENFORCE_UNIQUENESS, json);
+    PrimaryKey.Builder builder = PrimaryKey.builderFor(schema)
+        .withKeyId(primaryKeyId)
+        .withEnforceUniqueness(enforceUniqueness);
+    buildFromJsonFields(builder, json.get(FIELDS));
+    return builder.build();
+  }
+
+  private static void buildFromJsonFields(PrimaryKey.Builder builder, JsonNode json) {
+    Preconditions.checkArgument(json != null, "Cannot parse null primary key fields.");
+    Preconditions.checkArgument(json.isArray(), "Cannot parse primary key fields, not an array: %s", json);
+
+    Iterator<JsonNode> elements = json.elements();
+    while (elements.hasNext()) {
+      JsonNode element = elements.next();
+      Preconditions.checkArgument(element.isObject(), "Cannot parse primary key field, not an object: %s", element);
+
+      int fieldId = JsonUtil.getInt(SOURCE_ID, element);
+
+      builder.addFieldId(fieldId);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/PrimaryKeyParser.java
+++ b/core/src/main/java/org/apache/iceberg/PrimaryKeyParser.java
@@ -68,7 +68,7 @@ public class PrimaryKeyParser {
     int primaryKeyId = JsonUtil.getInt(PRIMARY_KEY_ID, json);
     boolean enforceUniqueness = JsonUtil.getBool(ENFORCE_UNIQUENESS, json);
     PrimaryKey.Builder builder = PrimaryKey.builderFor(schema)
-        .withPrimaryKeyId(primaryKeyId)
+        .withKeyId(primaryKeyId)
         .withEnforceUniqueness(enforceUniqueness);
     buildFromJsonFields(builder, json.get(FIELDS));
     return builder.build();
@@ -85,7 +85,7 @@ public class PrimaryKeyParser {
 
       int fieldId = JsonUtil.getInt(SOURCE_ID, element);
 
-      builder.addFieldId(fieldId);
+      builder.addField(fieldId);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -792,7 +792,7 @@ public class TableMetadata implements Serializable {
         .orElse(freshPrimaryKeyId);
 
     ImmutableList.Builder<PrimaryKey> primaryKeyBuilder = ImmutableList.<PrimaryKey>builder().addAll(primaryKeys);
-    if (primaryKeysById.containsKey(primaryKeyId)) {
+    if (!primaryKeysById.containsKey(primaryKeyId)) {
       primaryKeyBuilder.add(freshPrimaryKey);
     }
 
@@ -880,7 +880,7 @@ public class TableMetadata implements Serializable {
   }
 
   private static PrimaryKey updatePrimaryKeySchema(Schema schema, PrimaryKey primaryKey) {
-    PrimaryKey.Builder builder = PrimaryKey.builderFor(schema).withKeyId(primaryKey.keyId());
+    PrimaryKey.Builder builder = PrimaryKey.builderFor(schema).withPrimaryKeyId(primaryKey.keyId());
 
     // add all the fields to the builder, IDs should not change.
     for (Integer fieldId : primaryKey.fieldIds()) {
@@ -928,7 +928,7 @@ public class TableMetadata implements Serializable {
   private static PrimaryKey freshPrimaryKey(int primaryKeyId, Schema schema, PrimaryKey primaryKey) {
     PrimaryKey.Builder builder = PrimaryKey
         .builderFor(schema)
-        .withKeyId(primaryKeyId)
+        .withPrimaryKeyId(primaryKeyId)
         .withEnforceUniqueness(primaryKey.enforceUniqueness());
 
     for (Integer fieldId : primaryKey.fieldIds()) {

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -883,7 +883,7 @@ public class TableMetadata implements Serializable {
     PrimaryKey.Builder builder = PrimaryKey.builderFor(schema).withKeyId(primaryKey.keyId());
 
     // add all the fields to the builder, IDs should not change.
-    for (Integer fieldId : primaryKey.fieldIds()) {
+    for (Integer fieldId : primaryKey.sourceIds()) {
       builder.addField(fieldId);
     }
 
@@ -931,7 +931,7 @@ public class TableMetadata implements Serializable {
         .withKeyId(keyId)
         .withEnforceUniqueness(primaryKey.enforceUniqueness());
 
-    for (Integer fieldId : primaryKey.fieldIds()) {
+    for (Integer fieldId : primaryKey.sourceIds()) {
       // look up the name of the source field in the old schema to get the new schema's id
       String sourceName = primaryKey.schema().findColumnName(fieldId);
       // reassign all primary keys with fresh primary field IDs.

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -333,7 +333,7 @@ public class TableMetadataParser {
       primaryKeys = builder.build();
     } else {
       Preconditions.checkArgument(formatVersion == 1,
-          "%s must exist in format v%d", PRIMARY_KEYS, formatVersion);
+          "%s must exist in format v%s", PRIMARY_KEYS, formatVersion);
       PrimaryKey defaultPrimaryKey = PrimaryKey.nonPrimaryKey();
       primaryKeys = ImmutableList.of(defaultPrimaryKey);
       defaultPrimaryKeyId = defaultPrimaryKey.keyId();

--- a/core/src/test/java/org/apache/iceberg/TestPrimaryKey.java
+++ b/core/src/test/java/org/apache/iceberg/TestPrimaryKey.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.io.File;
+import java.io.IOException;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+@RunWith(Parameterized.class)
+public class TestPrimaryKey {
+
+  private final int formatVersion;
+
+  private static final Schema SCHEMA = new Schema(
+      required(10, "id", Types.IntegerType.get()),
+      required(11, "data", Types.StringType.get()),
+      optional(12, "s", Types.StructType.of(
+          required(13, "id", Types.IntegerType.get())
+      )),
+      optional(14, "map", Types.MapType.ofOptional(
+          15, 16, Types.IntegerType.get(), Types.IntegerType.get()
+      )),
+      required(17, "required_list", Types.ListType.ofOptional(18, Types.StringType.get()))
+  );
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+  private File tableDir = null;
+
+  @Parameterized.Parameters
+  public static Iterable<Object[]> parameters() {
+    return Lists.newArrayList(
+        new Object[] {1},
+        new Object[] {2}
+    );
+  }
+
+  public TestPrimaryKey(int formatVersion) {
+    this.formatVersion = formatVersion;
+  }
+
+  @Before
+  public void setupTableDir() throws IOException {
+    this.tableDir = temp.newFolder();
+  }
+
+  @After
+  public void cleanupTables() {
+    TestTables.clearTables();
+  }
+
+  @Test
+  public void testReservedPrimaryKey() {
+    Assert.assertEquals("Should be able to build non-primary key",
+        PrimaryKey.nonPrimaryKey(),
+        PrimaryKey.builderFor(SCHEMA).withKeyId(0).build());
+
+    AssertHelpers.assertThrows("Should not allow primary key ID 0",
+        IllegalArgumentException.class, "Primary key ID 0 is reserved for non-primary key",
+        () -> PrimaryKey.builderFor(SCHEMA).addField("id").withKeyId(0).build());
+
+    AssertHelpers.assertThrows("Should not allow non-primary key with arbitrary IDs",
+        IllegalArgumentException.class, "Non-primary key ID must be 0",
+        () -> PrimaryKey.builderFor(SCHEMA).withKeyId(1).build());
+  }
+
+  @Test
+  public void testDefaultPrimaryKey() {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    SortOrder order = SortOrder.unsorted();
+    PrimaryKey key = PrimaryKey.nonPrimaryKey();
+    TestTables.TestTable table = TestTables.create(tableDir, "test", SCHEMA, spec, order, key, formatVersion);
+    Assert.assertEquals("Expected 1 partition spec", 1, table.specs().size());
+    Assert.assertEquals("Expected 1 sort order", 1, table.sortOrders().size());
+    Assert.assertEquals("Expected 1 primary key", 1, table.primaryKeys().size());
+
+    PrimaryKey actualKey = table.primaryKey();
+    Assert.assertEquals("Primary key ID must match", 0, actualKey.keyId());
+    Assert.assertTrue("Primary key is non-primary key", actualKey.isNonPrimaryKey());
+  }
+
+  @Test
+  public void testFreshIds() {
+    PrimaryKey key = PrimaryKey.builderFor(SCHEMA)
+        .withKeyId(1)
+        .addField("id")
+        .addField("data")
+        .build();
+    TestTables.TestTable table = TestTables.create(tableDir, "test", SCHEMA,
+        PartitionSpec.unpartitioned(), SortOrder.unsorted(), key, formatVersion);
+
+    Assert.assertEquals("Expected 1 primary key", 1, table.primaryKeys().size());
+    Assert.assertTrue("Primary key ID must be fresh", table.primaryKeys().containsKey(1));
+
+    PrimaryKey actualKey = table.primaryKey();
+    Assert.assertEquals("Primary key must be fresh", TableMetadata.INITIAL_PRIMARY_KEY_ID, actualKey.keyId());
+    Assert.assertEquals("Primary key must have 2 fields", 2, actualKey.sourceIds().size());
+    Assert.assertEquals("Field id must be fresh", Integer.valueOf(1), actualKey.sourceIds().get(0));
+    Assert.assertEquals("Field id must be fresh", Integer.valueOf(2), actualKey.sourceIds().get(1));
+  }
+
+  @Test
+  public void testAddField() {
+    AssertHelpers.assertThrows("Should not allow to add no-existing field",
+        NullPointerException.class, "Cannot find source column: data0",
+        () -> PrimaryKey.builderFor(SCHEMA).addField("data0").build());
+
+    AssertHelpers.assertThrows("Should not allow to add no-existing field",
+        NullPointerException.class, "Cannot find source column: 2147483647",
+        () -> PrimaryKey.builderFor(SCHEMA).addField(2147483647).build());
+
+    AssertHelpers.assertThrows("Should not allow to add optional field",
+        IllegalArgumentException.class, "Cannot add optional source field to primary key: map",
+        () -> PrimaryKey.builderFor(SCHEMA).addField("map").build());
+
+    AssertHelpers.assertThrows("Should not allow to add optional field",
+        IllegalArgumentException.class, "Cannot add optional source field to primary key: 14",
+        () -> PrimaryKey.builderFor(SCHEMA).addField(14).build());
+
+    AssertHelpers.assertThrows("Should not allow to add non-primitive field",
+        ValidationException.class, "Cannot add non-primitive field: list<string>",
+        () -> PrimaryKey.builderFor(SCHEMA).addField("required_list").build());
+
+    AssertHelpers.assertThrows("Should not allow to add non-primitive field",
+        ValidationException.class, "Cannot add non-primitive field: list<string>",
+        () -> PrimaryKey.builderFor(SCHEMA).addField(17).build());
+  }
+
+  @Test
+  public void testSamePrimaryKey() {
+    PrimaryKey pk1 = PrimaryKey.builderFor(SCHEMA)
+        .withKeyId(1)
+        .addField("id")
+        .addField("data")
+        .withEnforceUniqueness(false)
+        .build();
+    PrimaryKey pk2 = PrimaryKey.builderFor(SCHEMA)
+        .withKeyId(2)
+        .addField("id")
+        .addField("data")
+        .build();
+    PrimaryKey pk3 = PrimaryKey.builderFor(SCHEMA)
+        .withKeyId(3)
+        .addField("data")
+        .addField("id")
+        .build();
+    PrimaryKey pk4 = PrimaryKey.builderFor(SCHEMA)
+        .withKeyId(1)
+        .addField("id")
+        .addField("data")
+        .withEnforceUniqueness(true)
+        .build();
+    PrimaryKey pk5 = PrimaryKey.builderFor(SCHEMA)
+        .withKeyId(1)
+        .addField("id")
+        .addField("data")
+        .withEnforceUniqueness(false)
+        .build();
+
+    Assert.assertNotEquals("Primary key must not be equal.", pk1, pk2);
+    Assert.assertTrue("Primary key must be equivalent", pk1.samePrimaryKey(pk2));
+    Assert.assertTrue("Primary key must be equivalent", pk2.samePrimaryKey(pk1));
+
+    Assert.assertNotEquals("Primary key must not be equal", pk1, pk3);
+    Assert.assertFalse("Primary key must not be equivalent", pk1.samePrimaryKey(pk3));
+    Assert.assertFalse("Primary key must not be equivalent", pk3.samePrimaryKey(pk1));
+
+    Assert.assertNotEquals("Primary key must not be equal", pk1, pk4);
+    Assert.assertTrue("Primary key must be equivalent", pk1.samePrimaryKey(pk4));
+    Assert.assertTrue("Primary key must be equivalent", pk4.samePrimaryKey(pk1));
+
+    Assert.assertEquals("Primary key must be equal", pk1, pk5);
+    Assert.assertTrue("Primary key must be equivalent", pk1.samePrimaryKey(pk5));
+    Assert.assertTrue("Primary key must be equivalent", pk5.samePrimaryKey(pk1));
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestPrimaryKey.java
+++ b/core/src/test/java/org/apache/iceberg/TestPrimaryKey.java
@@ -196,8 +196,8 @@ public class TestPrimaryKey {
     Assert.assertFalse("Primary key must not be equivalent", pk3.samePrimaryKey(pk1));
 
     Assert.assertNotEquals("Primary key must not be equal", pk1, pk4);
-    Assert.assertTrue("Primary key must be equivalent", pk1.samePrimaryKey(pk4));
-    Assert.assertTrue("Primary key must be equivalent", pk4.samePrimaryKey(pk1));
+    Assert.assertFalse("Primary key must not be equivalent", pk1.samePrimaryKey(pk4));
+    Assert.assertFalse("Primary key must not be equivalent", pk4.samePrimaryKey(pk1));
 
     Assert.assertEquals("Primary key must be equal", pk1, pk5);
     Assert.assertTrue("Primary key must be equivalent", pk1.samePrimaryKey(pk5));

--- a/core/src/test/java/org/apache/iceberg/TestPrimaryKeyParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestPrimaryKeyParser.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestPrimaryKeyParser extends TableTestBase {
+
+  @Parameterized.Parameters(name = "format = {0}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+        {1},
+        {2}
+    };
+  }
+
+  public TestPrimaryKeyParser(int formatVersion) {
+    super(formatVersion);
+  }
+
+  @Test
+  public void testToJson() {
+    String expected = "{\"key-id\":0,\"enforce-uniqueness\":false,\"fields\":[]}";
+    Assert.assertEquals(expected, PrimaryKeyParser.toJson(table.primaryKey(), false));
+
+    PrimaryKey key = PrimaryKey.builderFor(table.schema())
+        .addField("id")
+        .addField("data")
+        .withEnforceUniqueness(true)
+        .build();
+
+    table.ops().commit(table.ops().current(), table.ops().current().updatePrimaryKey(key));
+
+    expected = "{\n" +
+        "  \"key-id\" : 1,\n" +
+        "  \"enforce-uniqueness\" : true,\n" +
+        "  \"fields\" : [ {\n" +
+        "    \"source-id\" : 1\n" +
+        "  }, {\n" +
+        "    \"source-id\" : 2\n" +
+        "  } ]\n" +
+        "}";
+    Assert.assertEquals(expected, PrimaryKeyParser.toJson(key, true));
+  }
+
+  @Test
+  public void testFromJson() {
+    String keyString = "{\n" +
+        "  \"key-id\" : 1,\n" +
+        "  \"enforce-uniqueness\" : true,\n" +
+        "  \"fields\" : [ {\n" +
+        "    \"source-id\" : 1\n" +
+        "  } ]\n" +
+        "}";
+
+    PrimaryKey expectedKey = PrimaryKey.builderFor(table.schema())
+        .addField("id")
+        .withEnforceUniqueness(true)
+        .build();
+
+    PrimaryKey key = PrimaryKeyParser.fromJson(table.schema(), keyString);
+    Assert.assertEquals(expectedKey, key);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
@@ -132,11 +132,11 @@ public class TestReplaceTransaction extends TableTestBase {
     Assert.assertEquals("Table should have 2 primary keys", 2, table.primaryKeys().size());
     PrimaryKey primaryKey = table.primaryKey();
     Assert.assertEquals("Primary key ID must match", 1, primaryKey.keyId());
-    Assert.assertEquals("Primary key must have 2 fields", 2, primaryKey.fieldIds().size());
+    Assert.assertEquals("Primary key must have 2 fields", 2, primaryKey.sourceIds().size());
     Assert.assertTrue("Primary key must be enforced.", primaryKey.enforceUniqueness());
     Assert.assertEquals("Field ID must match",
         ImmutableList.of(table.schema().findField("id").fieldId(), table.schema().findField("data").fieldId()),
-        primaryKey.fieldIds());
+        primaryKey.sourceIds());
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
@@ -70,7 +70,8 @@ public class TestReplaceTransaction extends TableTestBase {
         .build();
 
     Map<String, String> props = Maps.newHashMap();
-    Transaction replace = TestTables.beginReplace(tableDir, "test", schema, unpartitioned(), newSortOrder, props);
+    Transaction replace = TestTables.beginReplace(tableDir, "test", schema, unpartitioned(), newSortOrder,
+        PrimaryKey.nonPrimaryKey(), props);
     replace.commitTransaction();
 
     table.refresh();

--- a/core/src/test/java/org/apache/iceberg/TestSortOrder.java
+++ b/core/src/test/java/org/apache/iceberg/TestSortOrder.java
@@ -118,7 +118,8 @@ public class TestSortOrder {
         .asc("s.id", NULLS_LAST)
         .desc(truncate("data", 10), NULLS_FIRST)
         .build();
-    TestTables.TestTable table = TestTables.create(tableDir, "test", SCHEMA, spec, order, formatVersion);
+    TestTables.TestTable table = TestTables.create(tableDir, "test", SCHEMA, spec, order,
+        PrimaryKey.nonPrimaryKey(), formatVersion);
 
     Assert.assertEquals("Expected 1 sort order", 1, table.sortOrders().size());
     Assert.assertTrue("Order ID must be fresh", table.sortOrders().containsKey(TableMetadata.INITIAL_SORT_ORDER_ID));
@@ -282,7 +283,8 @@ public class TestSortOrder {
         .asc("s.id")
         .desc(truncate("data", 10))
         .build();
-    TestTables.TestTable table = TestTables.create(tableDir, "test", SCHEMA, spec, order, formatVersion);
+    TestTables.TestTable table = TestTables.create(tableDir, "test", SCHEMA, spec, order,
+        PrimaryKey.nonPrimaryKey(), formatVersion);
 
     table.updateSchema()
         .renameColumn("s.id", "s.id2")
@@ -303,7 +305,8 @@ public class TestSortOrder {
         .asc("s.id")
         .desc(truncate("data", 10))
         .build();
-    TestTables.TestTable table = TestTables.create(tableDir, "test", SCHEMA, spec, order, formatVersion);
+    TestTables.TestTable table = TestTables.create(tableDir, "test", SCHEMA, spec, order,
+        PrimaryKey.nonPrimaryKey(), formatVersion);
 
     AssertHelpers.assertThrows("Should reject deletion of sort columns",
         ValidationException.class, "Cannot find source column",

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -79,10 +79,10 @@ public class TestTableMetadata {
       .desc(Expressions.bucket("z", 4), NullOrder.NULLS_LAST)
       .build();
   private static final PrimaryKey KEY_4 = PrimaryKey.builderFor(TEST_SCHEMA)
-      .withPrimaryKeyId(4)
+      .withKeyId(4)
       .withEnforceUniqueness(true)
-      .addFieldId(3)
-      .addFieldId(1)
+      .addField(3)
+      .addField(1)
       .build();
 
   @Rule

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -78,6 +78,12 @@ public class TestTableMetadata {
       .asc("y", NullOrder.NULLS_FIRST)
       .desc(Expressions.bucket("z", 4), NullOrder.NULLS_LAST)
       .build();
+  private static final PrimaryKey KEY_4 = PrimaryKey.builderFor(TEST_SCHEMA)
+      .withKeyId(4)
+      .withEnforceUniqueness(true)
+      .addFieldId(3)
+      .addFieldId(1)
+      .build();
 
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
@@ -102,7 +108,8 @@ public class TestTableMetadata {
 
     TableMetadata expected = new TableMetadata(null, 2, UUID.randomUUID().toString(), TEST_LOCATION,
         SEQ_NO, System.currentTimeMillis(), 3, TEST_SCHEMA, 5, ImmutableList.of(SPEC_5),
-        3, ImmutableList.of(SORT_ORDER_3), ImmutableMap.of("property", "value"), currentSnapshotId,
+        3, ImmutableList.of(SORT_ORDER_3), 4, ImmutableList.of(KEY_4),
+        ImmutableMap.of("property", "value"), currentSnapshotId,
         Arrays.asList(previousSnapshot, currentSnapshot), snapshotLog, ImmutableList.of());
 
     String asJson = TableMetadataParser.toJson(expected);
@@ -127,6 +134,18 @@ public class TestTableMetadata {
         expected.defaultSpecId(), metadata.defaultSpecId());
     Assert.assertEquals("PartitionSpec map should match",
         expected.specs(), metadata.specs());
+    Assert.assertEquals("Default sort ID should match",
+        expected.defaultSortOrderId(), metadata.defaultSortOrderId());
+    Assert.assertEquals("Sort order should match",
+        expected.sortOrder(), metadata.sortOrder());
+    Assert.assertEquals("Sort order map should match",
+        expected.sortOrders(), metadata.sortOrders());
+    Assert.assertEquals("Default primary key ID should match",
+        expected.defaultPrimaryKeyId(), metadata.defaultPrimaryKeyId());
+    Assert.assertEquals("Primary key should match",
+        expected.primaryKey(), metadata.primaryKey());
+    Assert.assertEquals("Primary key map should match",
+        expected.primaryKeys(), metadata.primaryKeys());
     Assert.assertEquals("Properties should match",
         expected.properties(), metadata.properties());
     Assert.assertEquals("Snapshot logs should match",
@@ -160,8 +179,9 @@ public class TestTableMetadata {
 
     TableMetadata expected = new TableMetadata(null, 1, null, TEST_LOCATION,
         0, System.currentTimeMillis(), 3, TEST_SCHEMA, 6, ImmutableList.of(spec),
-        TableMetadata.INITIAL_SORT_ORDER_ID, ImmutableList.of(sortOrder), ImmutableMap.of("property", "value"),
-        currentSnapshotId, Arrays.asList(previousSnapshot, currentSnapshot), ImmutableList.of(), ImmutableList.of());
+        TableMetadata.INITIAL_SORT_ORDER_ID, ImmutableList.of(sortOrder), 4, ImmutableList.of(KEY_4),
+        ImmutableMap.of("property", "value"), currentSnapshotId,
+        Arrays.asList(previousSnapshot, currentSnapshot), ImmutableList.of(), ImmutableList.of());
 
     String asJson = toJsonWithoutSpecList(expected);
     TableMetadata metadata = TableMetadataParser
@@ -270,7 +290,8 @@ public class TestTableMetadata {
 
     TableMetadata base = new TableMetadata(null, 1, UUID.randomUUID().toString(), TEST_LOCATION,
         0, System.currentTimeMillis(), 3, TEST_SCHEMA, 5, ImmutableList.of(SPEC_5),
-        3, ImmutableList.of(SORT_ORDER_3), ImmutableMap.of("property", "value"), currentSnapshotId,
+        3, ImmutableList.of(SORT_ORDER_3), 4, ImmutableList.of(KEY_4),
+        ImmutableMap.of("property", "value"), currentSnapshotId,
         Arrays.asList(previousSnapshot, currentSnapshot), reversedSnapshotLog,
         ImmutableList.copyOf(previousMetadataLog));
 
@@ -305,7 +326,8 @@ public class TestTableMetadata {
 
     TableMetadata base = new TableMetadata(localInput(latestPreviousMetadata.file()), 1, UUID.randomUUID().toString(),
         TEST_LOCATION, 0, currentTimestamp - 80, 3, TEST_SCHEMA, 5, ImmutableList.of(SPEC_5),
-        3, ImmutableList.of(SORT_ORDER_3), ImmutableMap.of("property", "value"), currentSnapshotId,
+        3, ImmutableList.of(SORT_ORDER_3), 4, ImmutableList.of(KEY_4),
+        ImmutableMap.of("property", "value"), currentSnapshotId,
         Arrays.asList(previousSnapshot, currentSnapshot), reversedSnapshotLog,
         ImmutableList.copyOf(previousMetadataLog));
 
@@ -350,7 +372,7 @@ public class TestTableMetadata {
 
     TableMetadata base = new TableMetadata(localInput(latestPreviousMetadata.file()), 1, UUID.randomUUID().toString(),
         TEST_LOCATION, 0, currentTimestamp - 50, 3, TEST_SCHEMA, 5,
-        ImmutableList.of(SPEC_5), 3, ImmutableList.of(SORT_ORDER_3),
+        ImmutableList.of(SPEC_5), 3, ImmutableList.of(SORT_ORDER_3), 4, ImmutableList.of(KEY_4),
         ImmutableMap.of("property", "value"), currentSnapshotId,
         Arrays.asList(previousSnapshot, currentSnapshot), reversedSnapshotLog,
         ImmutableList.copyOf(previousMetadataLog));
@@ -402,7 +424,7 @@ public class TestTableMetadata {
     TableMetadata base = new TableMetadata(localInput(latestPreviousMetadata.file()), 1, UUID.randomUUID().toString(),
         TEST_LOCATION, 0, currentTimestamp - 50, 3, TEST_SCHEMA, 2,
         ImmutableList.of(SPEC_5), TableMetadata.INITIAL_SORT_ORDER_ID, ImmutableList.of(SortOrder.unsorted()),
-        ImmutableMap.of("property", "value"), currentSnapshotId,
+        4, ImmutableList.of(KEY_4), ImmutableMap.of("property", "value"), currentSnapshotId,
         Arrays.asList(previousSnapshot, currentSnapshot), reversedSnapshotLog,
         ImmutableList.copyOf(previousMetadataLog));
 
@@ -428,8 +450,8 @@ public class TestTableMetadata {
         IllegalArgumentException.class, "UUID is required in format v2",
         () -> new TableMetadata(null, 2, null, TEST_LOCATION, SEQ_NO, System.currentTimeMillis(),
             LAST_ASSIGNED_COLUMN_ID, TEST_SCHEMA, SPEC_5.specId(), ImmutableList.of(SPEC_5),
-            3, ImmutableList.of(SORT_ORDER_3), ImmutableMap.of(), -1L,
-            ImmutableList.of(), ImmutableList.of(), ImmutableList.of())
+            3, ImmutableList.of(SORT_ORDER_3), 4, ImmutableList.of(KEY_4),
+            ImmutableMap.of(), -1L, ImmutableList.of(), ImmutableList.of(), ImmutableList.of())
     );
   }
 
@@ -440,8 +462,8 @@ public class TestTableMetadata {
         IllegalArgumentException.class, "Unsupported format version: v" + unsupportedVersion,
         () -> new TableMetadata(null, unsupportedVersion, null, TEST_LOCATION, SEQ_NO,
             System.currentTimeMillis(), LAST_ASSIGNED_COLUMN_ID, TEST_SCHEMA, SPEC_5.specId(), ImmutableList.of(SPEC_5),
-            3, ImmutableList.of(SORT_ORDER_3), ImmutableMap.of(), -1L,
-            ImmutableList.of(), ImmutableList.of(), ImmutableList.of())
+            3, ImmutableList.of(SORT_ORDER_3), 4, ImmutableList.of(KEY_4),
+            ImmutableMap.of(), -1L, ImmutableList.of(), ImmutableList.of(), ImmutableList.of())
     );
   }
 
@@ -553,7 +575,7 @@ public class TestTableMetadata {
     SortOrder order = SortOrder.builderFor(schema).asc("x").build();
 
     TableMetadata sortedByX = TableMetadata.newTableMetadata(
-        schema, PartitionSpec.unpartitioned(), order, null, ImmutableMap.of());
+        schema, PartitionSpec.unpartitioned(), order, PrimaryKey.nonPrimaryKey(), null, ImmutableMap.of());
     Assert.assertEquals("Should have 1 sort order", 1, sortedByX.sortOrders().size());
     Assert.assertEquals("Should use orderId 1", 1, sortedByX.sortOrder().orderId());
     Assert.assertEquals("Should be sorted by one field", 1, sortedByX.sortOrder().fields().size());
@@ -583,5 +605,10 @@ public class TestTableMetadata {
         SortDirection.DESC, sortedByXDesc.sortOrder().fields().get(0).direction());
     Assert.assertEquals("Should be nulls first",
         NullOrder.NULLS_FIRST, sortedByX.sortOrder().fields().get(0).nullOrder());
+  }
+
+  @Test
+  public void testPrimaryKey() {
+
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -79,7 +79,7 @@ public class TestTableMetadata {
       .desc(Expressions.bucket("z", 4), NullOrder.NULLS_LAST)
       .build();
   private static final PrimaryKey KEY_4 = PrimaryKey.builderFor(TEST_SCHEMA)
-      .withKeyId(4)
+      .withPrimaryKeyId(4)
       .withEnforceUniqueness(true)
       .addFieldId(3)
       .addFieldId(1)

--- a/core/src/test/java/org/apache/iceberg/TestTables.java
+++ b/core/src/test/java/org/apache/iceberg/TestTables.java
@@ -48,52 +48,55 @@ public class TestTables {
   }
 
   public static TestTable create(File temp, String name, Schema schema, PartitionSpec spec, int formatVersion) {
-    return create(temp, name, schema, spec, SortOrder.unsorted(), formatVersion);
+    return create(temp, name, schema, spec, SortOrder.unsorted(), PrimaryKey.nonPrimaryKey(), formatVersion);
   }
 
   public static TestTable create(File temp, String name, Schema schema, PartitionSpec spec,
-                                 SortOrder sortOrder, int formatVersion) {
+                                 SortOrder sortOrder, PrimaryKey primaryKey, int formatVersion) {
     TestTableOperations ops = new TestTableOperations(name, temp);
     if (ops.current() != null) {
       throw new AlreadyExistsException("Table %s already exists at location: %s", name, temp);
     }
 
-    ops.commit(null, newTableMetadata(schema, spec, sortOrder, temp.toString(), ImmutableMap.of(), formatVersion));
+    ops.commit(null, newTableMetadata(schema, spec, sortOrder, primaryKey,
+        temp.toString(), ImmutableMap.of(), formatVersion));
 
     return new TestTable(ops, name);
   }
 
   public static Transaction beginCreate(File temp, String name, Schema schema, PartitionSpec spec) {
-    return beginCreate(temp, name, schema, spec, SortOrder.unsorted());
+    return beginCreate(temp, name, schema, spec, SortOrder.unsorted(), PrimaryKey.nonPrimaryKey());
   }
 
   public static Transaction beginCreate(File temp, String name, Schema schema,
-                                        PartitionSpec spec, SortOrder sortOrder) {
+                                        PartitionSpec spec, SortOrder sortOrder,
+                                        PrimaryKey primaryKey) {
     TableOperations ops = new TestTableOperations(name, temp);
     if (ops.current() != null) {
       throw new AlreadyExistsException("Table %s already exists at location: %s", name, temp);
     }
 
-    TableMetadata metadata = newTableMetadata(schema, spec, sortOrder, temp.toString(), ImmutableMap.of(), 1);
+    TableMetadata metadata = newTableMetadata(schema, spec, sortOrder, primaryKey, temp.toString(),
+        ImmutableMap.of(), 1);
 
     return Transactions.createTableTransaction(name, ops, metadata);
   }
 
   public static Transaction beginReplace(File temp, String name, Schema schema, PartitionSpec spec) {
-    return beginReplace(temp, name, schema, spec, SortOrder.unsorted(), ImmutableMap.of());
+    return beginReplace(temp, name, schema, spec, SortOrder.unsorted(), PrimaryKey.nonPrimaryKey(), ImmutableMap.of());
   }
 
   public static Transaction beginReplace(File temp, String name, Schema schema, PartitionSpec spec,
-                                         SortOrder sortOrder, Map<String, String> properties) {
+                                         SortOrder sortOrder, PrimaryKey primaryKey, Map<String, String> properties) {
     TestTableOperations ops = new TestTableOperations(name, temp);
     TableMetadata current = ops.current();
 
     TableMetadata metadata;
     if (current != null) {
-      metadata = current.buildReplacement(schema, spec, sortOrder, current.location(), properties);
+      metadata = current.buildReplacement(schema, spec, sortOrder, primaryKey, current.location(), properties);
       return Transactions.replaceTableTransaction(name, ops, metadata);
     } else {
-      metadata = newTableMetadata(schema, spec, sortOrder, temp.toString(), properties);
+      metadata = newTableMetadata(schema, spec, sortOrder, primaryKey, temp.toString(), properties);
       return Transactions.createTableTransaction(name, ops, metadata);
     }
   }

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopTables.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopTables.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.PrimaryKey;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
@@ -128,7 +129,8 @@ public class TestHadoopTables {
     SortOrder order = SortOrder.builderFor(SCHEMA)
         .asc("id", NULLS_FIRST)
         .build();
-    Table table = TABLES.create(SCHEMA, spec, order, Maps.newHashMap(), tableDir.toURI().toString());
+    Table table = TABLES.create(SCHEMA, spec, order, PrimaryKey.nonPrimaryKey(),
+        Maps.newHashMap(), tableDir.toURI().toString());
 
     SortOrder sortOrder = table.sortOrder();
     Assert.assertEquals("Order ID must match", 1, sortOrder.orderId());

--- a/core/src/test/resources/TableMetadataV2Valid.json
+++ b/core/src/test/resources/TableMetadataV2Valid.json
@@ -43,6 +43,21 @@
       ]
     }
   ],
+  "default-primary-key-id": 3,
+  "primary-keys": [
+    {
+      "key-id": 3,
+      "enforce-uniqueness": true,
+      "fields": [
+        {
+          "source-id": 1
+        },
+        {
+          "source-id": 3
+        }
+      ]
+    }
+  ],
   "default-sort-order-id": 3,
   "sort-orders": [
     {

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.PrimaryKey;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.StructLike;
@@ -208,12 +209,13 @@ abstract class TestTables {
     }
 
     @Override
-    public Table create(Schema schema, PartitionSpec spec, SortOrder sortOrder,
+    public Table create(Schema schema, PartitionSpec spec, SortOrder sortOrder, PrimaryKey primaryKey,
                         Map<String, String> properties, String tableIdentifier) {
       TableIdentifier tableIdent = TableIdentifier.parse(tableIdentifier);
       return catalog.buildTable(tableIdent, schema)
           .withPartitionSpec(spec)
           .withSortOrder(sortOrder)
+          .withPrimaryKey(primaryKey)
           .withProperties(properties)
           .create();
     }


### PR DESCRIPTION
In this [discussion](https://github.com/apache/iceberg/pull/1974#discussion_r547411736),  we are planing to introduce __primary key__ for supporting equality deletes.  We have introduced the __equality field ids__ when developing the equality deletes feature in apache iceberg core. The __equality field ids__  is actually the similar meaning  to  __primary key__, but we did not define it in table-level.

The __primary key spec__ of this PR is resolving the problem,   we will add the primary key spec in table-level, then : 

1. The catalog table could load the primary keys easily,  then we don't have to define any extra `equality field ids`  (Just use the SQL's `primary key`)when writing SQL to export cdc events into iceberg table. 
2. The table metadata could track those primary key lifecycle.  

Currently, I've added the basic changes in this PR, the unit tests is still in-progress. 