### PR TITLE
Implement logic to group and sort rows before writing rows for MERGE INTO.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -286,6 +286,7 @@ This product includes code from Apache Spark.
 * portions of the extensions parser
 * casting logic in AssignmentAlignmentSupport
 * implementation of SetAccumulator.
+* Connector expressions.
 
 Copyright: 2011-2018 The Apache Software Foundation
 Home page: https://spark.apache.org/

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -140,6 +140,8 @@ public class TableProperties {
 
   public static final String WRITE_DISTRIBUTION_MODE = "write.distribution-mode";
   public static final String WRITE_DISTRIBUTION_MODE_DEFAULT = "none";
+  public static final String WRITE_DISTRIBUTION_MODE_HASH = "hash";
+  public static final String WRITE_DISTRIBUTION_MODE_RANGE = "range";
 
   public static final String GC_ENABLED = "gc.enabled";
   public static final boolean GC_ENABLED_DEFAULT = true;

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/expressions/TransformExpressions.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/expressions/TransformExpressions.scala
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.expressions
+
+import java.nio.ByteBuffer
+import org.apache.iceberg.spark.SparkSchemaUtil
+import org.apache.iceberg.transforms.Transform
+import org.apache.iceberg.transforms.Transforms
+import org.apache.iceberg.types.Type
+import org.apache.iceberg.types.Types
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.codegen.CodegenFallback
+import org.apache.spark.sql.types.AbstractDataType
+import org.apache.spark.sql.types.DataType
+import org.apache.spark.sql.types.Decimal
+import org.apache.spark.sql.types.DecimalType
+import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.sql.types.StringType
+import org.apache.spark.sql.types.TimestampType
+import org.apache.spark.unsafe.types.UTF8String
+
+// TODO : Implement truncate expression.
+
+abstract class IcebergTransformExpression
+  extends Expression with CodegenFallback with NullIntolerant {
+
+  def child: Expression
+
+  override def children: Seq[Expression] = child :: Nil
+
+  override def nullable: Boolean = true
+
+  @transient lazy val icebergInputType: Type = SparkSchemaUtil.convert(child.dataType)
+}
+
+abstract class IcebergTimeTransform
+  extends IcebergTransformExpression with ImplicitCastInputTypes {
+
+  def child: Expression
+  def transform: Transform[Any, Integer]
+
+  override def eval(input: InternalRow): Any = child.eval(input) match {
+    case null =>
+      null
+    case value =>
+      transform(value).toInt
+  }
+
+  override def dataType: DataType = IntegerType
+
+  override def inputTypes: Seq[AbstractDataType] = Seq(TimestampType)
+}
+
+case class IcebergYearTransform(child: Expression)
+  extends IcebergTimeTransform {
+
+  @transient lazy val transform: Transform[Any, Integer] = Transforms.year[Any](icebergInputType)
+}
+
+case class IcebergMonthTransform(child: Expression)
+  extends IcebergTimeTransform {
+
+  @transient lazy val transform: Transform[Any, Integer] = Transforms.month[Any](icebergInputType)
+}
+
+case class IcebergDayTransform(child: Expression)
+  extends IcebergTimeTransform {
+
+  @transient lazy val transform: Transform[Any, Integer] = Transforms.day[Any](icebergInputType)
+}
+
+case class IcebergHourTransform(child: Expression)
+  extends IcebergTimeTransform {
+
+  @transient lazy val transform: Transform[Any, Integer] = Transforms.hour[Any](icebergInputType)
+}
+
+case class IcebergBucketTransform(numBuckets: Int, child: Expression) extends IcebergTransformExpression {
+
+  override def children: Seq[Expression] = child :: Nil
+
+  @transient lazy val bucketFunc: Any => Int = child.dataType match {
+    case _: DecimalType =>
+      val t = Transforms.bucket[Any](icebergInputType, numBuckets)
+      d: Any => t(d.asInstanceOf[Decimal].toBigDecimal).toInt
+    case _: StringType =>
+      // the spec requires that the hash of a string is equal to the hash of its UTF-8 encoded bytes
+      // TODO: pass bytes without the copy out of the InternalRow
+      val t = Transforms.bucket[ByteBuffer](Types.BinaryType.get(), numBuckets)
+      s: Any => t(ByteBuffer.wrap(s.asInstanceOf[UTF8String].getBytes)).toInt
+    case _ =>
+      val t = Transforms.bucket[Any](icebergInputType, numBuckets)
+      a: Any => t(a).toInt
+  }
+
+  override def eval(input: InternalRow): Any = child.eval(input) match {
+    case null =>
+      null
+    case value =>
+      bucketFunc(value)
+  }
+
+  override def dataType: DataType = IntegerType
+}

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteMergeInto.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteMergeInto.scala
@@ -19,15 +19,23 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
+import java.util.Locale
+import org.apache.iceberg.TableProperties
 import org.apache.iceberg.TableProperties.MERGE_WRITE_CARDINALITY_CHECK
 import org.apache.iceberg.TableProperties.MERGE_WRITE_CARDINALITY_CHECK_DEFAULT
+import org.apache.iceberg.spark.Spark3Util.toClusteredDistribution
+import org.apache.iceberg.spark.Spark3Util.toOrderedDistribution
+import org.apache.iceberg.spark.source.SparkTable
 import org.apache.iceberg.util.PropertyUtil
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.analysis.Resolver
 import org.apache.spark.sql.catalyst.expressions.Alias
+import org.apache.spark.sql.catalyst.expressions.Ascending
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.expressions.IsNull
 import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.catalyst.expressions.NullsFirst
+import org.apache.spark.sql.catalyst.expressions.SortOrder
 import org.apache.spark.sql.catalyst.plans.FullOuter
 import org.apache.spark.sql.catalyst.plans.Inner
 import org.apache.spark.sql.catalyst.plans.LeftAnti
@@ -43,7 +51,10 @@ import org.apache.spark.sql.catalyst.plans.logical.MergeInto
 import org.apache.spark.sql.catalyst.plans.logical.MergeIntoParams
 import org.apache.spark.sql.catalyst.plans.logical.MergeIntoTable
 import org.apache.spark.sql.catalyst.plans.logical.Project
+import org.apache.spark.sql.catalyst.plans.logical.Repartition
+import org.apache.spark.sql.catalyst.plans.logical.RepartitionByExpression
 import org.apache.spark.sql.catalyst.plans.logical.ReplaceData
+import org.apache.spark.sql.catalyst.plans.logical.Sort
 import org.apache.spark.sql.catalyst.plans.logical.UpdateAction
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.utils.RewriteRowLevelOperationHelper
@@ -85,7 +96,7 @@ case class RewriteMergeInto(spark: SparkSession) extends Rule[LogicalPlan] with 
           joinedAttributes = joinPlan.output
         )
 
-        val mergePlan = MergeInto(mergeParams, target, joinPlan)
+        val mergePlan = MergeInto(mergeParams, target.output, joinPlan)
 
         AppendData.byPosition(target, mergePlan, Map.empty)
 
@@ -113,10 +124,11 @@ case class RewriteMergeInto(spark: SparkSession) extends Rule[LogicalPlan] with 
           targetOutput = target.output,
           joinedAttributes = joinPlan.output
         )
-        val mergePlan = MergeInto(mergeParams, target, joinPlan)
+        val mergePlan = MergeInto(mergeParams, target.output, joinPlan)
+        val writePlan = buildWritePlan(mergePlan, target.table)
         val batchWrite = mergeBuilder.asWriteBuilder.buildForBatch()
 
-        ReplaceData(target, batchWrite, mergePlan)
+        ReplaceData(target, batchWrite, writePlan)
 
       case MergeIntoTable(target: DataSourceV2Relation, source: LogicalPlan, cond, matchedActions, notMatchedActions) =>
 
@@ -142,10 +154,10 @@ case class RewriteMergeInto(spark: SparkSession) extends Rule[LogicalPlan] with 
           targetOutput = target.output,
           joinedAttributes = joinPlan.output
         )
