### PR TITLE
Flink: Initial implementation of  Flink source with the new FLIP-27 source interface

### DIFF
--- a/flink/v1.13/build.gradle
+++ b/flink/v1.13/build.gradle
@@ -33,6 +33,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
     implementation project(':iceberg-parquet')
     implementation project(':iceberg-hive-metastore')
 
+    compileOnly "org.apache.flink:flink-connector-base"
     compileOnly "org.apache.flink:flink-streaming-java_${scalaVersion}:${flinkVersion}"
     compileOnly "org.apache.flink:flink-streaming-java_${scalaVersion}:${flinkVersion}:tests"
     compileOnly "org.apache.flink:flink-table-api-java-bridge_${scalaVersion}:${flinkVersion}"
@@ -61,6 +62,7 @@ project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}") {
       exclude group: 'org.apache.hive', module: 'hive-storage-api'
     }
 
+    testImplementation "org.apache.flink:flink-connector-test-utils"
     testImplementation "org.apache.flink:flink-core:${flinkVersion}"
     testImplementation "org.apache.flink:flink-runtime_${scalaVersion}:${flinkVersion}"
     testImplementation "org.apache.flink:flink-table-planner-blink_${scalaVersion}:${flinkVersion}"
@@ -141,6 +143,10 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
     implementation(project(':iceberg-nessie')) {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }
