### PR TITLE
Core: rename HIVE related catalog properties before release

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -30,9 +30,9 @@ public class CatalogProperties {
   public static final String FILE_IO_IMPL = "io-impl";
   public static final String WAREHOUSE_LOCATION = "warehouse";
 
-  public static final String HIVE_URI = "uri";
-  public static final String HIVE_CLIENT_POOL_SIZE = "clients";
-  public static final int HIVE_CLIENT_POOL_SIZE_DEFAULT = 2;
+  public static final String URI = "uri";
+  public static final String CLIENT_POOL_SIZE = "clients";
+  public static final int CLIENT_POOL_SIZE_DEFAULT = 2;
 
   public static final String LOCK_IMPL = "lock-impl";
 

--- a/flink/src/main/java/org/apache/iceberg/flink/CatalogLoader.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/CatalogLoader.java
@@ -99,11 +99,11 @@ public interface CatalogLoader extends Serializable {
     private HiveCatalogLoader(String catalogName, Configuration conf, Map<String, String> properties) {
       this.catalogName = catalogName;
       this.hadoopConf = new SerializableConfiguration(conf);
-      this.uri = properties.get(CatalogProperties.HIVE_URI);
+      this.uri = properties.get(CatalogProperties.URI);
       this.warehouse = properties.get(CatalogProperties.WAREHOUSE_LOCATION);
-      this.clientPoolSize = properties.containsKey(CatalogProperties.HIVE_CLIENT_POOL_SIZE) ?
-          Integer.parseInt(properties.get(CatalogProperties.HIVE_CLIENT_POOL_SIZE)) :
-          CatalogProperties.HIVE_CLIENT_POOL_SIZE_DEFAULT;
+      this.clientPoolSize = properties.containsKey(CatalogProperties.CLIENT_POOL_SIZE) ?
+          Integer.parseInt(properties.get(CatalogProperties.CLIENT_POOL_SIZE)) :
+          CatalogProperties.CLIENT_POOL_SIZE_DEFAULT;
       this.properties = Maps.newHashMap(properties);
     }
 

--- a/flink/src/test/java/org/apache/iceberg/flink/FlinkCatalogTestBase.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/FlinkCatalogTestBase.java
@@ -103,7 +103,7 @@ public abstract class FlinkCatalogTestBase extends FlinkTestBase {
       config.put(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE, "hadoop");
     } else {
       config.put(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE, "hive");
-      config.put(CatalogProperties.HIVE_URI, getURI(hiveConf));
+      config.put(CatalogProperties.URI, getURI(hiveConf));
     }
     config.put(CatalogProperties.WAREHOUSE_LOCATION, String.format("file://%s", warehouseRoot()));
 

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkHiveCatalog.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkHiveCatalog.java
@@ -44,7 +44,7 @@ public class TestFlinkHiveCatalog extends FlinkTestBase {
     Map<String, String> props = Maps.newHashMap();
     props.put("type", "iceberg");
     props.put(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE, "hive");
-    props.put(CatalogProperties.HIVE_URI, FlinkCatalogTestBase.getURI(hiveConf));
+    props.put(CatalogProperties.URI, FlinkCatalogTestBase.getURI(hiveConf));
 
     File warehouseDir = tempFolder.newFolder();
     props.put(CatalogProperties.WAREHOUSE_LOCATION, "file://" + warehouseDir.getAbsolutePath());
@@ -70,7 +70,7 @@ public class TestFlinkHiveCatalog extends FlinkTestBase {
     Map<String, String> props = Maps.newHashMap();
     props.put("type", "iceberg");
     props.put(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE, "hive");
-    props.put(CatalogProperties.HIVE_URI, FlinkCatalogTestBase.getURI(hiveConf));
+    props.put(CatalogProperties.URI, FlinkCatalogTestBase.getURI(hiveConf));
     // Set the 'hive-conf-dir' instead of 'warehouse'
     props.put(FlinkCatalogFactory.HIVE_CONF_DIR, hiveConfDir.getAbsolutePath());
 

--- a/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkInputFormatReaderDeletes.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkInputFormatReaderDeletes.java
@@ -108,8 +108,8 @@ public class TestFlinkInputFormatReaderDeletes extends DeleteReadTests {
     RowType rowType = FlinkSchemaUtil.convert(projected);
     Map<String, String> properties = Maps.newHashMap();
     properties.put(CatalogProperties.WAREHOUSE_LOCATION, hiveConf.get(HiveConf.ConfVars.METASTOREWAREHOUSE.varname));
-    properties.put(CatalogProperties.HIVE_URI, hiveConf.get(HiveConf.ConfVars.METASTOREURIS.varname));
-    properties.put(CatalogProperties.HIVE_CLIENT_POOL_SIZE,
+    properties.put(CatalogProperties.URI, hiveConf.get(HiveConf.ConfVars.METASTOREURIS.varname));
+    properties.put(CatalogProperties.CLIENT_POOL_SIZE,
         Integer.toString(hiveConf.getInt("iceberg.hive.client-pool-size", 5)));
     CatalogLoader hiveCatalogLoader = CatalogLoader.hive(catalog.name(), hiveConf, properties);
     FlinkInputFormat inputFormat = FlinkSource.forRowData()

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -139,9 +139,9 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable, Supp
       props.put(CatalogProperties.WAREHOUSE_LOCATION, warehouse);
     }
     if (uri != null) {
-      props.put(CatalogProperties.HIVE_URI, uri);
+      props.put(CatalogProperties.URI, uri);
     }
-    props.put(CatalogProperties.HIVE_CLIENT_POOL_SIZE, Integer.toString(clientPoolSize));
+    props.put(CatalogProperties.CLIENT_POOL_SIZE, Integer.toString(clientPoolSize));
 
     setConf(conf);
     initialize(name, props);
@@ -150,8 +150,8 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable, Supp
   @Override
   public void initialize(String inputName, Map<String, String> properties) {
     this.name = inputName;
-    if (properties.containsKey(CatalogProperties.HIVE_URI)) {
-      this.conf.set(HiveConf.ConfVars.METASTOREURIS.varname, properties.get(CatalogProperties.HIVE_URI));
+    if (properties.containsKey(CatalogProperties.URI)) {
+      this.conf.set(HiveConf.ConfVars.METASTOREURIS.varname, properties.get(CatalogProperties.URI));
     }
 
     if (properties.containsKey(CatalogProperties.WAREHOUSE_LOCATION)) {
@@ -159,7 +159,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable, Supp
     }
 
     int clientPoolSize = Integer.parseInt(
-        properties.getOrDefault(CatalogProperties.HIVE_CLIENT_POOL_SIZE, "5"));
+        properties.getOrDefault(CatalogProperties.CLIENT_POOL_SIZE, "5"));
     this.clients = new HiveClientPool(clientPoolSize, this.conf);
     this.createStack = Thread.currentThread().getStackTrace();
     this.closed = false;

--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -26,8 +26,8 @@ Iceberg catalogs support using catalog properties to configure catalog behaviors
 | catalog-impl                      | null               | a custom `Catalog` implementation to use by an engine  |
 | io-impl                           | null               | a custom `FileIO` implementation to use in a catalog   |
 | warehouse                         | null               | the root path of the data warehouse                    |
-| uri                               | null               | (Hive catalog only) the Hive metastore URI             |
-| clients                           | 2                  | (Hive catalog only) the Hive client pool size          |
+| uri                               | null               | a URI string, such as Hive metastore URI               |
+| clients                           | 2                  | client pool size                                       |
 
 `HadoopCatalog` and `HiveCatalog` can access the properties in their constructors.
 Any other custom catalog can access the properties by implementing `Catalog.initialize(catalogName, catalogProperties)`.

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestCatalog.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestCatalog.java
@@ -92,7 +92,7 @@ public class TestCatalog implements Catalog, Configurable {
 
   @Override
   public void initialize(String name, Map<String, String> properties) {
-    String uri = properties.get(CatalogProperties.HIVE_URI);
+    String uri = properties.get(CatalogProperties.URI);
     warehouse = properties.get("warehouse");
     Preconditions.checkArgument(uri != null, "A uri parameter must be set");
     Preconditions.checkArgument(uri.contains("thrift"), "A ur parameter must be valid");

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestCustomCatalog.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestCustomCatalog.java
@@ -51,14 +51,14 @@ public class TestCustomCatalog {
   private static final String WAREHOUSE = String.format("%s.%s.%s", CustomCatalogs.ICEBERG_CATALOG_PREFIX,
       CustomCatalogs.ICEBERG_DEFAULT_CATALOG, CatalogProperties.WAREHOUSE_LOCATION);
   private static final String URI_KEY = String.format("%s.%s.%s", CustomCatalogs.ICEBERG_CATALOG_PREFIX,
-      CustomCatalogs.ICEBERG_DEFAULT_CATALOG, CatalogProperties.HIVE_URI);
+      CustomCatalogs.ICEBERG_DEFAULT_CATALOG, CatalogProperties.URI);
   private static final String TEST_CATALOG = "placeholder_catalog";
   private static final String TEST_CATALOG_IMPL = String.format("%s.%s.%s", CustomCatalogs.ICEBERG_CATALOG_PREFIX,
       TEST_CATALOG, CatalogProperties.CATALOG_IMPL);
   private static final String TEST_WAREHOUSE = String.format("%s.%s.%s", CustomCatalogs.ICEBERG_CATALOG_PREFIX,
       TEST_CATALOG, CatalogProperties.WAREHOUSE_LOCATION);
   private static final String TEST_URI_KEY = String.format("%s.%s.%s", CustomCatalogs.ICEBERG_CATALOG_PREFIX,
-      TEST_CATALOG, CatalogProperties.HIVE_URI);
+      TEST_CATALOG, CatalogProperties.URI);
   private static final String URI_VAL = "thrift://localhost:12345"; // dummy uri
   private static final String CATALOG_VAL = "org.apache.iceberg.spark.source.TestCatalog";
   private static final TableIdentifier TABLE = TableIdentifier.of("default", "table");


### PR DESCRIPTION
the ongoing work in JDBC catalog #1870 also uses the Hive catalog properties. So it does not make sense to have HIVE prefix for them. Remove those prefix before the initial release for `CatalogProperties`, it will be difficult to change it after released.