### PR TITLE
Spark: Override simpleString in dynamic file filter nodes

### DIFF
--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/DynamicFileFilter.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/DynamicFileFilter.scala
@@ -20,6 +20,7 @@
 package org.apache.spark.sql.catalyst.plans.logical
 
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet}
+import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.connector.iceberg.read.SupportsFileFilter
 
 // TODO: fix stats (ignore the fact it is a binary node and report only scanRelation stats)
@@ -34,4 +35,8 @@ case class DynamicFileFilter(
   override def left: LogicalPlan = scanPlan
   override def right: LogicalPlan = fileFilterPlan
   override def output: Seq[Attribute] = scanPlan.output
+
+  override def simpleString(maxFields: Int): String = {
+    s"DynamicFileFilter${truncatedString(output, "[", ", ", "]", maxFields)}"
+  }
 }

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DynamicFileFilterExec.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DynamicFileFilterExec.scala
@@ -24,6 +24,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeSet, SortOrder}
 import org.apache.spark.sql.catalyst.plans.physical
+import org.apache.spark.sql.catalyst.util.truncatedString
 import org.apache.spark.sql.connector.iceberg.read.SupportsFileFilter
 import org.apache.spark.sql.execution.{BinaryExecNode, SparkPlan}
 import org.apache.spark.sql.vectorized.ColumnarBatch
@@ -50,5 +51,9 @@ case class DynamicFileFilterExec(
     val rows = fileFilterExec.executeCollect()
     val matchedFileLocations = rows.map(_.getString(0))
     filterable.filterFiles(matchedFileLocations.toSet.asJava)
+  }
+
+  override def simpleString(maxFields: Int): String = {
+    s"DynamicFileFilterExec${truncatedString(output, "[", ", ", "]", maxFields)}"
   }
 }


### PR DESCRIPTION
This PR overrides `simpleString` in dynamic file filter nodes to limit their output.

After this PR:

```
+- DynamicFileFilter[id#20, dep#21, _file#28, _pos#29L]
   :- RelationV2[id#20, dep#21, _file#28, _pos#29L] testhive.default.table
   +- Aggregate [_file#28], [_file#28]
      +- Project [_file#28]
         +- Filter (id#20 <=> 1)
            +- RelationV2[id#20, dep#21, _file#28, _pos#29L] testhive.default.table

+- DynamicFileFilterExec[id#20, dep#21, _file#28, _pos#29L]
   :- *(1) Project [id#20, dep#21, _file#28, _pos#29L]
   :  +- ExtendedBatchScan[id#20, dep#21, _file#28, _pos#29L] testhive.default.table [filters=id = 1]
   +- *(2) HashAggregate(keys=[_file#28], functions=[], output=[_file#28])
      +- *(2) HashAggregate(keys=[_file#28], functions=[], output=[_file#28])
         +- *(2) Project [_file#28]
            +- *(2) Filter (id#20 <=> 1)
               +- ExtendedBatchScan[id#20, dep#21, _file#28, _pos#29L] testhive.default.table [filters=id = 1]
```

