### PR TITLE
Add equals and hashcode to BaseSnapshot

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -216,25 +216,26 @@ class BaseSnapshot implements Snapshot {
     if (this == o) {
       return true;
     }
+
     if (o instanceof BaseSnapshot) {
       BaseSnapshot other = (BaseSnapshot) o;
       return this.snapshotId == other.snapshotId() &&
           this.parentId.equals(other.parentId()) &&
           this.sequenceNumber == other.sequenceNumber() &&
           this.timestampMillis == other.timestampMillis();
-
     }
+
     return false;
   }
 
   @Override
   public int hashCode() {
-    int hash = 7;
-    hash = 31 * hash + (int) this.snapshotId;
-    hash = 31 * hash + (this.parentId == null ? 0 : this.parentId.hashCode());
-    hash = 31 * hash + (int) sequenceNumber;
-    hash = 31 * hash + (int) timestampMillis;
-    return hash;
+    return Objects.hashCode(
+      this.snapshotId,
+      this.parentId,
+      this.sequenceNumber,
+      this.timestampMillis
+    );
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -212,6 +212,32 @@ class BaseSnapshot implements Snapshot {
   }
 
   @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o instanceof BaseSnapshot) {
+      BaseSnapshot other = (BaseSnapshot) o;
+      return this.snapshotId == other.snapshotId() &&
+          this.parentId.equals(other.parentId()) &&
+          this.sequenceNumber == other.sequenceNumber() &&
+          this.timestampMillis == other.timestampMillis();
+
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = 7;
+    hash = 31 * hash + (int) this.snapshotId;
+    hash = 31 * hash + (this.parentId == null ? 0 : this.parentId.hashCode());
+    hash = 31 * hash + (int) sequenceNumber;
+    hash = 31 * hash + (int) timestampMillis;
+    return hash;
+  }
+
+  @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("id", snapshotId)


### PR DESCRIPTION
For the Beam runner, we emit the Snapshots after they are made. This can be done to notify downstream consumers of the data. Because the snapshots will be serialized, Beam needs to have the ability to compare them. This is done by the native Java equals function. Because we implement equals, we also need to implement the hashcode function.
```
[direct-runner-worker] WARN org.apache.beam.sdk.util.MutationDetectors - Coder of type class org.apache.beam.sdk.coders.SerializableCoder has a #structuralValue method which does not return true when the encoding of the elements is equal. Element BaseSnapshot{id=8584070983395915429, timestamp_ms=1609329789570, operation=append, summary={added-data-files=3, added-records=300, added-files-size=3072, changed-partition-count=1, total-records=300, total-data-files=3, total-delete-files=0, total-position-deletes=0, total-equality-deletes=0}, manifest-list=file:/tmp/test_batch/metadata/snap-8584070983395915429-1-84dd1557-d24b-4b8b-8511-75eac387a6c5.avro}
```
I thought it would be nice to separate small changes outside of the Iceberg PR in https://github.com/apache/iceberg/pull/1985. So we keep the changes a bit smaller and makes it easier to review.