### PR TITLE
Core: fix bug that interfaces in ExceptionUtil are not public

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/ExceptionUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/ExceptionUtil.java
@@ -41,15 +41,15 @@ public class ExceptionUtil {
     throw new RuntimeException(exception);
   }
 
-  interface Block<R, E1 extends Exception, E2 extends Exception, E3 extends Exception> {
+  public interface Block<R, E1 extends Exception, E2 extends Exception, E3 extends Exception> {
     R run() throws E1, E2, E3;
   }
 
-  interface CatchBlock {
+  public interface CatchBlock {
     void run(Throwable failure) throws Exception;
   }
 
-  interface FinallyBlock {
+  public interface FinallyBlock {
     void run() throws Exception;
   }
 


### PR DESCRIPTION
The interfaces `Block`, `CatchBlock` and `FinallyBlock` need to be public so that callers can use `runSafely` in other package paths.