+
+    // flink-connector-base is not part of Flink runtime. Hence,
+    // iceberg-flink-runtime should include it as a transitive dependency.
+    implementation "org.apache.flink:flink-connector-base"
   }
 
   shadowJar {

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/FlinkConfigOptions.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/FlinkConfigOptions.java
@@ -22,7 +22,30 @@ package org.apache.iceberg.flink;
 
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.iceberg.util.ThreadPools;
 
+/**
+ * When constructing Flink Iceberg source via Java API,
+ * configs can be set in {@link Configuration} passed to source builder. E.g.
+ * <pre>
+ *   configuration.setBoolean(FlinkConfigOptions.TABLE_EXEC_ICEBERG_INFER_SOURCE_PARALLELISM, true);
+ *   FlinkSource.forRowData()
+ *       .flinkConf(configuration)
+ *       ...
+ * </pre>
+ *
+ * <p></p>
+ *
+ * When using Flink SQL/table API, connector options can be set in Flink's {@link TableEnvironment}.
+ * <pre>
+ *   TableEnvironment tEnv = createTableEnv();
+ *   tEnv.getConfig()
+ *        .getConfiguration()
+ *        .setBoolean(FlinkConfigOptions.TABLE_EXEC_ICEBERG_INFER_SOURCE_PARALLELISM, true);
+ * </pre>
+ */
 public class FlinkConfigOptions {
 
   private FlinkConfigOptions() {
@@ -46,4 +69,16 @@ public class FlinkConfigOptions {
           .booleanType()
           .noDefaultValue()
           .withDescription("Expose split host information to use Flink's locality aware split assigner.");
+
+  public static final ConfigOption<Integer> SOURCE_READER_FETCH_BATCH_RECORD_COUNT = ConfigOptions
+      .key("table.exec.iceberg.fetch-batch-record-count")
+      .intType()
+      .defaultValue(2048)
+      .withDescription("The target number of records for Iceberg reader fetch batch.");
+
+  public static final ConfigOption<Integer> TABLE_EXEC_ICEBERG_WORKER_POOL_SIZE =
+      ConfigOptions.key("table.exec.iceberg.worker-pool-size")
+          .intType()
+          .defaultValue(ThreadPools.WORKER_THREAD_POOL_SIZE)
+          .withDescription("The size of workers pool used to plan or scan manifests.");
 }

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/DataIterator.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/DataIterator.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.encryption.InputFilesDecryptor;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 /**
  * Flink data iterator that reads {@link CombinedScanTask} into a {@link CloseableIterator}
@@ -41,16 +42,60 @@ public class DataIterator<T> implements CloseableIterator<T> {
   private final FileScanTaskReader<T> fileScanTaskReader;
 
   private final InputFilesDecryptor inputFilesDecryptor;
+  private final CombinedScanTask combinedTask;
+
   private Iterator<FileScanTask> tasks;
   private CloseableIterator<T> currentIterator;
+  private int fileOffset;
+  private long recordOffset;
 
   public DataIterator(FileScanTaskReader<T> fileScanTaskReader, CombinedScanTask task,
                       FileIO io, EncryptionManager encryption) {
     this.fileScanTaskReader = fileScanTaskReader;
 
     this.inputFilesDecryptor = new InputFilesDecryptor(task, io, encryption);
+    this.combinedTask = task;
+
     this.tasks = task.files().iterator();
     this.currentIterator = CloseableIterator.empty();
+
+    // fileOffset starts at -1 because we started
+    // from an empty iterator that is not from the split files.
+    this.fileOffset = -1;
+    // record offset points to the record that next() should return when called
+    this.recordOffset = 0L;
+  }
+
+  /**
+   * (startingFileOffset, startingRecordOffset) points to the next row that reader should resume from.
+   * E.g., if the seek position is (file=0, record=1), seek moves the iterator position to the 2nd row
+   * in file 0. When next() is called after seek, 2nd row from file 0 should be returned.
+   */
+  public void seek(int startingFileOffset, long startingRecordOffset) {
+    Preconditions.checkState(fileOffset == -1,
+        "Seek should be called before any other iterator actions");
+    // skip files
+    Preconditions.checkState(startingFileOffset < combinedTask.files().size(),
+        "Invalid starting file offset %d for combined scan task with %d files: %s",
+        startingFileOffset, combinedTask.files().size(), combinedTask);
+    for (long i = 0L; i < startingFileOffset; ++i) {
+      tasks.next();
+    }
+
+    updateCurrentIterator();
+    // skip records within the file
+    for (long i = 0; i < startingRecordOffset; ++i) {
+      if (currentFileHasNext() && hasNext()) {
+        next();
+      } else {
+        throw new IllegalStateException(String.format(
+            "Invalid starting record offset %d for file %d from CombinedScanTask: %s",
+            startingRecordOffset, startingFileOffset, combinedTask));
+      }
+    }
+
+    fileOffset = startingFileOffset;
+    recordOffset = startingRecordOffset;
   }
 
   @Override
@@ -62,7 +107,12 @@ public class DataIterator<T> implements CloseableIterator<T> {
   @Override
   public T next() {
     updateCurrentIterator();
+    recordOffset += 1;
     return currentIterator.next();
+  }
+
+  public boolean currentFileHasNext() {
+    return currentIterator.hasNext();
   }
 
   /**
@@ -74,6 +124,8 @@ public class DataIterator<T> implements CloseableIterator<T> {
       while (!currentIterator.hasNext() && tasks.hasNext()) {
         currentIterator.close();
         currentIterator = openTaskIterator(tasks.next());
+        fileOffset += 1;
+        recordOffset = 0L;
       }
     } catch (IOException e) {
       throw new UncheckedIOException(e);
@@ -89,5 +141,13 @@ public class DataIterator<T> implements CloseableIterator<T> {
     // close the current iterator
     currentIterator.close();
     tasks = null;
+  }
+
+  public int fileOffset() {
+    return fileOffset;
+  }
+
+  public long recordOffset() {
+    return recordOffset;
   }
 }

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/FlinkInputFormat.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/FlinkInputFormat.java
@@ -78,7 +78,7 @@ public class FlinkInputFormat extends RichInputFormat<RowData, FlinkInputSplit> 
     tableLoader.open();
     try (TableLoader loader = tableLoader) {
       Table table = loader.loadTable();
-      return FlinkSplitGenerator.createInputSplits(table, context);
+      return FlinkSplitPlanner.planInputSplits(table, context);
     }
   }
 

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitPlanner.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitPlanner.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import org.apache.flink.annotation.Internal;
+import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.hadoop.Util;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.Tasks;
+import org.apache.iceberg.util.ThreadPools;
+
+@Internal
+public class FlinkSplitPlanner {
+  private FlinkSplitPlanner() {
+  }
+
+  static FlinkInputSplit[] planInputSplits(Table table, ScanContext context) {
+    try (CloseableIterable<CombinedScanTask> tasksIterable = planTasks(table, context)) {
+      List<CombinedScanTask> tasks = Lists.newArrayList(tasksIterable);
+      FlinkInputSplit[] splits = new FlinkInputSplit[tasks.size()];
+      boolean exposeLocality = context.exposeLocality();
+
+      Tasks.range(tasks.size())
+          .stopOnFailure()
+          .executeWith(exposeLocality ? ThreadPools.getWorkerPool() : null)
+          .run(index -> {
+            CombinedScanTask task = tasks.get(index);
+            String[] hostnames = null;
+            if (exposeLocality) {
+              hostnames = Util.blockLocations(table.io(), task);
+            }
+            splits[index] = new FlinkInputSplit(index, task, hostnames);
+          });
+      return splits;
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to process tasks iterable", e);
+    }
+  }
+
+  /**
+   * This returns splits for the FLIP-27 source
+   */
+  public static List<IcebergSourceSplit> planIcebergSourceSplits(
+      Table table, ScanContext context) {
+    try (CloseableIterable<CombinedScanTask> tasksIterable = planTasks(table, context)) {
+      return Lists.newArrayList(CloseableIterable.transform(tasksIterable,
+          task -> IcebergSourceSplit.fromCombinedScanTask(task)));
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to process task iterable: ", e);
+    }
+  }
+
+  static CloseableIterable<CombinedScanTask> planTasks(Table table, ScanContext context) {
+    TableScan scan = table
+        .newScan()
+        .caseSensitive(context.caseSensitive())
+        .project(context.project());
+
+    if (context.includeColumnStats()) {
+      scan = scan.includeColumnStats();
+    }
+
+    if (context.snapshotId() != null) {
+      scan = scan.useSnapshot(context.snapshotId());
+    }
+
+    if (context.asOfTimestamp() != null) {
+      scan = scan.asOfTime(context.asOfTimestamp());
+    }
+
+    if (context.startSnapshotId() != null) {
+      if (context.endSnapshotId() != null) {
+        scan = scan.appendsBetween(context.startSnapshotId(), context.endSnapshotId());
+      } else {
+        scan = scan.appendsAfter(context.startSnapshotId());
+      }
+    }
+
+    if (context.splitSize() != null) {
+      scan = scan.option(TableProperties.SPLIT_SIZE, context.splitSize().toString());
+    }
+
+    if (context.splitLookback() != null) {
+      scan = scan.option(TableProperties.SPLIT_LOOKBACK, context.splitLookback().toString());
+    }
+
+    if (context.splitOpenFileCost() != null) {
+      scan = scan.option(TableProperties.SPLIT_OPEN_FILE_COST, context.splitOpenFileCost().toString());
+    }
+
+    if (context.filters() != null) {
+      for (Expression filter : context.filters()) {
+        scan = scan.filter(filter);
+      }
+    }
+
+    return scan.planTasks();
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/IcebergSource.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/IcebergSource.java
@@ -1,0 +1,284 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import javax.annotation.Nullable;
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.util.Preconditions;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.source.assigner.SplitAssigner;
+import org.apache.iceberg.flink.source.assigner.SplitAssignerFactory;
+import org.apache.iceberg.flink.source.enumerator.ContinuousIcebergEnumerator;
+import org.apache.iceberg.flink.source.enumerator.ContinuousSplitPlanner;
+import org.apache.iceberg.flink.source.enumerator.ContinuousSplitPlannerImpl;
+import org.apache.iceberg.flink.source.enumerator.IcebergEnumeratorState;
+import org.apache.iceberg.flink.source.enumerator.IcebergEnumeratorStateSerializer;
+import org.apache.iceberg.flink.source.enumerator.StaticIcebergEnumerator;
+import org.apache.iceberg.flink.source.reader.IcebergSourceReader;
+import org.apache.iceberg.flink.source.reader.ReaderFunction;
+import org.apache.iceberg.flink.source.reader.ReaderMetricsContext;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplitSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Experimental
+public class IcebergSource<T> implements Source<T, IcebergSourceSplit, IcebergEnumeratorState> {
+  private static final Logger LOG = LoggerFactory.getLogger(IcebergSource.class);
+
+  private final TableLoader tableLoader;
+  private final ScanContext scanContext;
+  private final ReaderFunction<T> readerFunction;
+  private final SplitAssignerFactory assignerFactory;
+
+  IcebergSource(
+      TableLoader tableLoader,
+      ScanContext scanContext,
+      ReaderFunction<T> readerFunction,
+      SplitAssignerFactory assignerFactory) {
+    this.tableLoader = tableLoader;
+    this.scanContext = scanContext;
+    this.readerFunction = readerFunction;
+    this.assignerFactory = assignerFactory;
+  }
+
+  private static Table loadTable(TableLoader tableLoader) {
+    tableLoader.open();
+    try (TableLoader loader = tableLoader) {
+      return loader.loadTable();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to close table loader", e);
+    }
+  }
+
+  @Override
+  public Boundedness getBoundedness() {
+    return scanContext.isStreaming() ? Boundedness.BOUNDED : Boundedness.CONTINUOUS_UNBOUNDED;
+  }
+
+  @Override
+  public SourceReader<T, IcebergSourceSplit> createReader(SourceReaderContext readerContext) {
+    ReaderMetricsContext readerMetrics =
+        new ReaderMetricsContext(readerContext.metricGroup());
+    return new IcebergSourceReader<>(readerFunction, readerContext, readerMetrics);
+  }
+
+  @Override
+  public SplitEnumerator<IcebergSourceSplit, IcebergEnumeratorState> createEnumerator(
+      SplitEnumeratorContext<IcebergSourceSplit> enumContext) {
+    return createEnumerator(enumContext, null);
+  }
+
+  @Override
+  public SplitEnumerator<IcebergSourceSplit, IcebergEnumeratorState> restoreEnumerator(
+      SplitEnumeratorContext<IcebergSourceSplit> enumContext, IcebergEnumeratorState enumState) {
+    return createEnumerator(enumContext, enumState);
+  }
+
+  @Override
+  public SimpleVersionedSerializer<IcebergSourceSplit> getSplitSerializer() {
+    return IcebergSourceSplitSerializer.INSTANCE;
+  }
+
+  @Override
+  public SimpleVersionedSerializer<IcebergEnumeratorState> getEnumeratorCheckpointSerializer() {
+    return IcebergEnumeratorStateSerializer.INSTANCE;
+  }
+
+  private SplitEnumerator<IcebergSourceSplit, IcebergEnumeratorState> createEnumerator(
+      SplitEnumeratorContext<IcebergSourceSplit> enumContext,
+      @Nullable IcebergEnumeratorState enumState) {
+    Table table = loadTable(tableLoader);
+    SplitAssigner assigner;
+    if (enumState == null) {
+      assigner = assignerFactory.createAssigner();
+    } else {
+      LOG.info("Iceberg source restored {} splits from state for table {}",
+          enumState.pendingSplits().size(), table.name());
+      assigner = assignerFactory.createAssigner(enumState.pendingSplits());
+    }
+
+    if (scanContext.isStreaming()) {
+      // Ideally, operatorId should be used as the threadPoolName as Flink guarantees its uniqueness within a job.
+      // SplitEnumeratorContext doesn't expose the OperatorCoordinator.Context, which would contain the OperatorID.
+      // Need to discuss with Flink community whether it is ok to expose a public API like the protected method
+      // "OperatorCoordinator.Context getCoordinatorContext()" from SourceCoordinatorContext implementation.
+      // For now, <table name>-<random UUID> is used as the unique thread pool name.
+      ContinuousSplitPlanner splitPlanner = new ContinuousSplitPlannerImpl(
+          table, scanContext, table.name() + "-" + UUID.randomUUID());
+      return new ContinuousIcebergEnumerator(enumContext, assigner, scanContext, splitPlanner, enumState);
+    } else {
+      return new StaticIcebergEnumerator(enumContext, assigner, table, scanContext, enumState);
+    }
+  }
+
+  public static <T> Builder<T> builder() {
+    return new Builder<>();
+  }
+
+  public static class Builder<T> {
+
+    // required
+    private TableLoader tableLoader;
+    private SplitAssignerFactory splitAssignerFactory;
+    private ReaderFunction<T> readerFunction;
+
+    // optional
+    private final ScanContext.Builder contextBuilder = ScanContext.builder();
+
+    Builder() {
+    }
+
+    public Builder<T> tableLoader(TableLoader loader) {
+      this.tableLoader = loader;
+      return this;
+    }
+
+    public Builder<T> assignerFactory(SplitAssignerFactory assignerFactory) {
+      this.splitAssignerFactory = assignerFactory;
+      return this;
+    }
+
+    public Builder<T> readerFunction(ReaderFunction<T> newReaderFunction) {
+      this.readerFunction = newReaderFunction;
+      return this;
+    }
+
+    public Builder caseSensitive(boolean newCaseSensitive) {
+      this.contextBuilder.caseSensitive(newCaseSensitive);
+      return this;
+    }
+
+    public Builder useSnapshotId(Long newSnapshotId) {
+      this.contextBuilder.useSnapshotId(newSnapshotId);
+      return this;
+    }
+
+    public Builder startingStrategy(StreamingStartingStrategy newStartingStrategy) {
+      this.contextBuilder.startingStrategy(newStartingStrategy);
+      return this;
+    }
+
+    public Builder startSnapshotTimestamp(Long newStartSnapshotTimestamp) {
+      this.contextBuilder.startSnapshotTimestamp(newStartSnapshotTimestamp);
+      return this;
+    }
+
+    public Builder startSnapshotId(Long newStartSnapshotId) {
+      this.contextBuilder.startSnapshotId(newStartSnapshotId);
+      return this;
+    }
+
+    public Builder endSnapshotId(Long newEndSnapshotId) {
+      this.contextBuilder.endSnapshotId(newEndSnapshotId);
+      return this;
+    }
+
+    public Builder asOfTimestamp(Long newAsOfTimestamp) {
+      this.contextBuilder.asOfTimestamp(newAsOfTimestamp);
+      return this;
+    }
+
+    public Builder splitSize(Long newSplitSize) {
+      this.contextBuilder.splitSize(newSplitSize);
+      return this;
+    }
+
+    public Builder splitLookback(Integer newSplitLookback) {
+      this.contextBuilder.splitLookback(newSplitLookback);
+      return this;
+    }
+
+    public Builder splitOpenFileCost(Long newSplitOpenFileCost) {
+      this.contextBuilder.splitOpenFileCost(newSplitOpenFileCost);
+      return this;
+    }
+
+    public Builder streaming(boolean streaming) {
+      this.contextBuilder.streaming(streaming);
+      return this;
+    }
+
+    public Builder monitorInterval(Duration newMonitorInterval) {
+      this.contextBuilder.monitorInterval(newMonitorInterval);
+      return this;
+    }
+
+    public Builder nameMapping(String newNameMapping) {
+      this.contextBuilder.nameMapping(newNameMapping);
+      return this;
+    }
+
+    public Builder project(Schema newProjectedSchema) {
+      this.contextBuilder.project(newProjectedSchema);
+      return this;
+    }
+
+    public Builder filters(List<Expression> newFilters) {
+      this.contextBuilder.filters(newFilters);
+      return this;
+    }
+
+    public Builder limit(long newLimit) {
+      this.contextBuilder.limit(newLimit);
+      return this;
+    }
+
+    public Builder includeColumnStats(boolean newIncludeColumnStats) {
+      this.contextBuilder.includeColumnStats(newIncludeColumnStats);
+      return this;
+    }
+
+    public Builder properties(Map<String, String> properties) {
+      contextBuilder.fromProperties(properties);
+      return this;
+    }
+
+    public IcebergSource<T> build() {
+      checkRequired();
+      return new IcebergSource<T>(
+          tableLoader,
+          contextBuilder.build(),
+          readerFunction,
+          splitAssignerFactory);
+    }
+
+    private void checkRequired() {
+      Preconditions.checkNotNull(tableLoader, "tableLoader is required.");
+      Preconditions.checkNotNull(splitAssignerFactory, "assignerFactory is required.");
+      Preconditions.checkNotNull(readerFunction, "readerFunction is required.");
+    }
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/StreamingMonitorFunction.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/StreamingMonitorFunction.java
@@ -140,7 +140,7 @@ public class StreamingMonitorFunction extends RichSourceFunction<FlinkInputSplit
         newScanContext = scanContext.copyWithAppendsBetween(lastSnapshotId, snapshotId);
       }
 
-      FlinkInputSplit[] splits = FlinkSplitGenerator.createInputSplits(table, newScanContext);
+      FlinkInputSplit[] splits = FlinkSplitPlanner.planInputSplits(table, newScanContext);
       for (FlinkInputSplit split : splits) {
         sourceContext.collect(split);
       }

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/StreamingStartingStrategy.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/StreamingStartingStrategy.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source;
+
+/**
+ * Starting strategy for streaming execution.
+ */
+public enum StreamingStartingStrategy {
+  /**
+   * Do a regular table scan then switch to the incremental mode.
+   * <p>
+   * The incremental mode starts from the current snapshot exclusive.
+   */
+  TABLE_SCAN_THEN_INCREMENTAL,
+
+  /**
+   * Start incremental mode from the latest snapshot inclusive.
+   * <p>
+   * If it is an empty map, all future append snapshots should be discovered.
+   */
+  INCREMENTAL_FROM_LATEST_SNAPSHOT,
+
+  /**
+   * Start incremental mode from the earliest snapshot inclusive.
+   * <p>
+   * If it is an empty map, all future append snapshots should be discovered.
+   */
+  INCREMENTAL_FROM_EARLIEST_SNAPSHOT,
+
+  /**
+   * Start incremental mode from a snapshot with a specific id inclusive.
+   */
+  INCREMENTAL_FROM_SNAPSHOT_ID,
+
+  /**
+   * Start incremental mode from a snapshot with a specific timestamp inclusive.
+   * <p>
+   * If the timestamp is between two snapshots, it should start from the snapshot after the timestamp.
+   */
+  INCREMENTAL_FROM_SNAPSHOT_TIMESTAMP
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/GetSplitResult.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/GetSplitResult.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.assigner;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.Preconditions;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+
+@Internal
+public class GetSplitResult {
+
+  public enum Status {
+
+    AVAILABLE,
+
+    /**
+     * There are pending splits. But they can't be assigned
+     * due to constraints (like event time alignment)
+     */
+    CONSTRAINED,
+
+    /**
+     * Assigner doesn't have pending splits.
+     */
+    UNAVAILABLE
+  }
+
+  private final Status status;
+  private final IcebergSourceSplit split;
+
+  private GetSplitResult(Status status) {
+    this.status = status;
+    this.split = null;
+  }
+
+  private GetSplitResult(IcebergSourceSplit split) {
+    Preconditions.checkNotNull(split, "Split cannot be null");
+    this.status = Status.AVAILABLE;
+    this.split = split;
+  }
+
+  public Status status() {
+    return status;
+  }
+
+  public IcebergSourceSplit split() {
+    return split;
+  }
+
+  private static final GetSplitResult UNAVAILABLE = new GetSplitResult(Status.UNAVAILABLE);
+  private static final GetSplitResult CONSTRAINED = new GetSplitResult(Status.CONSTRAINED);
+
+  public static GetSplitResult unavailable() {
+    return UNAVAILABLE;
+  }
+
+  public static GetSplitResult constrained() {
+    return CONSTRAINED;
+  }
+
+  public static GetSplitResult forSplit(IcebergSourceSplit split) {
+    return new GetSplitResult(split);
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/SimpleSplitAssigner.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/SimpleSplitAssigner.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.assigner;
+
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.flink.annotation.Internal;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplitState;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplitStatus;
+
+/**
+ * Since all methods are called in the source coordinator thread by enumerator,
+ * there is no need for locking.
+ */
+@Internal
+public class SimpleSplitAssigner implements SplitAssigner {
+
+  private final Deque<IcebergSourceSplit> pendingSplits;
+  private CompletableFuture<Void> availableFuture;
+
+  public SimpleSplitAssigner() {
+    this.pendingSplits = new ArrayDeque<>();
+  }
+
+  public SimpleSplitAssigner(Collection<IcebergSourceSplitState> assignerState) {
+    this.pendingSplits = new ArrayDeque<>(assignerState.size());
+    // Because simple assigner only tracks unassigned splits,
+    // there is no need to filter splits based on status (unassigned) here.
+    assignerState.forEach(splitState -> pendingSplits.add(splitState.split()));
+  }
+
+  @Override
+  public GetSplitResult getNext(@Nullable String hostname) {
+    if (pendingSplits.isEmpty()) {
+      return GetSplitResult.unavailable();
+    } else {
+      IcebergSourceSplit split = pendingSplits.poll();
+      return GetSplitResult.forSplit(split);
+    }
+  }
+
+  @Override
+  public void onDiscoveredSplits(Collection<IcebergSourceSplit> splits) {
+    pendingSplits.addAll(splits);
+    completeAvailableFuturesIfNeeded();
+  }
+
+  @Override
+  public void onUnassignedSplits(Collection<IcebergSourceSplit> splits) {
+    pendingSplits.addAll(splits);
+    completeAvailableFuturesIfNeeded();
+  }
+
+  /**
+   * Simple assigner only tracks unassigned splits
+   */
+  @Override
+  public Collection<IcebergSourceSplitState> state() {
+    return pendingSplits.stream()
+        .map(split -> new IcebergSourceSplitState(split, IcebergSourceSplitStatus.UNASSIGNED))
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public synchronized CompletableFuture<Void> isAvailable() {
+    if (availableFuture == null) {
+      availableFuture = new CompletableFuture<>();
+    }
+    return availableFuture;
+  }
+
+  private synchronized void completeAvailableFuturesIfNeeded() {
+    if (availableFuture != null && !pendingSplits.isEmpty()) {
+      availableFuture.complete(null);
+    }
+    availableFuture = null;
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/SimpleSplitAssignerFactory.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/SimpleSplitAssignerFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.assigner;
+
+import java.util.Collection;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplitState;
+
+/**
+ * Create simple assigner that hands out splits without any guarantee in order or locality.
+ */
+public class SimpleSplitAssignerFactory implements SplitAssignerFactory {
+
+  @Override
+  public SimpleSplitAssigner createAssigner() {
+    return new SimpleSplitAssigner();
+  }
+
+  @Override
+  public SimpleSplitAssigner createAssigner(Collection<IcebergSourceSplitState> assignerState) {
+    return new SimpleSplitAssigner(assignerState);
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/SplitAssigner.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/SplitAssigner.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.assigner;
+
+import java.io.Closeable;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nullable;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplitState;
+
+/**
+ * SplitAssigner interface is extracted out as a separate component so that
+ * we can plug in different split assignment strategy for different requirements. E.g.
+ * <ul>
+ * <li> Simple assigner with no ordering guarantee or locality aware optimization.</li>
+ * <li> Locality aware assigner that prefer splits that are local.</li>
+ * <li> Snapshot aware assigner that assign splits based on the order they are committed.</li>
+ * <li> Event time alignment assigner that assign splits satisfying certain time ordering
+ *      within a single source or across sources.</li>
+ * </ul>
+ *
+ * <p>
+ * Enumerator should call the assigner APIs from the coordinator thread.
+ * This is to simplify the thread safety for assigner implementation.
+ */
+public interface SplitAssigner extends Closeable {
+
+  /**
+   * Some assigners may need to start background threads or perform other activity such as
+   * registering as listeners to updates from other event sources e.g., watermark tracker.
+   */
+  default void start() {
+  }
+
+  /**
+   * Some assigners may need to perform certain actions
+   * when their corresponding enumerators are closed
+   */
+  @Override
+  default void close() {
+  }
+
+  /**
+   * Request a new split from the assigner
+   * when enumerator trying to assign splits to awaiting readers.
+   * <p>
+   * If enumerator wasn't able to assign the split (e.g., reader disconnected),
+   * enumerator should call {@link SplitAssigner#onUnassignedSplits} to return the split.
+   */
+  GetSplitResult getNext(@Nullable String hostname);
+
+  /**
+   * Add new splits discovered by enumerator
+   */
+  void onDiscoveredSplits(Collection<IcebergSourceSplit> splits);
+
+  /**
+   * Forward addSplitsBack event (for failed reader) to assigner
+   */
+  void onUnassignedSplits(Collection<IcebergSourceSplit> splits);
+
+  /**
+   * Some assigner (like event time alignment) may rack in-progress splits
+   * to advance watermark upon completed splits
+   */
+  default void onCompletedSplits(Collection<String> completedSplitIds) {
+  }
+
+  /**
+   * Get assigner state for checkpointing.
+   * This is a super-set API that works for all currently imagined assigners.
+   */
+  Collection<IcebergSourceSplitState> state();
+
+  /**
+   * Enumerator can get a notification via CompletableFuture
+   * when the assigner has more splits available later.
+   * Enumerator should schedule assignment in the thenAccept action of the future.
+   * <p>
+   * Assigner will return the same future if this method is called again
+   * before the previous future is completed.
+   * <p>
+   * The future can be completed from other thread,
+   * e.g. the coordinator thread from another thread
+   * for event time alignment.
+   * <p>
+   * If enumerator need to trigger action upon the future completion,
+   * it may want to run it in the coordinator thread
+   * using {@link SplitEnumeratorContext#runInCoordinatorThread(Runnable)}.
+   */
+  CompletableFuture<Void> isAvailable();
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/SplitAssignerFactory.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/SplitAssignerFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.assigner;
+
+import java.io.Serializable;
+import java.util.Collection;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplitState;
+
+public interface SplitAssignerFactory extends Serializable {
+
+  SplitAssigner createAssigner();
+
+  SplitAssigner createAssigner(Collection<IcebergSourceSplitState> assignerState);
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/ordered/AscendingTimestampSplitComparator.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/ordered/AscendingTimestampSplitComparator.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.assigner.ordered;
+
+import java.io.Serializable;
+import java.util.Comparator;
+import org.apache.flink.api.common.eventtime.TimestampAssigner;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+
+class AscendingTimestampSplitComparator
+    implements Comparator<IcebergSourceSplit>, Serializable {
+
+  private final TimestampAssigner<IcebergSourceSplit> timestampAssigner;
+
+  AscendingTimestampSplitComparator(TimestampAssigner<IcebergSourceSplit> timestampAssigner) {
+    this.timestampAssigner = timestampAssigner;
+  }
+
+  @Override
+  public int compare(IcebergSourceSplit a, IcebergSourceSplit b) {
+    if (a.splitId().equals(b.splitId())) {
+      return 0;
+    }
+    int temp =
+        Long.compare(
+            timestampAssigner.extractTimestamp(a, -1), timestampAssigner.extractTimestamp(b, -1));
+    if (temp != 0) {
+      return temp;
+    } else {
+      return a.splitId().compareTo(b.splitId());
+    }
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/ordered/ClockFactory.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/ordered/ClockFactory.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.assigner.ordered;
+
+import java.io.Serializable;
+import java.time.Clock;
+import java.util.function.Supplier;
+
+public interface ClockFactory extends Supplier<Clock>, Serializable {
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/ordered/EventTimeAlignmentAssigner.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/ordered/EventTimeAlignmentAssigner.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.assigner.ordered;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nullable;
+import org.apache.flink.api.common.eventtime.TimestampAssigner;
+import org.apache.iceberg.flink.source.assigner.GetSplitResult;
+import org.apache.iceberg.flink.source.assigner.SplitAssigner;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplitState;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class EventTimeAlignmentAssigner implements SplitAssigner, WatermarkTracker.Listener {
+  private static final Logger log = LoggerFactory.getLogger(EventTimeAlignmentAssigner.class);
+  private final Duration maxMisalignmentThreshold;
+
+  private final WatermarkTracker watermarkTracker;
+  private final TimestampAssigner<IcebergSourceSplit> timestampAssigner;
+
+  private final EventTimeAlignmentAssignerState assignerState;
+  private final UnassignedSplitsMaintainer unassignedSplitsMaintainer;
+  private final WatermarkUpdater watermarkUpdater;
+
+  private CompletableFuture<Void> availableFuture;
+  private boolean closed = false;
+
+  EventTimeAlignmentAssigner(
+      Duration maxMisalignmentThreshold,
+      TimestampAssigner<IcebergSourceSplit> timestampAssigner,
+      Clock clock, WatermarkTracker watermarkTracker) {
+    this(maxMisalignmentThreshold, Collections.emptyList(), watermarkTracker, timestampAssigner, clock);
+  }
+
+  EventTimeAlignmentAssigner(
+      Duration maxMisalignmentThreshold,
+      Collection<IcebergSourceSplitState> currentState,
+      WatermarkTracker watermarkTracker,
+      TimestampAssigner<IcebergSourceSplit> timestampAssigner,
+      Clock clock) {
+    this.maxMisalignmentThreshold = maxMisalignmentThreshold;
+    this.watermarkTracker = watermarkTracker;
+    this.timestampAssigner = timestampAssigner;
+    this.assignerState = new EventTimeAlignmentAssignerState(currentState, clock);
+    this.unassignedSplitsMaintainer =
+        new UnassignedSplitsMaintainer(new AscendingTimestampSplitComparator(timestampAssigner), this.assignerState);
+    this.watermarkUpdater = new WatermarkUpdater(watermarkTracker, timestampAssigner, this.assignerState);
+  }
+
+  @Override
+  public void start() {
+    watermarkTracker.addListener(this);
+  }
+
+  @Override
+  public void close() {
+    watermarkTracker.removeListener(this);
+    closed = true;
+    completeAvailableFuturesIfNeeded();
+  }
+
+  @Override
+  public GetSplitResult getNext(@Nullable String hostname) {
+    try {
+      Long watermark = watermarkTracker.getGlobalWatermark();
+
+      for (IcebergSourceSplit pendingSplit : unassignedSplitsMaintainer.getUnassignedSplits()) {
+        // break early if you encounter a split that's ahead of the misalignment threshold.
+        if (!isWithinBounds(pendingSplit, watermark)) {
+          log.info(
+              "split {} is not within bounds {} {}",
+              pendingSplit,
+              watermark,
+              timestampAssigner.extractTimestamp(pendingSplit, -1));
+          return GetSplitResult.constrained();
+        }
+
+        assignerState.assignSplits(ImmutableList.of(pendingSplit), hostname);
+        return GetSplitResult.forSplit(pendingSplit);
+      }
+
+      return GetSplitResult.unavailable();
+    } catch (Exception e) {
+      log.error("Couldn't obtain the watermark from the tracker", e);
+      return GetSplitResult.constrained();
+    }
+  }
+
+  private boolean isWithinBounds(IcebergSourceSplit split, Long watermark) {
+    if (maxMisalignmentThreshold == null) {
+      return true;
+    }
+
+    if (watermark == null) {
+      return true;
+    }
+
+    long splitTs = timestampAssigner.extractTimestamp(split, -1);
+    if (splitTs < watermark) {
+      log.warn("splitTs at {} is lower than the watermark {}", splitTs, watermark);
+    }
+
+    return Math.max(splitTs - watermark, 0L) <= maxMisalignmentThreshold.toMillis();
+  }
+
+  @Override
+  public void onDiscoveredSplits(Collection<IcebergSourceSplit> splits) {
+    assignerState.addSplits(splits);
+  }
+
+  @Override
+  public void onUnassignedSplits(Collection<IcebergSourceSplit> splits) {
+    assignerState.unassignSplits(splits);
+  }
+
+  @Override
+  public void onCompletedSplits(Collection<String> completedSplitIds) {
+    assignerState.completeSplits(completedSplitIds);
+  }
+
+  @Override
+  public Collection<IcebergSourceSplitState> state() {
+    return assignerState.snapshotState();
+  }
+
+  @Override
+  public CompletableFuture<Void> isAvailable() {
+    if (availableFuture == null) {
+      availableFuture = new CompletableFuture<>();
+    }
+    return availableFuture;
+  }
+
+  @Override
+  public void onWatermarkChange(Long watermark) {
+    Preconditions.checkArgument(!closed, "strategy is already closed");
+    log.info("Global watermark changed to {}; letting listeners know", watermark);
+    completeAvailableFuturesIfNeeded();
+  }
+
+  /**
+   * For now, we just simply complete the available future.
+   * Let enumerator to try {@link #getNext(String)} again
+   * and see if there is any assignable split.
+   */
+  private synchronized void completeAvailableFuturesIfNeeded() {
+    if (availableFuture != null) {
+      availableFuture.complete(null);
+    }
+    availableFuture = null;
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/ordered/EventTimeAlignmentAssignerFactory.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/ordered/EventTimeAlignmentAssignerFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.assigner.ordered;
+
+import java.time.Duration;
+import java.util.Collection;
+import org.apache.flink.api.common.eventtime.TimestampAssigner;
+import org.apache.iceberg.flink.source.assigner.SplitAssignerFactory;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplitState;
+
+public class EventTimeAlignmentAssignerFactory implements SplitAssignerFactory {
+  private final String sourceName;
+  private final Duration maxMisalignmentThreshold;
+
+  private final ClockFactory clockFactory;
+  private final GlobalWatermarkTracker.Factory trackerFactory;
+  private final TimestampAssigner<IcebergSourceSplit> timestampAssigner;
+
+  public EventTimeAlignmentAssignerFactory(
+      String sourceName,
+      Duration maxMisalignmentThreshold,
+      ClockFactory clockFactory,
+      GlobalWatermarkTracker.Factory trackerFactory,
+      TimestampAssigner<IcebergSourceSplit> timestampAssigner) {
+    this.sourceName = sourceName;
+    this.maxMisalignmentThreshold = maxMisalignmentThreshold;
+    this.clockFactory = clockFactory;
+    this.trackerFactory = trackerFactory;
+    this.timestampAssigner = timestampAssigner;
+  }
+
+  @Override
+  public EventTimeAlignmentAssigner createAssigner() {
+    return new EventTimeAlignmentAssigner(
+        maxMisalignmentThreshold,
+        timestampAssigner,
+        clockFactory.get(),
+        trackerFactory.<String>apply("iceberg").forPartition(sourceName)
+    );
+  }
+
+  @Override
+  public EventTimeAlignmentAssigner createAssigner(Collection<IcebergSourceSplitState> assignerState) {
+    return new EventTimeAlignmentAssigner(maxMisalignmentThreshold,
+        assignerState,
+        trackerFactory.<String>apply("iceberg").forPartition(sourceName),
+        timestampAssigner,
+        clockFactory.get());
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/ordered/EventTimeAlignmentAssignerState.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/ordered/EventTimeAlignmentAssignerState.java
@@ -1,0 +1,449 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.assigner.ordered;
+
+import java.io.Serializable;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplitState;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplitStatus;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class EventTimeAlignmentAssignerState {
+  private static final Logger log = LoggerFactory.getLogger(EventTimeAlignmentAssignerState.class);
+
+  // split IDs to their states
+  private final Map<String, SplitState> splitStateMap;
+
+  // flag that informs the state that there are no more splits to be added by the Enumerator
+  private volatile boolean noMoreSplits;
+
+  // timestamp the state was last updated
+  private volatile Instant lastUpdatedTs;
+
+  private volatile int numAssignedSplits;
+  private volatile int numCompletedSplits;
+  private final Clock clock;
+  private transient WeakHashMap<StateChangeListener, Void> listeners;
+
+  EventTimeAlignmentAssignerState(Clock clock) {
+    this(Collections.emptyList(), clock);
+  }
+
+  EventTimeAlignmentAssignerState(Collection<IcebergSourceSplitState> currentState, Clock clock) {
+    this.splitStateMap = Maps.newConcurrentMap();
+    currentState.forEach(icebergSourceSplitState -> splitStateMap.put(icebergSourceSplitState.split().splitId(),
+        new SplitState(icebergSourceSplitState.split(), icebergSourceSplitState.status())));
+    this.noMoreSplits = false;
+    this.clock = clock;
+    this.listeners = new WeakHashMap<>();
+    this.lastUpdatedTs = clock.instant();
+  }
+
+  public synchronized void register(StateChangeListener handler) {
+    listeners.put(handler, null);
+  }
+
+  public synchronized void unregister(StateChangeListener handler) {
+    Preconditions.checkArgument(listeners.containsKey(handler), "unknown handler %s", handler);
+    listeners.remove(handler);
+  }
+
+  public synchronized EventTimeAlignmentAssignerState addSplits(Collection<IcebergSourceSplit> splits) {
+    Preconditions.checkArgument(!noMoreSplits, "no more splits can be added");
+    List<IcebergSourceSplit> addedSplits =
+        splits
+            .stream()
+            .filter(
+                split -> splitStateMap.putIfAbsent(split.splitId(), SplitState.of(split)) == null)
+            .collect(Collectors.toList());
+
+    if (!addedSplits.isEmpty()) {
+      updateTs();
+      listeners.keySet().forEach(listener -> listener.onSplitsAdded(addedSplits));
+    }
+    return this;
+  }
+
+  public synchronized EventTimeAlignmentAssignerState onNoMoreSplits() {
+    if (!noMoreSplits) {
+      noMoreSplits = true;
+
+      updateTs();
+      // check if the state has reached the terminal condition and if this is the first
+      // time that condition has been reached
+      if (isTerminal()) {
+        updateListenersOnTerminalCondition();
+      }
+    }
+
+    return this;
+  }
+
+  public synchronized EventTimeAlignmentAssignerState assignSplits(
+      List<IcebergSourceSplit> splits, @Nullable String hostName) {
+    if (!splits.isEmpty()) {
+      splits.forEach(split ->
+          Preconditions.checkArgument(splitStateMap.get(split.splitId()).assignTo(hostName) ==
+                  IcebergSourceSplitStatus.UNASSIGNED));
+
+      numAssignedSplits += splits.size();
+      updateTs();
+      updateListeners(splits, IcebergSourceSplitStatus.UNASSIGNED, IcebergSourceSplitStatus.ASSIGNED);
+    }
+
+    return this;
+  }
+
+  public synchronized EventTimeAlignmentAssignerState unassignSplits(Collection<IcebergSourceSplit> splits) {
+    if (splits.isEmpty()) {
+      return this;
+    }
+
+    List<Tuple2<IcebergSourceSplitStatus, IcebergSourceSplit>> modifiedSplits =
+        splits
+            .stream()
+            .map(
+                split -> {
+                  IcebergSourceSplitStatus res = splitStateMap.get(split.splitId()).unassign();
+                  return new Tuple2<>(res, split);
+                })
+            .filter(t -> t.f0 == IcebergSourceSplitStatus.ASSIGNED || t.f0 == IcebergSourceSplitStatus.COMPLETED)
+            .collect(Collectors.toList());
+
+    List<IcebergSourceSplit> previousAssignedSplits =
+        modifiedSplits
+            .stream()
+            .filter(status -> status.f0 == IcebergSourceSplitStatus.ASSIGNED)
+            .map(t -> t.f1)
+            .collect(Collectors.toList());
+
+    List<IcebergSourceSplit> previousCompletedSplits =
+        modifiedSplits
+            .stream()
+            .filter(status -> status.f0 == IcebergSourceSplitStatus.COMPLETED)
+            .map(t -> t.f1)
+            .collect(Collectors.toList());
+
+    if (!previousAssignedSplits.isEmpty()) {
+      numAssignedSplits -= previousAssignedSplits.size();
+    }
+
+    if (!previousCompletedSplits.isEmpty()) {
+      numCompletedSplits -= previousCompletedSplits.size();
+    }
+
+    updateTs();
+
+    updateListeners(previousAssignedSplits, IcebergSourceSplitStatus.ASSIGNED, IcebergSourceSplitStatus.UNASSIGNED);
+    updateListeners(previousCompletedSplits, IcebergSourceSplitStatus.COMPLETED, IcebergSourceSplitStatus.UNASSIGNED);
+    return this;
+  }
+
+  public synchronized EventTimeAlignmentAssignerState completeSplits(Collection<String> splitIds) {
+    List<IcebergSourceSplit> completedSplitIds =
+        splitIds
+            .stream()
+            .filter(splitId -> splitStateMap.get(splitId).complete() == IcebergSourceSplitStatus.ASSIGNED)
+            .map(splitId -> splitStateMap.get(splitId).getSplit())
+            .collect(Collectors.toList());
+
+    if (!completedSplitIds.isEmpty()) {
+      numAssignedSplits -= completedSplitIds.size();
+      numCompletedSplits += completedSplitIds.size();
+      updateTs();
+      updateListeners(completedSplitIds, IcebergSourceSplitStatus.ASSIGNED, IcebergSourceSplitStatus.COMPLETED);
+
+      // check if we have reached the terminal condition
+      if (isTerminal()) {
+        updateListenersOnTerminalCondition();
+      }
+    }
+    return this;
+  }
+
+  private void updateListenersOnTerminalCondition() {
+    listeners.keySet().forEach(listener -> listener.onNoMoreStatusChanges());
+  }
+
+  @VisibleForTesting
+  synchronized Collection<IcebergSourceSplit> getUnassignedSplits() {
+    return splitStateMap
+        .values()
+        .stream()
+        .filter(SplitState::isUnassigned)
+        .map(s -> s.getSplit())
+        .collect(Collectors.toSet());
+  }
+
+  public synchronized Map<IcebergSourceSplit, String> getAssignedSplits() {
+    return splitStateMap
+        .values()
+        .stream()
+        .filter(SplitState::isAssigned)
+        .collect(Collectors.toMap(SplitState::getSplit, SplitState::getSubtaskId));
+  }
+
+  public synchronized Collection<IcebergSourceSplitState> snapshotState() {
+    return splitStateMap
+        .values()
+        .stream()
+        .filter(SplitState::notCompleted)
+        .map(splitState -> new IcebergSourceSplitState(splitState.getSplit(), splitState.getStatus()))
+        .collect(Collectors.toList());
+  }
+
+  public int getTotalSplits() {
+    return splitStateMap.size();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("assignedSplits", numAssignedSplits)
+        .add("completedSplits", numCompletedSplits)
+        .add("totalSplits", splitStateMap.size())
+        .toString();
+  }
+
+  private void updateListeners(
+      Collection<IcebergSourceSplit> splits, IcebergSourceSplitStatus oldStatus, IcebergSourceSplitStatus newStatus) {
+    if (!splits.isEmpty()) {
+      switch (newStatus) {
+        case UNASSIGNED:
+          if (oldStatus == IcebergSourceSplitStatus.COMPLETED) {
+            listeners.keySet().forEach(listener -> listener.onSplitsAdded(splits));
+          } else if (oldStatus == IcebergSourceSplitStatus.ASSIGNED) {
+            listeners.keySet().forEach(listener -> listener.onSplitsUnassigned(splits));
+          } else {
+            throw new IllegalArgumentException();
+          }
+          break;
+        case ASSIGNED:
+          listeners.keySet().forEach(listener -> listener.onSplitsAssigned(splits));
+          break;
+        case COMPLETED:
+          listeners.keySet().forEach(listener -> listener.onSplitsCompleted(splits));
+          break;
+        default:
+          throw new IllegalArgumentException();
+      }
+    }
+  }
+
+  private void updateTs() {
+    this.lastUpdatedTs = Instant.ofEpochMilli(clock.millis());
+    log.info("state={}", this);
+  }
+
+  // this is an expensive function. Please use this carefully.
+  public synchronized Map<String, List<IcebergSourceSplit>> getCompletedSplits() {
+    Map<String, List<IcebergSourceSplit>> completedMap = Maps.newHashMap();
+    splitStateMap
+        .values()
+        .forEach(
+            splitState -> {
+              if (splitState.isCompleted()) {
+                String subtaskId = splitState.getSubtaskId();
+                completedMap.compute(
+                    subtaskId,
+                    (dontCare, oldValue) -> {
+                      if (oldValue == null) {
+                        List<IcebergSourceSplit> temp = Lists.newArrayList();
+                        temp.add(splitState.getSplit());
+                        return temp;
+                      } else {
+                        oldValue.add(splitState.getSplit());
+                        return oldValue;
+                      }
+                    });
+              }
+            });
+
+    return completedMap;
+  }
+
+  // checks if the enumerator state has reached the terminal condition
+  public boolean isTerminal() {
+    // check if there are no more splits to be added by the system
+    // check if all the splits have been completed
+    return noMoreSplits && numCompletedSplits == splitStateMap.size();
+  }
+
+  public synchronized Stats getStats() {
+    return new Stats(
+        splitStateMap.size() - numAssignedSplits - numCompletedSplits,
+        numAssignedSplits,
+        numCompletedSplits,
+        splitStateMap.size());
+  }
+
+  public static class Stats {
+
+    private final int numUnassignedSplits;
+    private final int numAssignedSplits;
+    private final int numCompletedSplits;
+    private final int numTotalSplits;
+
+    Stats(int numUnassignedSplits, int numAssignedSplits, int numCompletedSplits, int numTotalSplits) {
+      this.numUnassignedSplits = numUnassignedSplits;
+      this.numAssignedSplits = numAssignedSplits;
+      this.numCompletedSplits = numCompletedSplits;
+      this.numTotalSplits = numTotalSplits;
+    }
+
+    public int getNumUnassignedSplits() {
+      return numUnassignedSplits;
+    }
+
+    public int getNumAssignedSplits() {
+      return numAssignedSplits;
+    }
+
+    public int getNumCompletedSplits() {
+      return numCompletedSplits;
+    }
+
+    public int getNumTotalSplits() {
+      return numTotalSplits;
+    }
+  }
+
+  static class SplitState implements Serializable {
+
+    private IcebergSourceSplit split;
+    private IcebergSourceSplitStatus status;
+    private String subtaskId;
+
+    SplitState(IcebergSourceSplit split, IcebergSourceSplitStatus status) {
+      this.split = split;
+      this.status = status;
+      this.subtaskId = null;
+    }
+
+    private static SplitState of(IcebergSourceSplit split) {
+      return new SplitState(split, IcebergSourceSplitStatus.UNASSIGNED);
+    }
+
+    private synchronized IcebergSourceSplitStatus assignTo(@Nullable String hostName) {
+      switch (status) {
+        case ASSIGNED:
+          Preconditions.checkArgument(hostName == null || this.subtaskId.equals(hostName));
+          return IcebergSourceSplitStatus.ASSIGNED;
+        case UNASSIGNED:
+          this.status = IcebergSourceSplitStatus.ASSIGNED;
+          this.subtaskId = hostName;
+          return IcebergSourceSplitStatus.UNASSIGNED;
+        default:
+          throw new IllegalArgumentException(
+              String.format(
+                  "This transition is not possible as the split is currently in %s state", this));
+      }
+    }
+
+    private synchronized IcebergSourceSplitStatus complete() {
+      switch (status) {
+        case COMPLETED:
+          return IcebergSourceSplitStatus.COMPLETED;
+        case ASSIGNED:
+          this.status = IcebergSourceSplitStatus.COMPLETED;
+          return IcebergSourceSplitStatus.ASSIGNED;
+        default:
+          throw new IllegalArgumentException(
+              String.format(
+                  "This transition is not possible as the split is currently in %s state", this));
+      }
+    }
+
+    private synchronized IcebergSourceSplitStatus unassign() {
+      switch (status) {
+        case UNASSIGNED:
+          return IcebergSourceSplitStatus.UNASSIGNED;
+        case ASSIGNED:
+          this.status = IcebergSourceSplitStatus.UNASSIGNED;
+          this.subtaskId = null;
+          return IcebergSourceSplitStatus.ASSIGNED;
+        case COMPLETED:
+          this.status = IcebergSourceSplitStatus.UNASSIGNED;
+          this.subtaskId = null;
+          log.warn(
+              "This transition should not be possible as the split is currently in {} state", this);
+          return IcebergSourceSplitStatus.COMPLETED;
+        default:
+          throw new IllegalArgumentException(String.format("Unexpected status %s", status));
+      }
+    }
+
+    private boolean isUnassigned() {
+      return status.equals(IcebergSourceSplitStatus.UNASSIGNED);
+    }
+
+    private boolean isAssigned() {
+      return status.equals(IcebergSourceSplitStatus.ASSIGNED);
+    }
+
+    private boolean isCompleted() {
+      return status.equals(IcebergSourceSplitStatus.COMPLETED);
+    }
+
+    private boolean notCompleted() {
+      return !isCompleted();
+    }
+
+    public IcebergSourceSplit getSplit() {
+      return split;
+    }
+
+    public String getSubtaskId() {
+      return subtaskId;
+    }
+
+    public IcebergSourceSplitStatus getStatus() {
+      return status;
+    }
+  }
+
+  public interface StateChangeListener {
+    void onSplitsAdded(Collection<IcebergSourceSplit> splits);
+
+    void onSplitsAssigned(Collection<IcebergSourceSplit> splits);
+
+    void onSplitsUnassigned(Collection<IcebergSourceSplit> splits);
+
+    void onSplitsCompleted(Collection<IcebergSourceSplit> splits);
+
+    void onNoMoreStatusChanges();
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/ordered/FutureNotifier.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/ordered/FutureNotifier.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.assigner.ordered;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class FutureNotifier {
+  /** A future reference. */
+  private final AtomicReference<CompletableFuture<Void>> futureRef;
+
+  public FutureNotifier() {
+    this.futureRef = new AtomicReference<>(null);
+  }
+
+  /**
+   * Get the future out of this notifier. The future will be completed when someone invokes {@link
+   * #notifyComplete()}. If there is already an uncompleted future, that existing future will be
+   * returned instead of a new one.
+   *
+   * @return a future that will be completed when {@link #notifyComplete()} is invoked.
+   */
+  public CompletableFuture<Void> future() {
+    CompletableFuture<Void> prevFuture = futureRef.get();
+    if (prevFuture != null) {
+      // Someone has created a future for us, don't create a new one.
+      return prevFuture;
+    } else {
+      CompletableFuture<Void> newFuture = new CompletableFuture<>();
+      boolean newFutureSet = futureRef.compareAndSet(null, newFuture);
+      // If someone created a future after our previous check, use that future.
+      // Otherwise, use the new future.
+      return newFutureSet ? newFuture : future();
+    }
+  }
+
+  /** Complete the future if there is one. This will release the thread that is waiting for data. */
+  public void notifyComplete() {
+    CompletableFuture<Void> future = futureRef.get();
+    // If there are multiple threads trying to complete the future, only the first one succeeds.
+    if (future != null && futureRef.compareAndSet(future, null)) {
+      future.complete(null);
+    }
+  }
+}
+

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/ordered/GlobalWatermarkTracker.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/ordered/GlobalWatermarkTracker.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.assigner.ordered;
+
+import java.io.Serializable;
+import javax.annotation.Nullable;
+
+/**
+ * Global Watermark Tracker is used to track watermarks across a set of partitions in Flink job.
+ * Watermark in this context captures the per-partition timestamp.
+ *
+ * @param <Partition> parametric type of partition
+ */
+public interface GlobalWatermarkTracker<Partition> {
+
+  /**
+   * If none of the partitions have registered, then this returns null.
+   *
+   * @return global watermark of all registered partitions
+   * @throws Exception if there are issues talking to the tracker.
+   */
+  @Nullable
+  Long getGlobalWatermark() throws Exception;
+
+  // updates the local watermark for a given partition
+  Long updateWatermarkForPartition(Partition partition, long watermark) throws Exception;
+
+  // updates the tracker that the partition has completed
+  void onPartitionCompletion(Partition partition) throws Exception;
+
+  /**
+   * This method is expected to be invoked when the partition has to register itself. This can also
+   * be used to get rid of any state assoc. with the partition from the last session.
+   *
+   * @param partition partition to be registered for the first time.
+   */
+  void onPartitionInitialization(Partition partition);
+
+  /**
+   * This method allows the user to subscribe to global watermark updates.
+   *
+   * @param partition partition for which you would like to listen to updates for.
+   * @param listener listener implementation that needs to be invoked on global watermark changes.
+   */
+  void addListener(Partition partition, WatermarkTracker.Listener listener);
+
+  void removeListener(Partition partition, WatermarkTracker.Listener listener);
+
+  // gets a GlobalWatermarkTracker for a given partition
+  default WatermarkTracker forPartition(Partition partition) {
+    return new WatermarkTracker() {
+      @Nullable
+      @Override
+      public Long getGlobalWatermark() throws Exception {
+        return GlobalWatermarkTracker.this.getGlobalWatermark();
+      }
+
+      @Override
+      public Long updateWatermark(long watermark) throws Exception {
+        return GlobalWatermarkTracker.this.updateWatermarkForPartition(partition, watermark);
+      }
+
+      @Override
+      public void onCompletion() throws Exception {
+        GlobalWatermarkTracker.this.onPartitionCompletion(partition);
+      }
+
+      @Override
+      public void onInitialization() {
+        GlobalWatermarkTracker.this.onPartitionInitialization(partition);
+      }
+
+      @Override
+      public void addListener(Listener listener) {
+        GlobalWatermarkTracker.this.addListener(partition, listener);
+      }
+
+      @Override
+      public void removeListener(Listener listener) {
+        GlobalWatermarkTracker.this.removeListener(partition, listener);
+      }
+    };
+  }
+
+  // Factory to create global watermark trackers for a given partition type
+  @FunctionalInterface
+  interface Factory extends Serializable {
+    <T> GlobalWatermarkTracker<T> apply(String name);
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/ordered/InMemoryGlobalWatermarkTracker.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/ordered/InMemoryGlobalWatermarkTracker.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.assigner.ordered;
+
+import java.io.Serializable;
+import java.util.Comparator;
+import java.util.Map.Entry;
+import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects.ToStringHelper;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * In-Memory version of GlobalWatermarkTracker that can be run on the JobMaster.
+ *
+ * <p>This particular implementation computes the watermark value on every read - so technically
+ * reads can be expensive. However, the reads are still bound by the number of partitions (which we
+ * expect to be super low). If this assumption becomes false in the future, we can revisit the
+ * implementation to cache the watermark on every write.
+ *
+ * @param <Partition> type of the partition
+ */
+class InMemoryGlobalWatermarkTracker<PartitionT> implements GlobalWatermarkTracker<PartitionT> {
+  private static final Logger log = LoggerFactory.getLogger(InMemoryGlobalWatermarkTracker.class);
+
+  private final ConcurrentMap<PartitionT, PartitionWatermarkState> acc = Maps.newConcurrentMap();
+  private final ConcurrentMap<PartitionT, WeakHashMap<WatermarkTracker.Listener, Void>> listeners =
+      Maps.newConcurrentMap();
+  private final AtomicReference<Long> globalWatermark = new AtomicReference<>();
+  // private final Registry registry;
+
+  // public InMemoryGlobalWatermarkTracker(Registry registry) {
+  //   this.registry = new FlinkRegistry(registry, "GlobalWatermarkTracker", ImmutableList.of());
+  // }
+
+  // private Gauge getWatermarkGaugeFor(String partition) {
+  //   return registry.gauge("watermark", "partition", partition);
+  // }
+
+  private Long updateAndGet() {
+    return globalWatermark.updateAndGet(
+        oldValue -> {
+          return acc.values()
+              .stream()
+              .filter(partitionWatermarkState -> !partitionWatermarkState.isComplete())
+              .map(PartitionWatermarkState::getWatermark)
+              .min(Comparator.naturalOrder())
+              .orElse(null);
+        });
+  }
+
+  private void updateWatermarkAndInformListeners(PartitionT updatedPartitionT) {
+    Long v1 = globalWatermark.get();
+    Long v2 = updateAndGet();
+
+    if (v1 == null || !v1.equals(v2)) {
+      listeners
+          .entrySet()
+          .stream()
+          .forEach(
+              entry -> {
+                entry.getValue().keySet().forEach(listener -> listener.onWatermarkChange(v2));
+              });
+    }
+
+    updateGauges();
+  }
+
+  @Nullable
+  @Override
+  public Long getGlobalWatermark() throws Exception {
+    return globalWatermark.get();
+  }
+
+  private void updateGauges() {
+    try {
+      ToStringHelper helper = MoreObjects.toStringHelper(this);
+      for (Entry<PartitionT, PartitionWatermarkState> entry : acc.entrySet()) {
+        PartitionT partition = entry.getKey();
+        PartitionWatermarkState partitionWatermarkState = entry.getValue();
+        helper = helper.add(partition.toString(), partitionWatermarkState.toString());
+        // getWatermarkGaugeFor(p.toString()).set(v.getWatermark());
+      }
+
+      helper.add("global", getGlobalWatermark());
+      log.info("watermarkState={}", helper.toString());
+      // if (globalWatermark != null) {
+      //   getWatermarkGaugeFor("global").set(globalWatermark);
+      // }
+    } catch (Exception e) {
+      log.error("Failed to update the gauges", e);
+    }
+  }
+
+  @Override
+  public Long updateWatermarkForPartition(PartitionT partitionT, long watermark) throws Exception {
+    log.info("Updating watermark tracker to {} for partition {}", watermark, partitionT);
+    acc.compute(
+        partitionT,
+        (dontCare, oldState) ->
+            PartitionWatermarkState.max(oldState, new PartitionWatermarkState(watermark, false)));
+    updateWatermarkAndInformListeners(partitionT);
+    return getGlobalWatermark();
+  }
+
+  @Override
+  public void onPartitionCompletion(PartitionT partitionT) throws Exception {
+    log.info("Marking partition {} as complete", partitionT);
+    acc.compute(
+        partitionT,
+        (dontCare, oldState) ->
+            PartitionWatermarkState.max(
+                oldState, new PartitionWatermarkState(Long.MIN_VALUE, true)));
+    updateWatermarkAndInformListeners(partitionT);
+  }
+
+  @Override
+  public void onPartitionInitialization(PartitionT partitionT) {
+    acc.remove(partitionT);
+    listeners.remove(partitionT);
+    updateWatermarkAndInformListeners(partitionT);
+  }
+
+  @Override
+  public void addListener(PartitionT partitionT, WatermarkTracker.Listener listener) {
+    listeners.compute(
+        partitionT,
+        (dontCare, oldValue) -> {
+          if (oldValue != null) {
+            oldValue.put(listener, null);
+            return oldValue;
+          } else {
+            WeakHashMap<WatermarkTracker.Listener, Void> temp = new WeakHashMap<>();
+            temp.put(listener, null);
+            return temp;
+          }
+        });
+  }
+
+  @Override
+  public void removeListener(PartitionT partitionT, WatermarkTracker.Listener listener) {
+    listeners.compute(
+        partitionT,
+        (dontCare, oldValue) -> {
+          Preconditions.checkArgument(
+              oldValue != null && oldValue.containsKey(listener), "listener not found");
+          oldValue.remove(listener);
+
+          if (oldValue.isEmpty()) {
+            return null;
+          } else {
+            return oldValue;
+          }
+        });
+  }
+
+  static class PartitionWatermarkState implements Serializable {
+
+    private final Long watermark;
+
+    private final boolean isComplete;
+
+    PartitionWatermarkState(Long watermark, boolean isComplete) {
+      this.watermark = watermark;
+      this.isComplete = isComplete;
+    }
+
+    public Long getWatermark() {
+      return watermark;
+    }
+
+    public boolean isComplete() {
+      return isComplete;
+    }
+
+    static PartitionWatermarkState max(PartitionWatermarkState first, PartitionWatermarkState second) {
+      if (first == null) {
+        return second;
+      }
+      if (second == null) {
+        return first;
+      }
+
+      return new PartitionWatermarkState(
+          Math.max(first.watermark, second.watermark), first.isComplete || second.isComplete);
+    }
+  }
+}
+

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/ordered/InMemoryGlobalWatermarkTrackerFactory.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/ordered/InMemoryGlobalWatermarkTrackerFactory.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.assigner.ordered;
+
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+
+/**
+ * GlobalWatermarkTracker Factory that caches the issued trackers. The caching is required because
+ * we could have multiple Iceberg Sources (one for each kafka source) trying to create the
+ * WatermarkTracker independently in parallel. This implementation ensures that there's only one
+ * instance for a given partition type.
+ */
+public class InMemoryGlobalWatermarkTrackerFactory implements GlobalWatermarkTracker.Factory {
+
+  private static final Map<String, GlobalWatermarkTracker<?>> trackerCache = Maps.newHashMap();
+  // private final Supplier<Registry> registrySupplier;
+
+  @SuppressWarnings("unchecked")
+  public synchronized <PartitionT> GlobalWatermarkTracker<PartitionT> apply(String name) {
+    return (GlobalWatermarkTracker<PartitionT>)
+        trackerCache.computeIfAbsent(
+            name, dontCare -> new InMemoryGlobalWatermarkTracker<>());
+  }
+
+  @VisibleForTesting
+  static void clear() {
+    trackerCache.clear();
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/ordered/UnassignedSplitsMaintainer.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/ordered/UnassignedSplitsMaintainer.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.assigner.ordered;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class UnassignedSplitsMaintainer
+    implements EventTimeAlignmentAssignerState.StateChangeListener {
+  private static final Logger log = LoggerFactory.getLogger(UnassignedSplitsMaintainer.class);
+
+  private final SortedSet<IcebergSourceSplit> unassignedSplits;
+
+  UnassignedSplitsMaintainer(
+      Comparator<IcebergSourceSplit> comparator, EventTimeAlignmentAssignerState assignerState) {
+    this.unassignedSplits = new TreeSet<>(comparator);
+    assignerState.register(this);
+  }
+
+  public Collection<IcebergSourceSplit> getUnassignedSplits() {
+    return Collections.unmodifiableCollection(unassignedSplits);
+  }
+
+  @Override
+  public void onSplitsAdded(Collection<IcebergSourceSplit> splits) {
+    unassignedSplits.addAll(splits);
+  }
+
+  @Override
+  public void onSplitsAssigned(Collection<IcebergSourceSplit> splits) {
+    for (IcebergSourceSplit split : splits) {
+      if (!unassignedSplits.contains(split)) {
+        log.error("split={} not found in unassigned splits", split);
+        throw new IllegalArgumentException("split not found in unassigned splits");
+      }
+    }
+    unassignedSplits.removeAll(splits);
+  }
+
+  @Override
+  public void onSplitsUnassigned(Collection<IcebergSourceSplit> splits) {
+    unassignedSplits.addAll(splits);
+  }
+
+  @Override
+  public void onSplitsCompleted(Collection<IcebergSourceSplit> splits) {
+  }
+
+  @Override
+  public void onNoMoreStatusChanges() {
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/ordered/WatermarkTracker.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/ordered/WatermarkTracker.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.assigner.ordered;
+
+import javax.annotation.Nullable;
+
+interface WatermarkTracker {
+  @Nullable
+  Long getGlobalWatermark() throws Exception;
+
+  Long updateWatermark(long watermark) throws Exception;
+
+  void onCompletion() throws Exception;
+
+  void onInitialization();
+
+  void addListener(Listener listener);
+
+  void removeListener(Listener listener);
+
+  @FunctionalInterface
+  interface Listener {
+    void onWatermarkChange(Long watermark);
+  }
+}
+

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/ordered/WatermarkUpdater.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/assigner/ordered/WatermarkUpdater.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.assigner.ordered;
+
+import java.util.Collection;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import org.apache.flink.api.common.eventtime.TimestampAssigner;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class WatermarkUpdater
+    implements EventTimeAlignmentAssignerState.StateChangeListener {
+
+  private final WatermarkTracker tracker;
+  private final SortedSet<IcebergSourceSplit> inCompleteSplits;
+  private final TimestampAssigner<IcebergSourceSplit> timestampAssigner;
+  private static final Logger log = LoggerFactory.getLogger(WatermarkUpdater.class);
+
+  WatermarkUpdater(
+      WatermarkTracker tracker,
+      TimestampAssigner<IcebergSourceSplit> timestampAssigner,
+      EventTimeAlignmentAssignerState assignerState) {
+    this.tracker = tracker;
+    this.timestampAssigner = timestampAssigner;
+    this.inCompleteSplits =
+        new TreeSet<>(new AscendingTimestampSplitComparator(timestampAssigner));
+    tracker.onInitialization();
+
+    assignerState.register(this);
+  }
+
+  @Override
+  public void onSplitsAdded(Collection<IcebergSourceSplit> splits) {
+    inCompleteSplits.addAll(splits);
+    updateWatermark();
+  }
+
+  @Override
+  public void onSplitsAssigned(Collection<IcebergSourceSplit> splits) {
+    inCompleteSplits.addAll(splits);
+    updateWatermark();
+  }
+
+  @Override
+  public void onSplitsUnassigned(Collection<IcebergSourceSplit> splits) {
+    inCompleteSplits.addAll(splits);
+    updateWatermark();
+  }
+
+  @Override
+  public void onSplitsCompleted(Collection<IcebergSourceSplit> splits) {
+    inCompleteSplits.removeAll(splits);
+    updateWatermark();
+  }
+
+  @Override
+  public void onNoMoreStatusChanges() {
+    try {
+      tracker.onCompletion();
+    } catch (Exception e) {
+      log.error("Failed to update watermark", e);
+    }
+  }
+
+  private void updateWatermark() {
+    if (!inCompleteSplits.isEmpty()) {
+      try {
+        tracker.updateWatermark(timestampAssigner.extractTimestamp(inCompleteSplits.first(), -1));
+      } catch (Exception e) {
+        log.error("Failed to update watermark", e);
+      }
+    }
+  }
+}
+

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/AbstractIcebergEnumerator.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/AbstractIcebergEnumerator.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.enumerator;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+import org.apache.flink.api.connector.source.SourceEvent;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.iceberg.flink.source.assigner.GetSplitResult;
+import org.apache.iceberg.flink.source.assigner.SplitAssigner;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.flink.source.split.SplitRequestEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * TODO: publish enumerator monitor metrics like number of pending metrics
+ * after FLINK-21000 is resolved
+ */
+abstract class AbstractIcebergEnumerator implements
+    SplitEnumerator<IcebergSourceSplit, IcebergEnumeratorState> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractIcebergEnumerator.class);
+
+  private final SplitEnumeratorContext<IcebergSourceSplit> enumeratorContext;
+  private final SplitAssigner assigner;
+  private final Map<Integer, String> readersAwaitingSplit;
+  private final AtomicReference<CompletableFuture<Void>> availableFuture;
+
+  AbstractIcebergEnumerator(
+      SplitEnumeratorContext<IcebergSourceSplit> enumeratorContext,
+      SplitAssigner assigner) {
+    this.enumeratorContext = enumeratorContext;
+    this.assigner = assigner;
+    this.readersAwaitingSplit = new LinkedHashMap<>();
+    this.availableFuture = new AtomicReference<>();
+  }
+
+  @Override
+  public void start() {
+    assigner.start();
+  }
+
+  @Override
+  public void close() throws IOException {
+    assigner.close();
+  }
+
+  /**
+   * Iceberg source uses a custom event inside handleSourceEvent
+   * so that we can piggyback the finishedSplitIds in SplitRequestEvent.
+   * We can move the logic back into this method once FLINK-21364 is resolved.
+   */
+  @Override
+  public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {
+    throw new UnsupportedOperationException("Iceberg source uses its own SplitRequestEvent");
+  }
+
+  @Override
+  public void handleSourceEvent(int subtaskId, SourceEvent sourceEvent) {
+    if (sourceEvent instanceof SplitRequestEvent) {
+      SplitRequestEvent splitRequestEvent =
+          (SplitRequestEvent) sourceEvent;
+      LOG.info("Received request split event from subtask {}", subtaskId);
+      assigner.onCompletedSplits(splitRequestEvent.finishedSplitIds());
+      readersAwaitingSplit.put(subtaskId, splitRequestEvent.requesterHostname());
+      assignSplits();
+    } else {
+      throw new IllegalArgumentException(String.format(
+          "Received unknown event %s from subtask %d", sourceEvent, subtaskId));
+    }
+  }
+
+  @Override
+  public void addSplitsBack(List<IcebergSourceSplit> splits, int subtaskId) {
+    LOG.info("Add {} splits back to the pool for failed subtask {}: {}",
+        splits.size(), subtaskId, splits);
+    assigner.onUnassignedSplits(splits);
+    assignSplits();
+  }
+
+  @Override
+  public void addReader(int subtaskId) {
+    LOG.info("Added reader: {}", subtaskId);
+  }
+
+  private void assignSplits() {
+    LOG.info("Assigning splits for {} awaiting readers", readersAwaitingSplit.size());
+    Iterator<Map.Entry<Integer, String>> awaitingReader =
+        readersAwaitingSplit.entrySet().iterator();
+    while (awaitingReader.hasNext()) {
+      Map.Entry<Integer, String> nextAwaiting = awaitingReader.next();
+      // if the reader that requested another split has failed in the meantime, remove
+      // it from the list of waiting readers
+      if (!enumeratorContext.registeredReaders().containsKey(nextAwaiting.getKey())) {
+        awaitingReader.remove();
+        continue;
+      }
+
+      int awaitingSubtask = nextAwaiting.getKey();
+      String hostname = nextAwaiting.getValue();
+      GetSplitResult getResult = assigner.getNext(hostname);
+      if (getResult.status() == GetSplitResult.Status.AVAILABLE) {
+        LOG.info("Assign split to subtask {}: {}", awaitingSubtask, getResult.split());
+        enumeratorContext.assignSplit(getResult.split(), awaitingSubtask);
+        awaitingReader.remove();
+      } else if (getResult.status() == GetSplitResult.Status.CONSTRAINED) {
+        getAvailableFutureIfNeeded();
+        break;
+      } else if (getResult.status() == GetSplitResult.Status.UNAVAILABLE) {
+        if (shouldWaitForMoreSplits()) {
+          getAvailableFutureIfNeeded();
+          break;
+        } else {
+          LOG.info("No more splits available for subtask {}", awaitingSubtask);
+          enumeratorContext.signalNoMoreSplits(awaitingSubtask);
+          awaitingReader.remove();
+        }
+      } else {
+        throw new IllegalArgumentException("Unsupported status: " + getResult.status());
+      }
+    }
+  }
+
+  /**
+   * return true if enumerator should wait for splits
+   * like in the continuous enumerator case
+   */
+  protected abstract boolean shouldWaitForMoreSplits();
+
+  private synchronized void getAvailableFutureIfNeeded() {
+    if (availableFuture.get() != null) {
+      return;
+    }
+    CompletableFuture<Void> future = assigner.isAvailable()
+        .thenAccept(ignore ->
+            // Must run assignSplits in coordinator thread
+            // because the future may be completed from other threads.
+            // E.g., in event time alignment assigner,
+            // watermark advancement from another source may
+            // cause the available future to be completed
+            enumeratorContext.runInCoordinatorThread(() -> {
+              LOG.debug("Executing callback of assignSplits");
+              availableFuture.set(null);
+              assignSplits();
+            }));
+    availableFuture.set(future);
+    LOG.debug("Registered callback for future available splits");
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousEnumerationResult.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousEnumerationResult.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.enumerator;
+
+import java.util.Collection;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+class ContinuousEnumerationResult {
+  private final Collection<IcebergSourceSplit> splits;
+  private final IcebergEnumeratorPosition fromPosition;
+  private final IcebergEnumeratorPosition toPosition;
+
+  /**
+   * @param splits should never be null. But it can be an empty collection
+   * @param fromPosition can be null
+   * @param toPosition should never be null. But it can have null snapshotId and snapshotTimestampMs
+   */
+  ContinuousEnumerationResult(
+      Collection<IcebergSourceSplit> splits,
+      IcebergEnumeratorPosition fromPosition,
+      IcebergEnumeratorPosition toPosition) {
+    Preconditions.checkArgument(splits != null, "Invalid to splits collection: null");
+    Preconditions.checkArgument(toPosition != null, "Invalid end position: null");
+    this.splits = splits;
+    this.fromPosition = fromPosition;
+    this.toPosition = toPosition;
+  }
+
+  public Collection<IcebergSourceSplit> splits() {
+    return splits;
+  }
+
+  public IcebergEnumeratorPosition fromPosition() {
+    return fromPosition;
+  }
+
+  public IcebergEnumeratorPosition toPosition() {
+    return toPosition;
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousIcebergEnumerator.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousIcebergEnumerator.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.enumerator;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.iceberg.flink.source.ScanContext;
+import org.apache.iceberg.flink.source.assigner.SplitAssigner;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ContinuousIcebergEnumerator extends AbstractIcebergEnumerator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ContinuousIcebergEnumerator.class);
+
+  private final SplitEnumeratorContext<IcebergSourceSplit> enumeratorContext;
+  private final SplitAssigner assigner;
+  private final ScanContext scanContext;
+  private final ContinuousSplitPlanner splitPlanner;
+
+  /**
+   * snapshotId for the last enumerated snapshot. next incremental enumeration
+   * should be based off this as the starting position.
+   */
+  private final AtomicReference<IcebergEnumeratorPosition> enumeratorPosition;
+
+  public ContinuousIcebergEnumerator(
+      SplitEnumeratorContext<IcebergSourceSplit> enumeratorContext,
+      SplitAssigner assigner,
+      ScanContext scanContext,
+      ContinuousSplitPlanner splitPlanner,
+      @Nullable IcebergEnumeratorState enumState) {
+    super(enumeratorContext, assigner);
+
+    this.enumeratorContext = enumeratorContext;
+    this.assigner = assigner;
+    this.scanContext = scanContext;
+    this.splitPlanner = splitPlanner;
+    this.enumeratorPosition = new AtomicReference<>();
+    if (enumState != null) {
+      this.enumeratorPosition.set(enumState.lastEnumeratedPosition());
+    }
+  }
+
+  @Override
+  public void start() {
+    super.start();
+    enumeratorContext.callAsync(
+        this::discoverSplits,
+        this::processDiscoveredSplits,
+        0L,
+        scanContext.monitorInterval().toMillis());
+  }
+
+  @Override
+  protected boolean shouldWaitForMoreSplits() {
+    return true;
+  }
+
+  @Override
+  public IcebergEnumeratorState snapshotState(long checkpointId) {
+    return new IcebergEnumeratorState(enumeratorPosition.get(), assigner.state());
+  }
+
+  private ContinuousEnumerationResult discoverSplits() {
+    return splitPlanner.planSplits(enumeratorPosition.get());
+  }
+
+  private void processDiscoveredSplits(ContinuousEnumerationResult result, Throwable error) {
+    if (error == null) {
+      if (!result.splits().isEmpty()) {
+        if (enumeratorPosition.get() != null &&
+            Objects.equals(result.toPosition().snapshotId(), enumeratorPosition.get().snapshotId())) {
+          // Multiple discoverSplits() may be triggered with the same starting snapshot to the I/O thread pool.
+          // E.g., the splitDiscoveryInterval is very short (like 10 ms in some unit tests) or the thread
+          // pool is busy and multiple discovery actions are executed concurrently. In this case, we need to
+          // ignore the redundant discovery results. Otherwise, we can add duplicate splits to the assigner.
+          LOG.info("Skip {} discovered splits with the same starting position: {}",
+              result.splits().size(), result.toPosition());
+        } else {
+          LOG.info("Add {} discovered splits from position: {}",
+              result.splits().size(), result.toPosition());
+          assigner.onDiscoveredSplits(result.splits());
+        }
+      }
+      // update the enumerator position when there is no error even if there is no split discovered
+      // or the position is null (e.g. for empty table).
+      enumeratorPosition.set(result.toPosition());
+      LOG.info("Set enumerator position: {}", result.toPosition());
+    } else {
+      LOG.error("Failed to enumerate splits", error);
+    }
+  }
+
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousSplitPlanner.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousSplitPlanner.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.enumerator;
+
+import java.io.Closeable;
+import org.apache.flink.annotation.Internal;
+
+/**
+ * This interface is introduced so that we can plug in different split planner for unit test
+ */
+@Internal
+public interface ContinuousSplitPlanner extends Closeable {
+
+  /**
+   * Discover the files appended between {@code lastPosition} and current table snapshot
+   */
+  ContinuousEnumerationResult planSplits(IcebergEnumeratorPosition lastPosition);
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousSplitPlannerImpl.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousSplitPlannerImpl.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.enumerator;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.util.Preconditions;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.source.FlinkSplitPlanner;
+import org.apache.iceberg.flink.source.ScanContext;
+import org.apache.iceberg.flink.source.StreamingStartingStrategy;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.util.SnapshotUtil;
+import org.apache.iceberg.util.ThreadPools;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Internal
+public class ContinuousSplitPlannerImpl implements ContinuousSplitPlanner {
+  private static final Logger LOG = LoggerFactory.getLogger(ContinuousSplitPlannerImpl.class);
+
+  private final Table table;
+  private final ScanContext scanContext;
+  private final boolean isSharedPool;
+  private final ExecutorService workerPool;
+
+  /**
+   * @param threadName thread name prefix for worker pool to run the split planning.
+   *                   If null, a shared worker pool will be used.
+   */
+  public ContinuousSplitPlannerImpl(Table table, ScanContext scanContext, String threadName) {
+    this.table = table;
+    this.scanContext = scanContext;
+    this.isSharedPool = threadName == null;
+    this.workerPool = isSharedPool ? ThreadPools.getWorkerPool()
+        : ThreadPools.newWorkerPool("iceberg-plan-worker-pool-" + threadName, scanContext.planParallelism());
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (!isSharedPool) {
+      workerPool.shutdown();
+    }
+  }
+
+  @Override
+  public ContinuousEnumerationResult planSplits(IcebergEnumeratorPosition lastPosition) {
+    table.refresh();
+    if (lastPosition != null) {
+      return discoverIncrementalSplits(lastPosition);
+    } else {
+      return discoverInitialSplits();
+    }
+  }
+
+  /**
+   * Discover incremental changes between @{code lastPosition} and current table snapshot
+   */
+  private ContinuousEnumerationResult discoverIncrementalSplits(IcebergEnumeratorPosition lastPosition) {
+    Snapshot currentSnapshot = table.currentSnapshot();
+    if (currentSnapshot == null) {
+      // empty table
+      Preconditions.checkArgument(lastPosition.snapshotId() == null,
+          "Invalid last enumerated position for an empty table: not null");
+      LOG.info("Skip incremental scan because table is empty");
+      return new ContinuousEnumerationResult(Collections.emptyList(), lastPosition, lastPosition);
+    } else if (lastPosition.snapshotId() != null && currentSnapshot.snapshotId() == lastPosition.snapshotId()) {
+      LOG.info("Current table snapshot is already enumerated: {}", currentSnapshot.snapshotId());
+      return new ContinuousEnumerationResult(Collections.emptyList(), lastPosition, lastPosition);
+    } else {
+      IcebergEnumeratorPosition newPosition = IcebergEnumeratorPosition.of(
+          currentSnapshot.snapshotId(), currentSnapshot.timestampMillis());
+      ScanContext incrementalScan = scanContext
+          .copyWithAppendsBetween(lastPosition.snapshotId(), currentSnapshot.snapshotId());
+      List<IcebergSourceSplit> splits = FlinkSplitPlanner.planIcebergSourceSplits(table, incrementalScan);
+      LOG.info("Discovered {} splits from incremental scan: " +
+              "from snapshot (exclusive) is {}, to snapshot (inclusive) is {}",
+          splits.size(), lastPosition, newPosition);
+      return new ContinuousEnumerationResult(splits, lastPosition, newPosition);
+    }
+  }
+
+  /**
+   * Discovery initial set of splits based on {@link StreamingStartingStrategy}.
+   *
+   * <li>{@link ContinuousEnumerationResult#splits()} should contain initial splits
+   * discovered from table scan for {@link StreamingStartingStrategy#TABLE_SCAN_THEN_INCREMENTAL}.
+   * For all other strategies, splits collection should be empty.
+   * <li>{@link ContinuousEnumerationResult#toPosition()} points to the starting position
+   * for the next incremental split discovery with exclusive behavior. Meaning files committed
+   * by the snapshot from the position in {@code ContinuousEnumerationResult} won't be included
+   * in the next incremental scan.
+   */
+  private ContinuousEnumerationResult discoverInitialSplits() {
+    Optional<Snapshot> startSnapshotOptional = startSnapshot(table, scanContext);
+    if (!startSnapshotOptional.isPresent()) {
+      return new ContinuousEnumerationResult(Collections.emptyList(), null,
+          IcebergEnumeratorPosition.empty());
+    }
+
+    Snapshot startSnapshot = startSnapshotOptional.get();
+    LOG.info("Get starting snapshot id {} based on strategy {}",
+        startSnapshot.snapshotId(), scanContext.startingStrategy());
+    List<IcebergSourceSplit> splits;
+    IcebergEnumeratorPosition toPosition;
+    if (scanContext.startingStrategy() == StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL) {
+      // do a batch table scan first
+      splits = FlinkSplitPlanner.planIcebergSourceSplits(table, scanContext);
+      LOG.info("Discovered {} splits from initial batch table scan with snapshot Id {}",
+          splits.size(), startSnapshot.snapshotId());
+      // For TABLE_SCAN_THEN_INCREMENTAL, incremental mode starts exclusive from the startSnapshot
+      toPosition = IcebergEnumeratorPosition.of(startSnapshot.snapshotId(), startSnapshot.timestampMillis());
+    } else {
+      // For all other modes, starting snapshot should be consumed inclusively.
+      // Use parentId to achieve the inclusive behavior. It is fine if parentId is null.
+      splits = Collections.emptyList();
+      Long parentSnapshotId = startSnapshot.parentId();
+      if (parentSnapshotId != null) {
+        Snapshot parentSnapshot = table.snapshot(parentSnapshotId);
+        Long parentSnapshotTimestampMs = parentSnapshot != null ? parentSnapshot.timestampMillis() : null;
+        toPosition = IcebergEnumeratorPosition.of(parentSnapshotId, parentSnapshotTimestampMs);
+      } else {
+        toPosition = IcebergEnumeratorPosition.empty();
+      }
+
+      LOG.info("Start incremental scan with start snapshot (inclusive): id = {}, timestamp = {}",
+          startSnapshot.snapshotId(), startSnapshot.timestampMillis());
+    }
+
+    return new ContinuousEnumerationResult(splits, null, toPosition);
+  }
+
+  /**
+   * Calculate the starting snapshot based on the {@link StreamingStartingStrategy} defined in {@code ScanContext}.
+   * <p>
+   * If the {@link StreamingStartingStrategy} is not {@link StreamingStartingStrategy#TABLE_SCAN_THEN_INCREMENTAL},
+   * the start snapshot should be consumed inclusively.
+   */
+  @VisibleForTesting
+  static Optional<Snapshot> startSnapshot(Table table, ScanContext scanContext) {
+    switch (scanContext.startingStrategy()) {
+      case TABLE_SCAN_THEN_INCREMENTAL:
+      case INCREMENTAL_FROM_LATEST_SNAPSHOT:
+        return Optional.ofNullable(table.currentSnapshot());
+      case INCREMENTAL_FROM_EARLIEST_SNAPSHOT:
+        return Optional.ofNullable(SnapshotUtil.oldestAncestor(table));
+      case INCREMENTAL_FROM_SNAPSHOT_ID:
+        Snapshot matchedSnapshotById = table.snapshot(scanContext.startSnapshotId());
+        Preconditions.checkArgument(matchedSnapshotById != null,
+            "Start snapshot id not found in history: " + scanContext.startSnapshotId());
+        return Optional.of(matchedSnapshotById);
+      case INCREMENTAL_FROM_SNAPSHOT_TIMESTAMP:
+        long snapshotIdAsOfTime = SnapshotUtil.snapshotIdAsOfTime(table, scanContext.startSnapshotTimestamp());
+        Snapshot matchedSnapshotByTimestamp = table.snapshot(snapshotIdAsOfTime);
+        if (matchedSnapshotByTimestamp.timestampMillis() == scanContext.startSnapshotTimestamp()) {
+          return Optional.of(matchedSnapshotByTimestamp);
+        } else {
+          // if the snapshotIdAsOfTime has the timestamp value smaller than the scanContext.startSnapshotTimestamp(),
+          // return the child snapshot whose timestamp value is larger
+          return Optional.of(SnapshotUtil.snapshotAfter(table, snapshotIdAsOfTime));
+        }
+      default:
+        throw new IllegalArgumentException("Unknown starting strategy: " + scanContext.startingStrategy());
+    }
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/IcebergEnumeratorPosition.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/IcebergEnumeratorPosition.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.enumerator;
+
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Objects;
+
+class IcebergEnumeratorPosition {
+  private final Long snapshotId;
+  // Track snapshot timestamp mainly for info logging
+  private final Long snapshotTimestampMs;
+
+  static IcebergEnumeratorPosition empty() {
+    return new IcebergEnumeratorPosition(null, null);
+  }
+
+  static IcebergEnumeratorPosition of(long snapshotId, Long snapshotTimestampMs) {
+    return new IcebergEnumeratorPosition(snapshotId, snapshotTimestampMs);
+  }
+
+  private IcebergEnumeratorPosition(Long snapshotId, Long snapshotTimestampMs) {
+    this.snapshotId = snapshotId;
+    this.snapshotTimestampMs = snapshotTimestampMs;
+  }
+
+  Long snapshotId() {
+    return snapshotId;
+  }
+
+  Long snapshotTimestampMs() {
+    return snapshotTimestampMs;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("snapshotId", snapshotId)
+        .add("snapshotTimestampMs", snapshotTimestampMs)
+        .toString();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(
+        snapshotId,
+        snapshotTimestampMs);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    IcebergEnumeratorPosition other = (IcebergEnumeratorPosition) o;
+    return Objects.equal(snapshotId, other.snapshotId()) &&
+        Objects.equal(snapshotTimestampMs, other.snapshotTimestampMs());
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/IcebergEnumeratorPositionSerializer.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/IcebergEnumeratorPositionSerializer.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.enumerator;
+
+import java.io.IOException;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataOutputSerializer;
+
+class IcebergEnumeratorPositionSerializer implements SimpleVersionedSerializer<IcebergEnumeratorPosition> {
+
+  public static final IcebergEnumeratorPositionSerializer INSTANCE = new IcebergEnumeratorPositionSerializer();
+
+  private static final int VERSION = 1;
+
+  private static final ThreadLocal<DataOutputSerializer> SERIALIZER_CACHE =
+      ThreadLocal.withInitial(() -> new DataOutputSerializer(128));
+
+  @Override
+  public int getVersion() {
+    return VERSION;
+  }
+
+  @Override
+  public byte[] serialize(IcebergEnumeratorPosition position) throws IOException {
+    return serializeV1(position);
+  }
+
+  @Override
+  public IcebergEnumeratorPosition deserialize(int version, byte[] serialized) throws IOException {
+    switch (version) {
+      case 1:
+        return deserializeV1(serialized);
+      default:
+        throw new IOException("Unknown version: " + version);
+    }
+  }
+
+  private byte[] serializeV1(IcebergEnumeratorPosition position) throws IOException {
+    DataOutputSerializer out = SERIALIZER_CACHE.get();
+    out.writeBoolean(position.snapshotId() != null);
+    if (position.snapshotId() != null) {
+      out.writeLong(position.snapshotId());
+    }
+    out.writeBoolean(position.snapshotTimestampMs() != null);
+    if (position.snapshotTimestampMs() != null) {
+      out.writeLong(position.snapshotTimestampMs());
+    }
+    byte[] result = out.getCopyOfBuffer();
+    out.clear();
+    return result;
+  }
+
+  private IcebergEnumeratorPosition deserializeV1(byte[] serialized) throws IOException {
+    DataInputDeserializer in = new DataInputDeserializer(serialized);
+    Long snapshotId = null;
+    if (in.readBoolean()) {
+      snapshotId = in.readLong();
+    }
+
+    Long snapshotTimestampMs = null;
+    if (in.readBoolean()) {
+      snapshotTimestampMs = in.readLong();
+    }
+
+    if (snapshotId != null) {
+      return IcebergEnumeratorPosition.of(snapshotId, snapshotTimestampMs);
+    } else {
+      return IcebergEnumeratorPosition.empty();
+    }
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/IcebergEnumeratorState.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/IcebergEnumeratorState.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.enumerator;
+
+import java.io.Serializable;
+import java.util.Collection;
+import javax.annotation.Nullable;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplitState;
+
+/**
+ * Enumerator state for checkpointing
+ */
+public class IcebergEnumeratorState implements Serializable {
+  @Nullable
+  private final IcebergEnumeratorPosition lastEnumeratedPosition;
+  private final Collection<IcebergSourceSplitState> pendingSplits;
+
+  public IcebergEnumeratorState(Collection<IcebergSourceSplitState> pendingSplits) {
+    this(null, pendingSplits);
+  }
+
+  public IcebergEnumeratorState(
+      @Nullable IcebergEnumeratorPosition lastEnumeratedPosition,
+      Collection<IcebergSourceSplitState> pendingSplits) {
+    this.lastEnumeratedPosition = lastEnumeratedPosition;
+    this.pendingSplits = pendingSplits;
+  }
+
+  @Nullable
+  public IcebergEnumeratorPosition lastEnumeratedPosition() {
+    return lastEnumeratedPosition;
+  }
+
+  public Collection<IcebergSourceSplitState> pendingSplits() {
+    return pendingSplits;
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/IcebergEnumeratorStateSerializer.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/IcebergEnumeratorStateSerializer.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.enumerator;
+
+import java.io.IOException;
+import java.util.Collection;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplitSerializer;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplitState;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplitStatus;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+public class IcebergEnumeratorStateSerializer implements SimpleVersionedSerializer<IcebergEnumeratorState> {
+
+  public static final IcebergEnumeratorStateSerializer INSTANCE = new IcebergEnumeratorStateSerializer();
+
+  private static final int VERSION = 1;
+
+  private static final ThreadLocal<DataOutputSerializer> SERIALIZER_CACHE =
+      ThreadLocal.withInitial(() -> new DataOutputSerializer(1024));
+
+  private final IcebergEnumeratorPositionSerializer positionSerializer = IcebergEnumeratorPositionSerializer.INSTANCE;
+  private final IcebergSourceSplitSerializer splitSerializer = IcebergSourceSplitSerializer.INSTANCE;
+
+  @Override
+  public int getVersion() {
+    return VERSION;
+  }
+
+  @Override
+  public byte[] serialize(IcebergEnumeratorState enumState) throws IOException {
+    return serializeV1(enumState);
+  }
+
+  @Override
+  public IcebergEnumeratorState deserialize(int version, byte[] serialized) throws IOException {
+    switch (version) {
+      case 1:
+        return deserializeV1(serialized);
+      default:
+        throw new IOException("Unknown version: " + version);
+    }
+  }
+
+  private byte[] serializeV1(IcebergEnumeratorState enumState) throws IOException {
+    DataOutputSerializer out = SERIALIZER_CACHE.get();
+
+    out.writeBoolean(enumState.lastEnumeratedPosition() != null);
+    if (enumState.lastEnumeratedPosition() != null) {
+      out.writeInt(positionSerializer.getVersion());
+      byte[] positionBytes = positionSerializer.serialize(enumState.lastEnumeratedPosition());
+      out.writeInt(positionBytes.length);
+      out.write(positionBytes);
+    }
+
+    out.writeInt(splitSerializer.getVersion());
+    out.writeInt(enumState.pendingSplits().size());
+    for (IcebergSourceSplitState splitState : enumState.pendingSplits()) {
+      byte[] splitBytes = splitSerializer.serialize(splitState.split());
+      out.writeInt(splitBytes.length);
+      out.write(splitBytes);
+      out.writeUTF(splitState.status().name());
+    }
+
+    byte[] result = out.getCopyOfBuffer();
+    out.clear();
+    return result;
+  }
+
+  private IcebergEnumeratorState deserializeV1(byte[] serialized) throws IOException {
+    DataInputDeserializer in = new DataInputDeserializer(serialized);
+
+    IcebergEnumeratorPosition enumeratorPosition = null;
+    if (in.readBoolean()) {
+      int version = in.readInt();
+      byte[] positionBytes = new byte[in.readInt()];
+      in.read(positionBytes);
+      enumeratorPosition = positionSerializer.deserialize(version, positionBytes);
+    }
+
+    int splitSerializerVersion = in.readInt();
+    int splitCount = in.readInt();
+    Collection<IcebergSourceSplitState> pendingSplits = Lists.newArrayListWithCapacity(splitCount);
+    for (int i = 0; i < splitCount; ++i) {
+      byte[] splitBytes = new byte[in.readInt()];
+      in.read(splitBytes);
+      IcebergSourceSplit split = splitSerializer.deserialize(splitSerializerVersion, splitBytes);
+      String statusName = in.readUTF();
+      pendingSplits.add(new IcebergSourceSplitState(split, IcebergSourceSplitStatus.valueOf(statusName)));
+    }
+    return new IcebergEnumeratorState(enumeratorPosition, pendingSplits);
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/StaticIcebergEnumerator.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/StaticIcebergEnumerator.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.enumerator;
+
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.source.FlinkSplitPlanner;
+import org.apache.iceberg.flink.source.ScanContext;
+import org.apache.iceberg.flink.source.assigner.SplitAssigner;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * One-time split enumeration at the start-up
+ */
+public class StaticIcebergEnumerator extends AbstractIcebergEnumerator {
+  private static final Logger LOG = LoggerFactory.getLogger(StaticIcebergEnumerator.class);
+
+  private final SplitAssigner assigner;
+  private final Table table;
+  private final ScanContext scanContext;
+  private final boolean shouldEnumerate;
+
+  public StaticIcebergEnumerator(
+      SplitEnumeratorContext<IcebergSourceSplit> enumeratorContext,
+      SplitAssigner assigner,
+      Table table,
+      ScanContext scanContext,
+      @Nullable IcebergEnumeratorState enumState) {
+    super(enumeratorContext, assigner);
+    this.assigner = assigner;
+    this.table = table;
+    this.scanContext = scanContext;
+    // split enumeration is not needed during restore scenario
+    this.shouldEnumerate = enumState == null;
+  }
+
+  @Override
+  public void start() {
+    super.start();
+    if (shouldEnumerate) {
+      List<IcebergSourceSplit> splits = FlinkSplitPlanner.planIcebergSourceSplits(table, scanContext);
+      assigner.onDiscoveredSplits(splits);
+      LOG.info("Discovered {} splits from table {} during job initialization",
+            splits.size(), table.name());
+    }
+  }
+
+  @Override
+  protected boolean shouldWaitForMoreSplits() {
+    return false;
+  }
+
+  @Override
+  public IcebergEnumeratorState snapshotState(long checkpointId) {
+    return new IcebergEnumeratorState(null, assigner.state());
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/reader/ArrayBatchRecords.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/reader/ArrayBatchRecords.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.reader;
+
+import java.util.Collections;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.file.src.util.Pool;
+import org.apache.flink.table.data.RowData;
+import org.apache.iceberg.flink.source.DataIterator;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+/**
+ * {@link RecordsWithSplitIds} is used to pass a batch of records from fetcher to source reader.
+ * Batching is to improve the efficiency for records handover.
+ *
+ * {@link RecordsWithSplitIds} interface can encapsulate batches from multiple splits.
+ * This is the case for Kafka source where fetchers can retrieve records from multiple
+ * Kafka partitions at the same time.
+ *
+ * For file-based sources like Iceberg, readers always read one split/file at a time.
+ * Hence, we will only have a batch of records for one split here.
+ *
+ * This class uses array to store a batch of records from the same file (with the same fileOffset).
+ */
+class ArrayBatchRecords<T> implements RecordsWithSplitIds<RecordAndPosition<T>> {
+  @Nullable
+  private String splitId;
+  @Nullable
+  private final Pool.Recycler<T[]> recycler;
+  @Nullable
+  private final T[] records;
+  private final int numberOfRecords;
+  private final Set<String> finishedSplits;
+  private final RecordAndPosition<T> recordAndPosition;
+
+  // point to current read position within the records array
+  private int position;
+
+  private ArrayBatchRecords(
+      @Nullable String splitId, @Nullable Pool.Recycler<T[]> recycler, @Nullable T[] records,
+      int numberOfRecords, int fileOffset, long startingRecordOffset, Set<String> finishedSplits) {
+    Preconditions.checkArgument(numberOfRecords >= 0, "numberOfRecords can't be negative");
+    Preconditions.checkArgument(fileOffset >= 0, "fileOffset can't be negative");
+    Preconditions.checkArgument(startingRecordOffset >= 0, "numberOfRecords can't be negative");
+
+    this.splitId = splitId;
+    this.recycler = recycler;
+    this.records = records;
+    this.numberOfRecords = numberOfRecords;
+    this.finishedSplits = Preconditions.checkNotNull(finishedSplits, "finishedSplits can be empty but not null");
+    this.recordAndPosition = new RecordAndPosition<>();
+
+    recordAndPosition.set(null, fileOffset, startingRecordOffset);
+    this.position = 0;
+  }
+
+  @Nullable
+  @Override
+  public String nextSplit() {
+    String nextSplit = this.splitId;
+    // set the splitId to null to indicate no more splits
+    // this class only contains record for one split
+    this.splitId = null;
+    return nextSplit;
+  }
+
+  @Nullable
+  @Override
+  public RecordAndPosition<T> nextRecordFromSplit() {
+    if (position < numberOfRecords) {
+      recordAndPosition.record(records[position]);
+      position++;
+      return recordAndPosition;
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * This method is called when all records from this batch has been emitted.
+   * If recycler is set, it should be called to return the records array back to pool.
+   */
+  @Override
+  public void recycle() {
+    if (recycler != null) {
+      recycler.recycle(records);
+    }
+  }
+
+  @Override
+  public Set<String> finishedSplits() {
+    return finishedSplits;
+  }
+
+  @VisibleForTesting
+  T[] records() {
+    return records;
+  }
+
+  @VisibleForTesting
+  int numberOfRecords() {
+    return numberOfRecords;
+  }
+
+  /**
+   * Create a ArrayBatchRecords backed up an array with records from the same file
+   *
+   * @param splitId Iceberg source only read from one split a time.
+   *                We never have multiple records from multiple splits.
+   * @param recycler Because {@link DataIterator} with {@link RowData} returns an iterator of reused RowData object,
+   *                 we need to clone RowData eagerly when constructing a batch of records.
+   *                 We can use object pool to reuse the RowData array object which can be expensive to create.
+   *                 This recycler can be provided to recycle the array object back to pool after read is exhausted.
+   *                 If the {@link DataIterator} returns an iterator of non-reused objects,
+   *                 we don't need to clone objects. It is cheap to just create the batch array.
+   *                 Hence, we don't need object pool and recycler can be set to null.
+   * @param records an array (maybe reused) holding a batch of records
+   * @param numberOfRecords actual number of records in the array
+   * @param fileOffset fileOffset for all records in this batch
+   * @param startingRecordOffset starting recordOffset
+   * @param <T> record type
+   */
+  public static <T> ArrayBatchRecords<T> forRecords(
+      String splitId, Pool.Recycler<T[]> recycler, T[] records, int numberOfRecords,
+      int fileOffset, long startingRecordOffset) {
+    return new ArrayBatchRecords<>(splitId, recycler, records, numberOfRecords,
+        fileOffset, startingRecordOffset, Collections.emptySet());
+  }
+
+  /**
+   * Create ab ArrayBatchRecords with only finished split id
+   *
+   * @param splitId for the split that is just exhausted
+   */
+  public static <T> ArrayBatchRecords<T> finishedSplit(String splitId) {
+    return new ArrayBatchRecords<>(null, null, null,
+        0, 0, 0, Collections.singleton(splitId));
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/reader/ArrayPoolDataIteratorBatcher.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/reader/ArrayPoolDataIteratorBatcher.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.reader;
+
+import java.io.IOException;
+import java.util.NoSuchElementException;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.SourceReaderOptions;
+import org.apache.flink.connector.file.src.util.Pool;
+import org.apache.iceberg.flink.FlinkConfigOptions;
+import org.apache.iceberg.flink.source.DataIterator;
+import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+/**
+ * This implementation stores record batch in array from recyclable pool
+ */
+class ArrayPoolDataIteratorBatcher<T> implements DataIteratorBatcher<T> {
+  private final int batchSize;
+  private final int handoverQueueSize;
+  private final RecordFactory<T> recordFactory;
+
+  private transient Pool<T[]> pool;
+
+  ArrayPoolDataIteratorBatcher(Configuration config, RecordFactory<T> recordFactory) {
+    this.batchSize = config.getInteger(FlinkConfigOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT);
+    this.handoverQueueSize = config.getInteger(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY);
+    this.recordFactory = recordFactory;
+  }
+
+  @Override
+  public CloseableIterator<RecordsWithSplitIds<RecordAndPosition<T>>> batch(
+      String splitId, DataIterator<T> inputIterator) {
+    Preconditions.checkArgument(inputIterator != null, "Input data iterator can't be null");
+    // lazily create pool as it is not serializable
+    if (pool == null) {
+      this.pool = createPoolOfBatches(handoverQueueSize);
+    }
+    return new ArrayPoolBatchIterator(splitId, inputIterator, pool);
+  }
+
+  private Pool<T[]> createPoolOfBatches(int numBatches) {
+    Pool<T[]> poolOfBatches = new Pool<>(numBatches);
+    for (int batchId = 0; batchId < numBatches; batchId++) {
+      T[] batch = recordFactory.createBatch(batchSize);
+      poolOfBatches.add(batch);
+    }
+
+    return poolOfBatches;
+  }
+
+  private class ArrayPoolBatchIterator implements CloseableIterator<RecordsWithSplitIds<RecordAndPosition<T>>> {
+
+    private final String splitId;
+    private final DataIterator<T> inputIterator;
+    private final Pool<T[]> pool;
+
+    ArrayPoolBatchIterator(String splitId, DataIterator<T> inputIterator, Pool<T[]> pool) {
+      this.splitId = splitId;
+      this.inputIterator = inputIterator;
+      this.pool = pool;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return inputIterator.hasNext();
+    }
+
+    @Override
+    public RecordsWithSplitIds<RecordAndPosition<T>> next() {
+      if (!inputIterator.hasNext()) {
+        throw new NoSuchElementException();
+      }
+
+      T[] batch = getCachedEntry();
+      int recordCount = 0;
+      while (inputIterator.hasNext() && recordCount < batchSize) {
+        // The record produced by inputIterator can be reused like for the RowData case.
+        // inputIterator.next() can't be called again until the copy is made
+        // since the record is not consumed immediately.
+        T nextRecord = inputIterator.next();
+        recordFactory.clone(nextRecord, batch, recordCount);
+        recordCount++;
+        if (!inputIterator.currentFileHasNext()) {
+          // break early so that records in the ArrayResultIterator
+          // have the same fileOffset.
+          break;
+        }
+      }
+
+      return ArrayBatchRecords.forRecords(splitId, pool.recycler(), batch, recordCount,
+          inputIterator.fileOffset(), inputIterator.recordOffset() - recordCount);
+    }
+
+    @Override
+    public void close() throws IOException {
+      inputIterator.close();
+    }
+
+    private T[] getCachedEntry() {
+      try {
+        return pool.pollEntry();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException("Interrupted while waiting for array pool entry", e);
+      }
+    }
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/reader/DataIteratorBatcher.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/reader/DataIteratorBatcher.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.reader;
+
+import java.io.Serializable;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.iceberg.flink.source.DataIterator;
+import org.apache.iceberg.io.CloseableIterator;
+
+/**
+ * Batcher converts iterator of T into iterator of batched {@code RecordsWithSplitIds<RecordAndPosition<T>>},
+ * as FLIP-27's {@link SplitReader#fetch()} returns batched records.
+ */
+@FunctionalInterface
+public interface DataIteratorBatcher<T> extends Serializable {
+  CloseableIterator<RecordsWithSplitIds<RecordAndPosition<T>>> batch(String splitId, DataIterator<T> inputIterator);
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/reader/DataIteratorReaderFunction.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/reader/DataIteratorReaderFunction.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.reader;
+
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.iceberg.flink.source.DataIterator;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.io.CloseableIterator;
+
+/**
+ * A {@link ReaderFunction} implementation that uses {@link DataIterator}.
+ */
+public abstract class DataIteratorReaderFunction<T> implements ReaderFunction<T> {
+  private final DataIteratorBatcher<T> batcher;
+
+  public DataIteratorReaderFunction(DataIteratorBatcher<T> batcher) {
+    this.batcher = batcher;
+  }
+
+  protected abstract DataIterator<T> createDataIterator(IcebergSourceSplit split);
+
+  @Override
+  public CloseableIterator<RecordsWithSplitIds<RecordAndPosition<T>>> apply(IcebergSourceSplit split) {
+    DataIterator<T> inputIterator = createDataIterator(split);
+    inputIterator.seek(split.fileOffset(), split.recordOffset());
+    return batcher.batch(split.splitId(), inputIterator);
+  }
+
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceReader.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceReader.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.reader;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSourceReaderBase;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.flink.source.split.SplitRequestEvent;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+public class IcebergSourceReader<T> extends
+    SingleThreadMultiplexSourceReaderBase<RecordAndPosition<T>, T, IcebergSourceSplit, IcebergSourceSplit> {
+
+  public IcebergSourceReader(
+      ReaderFunction<T> readerFunction,
+      SourceReaderContext context,
+      ReaderMetricsContext metrics) {
+    super(
+        () -> new IcebergSourceSplitReader<>(readerFunction, context, metrics),
+        new IcebergSourceRecordEmitter<>(),
+        context.getConfiguration(),
+        context);
+  }
+
+  @Override
+  public void start() {
+    // We request a split only if we did not restore any split from checkpoint.
+    // Otherwise, reader restarts will keep requesting more and more splits.
+    if (getNumberOfCurrentlyAssignedSplits() == 0) {
+      requestSplit(Collections.emptyList());
+    }
+  }
+
+  @Override
+  protected void onSplitFinished(Map<String, IcebergSourceSplit> finishedSplitIds) {
+    requestSplit(Lists.newArrayList(finishedSplitIds.keySet()));
+  }
+
+  @Override
+  protected IcebergSourceSplit initializedState(IcebergSourceSplit split) {
+    return split;
+  }
+
+  @Override
+  protected IcebergSourceSplit toSplitType(String splitId, IcebergSourceSplit splitState) {
+    return splitState;
+  }
+
+  private void requestSplit(Collection<String> finishedSplitIds) {
+    context.sendSourceEventToCoordinator(new SplitRequestEvent(finishedSplitIds));
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceRecordEmitter.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceRecordEmitter.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.reader;
+
+import org.apache.flink.api.connector.source.SourceOutput;
+import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+
+final class IcebergSourceRecordEmitter<T> implements RecordEmitter<RecordAndPosition<T>, T, IcebergSourceSplit> {
+
+  IcebergSourceRecordEmitter() {
+  }
+
+  @Override
+  public void emitRecord(
+      RecordAndPosition<T> element,
+      SourceOutput<T> output,
+      IcebergSourceSplit split) {
+    output.collect(element.record());
+    split.updatePosition(element.fileOffset(), element.recordOffset());
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceSplitReader.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceSplitReader.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.reader;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Queue;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.connector.base.source.reader.RecordsBySplits;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.metrics.MetricsContext.Counter;
+import org.apache.iceberg.metrics.MetricsContext.Unit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class IcebergSourceSplitReader<T> implements SplitReader<RecordAndPosition<T>, IcebergSourceSplit> {
+  private static final Logger LOG = LoggerFactory.getLogger(IcebergSourceSplitReader.class);
+
+  private final ReaderFunction<T> openSplitFunction;
+  private final int indexOfSubtask;
+  private final Queue<IcebergSourceSplit> splits;
+
+  private final Counter<Long> assignedSplits;
+  private final Counter<Long> assignedBytes;
+  private final Counter<Long> finishedSplits;
+  private final Counter<Long> finishedBytes;
+  private final Counter<Long> splitReaderFetchCalls;
+
+  private CloseableIterator<RecordsWithSplitIds<RecordAndPosition<T>>> currentReader;
+  private IcebergSourceSplit currentSplit;
+  private String currentSplitId;
+
+  IcebergSourceSplitReader(ReaderFunction<T> openSplitFunction,
+                           SourceReaderContext context,
+                           ReaderMetricsContext metrics) {
+    this.openSplitFunction = openSplitFunction;
+    this.indexOfSubtask = context.getIndexOfSubtask();
+    this.splits = new ArrayDeque<>();
+
+    this.assignedSplits = metrics.counter(ReaderMetricsContext.ASSIGNED_SPLITS, Long.class, Unit.COUNT);
+    this.assignedBytes = metrics.counter(ReaderMetricsContext.ASSIGNED_BYTES, Long.class, Unit.COUNT);
+    this.finishedSplits = metrics.counter(ReaderMetricsContext.FINISHED_SPLITS, Long.class, Unit.COUNT);
+    this.finishedBytes = metrics.counter(ReaderMetricsContext.FINISHED_BYTES, Long.class, Unit.COUNT);
+    this.splitReaderFetchCalls = metrics.counter(ReaderMetricsContext.SPLIT_READER_FETCH_CALLS, Long.class, Unit.COUNT);
+  }
+
+  @Override
+  public RecordsWithSplitIds<RecordAndPosition<T>> fetch() throws IOException {
+    splitReaderFetchCalls.increment();
+    if (currentReader == null) {
+      IcebergSourceSplit nextSplit = splits.poll();
+      if (nextSplit != null) {
+        currentSplit = nextSplit;
+        currentSplitId = nextSplit.splitId();
+        currentReader = openSplitFunction.apply(currentSplit);
+      } else {
+        // return an empty result, which will lead to split fetch to be idle.
+        // SplitFetcherManager will then close idle fetcher.
+        return new RecordsBySplits(Collections.emptyMap(), Collections.emptySet());
+      }
+    }
+
+    if (currentReader.hasNext()) {
+      // Because Iterator#next() doesn't support checked exception,
+      // we need to wrap and unwrap the checked IOException with UncheckedIOException
+      try {
+        return currentReader.next();
+      } catch (UncheckedIOException e) {
+        throw e.getCause();
+      }
+    } else {
+      return finishSplit();
+    }
+  }
+
+  @Override
+  public void handleSplitsChanges(SplitsChange<IcebergSourceSplit> splitsChange) {
+    if (!(splitsChange instanceof SplitsAddition)) {
+      throw new UnsupportedOperationException(String.format(
+          "Unsupported split change: %s", splitsChange.getClass()));
+    }
+
+    LOG.info("Add {} splits to reader", splitsChange.splits().size());
+    splits.addAll(splitsChange.splits());
+    assignedSplits.increment(Long.valueOf(splitsChange.splits().size()));
+    assignedBytes.increment(calculateBytes(splitsChange));
+  }
+
+  @Override
+  public void wakeUp() {
+  }
+
+  @Override
+  public void close() throws Exception {
+    currentSplitId = null;
+    if (currentReader != null) {
+      currentReader.close();
+    }
+  }
+
+  private long calculateBytes(IcebergSourceSplit split) {
+    return split.task().files().stream()
+        .map(fileScanTask -> fileScanTask.length())
+        .reduce(0L, Long::sum);
+  }
+
+  private long calculateBytes(SplitsChange<IcebergSourceSplit> splitsChanges) {
+    return splitsChanges.splits().stream()
+        .map(split -> calculateBytes(split))
+        .reduce(0L, Long::sum);
+  }
+
+  private ArrayBatchRecords<T> finishSplit() throws IOException {
+    if (currentReader != null) {
+      currentReader.close();
+      currentReader = null;
+    }
+
+    ArrayBatchRecords<T> finishRecords = ArrayBatchRecords.finishedSplit(currentSplitId);
+    LOG.info("Split reader {} finished split: {}", indexOfSubtask, currentSplitId);
+    finishedSplits.increment(1L);
+    finishedBytes.increment(calculateBytes(currentSplit));
+    currentSplitId = null;
+    return finishRecords;
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/reader/ReaderFunction.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/reader/ReaderFunction.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.reader;
+
+import java.io.Serializable;
+import java.util.function.Function;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.io.CloseableIterator;
+
+@FunctionalInterface
+public interface ReaderFunction<T> extends Serializable,
+    Function<IcebergSourceSplit, CloseableIterator<RecordsWithSplitIds<RecordAndPosition<T>>>> {
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/reader/ReaderMetricsContext.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/reader/ReaderMetricsContext.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.reader;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.metrics.MetricsContext;
+
+@Internal
+public class ReaderMetricsContext implements MetricsContext {
+  public static final String ASSIGNED_SPLITS = "assignedSplits";
+  public static final String ASSIGNED_BYTES = "assignedBytes";
+  public static final String FINISHED_SPLITS = "finishedSplits";
+  public static final String FINISHED_BYTES = "finishedBytes";
+  public static final String SPLIT_READER_FETCH_CALLS = "splitReaderFetchCalls";
+
+  private final AtomicLong assignedSplits;
+  private final AtomicLong assignedBytes;
+  private final AtomicLong finishedSplits;
+  private final AtomicLong finishedBytes;
+  private final AtomicLong splitReaderFetchCalls;
+
+  public ReaderMetricsContext(MetricGroup metricGroup) {
+    MetricGroup readerMetricGroup = metricGroup.addGroup("IcebergSourceReader");
+    this.assignedSplits = new AtomicLong();
+    this.assignedBytes = new AtomicLong();
+    this.finishedSplits = new AtomicLong();
+    this.finishedBytes = new AtomicLong();
+    this.splitReaderFetchCalls = new AtomicLong();
+    readerMetricGroup.gauge(ASSIGNED_SPLITS, assignedSplits::get);
+    readerMetricGroup.gauge(ASSIGNED_BYTES, assignedBytes::get);
+    readerMetricGroup.gauge(FINISHED_SPLITS, finishedSplits::get);
+    readerMetricGroup.gauge(FINISHED_BYTES, finishedBytes::get);
+    readerMetricGroup.gauge(SPLIT_READER_FETCH_CALLS, splitReaderFetchCalls::get);
+  }
+
+  @Override
+  public <T extends Number> Counter<T> counter(String name, Class<T> type, Unit unit) {
+    switch (name) {
+      case ASSIGNED_SPLITS:
+        ValidationException.check(type == Long.class, "'%s' requires Long type", ASSIGNED_SPLITS);
+        return (Counter<T>) longCounter(assignedSplits::addAndGet);
+      case ASSIGNED_BYTES:
+        ValidationException.check(type == Long.class, "'%s' requires Integer type", ASSIGNED_BYTES);
+        return (Counter<T>) longCounter(assignedBytes::addAndGet);
+      case FINISHED_SPLITS:
+        ValidationException.check(type == Long.class, "'%s' requires Long type", FINISHED_SPLITS);
+        return (Counter<T>) longCounter(finishedSplits::addAndGet);
+      case FINISHED_BYTES:
+        ValidationException.check(type == Long.class, "'%s' requires Integer type", FINISHED_BYTES);
+        return (Counter<T>) longCounter(finishedBytes::addAndGet);
+      case SPLIT_READER_FETCH_CALLS:
+        ValidationException.check(type == Long.class, "'%s' requires Integer type", SPLIT_READER_FETCH_CALLS);
+        return (Counter<T>) longCounter(splitReaderFetchCalls::addAndGet);
+      default:
+        throw new IllegalArgumentException(String.format("Unsupported counter: '%s'", name));
+    }
+  }
+
+  private Counter<Long> longCounter(Consumer<Long> consumer) {
+    return  new Counter<Long>() {
+      @Override
+      public void increment() {
+        increment(1L);
+      }
+
+      @Override
+      public void increment(Long amount) {
+        consumer.accept(amount);
+      }
+    };
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/reader/RecordAndPosition.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/reader/RecordAndPosition.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.reader;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * A record along with the reader position to be stored in the checkpoint.
+ *
+ * <p>The position defines the point in the reader AFTER the record. Record processing and updating
+ * checkpointed state happens atomically. The position points to where the reader should resume
+ * after this record is processed.
+ *
+ * <p>This mutable object is useful in cases where only one instance of a {@code RecordAndPosition}
+ * is needed at a time. Then the same instance of RecordAndPosition can be reused.
+ */
+@Internal
+public class RecordAndPosition<T> {
+  private T record;
+  private int fileOffset;
+  private long recordOffset;
+
+  public RecordAndPosition(T record, int fileOffset, long recordOffset) {
+    this.record = record;
+    this.fileOffset = fileOffset;
+    this.recordOffset = recordOffset;
+  }
+
+  public RecordAndPosition() {
+  }
+
+  // ------------------------------------------------------------------------
+
+  public T record() {
+    return record;
+  }
+
+  public int fileOffset() {
+    return fileOffset;
+  }
+
+  public long recordOffset() {
+    return recordOffset;
+  }
+
+  /** Updates the record and position in this object. */
+  public void set(T newRecord, int newFileOffset, long newRecordOffset) {
+    this.record = newRecord;
+    this.fileOffset = newFileOffset;
+    this.recordOffset = newRecordOffset;
+  }
+
+  /** Sets the next record of a sequence. This increments the {@code recordOffset} by one. */
+  public void record(T nextRecord) {
+    this.record = nextRecord;
+    this.recordOffset++;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s @ %d + %d", record, fileOffset, recordOffset);
+  }
+
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/reader/RecordFactory.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/reader/RecordFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.reader;
+
+import java.io.Serializable;
+
+/**
+ * In FLIP-27 source, SplitReader#fetch() returns a batch of records.
+ * Since DataIterator for RowData returns an iterator of reused RowData objects,
+ * RecordFactory is needed to (1) create object array that is recyclable via pool.
+ * (2) clone RowData element from DataIterator to the batch array.
+ */
+interface RecordFactory<T> extends Serializable {
+  /**
+   * Create a batch of records
+   */
+  T[] createBatch(int batchSize);
+
+  /**
+   * Clone record into the specified position of the batch array
+   */
+  void clone(T from, T[] batch, int position);
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/reader/RowDataReaderFunction.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/reader/RowDataReaderFunction.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.reader;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.RowData;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.source.DataIterator;
+import org.apache.iceberg.flink.source.RowDataFileScanTaskReader;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+public class RowDataReaderFunction extends DataIteratorReaderFunction<RowData> {
+  private final Schema tableSchema;
+  private final Schema readSchema;
+  private final String nameMapping;
+  private final boolean caseSensitive;
+  private final FileIO io;
+  private final EncryptionManager encryption;
+
+  public RowDataReaderFunction(
+      Configuration config, Schema tableSchema, Schema projectedSchema,
+      String nameMapping, boolean caseSensitive, FileIO io, EncryptionManager encryption) {
+    super(new ArrayPoolDataIteratorBatcher<>(config, new RowDataRecordFactory(
+        FlinkSchemaUtil.convert(readSchema(tableSchema, projectedSchema)))));
+    this.tableSchema = tableSchema;
+    this.readSchema = readSchema(tableSchema, projectedSchema);
+    this.nameMapping = nameMapping;
+    this.caseSensitive = caseSensitive;
+    this.io = io;
+    this.encryption = encryption;
+  }
+
+  @Override
+  public DataIterator<RowData> createDataIterator(IcebergSourceSplit split) {
+    return new DataIterator<>(
+        new RowDataFileScanTaskReader(
+            tableSchema,
+            readSchema,
+            nameMapping,
+            caseSensitive),
+        split.task(), io, encryption);
+  }
+
+  private static Schema readSchema(Schema tableSchema, Schema projectedSchema) {
+    Preconditions.checkNotNull(tableSchema, "Table schema can't be null");
+    return projectedSchema == null ? tableSchema : projectedSchema;
+  }
+
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/reader/RowDataRecordFactory.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/reader/RowDataRecordFactory.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.reader;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.InternalSerializers;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.iceberg.flink.data.RowDataUtil;
+
+class RowDataRecordFactory implements RecordFactory<RowData> {
+  private final RowType rowType;
+  private final TypeSerializer[] fieldSerializers;
+
+  RowDataRecordFactory(RowType rowType) {
+    this.rowType = rowType;
+    this.fieldSerializers = createFieldSerializers(rowType);
+  }
+
+  static TypeSerializer[] createFieldSerializers(RowType rowType) {
+    return rowType.getChildren().stream()
+        .map(InternalSerializers::create)
+        .toArray(TypeSerializer[]::new);
+  }
+
+  @Override
+  public RowData[] createBatch(int batchSize) {
+    RowData[] arr = new RowData[batchSize];
+    for (int i = 0; i < batchSize; ++i) {
+      arr[i] = new GenericRowData(rowType.getFieldCount());
+    }
+    return arr;
+  }
+
+  @Override
+  public void clone(RowData from, RowData[] batch, int position) {
+    // Set the return value from RowDataUtil.clone back to the array.
+    // Clone method returns same clone target object (reused) if it is a GenericRowData.
+    // Clone method will allocate a new GenericRowData object
+    // if the target object is NOT a GenericRowData.
+    // So we should always set the clone return value back to the array.
+    batch[position] = RowDataUtil.clone(from, batch[position], rowType, fieldSerializers);
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplit.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplit.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.split;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.util.InstantiationUtil;
+import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+
+@Internal
+public class IcebergSourceSplit implements SourceSplit, Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private final CombinedScanTask task;
+
+  private int fileOffset;
+  private long recordOffset;
+
+  // The splits are frequently serialized into checkpoints.
+  // Caching the byte representation makes repeated serialization cheap.
+  @Nullable
+  private transient byte[] serializedBytesCache;
+
+  private IcebergSourceSplit(CombinedScanTask task, int fileOffset, long recordOffset) {
+    this.task = task;
+    this.fileOffset = fileOffset;
+    this.recordOffset = recordOffset;
+  }
+
+  public static IcebergSourceSplit fromCombinedScanTask(CombinedScanTask combinedScanTask) {
+    return fromCombinedScanTask(combinedScanTask, 0, 0L);
+  }
+
+  public static IcebergSourceSplit fromCombinedScanTask(
+      CombinedScanTask combinedScanTask, int fileOffset, long recordOffset) {
+    return new IcebergSourceSplit(combinedScanTask, fileOffset, recordOffset);
+  }
+
+  public CombinedScanTask task() {
+    return task;
+  }
+
+  public int fileOffset() {
+    return fileOffset;
+  }
+
+  public long recordOffset() {
+    return recordOffset;
+  }
+
+  @Override
+  public String splitId() {
+    return MoreObjects.toStringHelper(this)
+        .add("files", toString(task.files()))
+        .toString();
+  }
+
+  public void updatePosition(int newFileOffset, long newRecordOffset) {
+    // invalidate the cache after position change
+    serializedBytesCache = null;
+    fileOffset = newFileOffset;
+    recordOffset = newRecordOffset;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("files", toString(task.files()))
+        .add("fileOffset", fileOffset)
+        .add("recordOffset", recordOffset)
+        .toString();
+  }
+
+  private String toString(Collection<FileScanTask> files) {
+    return Iterables.toString(files.stream().map(fileScanTask ->
+        MoreObjects.toStringHelper(fileScanTask)
+            .add("file", fileScanTask.file().path().toString())
+            .add("start", fileScanTask.start())
+            .add("length", fileScanTask.length())
+            .toString()).collect(Collectors.toList()));
+  }
+
+  byte[] serializeV1() throws IOException {
+    if (serializedBytesCache == null) {
+      serializedBytesCache = InstantiationUtil.serializeObject(this);
+    }
+    return serializedBytesCache;
+  }
+
+  static IcebergSourceSplit deserializeV1(byte[] serialized) throws IOException {
+    try {
+      return InstantiationUtil.deserializeObject(serialized, IcebergSourceSplit.class.getClassLoader());
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException("Failed to deserialize the split.", e);
+    }
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplitSerializer.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplitSerializer.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.split;
+
+import java.io.IOException;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+/**
+ * TODO: use Java serialization for now.
+ * Will switch to more stable serializer from
+ * <a href="https://github.com/apache/iceberg/issues/1698">issue-1698</a>.
+ */
+@Internal
+public class IcebergSourceSplitSerializer implements SimpleVersionedSerializer<IcebergSourceSplit> {
+  public static final IcebergSourceSplitSerializer INSTANCE = new IcebergSourceSplitSerializer();
+  private static final int VERSION = 1;
+
+  @Override
+  public int getVersion() {
+    return VERSION;
+  }
+
+  @Override
+  public byte[] serialize(IcebergSourceSplit split) throws IOException {
+    return split.serializeV1();
+  }
+
+  @Override
+  public IcebergSourceSplit deserialize(int version, byte[] serialized) throws IOException {
+    switch (version) {
+      case 1:
+        return IcebergSourceSplit.deserializeV1(serialized);
+      default:
+        throw new IOException(String.format("Failed to deserialize IcebergSourceSplit. " +
+            "Encountered unsupported version: %d. Supported version are [1]", version));
+    }
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplitState.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplitState.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.split;
+
+public class IcebergSourceSplitState {
+  private final IcebergSourceSplit split;
+  private final IcebergSourceSplitStatus status;
+
+  public IcebergSourceSplitState(IcebergSourceSplit split, IcebergSourceSplitStatus status) {
+    this.split = split;
+    this.status = status;
+  }
+
+  public IcebergSourceSplit split() {
+    return split;
+  }
+
+  public IcebergSourceSplitStatus status() {
+    return status;
+  }
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplitStatus.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/split/IcebergSourceSplitStatus.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.split;
+
+public enum IcebergSourceSplitStatus {
+  UNASSIGNED,
+  ASSIGNED,
+  COMPLETED
+}

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/split/SplitRequestEvent.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/split/SplitRequestEvent.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.split;
+
+import java.util.Collection;
+import java.util.Collections;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.SourceEvent;
+
+/**
+ * We can remove this class once FLINK-21364 is resolved.
+ */
+@Internal
+public class SplitRequestEvent implements SourceEvent {
+  private static final long serialVersionUID = 1L;
+
+  private final Collection<String> finishedSplitIds;
+  private final String requesterHostname;
+
+  public SplitRequestEvent() {
+    this(Collections.emptyList());
+  }
+
+  public SplitRequestEvent(Collection<String> finishedSplitIds) {
+    this(finishedSplitIds, null);
+  }
+
+  public SplitRequestEvent(Collection<String> finishedSplitIds, String requesterHostname) {
+    this.finishedSplitIds = finishedSplitIds;
+    this.requesterHostname = requesterHostname;
+  }
+
+  public Collection<String> finishedSplitIds() {
+    return finishedSplitIds;
+  }
+
+  public String requesterHostname() {
+    return requesterHostname;
+  }
+}

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/HadoopTableResource.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/HadoopTableResource.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink;
+
+import java.io.File;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.junit.Assert;
+import org.junit.rules.ExternalResource;
+import org.junit.rules.TemporaryFolder;
+
+public class HadoopTableResource extends ExternalResource {
+  private final TemporaryFolder temporaryFolder;
+  private final String database;
+  private final String tableName;
+  private final Schema schema;
+  private final PartitionSpec partitionSpec;
+
+  private HadoopCatalog catalog;
+  private TableLoader tableLoader;
+  private Table table;
+
+  public HadoopTableResource(TemporaryFolder temporaryFolder, String database, String tableName, Schema schema) {
+    this(temporaryFolder, database, tableName, schema, null);
+  }
+
+  public HadoopTableResource(TemporaryFolder temporaryFolder, String database, String tableName,
+                             Schema schema, PartitionSpec partitionSpec) {
+    this.temporaryFolder = temporaryFolder;
+    this.database = database;
+    this.tableName = tableName;
+    this.schema = schema;
+    this.partitionSpec = partitionSpec;
+  }
+
+  @Override
+  protected void before() throws Throwable {
+    File warehouseFile = temporaryFolder.newFolder();
+    Assert.assertTrue(warehouseFile.delete());
+    // before variables
+    String warehouse = "file:" + warehouseFile;
+    Configuration hadoopConf = new Configuration();
+    this.catalog = new HadoopCatalog(hadoopConf, warehouse);
+    String location = String.format("%s/%s/%s", warehouse, database, tableName);
+    this.tableLoader = TableLoader.fromHadoopTable(location);
+    if (partitionSpec == null) {
+      this.table = catalog.createTable(TableIdentifier.of(database, tableName), schema);
+    } else {
+      this.table = catalog.createTable(TableIdentifier.of(database, tableName), schema, partitionSpec);
+    }
+    tableLoader.open();
+  }
+
+  @Override
+  protected void after() {
+    try {
+      catalog.dropTable(TableIdentifier.of(database, tableName));
+      catalog.close();
+      tableLoader.close();
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to close catalog resource");
+    }
+  }
+
+  public TableLoader tableLoader() {
+    return tableLoader;
+  }
+
+  public Table table() {
+    return table;
+  }
+}

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestFixtures.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestFixtures.java
@@ -47,6 +47,17 @@ public class TestFixtures {
 
   public static final String DATABASE = "default";
   public static final String TABLE = "t";
+  public static final String SINK_TABLE = "t_sink";
 
   public static final TableIdentifier TABLE_IDENTIFIER = TableIdentifier.of(DATABASE, TABLE);
+
+  public static final Schema TS_SCHEMA = new Schema(
+      required(1, "ts", Types.TimestampType.withoutZone()),
+      required(2, "str", Types.StringType.get()));
+
+  public static final PartitionSpec TS_SPEC = PartitionSpec.builderFor(TS_SCHEMA)
+      .hour("ts")
+      .build();
+
+  public static final RowType TS_ROW_TYPE = FlinkSchemaUtil.convert(TS_SCHEMA);
 }

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/data/RowDataToRowMapper.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/data/RowDataToRowMapper.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.data;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.conversion.DataStructureConverter;
+import org.apache.flink.table.data.conversion.DataStructureConverters;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.utils.TypeConversions;
+import org.apache.flink.types.Row;
+
+public class RowDataToRowMapper extends RichMapFunction<RowData, Row> {
+
+  private final RowType rowType;
+
+  private transient DataStructureConverter<Object, Object> converter;
+
+  public RowDataToRowMapper(RowType rowType) {
+    this.rowType = rowType;
+  }
+
+  @Override
+  public void open(Configuration parameters) throws Exception {
+    this.converter = DataStructureConverters.getConverter(
+        TypeConversions.fromLogicalToDataType(rowType));
+  }
+
+  @Override
+  public Row map(RowData value) throws Exception {
+    return (Row) converter.toExternal(value);
+  }
+}

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/SplitHelpers.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/SplitHelpers.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.BaseCombinedScanTask;
+import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.GenericAppenderHelper;
+import org.apache.iceberg.data.RandomGenericData;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.flink.TestFixtures;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.Assert;
+import org.junit.rules.TemporaryFolder;
+
+public class SplitHelpers {
+
+  private static final AtomicLong splitLengthIncrement = new AtomicLong();
+
+  private SplitHelpers() {
+  }
+
+  /**
+   * This create a list of IcebergSourceSplit from real files
+   * <li>Create a new Hadoop table under the {@code temporaryFolder}
+   * <li>write {@code fileCount} number of files to the new Iceberg table
+   * <li>Discover the splits from the table and partition the splits by the {@code filePerSplit} limit
+   * <li>Delete the Hadoop table
+   *
+   * Since the table and data files are deleted before this method return,
+   * caller shouldn't attempt to read the data files.
+   */
+  public static List<IcebergSourceSplit> createSplitsFromTransientHadoopTable(
+      TemporaryFolder temporaryFolder, int fileCount, int filesPerSplit) throws Exception {
+    File warehouseFile = temporaryFolder.newFolder();
+    Assert.assertTrue(warehouseFile.delete());
+    String warehouse = "file:" + warehouseFile;
+    Configuration hadoopConf = new Configuration();
+    HadoopCatalog catalog = new HadoopCatalog(hadoopConf, warehouse);
+    try {
+      Table table = catalog.createTable(TestFixtures.TABLE_IDENTIFIER, TestFixtures.SCHEMA);
+      GenericAppenderHelper dataAppender = new GenericAppenderHelper(
+          table, FileFormat.PARQUET, temporaryFolder);
+      for (int i = 0; i < fileCount; ++i) {
+        List<Record> records = RandomGenericData.generate(TestFixtures.SCHEMA, 2, i);
+        dataAppender.appendToTable(records);
+      }
+
+      ScanContext scanContext = ScanContext.builder().build();
+      List<IcebergSourceSplit> splits = FlinkSplitPlanner.planIcebergSourceSplits(table, scanContext);
+      return splits.stream()
+          .flatMap(split -> {
+            List<List<FileScanTask>> filesList = Lists.partition(
+                Lists.newArrayList(split.task().files()), filesPerSplit);
+            return filesList.stream()
+                .map(files ->  new BaseCombinedScanTask(files))
+                .map(combinedScanTask -> IcebergSourceSplit.fromCombinedScanTask(combinedScanTask));
+          })
+          .collect(Collectors.toList());
+    } finally {
+      catalog.dropTable(TestFixtures.TABLE_IDENTIFIER);
+      catalog.close();
+    }
+  }
+
+  /**
+   * Split planning doesn't guarantee the order is the same as appended. To make it simpler
+   * to assert read and written records, this util sort the {@code FileScanTask} collection
+   * in IcebergSourceSplit to match the order files are written.
+   */
+  public static IcebergSourceSplit sortFilesAsAppendOrder(IcebergSourceSplit split, List<DataFile> dataFiles) {
+    Collection<FileScanTask> files = split.task().files();
+    Assert.assertEquals(files.size(), dataFiles.size());
+    FileScanTask[] sortedFileArray = new FileScanTask[files.size()];
+    for (FileScanTask fileScanTask : files) {
+      for (int i = 0; i < dataFiles.size(); ++i) {
+        if (fileScanTask.file().path().toString().equals(dataFiles.get(i).path().toString())) {
+          sortedFileArray[i] = fileScanTask;
+        }
+      }
+    }
+    List<FileScanTask> sortedFileList = Lists.newArrayList(sortedFileArray);
+    MatcherAssert.assertThat(sortedFileList, CoreMatchers.everyItem(CoreMatchers.notNullValue(FileScanTask.class)));
+    CombinedScanTask rearrangedCombinedTask = new BaseCombinedScanTask(sortedFileList);
+    return IcebergSourceSplit.fromCombinedScanTask(rearrangedCombinedTask);
+  }
+}

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkScan.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkScan.java
@@ -189,7 +189,7 @@ public abstract class TestFlinkScan {
   private void validateIdentityPartitionProjections(
       Table table, List<String> projectedFields, List<Record> inputRecords) throws Exception {
     List<Row> rows = runWithProjection(projectedFields.toArray(new String[0]));
-
+    Assert.assertEquals(inputRecords.size(), rows.size());
     for (int pos = 0; pos < inputRecords.size(); pos++) {
       Record inputRecord = inputRecords.get(pos);
       Row actualRecord = rows.get(pos);

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceBounded.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceBounded.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.TableColumn;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.flink.FlinkConfigOptions;
+import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.TestFixtures;
+import org.apache.iceberg.flink.data.RowDataToRowMapper;
+import org.apache.iceberg.flink.source.assigner.SimpleSplitAssignerFactory;
+import org.apache.iceberg.flink.source.reader.RowDataReaderFunction;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestIcebergSourceBounded extends TestFlinkScan {
+
+  public TestIcebergSourceBounded(String fileFormat) {
+    super(fileFormat);
+  }
+
+  @Override
+  protected List<Row> runWithProjection(String... projected) throws Exception {
+    Schema icebergTableSchema = catalog.loadTable(TestFixtures.TABLE_IDENTIFIER).schema();
+    TableSchema.Builder builder = TableSchema.builder();
+    TableSchema schema = FlinkSchemaUtil.toSchema(FlinkSchemaUtil.convert(icebergTableSchema));
+    for (String field : projected) {
+      TableColumn column = schema.getTableColumn(field).get();
+      builder.field(column.getName(), column.getType());
+    }
+    TableSchema flinkSchema = builder.build();
+    Schema projectedSchema = FlinkSchemaUtil.convert(icebergTableSchema, flinkSchema);
+    return run(projectedSchema, null, null);
+  }
+
+  @Override
+  protected List<Row> runWithFilter(Expression filter, String sqlFilter) throws Exception {
+    return run(null, Arrays.asList(filter), null);
+  }
+
+  @Override
+  protected List<Row> runWithOptions(Map<String, String> options) throws Exception {
+    return run(null, null, options);
+  }
+
+  @Override
+  protected List<Row> run() throws Exception {
+    return run(null, null, null);
+  }
+
+  private List<Row> run(Schema projectedSchema, List<Expression> filters,
+                        Map<String, String> options) throws Exception {
+
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    env.setParallelism(1);
+    Configuration config = new Configuration();
+    config.setInteger(FlinkConfigOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 128);
+    Table table;
+    try (TableLoader tableLoader = tableLoader()) {
+      tableLoader.open();
+      table = tableLoader.loadTable();
+    }
+
+    IcebergSource.Builder<RowData> sourceBuilder = IcebergSource.<RowData>builder()
+        .tableLoader(tableLoader())
+        .assignerFactory(new SimpleSplitAssignerFactory())
+        .readerFunction(new RowDataReaderFunction(config, table.schema(), projectedSchema,
+            null, false, table.io(), table.encryption()));
+    if (projectedSchema != null) {
+      sourceBuilder.project(projectedSchema);
+    }
+    if (filters != null) {
+      sourceBuilder.filters(filters);
+    }
+    if (options != null) {
+      sourceBuilder.properties(options);
+    }
+
+    DataStream<Row> stream = env.fromSource(
+        sourceBuilder.build(),
+        WatermarkStrategy.noWatermarks(),
+        "testBasicRead",
+        TypeInformation.of(RowData.class))
+        .map(new RowDataToRowMapper(FlinkSchemaUtil.convert(
+            projectedSchema == null ? table.schema() : projectedSchema)));
+
+    try (CloseableIterator<Row> iter = stream.executeAndCollect()) {
+      return Lists.newArrayList(iter);
+    }
+  }
+
+}

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceContinuous.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceContinuous.java
@@ -1,0 +1,353 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.client.JobStatusMessage;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.GenericAppenderHelper;
+import org.apache.iceberg.data.RandomGenericData;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.HadoopTableResource;
+import org.apache.iceberg.flink.MiniClusterResource;
+import org.apache.iceberg.flink.TestFixtures;
+import org.apache.iceberg.flink.TestHelpers;
+import org.apache.iceberg.flink.data.RowDataToRowMapper;
+import org.apache.iceberg.flink.source.assigner.SimpleSplitAssignerFactory;
+import org.apache.iceberg.flink.source.reader.RowDataReaderFunction;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestIcebergSourceContinuous {
+
+  @ClassRule
+  public static final MiniClusterWithClientResource MINI_CLUSTER_RESOURCE =
+      MiniClusterResource.createWithClassloaderCheckDisabled();
+
+  @ClassRule
+  public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+  @Rule
+  public final HadoopTableResource tableResource = new HadoopTableResource(TEMPORARY_FOLDER,
+      TestFixtures.DATABASE, TestFixtures.TABLE, TestFixtures.SCHEMA);
+
+  private final AtomicLong randomSeed = new AtomicLong(0L);
+
+  @Test
+  public void testTableScanThenIncremental() throws Exception {
+    GenericAppenderHelper dataAppender = new GenericAppenderHelper(
+        tableResource.table(), FileFormat.PARQUET, TEMPORARY_FOLDER);
+
+    // snapshot1
+    List<Record> batch1 = RandomGenericData.generate(
+        tableResource.table().schema(), 2, randomSeed.incrementAndGet());
+    dataAppender.appendToTable(batch1);
+
+    ScanContext scanContext = ScanContext.builder()
+        .streaming(true)
+        .monitorInterval(Duration.ofMillis(10L))
+        .startingStrategy(StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL)
+        .build();
+
+    try (CloseableIterator<Row> iter = createStream(scanContext).executeAndCollect(getClass().getSimpleName())) {
+      List<Row> result1 = waitForResult(iter, 2);
+      TestHelpers.assertRecords(result1, batch1, tableResource.table().schema());
+
+      // snapshot2
+      List<Record> batch2 = RandomGenericData.generate(
+          tableResource.table().schema(), 2, randomSeed.incrementAndGet());
+      dataAppender.appendToTable(batch2);
+      tableResource.table().currentSnapshot().snapshotId();
+
+      List<Row> result2 = waitForResult(iter, 2);
+      TestHelpers.assertRecords(result2, batch2, tableResource.table().schema());
+
+      // snapshot3
+      List<Record> batch3 = RandomGenericData.generate(
+          tableResource.table().schema(), 2, randomSeed.incrementAndGet());
+      dataAppender.appendToTable(batch3);
+      tableResource.table().currentSnapshot().snapshotId();
+
+      List<Row> result3 = waitForResult(iter, 2);
+      TestHelpers.assertRecords(result3, batch3, tableResource.table().schema());
+    }
+  }
+
+  @Test
+  public void testEarliestSnapshot() throws Exception {
+    GenericAppenderHelper dataAppender = new GenericAppenderHelper(
+        tableResource.table(), FileFormat.PARQUET, TEMPORARY_FOLDER);
+
+    // snapshot0
+    List<Record> batch0 = RandomGenericData.generate(
+        tableResource.table().schema(), 2, randomSeed.incrementAndGet());
+    dataAppender.appendToTable(batch0);
+
+    // snapshot1
+    List<Record> batch1 = RandomGenericData.generate(
+        tableResource.table().schema(), 2, randomSeed.incrementAndGet());
+    dataAppender.appendToTable(batch1);
+
+    ScanContext scanContext = ScanContext.builder()
+        .streaming(true)
+        .monitorInterval(Duration.ofMillis(10L))
+        .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_EARLIEST_SNAPSHOT)
+        .build();
+
+    try (CloseableIterator<Row> iter = createStream(scanContext).executeAndCollect(getClass().getSimpleName())) {
+      List<Row> result1 = waitForResult(iter, 4);
+      List<Record> combinedBatch0AndBatch1 = Lists.newArrayList(batch0);
+      combinedBatch0AndBatch1.addAll(batch1);
+      TestHelpers.assertRecords(result1, combinedBatch0AndBatch1, tableResource.table().schema());
+
+      // snapshot2
+      List<Record> batch2 = RandomGenericData.generate(
+          tableResource.table().schema(), 2, randomSeed.incrementAndGet());
+      dataAppender.appendToTable(batch2);
+
+      List<Row> result2 = waitForResult(iter, 2);
+      TestHelpers.assertRecords(result2, batch2, tableResource.table().schema());
+
+      // snapshot3
+      List<Record> batch3 = RandomGenericData.generate(
+          tableResource.table().schema(), 2, randomSeed.incrementAndGet());
+      dataAppender.appendToTable(batch3);
+
+      List<Row> result3 = waitForResult(iter, 2);
+      TestHelpers.assertRecords(result3, batch3, tableResource.table().schema());
+    }
+  }
+
+  @Test
+  public void testLatestSnapshot() throws Exception {
+    GenericAppenderHelper dataAppender = new GenericAppenderHelper(
+        tableResource.table(), FileFormat.PARQUET, TEMPORARY_FOLDER);
+
+    // snapshot0
+    List<Record> batch0 = RandomGenericData.generate(
+        tableResource.table().schema(), 2, randomSeed.incrementAndGet());
+    dataAppender.appendToTable(batch0);
+
+    // snapshot1
+    List<Record> batch1 = RandomGenericData.generate(
+        tableResource.table().schema(), 2, randomSeed.incrementAndGet());
+    dataAppender.appendToTable(batch1);
+
+    ScanContext scanContext = ScanContext.builder()
+        .streaming(true)
+        .monitorInterval(Duration.ofMillis(10L))
+        .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_LATEST_SNAPSHOT)
+        .build();
+
+    try (CloseableIterator<Row> iter = createStream(scanContext).executeAndCollect(getClass().getSimpleName())) {
+      // we want to make sure job is running first so that enumerator can
+      // start from the latest snapshot before inserting the next batch2 below.
+      waitUntilJobIsRunning(MINI_CLUSTER_RESOURCE.getClusterClient());
+
+      // inclusive behavior for starting snapshot
+      List<Row> result1 = waitForResult(iter, 2);
+      TestHelpers.assertRecords(result1, batch1, tableResource.table().schema());
+
+      // snapshot2
+      List<Record> batch2 = RandomGenericData.generate(
+          tableResource.table().schema(), 2, randomSeed.incrementAndGet());
+      dataAppender.appendToTable(batch2);
+
+      List<Row> result2 = waitForResult(iter, 2);
+      TestHelpers.assertRecords(result2, batch2, tableResource.table().schema());
+
+      // snapshot3
+      List<Record> batch3 = RandomGenericData.generate(
+          tableResource.table().schema(), 2, randomSeed.incrementAndGet());
+      dataAppender.appendToTable(batch3);
+
+      List<Row> result3 = waitForResult(iter, 2);
+      TestHelpers.assertRecords(result3, batch3, tableResource.table().schema());
+    }
+  }
+
+  @Test
+  public void testSpecificSnapshotId() throws Exception {
+    GenericAppenderHelper dataAppender = new GenericAppenderHelper(
+        tableResource.table(), FileFormat.PARQUET, TEMPORARY_FOLDER);
+
+    // snapshot0
+    List<Record> batch0 = RandomGenericData.generate(
+        tableResource.table().schema(), 2, randomSeed.incrementAndGet());
+    dataAppender.appendToTable(batch0);
+    long snapshot0 = tableResource.table().currentSnapshot().snapshotId();
+
+    // snapshot1
+    List<Record> batch1 = RandomGenericData.generate(
+        tableResource.table().schema(), 2, randomSeed.incrementAndGet());
+    dataAppender.appendToTable(batch1);
+    long snapshot1 = tableResource.table().currentSnapshot().snapshotId();
+
+    ScanContext scanContext = ScanContext.builder()
+        .streaming(true)
+        .monitorInterval(Duration.ofMillis(10L))
+        .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_ID)
+        .startSnapshotId(snapshot1)
+        .build();
+
+    try (CloseableIterator<Row> iter = createStream(scanContext).executeAndCollect(getClass().getSimpleName())) {
+      List<Row> result1 = waitForResult(iter, 2);
+      TestHelpers.assertRecords(result1, batch1, tableResource.table().schema());
+
+      // snapshot2
+      List<Record> batch2 = RandomGenericData.generate(
+          tableResource.table().schema(), 2, randomSeed.incrementAndGet());
+      dataAppender.appendToTable(batch2);
+
+      List<Row> result2 = waitForResult(iter, 2);
+      TestHelpers.assertRecords(result2, batch2, tableResource.table().schema());
+
+      // snapshot3
+      List<Record> batch3 = RandomGenericData.generate(
+          tableResource.table().schema(), 2, randomSeed.incrementAndGet());
+      dataAppender.appendToTable(batch3);
+
+      List<Row> result3 = waitForResult(iter, 2);
+      TestHelpers.assertRecords(result3, batch3, tableResource.table().schema());
+    }
+  }
+
+  @Test
+  public void testSpecificSnapshotTimestamp() throws Exception {
+    GenericAppenderHelper dataAppender = new GenericAppenderHelper(
+        tableResource.table(), FileFormat.PARQUET, TEMPORARY_FOLDER);
+
+    // snapshot0
+    List<Record> batch0 = RandomGenericData.generate(
+        tableResource.table().schema(), 2, randomSeed.incrementAndGet());
+    dataAppender.appendToTable(batch0);
+    long snapshot0Timestamp = tableResource.table().currentSnapshot().timestampMillis();
+
+    // sleep for 2 ms to make sure snapshot1 has a higher timestamp value
+    Thread.sleep(2);
+
+    // snapshot1
+    List<Record> batch1 = RandomGenericData.generate(
+        tableResource.table().schema(), 2, randomSeed.incrementAndGet());
+    dataAppender.appendToTable(batch1);
+    long snapshot1Timestamp = tableResource.table().currentSnapshot().timestampMillis();
+
+    ScanContext scanContext = ScanContext.builder()
+        .streaming(true)
+        .monitorInterval(Duration.ofMillis(10L))
+        .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_TIMESTAMP)
+        .startSnapshotTimestamp(snapshot1Timestamp)
+        .build();
+
+    try (CloseableIterator<Row> iter = createStream(scanContext).executeAndCollect(getClass().getSimpleName())) {
+      // consume data from snapshot1
+      List<Row> result1 = waitForResult(iter, 2);
+      TestHelpers.assertRecords(result1, batch1, tableResource.table().schema());
+
+      // snapshot2
+      List<Record> batch2 = RandomGenericData.generate(
+          tableResource.table().schema(), 2, randomSeed.incrementAndGet());
+      dataAppender.appendToTable(batch2);
+
+      List<Row> result2 = waitForResult(iter, 2);
+      TestHelpers.assertRecords(result2, batch2, tableResource.table().schema());
+
+      // snapshot3
+      List<Record> batch3 = RandomGenericData.generate(
+          tableResource.table().schema(), 2, randomSeed.incrementAndGet());
+      dataAppender.appendToTable(batch3);
+
+      List<Row> result3 = waitForResult(iter, 2);
+      TestHelpers.assertRecords(result3, batch3, tableResource.table().schema());
+    }
+  }
+
+  private DataStream<Row> createStream(ScanContext scanContext) throws Exception {
+    Table table = tableResource.table();
+    Configuration config = new Configuration();
+    // start the source and collect output
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    env.setParallelism(1);
+    DataStream<Row> stream = env.fromSource(
+        IcebergSource.<RowData>builder()
+            .tableLoader(tableResource.tableLoader())
+            .assignerFactory(new SimpleSplitAssignerFactory())
+            .readerFunction(new RowDataReaderFunction(config, table.schema(), null,
+                null, false, table.io(), table.encryption()))
+            .streaming(scanContext.isStreaming())
+            .startingStrategy(scanContext.startingStrategy())
+            .startSnapshotTimestamp(scanContext.startSnapshotTimestamp())
+            .startSnapshotId(scanContext.startSnapshotId())
+            .monitorInterval(Duration.ofMillis(10L))
+            .build(),
+        WatermarkStrategy.noWatermarks(),
+        "icebergSource",
+        TypeInformation.of(RowData.class))
+        .map(new RowDataToRowMapper(FlinkSchemaUtil.convert(tableResource.table().schema())));
+    return stream;
+  }
+
+  public static List<Row> waitForResult(CloseableIterator<Row> iter, int limit) {
+    List<Row> results = Lists.newArrayListWithCapacity(limit);
+    while (results.size() < limit) {
+      if (iter.hasNext()) {
+        results.add(iter.next());
+      } else {
+        break;
+      }
+    }
+    return results;
+  }
+
+  public static void waitUntilJobIsRunning(ClusterClient<?> client) throws Exception {
+    while (getRunningJobs(client).isEmpty()) {
+      Thread.sleep(10);
+    }
+  }
+
+  public static List<JobID> getRunningJobs(ClusterClient<?> client) throws Exception {
+    Collection<JobStatusMessage> statusMessages = client.listJobs().get();
+    return statusMessages.stream()
+        .filter(status -> status.getJobState() == JobStatus.RUNNING)
+        .map(JobStatusMessage::getJobId)
+        .collect(Collectors.toList());
+  }
+}

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceFailover.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceFailover.java
@@ -1,0 +1,299 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.runtime.highavailability.nonha.embedded.HaLeadershipControl;
+import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.minicluster.RpcServiceSharing;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.GenericAppenderHelper;
+import org.apache.iceberg.data.RandomGenericData;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.flink.FlinkConfigOptions;
+import org.apache.iceberg.flink.HadoopTableResource;
+import org.apache.iceberg.flink.SimpleDataUtil;
+import org.apache.iceberg.flink.TestFixtures;
+import org.apache.iceberg.flink.sink.FlinkSink;
+import org.apache.iceberg.flink.source.assigner.SimpleSplitAssignerFactory;
+import org.apache.iceberg.flink.source.reader.RowDataReaderFunction;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestIcebergSourceFailover {
+
+  private static final int PARALLELISM = 4;
+
+  @ClassRule
+  public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+
+  @Rule
+  public final MiniClusterWithClientResource miniClusterResource =
+      new MiniClusterWithClientResource(
+          new MiniClusterResourceConfiguration.Builder()
+              .setNumberTaskManagers(1)
+              .setNumberSlotsPerTaskManager(PARALLELISM)
+              .setRpcServiceSharing(RpcServiceSharing.DEDICATED)
+              .withHaLeadershipControl()
+              .build());
+
+  @Rule
+  public final HadoopTableResource sourceTableResource = new HadoopTableResource(TEMPORARY_FOLDER,
+      TestFixtures.DATABASE, TestFixtures.TABLE, schema());
+
+  @Rule
+  public final HadoopTableResource sinkTableResource = new HadoopTableResource(TEMPORARY_FOLDER,
+      TestFixtures.DATABASE, TestFixtures.SINK_TABLE, schema());
+
+  protected IcebergSource.Builder<RowData> sourceBuilder() {
+    Table sourceTable = sourceTableResource.table();
+    Configuration config = new Configuration();
+    config.setInteger(FlinkConfigOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 128);
+    return IcebergSource.<RowData>builder()
+        .tableLoader(sourceTableResource.tableLoader())
+        .assignerFactory(new SimpleSplitAssignerFactory())
+        .readerFunction(new RowDataReaderFunction(config, sourceTable.schema(), null,
+            null, false, sourceTable.io(), sourceTable.encryption()));
+  }
+
+  protected Schema schema() {
+    return TestFixtures.SCHEMA;
+  }
+
+  protected List<Record> generateRecords(int numRecords, long seed) {
+    return RandomGenericData.generate(schema(), numRecords, seed);
+  }
+
+  protected void assertRecords(Table table, List<Record> expectedRecords, Duration interval, int maxCount)
+      throws Exception {
+    SimpleDataUtil.assertTableRecords(table,
+        expectedRecords, interval, maxCount);
+  }
+
+  @Test
+  public void testBoundedWithTaskManagerFailover() throws Exception {
+    testBoundedIcebergSource(FailoverType.TM);
+  }
+
+  @Test
+  public void testBoundedWithJobManagerFailover() throws Exception {
+    testBoundedIcebergSource(FailoverType.JM);
+  }
+
+  private void testBoundedIcebergSource(FailoverType failoverType) throws Exception {
+    List<Record> expectedRecords = Lists.newArrayList();
+    GenericAppenderHelper dataAppender = new GenericAppenderHelper(
+        sourceTableResource.table(), FileFormat.PARQUET, TEMPORARY_FOLDER);
+    for (int i = 0; i < 4; ++i) {
+      List<Record> records = generateRecords(2, i);
+      expectedRecords.addAll(records);
+      dataAppender.appendToTable(records);
+    }
+
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    env.setParallelism(PARALLELISM);
+    env.setRestartStrategy(RestartStrategies.fixedDelayRestart(1, 0));
+
+    DataStream<RowData> stream = env.fromSource(
+        sourceBuilder().build(),
+        WatermarkStrategy.noWatermarks(),
+        "IcebergSource",
+        TypeInformation.of(RowData.class));
+
+    DataStream<RowData> streamFailingInTheMiddleOfReading =
+        RecordCounterToFail.wrapWithFailureAfter(stream, expectedRecords.size() / 2);
+
+    // CollectStreamSink from DataStream#executeAndCollect() doesn't guarantee
+    // exactly-once behavior. When Iceberg sink, we can verify end-to-end
+    // exactly-once. Here we mainly about source exactly-once behavior.
+    FlinkSink.forRowData(streamFailingInTheMiddleOfReading)
+        .table(sinkTableResource.table())
+        .tableLoader(sinkTableResource.tableLoader())
+        .append();
+
+    JobClient jobClient = env.executeAsync("Bounded Iceberg Source Failover Test");
+    JobID jobId = jobClient.getJobID();
+
+    RecordCounterToFail.waitToFail();
+    triggerFailover(
+        failoverType,
+        jobId,
+        RecordCounterToFail::continueProcessing,
+        miniClusterResource.getMiniCluster());
+
+    assertRecords(sinkTableResource.table(), expectedRecords, Duration.ofMillis(10), 12000);
+  }
+
+  @Test
+  public void testContinuousWithTaskManagerFailover() throws Exception {
+    testContinuousIcebergSource(FailoverType.TM);
+  }
+
+  @Test
+  public void testContinuousWithJobManagerFailover() throws Exception {
+    testContinuousIcebergSource(FailoverType.JM);
+  }
+
+  private void testContinuousIcebergSource(FailoverType failoverType) throws Exception {
+    GenericAppenderHelper dataAppender = new GenericAppenderHelper(
+        sourceTableResource.table(), FileFormat.PARQUET, TEMPORARY_FOLDER);
+    List<Record> expectedRecords = Lists.newArrayList();
+
+    List<Record> batch = generateRecords(2, 0);
+    expectedRecords.addAll(batch);
+    dataAppender.appendToTable(batch);
+
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    env.setParallelism(PARALLELISM);
+    env.enableCheckpointing(10L);
+    Configuration config = new Configuration();
+    config.setInteger(FlinkConfigOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 128);
+
+    DataStream<RowData> stream = env.fromSource(
+        sourceBuilder()
+            .streaming(true)
+            .monitorInterval(Duration.ofMillis(10))
+            .startingStrategy(StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL)
+            .build(),
+        WatermarkStrategy.noWatermarks(),
+        "IcebergSource",
+        TypeInformation.of(RowData.class));
+
+    // CollectStreamSink from DataStream#executeAndCollect() doesn't guarantee
+    // exactly-once behavior. When Iceberg sink, we can verify end-to-end
+    // exactly-once. Here we mainly about source exactly-once behavior.
+    FlinkSink.forRowData(stream)
+        .table(sinkTableResource.table())
+        .tableLoader(sinkTableResource.tableLoader())
+        .append();
+
+    JobClient jobClient = env.executeAsync("Continuous Iceberg Source Failover Test");
+    JobID jobId = jobClient.getJobID();
+
+    for (int i = 1; i < 5; i++) {
+      Thread.sleep(10);
+      List<Record> records = generateRecords(2, i);
+      expectedRecords.addAll(records);
+      dataAppender.appendToTable(records);
+      if (i == 2) {
+        triggerFailover(failoverType, jobId, () -> {
+        }, miniClusterResource.getMiniCluster());
+      }
+    }
+
+    // wait longer for continuous source to reduce flakiness
+    // because CI servers tend to be overloaded.
+    assertRecords(sinkTableResource.table(), expectedRecords, Duration.ofMillis(10), 12000);
+  }
+
+  // ------------------------------------------------------------------------
+  // test utilities copied from Flink's FileSourceTextLinesITCase
+  // ------------------------------------------------------------------------
+
+  private enum FailoverType {
+    NONE,
+    TM,
+    JM
+  }
+
+  private static void triggerFailover(
+      FailoverType type, JobID jobId, Runnable afterFailAction, MiniCluster miniCluster)
+      throws Exception {
+    switch (type) {
+      case NONE:
+        afterFailAction.run();
+        break;
+      case TM:
+        restartTaskManager(afterFailAction, miniCluster);
+        break;
+      case JM:
+        triggerJobManagerFailover(jobId, afterFailAction, miniCluster);
+        break;
+    }
+  }
+
+  private static void triggerJobManagerFailover(
+      JobID jobId, Runnable afterFailAction, MiniCluster miniCluster) throws Exception {
+    HaLeadershipControl haLeadershipControl = miniCluster.getHaLeadershipControl().get();
+    haLeadershipControl.revokeJobMasterLeadership(jobId).get();
+    afterFailAction.run();
+    haLeadershipControl.grantJobMasterLeadership(jobId).get();
+  }
+
+  private static void restartTaskManager(Runnable afterFailAction, MiniCluster miniCluster)
+      throws Exception {
+    miniCluster.terminateTaskManager(0).get();
+    afterFailAction.run();
+    miniCluster.startTaskManager();
+  }
+
+  private static class RecordCounterToFail {
+
+    private static AtomicInteger records;
+    private static CompletableFuture<Void> fail;
+    private static CompletableFuture<Void> continueProcessing;
+
+    private static <T> DataStream<T> wrapWithFailureAfter(DataStream<T> stream, int failAfter) {
+
+      records = new AtomicInteger();
+      fail = new CompletableFuture<>();
+      continueProcessing = new CompletableFuture<>();
+      return stream.map(
+          record -> {
+            boolean reachedFailPoint = records.incrementAndGet() > failAfter;
+            boolean notFailedYet = !fail.isDone();
+            if (notFailedYet && reachedFailPoint) {
+              fail.complete(null);
+              continueProcessing.get();
+            }
+            return record;
+          });
+    }
+
+    private static void waitToFail() throws ExecutionException, InterruptedException {
+      fail.get();
+    }
+
+    private static void continueProcessing() {
+      continueProcessing.complete(null);
+    }
+  }
+}

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceFailoverEventTimeAlignedAssinger.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceFailoverEventTimeAlignedAssinger.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source;
+
+import java.io.Serializable;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import org.apache.flink.api.common.eventtime.TimestampAssigner;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.RowData;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.RandomGenericData;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.flink.FlinkConfigOptions;
+import org.apache.iceberg.flink.SimpleDataUtil;
+import org.apache.iceberg.flink.TestFixtures;
+import org.apache.iceberg.flink.source.assigner.ordered.ClockFactory;
+import org.apache.iceberg.flink.source.assigner.ordered.EventTimeAlignmentAssignerFactory;
+import org.apache.iceberg.flink.source.assigner.ordered.InMemoryGlobalWatermarkTrackerFactory;
+import org.apache.iceberg.flink.source.reader.RowDataReaderFunction;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.types.Comparators;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.StructLikeWrapper;
+import org.junit.Ignore;
+
+/**
+ * This is ignored because testContinuousWithJobManagerFailover is flaky.
+ * Maybe there is a bug in the EventTimeAlignmentAssigner, as we didn't see
+ * the same flaky problem for the base class TestIcebergSourceFailover.
+ */
+@Ignore
+public class TestIcebergSourceFailoverEventTimeAlignedAssinger extends TestIcebergSourceFailover {
+  // increment ts by 60 minutes for each generateRecords batch
+  private static final long RECORD_BATCH_TS_INCREMENT_MILLI = TimeUnit.MINUTES.toMillis(15);
+  // Within a batch, increment ts by 1 minute
+  private static final long RECORD_TS_INCREMENT_MILLI = TimeUnit.SECONDS.toMillis(1);
+  // max out-of-orderliness threshold is 30 minutes
+  private static final Duration MAX_OUT_OF_ORDERLINESS_THRESHOLD_DURATION = Duration.ofMinutes(15);
+
+  private final AtomicLong tsMilli = new AtomicLong(System.currentTimeMillis());
+
+  @Override
+  protected IcebergSource.Builder<RowData> sourceBuilder() {
+    Table sourceTable = sourceTableResource.table();
+    Configuration config = new Configuration();
+    config.setInteger(FlinkConfigOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 128);
+    return IcebergSource.<RowData>builder()
+        .tableLoader(sourceTableResource.tableLoader())
+        .assignerFactory(new EventTimeAlignmentAssignerFactory(
+            TestFixtures.TABLE,
+            MAX_OUT_OF_ORDERLINESS_THRESHOLD_DURATION,
+            (ClockFactory) () -> Clock.systemUTC(),
+            new InMemoryGlobalWatermarkTrackerFactory(),
+            new IcebergSourceSplitTimeAssigner(TestFixtures.TS_SCHEMA, "ts")))
+        .readerFunction(new RowDataReaderFunction(config, sourceTable.schema(), null,
+            null, false, sourceTable.io(), sourceTable.encryption()))
+        .project(TestFixtures.TS_SCHEMA)
+        .includeColumnStats(true)
+        // essentially force one file per CombinedScanTask from split planning
+        .splitOpenFileCost(256 * 1024 * 1024L);
+  }
+
+  @Override
+  protected Schema schema() {
+    return TestFixtures.TS_SCHEMA;
+  }
+
+  @Override
+  protected List<Record> generateRecords(int numRecords, long seed) {
+    // Override the ts field to create a more realistic situation for event time alignment
+    tsMilli.addAndGet(RECORD_BATCH_TS_INCREMENT_MILLI);
+    return RandomGenericData.generate(schema(), numRecords, seed)
+        .stream()
+        .map(record -> {
+          LocalDateTime ts = LocalDateTime.ofInstant(
+              Instant.ofEpochMilli(tsMilli.addAndGet(RECORD_TS_INCREMENT_MILLI)), ZoneId.of("Z"));
+          record.setField("ts", ts);
+          return record;
+        })
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * This override is needed because {@link Comparators} used by {@link StructLikeWrapper}
+   * retrieves Timestamp type using Long type as inner class, while the {@link RandomGenericData}
+   * generates {@link LocalDateTime} for {@code TimestampType.withoutZone()}.
+   * This method normalizes the {@link LocalDateTime} to a Long type so that
+   * Comparators can continue to work.
+   */
+  @Override
+  protected void assertRecords(Table table, List<Record> expectedRecords, Duration interval, int maxCount)
+      throws Exception {
+    List<Record> expectedNormalized = convertTimestampField(expectedRecords);
+    for (int i = 0; i < maxCount; ++i) {
+      if (SimpleDataUtil.equalsRecords(expectedNormalized,
+          convertTimestampField(SimpleDataUtil.tableRecords(table)), table.schema())) {
+        break;
+      } else {
+        Thread.sleep(interval.toMillis());
+      }
+    }
+    SimpleDataUtil.assertRecordsEqual(expectedNormalized,
+        convertTimestampField(SimpleDataUtil.tableRecords(table)), table.schema());
+  }
+
+  private List<Record> convertTimestampField(List<Record> records) {
+    return records.stream()
+        .map(r -> {
+          LocalDateTime localDateTime = ((LocalDateTime) r.getField("ts"));
+          r.setField("ts", localDateTime.atZone(ZoneOffset.UTC).toInstant().toEpochMilli());
+          return r;
+        })
+        .collect(Collectors.toList());
+  }
+
+  private static class IcebergSourceSplitTimeAssigner implements Serializable, TimestampAssigner<IcebergSourceSplit> {
+    private final int tsFieldId;
+
+    IcebergSourceSplitTimeAssigner(Schema schema, String tsFieldName) {
+      this.tsFieldId = schema.findField(tsFieldName).fieldId();
+    }
+
+    @Override
+    public long extractTimestamp(IcebergSourceSplit split, long recordTimestamp) {
+      return split.task().files().stream()
+          .map(scanTask -> (long) Conversions.fromByteBuffer(
+              Types.LongType.get(), scanTask.file().lowerBounds().get(tsFieldId)) / 1000L)
+          .min(Comparator.comparingLong(l -> l))
+          .get();
+    }
+  }
+}

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceReaderDeletes.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceReaderDeletes.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.util.CloseableIterator;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.flink.CatalogLoader;
+import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.RowDataWrapper;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.source.assigner.SimpleSplitAssignerFactory;
+import org.apache.iceberg.flink.source.reader.RowDataReaderFunction;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.StructLikeSet;
+import org.junit.ClassRule;
+import org.junit.rules.TemporaryFolder;
+
+public class TestIcebergSourceReaderDeletes extends TestFlinkReaderDeletesBase {
+
+  private static final int PARALLELISM = 4;
+
+  @ClassRule
+  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+
+  @ClassRule
+  public static final MiniClusterWithClientResource MINI_CLUSTER = new MiniClusterWithClientResource(
+      new MiniClusterResourceConfiguration.Builder()
+          .setNumberTaskManagers(1)
+          .setNumberSlotsPerTaskManager(PARALLELISM)
+          .build());
+
+  public TestIcebergSourceReaderDeletes(FileFormat inputFormat) {
+    super(inputFormat);
+  }
+
+  @Override
+  protected StructLikeSet rowSet(String tableName, Table testTable, String... columns) throws IOException {
+    Schema projected = testTable.schema().select(columns);
+    RowType rowType = FlinkSchemaUtil.convert(projected);
+
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(CatalogProperties.WAREHOUSE_LOCATION, hiveConf.get(HiveConf.ConfVars.METASTOREWAREHOUSE.varname));
+    properties.put(CatalogProperties.URI, hiveConf.get(HiveConf.ConfVars.METASTOREURIS.varname));
+    properties.put(CatalogProperties.CLIENT_POOL_SIZE,
+        Integer.toString(hiveConf.getInt("iceberg.hive.client-pool-size", 5)));
+    CatalogLoader hiveCatalogLoader = CatalogLoader.hive(catalog.name(), hiveConf, properties);
+    TableLoader hiveTableLoader = TableLoader.fromCatalog(hiveCatalogLoader, TableIdentifier.of("default", tableName));
+    hiveTableLoader.open();
+    try (TableLoader tableLoader = hiveTableLoader) {
+      Configuration config = new Configuration();
+      Table table = tableLoader.loadTable();
+      StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+      env.setParallelism(1);
+      DataStream<RowData> stream = env.fromSource(
+          IcebergSource.<RowData>builder()
+              .tableLoader(tableLoader)
+              .assignerFactory(new SimpleSplitAssignerFactory())
+              .readerFunction(new RowDataReaderFunction(config, table.schema(), projected,
+                  null, false, table.io(), table.encryption()))
+              .project(projected)
+              .build(),
+          WatermarkStrategy.noWatermarks(),
+          "testBasicRead",
+          TypeInformation.of(RowData.class));
+
+      try (CloseableIterator<RowData> iter = stream.executeAndCollect()) {
+        List<RowData> rowDataList = Lists.newArrayList(iter);
+        StructLikeSet set = StructLikeSet.create(projected.asStruct());
+        rowDataList.forEach(rowData -> {
+          RowDataWrapper wrapper = new RowDataWrapper(rowType, projected.asStruct());
+          set.add(wrapper.wrap(rowData));
+        });
+        return set;
+      } catch (Exception e) {
+        throw new IOException("Failed to collect result", e);
+      }
+    }
+  }
+
+}

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingReaderOperator.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingReaderOperator.java
@@ -254,7 +254,7 @@ public class TestStreamingReaderOperator extends TableTestBase {
             .build();
       }
 
-      Collections.addAll(inputSplits, FlinkSplitGenerator.createInputSplits(table, scanContext));
+      Collections.addAll(inputSplits, FlinkSplitPlanner.planInputSplits(table, scanContext));
     }
 
     return inputSplits;

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/assigner/TestSimpleSplitAssigner.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/assigner/TestSimpleSplitAssigner.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.assigner;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.iceberg.flink.source.SplitHelpers;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplitState;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestSimpleSplitAssigner {
+  @ClassRule
+  public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+  @Test
+  public void testEmptyInitialization() {
+    SimpleSplitAssigner assigner = new SimpleSplitAssigner();
+    assertGetNext(assigner, GetSplitResult.Status.UNAVAILABLE);
+  }
+
+  /**
+   * Test a sequence of interactions for StaticEnumerator
+   */
+  @Test
+  public void testStaticEnumeratorSequence() throws Exception {
+    SimpleSplitAssigner assigner = new SimpleSplitAssigner();
+    assigner.onDiscoveredSplits(SplitHelpers.createSplitsFromTransientHadoopTable(
+        TEMPORARY_FOLDER, 4, 2));
+
+    assertGetNext(assigner, GetSplitResult.Status.AVAILABLE);
+    assertSnapshot(assigner, 1);
+    assigner.onUnassignedSplits(SplitHelpers.createSplitsFromTransientHadoopTable(
+        TEMPORARY_FOLDER, 1, 1));
+    assertSnapshot(assigner, 2);
+
+    assertGetNext(assigner, GetSplitResult.Status.AVAILABLE);
+    assertGetNext(assigner, GetSplitResult.Status.AVAILABLE);
+    assertGetNext(assigner, GetSplitResult.Status.UNAVAILABLE);
+    assertSnapshot(assigner, 0);
+  }
+
+  /**
+   * Test a sequence of interactions for ContinuousEnumerator
+   */
+  @Test
+  public void testContinuousEnumeratorSequence() throws Exception {
+    SimpleSplitAssigner assigner = new SimpleSplitAssigner();
+    assertGetNext(assigner, GetSplitResult.Status.UNAVAILABLE);
+
+    List<IcebergSourceSplit> splits1 = SplitHelpers.createSplitsFromTransientHadoopTable(TEMPORARY_FOLDER, 1, 1);
+    assertAvailableFuture(assigner, 1, () -> assigner.onDiscoveredSplits(splits1));
+    List<IcebergSourceSplit> splits2 = SplitHelpers.createSplitsFromTransientHadoopTable(TEMPORARY_FOLDER, 1, 1);
+    assertAvailableFuture(assigner, 1, () -> assigner.onUnassignedSplits(splits2));
+
+    assigner.onDiscoveredSplits(SplitHelpers.createSplitsFromTransientHadoopTable(TEMPORARY_FOLDER, 2, 1));
+    assertSnapshot(assigner, 2);
+    assertGetNext(assigner, GetSplitResult.Status.AVAILABLE);
+    assertGetNext(assigner, GetSplitResult.Status.AVAILABLE);
+    assertGetNext(assigner, GetSplitResult.Status.UNAVAILABLE);
+    assertSnapshot(assigner, 0);
+  }
+
+  private void assertAvailableFuture(SimpleSplitAssigner assigner, int splitCount, Runnable addSplitsRunnable) {
+    // register callback
+    AtomicBoolean futureCompleted = new AtomicBoolean();
+    CompletableFuture<Void> future = assigner.isAvailable();
+    future.thenAccept(ignored -> futureCompleted.set(true));
+    // calling isAvailable again should return the same object reference
+    // note that thenAccept will return a new future.
+    // we want to assert the same instance on the assigner returned future
+    Assert.assertSame(future, assigner.isAvailable());
+
+    // now add some splits
+    addSplitsRunnable.run();
+    Assert.assertEquals(true, futureCompleted.get());
+
+    for (int i = 0; i < splitCount; ++i) {
+      assertGetNext(assigner, GetSplitResult.Status.AVAILABLE);
+    }
+    assertGetNext(assigner, GetSplitResult.Status.UNAVAILABLE);
+    assertSnapshot(assigner, 0);
+  }
+
+  private void assertGetNext(SimpleSplitAssigner assigner, GetSplitResult.Status expectedStatus) {
+    GetSplitResult result = assigner.getNext(null);
+    Assert.assertEquals(expectedStatus, result.status());
+    switch (expectedStatus) {
+      case AVAILABLE:
+        Assert.assertNotNull(result.split());
+        break;
+      case CONSTRAINED:
+      case UNAVAILABLE:
+        Assert.assertNull(result.split());
+        break;
+      default:
+        Assert.fail("Unknown status: " + expectedStatus);
+    }
+  }
+
+  private void assertSnapshot(SimpleSplitAssigner assigner, int splitCount) {
+    Collection<IcebergSourceSplitState> stateBeforeGet = assigner.state();
+    Assert.assertEquals(splitCount, stateBeforeGet.size());
+  }
+}

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/ManualContinuousSplitPlanner.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/ManualContinuousSplitPlanner.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.enumerator;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.List;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+class ManualContinuousSplitPlanner implements ContinuousSplitPlanner {
+  private final ArrayDeque<IcebergSourceSplit> splits = new ArrayDeque<>();
+  private IcebergEnumeratorPosition latestPosition;
+
+  @Override
+  public ContinuousEnumerationResult planSplits(IcebergEnumeratorPosition lastPosition) {
+    ContinuousEnumerationResult result = new ContinuousEnumerationResult(
+        Lists.newArrayList(splits), lastPosition, latestPosition);
+    return result;
+  }
+
+  /**
+   * Add new splits to the collection
+   */
+  public void addSplits(List<IcebergSourceSplit> newSplits, IcebergEnumeratorPosition newPosition) {
+    splits.addAll(newSplits);
+    this.latestPosition = newPosition;
+  }
+
+  /**
+   * Clear the splits collection
+   */
+  public void clearSplits() {
+    splits.clear();
+  }
+
+  @Override
+  public void close() throws IOException {
+  }
+}

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousIcebergEnumerator.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousIcebergEnumerator.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.enumerator;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.connector.testutils.source.reader.TestingSplitEnumeratorContext;
+import org.apache.iceberg.flink.source.ScanContext;
+import org.apache.iceberg.flink.source.SplitHelpers;
+import org.apache.iceberg.flink.source.StreamingStartingStrategy;
+import org.apache.iceberg.flink.source.assigner.SimpleSplitAssigner;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplitState;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplitStatus;
+import org.apache.iceberg.flink.source.split.SplitRequestEvent;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestContinuousIcebergEnumerator {
+  @ClassRule
+  public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+  @Test
+  public void testDiscoverSplitWhenNoReaderRegistered() throws Exception {
+    ManualContinuousSplitPlanner splitPlanner = new ManualContinuousSplitPlanner();
+    TestingSplitEnumeratorContext<IcebergSourceSplit> enumeratorContext =
+        new TestingSplitEnumeratorContext<>(4);
+    ScanContext scanContext = ScanContext.builder()
+        .streaming(true)
+        .startingStrategy(StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL)
+        .build();
+    ContinuousIcebergEnumerator enumerator = createEnumerator(enumeratorContext, scanContext, splitPlanner);
+
+    Collection<IcebergSourceSplitState> pendingSplitsEmpty = enumerator.snapshotState(1).pendingSplits();
+    Assert.assertEquals(0, pendingSplitsEmpty.size());
+
+    // make one split available and trigger the periodic discovery
+    List<IcebergSourceSplit> splits = SplitHelpers
+        .createSplitsFromTransientHadoopTable(TEMPORARY_FOLDER, 1, 1);
+    splitPlanner.addSplits(splits, IcebergEnumeratorPosition.of(1L, 1L));
+    enumeratorContext.triggerAllActions();
+
+    Collection<IcebergSourceSplitState> pendingSplits = enumerator.snapshotState(2).pendingSplits();
+    Assert.assertEquals(1, pendingSplits.size());
+    IcebergSourceSplitState pendingSplit = pendingSplits.iterator().next();
+    Assert.assertEquals(splits.get(0).splitId(), pendingSplit.split().splitId());
+    Assert.assertEquals(IcebergSourceSplitStatus.UNASSIGNED, pendingSplit.status());
+  }
+
+  @Test
+  public void testDiscoverWhenReaderRegistered() throws Exception {
+    ManualContinuousSplitPlanner splitPlanner = new ManualContinuousSplitPlanner();
+    TestingSplitEnumeratorContext<IcebergSourceSplit> enumeratorContext =
+        new TestingSplitEnumeratorContext<>(4);
+    ScanContext scanContext = ScanContext.builder()
+        .streaming(true)
+        .startingStrategy(StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL)
+        .build();
+    ContinuousIcebergEnumerator enumerator = createEnumerator(enumeratorContext, scanContext, splitPlanner);
+
+    // register one reader, and let it request a split
+    enumeratorContext.registerReader(2, "localhost");
+    enumerator.addReader(2);
+    enumerator.handleSourceEvent(2,
+        new SplitRequestEvent());
+
+    // make one split available and trigger the periodic discovery
+    List<IcebergSourceSplit> splits = SplitHelpers
+        .createSplitsFromTransientHadoopTable(TEMPORARY_FOLDER, 1, 1);
+    splitPlanner.addSplits(splits, IcebergEnumeratorPosition.of(1L, 1L));
+    enumeratorContext.triggerAllActions();
+
+    Assert.assertTrue(enumerator.snapshotState(1).pendingSplits().isEmpty());
+    MatcherAssert.assertThat(enumeratorContext.getSplitAssignments().get(2).getAssignedSplits(),
+        CoreMatchers.hasItem(splits.get(0)));
+  }
+
+  @Test
+  public void testRequestingReaderUnavailableWhenSplitDiscovered() throws Exception {
+    ManualContinuousSplitPlanner splitPlanner = new ManualContinuousSplitPlanner();
+    TestingSplitEnumeratorContext<IcebergSourceSplit> enumeratorContext =
+        new TestingSplitEnumeratorContext<>(4);
+    ScanContext config = ScanContext.builder()
+        .streaming(true)
+        .startingStrategy(StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL)
+        .build();
+    ContinuousIcebergEnumerator enumerator = createEnumerator(enumeratorContext, config, splitPlanner);
+
+    // register one reader, and let it request a split
+    enumeratorContext.registerReader(2, "localhost");
+    enumerator.addReader(2);
+    enumerator.handleSourceEvent(2,
+        new SplitRequestEvent());
+
+    // remove the reader (like in a failure)
+    enumeratorContext.registeredReaders().remove(2);
+
+    // make one split available and trigger the periodic discovery
+    List<IcebergSourceSplit> splits = SplitHelpers
+        .createSplitsFromTransientHadoopTable(TEMPORARY_FOLDER, 1, 1);
+    Assert.assertEquals(1, splits.size());
+    splitPlanner.addSplits(splits, IcebergEnumeratorPosition.of(1L, 1L));
+    enumeratorContext.triggerAllActions();
+
+    Assert.assertFalse(enumeratorContext.getSplitAssignments().containsKey(2));
+    List<String> pendingSplitIds = enumerator.snapshotState(1).pendingSplits().stream()
+        .map(IcebergSourceSplitState::split)
+        .map(IcebergSourceSplit::splitId)
+        .collect(Collectors.toList());
+    Assert.assertEquals(splits.size(), pendingSplitIds.size());
+    Assert.assertEquals(splits.get(0).splitId(), pendingSplitIds.get(0));
+
+    // register the reader again, and let it request a split
+    enumeratorContext.registerReader(2, "localhost");
+    enumerator.addReader(2);
+    enumerator.handleSourceEvent(2,
+        new SplitRequestEvent());
+
+    Assert.assertTrue(enumerator.snapshotState(2).pendingSplits().isEmpty());
+    MatcherAssert.assertThat(enumeratorContext.getSplitAssignments().get(2).getAssignedSplits(),
+        CoreMatchers.hasItem(splits.get(0)));
+  }
+
+  private static ContinuousIcebergEnumerator createEnumerator(
+      SplitEnumeratorContext<IcebergSourceSplit> context,
+      ScanContext scanContext,
+      ContinuousSplitPlanner splitPlanner) {
+
+    ContinuousIcebergEnumerator enumerator =
+        new ContinuousIcebergEnumerator(
+            context,
+            new SimpleSplitAssigner(Collections.emptyList()),
+            scanContext,
+            splitPlanner,
+            null);
+    enumerator.start();
+    return enumerator;
+  }
+
+}

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
@@ -1,0 +1,461 @@
+flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.enumerator;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.data.GenericAppenderHelper;
+import org.apache.iceberg.data.RandomGenericData;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.flink.HadoopTableResource;
+import org.apache.iceberg.flink.TestFixtures;
+import org.apache.iceberg.flink.source.ScanContext;
+import org.apache.iceberg.flink.source.StreamingStartingStrategy;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.joda.time.format.DateTimeFormat;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
+
+public class TestContinuousSplitPlannerImpl {
+  @ClassRule
+  public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+  private static final FileFormat fileFormat = FileFormat.PARQUET;
+  private static final AtomicLong randomSeed = new AtomicLong();
+
+  @Rule
+  public final HadoopTableResource tableResource = new HadoopTableResource(TEMPORARY_FOLDER,
+      TestFixtures.DATABASE, TestFixtures.TABLE, TestFixtures.SCHEMA);
+
+  @Rule
+  public TestName testName = new TestName();
+
+  private GenericAppenderHelper dataAppender;
+  private DataFile dataFile1;
+  private Snapshot snapshot1;
+  private DataFile dataFile2;
+  private Snapshot snapshot2;
+
+  @Before
+  public void before() throws IOException {
+    dataAppender = new GenericAppenderHelper(tableResource.table(), fileFormat, TEMPORARY_FOLDER);
+  }
+
+  private void appendTwoSnapshots() throws IOException {
+    // snapshot1
+    List<Record> batch1 = RandomGenericData.generate(TestFixtures.SCHEMA, 2, 0L);
+    dataFile1 = dataAppender.writeFile(null, batch1);
+    dataAppender.appendToTable(dataFile1);
+    snapshot1 = tableResource.table().currentSnapshot();
+
+    // snapshot2
+    List<Record> batch2 = RandomGenericData.generate(TestFixtures.SCHEMA, 2, 1L);
+    dataFile2 = dataAppender.writeFile(null, batch2);
+    dataAppender.appendToTable(dataFile2);
+    snapshot2 = tableResource.table().currentSnapshot();
+  }
+
+  /**
+   * @return the last enumerated snapshot id
+   */
+  private IcebergEnumeratorPosition verifyOneCycle(
+      ContinuousSplitPlannerImpl splitPlanner, IcebergEnumeratorPosition lastPosition) throws Exception {
+    List<Record> batch = RandomGenericData.generate(TestFixtures.SCHEMA, 2, randomSeed.incrementAndGet());
+    DataFile dataFile = dataAppender.writeFile(null, batch);
+    dataAppender.appendToTable(dataFile);
+    Snapshot snapshot = tableResource.table().currentSnapshot();
+
+    ContinuousEnumerationResult result = splitPlanner.planSplits(lastPosition);
+    Assert.assertEquals(lastPosition.snapshotId(), result.fromPosition().snapshotId());
+    Assert.assertEquals(lastPosition.snapshotTimestampMs(), result.fromPosition().snapshotTimestampMs());
+    Assert.assertEquals(snapshot.snapshotId(), result.toPosition().snapshotId().longValue());
+    Assert.assertEquals(snapshot.timestampMillis(), result.toPosition().snapshotTimestampMs().longValue());
+    Assert.assertEquals(1, result.splits().size());
+    IcebergSourceSplit split = result.splits().iterator().next();
+    Assert.assertEquals(1, split.task().files().size());
+    Assert.assertEquals(dataFile.path().toString(), split.task().files().iterator().next().file().path().toString());
+    return result.toPosition();
+  }
+
+  @Test
+  public void testTableScanThenIncrementalWithEmptyTable() throws Exception {
+    ScanContext scanContext = ScanContext.builder()
+        .startingStrategy(StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL)
+        .build();
+    ContinuousSplitPlannerImpl splitPlanner = new ContinuousSplitPlannerImpl(
+        tableResource.table(), scanContext, null);
+
+    ContinuousEnumerationResult emptyTableInitialDiscoveryResult = splitPlanner.planSplits(null);
+    Assert.assertTrue(emptyTableInitialDiscoveryResult.splits().isEmpty());
+    Assert.assertNull(emptyTableInitialDiscoveryResult.fromPosition());
+    Assert.assertNull(emptyTableInitialDiscoveryResult.toPosition().snapshotId());
+    Assert.assertNull(emptyTableInitialDiscoveryResult.toPosition().snapshotTimestampMs());
+
+    ContinuousEnumerationResult emptyTableSecondDiscoveryResult = splitPlanner
+        .planSplits(emptyTableInitialDiscoveryResult.toPosition());
+    Assert.assertTrue(emptyTableSecondDiscoveryResult.splits().isEmpty());
+    Assert.assertNull(emptyTableSecondDiscoveryResult.fromPosition().snapshotId());
+    Assert.assertNull(emptyTableSecondDiscoveryResult.fromPosition().snapshotTimestampMs());
+    Assert.assertNull(emptyTableSecondDiscoveryResult.toPosition().snapshotId());
+    Assert.assertNull(emptyTableSecondDiscoveryResult.toPosition().snapshotTimestampMs());
+
+    // next 3 snapshots
+    IcebergEnumeratorPosition lastPosition = emptyTableSecondDiscoveryResult.toPosition();
+    for (int i = 0; i < 3; ++i) {
+      lastPosition = verifyOneCycle(splitPlanner, lastPosition);
+    }
+  }
+
+  @Test
+  public void testTableScanThenIncrementalWithNonEmptyTable() throws Exception {
+    appendTwoSnapshots();
+
+    ScanContext scanContext = ScanContext.builder()
+        .startingStrategy(StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL)
+        .build();
+    ContinuousSplitPlannerImpl splitPlanner = new ContinuousSplitPlannerImpl(
+        tableResource.table(), scanContext, null);
+
+    ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
+    Assert.assertNull(initialResult.fromPosition());
+    Assert.assertEquals(snapshot2.snapshotId(), initialResult.toPosition().snapshotId().longValue());
+    Assert.assertEquals(snapshot2.timestampMillis(), initialResult.toPosition().snapshotTimestampMs().longValue());
+    Assert.assertEquals(1, initialResult.splits().size());
+    IcebergSourceSplit split = initialResult.splits().iterator().next();
+    Assert.assertEquals(2, split.task().files().size());
+    Set<String> discoveredFiles = split.task().files().stream()
+        .map(fileScanTask -> fileScanTask.file().path().toString())
+        .collect(Collectors.toSet());
+    Set<String> expectedFiles = ImmutableSet.of(dataFile1.path().toString(), dataFile2.path().toString());
+    Assert.assertEquals(expectedFiles, discoveredFiles);
+
+    IcebergEnumeratorPosition lastPosition = initialResult.toPosition();
+    for (int i = 0; i < 3; ++i) {
+      lastPosition = verifyOneCycle(splitPlanner, lastPosition);
+    }
+  }
+
+  @Test
+  public void testIncrementalFromLatestSnapshotWithEmptyTable() throws Exception {
+    ScanContext scanContext = ScanContext.builder()
+        .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_LATEST_SNAPSHOT)
+        .splitSize(1L)
+        .build();
+    ContinuousSplitPlannerImpl splitPlanner = new ContinuousSplitPlannerImpl(
+        tableResource.table(), scanContext, null);
+
+    ContinuousEnumerationResult emptyTableInitialDiscoveryResult = splitPlanner.planSplits(null);
+    Assert.assertTrue(emptyTableInitialDiscoveryResult.splits().isEmpty());
+    Assert.assertNull(emptyTableInitialDiscoveryResult.fromPosition());
+    Assert.assertNull(emptyTableInitialDiscoveryResult.toPosition().snapshotId());
+    Assert.assertNull(emptyTableInitialDiscoveryResult.toPosition().snapshotTimestampMs());
+
+    ContinuousEnumerationResult emptyTableSecondDiscoveryResult = splitPlanner
+        .planSplits(emptyTableInitialDiscoveryResult.toPosition());
+    Assert.assertTrue(emptyTableSecondDiscoveryResult.splits().isEmpty());
+    Assert.assertNull(emptyTableSecondDiscoveryResult.fromPosition().snapshotId());
+    Assert.assertNull(emptyTableSecondDiscoveryResult.fromPosition().snapshotTimestampMs());
+    Assert.assertNull(emptyTableSecondDiscoveryResult.toPosition().snapshotId());
+    Assert.assertNull(emptyTableSecondDiscoveryResult.toPosition().snapshotTimestampMs());
+
+    // latest mode should discover both snapshots, as latest position is marked by when job starts
+    appendTwoSnapshots();
+    ContinuousEnumerationResult afterTwoSnapshotsAppended = splitPlanner
+        .planSplits(emptyTableSecondDiscoveryResult.toPosition());
+    Assert.assertEquals(2, afterTwoSnapshotsAppended.splits().size());
+
+    // next 3 snapshots
+    IcebergEnumeratorPosition lastPosition = afterTwoSnapshotsAppended.toPosition();
+    for (int i = 0; i < 3; ++i) {
+      lastPosition = verifyOneCycle(splitPlanner, lastPosition);
+    }
+  }
+
+  @Test
+  public void testIncrementalFromLatestSnapshotWithNonEmptyTable() throws Exception {
+    appendTwoSnapshots();
+
+    ScanContext scanContext = ScanContext.builder()
+        .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_LATEST_SNAPSHOT)
+        .build();
+    ContinuousSplitPlannerImpl splitPlanner = new ContinuousSplitPlannerImpl(
+        tableResource.table(), scanContext, null);
+
+    ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
+    Assert.assertNull(initialResult.fromPosition());
+    // For inclusive behavior, the initial result should point to snapshot1
+    // Then the next incremental scan shall discover files from latest snapshot2 (inclusive)
+    Assert.assertEquals(snapshot1.snapshotId(), initialResult.toPosition().snapshotId().longValue());
+    Assert.assertEquals(snapshot1.timestampMillis(), initialResult.toPosition().snapshotTimestampMs().longValue());
+    Assert.assertEquals(0, initialResult.splits().size());
+
+    ContinuousEnumerationResult secondResult = splitPlanner.planSplits(initialResult.toPosition());
+    Assert.assertEquals(snapshot1.snapshotId(), secondResult.fromPosition().snapshotId().longValue());
+    Assert.assertEquals(snapshot1.timestampMillis(), secondResult.fromPosition().snapshotTimestampMs().longValue());
+    Assert.assertEquals(snapshot2.snapshotId(), secondResult.toPosition().snapshotId().longValue());
+    Assert.assertEquals(snapshot2.timestampMillis(), secondResult.toPosition().snapshotTimestampMs().longValue());
+    IcebergSourceSplit split = secondResult.splits().iterator().next();
+    Assert.assertEquals(1, split.task().files().size());
+    Set<String> discoveredFiles = split.task().files().stream()
+        .map(fileScanTask -> fileScanTask.file().path().toString())
+        .collect(Collectors.toSet());
+    // should discover dataFile2 appended in snapshot2
+    Set<String> expectedFiles = ImmutableSet.of(dataFile2.path().toString());
+    Assert.assertEquals(expectedFiles, discoveredFiles);
+
+    IcebergEnumeratorPosition lastPosition = secondResult.toPosition();
+    for (int i = 0; i < 3; ++i) {
+      lastPosition = verifyOneCycle(splitPlanner, lastPosition);
+    }
+  }
+
+  @Test
+  public void testIncrementalFromEarliestSnapshotWithEmptyTable() throws Exception {
+    ScanContext scanContext = ScanContext.builder()
+        .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_EARLIEST_SNAPSHOT)
+        .build();
+    ContinuousSplitPlannerImpl splitPlanner = new ContinuousSplitPlannerImpl(
+        tableResource.table(), scanContext, null);
+
+    ContinuousEnumerationResult emptyTableInitialDiscoveryResult = splitPlanner.planSplits(null);
+    Assert.assertTrue(emptyTableInitialDiscoveryResult.splits().isEmpty());
+    Assert.assertNull(emptyTableInitialDiscoveryResult.fromPosition());
+    Assert.assertNull(emptyTableInitialDiscoveryResult.toPosition().snapshotId());
+    Assert.assertNull(emptyTableInitialDiscoveryResult.toPosition().snapshotTimestampMs());
+
+    ContinuousEnumerationResult emptyTableSecondDiscoveryResult = splitPlanner
+        .planSplits(emptyTableInitialDiscoveryResult.toPosition());
+    Assert.assertTrue(emptyTableSecondDiscoveryResult.splits().isEmpty());
+    Assert.assertNull(emptyTableSecondDiscoveryResult.fromPosition().snapshotId());
+    Assert.assertNull(emptyTableSecondDiscoveryResult.fromPosition().snapshotTimestampMs());
+    Assert.assertNull(emptyTableSecondDiscoveryResult.toPosition().snapshotId());
+    Assert.assertNull(emptyTableSecondDiscoveryResult.toPosition().snapshotTimestampMs());
+
+    // next 3 snapshots
+    IcebergEnumeratorPosition lastPosition = emptyTableSecondDiscoveryResult.toPosition();
+    for (int i = 0; i < 3; ++i) {
+      lastPosition = verifyOneCycle(splitPlanner, lastPosition);
+    }
+  }
+
+  @Test
+  public void testIncrementalFromEarliestSnapshotWithNonEmptyTable() throws Exception {
+    appendTwoSnapshots();
+
+    ScanContext scanContext = ScanContext.builder()
+        .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_EARLIEST_SNAPSHOT)
+        .build();
+    ContinuousSplitPlannerImpl splitPlanner = new ContinuousSplitPlannerImpl(
+        tableResource.table(), scanContext, null);
+
+    ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
+    Assert.assertNull(initialResult.fromPosition());
+    // For inclusive behavior, the initial result should point to snapshot1's parent,
+    // which leads to null snapshotId and snapshotTimestampMs.
+    Assert.assertNull(initialResult.toPosition().snapshotId());
+    Assert.assertNull(initialResult.toPosition().snapshotTimestampMs());
+    Assert.assertEquals(0, initialResult.splits().size());
+
+    ContinuousEnumerationResult secondResult = splitPlanner.planSplits(initialResult.toPosition());
+    Assert.assertNull(secondResult.fromPosition().snapshotId());
+    Assert.assertNull(secondResult.fromPosition().snapshotTimestampMs());
+    Assert.assertEquals(snapshot2.snapshotId(), secondResult.toPosition().snapshotId().longValue());
+    Assert.assertEquals(snapshot2.timestampMillis(), secondResult.toPosition().snapshotTimestampMs().longValue());
+    IcebergSourceSplit split = secondResult.splits().iterator().next();
+    Assert.assertEquals(2, split.task().files().size());
+    Set<String> discoveredFiles = split.task().files().stream()
+        .map(fileScanTask -> fileScanTask.file().path().toString())
+        .collect(Collectors.toSet());
+    // should discover files appended in both snapshot1 and snapshot2
+    Set<String> expectedFiles = ImmutableSet.of(dataFile1.path().toString(), dataFile2.path().toString());
+    Assert.assertEquals(expectedFiles, discoveredFiles);
+
+    IcebergEnumeratorPosition lastPosition = secondResult.toPosition();
+    for (int i = 0; i < 3; ++i) {
+      lastPosition = verifyOneCycle(splitPlanner, lastPosition);
+    }
+  }
+
+  @Test
+  public void testIncrementalFromSnapshotIdWithEmptyTable() throws Exception {
+    ScanContext scanContextWithInvalidSnapshotId = ScanContext.builder()
+        .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_ID)
+        .startSnapshotId(1L)
+        .build();
+    ContinuousSplitPlannerImpl splitPlanner = new ContinuousSplitPlannerImpl(
+        tableResource.table(), scanContextWithInvalidSnapshotId, null);
+
+    AssertHelpers.assertThrows("Should detect invalid starting snapshot id",
+        IllegalArgumentException.class,
+        "Start snapshot id not found in history: 1",
+        () -> splitPlanner.planSplits(null));
+  }
+
+  @Test
+  public void testIncrementalFromSnapshotIdWithInvalidIds() throws Exception {
+    appendTwoSnapshots();
+
+    // find an invalid snapshotId
+    long invalidSnapshotId = 0L;
+    while (invalidSnapshotId == snapshot1.snapshotId() || invalidSnapshotId == snapshot2.snapshotId()) {
+      invalidSnapshotId++;
+    }
+
+    ScanContext scanContextWithInvalidSnapshotId = ScanContext.builder()
+        .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_ID)
+        .startSnapshotId(invalidSnapshotId)
+        .build();
+
+    ContinuousSplitPlannerImpl splitPlanner = new ContinuousSplitPlannerImpl(
+        tableResource.table(), scanContextWithInvalidSnapshotId, null);
+
+    AssertHelpers.assertThrows("Should detect invalid starting snapshot id",
+        IllegalArgumentException.class,
+        "Start snapshot id not found in history: " + invalidSnapshotId,
+        () -> splitPlanner.planSplits(null));
+  }
+
+  @Test
+  public void testIncrementalFromSnapshotId() throws Exception {
+    appendTwoSnapshots();
+
+    ScanContext scanContext = ScanContext.builder()
+        .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_ID)
+        .startSnapshotId(snapshot2.snapshotId())
+        .build();
+    ContinuousSplitPlannerImpl splitPlanner = new ContinuousSplitPlannerImpl(
+        tableResource.table(), scanContext, null);
+
+    ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
+    Assert.assertNull(initialResult.fromPosition());
+    // For inclusive behavior of snapshot2, the initial result should point to snapshot1 (as snapshot2's parent)
+    Assert.assertEquals(snapshot1.snapshotId(), initialResult.toPosition().snapshotId().longValue());
+    Assert.assertEquals(snapshot1.timestampMillis(), initialResult.toPosition().snapshotTimestampMs().longValue());
+    Assert.assertEquals(0, initialResult.splits().size());
+
+    ContinuousEnumerationResult secondResult = splitPlanner.planSplits(initialResult.toPosition());
+    Assert.assertEquals(snapshot1.snapshotId(), secondResult.fromPosition().snapshotId().longValue());
+    Assert.assertEquals(snapshot1.timestampMillis(), secondResult.fromPosition().snapshotTimestampMs().longValue());
+    Assert.assertEquals(snapshot2.snapshotId(), secondResult.toPosition().snapshotId().longValue());
+    Assert.assertEquals(snapshot2.timestampMillis(), secondResult.toPosition().snapshotTimestampMs().longValue());
+    IcebergSourceSplit split = secondResult.splits().iterator().next();
+    Assert.assertEquals(1, split.task().files().size());
+    Set<String> discoveredFiles = split.task().files().stream()
+        .map(fileScanTask -> fileScanTask.file().path().toString())
+        .collect(Collectors.toSet());
+    // should  discover dataFile2 appended in snapshot2
+    Set<String> expectedFiles = ImmutableSet.of(dataFile2.path().toString());
+    Assert.assertEquals(expectedFiles, discoveredFiles);
+
+    IcebergEnumeratorPosition lastPosition = secondResult.toPosition();
+    for (int i = 0; i < 3; ++i) {
+      lastPosition = verifyOneCycle(splitPlanner, lastPosition);
+    }
+  }
+
+  @Test
+  public void testIncrementalFromSnapshotTimestampWithEmptyTable() throws Exception {
+    ScanContext scanContextWithInvalidSnapshotId = ScanContext.builder()
+        .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_TIMESTAMP)
+        .startSnapshotTimestamp(1L)
+        .build();
+    ContinuousSplitPlannerImpl splitPlanner = new ContinuousSplitPlannerImpl(
+        tableResource.table(), scanContextWithInvalidSnapshotId, null);
+
+    AssertHelpers.assertThrows("Should detect invalid starting snapshot timestamp",
+        IllegalArgumentException.class,
+        "Cannot find a snapshot older than 1970-01-01 00:00:00.001",
+        () -> splitPlanner.planSplits(null));
+  }
+
+  @Test
+  public void testIncrementalFromSnapshotTimestampWithInvalidIds() throws Exception {
+    appendTwoSnapshots();
+
+    long invalidSnapshotTimestampMs = snapshot1.timestampMillis() - 1000L;
+    String invalidSnapshotTimestampMsStr = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSS")
+        .withZoneUTC()
+        .print(invalidSnapshotTimestampMs);
+
+    ScanContext scanContextWithInvalidSnapshotId = ScanContext.builder()
+        .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_TIMESTAMP)
+        .startSnapshotTimestamp(invalidSnapshotTimestampMs)
+        .build();
+
+    ContinuousSplitPlannerImpl splitPlanner = new ContinuousSplitPlannerImpl(
+        tableResource.table(), scanContextWithInvalidSnapshotId, null);
+
+    AssertHelpers.assertThrows("Should detect invalid starting snapshot timestamp",
+        IllegalArgumentException.class,
+        "Cannot find a snapshot older than " + invalidSnapshotTimestampMsStr,
+        () -> splitPlanner.planSplits(null));
+  }
+
+  @Test
+  public void testIncrementalFromSnapshotTimestamp() throws Exception {
+    appendTwoSnapshots();
+
+    ScanContext scanContext = ScanContext.builder()
+        .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_TIMESTAMP)
+        .startSnapshotTimestamp(snapshot2.timestampMillis())
+        .build();
+    ContinuousSplitPlannerImpl splitPlanner = new ContinuousSplitPlannerImpl(
+        tableResource.table(), scanContext, null);
+
+    ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
+    Assert.assertNull(initialResult.fromPosition());
+    // For inclusive behavior, the initial result should point to snapshot1 (as snapshot2's parent).
+    Assert.assertEquals(snapshot1.snapshotId(), initialResult.toPosition().snapshotId().longValue());
+    Assert.assertEquals(snapshot1.timestampMillis(), initialResult.toPosition().snapshotTimestampMs().longValue());
+    Assert.assertEquals(0, initialResult.splits().size());
+
+    ContinuousEnumerationResult secondResult = splitPlanner.planSplits(initialResult.toPosition());
+    Assert.assertEquals(snapshot1.snapshotId(), secondResult.fromPosition().snapshotId().longValue());
+    Assert.assertEquals(snapshot1.timestampMillis(), secondResult.fromPosition().snapshotTimestampMs().longValue());
+    Assert.assertEquals(snapshot2.snapshotId(), secondResult.toPosition().snapshotId().longValue());
+    Assert.assertEquals(snapshot2.timestampMillis(), secondResult.toPosition().snapshotTimestampMs().longValue());
+    IcebergSourceSplit split = secondResult.splits().iterator().next();
+    Assert.assertEquals(1, split.task().files().size());
+    Set<String> discoveredFiles = split.task().files().stream()
+        .map(fileScanTask -> fileScanTask.file().path().toString())
+        .collect(Collectors.toSet());
+    // should discover dataFile2 appended in snapshot2
+    Set<String> expectedFiles = ImmutableSet.of(dataFile2.path().toString());
+    Assert.assertEquals(expectedFiles, discoveredFiles);
+
+    IcebergEnumeratorPosition lastPosition = secondResult.toPosition();
+    for (int i = 0; i < 3; ++i) {
+      lastPosition = verifyOneCycle(splitPlanner, lastPosition);
+    }
+  }
+}

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImplStartStrategy.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImplStartStrategy.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.enumerator;
+
+import java.io.IOException;
+import java.util.List;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.data.GenericAppenderHelper;
+import org.apache.iceberg.data.RandomGenericData;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.flink.HadoopTableResource;
+import org.apache.iceberg.flink.TestFixtures;
+import org.apache.iceberg.flink.source.ScanContext;
+import org.apache.iceberg.flink.source.StreamingStartingStrategy;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
+
+public class TestContinuousSplitPlannerImplStartStrategy {
+  private static final FileFormat FILE_FORMAT = FileFormat.PARQUET;
+
+  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  public final HadoopTableResource tableResource = new HadoopTableResource(temporaryFolder,
+      TestFixtures.DATABASE, TestFixtures.TABLE, TestFixtures.SCHEMA);
+  @Rule
+  public final TestRule chain = RuleChain
+      .outerRule(temporaryFolder)
+      .around(tableResource);
+
+  private GenericAppenderHelper dataAppender;
+  private Snapshot snapshot1;
+  private Snapshot snapshot2;
+  private Snapshot snapshot3;
+
+  @Before
+  public void before() throws IOException {
+    dataAppender = new GenericAppenderHelper(tableResource.table(), FILE_FORMAT, temporaryFolder);
+  }
+
+  private void appendThreeSnapshots() throws IOException {
+    List<Record> batch1 = RandomGenericData.generate(TestFixtures.SCHEMA, 2, 0L);
+    dataAppender.appendToTable(batch1);
+    snapshot1 = tableResource.table().currentSnapshot();
+
+    List<Record> batch2 = RandomGenericData.generate(TestFixtures.SCHEMA, 2, 1L);
+    dataAppender.appendToTable(batch2);
+    snapshot2 = tableResource.table().currentSnapshot();
+
+    List<Record> batch3 = RandomGenericData.generate(TestFixtures.SCHEMA, 2, 2L);
+    dataAppender.appendToTable(batch3);
+    snapshot3 = tableResource.table().currentSnapshot();
+  }
+
+  @Test
+  public void testTableScanThenIncrementalStrategy()  throws IOException {
+    ScanContext scanContext = ScanContext.builder()
+        .streaming(true)
+        .startingStrategy(StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL)
+        .build();
+
+    // emtpy table
+    Assert.assertFalse(ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContext).isPresent());
+
+    appendThreeSnapshots();
+    Snapshot startSnapshot = ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContext).get();
+    Assert.assertEquals(snapshot3.snapshotId(), startSnapshot.snapshotId());
+  }
+
+  @Test
+  public void testForLatestSnapshotStrategy() throws IOException {
+    ScanContext scanContext = ScanContext.builder()
+        .streaming(true)
+        .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_LATEST_SNAPSHOT)
+        .build();
+
+    // emtpy table
+    Assert.assertFalse(ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContext).isPresent());
+
+    appendThreeSnapshots();
+    Snapshot startSnapshot = ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContext).get();
+    Assert.assertEquals(snapshot3.snapshotId(), startSnapshot.snapshotId());
+  }
+
+  @Test
+  public void testForEarliestSnapshotStrategy() throws IOException {
+    ScanContext scanContext = ScanContext.builder()
+        .streaming(true)
+        .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_EARLIEST_SNAPSHOT)
+        .build();
+
+    // emtpy table
+    Assert.assertFalse(ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContext).isPresent());
+
+    appendThreeSnapshots();
+    Snapshot startSnapshot = ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContext).get();
+    Assert.assertEquals(snapshot1.snapshotId(), startSnapshot.snapshotId());
+  }
+
+  @Test
+  public void testForSpecificSnapshotIdStrategy() throws IOException {
+    ScanContext scanContextInvalidSnapshotId = ScanContext.builder()
+        .streaming(true)
+        .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_ID)
+        .startSnapshotId(1L)
+        .build();
+
+    // emtpy table
+    AssertHelpers.assertThrows("Should detect invalid starting snapshot id",
+        IllegalArgumentException.class,
+        "Start snapshot id not found in history: 1",
+        () -> ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContextInvalidSnapshotId));
+
+    appendThreeSnapshots();
+
+    ScanContext scanContext = ScanContext.builder()
+        .streaming(true)
+        .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_ID)
+        .startSnapshotId(snapshot2.snapshotId())
+        .build();
+
+    Snapshot startSnapshot = ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContext).get();
+    Assert.assertEquals(snapshot2.snapshotId(), startSnapshot.snapshotId());
+  }
+
+  @Test
+  public void testForSpecificSnapshotTimestampStrategySnapshot2() throws IOException {
+    ScanContext scanContextInvalidSnapshotTimestamp = ScanContext.builder()
+        .streaming(true)
+        .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_TIMESTAMP)
+        .startSnapshotTimestamp(1L)
+        .build();
+
+    // emtpy table
+    AssertHelpers.assertThrows("Should detect invalid starting snapshot timestamp",
+        IllegalArgumentException.class,
+        "Cannot find a snapshot older than 1970-01-01 00:00:00.001",
+        () -> ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContextInvalidSnapshotTimestamp));
+
+    appendThreeSnapshots();
+
+    ScanContext scanContext = ScanContext.builder()
+        .streaming(true)
+        .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_TIMESTAMP)
+        .startSnapshotTimestamp(snapshot2.timestampMillis())
+        .build();
+
+    Snapshot startSnapshot = ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), scanContext).get();
+    Assert.assertEquals(snapshot2.snapshotId(), startSnapshot.snapshotId());
+  }
+
+  @Test
+  public void testForSpecificSnapshotTimestampStrategySnapshot2Minus1() throws IOException {
+    appendThreeSnapshots();
+
+    ScanContext config = ScanContext.builder()
+        .streaming(true)
+        .startingStrategy(StreamingStartingStrategy.INCREMENTAL_FROM_SNAPSHOT_TIMESTAMP)
+        .startSnapshotTimestamp(snapshot2.timestampMillis() - 1L)
+        .build();
+
+    Snapshot startSnapshot = ContinuousSplitPlannerImpl.startSnapshot(tableResource.table(), config).get();
+    Assert.assertEquals(snapshot2.snapshotId(), startSnapshot.snapshotId());
+  }
+}

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestIcebergEnumeratorStateSerializer.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestIcebergEnumeratorStateSerializer.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.enumerator;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import org.apache.iceberg.flink.source.SplitHelpers;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplitState;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplitStatus;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestIcebergEnumeratorStateSerializer {
+  @ClassRule
+  public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+  private final IcebergEnumeratorStateSerializer serializer = IcebergEnumeratorStateSerializer.INSTANCE;
+
+  @Test
+  public void testEmptySnapshotIdAndPendingSplits() throws Exception {
+    IcebergEnumeratorState enumeratorState = new IcebergEnumeratorState(Collections.emptyList());
+    byte[] result = serializer.serialize(enumeratorState);
+    IcebergEnumeratorState deserialized = serializer.deserialize(serializer.getVersion(), result);
+    assertEnumeratorStateEquals(enumeratorState, deserialized);
+  }
+
+  @Test
+  public void testSomeSnapshotIdAndEmptyPendingSplits() throws Exception {
+    IcebergEnumeratorPosition position = IcebergEnumeratorPosition.of(1L, System.currentTimeMillis());
+    IcebergEnumeratorState enumeratorState = new IcebergEnumeratorState(position, Collections.emptyList());
+    byte[] result = serializer.serialize(enumeratorState);
+    IcebergEnumeratorState deserialized = serializer.deserialize(serializer.getVersion(), result);
+    assertEnumeratorStateEquals(enumeratorState, deserialized);
+  }
+
+  @Test
+  public void testSomeSnapshotIdAndPendingSplits() throws Exception {
+    IcebergEnumeratorPosition position = IcebergEnumeratorPosition.of(2L, System.currentTimeMillis());
+    List<IcebergSourceSplit> splits = SplitHelpers
+        .createSplitsFromTransientHadoopTable(TEMPORARY_FOLDER, 3, 1);
+    Collection<IcebergSourceSplitState> pendingSplits = Lists.newArrayList();
+    pendingSplits.add(new IcebergSourceSplitState(splits.get(0), IcebergSourceSplitStatus.UNASSIGNED));
+    pendingSplits.add(new IcebergSourceSplitState(splits.get(1), IcebergSourceSplitStatus.ASSIGNED));
+    pendingSplits.add(new IcebergSourceSplitState(splits.get(2), IcebergSourceSplitStatus.COMPLETED));
+
+    IcebergEnumeratorState enumeratorState = new IcebergEnumeratorState(position, pendingSplits);
+    byte[] result = serializer.serialize(enumeratorState);
+    IcebergEnumeratorState deserialized = serializer.deserialize(serializer.getVersion(), result);
+    assertEnumeratorStateEquals(enumeratorState, deserialized);
+  }
+
+  private void assertEnumeratorStateEquals(IcebergEnumeratorState expected, IcebergEnumeratorState actual) {
+    Assert.assertEquals(expected.lastEnumeratedPosition(), actual.lastEnumeratedPosition());
+    Assert.assertEquals(expected.pendingSplits().size(), actual.pendingSplits().size());
+    Iterator<IcebergSourceSplitState> expectedIterator = expected.pendingSplits().iterator();
+    Iterator<IcebergSourceSplitState> actualIterator = actual.pendingSplits().iterator();
+    for (int i = 0; i < expected.pendingSplits().size(); ++i) {
+      IcebergSourceSplitState expectedSplitState = expectedIterator.next();
+      IcebergSourceSplitState actualSplitState = actualIterator.next();
+      Assert.assertEquals(expectedSplitState.split().splitId(), actualSplitState.split().splitId());
+      Assert.assertEquals(expectedSplitState.split().fileOffset(), actualSplitState.split().fileOffset());
+      Assert.assertEquals(expectedSplitState.split().recordOffset(), actualSplitState.split().recordOffset());
+      Assert.assertEquals(expectedSplitState.status(), actualSplitState.status());
+    }
+  }
+}

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/reader/ReaderFunctionTestBase.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/reader/ReaderFunctionTestBase.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.reader;
+
+import java.io.IOException;
+import java.util.List;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.iceberg.BaseCombinedScanTask;
+import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericAppenderFactory;
+import org.apache.iceberg.data.RandomGenericData;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.flink.TestFixtures;
+import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public abstract class ReaderFunctionTestBase<T> {
+
+  @Parameterized.Parameters(name = "fileFormat={0}")
+  public static Object[][] parameters() {
+    return new Object[][]{
+        new Object[]{FileFormat.AVRO},
+        new Object[]{FileFormat.ORC},
+        new Object[]{FileFormat.PARQUET}
+    };
+  }
+
+  @ClassRule
+  public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+  protected abstract ReaderFunction<T> readerFunction();
+
+  protected abstract void assertRecords(List<Record> expected, List<T> actual, Schema schema);
+
+  private final FileFormat fileFormat;
+  private final GenericAppenderFactory appenderFactory;
+
+  public ReaderFunctionTestBase(FileFormat fileFormat) {
+    this.fileFormat = fileFormat;
+    this.appenderFactory = new GenericAppenderFactory(TestFixtures.SCHEMA);
+  }
+
+  private List<List<Record>> createRecordBatchList(int batchCount) {
+    List<List<Record>> recordBatchList = Lists.newArrayListWithCapacity(batchCount);
+    for (int i = 0; i < batchCount; ++i) {
+      List<Record> records = RandomGenericData.generate(TestFixtures.SCHEMA, 2, i);
+      recordBatchList.add(records);
+    }
+
+    return recordBatchList;
+  }
+
+  private CombinedScanTask createCombinedScanTask(List<List<Record>> recordBatchList) throws IOException {
+    List<FileScanTask> fileTasks = Lists.newArrayListWithCapacity(recordBatchList.size());
+    for (int i = 0; i < recordBatchList.size(); ++i) {
+      FileScanTask fileTask = ReaderUtil.createFileTask(
+          recordBatchList.get(i), TEMPORARY_FOLDER.newFile(), fileFormat, appenderFactory);
+      fileTasks.add(fileTask);
+    }
+
+    return new BaseCombinedScanTask(fileTasks);
+  }
+
+  private void assertRecordsAndPosition(
+      List<Record> expectedRecords, int expectedFileOffset, long startRecordOffset,
+      RecordsWithSplitIds<RecordAndPosition<T>> batch) {
+    batch.nextSplit();
+    List<T> actualRecords = Lists.newArrayList();
+    long recordOffset = startRecordOffset;
+    RecordAndPosition<T> recordAndPosition;
+    while ((recordAndPosition = batch.nextRecordFromSplit()) != null) {
+      actualRecords.add(recordAndPosition.record());
+      Assert.assertEquals("expected file offset", expectedFileOffset, recordAndPosition.fileOffset());
+      Assert.assertEquals("expected record offset", recordOffset, recordAndPosition.recordOffset() - 1);
+      recordOffset++;
+    }
+
+    Assert.assertEquals("expected record count", expectedRecords.size(), actualRecords.size());
+    assertRecords(expectedRecords, actualRecords, TestFixtures.SCHEMA);
+  }
+
+  @Test
+  public void testNoCheckpointedPosition() throws IOException {
+    List<List<Record>> recordBatchList = createRecordBatchList(3);
+    CombinedScanTask combinedScanTask = createCombinedScanTask(recordBatchList);
+    IcebergSourceSplit split = IcebergSourceSplit.fromCombinedScanTask(combinedScanTask);
+    CloseableIterator<RecordsWithSplitIds<RecordAndPosition<T>>> reader = readerFunction().apply(split);
+
+    RecordsWithSplitIds<RecordAndPosition<T>> batch0 = reader.next();
+    assertRecordsAndPosition(recordBatchList.get(0), 0, 0L, batch0);
+    batch0.recycle();
+
+    RecordsWithSplitIds<RecordAndPosition<T>> batch1 = reader.next();
+    assertRecordsAndPosition(recordBatchList.get(1), 1, 0L, batch1);
+    batch1.recycle();
+
+    RecordsWithSplitIds<RecordAndPosition<T>> batch2 = reader.next();
+    assertRecordsAndPosition(recordBatchList.get(2), 2, 0L, batch2);
+    batch2.recycle();
+  }
+
+  @Test
+  public void testCheckpointedPositionBeforeFirstFile() throws IOException {
+    List<List<Record>> recordBatchList = createRecordBatchList(3);
+    CombinedScanTask combinedScanTask = createCombinedScanTask(recordBatchList);
+    IcebergSourceSplit split = IcebergSourceSplit.fromCombinedScanTask(combinedScanTask, 0, 0L);
+    CloseableIterator<RecordsWithSplitIds<RecordAndPosition<T>>> reader = readerFunction().apply(split);
+
+    RecordsWithSplitIds<RecordAndPosition<T>> batch0 = reader.next();
+    assertRecordsAndPosition(recordBatchList.get(0), 0, 0L, batch0);
+    batch0.recycle();
+
+    RecordsWithSplitIds<RecordAndPosition<T>> batch1 = reader.next();
+    assertRecordsAndPosition(recordBatchList.get(1), 1, 0L, batch1);
+    batch1.recycle();
+
+    RecordsWithSplitIds<RecordAndPosition<T>> batch2 = reader.next();
+    assertRecordsAndPosition(recordBatchList.get(2), 2, 0L, batch2);
+    batch2.recycle();
+  }
+
+  @Test
+  public void testCheckpointedPositionMiddleFirstFile() throws IOException {
+    List<List<Record>> recordBatchList = createRecordBatchList(3);
+    CombinedScanTask combinedScanTask = createCombinedScanTask(recordBatchList);
+    IcebergSourceSplit split = IcebergSourceSplit.fromCombinedScanTask(combinedScanTask, 0, 1L);
+    CloseableIterator<RecordsWithSplitIds<RecordAndPosition<T>>> reader = readerFunction().apply(split);
+
+    RecordsWithSplitIds<RecordAndPosition<T>> batch0 = reader.next();
+    assertRecordsAndPosition(recordBatchList.get(0).subList(1, 2), 0, 1L, batch0);
+    batch0.recycle();
+
+    RecordsWithSplitIds<RecordAndPosition<T>> batch1 = reader.next();
+    assertRecordsAndPosition(recordBatchList.get(1), 1, 0L, batch1);
+    batch1.recycle();
+
+    RecordsWithSplitIds<RecordAndPosition<T>> batch2 = reader.next();
+    assertRecordsAndPosition(recordBatchList.get(2), 2, 0L, batch2);
+    batch2.recycle();
+  }
+
+  @Test
+  public void testCheckpointedPositionAfterFirstFile() throws IOException {
+    List<List<Record>> recordBatchList = createRecordBatchList(3);
+    CombinedScanTask combinedScanTask = createCombinedScanTask(recordBatchList);
+    IcebergSourceSplit split = IcebergSourceSplit.fromCombinedScanTask(combinedScanTask, 0, 2L);
+    CloseableIterator<RecordsWithSplitIds<RecordAndPosition<T>>> reader = readerFunction().apply(split);
+
+    RecordsWithSplitIds<RecordAndPosition<T>> batch1 = reader.next();
+    assertRecordsAndPosition(recordBatchList.get(1), 1, 0L, batch1);
+    batch1.recycle();
+
+    RecordsWithSplitIds<RecordAndPosition<T>> batch2 = reader.next();
+    assertRecordsAndPosition(recordBatchList.get(2), 2, 0L, batch2);
+    batch2.recycle();
+  }
+
+  @Test
+  public void testCheckpointedPositionBeforeSecondFile() throws IOException {
+    List<List<Record>> recordBatchList = createRecordBatchList(3);
+    CombinedScanTask combinedScanTask = createCombinedScanTask(recordBatchList);
+    IcebergSourceSplit split = IcebergSourceSplit.fromCombinedScanTask(combinedScanTask, 1, 0L);
+    CloseableIterator<RecordsWithSplitIds<RecordAndPosition<T>>> reader = readerFunction().apply(split);
+
+    RecordsWithSplitIds<RecordAndPosition<T>> batch1 = reader.next();
+    assertRecordsAndPosition(recordBatchList.get(1), 1, 0L, batch1);
+    batch1.recycle();
+
+    RecordsWithSplitIds<RecordAndPosition<T>> batch2 = reader.next();
+    assertRecordsAndPosition(recordBatchList.get(2), 2, 0L, batch2);
+    batch2.recycle();
+  }
+
+  @Test
+  public void testCheckpointedPositionMidSecondFile() throws IOException {
+    List<List<Record>> recordBatchList = createRecordBatchList(3);
+    CombinedScanTask combinedScanTask = createCombinedScanTask(recordBatchList);
+    IcebergSourceSplit split = IcebergSourceSplit.fromCombinedScanTask(combinedScanTask, 1, 1L);
+    CloseableIterator<RecordsWithSplitIds<RecordAndPosition<T>>> reader = readerFunction().apply(split);
+
+    RecordsWithSplitIds<RecordAndPosition<T>> batch1 = reader.next();
+    assertRecordsAndPosition(recordBatchList.get(1).subList(1, 2), 1, 1L, batch1);
+    batch1.recycle();
+
+    RecordsWithSplitIds<RecordAndPosition<T>> batch2 = reader.next();
+    assertRecordsAndPosition(recordBatchList.get(2), 2, 0L, batch2);
+    batch2.recycle();
+  }
+
+}

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/reader/ReaderUtil.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/reader/ReaderUtil.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.reader;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.apache.flink.table.data.RowData;
+import org.apache.iceberg.BaseFileScanTask;
+import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.PartitionSpecParser;
+import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.encryption.PlaintextEncryptionManager;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.ResidualEvaluator;
+import org.apache.iceberg.flink.TestFixtures;
+import org.apache.iceberg.flink.source.DataIterator;
+import org.apache.iceberg.flink.source.RowDataFileScanTaskReader;
+import org.apache.iceberg.hadoop.HadoopFileIO;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.io.FileAppenderFactory;
+
+public class ReaderUtil {
+
+  private ReaderUtil() {
+  }
+
+  public static FileScanTask createFileTask(List<Record> records, File file, FileFormat fileFormat,
+                                            FileAppenderFactory<Record>  appenderFactory) throws IOException {
+    try (FileAppender<Record> appender = appenderFactory.newAppender(Files.localOutput(file), fileFormat)) {
+      appender.addAll(records);
+    }
+
+    DataFile dataFile = DataFiles.builder(PartitionSpec.unpartitioned())
+        .withRecordCount(records.size())
+        .withFileSizeInBytes(file.length())
+        .withPath(file.toString())
+        .withFormat(fileFormat)
+        .build();
+
+    ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(Expressions.alwaysTrue());
+    return new BaseFileScanTask(dataFile, null, SchemaParser.toJson(TestFixtures.SCHEMA),
+        PartitionSpecParser.toJson(PartitionSpec.unpartitioned()), residuals);
+  }
+
+  public static DataIterator<RowData> createDataIterator(CombinedScanTask combinedTask) {
+    return new DataIterator<>(
+        new RowDataFileScanTaskReader(TestFixtures.SCHEMA, TestFixtures.SCHEMA, null, true),
+        combinedTask, new HadoopFileIO(new org.apache.hadoop.conf.Configuration()), new PlaintextEncryptionManager());
+  }
+}

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestArrayBatchRecords.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestArrayBatchRecords.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.reader;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestArrayBatchRecords {
+
+  @Test
+  public void testFullRange() {
+    String[] elements = new String[]{"0", "1", "2", "3"};
+    testArray(elements, elements.length, 2, 119);
+  }
+
+  @Test
+  public void testSubRange() {
+    String[] elements = new String[]{"0", "1", "2", "3"};
+    testArray(elements, 2, 0, 0);
+  }
+
+  private void testArray(String[] elements, int numberOfRecords, int fileOffset, long startingRecordOffset) {
+    String splitId = "iceberg_split_1";
+    AtomicBoolean recycled = new AtomicBoolean();
+
+    ArrayBatchRecords<String> recordsWithSplitIds = ArrayBatchRecords.forRecords(splitId,
+        ignored -> recycled.set(true), elements, numberOfRecords, fileOffset, startingRecordOffset);
+
+    Assert.assertEquals(splitId, recordsWithSplitIds.nextSplit());
+
+    for (int i = 0; i < numberOfRecords; i++) {
+      RecordAndPosition<String> recAndPos = recordsWithSplitIds.nextRecordFromSplit();
+      Assert.assertEquals(elements[i], recAndPos.record());
+      Assert.assertEquals(fileOffset, recAndPos.fileOffset());
+      // recordOffset points to the position after this one
+      Assert.assertEquals(startingRecordOffset + i + 1, recAndPos.recordOffset());
+    }
+
+    Assert.assertNull(recordsWithSplitIds.nextRecordFromSplit());
+    Assert.assertNull(recordsWithSplitIds.nextSplit());
+    recordsWithSplitIds.recycle();
+    Assert.assertTrue(recycled.get());
+  }
+
+}

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestArrayPoolDataIteratorBatcherRowData.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestArrayPoolDataIteratorBatcherRowData.java
@@ -1,0 +1,357 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.reader;
+
+import java.util.Arrays;
+import java.util.List;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.SourceReaderOptions;
+import org.apache.flink.table.data.RowData;
+import org.apache.iceberg.BaseCombinedScanTask;
+import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.data.GenericAppenderFactory;
+import org.apache.iceberg.data.RandomGenericData;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.flink.FlinkConfigOptions;
+import org.apache.iceberg.flink.TestFixtures;
+import org.apache.iceberg.flink.TestHelpers;
+import org.apache.iceberg.flink.source.DataIterator;
+import org.apache.iceberg.io.CloseableIterator;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestArrayPoolDataIteratorBatcherRowData {
+
+  @ClassRule
+  public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+  private static final FileFormat fileFormat = FileFormat.PARQUET;
+
+  private final GenericAppenderFactory appenderFactory;
+  private final DataIteratorBatcher<RowData> batcher;
+
+  public TestArrayPoolDataIteratorBatcherRowData() {
+    Configuration config = new Configuration();
+    // set array pool size to 1
+    config.set(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY, 1);
+    // set batch array size to 2
+    config.set(FlinkConfigOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 2);
+    this.batcher = new ArrayPoolDataIteratorBatcher<>(config, new RowDataRecordFactory(TestFixtures.ROW_TYPE));
+    this.appenderFactory = new GenericAppenderFactory(TestFixtures.SCHEMA);
+  }
+
+  /**
+   * Read a CombinedScanTask that contains a single file with less than a full batch of records
+   */
+  @Test
+  public void testSingleFileLessThanOneFullBatch() throws Exception {
+    List<Record> records = RandomGenericData.generate(TestFixtures.SCHEMA, 1, 1);
+    FileScanTask fileTask = ReaderUtil.createFileTask(
+        records, TEMPORARY_FOLDER.newFile(), fileFormat, appenderFactory);
+    CombinedScanTask combinedTask = new BaseCombinedScanTask(fileTask);
+    DataIterator<RowData> dataIterator = ReaderUtil.createDataIterator(combinedTask);
+    String splitId = "someSplitId";
+    CloseableIterator<RecordsWithSplitIds<RecordAndPosition<RowData>>> recordBatchIterator =
+        batcher.batch(splitId, dataIterator);
+
+    ArrayBatchRecords<RowData> batch = (ArrayBatchRecords<RowData>) recordBatchIterator.next();
+    Assert.assertTrue(batch.finishedSplits().isEmpty());
+    Assert.assertEquals(splitId, batch.nextSplit());
+    // reusable array size should be the configured value of 2
+    Assert.assertEquals(2, batch.records().length);
+    // assert actual number of records in the array
+    Assert.assertEquals(1, batch.numberOfRecords());
+
+    RecordAndPosition<RowData> recordAndPosition = batch.nextRecordFromSplit();
+
+    ///////////////////////////////
+    // assert first record
+
+    Assert.assertEquals(0, recordAndPosition.fileOffset());
+    // The position points to where the reader should resume after this record is processed.
+    Assert.assertEquals(1, recordAndPosition.recordOffset());
+    TestHelpers.assertRowData(TestFixtures.SCHEMA, records.get(0), recordAndPosition.record());
+
+    Assert.assertNull(batch.nextRecordFromSplit());
+    Assert.assertNull(batch.nextSplit());
+    batch.recycle();
+
+    // assert end of input
+    Assert.assertFalse(recordBatchIterator.hasNext());
+  }
+
+  /**
+   * Read a CombinedScanTask that contains a single file with multiple batches.
+   *
+   * Insert 5 records in a single file that should result in 3 batches
+   */
+  @Test
+  public void testSingleFileWithMultipleBatches() throws Exception {
+    List<Record> records = RandomGenericData.generate(TestFixtures.SCHEMA, 5, 1);
+    FileScanTask fileTask = ReaderUtil.createFileTask(
+        records, TEMPORARY_FOLDER.newFile(), fileFormat, appenderFactory);
+    CombinedScanTask combinedTask = new BaseCombinedScanTask(fileTask);
+    DataIterator<RowData> dataIterator = ReaderUtil.createDataIterator(combinedTask);
+    String splitId = "someSplitId";
+    CloseableIterator<RecordsWithSplitIds<RecordAndPosition<RowData>>> recordBatchIterator =
+        batcher.batch(splitId, dataIterator);
+
+    ///////////////////////////////
+    // assert first batch with full batch of 2 records
+
+    ArrayBatchRecords<RowData> batch0 = (ArrayBatchRecords<RowData>) recordBatchIterator.next();
+    Assert.assertTrue(batch0.finishedSplits().isEmpty());
+    Assert.assertEquals(splitId, batch0.nextSplit());
+    // reusable array size should be the configured value of 2
+    Assert.assertEquals(2, batch0.records().length);
+    // assert actual number of records in the array
+    Assert.assertEquals(2, batch0.numberOfRecords());
+
+    RecordAndPosition<RowData> recordAndPosition;
+
+    // assert first record
+    recordAndPosition = batch0.nextRecordFromSplit();
+    Assert.assertEquals(0, recordAndPosition.fileOffset());
+    // The position points to where the reader should resume after this record is processed.
+    Assert.assertEquals(1, recordAndPosition.recordOffset());
+    TestHelpers.assertRowData(TestFixtures.SCHEMA, records.get(0), recordAndPosition.record());
+
+    // assert second record
+    recordAndPosition = batch0.nextRecordFromSplit();
+    Assert.assertEquals(0, recordAndPosition.fileOffset());
+    // The position points to where the reader should resume after this record is processed.
+    Assert.assertEquals(2, recordAndPosition.recordOffset());
+    TestHelpers.assertRowData(TestFixtures.SCHEMA, records.get(1), recordAndPosition.record());
+
+    Assert.assertNull(batch0.nextRecordFromSplit());
+    Assert.assertNull(batch0.nextSplit());
+    batch0.recycle();
+
+    ///////////////////////////////
+    // assert second batch with full batch of 2 records
+
+    ArrayBatchRecords<RowData> batch1 = (ArrayBatchRecords<RowData>) recordBatchIterator.next();
+    // assert array is reused
+    Assert.assertSame(batch0.records(), batch1.records());
+    Assert.assertTrue(batch1.finishedSplits().isEmpty());
+    Assert.assertEquals(splitId, batch1.nextSplit());
+    // reusable array size should be the configured value of 2
+    Assert.assertEquals(2, batch1.records().length);
+    // assert actual number of records in the array
+    Assert.assertEquals(2, batch1.numberOfRecords());
+
+    // assert third record
+    recordAndPosition = batch1.nextRecordFromSplit();
+    Assert.assertEquals(0, recordAndPosition.fileOffset());
+    // The position points to where the reader should resume after this record is processed.
+    Assert.assertEquals(3, recordAndPosition.recordOffset());
+    TestHelpers.assertRowData(TestFixtures.SCHEMA, records.get(2), recordAndPosition.record());
+
+    // assert fourth record
+    recordAndPosition = batch1.nextRecordFromSplit();
+    Assert.assertEquals(0, recordAndPosition.fileOffset());
+    // The position points to where the reader should resume after this record is processed.
+    Assert.assertEquals(4, recordAndPosition.recordOffset());
+    TestHelpers.assertRowData(TestFixtures.SCHEMA, records.get(3), recordAndPosition.record());
+
+    Assert.assertNull(batch1.nextRecordFromSplit());
+    Assert.assertNull(batch1.nextSplit());
+    batch1.recycle();
+
+    ///////////////////////////////
+    // assert third batch with partial batch of 1 record
+
+    ArrayBatchRecords<RowData> batch2 = (ArrayBatchRecords<RowData>) recordBatchIterator.next();
+    // assert array is reused
+    Assert.assertSame(batch0.records(), batch2.records());
+    Assert.assertTrue(batch2.finishedSplits().isEmpty());
+    Assert.assertEquals(splitId, batch2.nextSplit());
+    // reusable array size should be the configured value of 2
+    Assert.assertEquals(2, batch2.records().length);
+    // assert actual number of records in the array
+    Assert.assertEquals(1, batch2.numberOfRecords());
+
+    // assert fifth record
+    recordAndPosition = batch2.nextRecordFromSplit();
+    Assert.assertEquals(0, recordAndPosition.fileOffset());
+    // The position points to where the reader should resume after this record is processed.
+    Assert.assertEquals(5, recordAndPosition.recordOffset());
+    TestHelpers.assertRowData(TestFixtures.SCHEMA, records.get(4), recordAndPosition.record());
+
+    Assert.assertNull(batch2.nextRecordFromSplit());
+    Assert.assertNull(batch2.nextSplit());
+    batch2.recycle();
+
+    // assert end of input
+    Assert.assertFalse(recordBatchIterator.hasNext());
+  }
+
+  /**
+   * Read a CombinedScanTask that contains with multiple files.
+   *
+   * In this test, we also seek the iterator to starting position (1, 1).
+   */
+  @Test
+  public void testMultipleFilesWithSeekPosition() throws Exception {
+    List<Record> records0 = RandomGenericData.generate(TestFixtures.SCHEMA, 1, 1);
+    FileScanTask fileTask0 = ReaderUtil.createFileTask(
+        records0, TEMPORARY_FOLDER.newFile(), fileFormat, appenderFactory);
+    List<Record> records1 = RandomGenericData.generate(TestFixtures.SCHEMA, 4, 2);
+    FileScanTask fileTask1 = ReaderUtil.createFileTask(
+        records1, TEMPORARY_FOLDER.newFile(), fileFormat, appenderFactory);
+    List<Record> records2 = RandomGenericData.generate(TestFixtures.SCHEMA, 3, 3);
+    FileScanTask fileTask2 = ReaderUtil.createFileTask(
+        records2, TEMPORARY_FOLDER.newFile(), fileFormat, appenderFactory);
+    CombinedScanTask combinedTask = new BaseCombinedScanTask(Arrays.asList(fileTask0, fileTask1, fileTask2));
+
+    DataIterator<RowData> dataIterator = ReaderUtil.createDataIterator(combinedTask);
+    // seek to file1 and after record 1
+    dataIterator.seek(1, 1);
+
+    String splitId = "someSplitId";
+    CloseableIterator<RecordsWithSplitIds<RecordAndPosition<RowData>>> recordBatchIterator =
+        batcher.batch(splitId, dataIterator);
+
+    ///////////////////////////////
+    // file0 is skipped by seek
+
+    ///////////////////////////////
+    // file1 has 4 records. because the seek position, first record is skipped.
+    // we should read 3 remaining records in 2 batches:
+    // batch10 with 2 records and batch11 with 1 records.
+
+    // assert first batch from file1 with full batch of 2 records
+
+    // variable naming convention: batch<fileOffset><batchId>
+    ArrayBatchRecords<RowData> batch10 = (ArrayBatchRecords<RowData>) recordBatchIterator.next();
+    Assert.assertTrue(batch10.finishedSplits().isEmpty());
+    Assert.assertEquals(splitId, batch10.nextSplit());
+    // reusable array size should be the configured value of 2
+    Assert.assertEquals(2, batch10.records().length);
+    // assert actual number of records in the array
+    Assert.assertEquals(2, batch10.numberOfRecords());
+
+    RecordAndPosition<RowData> recordAndPosition;
+
+    recordAndPosition = batch10.nextRecordFromSplit();
+    Assert.assertEquals(1, recordAndPosition.fileOffset());
+    // seek should skip the first record in file1. starting from the second record
+    Assert.assertEquals(2, recordAndPosition.recordOffset());
+    TestHelpers.assertRowData(TestFixtures.SCHEMA, records1.get(1), recordAndPosition.record());
+
+    recordAndPosition = batch10.nextRecordFromSplit();
+    Assert.assertEquals(1, recordAndPosition.fileOffset());
+    // The position points to where the reader should resume after this record is processed.
+    Assert.assertEquals(3, recordAndPosition.recordOffset());
+    TestHelpers.assertRowData(TestFixtures.SCHEMA, records1.get(2), recordAndPosition.record());
+
+    Assert.assertNull(batch10.nextRecordFromSplit());
+    Assert.assertNull(batch10.nextSplit());
+    batch10.recycle();
+
+    // assert second batch from file1 with partial batch of 1 record
+
+    // variable naming convention: batch_<fileOffset>_<batchId>
+    ArrayBatchRecords<RowData> batch11 = (ArrayBatchRecords<RowData>) recordBatchIterator.next();
+    // assert array is reused
+    Assert.assertSame(batch10.records(), batch11.records());
+    Assert.assertTrue(batch11.finishedSplits().isEmpty());
+    Assert.assertEquals(splitId, batch11.nextSplit());
+    // reusable array size should be the configured value of 2
+    Assert.assertEquals(2, batch11.records().length);
+    // assert actual number of records in the array
+    Assert.assertEquals(1, batch11.numberOfRecords());
+
+    recordAndPosition = batch11.nextRecordFromSplit();
+    Assert.assertEquals(1, recordAndPosition.fileOffset());
+    // The position points to where the reader should resume after this record is processed.
+    Assert.assertEquals(4, recordAndPosition.recordOffset());
+    TestHelpers.assertRowData(TestFixtures.SCHEMA, records1.get(3), recordAndPosition.record());
+
+    Assert.assertNull(batch11.nextRecordFromSplit());
+    Assert.assertNull(batch11.nextSplit());
+    batch11.recycle();
+
+    ///////////////////////////////
+    // file2 has 3 records.
+    // we should read 3 records in 2 batches:
+    // batch20 with 2 records and batch21 with 1 records
+
+    // assert first batch from file2 with full batch of 2 records
+
+    // variable naming convention: batch_<fileOffset>_<batchId>
+    ArrayBatchRecords<RowData> batch20 = (ArrayBatchRecords<RowData>) recordBatchIterator.next();
+    // assert array is reused
+    Assert.assertSame(batch10.records(), batch20.records());
+    Assert.assertTrue(batch20.finishedSplits().isEmpty());
+    Assert.assertEquals(splitId, batch20.nextSplit());
+    // reusable array size should be the configured value of 2
+    Assert.assertEquals(2, batch20.records().length);
+    // assert actual number of records in the array
+    Assert.assertEquals(2, batch20.numberOfRecords());
+
+    recordAndPosition = batch20.nextRecordFromSplit();
+    Assert.assertEquals(2, recordAndPosition.fileOffset());
+    // The position points to where the reader should resume after this record is processed.
+    Assert.assertEquals(1, recordAndPosition.recordOffset());
+    TestHelpers.assertRowData(TestFixtures.SCHEMA, records2.get(0), recordAndPosition.record());
+
+    recordAndPosition = batch20.nextRecordFromSplit();
+    Assert.assertEquals(2, recordAndPosition.fileOffset());
+    // The position points to where the reader should resume after this record is processed.
+    Assert.assertEquals(2, recordAndPosition.recordOffset());
+    TestHelpers.assertRowData(TestFixtures.SCHEMA, records2.get(1), recordAndPosition.record());
+
+    Assert.assertNull(batch20.nextRecordFromSplit());
+    Assert.assertNull(batch20.nextSplit());
+    batch20.recycle();
+
+    ///////////////////////////////
+    // assert second batch from file2 with partial batch of 1 record
+
+    // variable naming convention: batch_<fileOffset>_<batchId>
+    ArrayBatchRecords<RowData> batch21 = (ArrayBatchRecords<RowData>) recordBatchIterator.next();
+    // assert array is reused
+    Assert.assertSame(batch10.records(), batch21.records());
+    Assert.assertTrue(batch21.finishedSplits().isEmpty());
+    Assert.assertEquals(splitId, batch21.nextSplit());
+    // reusable array size should be the configured value of 2
+    Assert.assertEquals(2, batch21.records().length);
+    // assert actual number of records in the array
+    Assert.assertEquals(1, batch21.numberOfRecords());
+
+    recordAndPosition = batch21.nextRecordFromSplit();
+    Assert.assertEquals(2, recordAndPosition.fileOffset());
+    // The position points to where the reader should resume after this record is processed.
+    Assert.assertEquals(3, recordAndPosition.recordOffset());
+    TestHelpers.assertRowData(TestFixtures.SCHEMA, records2.get(2), recordAndPosition.record());
+
+    Assert.assertNull(batch21.nextRecordFromSplit());
+    Assert.assertNull(batch21.nextSplit());
+    batch21.recycle();
+
+    // assert end of input
+    Assert.assertFalse(recordBatchIterator.hasNext());
+  }
+}

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestRowDataReaderFunction.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestRowDataReaderFunction.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.reader;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.conversion.DataStructureConverter;
+import org.apache.flink.table.data.conversion.DataStructureConverters;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.utils.TypeConversions;
+import org.apache.flink.types.Row;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.encryption.PlaintextEncryptionManager;
+import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.TestFixtures;
+import org.apache.iceberg.flink.TestHelpers;
+import org.apache.iceberg.hadoop.HadoopFileIO;
+
+public class TestRowDataReaderFunction extends ReaderFunctionTestBase<RowData> {
+
+  protected static final RowType rowType = FlinkSchemaUtil
+      .convert(TestFixtures.SCHEMA);
+  private static final DataStructureConverter<Object, Object> rowDataConverter = DataStructureConverters.getConverter(
+      TypeConversions.fromLogicalToDataType(rowType));
+
+  public TestRowDataReaderFunction(FileFormat fileFormat) {
+    super(fileFormat);
+  }
+
+  @Override
+  protected ReaderFunction<RowData> readerFunction() {
+    return new RowDataReaderFunction(new Configuration(), TestFixtures.SCHEMA, TestFixtures.SCHEMA, null, true,
+        new HadoopFileIO(new org.apache.hadoop.conf.Configuration()), new PlaintextEncryptionManager());
+  }
+
+  @Override
+  protected void assertRecords(List<Record> expected, List<RowData> actual, Schema schema) {
+    List<Row> rows = toRows(actual);
+    TestHelpers.assertRecords(rows, expected, TestFixtures.SCHEMA);
+  }
+
+  private List<Row> toRows(List<RowData> actual) {
+    return actual.stream()
+        .map(rowData -> (Row) rowDataConverter.toExternal(rowData))
+        .collect(Collectors.toList());
+  }
+}

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/split/TestIcebergSourceSplitSerializer.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/split/TestIcebergSourceSplitSerializer.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source.split;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import org.apache.iceberg.flink.source.SplitHelpers;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestIcebergSourceSplitSerializer {
+
+  @ClassRule
+  public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+
+  private final IcebergSourceSplitSerializer serializer = IcebergSourceSplitSerializer.INSTANCE;
+
+  @Test
+  public void testLatestVersion() throws Exception {
+    serializeAndDeserialize(1, 1);
+    serializeAndDeserialize(10, 2);
+  }
+
+  private void serializeAndDeserialize(int splitCount, int filesPerSplit) throws Exception {
+    List<IcebergSourceSplit> splits = SplitHelpers
+        .createSplitsFromTransientHadoopTable(TEMPORARY_FOLDER, splitCount, filesPerSplit);
+    for (IcebergSourceSplit split : splits) {
+      byte[] result = serializer.serialize(split);
+      IcebergSourceSplit deserialized = serializer.deserialize(serializer.getVersion(), result);
+      assertSplitEquals(split, deserialized);
+
+      byte[] cachedResult = serializer.serialize(split);
+      Assert.assertSame(result, cachedResult);
+      IcebergSourceSplit deserialized2 = serializer.deserialize(serializer.getVersion(), cachedResult);
+      assertSplitEquals(split, deserialized2);
+
+      split.updatePosition(0, 100);
+      byte[] resultAfterUpdatePosition = serializer.serialize(split);
+      // after position change, serialized bytes should have changed
+      Assert.assertNotSame(cachedResult, resultAfterUpdatePosition);
+      IcebergSourceSplit deserialized3 = serializer.deserialize(serializer.getVersion(), resultAfterUpdatePosition);
+      assertSplitEquals(split, deserialized3);
+    }
+  }
+
+  @Test
+  public void testV1() throws Exception {
+    serializeAndDeserializeV1(1, 1);
+    serializeAndDeserializeV1(10, 2);
+  }
+
+  private void serializeAndDeserializeV1(int splitCount, int filesPerSplit) throws Exception {
+    List<IcebergSourceSplit> splits = SplitHelpers
+        .createSplitsFromTransientHadoopTable(TEMPORARY_FOLDER, splitCount, filesPerSplit);
+    for (IcebergSourceSplit split : splits) {
+      byte[] result = split.serializeV1();
+      IcebergSourceSplit deserialized = IcebergSourceSplit.deserializeV1(result);
+      assertSplitEquals(split, deserialized);
+    }
+  }
+
+  @Test
+  public void testCheckpointedPosition() throws Exception {
+    AtomicInteger index = new AtomicInteger();
+    List<IcebergSourceSplit> splits = SplitHelpers
+        .createSplitsFromTransientHadoopTable(TEMPORARY_FOLDER, 10, 2).stream()
+        .map(split -> {
+          IcebergSourceSplit result;
+          if (index.get() % 2 == 0) {
+            result = IcebergSourceSplit.fromCombinedScanTask(split.task(), index.get(), index.get());
+          } else {
+            result = split;
+          }
+          index.incrementAndGet();
+          return result;
+        })
+        .collect(Collectors.toList());
+
+    for (IcebergSourceSplit split : splits) {
+      byte[] result = serializer.serialize(split);
+      IcebergSourceSplit deserialized = serializer.deserialize(serializer.getVersion(), result);
+      assertSplitEquals(split, deserialized);
+
+      byte[] cachedResult = serializer.serialize(split);
+      Assert.assertSame(result, cachedResult);
+      IcebergSourceSplit deserialized2 = serializer.deserialize(serializer.getVersion(), cachedResult);
+      assertSplitEquals(split, deserialized2);
+    }
+  }
+
+  private void assertSplitEquals(IcebergSourceSplit expected, IcebergSourceSplit actual) {
+    Assert.assertEquals(expected.splitId(), actual.splitId());
+    Assert.assertEquals(expected.fileOffset(), actual.fileOffset());
+    Assert.assertEquals(expected.recordOffset(), actual.recordOffset());
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@
 
 jmhOutputPath=build/reports/jmh/human-readable-output.txt
 jmhIncludeRegex=.*
-systemProp.defaultFlinkVersions=1.15
+systemProp.defaultFlinkVersions=1.13,1.14,1.15
 systemProp.knownFlinkVersions=1.13,1.14,1.15
 systemProp.defaultHiveVersions=2
 systemProp.knownHiveVersions=2,3


### PR DESCRIPTION
Scope in the first version

- simple split assigner (no ordering or locality aware)
- support both batch and streaming read

This is the uber PR for the reference of complete context. Will submit smaller PRs for the code review

1. [MERGED] refactor Flink tests so that new source implementation can reuse](#2047)
2. [MERGED] Upgrade Flink version to 1.12.1(#1956)
3. [PENDING] FLIP-27 Iceberg source split (#3501 )
4. SimpleSplitAssigner (TBD). Note that other assigners will be added after this work is completed.
5. Split enumerator (TBD)
6. IcebergSource where everything put together (TBD)

The new `IcebergSource` will be marked as `@Experimental` as FLIP-27 source is maturing and we are making it production ready.

Here is the [design doc](https://docs.google.com/document/d/1q6xaBxUPFwYsW9aXWxYUh7die6O7rDeAPFQcTAMQ0GM/edit#heading=h.z2xhib39g0nm) that my colleague (@sundargates) and I created, as mentioned in #1626.