### PR TITLE
Bump Nessie version to 0.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ buildscript {
 
 plugins {
   id 'nebula.dependency-recommender' version '9.0.2'
-  id 'org.projectnessie' version '0.2.1'
+  id 'org.projectnessie' version '0.3.0'
 }
 
 try {

--- a/build.gradle
+++ b/build.gradle
@@ -1079,41 +1079,15 @@ project(':iceberg-pig') {
 project(':iceberg-nessie') {
   apply plugin: 'org.projectnessie'
 
-  java {
-    registerFeature('clientSupport') {
-      usingSourceSet(sourceSets.main)
-    }
-  }
-
   dependencies {
     compile project(':iceberg-core')
     compile project(path: ':iceberg-bundled-guava', configuration: 'shadow')
     compile "org.projectnessie:nessie-client"
     quarkusAppRunnerConfig "org.projectnessie:nessie-quarkus:0.2.1"
-    clientSupportImplementation("io.quarkus:quarkus-rest-client") {
-      exclude group: "org.jboss.logging", module: "commons-logging-jboss-logging"
-    }
-    clientSupportImplementation("io.quarkus:quarkus-resteasy-jackson") {
-      exclude group: "org.codehaus.mojo", module: "animal-sniffer-annotations"
-    }
 
-
-    compileOnly("org.apache.hadoop:hadoop-common") {
-      exclude group: 'org.apache.avro', module: 'avro'
-      exclude group: 'org.apache.httpcomponents', module: 'httpclient'
-      exclude group: 'org.apache.httpcomponents', module: 'httpcore'
-      exclude group: 'commons-httpclient', module: 'commons-httpclient'
-      exclude group: "com.sun.jersey", module: 'jersey-core'
-      exclude group: "com.sun.jersey", module: 'jersey-json'
-      exclude group: "com.sun.jersey", module: 'jersey-server'
-    }
+    compileOnly "org.apache.hadoop:hadoop-common"
 
     testCompile project(path: ':iceberg-api', configuration: 'testArtifacts')
-    testCompile(project(":iceberg-nessie")) {
-      capabilities {
-        requireCapability("org.apache.iceberg:iceberg-nessie-client-support")
-      }
-    }
   }
   quarkusAppRunnerProperties {
     props = ["quarkus.http.test-port": 0]

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.nessie;
 
 import com.dremio.nessie.api.TreeApi;
 import com.dremio.nessie.client.NessieClient;
+import com.dremio.nessie.client.NessieConfigConstants;
 import com.dremio.nessie.error.BaseNessieClientServerException;
 import com.dremio.nessie.error.NessieConflictException;
 import com.dremio.nessie.error.NessieNotFoundException;
@@ -95,7 +96,7 @@ public class NessieCatalog extends BaseMetastoreCatalog implements AutoCloseable
     if (warehouseLocation == null) {
       throw new IllegalStateException("Parameter warehouse not set, nessie can't store data.");
     }
-    final String requestedRef = options.get(removePrefix.apply(NessieClient.CONF_NESSIE_REF));
+    final String requestedRef = options.get(removePrefix.apply(NessieConfigConstants.CONF_NESSIE_REF));
     this.reference = loadReference(requestedRef);
   }
 
@@ -303,7 +304,7 @@ public class NessieCatalog extends BaseMetastoreCatalog implements AutoCloseable
 
       throw new IllegalArgumentException(String.format("Nessie does not have an existing default branch." +
               "Either configure an alternative ref via %s or create the default branch on the server.",
-          NessieClient.CONF_NESSIE_REF), ex);
+          NessieConfigConstants.CONF_NESSIE_REF), ex);
     }
   }
 

--- a/versions.props
+++ b/versions.props
@@ -19,7 +19,7 @@ org.apache.arrow:arrow-memory-netty = 2.0.0
 com.github.stephenc.findbugs:findbugs-annotations = 1.3.9-1
 software.amazon.awssdk:* = 2.15.7
 org.scala-lang:scala-library = 2.12.10
-org.projectnessie:* = 0.2.1
+org.projectnessie:* = 0.3.0
 javax.ws.rs:javax.ws.rs-api = 2.1.1
 io.quarkus:* = 1.9.1.Final
 


### PR DESCRIPTION
This bumps nessie to [0.3.0 ](https://github.com/projectnessie/nessie/releases/tag/nessie-0.3.0). The new release removes the JAX-RS client in favour of `HttpUrlConnection`.

We have simplified the gradle build accordingly and bumped the version of Nessie