### PR TITLE
Hive: Add ObjectInspector implementations for UUID, Fixed and Time type

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergBinaryObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergBinaryObjectInspector.java
@@ -29,15 +29,15 @@ import org.apache.iceberg.util.ByteBuffers;
 
 public class IcebergBinaryObjectInspector extends AbstractPrimitiveJavaObjectInspector
     implements BinaryObjectInspector, WriteObjectInspector {
-  
-  private static final IcebergBinaryObjectInspector INSTANCE = new IcebergBinaryObjectInspector();
 
-  private IcebergBinaryObjectInspector() {
-    super(TypeInfoFactory.binaryTypeInfo);
-  }
+  private static final IcebergBinaryObjectInspector INSTANCE = new IcebergBinaryObjectInspector();
 
   public static IcebergBinaryObjectInspector get() {
     return INSTANCE;
+  }
+
+  private IcebergBinaryObjectInspector() {
+    super(TypeInfoFactory.binaryTypeInfo);
   }
 
   @Override
@@ -69,7 +69,7 @@ public class IcebergBinaryObjectInspector extends AbstractPrimitiveJavaObjectIns
 
   @Override
   public ByteBuffer convert(Object o) {
-    return o == null ? null : ByteBuffer.wrap(((BytesWritable) o).getBytes());
+    return o == null ? null : ByteBuffer.wrap((byte[]) o);
   }
 
 }

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergFixedObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergFixedObjectInspector.java
@@ -19,35 +19,38 @@
 
 package org.apache.iceberg.mr.hive.serde.objectinspector;
 
-import java.nio.ByteBuffer;
 import java.util.Arrays;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.AbstractPrimitiveJavaObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.BinaryObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.BytesWritable;
-import org.apache.iceberg.util.ByteBuffers;
 
