### PR TITLE
AWS: fix S3FileIO executor service creation synchronization

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -85,10 +85,10 @@ class S3OutputStream extends PositionOutputStream {
   private long pos = 0;
   private boolean closed = false;
 
-  @SuppressWarnings({"StaticAssignmentInConstructor", "StaticGuardedByInstance"})
+  @SuppressWarnings("StaticAssignmentInConstructor")
   S3OutputStream(S3Client s3, S3URI location, AwsProperties awsProperties) throws IOException {
     if (executorService == null) {
-      synchronized (this) {
+      synchronized (S3OutputStream.class) {
         if (executorService == null) {
           executorService = MoreExecutors.getExitingExecutorService(
               (ThreadPoolExecutor) Executors.newFixedThreadPool(


### PR DESCRIPTION
`ExecutorService` should be created with synchronized static variable guard.