### PR TITLE
Spark - Fix parquet vectorized reads when column types are promoted

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -31,6 +31,7 @@ import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.TimeStampMicroTZVector;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -279,13 +280,21 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
             this.typeWidth = UNKNOWN_WIDTH;
             break;
           case INT32:
-            this.vec = arrowField.createVector(rootAlloc);
+            Field intField = new Field(
+                    icebergField.name(),
+                    new FieldType(icebergField.isOptional(), new ArrowType.Int(Integer.SIZE, true),
+                            null, null), null);
+            this.vec = intField.createVector(rootAlloc);
             ((IntVector) vec).allocateNew(batchSize);
             this.readType = ReadType.INT;
             this.typeWidth = (int) IntVector.TYPE_WIDTH;
             break;
           case FLOAT:
-            this.vec = arrowField.createVector(rootAlloc);
+            Field floatField = new Field(
+                    icebergField.name(),
+                    new FieldType(icebergField.isOptional(), new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE),
+                            null, null), null);
+            this.vec = floatField.createVector(rootAlloc);
             ((Float4Vector) vec).allocateNew(batchSize);
             this.readType = ReadType.FLOAT;
             this.typeWidth = (int) Float4Vector.TYPE_WIDTH;

--- a/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ArrowVectorAccessors.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ArrowVectorAccessors.java
@@ -184,6 +184,11 @@ public class ArrowVectorAccessors {
     final int getInt(int rowId) {
       return vector.get(rowId);
     }
+
+    @Override
+    final long getLong(int rowId) {
+      return getInt(rowId);
+    }
   }
 
   private static class LongAccessor extends ArrowVectorAccessor {
@@ -232,6 +237,11 @@ public class ArrowVectorAccessors {
     final float getFloat(int rowId) {
       return vector.get(rowId);
     }
+
+    @Override
+    final double getDouble(int rowId) {
+      return getFloat(rowId);
+    }
   }
 
   private static class DictionaryFloatAccessor extends ArrowVectorAccessor {
@@ -250,6 +260,11 @@ public class ArrowVectorAccessors {
     @Override
     final float getFloat(int rowId) {
       return decodedDictionary[offsetVector.get(rowId)];
+    }
+
+    @Override
+    final double getDouble(int rowId) {
+      return getFloat(rowId);
     }
   }
 

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -276,8 +276,8 @@ public class TestHelpers {
                 ((Number) actual).longValue());
         break;
       case FLOAT:
-        Assert.assertEquals("Values didn't match", ((Number) expected).floatValue(),
-                ((Number) actual).floatValue(), 0.01F);
+        Assert.assertEquals("Values didn't match", Float.floatToIntBits(((Number) expected).floatValue()),
+                Float.floatToIntBits(((Number) actual).floatValue()));
         break;
       case DOUBLE:
         Assert.assertEquals("Values didn't match", ((Number) expected).doubleValue(),

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -278,8 +278,8 @@ public class TestHelpers {
       case DOUBLE:
         Assert.assertTrue("Should be a double", actual instanceof Double);
         if (expected instanceof Float) {
-          Assert.assertEquals("Values didn't match", Float.floatToIntBits(((Number) expected).floatValue()),
-                    Float.floatToIntBits(((Number) actual).floatValue()));
+          Assert.assertEquals("Values didn't match", Double.doubleToLongBits(((Double) expected).doubleValue()),
+                  Double.doubleToLongBits((double) actual));
         } else {
           Assert.assertEquals("Primitive value should be equal to expected", expected, actual);
         }

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -278,7 +278,7 @@ public class TestHelpers {
       case DOUBLE:
         Assert.assertTrue("Should be a double", actual instanceof Double);
         if (expected instanceof Float) {
-          Assert.assertEquals("Values didn't match", Double.doubleToLongBits(((Double) expected).doubleValue()),
+          Assert.assertEquals("Values didn't match", Double.doubleToLongBits(((Number) expected).doubleValue()),
                   Double.doubleToLongBits((double) actual));
         } else {
           Assert.assertEquals("Primitive value should be equal to expected", expected, actual);

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -267,22 +267,24 @@ public class TestHelpers {
     }
 
     switch (type.typeId()) {
-      case INTEGER:
-        Assert.assertEquals("Values didn't match", ((Number) expected).intValue(),
-                ((Number) actual).intValue());
-        break;
       case LONG:
-        Assert.assertEquals("Values didn't match", ((Number) expected).longValue(),
-                ((Number) actual).longValue());
-        break;
-      case FLOAT:
-        Assert.assertEquals("Values didn't match", Float.floatToIntBits(((Number) expected).floatValue()),
-                Float.floatToIntBits(((Number) actual).floatValue()));
+        if (expected instanceof Integer) {
+          Assert.assertEquals("Values didn't match", ((Number) expected).longValue(),
+              ((Number) actual).longValue());
+        } else {
+          Assert.assertEquals("Primitive value should be equal to expected", expected, actual);
+        }
         break;
       case DOUBLE:
-        Assert.assertEquals("Values didn't match", ((Number) expected).doubleValue(),
-                ((Number) actual).doubleValue(), 0.01D);
+        if (expected instanceof Float) {
+          Assert.assertEquals("Values didn't match", Float.floatToIntBits(((Number) expected).floatValue()),
+              Float.floatToIntBits(((Number) actual).floatValue()));
+        } else {
+          Assert.assertEquals("Primitive value should be equal to expected", expected, actual);
+        }
         break;
+      case INTEGER:
+      case FLOAT:
       case BOOLEAN:
       case DATE:
       case TIMESTAMP:

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -268,17 +268,18 @@ public class TestHelpers {
 
     switch (type.typeId()) {
       case LONG:
+        Assert.assertTrue("Should be a long", actual instanceof Long);
         if (expected instanceof Integer) {
-          Assert.assertEquals("Values didn't match", ((Number) expected).longValue(),
-              ((Number) actual).longValue());
+          Assert.assertEquals("Values didn't match", ((Number) expected).longValue(), actual);
         } else {
           Assert.assertEquals("Primitive value should be equal to expected", expected, actual);
         }
         break;
       case DOUBLE:
+        Assert.assertTrue("Should be a double", actual instanceof Double);
         if (expected instanceof Float) {
           Assert.assertEquals("Values didn't match", Float.floatToIntBits(((Number) expected).floatValue()),
-              Float.floatToIntBits(((Number) actual).floatValue()));
+                    Float.floatToIntBits(((Number) actual).floatValue()));
         } else {
           Assert.assertEquals("Primitive value should be equal to expected", expected, actual);
         }

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -267,11 +267,23 @@ public class TestHelpers {
     }
 
     switch (type.typeId()) {
-      case BOOLEAN:
       case INTEGER:
+        Assert.assertEquals("Values didn't match", ((Number) expected).intValue(),
+                ((Number) actual).intValue());
+        break;
       case LONG:
+        Assert.assertEquals("Values didn't match", ((Number) expected).longValue(),
+                ((Number) actual).longValue());
+        break;
       case FLOAT:
+        Assert.assertEquals("Values didn't match", ((Number) expected).floatValue(),
+                ((Number) actual).floatValue(), 0.01F);
+        break;
       case DOUBLE:
+        Assert.assertEquals("Values didn't match", ((Number) expected).doubleValue(),
+                ((Number) actual).doubleValue(), 0.01D);
+        break;
+      case BOOLEAN:
       case DATE:
       case TIMESTAMP:
         Assert.assertEquals("Primitive value should be equal to expected", expected, actual);

--- a/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
@@ -236,29 +236,28 @@ public class TestParquetVectorizedReads extends AvroDataTest {
   @Test
   public void testReadsForTypePromotedColumns() throws Exception {
     Schema writeSchema = new Schema(
-            required(100, "id", Types.LongType.get()),
-            optional(101, "int_data", Types.IntegerType.get()),
-            optional(102, "float_data", Types.FloatType.get()),
-            optional(103, "decimal_data", Types.DecimalType.of(10, 5))
+        required(100, "id", Types.LongType.get()),
+        optional(101, "int_data", Types.IntegerType.get()),
+        optional(102, "float_data", Types.FloatType.get()),
+        optional(103, "decimal_data", Types.DecimalType.of(10, 5))
     );
 
     File dataFile = temp.newFile();
     Assert.assertTrue("Delete should succeed", dataFile.delete());
     Iterable<GenericData.Record> data = generateData(writeSchema, 30000, 0L,
-            RandomData.DEFAULT_NULL_PERCENTAGE, IDENTITY);
+        RandomData.DEFAULT_NULL_PERCENTAGE, IDENTITY);
     try (FileAppender<GenericData.Record> writer = getParquetWriter(writeSchema, dataFile)) {
       writer.addAll(data);
     }
 
     Schema readSchema = new Schema(
-            required(100, "id", Types.LongType.get()),
-            optional(101, "int_data", Types.LongType.get()),
-            optional(102, "float_data", Types.DoubleType.get()),
-            optional(103, "decimal_data", Types.DecimalType.of(25, 5))
+        required(100, "id", Types.LongType.get()),
+        optional(101, "int_data", Types.LongType.get()),
+        optional(102, "float_data", Types.DoubleType.get()),
+        optional(103, "decimal_data", Types.DecimalType.of(25, 5))
     );
 
-    assertRecordsMatch(
-            readSchema, 30000, data, dataFile, false,
-            true, BATCH_SIZE);
+    assertRecordsMatch(readSchema, 30000, data, dataFile, false,
+        true, BATCH_SIZE);
   }
 }

--- a/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
@@ -48,6 +48,7 @@ import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class TestParquetVectorizedReads extends AvroDataTest {
@@ -230,5 +231,34 @@ public class TestParquetVectorizedReads extends AvroDataTest {
           }
           return record;
         });
+  }
+
+  @Test
+  public void testReadsForTypePromotedColumns() throws Exception {
+    Schema writeSchema = new Schema(
+            required(100, "id", Types.LongType.get()),
+            optional(101, "int_data", Types.IntegerType.get()),
+            optional(102, "float_data", Types.FloatType.get()),
+            optional(103, "decimal_data", Types.DecimalType.of(10, 5))
+    );
+
+    File dataFile = temp.newFile();
+    Assert.assertTrue("Delete should succeed", dataFile.delete());
+    Iterable<GenericData.Record> data = generateData(writeSchema, 30000, 0L,
+            RandomData.DEFAULT_NULL_PERCENTAGE, IDENTITY);
+    try (FileAppender<GenericData.Record> writer = getParquetWriter(writeSchema, dataFile)) {
+      writer.addAll(data);
+    }
+
+    Schema readSchema = new Schema(
+            required(100, "id", Types.LongType.get()),
+            optional(101, "int_data", Types.LongType.get()),
+            optional(102, "float_data", Types.DoubleType.get()),
+            optional(103, "decimal_data", Types.DecimalType.of(25, 5))
+    );
+
+    assertRecordsMatch(
+            readSchema, 30000, data, dataFile, false,
+            true, BATCH_SIZE);
   }
 }


### PR DESCRIPTION
When the type of a column in iceberg-parquet table is promoted from int->long, or float->double, vectorized reads fail with a ClassCastException. 
```
java.lang.ClassCastException: org.apache.iceberg.bdp.shaded.org.apache.arrow.vector.BigIntVector cannot be cast to org.apache.iceberg.bdp.shaded.org.apache.arrow.vector.IntVector
	at org.apache.iceberg.arrow.vectorized.VectorizedArrowReader.allocateFieldVector(VectorizedArrowReader.java:280)
	at org.apache.iceberg.arrow.vectorized.VectorizedArrowReader.read(VectorizedArrowReader.java:120)
	at org.apache.iceberg.spark.data.vectorized.ColumnarBatchReader.read(ColumnarBatchReader.java:69)
	at org.apache.iceberg.spark.data.vectorized.ColumnarBatchReader.read(ColumnarBatchReader.java:39)
	at org.apache.iceberg.parquet.VectorizedParquetReader$FileIterator.next(VectorizedParquetReader.java:132)
	at org.apache.iceberg.spark.source.BaseDataReader.next(BaseDataReader.java:78)
```

The fix is to create Arrow vectors by looking at the Parquet file schema instead of the Iceberg schema for Int32/64 fields. 