### PR TITLE
Hive: Allow auto conversion of Hive types when the CREATE TABLE statement contains a not supported type

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaConverter.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaConverter.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.slf4j.Logger;
@@ -79,14 +80,11 @@ class HiveSchemaConverter {
             return Types.BooleanType.get();
           case BYTE:
           case SHORT:
-            if (autoConvert) {
-              LOG.debug("Using auto conversion from SHORT to INTEGER");
-              return Types.IntegerType.get();
-            } else {
-              throw new IllegalArgumentException("Unsupported Hive type (" +
-                  ((PrimitiveTypeInfo) typeInfo).getPrimitiveCategory() +
-                  ") for Iceberg tables. Consider using INT/INTEGER type instead.");
-            }
+            Preconditions.checkArgument(autoConvert, "Unsupported Hive type: %s, use integer instead",
+                ((PrimitiveTypeInfo) typeInfo).getPrimitiveCategory());
+
+            LOG.debug("Using auto conversion from SHORT/BYTE to INTEGER");
+            return Types.IntegerType.get();
           case INT:
             return Types.IntegerType.get();
           case LONG:
@@ -95,14 +93,11 @@ class HiveSchemaConverter {
             return Types.BinaryType.get();
           case CHAR:
           case VARCHAR:
-            if (autoConvert) {
-              LOG.debug("Using auto conversion from {} to STRING", typeInfo.getCategory());
-              return Types.StringType.get();
-            } else {
-              throw new IllegalArgumentException("Unsupported Hive type (" +
-                  ((PrimitiveTypeInfo) typeInfo).getPrimitiveCategory() +
-                  ") for Iceberg tables. Consider using STRING type instead.");
-            }
+            Preconditions.checkArgument(autoConvert, "Unsupported Hive type: %s, use string instead",
+                ((PrimitiveTypeInfo) typeInfo).getPrimitiveCategory());
+
+            LOG.debug("Using auto conversion from CHAR/VARCHAR to STRING");
+            return Types.StringType.get();
           case STRING:
             return Types.StringType.get();
           case TIMESTAMP:

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaConverter.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaConverter.java
@@ -30,12 +30,16 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Package private class for converting Hive schema to Iceberg schema. Should be used only by the HiveSchemaUtil.
  * Use {@link HiveSchemaUtil} for conversion purposes.
  */
 class HiveSchemaConverter {
+  private static final Logger LOG = LoggerFactory.getLogger(HiveSchemaConverter.class);
+
   private int id;
   private boolean autoConvert;
 
@@ -76,6 +80,7 @@ class HiveSchemaConverter {
           case BYTE:
           case SHORT:
             if (autoConvert) {
+              LOG.debug("Using auto conversion from SHORT to INTEGER");
               return Types.IntegerType.get();
             } else {
               throw new IllegalArgumentException("Unsupported Hive type (" +
@@ -91,6 +96,7 @@ class HiveSchemaConverter {
           case CHAR:
           case VARCHAR:
             if (autoConvert) {
+              LOG.debug("Using auto conversion from {} to STRING", typeInfo.getCategory());
               return Types.StringType.get();
             } else {
               throw new IllegalArgumentException("Unsupported Hive type (" +

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaUtil.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaUtil.java
@@ -48,11 +48,24 @@ public final class HiveSchemaUtil {
   }
 
   /**
-   * Converts a Hive schema (list of FieldSchema objects) to an Iceberg schema.
+   * Converts a Hive schema (list of FieldSchema objects) to an Iceberg schema. If some of the types are not convertible
+   * then exception is thrown.
    * @param fieldSchemas The list of the columns
    * @return An equivalent Iceberg Schema
    */
   public static Schema convert(List<FieldSchema> fieldSchemas) {
+    return convert(fieldSchemas, false);
+  }
+
+  /**
+   * Converts a Hive schema (list of FieldSchema objects) to an Iceberg schema.
+   * @param fieldSchemas The list of the columns
+   * @param autoConvert If <code>true</code> then TINYINT and SMALLINT is converted to INTEGER and VARCHAR and CHAR is
+   *                    converted to STRING. Otherwise if these types are used in the Hive schema then exception is
+   *                    thrown.
+   * @return An equivalent Iceberg Schema
+   */
+  public static Schema convert(List<FieldSchema> fieldSchemas, boolean autoConvert) {
     List<String> names = new ArrayList<>(fieldSchemas.size());
     List<TypeInfo> typeInfos = new ArrayList<>(fieldSchemas.size());
 
@@ -61,7 +74,7 @@ public final class HiveSchemaUtil {
       typeInfos.add(TypeInfoUtils.getTypeInfoFromTypeString(col.getType()));
     }
 
-    return HiveSchemaConverter.convert(names, typeInfos);
+    return HiveSchemaConverter.convert(names, typeInfos, autoConvert);
   }
 
   /**
@@ -77,13 +90,27 @@ public final class HiveSchemaUtil {
   }
 
   /**
-   * Converts the Hive list of column names and column types to an Iceberg schema.
+   * Converts the Hive list of column names and column types to an Iceberg schema. If some of the types are not
+   * convertible then exception is thrown.
    * @param names The list of the Hive column names
    * @param types The list of the Hive column types
    * @return The Iceberg schema
    */
   public static Schema convert(List<String> names, List<TypeInfo> types) {
-    return HiveSchemaConverter.convert(names, types);
+    return HiveSchemaConverter.convert(names, types, false);
+  }
+
+  /**
+   * Converts the Hive list of column names and column types to an Iceberg schema.
+   * @param names The list of the Hive column names
+   * @param types The list of the Hive column types
+   * @param autoConvert If <code>true</code> then TINYINT and SMALLINT is converted to INTEGER and VARCHAR and CHAR is
+   *                    converted to STRING. Otherwise if these types are used in the Hive schema then exception is
+   *                    thrown.
+   * @return The Iceberg schema
+   */
+  public static Schema convert(List<String> names, List<TypeInfo> types, boolean autoConvert) {
+    return HiveSchemaConverter.convert(names, types, autoConvert);
   }
 
   /**
@@ -101,7 +128,7 @@ public final class HiveSchemaUtil {
    * @return The Iceberg type
    */
   public static Type convert(TypeInfo typeInfo) {
-    return HiveSchemaConverter.convert(typeInfo);
+    return HiveSchemaConverter.convert(typeInfo, false);
   }
 
   private static String convertToTypeString(Type type) {

--- a/mr/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
@@ -41,6 +41,7 @@ public class InputFormatConfig {
   public static final String READ_SCHEMA = "iceberg.mr.read.schema";
   public static final String SNAPSHOT_ID = "iceberg.mr.snapshot.id";
   public static final String SPLIT_SIZE = "iceberg.mr.split.size";
+  public static final String SCHEMA_AUTO_CONVERSION = "iceberg.mr.schema.auto.conversion";
   public static final String TABLE_IDENTIFIER = "iceberg.mr.table.identifier";
   public static final String TABLE_LOCATION = "iceberg.mr.table.location";
   public static final String TABLE_SCHEMA = "iceberg.mr.table.schema";

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -206,16 +206,18 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
     return properties;
   }
 
-  private static Schema schema(Properties properties, org.apache.hadoop.hive.metastore.api.Table hmsTable) {
+  private Schema schema(Properties properties, org.apache.hadoop.hive.metastore.api.Table hmsTable) {
+    boolean autoConversion = conf.getBoolean(InputFormatConfig.SCHEMA_AUTO_CONVERSION, false);
+
     if (properties.getProperty(InputFormatConfig.TABLE_SCHEMA) != null) {
       return SchemaParser.fromJson(properties.getProperty(InputFormatConfig.TABLE_SCHEMA));
     } else if (hmsTable.isSetPartitionKeys() && !hmsTable.getPartitionKeys().isEmpty()) {
       // Add partitioning columns to the original column list before creating the Iceberg Schema
       List<FieldSchema> cols = Lists.newArrayList(hmsTable.getSd().getCols());
       cols.addAll(hmsTable.getPartitionKeys());
-      return HiveSchemaUtil.convert(cols);
+      return HiveSchemaUtil.convert(cols, autoConversion);
     } else {
-      return HiveSchemaUtil.convert(hmsTable.getSd().getCols());
+      return HiveSchemaUtil.convert(hmsTable.getSd().getCols(), autoConversion);
     }
   }
 

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
@@ -81,8 +81,9 @@ public class HiveIcebergSerDe extends AbstractSerDe {
         this.tableSchema = Catalogs.loadTable(configuration, serDeProperties).schema();
         LOG.info("Using schema from existing table {}", SchemaParser.toJson(tableSchema));
       } catch (Exception e) {
+        boolean autoConversion = configuration.getBoolean(InputFormatConfig.SCHEMA_AUTO_CONVERSION, false);
         // If we can not load the table try the provided hive schema
-        this.tableSchema = hiveSchemaOrThrow(serDeProperties, e);
+        this.tableSchema = hiveSchemaOrThrow(serDeProperties, e, autoConversion);
       }
     }
 
@@ -156,10 +157,12 @@ public class HiveIcebergSerDe extends AbstractSerDe {
    * it adds the previousException as a root cause.
    * @param serDeProperties The source of the hive schema
    * @param previousException If we had an exception previously
+   * @param autoConversion If <code>true</code> then autoConversion of the schema is enabled
    * @return The hive schema parsed from the serDeProperties
    * @throws SerDeException If there is no schema information in the serDeProperties
    */
-  private static Schema hiveSchemaOrThrow(Properties serDeProperties, Exception previousException)
+  private static Schema hiveSchemaOrThrow(Properties serDeProperties, Exception previousException,
+                                          boolean autoConversion)
       throws SerDeException {
     // Read the configuration parameters
     String columnNames = serDeProperties.getProperty(serdeConstants.LIST_COLUMNS);
@@ -172,7 +175,8 @@ public class HiveIcebergSerDe extends AbstractSerDe {
       List<String> names = new ArrayList<>();
       Collections.addAll(names, columnNames.split(columnNameDelimiter));
 
-      Schema hiveSchema = HiveSchemaUtil.convert(names, TypeInfoUtils.getTypeInfosFromTypeString(columnTypes));
+      Schema hiveSchema = HiveSchemaUtil.convert(names, TypeInfoUtils.getTypeInfosFromTypeString(columnTypes),
+          autoConversion);
       LOG.info("Using hive schema {}", SchemaParser.toJson(hiveSchema));
       return hiveSchema;
     } else {

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
@@ -157,7 +157,8 @@ public class HiveIcebergSerDe extends AbstractSerDe {
    * it adds the previousException as a root cause.
    * @param serDeProperties The source of the hive schema
    * @param previousException If we had an exception previously
-   * @param autoConversion If <code>true</code> then autoConversion of the schema is enabled
+   * @param autoConversion When <code>true</code>, convert unsupported types to more permissive ones, like tinyint to
+   *                       int
    * @return The hive schema parsed from the serDeProperties
    * @throws SerDeException If there is no schema information in the serDeProperties
    */

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -498,7 +498,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
       );
     }
 
-    shell.executeStatement("SET " + InputFormatConfig.SCHEMA_AUTO_CONVERSION + "=true");
+    shell.setHiveSessionValue(InputFormatConfig.SCHEMA_AUTO_CONVERSION, "true");
 
     for (String notSupportedType : notSupportedTypes.keySet()) {
       shell.executeStatement("CREATE EXTERNAL TABLE not_supported_types (not_supported " + notSupportedType + ") " +

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -497,6 +497,17 @@ public class TestHiveIcebergStorageHandlerNoScan {
           }
       );
     }
+  }
+
+  @Test
+  public void testCreateTableWithNotSupportedTypesWithAutoConversion() {
+    TableIdentifier identifier = TableIdentifier.of("default", "not_supported_types");
+    // Can not create INTERVAL types from normal create table, so leave them out from this test
+    Map<String, Type> notSupportedTypes = ImmutableMap.of(
+        "TINYINT", Types.IntegerType.get(),
+        "SMALLINT", Types.IntegerType.get(),
+        "VARCHAR(1)", Types.StringType.get(),
+        "CHAR(1)", Types.StringType.get());
 
     shell.setHiveSessionValue(InputFormatConfig.SCHEMA_AUTO_CONVERSION, "true");
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -43,7 +43,9 @@ import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.mr.Catalogs;
 import org.apache.iceberg.mr.InputFormatConfig;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.thrift.TException;
 import org.junit.After;
@@ -479,9 +481,13 @@ public class TestHiveIcebergStorageHandlerNoScan {
   public void testCreateTableWithNotSupportedTypes() {
     TableIdentifier identifier = TableIdentifier.of("default", "not_supported_types");
     // Can not create INTERVAL types from normal create table, so leave them out from this test
-    String[] notSupportedTypes = new String[] { "TINYINT", "SMALLINT", "VARCHAR(1)", "CHAR(1)" };
+    Map<String, Type> notSupportedTypes = ImmutableMap.of(
+        "TINYINT", Types.IntegerType.get(),
+        "SMALLINT", Types.IntegerType.get(),
+        "VARCHAR(1)", Types.StringType.get(),
+        "CHAR(1)", Types.StringType.get());
 
-    for (String notSupportedType : notSupportedTypes) {
+    for (String notSupportedType : notSupportedTypes.keySet()) {
       AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
           "Unsupported Hive type", () -> {
             shell.executeStatement("CREATE EXTERNAL TABLE not_supported_types " +
@@ -490,6 +496,18 @@ public class TestHiveIcebergStorageHandlerNoScan {
                 testTables.locationForCreateTableSQL(identifier));
           }
       );
+    }
+
+    shell.executeStatement("SET " + InputFormatConfig.SCHEMA_AUTO_CONVERSION + "=true");
+
+    for (String notSupportedType : notSupportedTypes.keySet()) {
+      shell.executeStatement("CREATE EXTERNAL TABLE not_supported_types (not_supported " + notSupportedType + ") " +
+          "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
+          testTables.locationForCreateTableSQL(identifier));
+
+      org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);
+      Assert.assertEquals(notSupportedTypes.get(notSupportedType), icebergTable.schema().columns().get(0).type());
+      shell.executeStatement("DROP TABLE not_supported_types");
     }
   }
 }


### PR DESCRIPTION
To allow existing Hive workloads to easily move to Iceberg tables we should make it easier to migrate the scripts.
Currently the following types are not allowed in Hive `CREATE TABLE` statements since they do not have an exact match in Iceberg types:
- TINYINT
- SMALLINT
- VARCHAR
- CHAR

We still want to keep the 1-on-1 schema mapping between Hive and Iceberg, but for the table creation we can convert unsupported types to supported ones:
- TINYINT - INTEGER
- SMALLINT - INTERER
- VARCHAR - STRING
- CHAR - STRING

So this PR introduces a new configuration key: `iceberg.mr.schema.auto.conversion` which if it set to `true` then the `CREATE TABLE` query will not throw an exception, but will convert the columns instead.
For example:
```
CREATE EXTERNAL TABLE not_supported_types (not_supported TINYINT);

DESCRIBE not_supported_types;
----------------
not_supported | int | from deserializer
----------------
```
