### PR TITLE
ORC, Hive: Fix column projection when reading ORC files and `orc.force.positional.evolution` is set to `true` on the default configuration

### DIFF
--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveMetastoreTest.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveMetastoreTest.java
@@ -38,7 +38,7 @@ public abstract class HiveMetastoreTest {
   @BeforeClass
   public static void startMetastore() throws Exception {
     HiveMetastoreTest.metastore = new TestHiveMetastore();
-    metastore.start();
+    metastore.start(new HiveConf(HiveMetastoreTest.class));
     HiveMetastoreTest.hiveConf = metastore.hiveConf();
     HiveMetastoreTest.metastoreClient = new HiveMetaStoreClient(hiveConf);
     String dbPath = metastore.getDatabasePath(DB_NAME);

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveMetastoreTest.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveMetastoreTest.java
@@ -38,7 +38,7 @@ public abstract class HiveMetastoreTest {
   @BeforeClass
   public static void startMetastore() throws Exception {
     HiveMetastoreTest.metastore = new TestHiveMetastore();
-    metastore.start(new HiveConf(HiveMetastoreTest.class));
+    metastore.start();
     HiveMetastoreTest.hiveConf = metastore.hiveConf();
     HiveMetastoreTest.metastoreClient = new HiveMetaStoreClient(hiveConf);
     String dbPath = metastore.getDatabasePath(DB_NAME);

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandlerTestUtils.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandlerTestUtils.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.mr.TestHelper;
 import org.apache.iceberg.types.Types;
+import org.apache.orc.OrcConf;
 import org.junit.rules.TemporaryFolder;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
@@ -61,6 +62,7 @@ public class HiveIcebergStorageHandlerTestUtils {
     TestHiveShell shell = new TestHiveShell();
     shell.setHiveConfValue("hive.notification.event.poll.interval", "-1");
     shell.setHiveConfValue("hive.tez.exec.print.summary", "true");
+    shell.setHiveConfValue(OrcConf.FORCE_POSITIONAL_EVOLUTION.getHiveConfName(), "true");
     shell.start();
     return shell;
   }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandlerTestUtils.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandlerTestUtils.java
@@ -62,6 +62,8 @@ public class HiveIcebergStorageHandlerTestUtils {
     TestHiveShell shell = new TestHiveShell();
     shell.setHiveConfValue("hive.notification.event.poll.interval", "-1");
     shell.setHiveConfValue("hive.tez.exec.print.summary", "true");
+    // We would like to make sure that ORC reading overrides this config, so reading Iceberg tables could work in
+    // systems (like Hive 3.2 and higher) where this value is set to true explicitly.
     shell.setHiveConfValue(OrcConf.FORCE_POSITIONAL_EVOLUTION.getHiveConfName(), "true");
     shell.start();
     return shell;

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveShell.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveShell.java
@@ -78,7 +78,8 @@ public class TestHiveShell {
   }
 
   public void start() {
-    metastore.start();
+    // Create a copy of the HiveConf for the metastore
+    metastore.start(new HiveConf(hs2Conf));
     hs2Conf.setVar(HiveConf.ConfVars.METASTOREURIS, metastore.hiveConf().getVar(HiveConf.ConfVars.METASTOREURIS));
     hs2Conf.setVar(HiveConf.ConfVars.METASTOREWAREHOUSE,
         metastore.hiveConf().getVar(HiveConf.ConfVars.METASTOREWAREHOUSE));

--- a/orc/src/main/java/org/apache/iceberg/orc/ORC.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORC.java
@@ -148,6 +148,9 @@ public class ORC {
       } else {
         this.conf = new Configuration();
       }
+
+      // We need to turn positional schema evolution off since we use column name based schema evolution for projection
+      this.conf.setBoolean(OrcConf.FORCE_POSITIONAL_EVOLUTION.getHiveConfName(), false);
     }
 
     /**


### PR DESCRIPTION
After this change (_[HIVE-20129](https://issues.apache.org/jira/browse/HIVE-20129) Revert to position based schema evolution for orc tables_) in Hive the Iceberg ORC column projection is not working as expected.

The effect:
- If the table has 3 columns (customer_id, first_name, last_name)
- And the query requests the last 2 columns (first_name, last_name)
- We will read the first 2 (customer_id, first_name) instead of the requested ones

I think it would be good to turn off this config for our Iceberg ORC readers as we expect it to be false anyway and other systems using Iceberg might need it to be set differently.

The patch contains 3 groups of changes:
- Test infra changes so we can change HMS configuration (this is used for HiveCatalog FileIO creation)
- Actually setting the `orc.force.positional.evolution` to `true` in the tests - this causes `TestHiveIcebergStorageHandlerLocalScan.testColumnSelection()` to fail
- Setting `orc.force.positional.evolution` to `false` in `ORC.ReadBuilder` to override the configuration values to the expected one - tis fixes the test failures