-        val mergePlan = MergeInto(mergeParams, target, joinPlan)
+        val mergePlan = MergeInto(mergeParams, target.output, joinPlan)
+        val writePlan = buildWritePlan(mergePlan, target.table)
         val batchWrite = mergeBuilder.asWriteBuilder.buildForBatch()
-
-        ReplaceData(target, batchWrite, mergePlan)
+        ReplaceData(target, batchWrite, writePlan)
     }
   }
 
@@ -214,6 +226,42 @@ case class RewriteMergeInto(spark: SparkSession) extends Rule[LogicalPlan] with 
       }
     }
     !(actions.size == 1 && hasUnconditionalDelete(actions.headOption))
+  }
+
+  def buildWritePlan(
+     childPlan: LogicalPlan,
+     table: Table): LogicalPlan = {
+    table match {
+      case iceTable: SparkTable =>
+        val numShufflePartitions = spark.sessionState.conf.numShufflePartitions
+        val table = iceTable.table()
+        val distributionMode: String = table.properties
+          .getOrDefault("write.distribution-mode", TableProperties.WRITE_DISTRIBUTION_MODE_RANGE)
+        val order = toCatalyst(toOrderedDistribution(table.spec(), table.sortOrder(), true), childPlan)
+        distributionMode.toLowerCase(Locale.ROOT) match {
+          case TableProperties.WRITE_DISTRIBUTION_MODE_DEFAULT =>
+            Sort(buildSortOrder(order), global = false, childPlan)
+          case TableProperties.WRITE_DISTRIBUTION_MODE_HASH =>
+            val clustering = toCatalyst(toClusteredDistribution(table.spec()), childPlan)
+            val hashPartitioned = RepartitionByExpression(clustering, childPlan, numShufflePartitions)
+            Sort(buildSortOrder(order), global = false, hashPartitioned)
+          case TableProperties.WRITE_DISTRIBUTION_MODE_RANGE =>
+            val roundRobin = Repartition(numShufflePartitions, shuffle = true, childPlan)
+            Sort(buildSortOrder(order), global = true, roundRobin)
+        }
+      case _ =>
+        childPlan
+    }
+  }
+
+  private def buildSortOrder(exprs: Seq[Expression]): Seq[SortOrder] = {
+    exprs.map { expr =>
+      expr match {
+        case e: SortOrder => e
+        case other =>
+          SortOrder(other, Ascending, NullsFirst, Set.empty)
+      }
+    }
   }
 }
 

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/MergeInto.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/MergeInto.scala
@@ -24,10 +24,8 @@ import org.apache.spark.sql.catalyst.expressions.Expression
 
 case class MergeInto(
     mergeIntoProcessor: MergeIntoParams,
-    targetOutput: Seq[Attribute],
-    child: LogicalPlan) extends UnaryNode {
-  override def output: Seq[Attribute] = targetOutput
-}
+    output: Seq[Attribute],
+    child: LogicalPlan) extends UnaryNode
 
 case class MergeIntoParams(
     isSourceRowNotPresent: Expression,

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/utils/RewriteRowLevelOperationHelper.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/utils/RewriteRowLevelOperationHelper.scala
@@ -286,7 +286,6 @@ trait RewriteRowLevelOperationHelper extends PredicateHelper with Logging {
     }
   }
 
