### PR TITLE
Set Input and OutputFormat in the hive meta hook

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -114,6 +114,10 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
       hmsTable.getParameters().put(InputFormatConfig.EXTERNAL_TABLE_PURGE, "TRUE");
     }
 
+    // For a table created by Hive DDL to be readable by Impala, we need the Input and OutputFormat set explicitly
+    hmsTable.getSd().setInputFormat(HiveIcebergInputFormat.class.getCanonicalName());
+    hmsTable.getSd().setOutputFormat(HiveIcebergOutputFormat.class.getCanonicalName());
+
     // If the table is not managed by Hive catalog then the location should be set
     if (!Catalogs.hiveCatalog(conf)) {
       Preconditions.checkArgument(hmsTable.getSd() != null && hmsTable.getSd().getLocation() != null,

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -80,6 +80,11 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
       try {
         this.icebergTable = Catalogs.loadTable(conf, catalogProperties);
 
+        // For non-HiveCatalog tables too, we should set the input and output format
+        // so that the table can be read by other engines like Impala
+        hmsTable.getSd().setInputFormat(HiveIcebergInputFormat.class.getCanonicalName());
+        hmsTable.getSd().setOutputFormat(HiveIcebergOutputFormat.class.getCanonicalName());
+
         Preconditions.checkArgument(catalogProperties.getProperty(InputFormatConfig.TABLE_SCHEMA) == null,
             "Iceberg table already created - can not use provided schema");
         Preconditions.checkArgument(catalogProperties.getProperty(InputFormatConfig.PARTITION_SPEC) == null,
@@ -113,10 +118,6 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
     if (hmsTable.getParameters().get(InputFormatConfig.EXTERNAL_TABLE_PURGE) == null) {
       hmsTable.getParameters().put(InputFormatConfig.EXTERNAL_TABLE_PURGE, "TRUE");
     }
-
-    // For a table created by Hive DDL to be readable by Impala, we need the Input and OutputFormat set explicitly
-    hmsTable.getSd().setInputFormat(HiveIcebergInputFormat.class.getCanonicalName());
-    hmsTable.getSd().setOutputFormat(HiveIcebergOutputFormat.class.getCanonicalName());
 
     // If the table is not managed by Hive catalog then the location should be set
     if (!Catalogs.hiveCatalog(conf)) {

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -76,14 +76,14 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
         BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE.toUpperCase());
 
     if (!Catalogs.hiveCatalog(conf)) {
+      // For non-HiveCatalog tables too, we should set the input and output format
+      // so that the table can be read by other engines like Impala
+      hmsTable.getSd().setInputFormat(HiveIcebergInputFormat.class.getCanonicalName());
+      hmsTable.getSd().setOutputFormat(HiveIcebergOutputFormat.class.getCanonicalName());
+
       // If not using HiveCatalog check for existing table
       try {
         this.icebergTable = Catalogs.loadTable(conf, catalogProperties);
-
-        // For non-HiveCatalog tables too, we should set the input and output format
-        // so that the table can be read by other engines like Impala
-        hmsTable.getSd().setInputFormat(HiveIcebergInputFormat.class.getCanonicalName());
-        hmsTable.getSd().setOutputFormat(HiveIcebergOutputFormat.class.getCanonicalName());
 
         Preconditions.checkArgument(catalogProperties.getProperty(InputFormatConfig.TABLE_SCHEMA) == null,
             "Iceberg table already created - can not use provided schema");

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandler.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandler.java
@@ -382,6 +382,11 @@ public class TestHiveIcebergStorageHandler {
     Assert.assertEquals(BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE.toUpperCase(),
         hmsTable.getParameters().get(BaseMetastoreTableOperations.TABLE_TYPE_PROP));
 
+    // verify that storage descriptor is filled out with inputformat/outputformat/serde
+    Assert.assertEquals(HiveIcebergInputFormat.class.getName(), hmsTable.getSd().getInputFormat());
+    Assert.assertEquals(HiveIcebergOutputFormat.class.getName(), hmsTable.getSd().getOutputFormat());
+    Assert.assertEquals(HiveIcebergSerDe.class.getName(), hmsTable.getSd().getSerdeInfo().getSerializationLib());
+
     if (!Catalogs.hiveCatalog(shell.getHiveConf())) {
       Assert.assertEquals(Collections.singletonMap("dummy", "test"), icebergTable.properties());
 


### PR DESCRIPTION
Impala retrieves the Input and OutputFormat classes directly from the HMS properties, and not from the StorageHandler. Therefore, we need to explicitly set these values during the Hive metahook operations, so that we have those present even when the table was created using Hive DDL. The analogous change in the Iceberg API has been added in this commit: https://github.com/apache/iceberg/commit/45caac4927fedc8313aba79d49f5911eccee2474

@rdblue, @pvary could you please take a look? Thank you
