### PR TITLE
Core: provide new api of table exists for HadoopTables

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Tables.java
+++ b/api/src/main/java/org/apache/iceberg/Tables.java
@@ -50,4 +50,6 @@ public interface Tables {
   }
 
   Table load(String tableIdentifier);
+
+  boolean exists(String tableIdentifier);
 }

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTables.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTables.java
@@ -94,6 +94,11 @@ public class HadoopTables implements Tables, Configurable {
     return result;
   }
 
+  @Override
+  public boolean exists(String location) {
+    return newTableOps(location).current() != null;
+  }
+
   /**
    * Try to resolve a metadata table, which we encode as URI fragments
    * e.g. hdfs:///warehouse/my_table#snapshots

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopTables.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopTables.java
@@ -66,6 +66,16 @@ public class TestHadoopTables {
   }
 
   @Test
+  public void testTableExists() {
+    Assert.assertFalse(TABLES.exists(tableDir.toURI().toString()));
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA)
+            .bucket("data", 16)
+            .build();
+    TABLES.create(SCHEMA, spec, tableDir.toURI().toString());
+    Assert.assertTrue(TABLES.exists(tableDir.toURI().toString()));
+  }
+
+  @Test
   public void testDropTable() {
     TABLES.create(SCHEMA, tableDir.toURI().toString());
     TABLES.dropTable(tableDir.toURI().toString());

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
@@ -222,6 +222,11 @@ abstract class TestTables {
     public Table load(String tableIdentifier) {
       return catalog.loadTable(TableIdentifier.parse(tableIdentifier));
     }
+
+    @Override
+    public boolean exists(String tableIdentifier) {
+      return catalog.tableExists(TableIdentifier.parse(tableIdentifier));
+    }
   }
 
   static class CustomCatalogTestTables extends TestTables {


### PR DESCRIPTION
currently we do not have a straightforward way to check the existence of HadoopTables.

instead of capturing exception when calling load/create and then justify whether the table is in the path, this PR provides a new API exists() 