-public class IcebergBinaryObjectInspector extends AbstractPrimitiveJavaObjectInspector
+public class IcebergFixedObjectInspector extends AbstractPrimitiveJavaObjectInspector
     implements BinaryObjectInspector, WriteObjectInspector {
-  
-  private static final IcebergBinaryObjectInspector INSTANCE = new IcebergBinaryObjectInspector();
 
-  private IcebergBinaryObjectInspector() {
+  private static final IcebergFixedObjectInspector INSTANCE = new IcebergFixedObjectInspector();
+
+  private IcebergFixedObjectInspector() {
     super(TypeInfoFactory.binaryTypeInfo);
   }
 
-  public static IcebergBinaryObjectInspector get() {
+  public static IcebergFixedObjectInspector get() {
     return INSTANCE;
   }
 
   @Override
   public byte[] getPrimitiveJavaObject(Object o) {
-    return ByteBuffers.toByteArray((ByteBuffer) o);
+    return (byte[]) o;
   }
 
   @Override
   public BytesWritable getPrimitiveWritableObject(Object o) {
     return o == null ? null : new BytesWritable(getPrimitiveJavaObject(o));
+  }
+
+  @Override
+  public byte[] convert(Object o) {
+    return o == null ? null : ((BytesWritable) o).getBytes();
   }
 
   @Override
@@ -58,18 +61,8 @@ public class IcebergBinaryObjectInspector extends AbstractPrimitiveJavaObjectIns
     if (o instanceof byte[]) {
       byte[] bytes = (byte[]) o;
       return Arrays.copyOf(bytes, bytes.length);
-    } else if (o instanceof ByteBuffer) {
-      ByteBuffer copy =
-          ByteBuffer.wrap(((ByteBuffer) o).array(), ((ByteBuffer) o).arrayOffset(), ((ByteBuffer) o).limit());
-      return copy;
     } else {
       return o;
     }
   }
-
-  @Override
-  public ByteBuffer convert(Object o) {
-    return o == null ? null : ByteBuffer.wrap(((BytesWritable) o).getBytes());
-  }
-
 }

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergFixedObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergFixedObjectInspector.java
@@ -50,7 +50,7 @@ public class IcebergFixedObjectInspector extends AbstractPrimitiveJavaObjectInsp
 
   @Override
   public byte[] convert(Object o) {
-    return o == null ? null : ((BytesWritable) o).getBytes();
+    return o == null ? null : (byte[]) o;
   }
 
   @Override

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergFixedObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergFixedObjectInspector.java
@@ -30,12 +30,12 @@ public class IcebergFixedObjectInspector extends AbstractPrimitiveJavaObjectInsp
 
   private static final IcebergFixedObjectInspector INSTANCE = new IcebergFixedObjectInspector();
 
-  private IcebergFixedObjectInspector() {
-    super(TypeInfoFactory.binaryTypeInfo);
-  }
-
   public static IcebergFixedObjectInspector get() {
     return INSTANCE;
+  }
+
+  private IcebergFixedObjectInspector() {
+    super(TypeInfoFactory.binaryTypeInfo);
   }
 
   @Override

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergObjectInspector.java
@@ -98,7 +98,7 @@ public final class IcebergObjectInspector extends TypeUtil.SchemaVisitor<ObjectI
 
     switch (primitiveType.typeId()) {
       case BINARY:
-        return IcebergBinaryObjectInspector.byteBuffer();
+        return IcebergBinaryObjectInspector.get();
       case BOOLEAN:
         primitiveTypeInfo = TypeInfoFactory.booleanTypeInfo;
         break;
@@ -111,7 +111,7 @@ public final class IcebergObjectInspector extends TypeUtil.SchemaVisitor<ObjectI
         primitiveTypeInfo = TypeInfoFactory.doubleTypeInfo;
         break;
       case FIXED:
-        return IcebergBinaryObjectInspector.byteArray();
+        return IcebergFixedObjectInspector.get();
       case FLOAT:
         primitiveTypeInfo = TypeInfoFactory.floatTypeInfo;
         break;
@@ -122,14 +122,15 @@ public final class IcebergObjectInspector extends TypeUtil.SchemaVisitor<ObjectI
         primitiveTypeInfo = TypeInfoFactory.longTypeInfo;
         break;
       case STRING:
-      case UUID:
         primitiveTypeInfo = TypeInfoFactory.stringTypeInfo;
         break;
+      case UUID:
+        return IcebergUUIDObjectInspector.get();
       case TIMESTAMP:
         boolean adjustToUTC = ((Types.TimestampType) primitiveType).shouldAdjustToUTC();
         return adjustToUTC ? TIMESTAMP_INSPECTOR_WITH_TZ : TIMESTAMP_INSPECTOR;
-
       case TIME:
+        return IcebergTimeObjectInspector.get();
       default:
         throw new IllegalArgumentException(primitiveType.typeId() + " type is not supported");
     }

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimeObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimeObjectInspector.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.mr.hive.serde.objectinspector;
+
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.AbstractPrimitiveJavaObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.StringObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.io.Text;
+
+public class IcebergTimeObjectInspector extends AbstractPrimitiveJavaObjectInspector
+    implements StringObjectInspector, WriteObjectInspector {
+
+  private static final IcebergTimeObjectInspector INSTANCE = new IcebergTimeObjectInspector();
+
+  private IcebergTimeObjectInspector() {
+    super(TypeInfoFactory.stringTypeInfo);
+  }
+
+  public static IcebergTimeObjectInspector get() {
+    return INSTANCE;
+  }
+
+  @Override
+  public String getPrimitiveJavaObject(Object o) {
+    return o == null ? null : o.toString();
+  }
+
+  @Override
+  public Text getPrimitiveWritableObject(Object o) {
+    String value = getPrimitiveJavaObject(o);
+    return value == null ? null : new Text(value);
+  }
+
+  @Override
+  public Object convert(Object o) {
+    return o == null ? null : o.toString();
+  }
+
+  @Override
+  public Object copyObject(Object o) {
+    if (o == null) {
+      return null;
+    }
+
+    if (o instanceof Text) {
+      return new Text((Text) o);
+    } else {
+      return o;
+    }
+  }
+}

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergUUIDObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergUUIDObjectInspector.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.mr.hive.serde.objectinspector;
+
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.AbstractPrimitiveJavaObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.StringObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.io.Text;
+
+public class IcebergUUIDObjectInspector extends AbstractPrimitiveJavaObjectInspector
+    implements StringObjectInspector, WriteObjectInspector {
+
+  private static final IcebergUUIDObjectInspector INSTANCE = new IcebergUUIDObjectInspector();
+
+  private IcebergUUIDObjectInspector() {
+    super(TypeInfoFactory.stringTypeInfo);
+  }
+
+  public static IcebergUUIDObjectInspector get() {
+    return INSTANCE;
+  }
+
+  @Override
+  public String getPrimitiveJavaObject(Object o) {
+    return o == null ? null : o.toString();
+  }
+
+  @Override
+  public Text getPrimitiveWritableObject(Object o) {
+    String value = getPrimitiveJavaObject(o);
+    return value == null ? null : new Text(value);
+  }
+
+  @Override
+  public String convert(Object o) {
+    return o == null ? null : o.toString();
+  }
+
+  @Override
+  public Object copyObject(Object o) {
+    if (o == null) {
+      return null;
+    }
+
+    if (o instanceof Text) {
+      return new Text((Text) o);
+    } else {
+      return o;
+    }
+  }
+}

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
@@ -29,7 +29,6 @@ import java.nio.file.Paths;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
@@ -129,7 +128,7 @@ public class HiveIcebergTestUtils {
     record.set(9, new byte[]{0, 1, 2});
     record.set(10, ByteBuffer.wrap(new byte[]{0, 1, 2, 3}));
     record.set(11, new BigDecimal("0.0000000013"));
-    record.set(12, LocalTime.of(11, 33));
+    record.set(12, "11:33");
     record.set(13, "73689599-d7fc-4dfb-b94e-106ff20284a5");
 
     return record;

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
@@ -29,6 +29,7 @@ import java.nio.file.Paths;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
@@ -74,19 +75,20 @@ public class HiveIcebergTestUtils {
       optional(4, "float_type", Types.FloatType.get()),
       optional(5, "double_type", Types.DoubleType.get()),
       optional(6, "date_type", Types.DateType.get()),
-      // TimeType is not supported
-      // required(7, "time_type", Types.TimeType.get()),
       optional(7, "tstz", Types.TimestampType.withZone()),
       optional(8, "ts", Types.TimestampType.withoutZone()),
       optional(9, "string_type", Types.StringType.get()),
       optional(10, "fixed_type", Types.FixedType.ofLength(3)),
       optional(11, "binary_type", Types.BinaryType.get()),
-      optional(12, "decimal_type", Types.DecimalType.of(38, 10)));
+      optional(12, "decimal_type", Types.DecimalType.of(38, 10)),
+      optional(13, "time_type", Types.TimeType.get()),
+      optional(14, "uuid_type", Types.UUIDType.get()));
 
   public static final StandardStructObjectInspector FULL_SCHEMA_OBJECT_INSPECTOR =
       ObjectInspectorFactory.getStandardStructObjectInspector(
           Arrays.asList("boolean_type", "integer_type", "long_type", "float_type", "double_type",
-              "date_type", "tstz", "ts", "string_type", "fixed_type", "binary_type", "decimal_type"),
+              "date_type", "tstz", "ts", "string_type", "fixed_type", "binary_type", "decimal_type",
+              "time_type", "uuid_type"),
           Arrays.asList(
               PrimitiveObjectInspectorFactory.writableBooleanObjectInspector,
               PrimitiveObjectInspectorFactory.writableIntObjectInspector,
@@ -99,7 +101,9 @@ public class HiveIcebergTestUtils {
               PrimitiveObjectInspectorFactory.writableStringObjectInspector,
               PrimitiveObjectInspectorFactory.writableBinaryObjectInspector,
               PrimitiveObjectInspectorFactory.writableBinaryObjectInspector,
-              PrimitiveObjectInspectorFactory.writableHiveDecimalObjectInspector
+              PrimitiveObjectInspectorFactory.writableHiveDecimalObjectInspector,
+              PrimitiveObjectInspectorFactory.writableStringObjectInspector,
+              PrimitiveObjectInspectorFactory.writableStringObjectInspector
           ));
 
   private HiveIcebergTestUtils() {
@@ -118,8 +122,6 @@ public class HiveIcebergTestUtils {
     record.set(3, 3.1f);
     record.set(4, 4.2d);
     record.set(5, LocalDate.of(2020, 1, 21));
-    // TimeType is not supported
-    // record.set(6, LocalTime.of(11, 33));
     // Nano is not supported ?
     record.set(6, OffsetDateTime.of(2017, 11, 22, 11, 30, 7, 0, ZoneOffset.ofHours(2)));
     record.set(7, LocalDateTime.of(2019, 2, 22, 9, 44, 54));
@@ -127,6 +129,8 @@ public class HiveIcebergTestUtils {
     record.set(9, new byte[]{0, 1, 2});
     record.set(10, ByteBuffer.wrap(new byte[]{0, 1, 2, 3}));
     record.set(11, new BigDecimal("0.0000000013"));
+    record.set(12, LocalTime.of(11, 33));
+    record.set(13, "73689599-d7fc-4dfb-b94e-106ff20284a5");
 
     return record;
   }
@@ -158,14 +162,14 @@ public class HiveIcebergTestUtils {
         new FloatWritable(record.get(3, Float.class)),
         new DoubleWritable(record.get(4, Double.class)),
         new DateWritable((int) record.get(5, LocalDate.class).toEpochDay()),
-        // TimeType is not supported
-        // new Timestamp()
         new TimestampWritable(Timestamp.from(record.get(6, OffsetDateTime.class).toInstant())),
         new TimestampWritable(Timestamp.valueOf(record.get(7, LocalDateTime.class))),
         new Text(record.get(8, String.class)),
         new BytesWritable(record.get(9, byte[].class)),
         new BytesWritable(ByteBuffers.toByteArray(record.get(10, ByteBuffer.class))),
-        new HiveDecimalWritable(HiveDecimal.create(record.get(11, BigDecimal.class)))
+        new HiveDecimalWritable(HiveDecimal.create(record.get(11, BigDecimal.class))),
+        new Text(record.get(12, String.class)),
+        new Text(record.get(13, String.class))
     );
   }
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestDeserializer.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestDeserializer.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectIn
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.MapWritable;
 import org.apache.hadoop.io.Text;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
@@ -195,27 +194,5 @@ public class TestDeserializer {
 
     // Check null record as well
     Assert.assertNull(deserializer.deserialize(null));
-  }
-
-  @Test
-  public void testUnsupportedType() {
-    Schema unsupported = new Schema(
-        optional(1, "time_type", Types.TimeType.get())
-    );
-    StandardStructObjectInspector objectInspector = ObjectInspectorFactory.getStandardStructObjectInspector(
-        Arrays.asList("time_type"),
-        Arrays.asList(
-            PrimitiveObjectInspectorFactory.writableStringObjectInspector
-        ));
-
-    AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
-        "type is not supported", () -> {
-          new Deserializer.Builder()
-              .schema(unsupported)
-              .writerInspector((StructObjectInspector) IcebergObjectInspector.create(unsupported))
-              .sourceInspector(objectInspector)
-              .build();
-        }
-    );
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -81,7 +81,8 @@ public class TestHiveIcebergStorageHandlerWithEngine {
           ImmutableList.of(Types.BooleanType.get(), Types.IntegerType.get(), Types.LongType.get(),
                   Types.FloatType.get(), Types.DoubleType.get(), Types.DateType.get(), Types.TimestampType.withZone(),
                   Types.TimestampType.withoutZone(), Types.StringType.get(), Types.BinaryType.get(),
-                  Types.DecimalType.of(3, 1));
+                  Types.DecimalType.of(3, 1), Types.UUIDType.get(), Types.FixedType.ofLength(5),
+                  Types.TimeType.get());
 
   @Parameters(name = "fileFormat={0}, engine={1}, catalog={2}")
   public static Collection<Object[]> parameters() {
@@ -224,6 +225,9 @@ public class TestHiveIcebergStorageHandlerWithEngine {
   public void testJoinTablesSupportedTypes() throws IOException {
     for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
       Type type = SUPPORTED_TYPES.get(i);
+      if (type == Types.UUIDType.get() && fileFormat == FileFormat.PARQUET) {
+        continue;
+      }
       String tableName = type.typeId().toString().toLowerCase() + "_table_" + i;
       String columnName = type.typeId().toString().toLowerCase() + "_column";
 
@@ -243,6 +247,9 @@ public class TestHiveIcebergStorageHandlerWithEngine {
   public void testSelectDistinctFromTable() throws IOException {
     for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
       Type type = SUPPORTED_TYPES.get(i);
+      if (type == Types.UUIDType.get() && fileFormat == FileFormat.PARQUET) {
+        continue;
+      }
       String tableName = type.typeId().toString().toLowerCase() + "_table_" + i;
       String columnName = type.typeId().toString().toLowerCase() + "_column";
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -225,6 +225,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
   public void testJoinTablesSupportedTypes() throws IOException {
     for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
       Type type = SUPPORTED_TYPES.get(i);
+      // TODO: remove this filter when issue #1881 is resolved
       if (type == Types.UUIDType.get() && fileFormat == FileFormat.PARQUET) {
         continue;
       }
@@ -247,6 +248,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
   public void testSelectDistinctFromTable() throws IOException {
     for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
       Type type = SUPPORTED_TYPES.get(i);
+      // TODO: remove this filter when issue #1881 is resolved
       if (type == Types.UUIDType.get() && fileFormat == FileFormat.PARQUET) {
         continue;
       }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergFixedObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergFixedObjectInspector.java
@@ -51,7 +51,7 @@ public class TestIcebergFixedObjectInspector {
 
     Assert.assertArrayEquals(bytes, oi.getPrimitiveJavaObject(bytes));
     Assert.assertEquals(bytesWritable, oi.getPrimitiveWritableObject(bytes));
-    Assert.assertEquals(bytes, oi.convert(bytesWritable));
+    Assert.assertEquals(bytes, oi.convert(bytes));
 
     byte[] copy = (byte[]) oi.copyObject(bytes);
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergFixedObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergFixedObjectInspector.java
@@ -47,9 +47,11 @@ public class TestIcebergFixedObjectInspector {
     Assert.assertNull(oi.convert(null));
 
     byte[] bytes = new byte[] { 0, 1 };
+    BytesWritable bytesWritable = new BytesWritable(bytes);
 
     Assert.assertArrayEquals(bytes, oi.getPrimitiveJavaObject(bytes));
-    Assert.assertEquals(new BytesWritable(bytes), oi.getPrimitiveWritableObject(bytes));
+    Assert.assertEquals(bytesWritable, oi.getPrimitiveWritableObject(bytes));
+    Assert.assertEquals(bytes, oi.convert(bytesWritable));
 
     byte[] copy = (byte[]) oi.copyObject(bytes);
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergFixedObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergFixedObjectInspector.java
@@ -19,20 +19,18 @@
 
 package org.apache.iceberg.mr.hive.serde.objectinspector;
 
-import java.nio.ByteBuffer;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.primitive.BinaryObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.BytesWritable;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class TestIcebergBinaryObjectInspector {
+public class TestIcebergFixedObjectInspector {
 
   @Test
-  public void testIcebergByteBufferObjectInspector() {
-    BinaryObjectInspector oi = IcebergBinaryObjectInspector.get();
+  public void testIcebergFixedObjectInspector() {
+    IcebergFixedObjectInspector oi = IcebergFixedObjectInspector.get();
 
     Assert.assertEquals(ObjectInspector.Category.PRIMITIVE, oi.getCategory());
     Assert.assertEquals(PrimitiveObjectInspector.PrimitiveCategory.BINARY, oi.getPrimitiveCategory());
@@ -46,20 +44,12 @@ public class TestIcebergBinaryObjectInspector {
     Assert.assertNull(oi.copyObject(null));
     Assert.assertNull(oi.getPrimitiveJavaObject(null));
     Assert.assertNull(oi.getPrimitiveWritableObject(null));
+    Assert.assertNull(oi.convert(null));
 
-    byte[] bytes = new byte[] {0, 1, 2, 3};
+    byte[] bytes = new byte[] { 0, 1 };
 
-    ByteBuffer buffer = ByteBuffer.wrap(bytes);
-    Assert.assertArrayEquals(bytes, oi.getPrimitiveJavaObject(buffer));
-    Assert.assertEquals(new BytesWritable(bytes), oi.getPrimitiveWritableObject(buffer));
-
-    ByteBuffer slice = ByteBuffer.wrap(bytes, 1, 2).slice();
-    Assert.assertArrayEquals(new byte[] {1, 2}, oi.getPrimitiveJavaObject(slice));
-    Assert.assertEquals(new BytesWritable(new byte[] {1, 2}), oi.getPrimitiveWritableObject(slice));
-
-    slice.position(1);
-    Assert.assertArrayEquals(new byte[] {2}, oi.getPrimitiveJavaObject(slice));
-    Assert.assertEquals(new BytesWritable(new byte[] {2}), oi.getPrimitiveWritableObject(slice));
+    Assert.assertArrayEquals(bytes, oi.getPrimitiveJavaObject(bytes));
+    Assert.assertEquals(new BytesWritable(bytes), oi.getPrimitiveWritableObject(bytes));
 
     byte[] copy = (byte[]) oi.copyObject(bytes);
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergObjectInspector.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.hive.MetastoreUtil;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -61,7 +60,8 @@ public class TestIcebergObjectInspector {
           required(19, "struct_field", Types.StructType.of(
                   Types.NestedField.required(20, "nested_field", Types.StringType.get(), "nested field comment")),
                   "struct comment"
-          )
+          ),
+          required(21, "time_field", Types.TimeType.get(), "time comment")
   );
 
   @Test
@@ -77,7 +77,7 @@ public class TestIcebergObjectInspector {
     Assert.assertEquals(1, binaryField.getFieldID());
     Assert.assertEquals("binary_field", binaryField.getFieldName());
     Assert.assertEquals("binary comment", binaryField.getFieldComment());
-    Assert.assertEquals(IcebergBinaryObjectInspector.byteBuffer(), binaryField.getFieldObjectInspector());
+    Assert.assertEquals(IcebergBinaryObjectInspector.get(), binaryField.getFieldObjectInspector());
 
     // boolean
     StructField booleanField = soi.getStructFieldRef("boolean_field");
@@ -118,7 +118,7 @@ public class TestIcebergObjectInspector {
     Assert.assertEquals(6, fixedField.getFieldID());
     Assert.assertEquals("fixed_field", fixedField.getFieldName());
     Assert.assertEquals("fixed comment", fixedField.getFieldComment());
-    Assert.assertEquals(IcebergBinaryObjectInspector.byteArray(), fixedField.getFieldObjectInspector());
+    Assert.assertEquals(IcebergFixedObjectInspector.get(), fixedField.getFieldObjectInspector());
 
     // float
     StructField floatField = soi.getStructFieldRef("float_field");
@@ -177,7 +177,7 @@ public class TestIcebergObjectInspector {
     Assert.assertEquals(13, uuidField.getFieldID());
     Assert.assertEquals("uuid_field", uuidField.getFieldName());
     Assert.assertEquals("uuid comment", uuidField.getFieldComment());
-    Assert.assertEquals(getPrimitiveObjectInspector(String.class), uuidField.getFieldObjectInspector());
+    Assert.assertEquals(IcebergUUIDObjectInspector.get(), uuidField.getFieldObjectInspector());
 
     // list
     StructField listField = soi.getStructFieldRef("list_field");
@@ -202,13 +202,13 @@ public class TestIcebergObjectInspector {
     ObjectInspector expectedObjectInspector = new IcebergRecordObjectInspector(
             (Types.StructType) schema.findType(19), ImmutableList.of(getPrimitiveObjectInspector(String.class)));
     Assert.assertEquals(expectedObjectInspector, structField.getFieldObjectInspector());
-  }
 
-  @Test
-  public void testIcebergObjectInspectorUnsupportedTypes() {
-    AssertHelpers.assertThrows(
-        "Hive does not support time type", IllegalArgumentException.class, "TIME type is not supported",
-        () -> IcebergObjectInspector.create(required(1, "time_field", Types.TimeType.get())));
+    // time
+    StructField timeField = soi.getStructFieldRef("time_field");
+    Assert.assertEquals(21, timeField.getFieldID());
+    Assert.assertEquals("time_field", timeField.getFieldName());
+    Assert.assertEquals("time comment", timeField.getFieldComment());
+    Assert.assertEquals(IcebergTimeObjectInspector.get(), timeField.getFieldObjectInspector());
   }
 
   private static ObjectInspector getPrimitiveObjectInspector(Class<?> clazz) {

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimeObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimeObjectInspector.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.mr.hive.serde.objectinspector;
+
+import java.time.LocalTime;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.io.Text;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestIcebergTimeObjectInspector {
+
+  @Test
+  public void testIcebergTimeObjectInspector() {
+
+    IcebergTimeObjectInspector oi = IcebergTimeObjectInspector.get();
+
+    Assert.assertEquals(ObjectInspector.Category.PRIMITIVE, oi.getCategory());
+    Assert.assertEquals(PrimitiveObjectInspector.PrimitiveCategory.STRING, oi.getPrimitiveCategory());
+
+    Assert.assertEquals(TypeInfoFactory.stringTypeInfo, oi.getTypeInfo());
+    Assert.assertEquals(TypeInfoFactory.stringTypeInfo.getTypeName(), oi.getTypeName());
+
+    Assert.assertEquals(String.class, oi.getJavaPrimitiveClass());
+    Assert.assertEquals(Text.class, oi.getPrimitiveWritableClass());
+
+    Assert.assertNull(oi.copyObject(null));
+    Assert.assertNull(oi.getPrimitiveJavaObject(null));
+    Assert.assertNull(oi.getPrimitiveWritableObject(null));
+    Assert.assertNull(oi.convert(null));
+
+    String time = LocalTime.now().toString();
+    Text text = new Text(time);
+
+    Assert.assertEquals(time, oi.getPrimitiveJavaObject(text));
+    Assert.assertEquals(text, oi.getPrimitiveWritableObject(time));
+    Assert.assertEquals(time, oi.convert(text));
+
+    Text copy = (Text) oi.copyObject(text);
+
+    Assert.assertEquals(text, copy);
+    Assert.assertNotSame(text, copy);
+
+    Assert.assertFalse(oi.preferWritable());
+  }
+}

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergUUIDObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergUUIDObjectInspector.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.mr.hive.serde.objectinspector;
+
+import java.util.UUID;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.io.Text;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestIcebergUUIDObjectInspector {
+
+  @Test
+  public void testIcebergUUIDObjectInspector() {
+    IcebergUUIDObjectInspector oi = IcebergUUIDObjectInspector.get();
+
+    Assert.assertEquals(ObjectInspector.Category.PRIMITIVE, oi.getCategory());
+    Assert.assertEquals(PrimitiveObjectInspector.PrimitiveCategory.STRING, oi.getPrimitiveCategory());
+
+    Assert.assertEquals(TypeInfoFactory.stringTypeInfo, oi.getTypeInfo());
+    Assert.assertEquals(TypeInfoFactory.stringTypeInfo.getTypeName(), oi.getTypeName());
+
+    Assert.assertEquals(String.class, oi.getJavaPrimitiveClass());
+    Assert.assertEquals(Text.class, oi.getPrimitiveWritableClass());
+
+    Assert.assertNull(oi.copyObject(null));
+    Assert.assertNull(oi.getPrimitiveJavaObject(null));
+    Assert.assertNull(oi.getPrimitiveWritableObject(null));
+    Assert.assertNull(oi.convert(null));
+
+    String uuid = UUID.randomUUID().toString();
+    Text text = new Text(uuid);
+
+    Assert.assertEquals(uuid, oi.getPrimitiveJavaObject(text));
+    Assert.assertEquals(text, oi.getPrimitiveWritableObject(uuid));
+    Assert.assertEquals(uuid, oi.convert(text));
+
+    Text copy = (Text) oi.copyObject(text);
+
+    Assert.assertEquals(text, copy);
+    Assert.assertNotSame(text, copy);
+
+    Assert.assertFalse(oi.preferWritable());
+  }
+}


### PR DESCRIPTION
This PR covers the schema conversion for UUID, Fixed and Time types between Iceberg and Hive.
The following mapping is used:
- UUID -> String
- Fixed -> Binary
- Time -> String