### PR TITLE
[MISC] Fix missing override warnings in SortOrder

### DIFF
--- a/api/src/main/java/org/apache/iceberg/SortOrder.java
+++ b/api/src/main/java/org/apache/iceberg/SortOrder.java
@@ -202,6 +202,7 @@ public class SortOrder implements Serializable {
      * @param nullOrder a null order (first or last)
      * @return this for method chaining
      */
+    @Override
     public Builder asc(Term term, NullOrder nullOrder) {
       return addSortField(term, SortDirection.ASC, nullOrder);
     }
@@ -213,6 +214,7 @@ public class SortOrder implements Serializable {
      * @param nullOrder a null order (first or last)
      * @return this for method chaining
      */
+    @Override
     public Builder desc(Term term, NullOrder nullOrder) {
       return addSortField(term, SortDirection.DESC, nullOrder);
     }


### PR DESCRIPTION
When going back over fixing some NarrowingCompoundAssignment warnings, I caught these two left over instances of missing overrides.