### PR TITLE
[MISC] Fix NarrowingCompoundAssignment warnings

### DIFF
--- a/data/src/main/java/org/apache/iceberg/data/orc/GenericOrcWriters.java
+++ b/data/src/main/java/org/apache/iceberg/data/orc/GenericOrcWriters.java
@@ -428,7 +428,7 @@ public class GenericOrcWriters {
       // record the length and start of the list elements
       cv.lengths[rowId] = value.size();
       cv.offsets[rowId] = cv.childCount;
-      cv.childCount += cv.lengths[rowId];
+      cv.childCount = (int) (cv.childCount + cv.lengths[rowId]);
       // make sure the child is big enough
       cv.child.ensureSize(cv.childCount, true);
       // Add each element
@@ -464,7 +464,7 @@ public class GenericOrcWriters {
       // record the length and start of the list elements
       cv.lengths[rowId] = map.size();
       cv.offsets[rowId] = cv.childCount;
-      cv.childCount += cv.lengths[rowId];
+      cv.childCount = (int) (cv.childCount + cv.lengths[rowId]);
       // make sure the child is big enough
       cv.keys.ensureSize(cv.childCount, true);
       cv.values.ensureSize(cv.childCount, true);

--- a/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcWriters.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcWriters.java
@@ -245,7 +245,7 @@ class FlinkOrcWriters {
       ListColumnVector cv = (ListColumnVector) output;
       cv.lengths[rowId] = data.size();
       cv.offsets[rowId] = cv.childCount;
-      cv.childCount += cv.lengths[rowId];
+      cv.childCount = (int) (cv.childCount + cv.lengths[rowId]);
       // make sure the child is big enough.
       cv.child.ensureSize(cv.childCount, true);
 
@@ -285,7 +285,7 @@ class FlinkOrcWriters {
       // record the length and start of the list elements
       cv.lengths[rowId] = data.size();
       cv.offsets[rowId] = cv.childCount;
-      cv.childCount += cv.lengths[rowId];
+      cv.childCount = (int) (cv.childCount + cv.lengths[rowId]);
       // make sure the child is big enough
       cv.keys.ensureSize(cv.childCount, true);
       cv.values.ensureSize(cv.childCount, true);

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueWriters.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueWriters.java
@@ -236,7 +236,7 @@ class SparkOrcValueWriters {
       // record the length and start of the list elements
       cv.lengths[rowId] = value.numElements();
       cv.offsets[rowId] = cv.childCount;
-      cv.childCount += cv.lengths[rowId];
+      cv.childCount = (int) (cv.childCount + cv.lengths[rowId]);
       // make sure the child is big enough
       cv.child.ensureSize(cv.childCount, true);
       // Add each element
@@ -264,7 +264,7 @@ class SparkOrcValueWriters {
       // record the length and start of the list elements
       cv.lengths[rowId] = value.numElements();
       cv.offsets[rowId] = cv.childCount;
-      cv.childCount += cv.lengths[rowId];
+      cv.childCount = (int) (cv.childCount + cv.lengths[rowId]);
       // make sure the child is big enough
       cv.keys.ensureSize(cv.childCount, true);
       cv.values.ensureSize(cv.childCount, true);


### PR DESCRIPTION
This fixes all current instances of `NarrowingCompoundAssignment` warnings when running `./gradlew check --continue`.

This does not handle the possibility of overflow when adding the current elements size or number of elements to the existing `cv.childCount`, but the old code did not handle that either.

I chose to continue to use the addition of `cv.lengths[rowId]`, which could have typically been substituted for `value.size()`  / `data.size()` / `value.numElements()`, in the off chance that the input `ColumnVector` computes the `size` / `numElements` lazily each time that the method is called. I don't personally think that's likely, but we get the same result either way and this avoids unnecessary repeated work if that is ever the case.

This closes issue https://github.com/apache/iceberg/issues/1290 