### PR TITLE
Nit - Align all comment indentation in TestStrictMetricsEvaluator

### DIFF
--- a/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
@@ -95,7 +95,7 @@ public class TestStrictMetricsEvaluator {
           .put(12, 0L)
           .put(13, 1L)
           .build(),
-  // nan value counts
+      // nan value counts
       ImmutableMap.of(
           8, 50L,
           9, 10L,


### PR DESCRIPTION
I came across this small a nit of a formatting issue when working on another ticket.

This aligns the comments for all of the metrics instantiated when building the metrics of the TestDataFile.