### PR TITLE
Add the cardinality check to detect ambiguous target row for MERGE INTO

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -285,6 +285,7 @@ This product includes code from Apache Spark.
 * vectorized reading of definition levels in BaseVectorizedParquetValuesReader.java
 * portions of the extensions parser
 * casting logic in AssignmentAlignmentSupport
+* implementation of SetAccumulator.
 
 Copyright: 2011-2018 The Apache Software Foundation
 Home page: https://spark.apache.org/

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -164,4 +164,7 @@ public class TableProperties {
 
   public static final String MERGE_MODE = "write.merge.mode";
   public static final String MERGE_MODE_DEFAULT = "copy-on-write";
+
+  public static final String MERGE_WRITE_CARDINALITY_CHECK = "write.merge.cardinality-check.enabled";
+  public static final boolean MERGE_WRITE_CARDINALITY_CHECK_DEFAULT = true;
 }

--- a/spark3-extensions/src/main/scala/org/apache/iceberg/spark/extensions/IcebergSparkSessionExtensions.scala
+++ b/spark3-extensions/src/main/scala/org/apache/iceberg/spark/extensions/IcebergSparkSessionExtensions.scala
@@ -42,8 +42,8 @@ class IcebergSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
     extensions.injectOptimizerRule { _ => OptimizeConditionsInRowLevelOperations }
     // TODO: PullupCorrelatedPredicates should handle row-level operations
     extensions.injectOptimizerRule { _ => PullupCorrelatedPredicatesInRowLevelOperations }
-    extensions.injectOptimizerRule { spark => RewriteDelete(spark.sessionState.conf) }
-    extensions.injectOptimizerRule { spark => RewriteMergeInto(spark.sessionState.conf) }
+    extensions.injectOptimizerRule { spark => RewriteDelete(spark) }
+    extensions.injectOptimizerRule { spark => RewriteMergeInto(spark) }
 
     // planner extensions
     extensions.injectPlannerStrategy { spark => ExtendedDataSourceV2Strategy(spark) }

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/expressions/AccumulateFiles.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/expressions/AccumulateFiles.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.catalyst.utils.SetAccumulator
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types.IntegerType
+
+case class AccumulateFiles(
+    filesAccumulator: SetAccumulator[String],
+    child: Expression) extends UnaryExpression with CodegenFallback {
+  override def dataType: DataType = IntegerType
+
+  override def nullable: Boolean = true
+  override def prettyName: String = "AccumulateFiles"
+  override lazy val deterministic = false
+  val RETURN_VAL: Integer = 1
+
+  override def eval(input: InternalRow) : Any = {
+    val resultVal = child.eval(input)
+    filesAccumulator.add(resultVal.toString)
+    RETURN_VAL
+  }
+}

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/DynamicFileFilter.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/DynamicFileFilter.scala
@@ -21,6 +21,7 @@ package org.apache.spark.sql.catalyst.plans.logical
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet}
 import org.apache.spark.sql.catalyst.util.truncatedString
+import org.apache.spark.sql.catalyst.utils.SetAccumulator
 import org.apache.spark.sql.connector.iceberg.read.SupportsFileFilter
 
 // TODO: fix stats (ignore the fact it is a binary node and report only scanRelation stats)
@@ -38,5 +39,24 @@ case class DynamicFileFilter(
 
   override def simpleString(maxFields: Int): String = {
     s"DynamicFileFilter${truncatedString(output, "[", ", ", "]", maxFields)}"
+  }
+}
+
+case class DynamicFileFilterWithCountCheck(
+    scanPlan: LogicalPlan,
+    fileFilterPlan: LogicalPlan,
+    filterable: SupportsFileFilter,
+    filesAccumulator: SetAccumulator[String],
+    targetTableName: String) extends BinaryNode {
+
+  @transient
+  override lazy val references: AttributeSet = AttributeSet(fileFilterPlan.output)
+
+  override def left: LogicalPlan = scanPlan
+  override def right: LogicalPlan = fileFilterPlan
+  override def output: Seq[Attribute] = scanPlan.output
+
+  override def simpleString(maxFields: Int): String = {
+    s"DynamicFileFilterWithCountCheck${truncatedString(output, "[", ", ", "]", maxFields)}"
   }
 }

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/utils/SetAccumulator.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/utils/SetAccumulator.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.utils
+
+import java.util.Collections
+import org.apache.spark.util.AccumulatorV2
+
+class SetAccumulator[T] extends AccumulatorV2[T, java.util.Set[T]] {
+  private val _set = Collections.synchronizedSet(new java.util.HashSet[T]())
+
+  override def isZero: Boolean = _set.isEmpty
+
+  override def copy(): AccumulatorV2[T, java.util.Set[T]] = {
+    val newAcc = new SetAccumulator[T]()
+    newAcc._set.addAll(_set)
+    newAcc
+  }
+
+  override def reset(): Unit = _set.clear()
+
+  override def add(v: T): Unit = _set.add(v)
+
+  override def merge(other: AccumulatorV2[T, java.util.Set[T]]): Unit = {
+    _set.addAll(other.value)
+  }
+
+  override def value: java.util.Set[T] = _set
+}

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Strategy.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Strategy.scala
@@ -34,6 +34,7 @@ import org.apache.spark.sql.catalyst.plans.logical.AddPartitionField
 import org.apache.spark.sql.catalyst.plans.logical.Call
 import org.apache.spark.sql.catalyst.plans.logical.DropPartitionField
 import org.apache.spark.sql.catalyst.plans.logical.DynamicFileFilter
+import org.apache.spark.sql.catalyst.plans.logical.DynamicFileFilterWithCountCheck
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.logical.MergeInto
 import org.apache.spark.sql.catalyst.plans.logical.ReplaceData
@@ -65,6 +66,10 @@ case class ExtendedDataSourceV2Strategy(spark: SparkSession) extends Strategy {
 
     case DynamicFileFilter(scanPlan, fileFilterPlan, filterable) =>
       DynamicFileFilterExec(planLater(scanPlan), planLater(fileFilterPlan), filterable) :: Nil
+
+    case DynamicFileFilterWithCountCheck(scanPlan, fileFilterPlan, filterable, filesAccumulator, name) =>
+      DynamicFileFilterWithCountCheckExec(planLater(scanPlan),
+        planLater(fileFilterPlan), filterable, filesAccumulator, name) :: Nil
 
     case PhysicalOperation(project, filters, DataSourceV2ScanRelation(_, scan: SupportsFileFilter, output)) =>
       // projection and filters were already pushed down in the optimizer.


### PR DESCRIPTION
SQL standard requires an exception to be thrown if the ON clause in MERGE is such that more than 1 row in source matches a row in target

Implements suggestion 1 from Anton in [comment](https://github.com/apache/iceberg/pull/1947#issuecomment-747450897)

```

1. append _row_id and _file columns to the target table
2. do an inner join on the merge condition
3. define an udf that accepts the file name, adds it to the accumulator and retuns 1 => Changed it to an expression to stay in catalyst world.
4. group by _row_id, perform the cardinality check
5. access the accumulator to get the matching files

```