### PR TITLE
Spark: Replace spec.fields().isEmpty() to isUnpartitioned()

### DIFF
--- a/spark/src/main/java/org/apache/iceberg/spark/source/RowDataRewriter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/RowDataRewriter.java
@@ -103,8 +103,8 @@ public class RowDataRewriter implements Serializable {
     OutputFileFactory fileFactory = new OutputFileFactory(
         spec, format, locations, io.value(), encryptionManager.value(), partitionId, taskId);
 
-    TaskWriter<InternalRow> writer;
-    if (spec.fields().isEmpty()) {
+    final TaskWriter<InternalRow> writer;
+    if (spec.isUnpartitioned()) {
       writer = new UnpartitionedWriter<>(spec, format, appenderFactory, fileFactory, io.value(),
           Long.MAX_VALUE);
     } else if (PropertyUtil.propertyAsBoolean(properties,

--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Writer.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Writer.java
@@ -278,7 +278,7 @@ class Writer implements DataSourceWriter {
           spec, format, locations, io.value(), encryptionManager.value(), partitionId, taskId);
       SparkAppenderFactory appenderFactory = new SparkAppenderFactory(properties, writeSchema, dsSchema, spec);
 
-      if (spec.fields().isEmpty()) {
+      if (spec.isUnpartitioned()) {
         return new Unpartitioned24Writer(spec, format, appenderFactory, fileFactory, io.value(), targetFileSize);
       } else if (partitionedFanoutEnabled) {
         return new PartitionedFanout24Writer(spec, format, appenderFactory, fileFactory, io.value(), targetFileSize,

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -516,7 +516,7 @@ class SparkWrite {
       OutputFileFactory fileFactory = new OutputFileFactory(
           spec, format, locations, io.value(), encryptionManager.value(), partitionId, taskId);
       SparkAppenderFactory appenderFactory = new SparkAppenderFactory(properties, writeSchema, dsSchema, spec);
-      if (spec.fields().isEmpty()) {
+      if (spec.isUnpartitioned()) {
         return new Unpartitioned3Writer(spec, format, appenderFactory, fileFactory, io.value(), targetFileSize);
       } else if (partitionedFanoutEnabled) {
         return new PartitionedFanout3Writer(


### PR DESCRIPTION
While going through the structure, I thought it would make the code easier to read.