### PR TITLE
Fix the partition field id when appending a field to the V2 spec.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
@@ -69,7 +69,8 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
     this.schema = spec.schema();
     this.nameToField = indexSpecByName(spec);
     this.transformToField = indexSpecByTransform(spec);
-    this.lastAssignedPartitionId = spec.fields().stream().mapToInt(PartitionField::fieldId).max().orElse(999);
+    this.lastAssignedPartitionId =
+        base.specs().stream().mapToInt(PartitionSpec::lastAssignedFieldId).max().orElse(999);
 
     spec.fields().stream()
         .filter(field -> field.transform() instanceof UnknownTransform)

--- a/core/src/test/java/org/apache/iceberg/TestTableUpdatePartitionSpec.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableUpdatePartitionSpec.java
@@ -196,4 +196,26 @@ public class TestTableUpdatePartitionSpec extends TableTestBase {
         .build(), table.spec());
     Assert.assertEquals(1001, table.spec().lastAssignedFieldId());
   }
+
+  @Test
+  public void testAddAfterLastFieldRemoved() {
+    table.updateSpec()
+        .removeField("data_bucket")
+        .commit();
+
+    table.updateSpec()
+        .addField(bucket("id", 8))
+        .commit();
+
+    V1Assert.assertEquals("Should add a new id bucket", PartitionSpec.builderFor(table.schema())
+        .withSpecId(2)
+        .alwaysNull("data", "data_bucket")
+        .bucket("id", 8, "id_bucket_8")
+        .build(), table.spec());
+    V2Assert.assertEquals("Should add a new id bucket", PartitionSpec.builderFor(table.schema())
+        .withSpecId(2)
+        .add(1, 1001, "id_bucket_8", "bucket[8]")
+        .build(), table.spec());
+    Assert.assertEquals(1001, table.spec().lastAssignedFieldId());
+  }
 }


### PR DESCRIPTION
The field ID in the new spec should start with the largest last assigned partition id among all table specs.