-
   private def toCatalyst(direction: SortDirection): catalyst.expressions.SortDirection = {
     direction match {
       case SortDirection.ASCENDING => catalyst.expressions.Ascending

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/utils/RewriteRowLevelOperationHelper.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/utils/RewriteRowLevelOperationHelper.scala
@@ -22,6 +22,7 @@ import java.util.UUID
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst
 import org.apache.spark.sql.catalyst.analysis.Resolver
 import org.apache.spark.sql.catalyst.expressions.AccumulateFiles
 import org.apache.spark.sql.catalyst.expressions.Alias
@@ -29,9 +30,14 @@ import org.apache.spark.sql.catalyst.expressions.And
 import org.apache.spark.sql.catalyst.expressions.Attribute
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.expressions.AttributeSet
-import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.expressions.GreaterThan
+import org.apache.spark.sql.catalyst.expressions.IcebergBucketTransform
+import org.apache.spark.sql.catalyst.expressions.IcebergDayTransform
+import org.apache.spark.sql.catalyst.expressions.IcebergHourTransform
+import org.apache.spark.sql.catalyst.expressions.IcebergMonthTransform
+import org.apache.spark.sql.catalyst.expressions.IcebergYearTransform
 import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.catalyst.expressions.NamedExpression
 import org.apache.spark.sql.catalyst.expressions.PredicateHelper
 import org.apache.spark.sql.catalyst.expressions.aggregate.AggregateExpression
 import org.apache.spark.sql.catalyst.expressions.aggregate.Complete
@@ -42,7 +48,25 @@ import org.apache.spark.sql.catalyst.plans.logical.DynamicFileFilterWithCountChe
 import org.apache.spark.sql.catalyst.plans.logical.Filter
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.logical.Project
+import org.apache.spark.sql.connector.catalog.CatalogV2Implicits.quoteIfNeeded
 import org.apache.spark.sql.connector.catalog.Table
+import org.apache.spark.sql.connector.expressions.BucketTransform
+import org.apache.spark.sql.connector.expressions.DaysTransform
+import org.apache.spark.sql.connector.expressions.Expression
+import org.apache.spark.sql.connector.expressions.FieldReference
+import org.apache.spark.sql.connector.expressions.HoursTransform
+import org.apache.spark.sql.connector.expressions.IdentityTransform
+import org.apache.spark.sql.connector.expressions.MonthsTransform
+import org.apache.spark.sql.connector.expressions.NamedReference
+import org.apache.spark.sql.connector.expressions.Transform
+import org.apache.spark.sql.connector.expressions.YearsTransform
+import org.apache.spark.sql.connector.iceberg.distributions.ClusteredDistribution
+import org.apache.spark.sql.connector.iceberg.distributions.Distribution
+import org.apache.spark.sql.connector.iceberg.distributions.OrderedDistribution
+import org.apache.spark.sql.connector.iceberg.distributions.UnspecifiedDistribution
+import org.apache.spark.sql.connector.iceberg.expressions.NullOrdering
+import org.apache.spark.sql.connector.iceberg.expressions.SortDirection
+import org.apache.spark.sql.connector.iceberg.expressions.SortOrder
 import org.apache.spark.sql.connector.iceberg.read.SupportsFileFilter
 import org.apache.spark.sql.connector.iceberg.write.MergeBuilder
 import org.apache.spark.sql.connector.read.ScanBuilder
@@ -71,7 +95,7 @@ trait RewriteRowLevelOperationHelper extends PredicateHelper with Logging {
 
   protected def buildSimpleScanPlan(
       relation: DataSourceV2Relation,
-      cond: Expression): LogicalPlan = {
+      cond: catalyst.expressions.Expression): LogicalPlan = {
 
     val scanBuilder = relation.table.asReadable.newScanBuilder(relation.options)
 
@@ -90,7 +114,7 @@ trait RewriteRowLevelOperationHelper extends PredicateHelper with Logging {
       table: Table,
       tableAttrs: Seq[AttributeReference],
       mergeBuilder: MergeBuilder,
-      cond: Expression,
+      cond: catalyst.expressions.Expression,
       matchingRowsPlanBuilder: DataSourceV2ScanRelation => LogicalPlan,
       performCountCheckForMerge: Boolean = false): LogicalPlan = {
 
@@ -120,14 +144,16 @@ trait RewriteRowLevelOperationHelper extends PredicateHelper with Logging {
     }
   }
 
-  private def extractFilters(cond: Expression, tableAttrs: Seq[AttributeReference]): Seq[Expression] = {
+  private def extractFilters(
+      cond: catalyst.expressions.Expression,
+      tableAttrs: Seq[AttributeReference]): Seq[catalyst.expressions.Expression] = {
     val tableAttrSet = AttributeSet(tableAttrs)
     splitConjunctivePredicates(cond).filter(_.references.subsetOf(tableAttrSet))
   }
 
   private def pushFilters(
       scanBuilder: ScanBuilder,
-      cond: Expression,
+      cond: catalyst.expressions.Expression,
       tableAttrs: Seq[AttributeReference]): Unit = {
     val predicates = extractFilters(cond, tableAttrs)
     if (predicates.nonEmpty) {
@@ -136,7 +162,7 @@ trait RewriteRowLevelOperationHelper extends PredicateHelper with Logging {
     }
   }
 
-  protected def toDataSourceFilters(predicates: Seq[Expression]): Array[sources.Filter] = {
+  protected def toDataSourceFilters(predicates: Seq[catalyst.expressions.Expression]): Array[sources.Filter] = {
     predicates.flatMap { p =>
       val translatedFilter = DataSourceStrategy.translateFilter(p, supportNestedPredicatePushdown = true)
       if (translatedFilter.isEmpty) {
@@ -192,6 +218,86 @@ trait RewriteRowLevelOperationHelper extends PredicateHelper with Logging {
           // if the field is new, create a new attribute
           AttributeReference(a.name, a.dataType, a.nullable, a.metadata)()
       }
+    }
+  }
+
+  private object BucketTransform {
+    def unapply(transform: Transform): Option[(Int, FieldReference)] = transform match {
+      case bt: BucketTransform => bt.columns match {
+        case Seq(nf: NamedReference) =>
+          Some(bt.numBuckets.value(), FieldReference(nf.fieldNames()))
+        case _ =>
+          None
+      }
+      case _ => None
+    }
+  }
+
+  protected def toCatalyst(
+      distribution: Distribution,
+      plan: LogicalPlan): Seq[catalyst.expressions.Expression] = {
+
+    distribution match {
+      case d: OrderedDistribution =>
+        d.ordering.map(e => toCatalyst(e, plan, resolver))
+      case d: ClusteredDistribution =>
+        d.clustering.map(e => toCatalyst(e, plan, resolver))
+      case _: UnspecifiedDistribution =>
+        Array.empty[catalyst.expressions.Expression]
+    }
+  }
+
+  private def toCatalyst(
+      expr: Expression,
+      query: LogicalPlan,
+      resolver: Resolver): catalyst.expressions.Expression = {
+
+    def resolve(parts: Seq[String]): NamedExpression = {
+      // this part is controversial as we perform resolution in the optimizer
+      // we cannot perform this step in the analyzer since we need to optimize expressions
+      // in nodes like OverwriteByExpression before constructing a logical write
+      query.resolve(parts, resolver) match {
+        case Some(attr) => attr
+        case None => throw new AnalysisException(s"Cannot resolve '${parts.map(quoteIfNeeded).mkString(".")}'" +
+          s" using ${query.output}")
+      }
+    }
+
+    expr match {
+      case s: SortOrder =>
+        val catalystChild = toCatalyst(s.expression(), query, resolver)
+        catalyst.expressions.SortOrder(catalystChild, toCatalyst(s.direction), toCatalyst(s.nullOrdering), Set.empty)
+      case it: IdentityTransform =>
+        resolve(it.ref.fieldNames())
+      case BucketTransform(numBuckets, ref) =>
+        IcebergBucketTransform(numBuckets, resolve(ref.fieldNames))
+      case yt: YearsTransform =>
+        IcebergYearTransform(resolve(yt.ref.fieldNames))
+      case mt: MonthsTransform =>
+        IcebergMonthTransform(resolve(mt.ref.fieldNames))
+      case dt: DaysTransform =>
+        IcebergDayTransform(resolve(dt.ref.fieldNames))
+      case ht: HoursTransform =>
+        IcebergHourTransform(resolve(ht.ref.fieldNames))
+      case ref: FieldReference =>
+        resolve(ref.fieldNames)
+      case _ =>
+        throw new RuntimeException(s"$expr is not currently supported")
+    }
+  }
+
+
+  private def toCatalyst(direction: SortDirection): catalyst.expressions.SortDirection = {
+    direction match {
+      case SortDirection.ASCENDING => catalyst.expressions.Ascending
+      case SortDirection.DESCENDING => catalyst.expressions.Descending
+    }
+  }
+
+  private def toCatalyst(nullOrdering: NullOrdering): catalyst.expressions.NullOrdering = {
+    nullOrdering match {
+      case NullOrdering.NULLS_FIRST => catalyst.expressions.NullsFirst
+      case NullOrdering.NULLS_LAST => catalyst.expressions.NullsLast
     }
   }
 }

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Strategy.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Strategy.scala
@@ -81,8 +81,8 @@ case class ExtendedDataSourceV2Strategy(spark: SparkSession) extends Strategy {
     case ReplaceData(_, batchWrite, query) =>
       ReplaceDataExec(batchWrite, planLater(query)) :: Nil
 
-    case MergeInto(mergeIntoParms, targetAttributes, child) =>
-      MergeIntoExec(mergeIntoParms, targetAttributes, planLater(child)) :: Nil
+    case MergeInto(mergeIntoParams, output, child) =>
+      MergeIntoExec(mergeIntoParams, output, planLater(child)) :: Nil
 
     case _ => Nil
   }

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Strategy.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Strategy.scala
@@ -81,8 +81,8 @@ case class ExtendedDataSourceV2Strategy(spark: SparkSession) extends Strategy {
     case ReplaceData(_, batchWrite, query) =>
       ReplaceDataExec(batchWrite, planLater(query)) :: Nil
 
-    case MergeInto(mergeIntoProcessor, targetRelation, child) =>
-      MergeIntoExec(mergeIntoProcessor, targetRelation, planLater(child)) :: Nil
+    case MergeInto(mergeIntoParms, targetAttributes, child) =>
+      MergeIntoExec(mergeIntoParms, targetAttributes, planLater(child)) :: Nil
 
     case _ => Nil
   }

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeIntoExec.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeIntoExec.scala
@@ -32,10 +32,8 @@ import org.apache.spark.sql.execution.UnaryExecNode
 
 case class MergeIntoExec(
     mergeIntoParams: MergeIntoParams,
-    targetOutput: Seq[Attribute],
+    output: Seq[Attribute],
     override val child: SparkPlan) extends UnaryExecNode {
-
-  override def output: Seq[Attribute] = targetOutput
 
   protected override def doExecute(): RDD[InternalRow] = {
     child.execute().mapPartitions {

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeIntoExec.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/MergeIntoExec.scala
@@ -32,10 +32,10 @@ import org.apache.spark.sql.execution.UnaryExecNode
 
 case class MergeIntoExec(
     mergeIntoParams: MergeIntoParams,
-    @transient targetRelation: DataSourceV2Relation,
+    targetOutput: Seq[Attribute],
     override val child: SparkPlan) extends UnaryExecNode {
 
-  override def output: Seq[Attribute] = targetRelation.output
+  override def output: Seq[Attribute] = targetOutput
 
   protected override def doExecute(): RDD[InternalRow] = {
     child.execute().mapPartitions {

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeIntoTable.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeIntoTable.java
@@ -346,8 +346,8 @@ public class TestMergeIntoTable extends SparkRowLevelOperationsTestBase {
 
       sql(sqlText, targetName, sourceName);
       assertEquals("Should have expected rows",
-              ImmutableList.of(row(1, "emp-id-1"), row(2, "emp-id-2")),
-              sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", targetName));
+             ImmutableList.of(row(1, "emp-id-1"), row(2, "emp-id-2")),
+             sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", targetName));
     });
   }
 
@@ -375,8 +375,8 @@ public class TestMergeIntoTable extends SparkRowLevelOperationsTestBase {
 
       sql(sqlText, targetName, sourceName);
       assertEquals("Should have expected rows",
-              ImmutableList.of(row(1, "2001-01-01 00:00:00"), row(2, "2001-01-02 00:00:00")),
-              sql("SELECT id, CAST(ts AS STRING) FROM %s ORDER BY id ASC NULLS LAST", targetName));
+             ImmutableList.of(row(1, "2001-01-01 00:00:00"), row(2, "2001-01-02 00:00:00")),
+             sql("SELECT id, CAST(ts AS STRING) FROM %s ORDER BY id ASC NULLS LAST", targetName));
     });
   }
 
@@ -400,8 +400,8 @@ public class TestMergeIntoTable extends SparkRowLevelOperationsTestBase {
 
       sql(sqlText, targetName, sourceName);
       assertEquals("Should have expected rows",
-              ImmutableList.of(row(1, "emp-id-1"), row(2, "emp-id-2")),
-              sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", targetName));
+             ImmutableList.of(row(1, "emp-id-1"), row(2, "emp-id-2")),
+             sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", targetName));
     });
   }
 
@@ -426,8 +426,8 @@ public class TestMergeIntoTable extends SparkRowLevelOperationsTestBase {
 
       sql(sqlText, "");
       assertEquals("Should have expected rows",
-              ImmutableList.of(row(1, "emp-id-1"), row(2, "emp-id-2")),
-              sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", targetName));
+             ImmutableList.of(row(1, "emp-id-1"), row(2, "emp-id-2")),
+             sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", targetName));
     });
   }
 

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeIntoTable.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeIntoTable.java
@@ -417,14 +417,14 @@ public class TestMergeIntoTable extends SparkRowLevelOperationsTestBase {
       createAndInitSourceTable(sourceName);
       append(targetName, new Employee(1, "emp-id-one"), new Employee(6, "emp-id-6"));
       append(sourceName, new Employee(2, "emp-id-2"), new Employee(1, "emp-id-1"), new Employee(6, "emp-id-6"));
-      String sqlText = "MERGE INTO " + targetName + " AS target \n" +
-              "USING " + sourceName + " AS source \n" +
+      String sqlText = "MERGE INTO %s AS target \n" +
+              "USING %s AS source \n" +
               "ON target.id = source.id \n" +
               "WHEN MATCHED AND target.id = 1 THEN UPDATE SET * \n" +
               "WHEN MATCHED AND target.id = 6 THEN DELETE \n" +
               "WHEN NOT MATCHED AND source.id = 2 THEN INSERT * ";
 
-      sql(sqlText, "");
+      sql(sqlText, targetName, sourceName);
       assertEquals("Should have expected rows",
              ImmutableList.of(row(1, "emp-id-1"), row(2, "emp-id-2")),
              sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", targetName));

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeIntoTable.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeIntoTable.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.spark.extensions;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +48,7 @@ import static org.apache.iceberg.TableProperties.PARQUET_VECTORIZATION_ENABLED;
 public class TestMergeIntoTable extends SparkRowLevelOperationsTestBase {
   private final String sourceName;
   private final String targetName;
+  private final List<String> writeModes = new ArrayList<>(Arrays.asList("none", "hash", "range"));
 
   @Parameterized.Parameters(
       name = "catalogName = {0}, implementation = {1}, config = {2}, format = {3}, vectorized = {4}")
@@ -303,25 +305,107 @@ public class TestMergeIntoTable extends SparkRowLevelOperationsTestBase {
   }
 
   @Test
-  public void testSingleConditionalDeleteCountCheck() throws NoSuchTableException {
-    append(targetName, new Employee(1, "emp-id-one"), new Employee(6, "emp-id-6"));
-    append(sourceName, new Employee(1, "emp-id-1"), new Employee(1, "emp-id-1"),
-           new Employee(2, "emp-id-2"), new Employee(6, "emp-id-6"));
+  public void testIdentityPartition()  {
+    writeModes.forEach(mode -> {
+      removeTables();
+      sql("CREATE TABLE %s (id INT, dep STRING) USING iceberg PARTITIONED BY (identity(dep))", targetName);
+      initTable(targetName);
+      setWriteMode(targetName, mode);
+      createAndInitSourceTable(sourceName);
+      append(targetName, new Employee(1, "emp-id-one"), new Employee(6, "emp-id-6"));
+      append(sourceName, new Employee(2, "emp-id-2"), new Employee(1, "emp-id-1"), new Employee(6, "emp-id-6"));
 
-    String sqlText = "MERGE INTO %s AS target " +
-           "USING %s AS source " +
-           "ON target.id = source.id " +
-           "WHEN MATCHED AND target.id = 1 THEN DELETE " +
-           "WHEN NOT MATCHED AND source.id = 2 THEN INSERT * ";
+      String sqlText = "MERGE INTO " + targetName + " AS target \n" +
+              "USING " + sourceName + " AS source \n" +
+              "ON target.id = source.id \n" +
+              "WHEN MATCHED AND target.id = 1 THEN UPDATE SET * \n" +
+              "WHEN MATCHED AND target.id = 6 THEN DELETE \n" +
+              "WHEN NOT MATCHED AND source.id = 2 THEN INSERT * ";
 
-    String tabName = catalogName + "." + "default.target";
-    String errorMsg = "The same row of target table `" + tabName + "` was identified more than\n" +
-            " once for an update, delete or insert operation of the MERGE statement.";
-    AssertHelpers.assertThrows("Should complain ambiguous row in target",
-           SparkException.class, errorMsg, () -> sql(sqlText, targetName, sourceName));
-    assertEquals("Target should be unchanged",
-           ImmutableList.of(row(1, "emp-id-one"), row(6, "emp-id-6")),
-           sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", targetName));
+      sql(sqlText, "");
+      assertEquals("Should have expected rows",
+              ImmutableList.of(row(1, "emp-id-1"), row(2, "emp-id-2")),
+              sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", targetName));
+    });
+  }
+
+  @Test
+  public void testDaysTransform() {
+    writeModes.forEach(mode -> {
+      removeTables();
+      sql("CREATE TABLE %s (id INT, ts timestamp) USING iceberg PARTITIONED BY (days(ts))", targetName);
+      initTable(targetName);
+      setWriteMode(targetName, mode);
+      sql("CREATE TABLE %s (id INT, ts timestamp) USING iceberg", sourceName);
+      initTable(sourceName);
+      sql("INSERT INTO " + targetName + " VALUES (1, timestamp('2001-01-01 00:00:00'))," +
+              "(6, timestamp('2001-01-06 00:00:00'))");
+      sql("INSERT INto " + sourceName + " VALUES (2, timestamp('2001-01-02 00:00:00'))," +
+              "(1, timestamp('2001-01-01 00:00:00'))," +
+              "(6, timestamp('2001-01-06 00:00:00'))");
+
+      String sqlText = "MERGE INTO " + targetName + " AS target \n" +
+              "USING " + sourceName + " AS source \n" +
+              "ON target.id = source.id \n" +
+              "WHEN MATCHED AND target.id = 1 THEN UPDATE SET * \n" +
+              "WHEN MATCHED AND target.id = 6 THEN DELETE \n" +
+              "WHEN NOT MATCHED AND source.id = 2 THEN INSERT * ";
+
+      sql(sqlText, "");
+      assertEquals("Should have expected rows",
+              ImmutableList.of(row(1, "2001-01-01 00:00:00"), row(2, "2001-01-02 00:00:00")),
+              sql("SELECT id, CAST(ts AS STRING) FROM %s ORDER BY id ASC NULLS LAST", targetName));
+    });
+  }
+
+  @Test
+  public void testBucketExpression() {
+    writeModes.forEach(mode -> {
+      removeTables();
+      sql("CREATE TABLE %s (id INT, dep STRING) USING iceberg" +
+              " CLUSTERED BY (dep) INTO 2 BUCKETS", targetName);
+      initTable(targetName);
+      setWriteMode(targetName, mode);
+      createAndInitSourceTable(sourceName);
+      append(targetName, new Employee(1, "emp-id-one"), new Employee(6, "emp-id-6"));
+      append(sourceName, new Employee(2, "emp-id-2"), new Employee(1, "emp-id-1"), new Employee(6, "emp-id-6"));
+      String sqlText = "MERGE INTO " + targetName + " AS target \n" +
+              "USING " + sourceName + " AS source \n" +
+              "ON target.id = source.id \n" +
+              "WHEN MATCHED AND target.id = 1 THEN UPDATE SET * \n" +
+              "WHEN MATCHED AND target.id = 6 THEN DELETE \n" +
+              "WHEN NOT MATCHED AND source.id = 2 THEN INSERT * ";
+
+      sql(sqlText, "");
+      assertEquals("Should have expected rows",
+              ImmutableList.of(row(1, "emp-id-1"), row(2, "emp-id-2")),
+              sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", targetName));
+    });
+  }
+
+  @Test
+  public void testPartitionedAndOrderedTable() {
+    writeModes.forEach(mode -> {
+      removeTables();
+      sql("CREATE TABLE %s (id INT, dep STRING) USING iceberg" +
+              " PARTITIONED BY (id) CLUSTERED BY (dep) INTO 2 BUCKETS", targetName);
+      initTable(targetName);
+      setWriteMode(targetName, mode);
+      createAndInitSourceTable(sourceName);
+      append(targetName, new Employee(1, "emp-id-one"), new Employee(6, "emp-id-6"));
+      append(sourceName, new Employee(2, "emp-id-2"), new Employee(1, "emp-id-1"), new Employee(6, "emp-id-6"));
+      String sqlText = "MERGE INTO " + targetName + " AS target \n" +
+              "USING " + sourceName + " AS source \n" +
+              "ON target.id = source.id \n" +
+              "WHEN MATCHED AND target.id = 1 THEN UPDATE SET * \n" +
+              "WHEN MATCHED AND target.id = 6 THEN DELETE \n" +
+              "WHEN NOT MATCHED AND source.id = 2 THEN INSERT * ";
+
+      sql(sqlText, "");
+      assertEquals("Should have expected rows",
+              ImmutableList.of(row(1, "emp-id-1"), row(2, "emp-id-2")),
+              sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", targetName));
+    });
   }
 
   protected void createAndInitUnPartitionedTargetTable(String tabName) {
@@ -355,9 +439,17 @@ public class TestMergeIntoTable extends SparkRowLevelOperationsTestBase {
     });
   }
 
-  protected void append(String tabName, Employee... employees) throws NoSuchTableException {
-    List<Employee> input = Arrays.asList(employees);
-    Dataset<Row> inputDF = spark.createDataFrame(input, Employee.class);
-    inputDF.coalesce(1).writeTo(tabName).append();
+  private void setWriteMode(String tabName, String mode) {
+    sql("ALTER TABLE %s SET TBLPROPERTIES('%s' '%s')", tabName, TableProperties.WRITE_DISTRIBUTION_MODE, mode);
+  }
+
+  protected void append(String tabName, Employee... employees) {
+    try {
+      List<Employee> input = Arrays.asList(employees);
+      Dataset<Row> inputDF = spark.createDataFrame(input, Employee.class);
+      inputDF.coalesce(1).writeTo(tabName).append();
+    } catch (NoSuchTableException e) {
+      throw new RuntimeException(e.getMessage());
+    }
   }
 }

--- a/spark3/src/main/java/org/apache/iceberg/spark/CopySortOrderFields.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/CopySortOrderFields.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark;
+
+import org.apache.iceberg.NullOrder;
+import org.apache.iceberg.SortDirection;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.transforms.SortOrderVisitor;
+
+class CopySortOrderFields implements SortOrderVisitor<Void> {
+  private final SortOrder.Builder builder;
+
+  CopySortOrderFields(SortOrder.Builder builder) {
+    this.builder = builder;
+  }
+
+  @Override
+  public Void field(String sourceName, int sourceId, SortDirection direction, NullOrder nullOrder) {
+    if (direction == SortDirection.ASC) {
+      builder.asc(sourceName, nullOrder);
+    } else {
+      builder.desc(sourceName, nullOrder);
+    }
+    return null;
+  }
+
+  @Override
+  public Void bucket(String sourceName, int sourceId, int numBuckets, SortDirection direction, NullOrder nullOrder) {
+    if (direction == SortDirection.ASC) {
+      builder.asc(Expressions.bucket(sourceName, numBuckets), nullOrder);
+    } else {
+      builder.desc(Expressions.bucket(sourceName, numBuckets), nullOrder);
+    }
+    return null;
+  }
+
+  @Override
+  public Void truncate(String sourceName, int sourceId, int width, SortDirection direction, NullOrder nullOrder) {
+    if (direction == SortDirection.ASC) {
+      builder.asc(Expressions.truncate(sourceName, width), nullOrder);
+    } else {
+      builder.desc(Expressions.truncate(sourceName, width), nullOrder);
+    }
+    return null;
+  }
+
+  @Override
+  public Void year(String sourceName, int sourceId, SortDirection direction, NullOrder nullOrder) {
+    if (direction == SortDirection.ASC) {
+      builder.asc(Expressions.year(sourceName), nullOrder);
+    } else {
+      builder.desc(Expressions.year(sourceName), nullOrder);
+    }
+    return null;
+  }
+
+  @Override
+  public Void month(String sourceName, int sourceId, SortDirection direction, NullOrder nullOrder) {
+    if (direction == SortDirection.ASC) {
+      builder.asc(Expressions.month(sourceName), nullOrder);
+    } else {
+      builder.desc(Expressions.month(sourceName), nullOrder);
+    }
+    return null;
+  }
+
+  @Override
+  public Void day(String sourceName, int sourceId, SortDirection direction, NullOrder nullOrder) {
+    if (direction == SortDirection.ASC) {
+      builder.asc(Expressions.day(sourceName), nullOrder);
+    } else {
+      builder.desc(Expressions.day(sourceName), nullOrder);
+    }
+    return null;
+  }
+
+  @Override
+  public Void hour(String sourceName, int sourceId, SortDirection direction, NullOrder nullOrder) {
+    if (direction == SortDirection.ASC) {
+      builder.asc(Expressions.hour(sourceName), nullOrder);
+    } else {
+      builder.desc(Expressions.hour(sourceName), nullOrder);
+    }
+    return null;
+  }
+}

--- a/spark3/src/main/java/org/apache/iceberg/spark/OrderField.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/OrderField.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark;
+
+import org.apache.iceberg.NullOrder;
+import org.apache.spark.sql.connector.expressions.Expression;
+import org.apache.spark.sql.connector.expressions.Expressions;
+import org.apache.spark.sql.connector.iceberg.expressions.NullOrdering;
+import org.apache.spark.sql.connector.iceberg.expressions.SortDirection;
+import org.apache.spark.sql.connector.iceberg.expressions.SortOrder;
+
+class OrderField implements SortOrder {
+  static OrderField column(String fieldName, org.apache.iceberg.SortDirection direction, NullOrder nullOrder) {
+    return new OrderField(Expressions.column(fieldName), toSpark(direction), toSpark(nullOrder));
+  }
+
+  static OrderField bucket(String fieldName, int numBuckets, org.apache.iceberg.SortDirection direction,
+                           NullOrder nullOrder) {
+    return new OrderField(Expressions.bucket(numBuckets, fieldName), toSpark(direction), toSpark(nullOrder));
+  }
+
+  static OrderField truncate(String fieldName, int width, org.apache.iceberg.SortDirection direction,
+                             NullOrder nullOrder) {
+    return new OrderField(Expressions.apply(
+      "truncate", Expressions.column(fieldName), Expressions.literal(width)),
+      toSpark(direction), toSpark(nullOrder));
+  }
+
+  static OrderField year(String fieldName, org.apache.iceberg.SortDirection direction, NullOrder nullOrder) {
+    return new OrderField(Expressions.years(fieldName), toSpark(direction), toSpark(nullOrder));
+  }
+
+  static OrderField month(String fieldName, org.apache.iceberg.SortDirection direction, NullOrder nullOrder) {
+    return new OrderField(Expressions.months(fieldName), toSpark(direction), toSpark(nullOrder));
+  }
+
+  static OrderField day(String fieldName, org.apache.iceberg.SortDirection direction, NullOrder nullOrder) {
+    return new OrderField(Expressions.days(fieldName), toSpark(direction), toSpark(nullOrder));
+  }
+
+  static OrderField hour(String fieldName, org.apache.iceberg.SortDirection direction, NullOrder nullOrder) {
+    return new OrderField(Expressions.hours(fieldName), toSpark(direction), toSpark(nullOrder));
+  }
+
+  private static SortDirection toSpark(org.apache.iceberg.SortDirection direction) {
+    return direction == org.apache.iceberg.SortDirection.ASC ? SortDirection.ASCENDING : SortDirection.DESCENDING;
+  }
+
+  private static NullOrdering toSpark(NullOrder nullOrder) {
+    return nullOrder == NullOrder.NULLS_FIRST ? NullOrdering.NULLS_FIRST : NullOrdering.NULLS_LAST;
+  }
+
+  private final Expression expr;
+  private final SortDirection direction;
+  private final NullOrdering nullOrder;
+
+  private OrderField(Expression expr, SortDirection direction, NullOrdering nullOrder) {
+    this.expr = expr;
+    this.direction = direction;
+    this.nullOrder = nullOrder;
+  }
+
+  @Override
+  public Expression expression() {
+    return expr;
+  }
+
+  @Override
+  public SortDirection direction() {
+    return direction;
+  }
+
+  @Override
+  public NullOrdering nullOrdering() {
+    return nullOrder;
+  }
+
+  @Override
+  public String describe() {
+    return String.format("%s %s %s",
+      expr.describe(),
+      direction == SortDirection.ASCENDING ? "ASC" : "DESC",
+      nullOrder == NullOrdering.NULLS_FIRST ? "NULLS FIRST" : "NULLS LAST");
+  }
+}

--- a/spark3/src/main/java/org/apache/iceberg/spark/SortOrderToSpark.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/SortOrderToSpark.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark;
+
+import org.apache.iceberg.NullOrder;
+import org.apache.iceberg.SortDirection;
+import org.apache.iceberg.transforms.SortOrderVisitor;
+
+class SortOrderToSpark implements SortOrderVisitor<OrderField> {
+  @Override
+  public OrderField field(String sourceName, int id, SortDirection direction, NullOrder nullOrder) {
+    return OrderField.column(sourceName, direction, nullOrder);
+  }
+
+  @Override
+  public OrderField bucket(String sourceName, int id, int width, SortDirection direction, NullOrder nullOrder) {
+    return OrderField.bucket(sourceName, width, direction, nullOrder);
+  }
+
+  @Override
+  public OrderField truncate(String sourceName, int id, int width, SortDirection direction, NullOrder nullOrder) {
+    return OrderField.truncate(sourceName, width, direction, nullOrder);
+  }
+
+  @Override
+  public OrderField year(String sourceName, int id, SortDirection direction, NullOrder nullOrder) {
+    return OrderField.year(sourceName, direction, nullOrder);
+  }
+
+  @Override
+  public OrderField month(String sourceName, int id, SortDirection direction, NullOrder nullOrder) {
+    return OrderField.month(sourceName, direction, nullOrder);
+  }
+
+  @Override
+  public OrderField day(String sourceName, int id, SortDirection direction, NullOrder nullOrder) {
+    return OrderField.day(sourceName, direction, nullOrder);
+  }
+
+  @Override
+  public OrderField hour(String sourceName, int id, SortDirection direction, NullOrder nullOrder) {
+    return OrderField.hour(sourceName, direction, nullOrder);
+  }
+}
+

--- a/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -21,14 +21,19 @@ package org.apache.iceberg.spark;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Partitioning;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortField;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.UpdateProperties;
 import org.apache.iceberg.UpdateSchema;
@@ -45,7 +50,10 @@ import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Multimap;
+import org.apache.iceberg.relocated.com.google.common.collect.Multimaps;
 import org.apache.iceberg.transforms.PartitionSpecVisitor;
+import org.apache.iceberg.transforms.SortOrderVisitor;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
@@ -67,6 +75,8 @@ import org.apache.spark.sql.connector.expressions.Expression;
 import org.apache.spark.sql.connector.expressions.Expressions;
 import org.apache.spark.sql.connector.expressions.Literal;
 import org.apache.spark.sql.connector.expressions.Transform;
+import org.apache.spark.sql.connector.iceberg.distributions.Distribution;
+import org.apache.spark.sql.connector.iceberg.distributions.Distributions;
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
@@ -223,7 +233,7 @@ public class Spark3Util {
    * @return an array of Transforms
    */
   public static Transform[] toTransforms(PartitionSpec spec) {
-    List<Transform> transforms = PartitionSpecVisitor.visit(spec.schema(), spec,
+    List<Transform> transforms = PartitionSpecVisitor.visit(spec,
         new PartitionSpecVisitor<Transform>() {
           @Override
           public Transform identity(String sourceName, int sourceId) {
@@ -267,6 +277,50 @@ public class Spark3Util {
         });
 
     return transforms.toArray(new Transform[0]);
+  }
+
+  public static Distribution toOrderedDistribution(PartitionSpec spec, SortOrder sortOrder, boolean inferFromSpec) {
+    if (sortOrder.isUnsorted()) {
+      if (inferFromSpec) {
+        SortOrder specOrder = Partitioning.sortOrderFor(spec);
+        return Distributions.ordered(convert(specOrder));
+      }
+
+      return Distributions.unspecified();
+    }
+
+    Schema schema = spec.schema();
+    Multimap<Integer, SortField> sortFieldIndex = Multimaps.index(sortOrder.fields(), SortField::sourceId);
+
+    // build a sort prefix of partition fields that are not already in the sort order
+    SortOrder.Builder builder = SortOrder.builderFor(schema);
+    for (PartitionField field : spec.fields()) {
+      Collection<SortField> sortFields = sortFieldIndex.get(field.sourceId());
+      boolean isSorted = sortFields.stream().anyMatch(sortField ->
+          field.transform().equals(sortField.transform()) || sortField.transform().satisfiesOrderOf(field.transform()));
+      if (!isSorted) {
+        String sourceName = schema.findColumnName(field.sourceId());
+        builder.asc(org.apache.iceberg.expressions.Expressions.transform(sourceName, field.transform()));
+      }
+    }
+
+    // add the configured sort to the partition spec prefix sort
+    SortOrderVisitor.visit(sortOrder, new CopySortOrderFields(builder));
+
+    return Distributions.ordered(convert(builder.build()));
+  }
+
+  public static Distribution toClusteredDistribution(PartitionSpec spec) {
+    if (spec.isUnpartitioned()) {
+      return Distributions.unspecified();
+    } else {
+      return Distributions.clustered(toTransforms(spec));
+    }
+  }
+
+  public static OrderField[] convert(SortOrder sortOrder) {
+    List<OrderField> converted = SortOrderVisitor.visit(sortOrder, new SortOrderToSpark());
+    return converted.toArray(new OrderField[0]);
   }
 
   public static Term toIcebergTerm(Transform transform) {

--- a/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/distributions/ClusteredDistribution.java
+++ b/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/distributions/ClusteredDistribution.java
@@ -17,24 +17,21 @@
  * under the License.
  */
 
-package org.apache.spark.sql.catalyst.plans.logical
+package org.apache.spark.sql.connector.iceberg.distributions;
 
-import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.annotation.Experimental;
+import org.apache.spark.sql.connector.expressions.Expression;
 
-case class MergeInto(
-    mergeIntoProcessor: MergeIntoParams,
-    targetOutput: Seq[Attribute],
-    child: LogicalPlan) extends UnaryNode {
-  override def output: Seq[Attribute] = targetOutput
+/**
+ * A distribution where tuples that share the same values for clustering expressions are co-located
+ * in the same partition.
+ *
+ * @since 3.2.0
+ */
+@Experimental
+public interface ClusteredDistribution extends Distribution {
+  /**
+   * Returns clustering expressions.
+   */
+  Expression[] clustering();
 }
-
-case class MergeIntoParams(
-    isSourceRowNotPresent: Expression,
-    isTargetRowNotPresent: Expression,
-    matchedConditions: Seq[Expression],
-    matchedOutputs: Seq[Option[Seq[Expression]]],
-    notMatchedConditions: Seq[Expression],
-    notMatchedOutputs: Seq[Option[Seq[Expression]]],
-    targetOutput: Seq[Expression],
-    joinedAttributes: Seq[Attribute]) extends Serializable

--- a/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/distributions/Distribution.java
+++ b/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/distributions/Distribution.java
@@ -17,24 +17,16 @@
  * under the License.
  */
 
-package org.apache.spark.sql.catalyst.plans.logical
+package org.apache.spark.sql.connector.iceberg.distributions;
 
-import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.annotation.Experimental;
 
-case class MergeInto(
-    mergeIntoProcessor: MergeIntoParams,
-    targetOutput: Seq[Attribute],
-    child: LogicalPlan) extends UnaryNode {
-  override def output: Seq[Attribute] = targetOutput
+/**
+ * An interface that defines how data is distributed across partitions.
+ *
+ * @since 3.2.0
+ */
+@Experimental
+public interface Distribution {
 }
 
-case class MergeIntoParams(
-    isSourceRowNotPresent: Expression,
-    isTargetRowNotPresent: Expression,
-    matchedConditions: Seq[Expression],
-    matchedOutputs: Seq[Option[Seq[Expression]]],
-    notMatchedConditions: Seq[Expression],
-    notMatchedOutputs: Seq[Option[Seq[Expression]]],
-    targetOutput: Seq[Expression],
-    joinedAttributes: Seq[Attribute]) extends Serializable

--- a/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/distributions/Distributions.java
+++ b/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/distributions/Distributions.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.connector.iceberg.distributions;
+
+import org.apache.spark.annotation.Experimental;
+import org.apache.spark.sql.connector.expressions.Expression;
+import org.apache.spark.sql.connector.iceberg.distributions.impl.ClusterDistributionImpl;
+import org.apache.spark.sql.connector.iceberg.distributions.impl.OrderedDistributionImpl;
+import org.apache.spark.sql.connector.iceberg.distributions.impl.UnspecifiedDistributionImpl;
+import org.apache.spark.sql.connector.iceberg.expressions.SortOrder;
+
+/**
+ * Helper methods to create distributions to pass into Spark.
+ *
+ * @since 3.2.0
+ */
+@Experimental
+public class Distributions {
+  private Distributions() {
+  }
+
+  /**
+   * Creates a distribution where no promises are made about co-location of data.
+   */
+  public static UnspecifiedDistribution unspecified() {
+    return new UnspecifiedDistributionImpl();
+  }
+
+  /**
+   * Creates a distribution where tuples that share the same values for clustering expressions are
+   * co-located in the same partition.
+   */
+  public static ClusteredDistribution clustered(Expression[] clustering) {
+    return new ClusterDistributionImpl(clustering);
+  }
+
+  /**
+   * Creates a distribution where tuples have been ordered across partitions according
+   * to ordering expressions, but not necessarily within a given partition.
+   */
+  public static OrderedDistribution ordered(SortOrder[] ordering) {
+    return new OrderedDistributionImpl(ordering);
+  }
+}

--- a/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/distributions/OrderedDistribution.java
+++ b/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/distributions/OrderedDistribution.java
@@ -17,24 +17,21 @@
  * under the License.
  */
 
-package org.apache.spark.sql.catalyst.plans.logical
+package org.apache.spark.sql.connector.iceberg.distributions;
 
-import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.annotation.Experimental;
+import org.apache.spark.sql.connector.iceberg.expressions.SortOrder;
 
-case class MergeInto(
-    mergeIntoProcessor: MergeIntoParams,
-    targetOutput: Seq[Attribute],
-    child: LogicalPlan) extends UnaryNode {
-  override def output: Seq[Attribute] = targetOutput
+/**
+ * A distribution where tuples have been ordered across partitions according
+ * to ordering expressions, but not necessarily within a given partition.
+ *
+ * @since 3.2.0
+ */
+@Experimental
+public interface OrderedDistribution extends Distribution {
+  /**
+   * Returns ordering expressions.
+   */
+  SortOrder[] ordering();
 }
-
-case class MergeIntoParams(
-    isSourceRowNotPresent: Expression,
-    isTargetRowNotPresent: Expression,
-    matchedConditions: Seq[Expression],
-    matchedOutputs: Seq[Option[Seq[Expression]]],
-    notMatchedConditions: Seq[Expression],
-    notMatchedOutputs: Seq[Option[Seq[Expression]]],
-    targetOutput: Seq[Expression],
-    joinedAttributes: Seq[Attribute]) extends Serializable

--- a/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/distributions/UnspecifiedDistribution.java
+++ b/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/distributions/UnspecifiedDistribution.java
@@ -17,24 +17,14 @@
  * under the License.
  */
 
-package org.apache.spark.sql.catalyst.plans.logical
+package org.apache.spark.sql.connector.iceberg.distributions;
 
-import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.annotation.Experimental;
 
-case class MergeInto(
-    mergeIntoProcessor: MergeIntoParams,
-    targetOutput: Seq[Attribute],
-    child: LogicalPlan) extends UnaryNode {
-  override def output: Seq[Attribute] = targetOutput
-}
-
-case class MergeIntoParams(
-    isSourceRowNotPresent: Expression,
-    isTargetRowNotPresent: Expression,
-    matchedConditions: Seq[Expression],
-    matchedOutputs: Seq[Option[Seq[Expression]]],
-    notMatchedConditions: Seq[Expression],
-    notMatchedOutputs: Seq[Option[Seq[Expression]]],
-    targetOutput: Seq[Expression],
-    joinedAttributes: Seq[Attribute]) extends Serializable
+/**
+ * A distribution where no promises are made about co-location of data.
+ *
+ * @since 3.2.0
+ */
+@Experimental
+public interface UnspecifiedDistribution extends Distribution {}

--- a/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/distributions/impl/ClusterDistributionImpl.java
+++ b/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/distributions/impl/ClusterDistributionImpl.java
@@ -17,24 +17,21 @@
  * under the License.
  */
 
-package org.apache.spark.sql.catalyst.plans.logical
 
-import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.expressions.Expression
+package org.apache.spark.sql.connector.iceberg.distributions.impl;
 
-case class MergeInto(
-    mergeIntoProcessor: MergeIntoParams,
-    targetOutput: Seq[Attribute],
-    child: LogicalPlan) extends UnaryNode {
-  override def output: Seq[Attribute] = targetOutput
+import org.apache.spark.sql.connector.expressions.Expression;
+import org.apache.spark.sql.connector.iceberg.distributions.ClusteredDistribution;
+
+public class ClusterDistributionImpl implements ClusteredDistribution {
+  private Expression[] clusterExprs;
+
+  public ClusterDistributionImpl(Expression[] clusterExprs) {
+    this.clusterExprs = clusterExprs;
+  }
+
+  @Override
+  public Expression[] clustering() {
+    return clusterExprs;
+  }
 }
-
-case class MergeIntoParams(
-    isSourceRowNotPresent: Expression,
-    isTargetRowNotPresent: Expression,
-    matchedConditions: Seq[Expression],
-    matchedOutputs: Seq[Option[Seq[Expression]]],
-    notMatchedConditions: Seq[Expression],
-    notMatchedOutputs: Seq[Option[Seq[Expression]]],
-    targetOutput: Seq[Expression],
-    joinedAttributes: Seq[Attribute]) extends Serializable

--- a/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/distributions/impl/OrderedDistributionImpl.java
+++ b/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/distributions/impl/OrderedDistributionImpl.java
@@ -17,24 +17,21 @@
  * under the License.
  */
 
-package org.apache.spark.sql.catalyst.plans.logical
 
-import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.expressions.Expression
+package org.apache.spark.sql.connector.iceberg.distributions.impl;
 
-case class MergeInto(
-    mergeIntoProcessor: MergeIntoParams,
-    targetOutput: Seq[Attribute],
-    child: LogicalPlan) extends UnaryNode {
-  override def output: Seq[Attribute] = targetOutput
+import org.apache.spark.sql.connector.iceberg.distributions.OrderedDistribution;
+import org.apache.spark.sql.connector.iceberg.expressions.SortOrder;
+
+public class OrderedDistributionImpl implements OrderedDistribution {
+  private SortOrder[] orderingExprs;
+
+  public OrderedDistributionImpl(SortOrder[] orderingExprs) {
+    this.orderingExprs = orderingExprs;
+  }
+
+  @Override
+  public SortOrder[] ordering() {
+    return orderingExprs;
+  }
 }
-
-case class MergeIntoParams(
-    isSourceRowNotPresent: Expression,
-    isTargetRowNotPresent: Expression,
-    matchedConditions: Seq[Expression],
-    matchedOutputs: Seq[Option[Seq[Expression]]],
-    notMatchedConditions: Seq[Expression],
-    notMatchedOutputs: Seq[Option[Seq[Expression]]],
-    targetOutput: Seq[Expression],
-    joinedAttributes: Seq[Attribute]) extends Serializable

--- a/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/distributions/impl/UnspecifiedDistributionImpl.java
+++ b/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/distributions/impl/UnspecifiedDistributionImpl.java
@@ -17,24 +17,11 @@
  * under the License.
  */
 
-package org.apache.spark.sql.catalyst.plans.logical
 
-import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.expressions.Expression
+package org.apache.spark.sql.connector.iceberg.distributions.impl;
 
-case class MergeInto(
-    mergeIntoProcessor: MergeIntoParams,
-    targetOutput: Seq[Attribute],
-    child: LogicalPlan) extends UnaryNode {
-  override def output: Seq[Attribute] = targetOutput
+import org.apache.spark.sql.connector.iceberg.distributions.UnspecifiedDistribution;
+
+public class UnspecifiedDistributionImpl implements UnspecifiedDistribution {
+
 }
-
-case class MergeIntoParams(
-    isSourceRowNotPresent: Expression,
-    isTargetRowNotPresent: Expression,
-    matchedConditions: Seq[Expression],
-    matchedOutputs: Seq[Option[Seq[Expression]]],
-    notMatchedConditions: Seq[Expression],
-    notMatchedOutputs: Seq[Option[Seq[Expression]]],
-    targetOutput: Seq[Expression],
-    joinedAttributes: Seq[Attribute]) extends Serializable

--- a/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/expressions/NullOrdering.java
+++ b/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/expressions/NullOrdering.java
@@ -17,24 +17,28 @@
  * under the License.
  */
 
-package org.apache.spark.sql.catalyst.plans.logical
+package org.apache.spark.sql.connector.iceberg.expressions;
 
-import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.annotation.Experimental;
 
-case class MergeInto(
-    mergeIntoProcessor: MergeIntoParams,
-    targetOutput: Seq[Attribute],
-    child: LogicalPlan) extends UnaryNode {
-  override def output: Seq[Attribute] = targetOutput
+/**
+ * A null order used in sorting expressions.
+ *
+ * @since 3.2.0
+ */
+@Experimental
+public enum NullOrdering {
+  NULLS_FIRST, NULLS_LAST;
+
+  @Override
+  public String toString() {
+    switch (this) {
+      case NULLS_FIRST:
+        return "NULLS FIRST";
+      case NULLS_LAST:
+        return "NULLS LAST";
+      default:
+        throw new IllegalArgumentException("Unexpected null order: " + this);
+    }
+  }
 }
-
-case class MergeIntoParams(
-    isSourceRowNotPresent: Expression,
-    isTargetRowNotPresent: Expression,
-    matchedConditions: Seq[Expression],
-    matchedOutputs: Seq[Option[Seq[Expression]]],
-    notMatchedConditions: Seq[Expression],
-    notMatchedOutputs: Seq[Option[Seq[Expression]]],
-    targetOutput: Seq[Expression],
-    joinedAttributes: Seq[Attribute]) extends Serializable

--- a/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/expressions/SortDirection.java
+++ b/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/expressions/SortDirection.java
@@ -17,24 +17,28 @@
  * under the License.
  */
 
-package org.apache.spark.sql.catalyst.plans.logical
+package org.apache.spark.sql.connector.iceberg.expressions;
 
-import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.annotation.Experimental;
 
-case class MergeInto(
-    mergeIntoProcessor: MergeIntoParams,
-    targetOutput: Seq[Attribute],
-    child: LogicalPlan) extends UnaryNode {
-  override def output: Seq[Attribute] = targetOutput
+/**
+ * A sort direction used in sorting expressions.
+ *
+ * @since 3.2.0
+ */
+@Experimental
+public enum SortDirection {
+  ASCENDING, DESCENDING;
+
+  @Override
+  public String toString() {
+    switch (this) {
+      case ASCENDING:
+        return "ASC";
+      case DESCENDING:
+        return "DESC";
+      default:
+        throw new IllegalArgumentException("Unexpected sort direction: " + this);
+    }
+  }
 }
-
-case class MergeIntoParams(
-    isSourceRowNotPresent: Expression,
-    isTargetRowNotPresent: Expression,
-    matchedConditions: Seq[Expression],
-    matchedOutputs: Seq[Option[Seq[Expression]]],
-    notMatchedConditions: Seq[Expression],
-    notMatchedOutputs: Seq[Option[Seq[Expression]]],
-    targetOutput: Seq[Expression],
-    joinedAttributes: Seq[Attribute]) extends Serializable

--- a/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/expressions/SortOrder.java
+++ b/spark3/src/main/java/org/apache/spark/sql/connector/iceberg/expressions/SortOrder.java
@@ -17,24 +17,30 @@
  * under the License.
  */
 
-package org.apache.spark.sql.catalyst.plans.logical
+package org.apache.spark.sql.connector.iceberg.expressions;
 
-import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.annotation.Experimental;
+import org.apache.spark.sql.connector.expressions.Expression;
 
-case class MergeInto(
-    mergeIntoProcessor: MergeIntoParams,
-    targetOutput: Seq[Attribute],
-    child: LogicalPlan) extends UnaryNode {
-  override def output: Seq[Attribute] = targetOutput
+/**
+ * Represents a sort order in the public expression API.
+ *
+ * @since 3.2.0
+ */
+@Experimental
+public interface SortOrder extends Expression {
+  /**
+   * Returns the sort expression.
+   */
+  Expression expression();
+
+  /**
+   * Returns the sort direction.
+   */
+  SortDirection direction();
+
+  /**
+   * Returns the null ordering.
+   */
+  NullOrdering nullOrdering();
 }
-
-case class MergeIntoParams(
-    isSourceRowNotPresent: Expression,
-    isTargetRowNotPresent: Expression,
-    matchedConditions: Seq[Expression],
-    matchedOutputs: Seq[Option[Seq[Expression]]],
-    notMatchedConditions: Seq[Expression],
-    notMatchedOutputs: Seq[Option[Seq[Expression]]],
-    targetOutput: Seq[Expression],
-    joinedAttributes: Seq[Attribute]) extends Serializable


### PR DESCRIPTION
- Group and sort the rows based on partition spec and sort order of target table.
- If the above is not available, then group and sort rows based on columns from join condition.

**Note:**
There is proposal from Anton to group and sort rows based on `_file` and `_pos` for unchanged rows and partition spec and sort order for unchanged rows. This can be added in a follow-up.