### PR TITLE
Move RewriteDelete to the analyzer

### DIFF
--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/ConvertMetadataDelete.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/ConvertMetadataDelete.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.optimizer
+
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.catalyst.expressions.PredicateHelper
+import org.apache.spark.sql.catalyst.expressions.SubqueryExpression
+import org.apache.spark.sql.catalyst.plans.logical.DeleteFrom
+import org.apache.spark.sql.catalyst.plans.logical.DeleteFromTable
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.connector.iceberg.catalog.ExtendedSupportsDelete
+import org.apache.spark.sql.execution.datasources.DataSourceStrategy
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.sources
+import org.apache.spark.sql.types.BooleanType
+
+object ConvertMetadataDelete extends Rule[LogicalPlan] with PredicateHelper {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan transform {
+    case DeleteFrom(relation: DataSourceV2Relation, Some(Literal(const, BooleanType)), _, _) =>
+      if (const != null && const == true) {
+        DeleteFromTable(relation, Some(Literal(true, BooleanType)))
+      } else {
+        DeleteFromTable(relation, Some(Literal(false, BooleanType)))
+      }
+
+    case DeleteFrom(relation: DataSourceV2Relation, Some(cond), _, _) if isMetadataDelete(relation, cond) =>
+      DeleteFromTable(relation, Some(cond))
+  }
+
+  private def isMetadataDelete(relation: DataSourceV2Relation, cond: Expression): Boolean = {
+    relation.table match {
+      case t: ExtendedSupportsDelete if !SubqueryExpression.hasSubquery(cond) =>
+        val predicates = splitConjunctivePredicates(cond)
+        val normalizedPredicates = DataSourceStrategy.normalizeExprs(predicates, relation.output)
+        val dataSourceFilters = toDataSourceFilters(normalizedPredicates)
+        val allPredicatesTranslated = normalizedPredicates.size == dataSourceFilters.length
+        allPredicatesTranslated && t.canDeleteWhere(dataSourceFilters)
+      case _ => false
+    }
+  }
+
+  private def toDataSourceFilters(predicates: Seq[Expression]): Array[sources.Filter] = {
+    predicates.flatMap { p =>
+      val translatedFilter = DataSourceStrategy.translateFilter(p, supportNestedPredicatePushdown = true)
+      if (translatedFilter.isEmpty) {
+        logWarning(s"Cannot translate expression to source filter: $p")
+      }
+      translatedFilter
+    }.toArray
+  }
+}

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/DeleteFrom.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/DeleteFrom.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.connector.write.BatchWrite
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+
+case class DeleteFrom(
+    rel: DataSourceV2Relation,
+    condition: Option[Expression],
+    remainingRows: LogicalPlan,
+    write: Option[BatchWrite]) extends Command with SupportsSubquery {
+  override def output: Seq[Attribute] = Nil
+  override def children: Seq[LogicalPlan] = remainingRows :: Nil
+}

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/DynamicFileFilter.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/DynamicFileFilter.scala
@@ -20,13 +20,13 @@
 package org.apache.spark.sql.catalyst.plans.logical
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet}
-import org.apache.spark.sql.connector.iceberg.read.SupportsFileFilter
+import org.apache.spark.sql.connector.iceberg.read.SupportsFileFilter.FilterFiles
 
 // TODO: fix stats (ignore the fact it is a binary node and report only scanRelation stats)
 case class DynamicFileFilter(
     scanPlan: LogicalPlan,
     fileFilterPlan: LogicalPlan,
-    filterable: SupportsFileFilter) extends BinaryNode {
+    filterable: FilterFiles) extends BinaryNode {
 
   @transient
   override lazy val references: AttributeSet = AttributeSet(fileFilterPlan.output)

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -425,7 +425,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", tableName));
   }
 
-  @Ignore // TODO: not supported since SPARK-25154 fix is not yet available
+  @Test // TODO: not supported since SPARK-25154 fix is not yet available
   public void testDeleteWithNotInSubquery() throws NoSuchTableException {
     createAndInitUnpartitionedTable();
 
@@ -457,16 +457,17 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
   }
 
   @Test
-  public void testDeleteWithNotInSubqueryNotSupported() throws NoSuchTableException {
+  public void testDeleteWithSimpleNotInSubquery() throws NoSuchTableException {
     createAndInitUnpartitionedTable();
 
-    append(new Employee(1, "hr"), new Employee(2, "hardware"));
+    append(new Employee(1, "hr"), new Employee(2, "hardware"), new Employee(null, "hr"));
 
     createOrReplaceView("deleted_id", Arrays.asList(-1, -2, null), Encoders.INT());
+    sql("DELETE FROM %s WHERE id NOT IN (SELECT * FROM deleted_id)", tableName);
 
-    AssertHelpers.assertThrows("Should complain about NOT IN subquery",
-        AnalysisException.class, "Null-aware predicate sub-queries are not currently supported",
-        () -> sql("DELETE FROM %s WHERE id NOT IN (SELECT * FROM deleted_id)", tableName));
+    assertEquals("Should have expected rows",
+        ImmutableList.of(row(1, "hr"), row(2, "hardware"), row(null, "hr")),
+        sql("SELECT * FROM %s", tableName));
   }
 
   @Test

--- a/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/read/SupportsFileFilter.java
+++ b/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/read/SupportsFileFilter.java
@@ -19,18 +19,34 @@
 
 package org.apache.spark.sql.connector.iceberg.read;
 
+import java.util.List;
 import java.util.Set;
-import org.apache.spark.sql.connector.read.Scan;
+import java.util.function.Consumer;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
 /**
  * A mix-in interface for Scan. Data sources can implement this interface if they support dynamic
  * file filters.
  */
-public interface SupportsFileFilter extends Scan {
+public interface SupportsFileFilter {
   /**
    * Filters this scan to query only selected files.
    *
-   * @param locations file locations
+   * @param files file locations
    */
-  void filterFiles(Set<String> locations);
+  void filterFiles(FilterFiles files);
+
+  final class FilterFiles {
+    private final List<Consumer<Set<String>>> filterActions = Lists.newArrayList();
+
+    public void setFilteredLocations(Set<String> locations) {
+      for (Consumer<Set<String>> action : filterActions) {
+        action.accept(locations);
+      }
+    }
+
+    public void onLocationsFilter(Consumer<Set<String>> filterAction) {
+      this.filterActions.add(filterAction);
+    }
+  }
 }


### PR DESCRIPTION
This is a work-in-progress that moves the `RewriteDelete` rule from the optimizer to the analyzer. The analyzer is a better fit for this so that more can be delegated to existing rules in Spark.