### PR TITLE
Update NOTICE files to include 2021 in copyright years

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,6 @@
 
 Apache Iceberg
-Copyright 2017-2020 The Apache Software Foundation
+Copyright 2017-2021 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/bundled-guava/NOTICE
+++ b/bundled-guava/NOTICE
@@ -1,6 +1,6 @@
 
 Apache Iceberg
-Copyright 2017-2020 The Apache Software Foundation
+Copyright 2017-2021 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/flink-runtime/NOTICE
+++ b/flink-runtime/NOTICE
@@ -1,6 +1,6 @@
 
 Apache Iceberg
-Copyright 2017-2020 The Apache Software Foundation
+Copyright 2017-2021 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/hive-runtime/NOTICE
+++ b/hive-runtime/NOTICE
@@ -1,6 +1,6 @@
 
 Apache Iceberg
-Copyright 2017-2020 The Apache Software Foundation
+Copyright 2017-2021 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/spark-runtime/NOTICE
+++ b/spark-runtime/NOTICE
@@ -1,6 +1,6 @@
 
 Apache Iceberg
-Copyright 2017-2020 The Apache Software Foundation
+Copyright 2017-2021 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/spark3-runtime/NOTICE
+++ b/spark3-runtime/NOTICE
@@ -1,6 +1,6 @@
 
 Apache Iceberg
-Copyright 2017-2020 The Apache Software Foundation
+Copyright 2017-2021 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
This is a follow up to this PR: https://github.com/apache/iceberg/pull/2106

Updates the NOTICE files to include 2021 in the copyright years for Iceberg.

cc @rdblue 