### PR TITLE
Build: Remove additional logging for Travis CI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -151,11 +151,7 @@ subprojects {
     })
 
     testLogging {
-      if ("true".equalsIgnoreCase(System.getenv('CI'))) {
-        events "failed", "passed"
-      } else {
-        events "failed"
-      }
+      events "failed"
       exceptionFormat "full"
     }
   }


### PR DESCRIPTION
This removes additional logging added in #1210 and #1212 to avoid timeouts in Travis CI. Now that the project uses github actions, it shouldn't be needed any longer.