### PR TITLE
The this.parentId can be null

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -220,7 +220,7 @@ class BaseSnapshot implements Snapshot {
     if (o instanceof BaseSnapshot) {
       BaseSnapshot other = (BaseSnapshot) o;
       return this.snapshotId == other.snapshotId() &&
-          this.parentId.equals(other.parentId()) &&
+          Objects.equal(this.parentId, other.parentId()) &&
           this.sequenceNumber == other.sequenceNumber() &&
           this.timestampMillis == other.timestampMillis();
     }


### PR DESCRIPTION
Using the Objects.equal, we're safe against NPE's. Others are primitives, so that should be fine.