### PR TITLE
[MISC] Add rat library install location from dev/check-license to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ gradle/
 out
 gradle/wrapper/gradle-wrapper.jar
 
+# rat library install location
+lib/
+
 # web site build
 site/site
 


### PR DESCRIPTION
I was checking to see if we had any scripts or automation to automatically update our NOTICE files to the current year.

I didn't find any. But I did notice that when I ran the `dev/check-license` bash script that it downloads `apache-rat-0.xx.jar` into `/lib`, which then made my git working tree dirty.

To prevent users from accidentally checking in the rat jar or any future libraries, I've added `/lib` to the `.gitignore` file.