### PR TITLE
Flink: Support write.distribution-mode.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/DistributionMode.java
+++ b/api/src/main/java/org/apache/iceberg/DistributionMode.java
@@ -20,10 +20,20 @@
 package org.apache.iceberg;
 
 /**
- * Enum of supported write distribution mode.
+ * Enum of supported write distribution mode, it defines the write behavior of batch or streaming job:
+ * <p>
+ * 1. none: don't shuffle rows. It is suitable for scenarios where the rows are located in only few
+ * partitions, otherwise that may produce too many small files because each task is writing rows into different
+ * partitions randomly.
+ * <p>
+ * 2. hash-partition: hash distribute by partition keys, which is suitable for the scenarios where the rows are located
+ * into different partitions evenly.
+ * <p>
+ * 3. range-partition: range distribute by partition key (or sort key if table has an {@link SortOrder}), which is
+ * suitable for the scenarios where rows are located into different partitions with skew distribution.
  */
 public enum DistributionMode {
-  NONE("none"), PARTITION("partition"), SORT("sort");
+  NONE("none"), HASH("hash-partition"), RANGE("range-partition");
 
   private final String name;
 

--- a/api/src/main/java/org/apache/iceberg/DistributionMode.java
+++ b/api/src/main/java/org/apache/iceberg/DistributionMode.java
@@ -29,7 +29,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
  * partitions, otherwise that may produce too many small files because each task is writing rows into different
  * partitions randomly.
  * <p>
- * 2. hash: hash distribute by partition keys, which is suitable for the scenarios where the rows are located
+ * 2. hash: hash distribute by partition key, which is suitable for the scenarios where the rows are located
  * into different partitions evenly.
  * <p>
  * 3. range: range distribute by partition key (or sort key if table has an {@link SortOrder}), which is suitable
@@ -48,8 +48,8 @@ public enum DistributionMode {
     return modeName;
   }
 
-  public static DistributionMode fromName(String name) {
-    Preconditions.checkNotNull(name, "Name should not be null");
-    return DistributionMode.valueOf(name.toUpperCase(Locale.ENGLISH));
+  public static DistributionMode fromName(String modeName) {
+    Preconditions.checkNotNull(modeName, "Name of distribution mode should not be null");
+    return DistributionMode.valueOf(modeName.toUpperCase(Locale.ENGLISH));
   }
 }

--- a/api/src/main/java/org/apache/iceberg/DistributionMode.java
+++ b/api/src/main/java/org/apache/iceberg/DistributionMode.java
@@ -19,6 +19,9 @@
 
 package org.apache.iceberg;
 
+import java.util.Locale;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
 /**
  * Enum of supported write distribution mode, it defines the write behavior of batch or streaming job:
  * <p>
@@ -26,32 +29,27 @@ package org.apache.iceberg;
  * partitions, otherwise that may produce too many small files because each task is writing rows into different
  * partitions randomly.
  * <p>
- * 2. hash-partition: hash distribute by partition keys, which is suitable for the scenarios where the rows are located
+ * 2. hash: hash distribute by partition keys, which is suitable for the scenarios where the rows are located
  * into different partitions evenly.
  * <p>
- * 3. range-partition: range distribute by partition key (or sort key if table has an {@link SortOrder}), which is
- * suitable for the scenarios where rows are located into different partitions with skew distribution.
+ * 3. range: range distribute by partition key (or sort key if table has an {@link SortOrder}), which is suitable
+ * for the scenarios where rows are located into different partitions with skew distribution.
  */
 public enum DistributionMode {
-  NONE("none"), HASH("hash-partition"), RANGE("range-partition");
+  NONE("none"), HASH("hash"), RANGE("range");
 
-  private final String name;
+  private final String modeName;
 
-  DistributionMode(String mode) {
-    this.name = mode;
+  DistributionMode(String modeName) {
+    this.modeName = modeName;
   }
 
   public String modeName() {
-    return name;
+    return modeName;
   }
 
   public static DistributionMode fromName(String name) {
-    for (DistributionMode mode : DistributionMode.values()) {
-      if (mode.name.equals(name)) {
-        return mode;
-      }
-    }
-
-    throw new IllegalArgumentException("Invalid write.distribution-mode name: " + name);
+    Preconditions.checkNotNull(name, "Name should not be null");
+    return DistributionMode.valueOf(name.toUpperCase(Locale.ENGLISH));
   }
 }

--- a/api/src/main/java/org/apache/iceberg/DistributionMode.java
+++ b/api/src/main/java/org/apache/iceberg/DistributionMode.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+/**
+ * Enum of supported write distribution mode.
+ */
+public enum DistributionMode {
+  NONE("none"), PARTITION("partition"), SORT("sort");
+
+  private final String name;
+
+  DistributionMode(String mode) {
+    this.name = mode;
+  }
+
+  public String modeName() {
+    return name;
+  }
+
+  public static DistributionMode fromName(String name) {
+    for (DistributionMode mode : DistributionMode.values()) {
+      if (mode.name.equals(name)) {
+        return mode;
+      }
+    }
+
+    throw new IllegalArgumentException("Invalid write.distribution-mode name: " + name);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -138,6 +138,9 @@ public class TableProperties {
   public static final String ENGINE_HIVE_ENABLED = "engine.hive.enabled";
   public static final boolean ENGINE_HIVE_ENABLED_DEFAULT = false;
 
+  public static final String WRITE_SHUFFLE_BY_PARTITION = "write.shuffle-by.partition";
+  public static final boolean WRITE_SHUFFLE_BY_PARTITION_DEFAULT = false;
+
   public static final String GC_ENABLED = "gc.enabled";
   public static final boolean GC_ENABLED_DEFAULT = true;
 

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -138,8 +138,8 @@ public class TableProperties {
   public static final String ENGINE_HIVE_ENABLED = "engine.hive.enabled";
   public static final boolean ENGINE_HIVE_ENABLED_DEFAULT = false;
 
-  public static final String WRITE_SHUFFLE_BY_PARTITION = "write.shuffle-by.partition";
-  public static final boolean WRITE_SHUFFLE_BY_PARTITION_DEFAULT = false;
+  public static final String WRITE_DISTRIBUTION_MODE = "write.distribution-mode";
+  public static final String WRITE_DISTRIBUTION_MODE_DEFAULT = "none";
 
   public static final String GC_ENABLED = "gc.enabled";
   public static final boolean GC_ENABLED_DEFAULT = true;

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -231,13 +231,13 @@ public class FlinkSink {
         }
       }
 
-      // Convert the flink requested table schema to flink row type.
+      // Convert the requested flink table schema to flink row type.
       RowType flinkRowType = toFlinkRowType(table.schema(), tableSchema);
 
       // Distribute the records from input data stream based on the write.distribution-mode.
       rowDataInput = distributeDataStream(rowDataInput, table.properties(), table.spec(), table.schema(), flinkRowType);
 
-      // Concat the iceberg stream writer and committer operators.
+      // Chain the iceberg stream writer and committer operator.
       IcebergStreamWriter<RowData> streamWriter = createStreamWriter(table, flinkRowType, equalityFieldIds);
       IcebergFilesCommitter filesCommitter = new IcebergFilesCommitter(tableLoader, overwrite);
 
@@ -295,7 +295,6 @@ public class FlinkSink {
   }
 
   static RowType toFlinkRowType(Schema schema, TableSchema requestedSchema) {
-    RowType flinkRowType;
     if (requestedSchema != null) {
       // Convert the flink schema to iceberg schema firstly, then reassign ids to match the existing iceberg schema.
       Schema writeSchema = TypeUtil.reassignIds(FlinkSchemaUtil.convert(requestedSchema), schema);
@@ -305,12 +304,10 @@ public class FlinkSink {
       // iceberg INTEGER, that means if we use iceberg's table schema to read TINYINT (backend by 1 'byte'), we will
       // read 4 bytes rather than 1 byte, it will mess up the byte array in BinaryRowData. So here we must use flink
       // schema.
-      flinkRowType = (RowType) requestedSchema.toRowDataType().getLogicalType();
+      return (RowType) requestedSchema.toRowDataType().getLogicalType();
     } else {
-      flinkRowType = FlinkSchemaUtil.convert(schema);
+      return FlinkSchemaUtil.convert(schema);
     }
-
-    return flinkRowType;
   }
 
   static IcebergStreamWriter<RowData> createStreamWriter(Table table,

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -168,7 +168,7 @@ public class FlinkSink {
 
     /**
      * Configure the write distribution mode that the flink sink will use. Currently, flink support
-     * {@link DistributionMode#NONE} and {@link DistributionMode#PARTITION}.
+     * {@link DistributionMode#NONE} and {@link DistributionMode#HASH}.
      *
      * @param mode to specify the write distribution mode.
      * @return {@link Builder} to connect the iceberg table.
@@ -271,15 +271,15 @@ public class FlinkSink {
         case NONE:
           return input;
 
-        case PARTITION:
+        case HASH:
           if (partitionSpec.isUnpartitioned()) {
             return input;
           } else {
             return input.keyBy(new PartitionKeySelector(partitionSpec, iSchema, flinkRowType));
           }
 
-        case SORT:
-          throw new UnsupportedOperationException("The write.distribution-mode=sort is not supported in flink now");
+        case RANGE:
+          throw new UnsupportedOperationException("The write.distribution-mode=range is not supported in flink now");
 
         default:
           throw new RuntimeException("Unrecognized write.distribution-mode: " + writeMode);

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/PartitionKeySelector.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/PartitionKeySelector.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.sink;
+
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.iceberg.PartitionKey;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.flink.RowDataWrapper;
+
+/**
+ * Provide {@link KeySelector} to shuffle by partition key, so that each partition/bucket will be wrote by only one
+ * task. That will reduce lots of small files in partitioned fanout write policy for flink sink.
+ */
+class PartitionKeySelector implements KeySelector<RowData, String> {
+
+  private final Schema schema;
+  private final PartitionKey partitionKey;
+  private final RowType flinkSchema;
+
+  private transient RowDataWrapper rowDataWrapper;
+
+  PartitionKeySelector(PartitionSpec spec, Schema schema, RowType flinkSchema) {
+    this.schema = schema;
+    this.partitionKey = new PartitionKey(spec, schema);
+    this.flinkSchema = flinkSchema;
+  }
+
+  /**
+   * Construct the {@link RowDataWrapper} lazily here because few members in it are not serializable. In this way, we
+   * don't have to serialize them with forcing.
+   */
+  private RowDataWrapper lazyRowDataWrapper() {
+    if (rowDataWrapper == null) {
+      rowDataWrapper = new RowDataWrapper(flinkSchema, schema.asStruct());
+    }
+    return rowDataWrapper;
+  }
+
+  @Override
+  public String getKey(RowData row) {
+    partitionKey.partition(lazyRowDataWrapper().wrap(row));
+    return partitionKey.toPath();
+  }
+}

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/PartitionKeySelector.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/PartitionKeySelector.java
@@ -28,8 +28,8 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.flink.RowDataWrapper;
 
 /**
- * Provide {@link KeySelector} to shuffle by partition key, so that each partition/bucket will be wrote by only one
- * task. That will reduce lots of small files in partitioned fanout write policy for flink sink.
+ * Create a {@link KeySelector} to shuffle by partition key, then each partition/bucket will be wrote by only one
+ * task. That will reduce lots of small files in partitioned fanout write policy for {@link FlinkSink}.
  */
 class PartitionKeySelector implements KeySelector<RowData, String> {
 

--- a/flink/src/test/java/org/apache/iceberg/flink/FlinkCatalogTestBase.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/FlinkCatalogTestBase.java
@@ -101,15 +101,22 @@ public abstract class FlinkCatalogTestBase extends FlinkTestBase {
     }
     if (isHadoopCatalog) {
       config.put(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE, "hadoop");
-      config.put(CatalogProperties.WAREHOUSE_LOCATION, "file://" + hadoopWarehouse.getRoot());
     } else {
       config.put(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE, "hive");
-      config.put(CatalogProperties.WAREHOUSE_LOCATION, "file://" + hiveWarehouse.getRoot());
       config.put(CatalogProperties.HIVE_URI, getURI(hiveConf));
     }
+    config.put(CatalogProperties.WAREHOUSE_LOCATION, String.format("file://%s", warehouseRoot()));
 
     this.flinkDatabase = catalogName + "." + DATABASE;
     this.icebergNamespace = Namespace.of(ArrayUtils.concat(baseNamespace.levels(), new String[] {DATABASE}));
+  }
+
+  protected String warehouseRoot() {
+    if (isHadoopCatalog) {
+      return hadoopWarehouse.getRoot().getAbsolutePath();
+    } else {
+      return hiveWarehouse.getRoot().getAbsolutePath();
+    }
   }
 
   static String getURI(HiveConf conf) {

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
@@ -236,8 +236,8 @@ public class TestFlinkTableSink extends FlinkCatalogTestBase {
   }
 
   @Test
-  public void testPartitionWriteMode() throws Exception {
-    String tableName = "test_shuffle_by_partition";
+  public void testHashDistributeMode() throws Exception {
+    String tableName = "test_hash_distribution_mode";
 
     Map<String, String> tableProps = ImmutableMap.of(
         "write.format.default", format.name(),
@@ -265,9 +265,12 @@ public class TestFlinkTableSink extends FlinkCatalogTestBase {
         SimpleDataUtil.createRecord(3, "ccc")
     ));
 
-    Assert.assertEquals("Should 1 data file in partition 'aaa'", 1, partitionFiles(tableName, "aaa").size());
-    Assert.assertEquals("Should 1 data file in partition 'bbb'", 1, partitionFiles(tableName, "bbb").size());
-    Assert.assertEquals("Should 1 data file in partition 'ccc'", 1, partitionFiles(tableName, "ccc").size());
+    Assert.assertEquals("There should be only 1 data file in partition 'aaa'", 1,
+        partitionFiles(tableName, "aaa").size());
+    Assert.assertEquals("There should be only 1 data file in partition 'bbb'", 1,
+        partitionFiles(tableName, "bbb").size());
+    Assert.assertEquals("There should be only 1 data file in partition 'ccc'", 1,
+        partitionFiles(tableName, "ccc").size());
 
     sql("DROP TABLE IF EXISTS %s.%s", flinkDatabase, tableName);
   }

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
@@ -32,8 +32,10 @@ import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Expressions;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
@@ -234,12 +236,12 @@ public class TestFlinkTableSink extends FlinkCatalogTestBase {
   }
 
   @Test
-  public void testWithShuffleByPartition() throws Exception {
+  public void testPartitionWriteMode() throws Exception {
     String tableName = "test_shuffle_by_partition";
 
     Map<String, String> tableProps = ImmutableMap.of(
         "write.format.default", format.name(),
-        "write.shuffle-by.partition", "true"
+        TableProperties.WRITE_DISTRIBUTION_MODE, DistributionMode.PARTITION.modeName()
     );
     sql("CREATE TABLE %s(id INT, data VARCHAR) PARTITIONED BY (data) WITH %s",
         tableName, toWithClause(tableProps));

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
@@ -60,31 +60,22 @@ public class TestFlinkTableSink extends FlinkCatalogTestBase {
 
   @Parameterized.Parameters(name = "catalogName={0}, baseNamespace={1}, format={2}, isStreaming={3}")
   public static Iterable<Object[]> parameters() {
-    return ImmutableList.of(
-        new Object[] {"testhive", Namespace.empty(), "avro", true},
-        new Object[] {"testhive", Namespace.empty(), "avro", false},
-        new Object[] {"testhive", Namespace.empty(), "orc", true},
-        new Object[] {"testhive", Namespace.empty(), "orc", false},
-        new Object[] {"testhive", Namespace.empty(), "parquet", true},
-        new Object[] {"testhive", Namespace.empty(), "parquet", false},
-        new Object[] {"testhadoop", Namespace.empty(), "avro", true},
-        new Object[] {"testhadoop", Namespace.empty(), "avro", false},
-        new Object[] {"testhadoop", Namespace.empty(), "orc", true},
-        new Object[] {"testhadoop", Namespace.empty(), "orc", false},
-        new Object[] {"testhadoop", Namespace.empty(), "parquet", true},
-        new Object[] {"testhadoop", Namespace.empty(), "parquet", false},
-        new Object[] {"testhadoop_basenamespace", Namespace.of("l0", "l1"), "avro", true},
-        new Object[] {"testhadoop_basenamespace", Namespace.of("l0", "l1"), "avro", false},
-        new Object[] {"testhadoop_basenamespace", Namespace.of("l0", "l1"), "orc", true},
-        new Object[] {"testhadoop_basenamespace", Namespace.of("l0", "l1"), "orc", false},
-        new Object[] {"testhadoop_basenamespace", Namespace.of("l0", "l1"), "parquet", true},
-        new Object[] {"testhadoop_basenamespace", Namespace.of("l0", "l1"), "parquet", false}
-    );
+    List<Object[]> parameters = Lists.newArrayList();
+    for (FileFormat format : new FileFormat[] {FileFormat.ORC, FileFormat.AVRO, FileFormat.PARQUET}) {
+      for (Boolean isStreaming : new Boolean[] {true, false}) {
+        for (Object[] catalogParams : FlinkCatalogTestBase.parameters()) {
+          String catalogName = (String) catalogParams[0];
+          Namespace baseNamespace = (Namespace) catalogParams[1];
+          parameters.add(new Object[] {catalogName, baseNamespace, format, isStreaming});
+        }
+      }
+    }
+    return parameters;
   }
 
-  public TestFlinkTableSink(String catalogName, Namespace baseNamespace, String format, Boolean isStreamingJob) {
+  public TestFlinkTableSink(String catalogName, Namespace baseNamespace, FileFormat format, Boolean isStreamingJob) {
     super(catalogName, baseNamespace);
-    this.format = FileFormat.valueOf(format.toUpperCase(Locale.ENGLISH));
+    this.format = format;
     this.isStreamingJob = isStreamingJob;
   }
 

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
@@ -241,7 +241,7 @@ public class TestFlinkTableSink extends FlinkCatalogTestBase {
 
     Map<String, String> tableProps = ImmutableMap.of(
         "write.format.default", format.name(),
-        TableProperties.WRITE_DISTRIBUTION_MODE, DistributionMode.PARTITION.modeName()
+        TableProperties.WRITE_DISTRIBUTION_MODE, DistributionMode.HASH.modeName()
     );
     sql("CREATE TABLE %s(id INT, data VARCHAR) PARTITIONED BY (data) WITH %s",
         tableName, toWithClause(tableProps));

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
@@ -24,7 +24,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.flink.streaming.api.TimeCharacteristic;

--- a/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
@@ -147,7 +147,7 @@ public class TestFlinkIcebergSink extends AbstractTestBase {
     SimpleDataUtil.assertTableRows(tablePath, convertToRowData(rows));
   }
 
-  private void testWriteRow(TableSchema tableSchema, boolean keyByPartition) throws Exception {
+  private void testWriteRow(TableSchema tableSchema, boolean shuffleByPartition) throws Exception {
     List<Row> rows = Lists.newArrayList(
         Row.of(1, "aaa"),
         Row.of(1, "bbb"),
@@ -166,7 +166,7 @@ public class TestFlinkIcebergSink extends AbstractTestBase {
         .tableLoader(tableLoader)
         .tableSchema(tableSchema)
         .writeParallelism(parallelism)
-        .keyByPartition(keyByPartition)
+        .shuffleByPartition(shuffleByPartition)
         .build();
 
     // Execute the program.

--- a/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
@@ -232,9 +232,9 @@ public class TestFlinkIcebergSink extends AbstractTestBase {
     testWriteRow(null, null);
 
     if (partitioned) {
-      Assert.assertEquals("Should have 1 data file in partition 'aaa'", 1, partitionFiles("aaa").size());
-      Assert.assertEquals("Should have 1 data file in partition 'bbb'", 1, partitionFiles("bbb").size());
-      Assert.assertEquals("Should have 1 data file in partition 'ccc'", 1, partitionFiles("ccc").size());
+      Assert.assertEquals("There should be only 1 data file in partition 'aaa'", 1, partitionFiles("aaa").size());
+      Assert.assertEquals("There should be only 1 data file in partition 'bbb'", 1, partitionFiles("bbb").size());
+      Assert.assertEquals("There should be only 1 data file in partition 'ccc'", 1, partitionFiles("ccc").size());
     }
   }
 
@@ -242,9 +242,9 @@ public class TestFlinkIcebergSink extends AbstractTestBase {
   public void testPartitionWriteMode() throws Exception {
     testWriteRow(null, DistributionMode.HASH);
     if (partitioned) {
-      Assert.assertEquals("Should have 1 data file in partition 'aaa'", 1, partitionFiles("aaa").size());
-      Assert.assertEquals("Should have 1 data file in partition 'bbb'", 1, partitionFiles("bbb").size());
-      Assert.assertEquals("Should have 1 data file in partition 'ccc'", 1, partitionFiles("ccc").size());
+      Assert.assertEquals("There should be only 1 data file in partition 'aaa'", 1, partitionFiles("aaa").size());
+      Assert.assertEquals("There should be only 1 data file in partition 'bbb'", 1, partitionFiles("bbb").size());
+      Assert.assertEquals("There should be only 1 data file in partition 'ccc'", 1, partitionFiles("ccc").size());
     }
   }
 
@@ -252,9 +252,9 @@ public class TestFlinkIcebergSink extends AbstractTestBase {
   public void testShuffleByPartitionWithSchema() throws Exception {
     testWriteRow(SimpleDataUtil.FLINK_SCHEMA, DistributionMode.HASH);
     if (partitioned) {
-      Assert.assertEquals("Should have 1 data file in partition 'aaa'", 1, partitionFiles("aaa").size());
-      Assert.assertEquals("Should have 1 data file in partition 'bbb'", 1, partitionFiles("bbb").size());
-      Assert.assertEquals("Should have 1 data file in partition 'ccc'", 1, partitionFiles("ccc").size());
+      Assert.assertEquals("There should be only 1 data file in partition 'aaa'", 1, partitionFiles("aaa").size());
+      Assert.assertEquals("There should be only 1 data file in partition 'bbb'", 1, partitionFiles("bbb").size());
+      Assert.assertEquals("There should be only 1 data file in partition 'ccc'", 1, partitionFiles("ccc").size());
     }
   }
 }

--- a/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
@@ -216,7 +216,7 @@ public class TestFlinkIcebergSink extends AbstractTestBase {
         .commit();
 
     AssertHelpers.assertThrows("Does not support range distribution-mode now.",
-        UnsupportedOperationException.class, "The write.distribution-mode=range is not supported in flink now",
+        IllegalArgumentException.class, "Flink does not support 'range' write distribution mode now.",
         () -> {
           testWriteRow(null, DistributionMode.RANGE);
           return null;

--- a/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergStreamWriter.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergStreamWriter.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
@@ -337,7 +338,8 @@ public class TestIcebergStreamWriter {
 
   private OneInputStreamOperatorTestHarness<RowData, WriteResult> createIcebergStreamWriter(
       Table icebergTable, TableSchema flinkSchema) throws Exception {
-    IcebergStreamWriter<RowData> streamWriter = FlinkSink.createStreamWriter(icebergTable, flinkSchema, null);
+    RowType flinkRowType = FlinkSink.toFlinkRowType(icebergTable.schema(), flinkSchema);
+    IcebergStreamWriter<RowData> streamWriter = FlinkSink.createStreamWriter(icebergTable, flinkRowType, null);
     OneInputStreamOperatorTestHarness<RowData, WriteResult> harness = new OneInputStreamOperatorTestHarness<>(
         streamWriter, 1, 1, 0);
 


### PR DESCRIPTION
Provides a switch in org.apache.flink.sink.FlinkSink to shuffle by partition key, so that each partition/bucket will be wrote by only one task. That will reduce lots of small files in partitioned fanout write policy for flink sink.