### PR TITLE
[python] Completing ResidualEvaluator Implementation

### DIFF
--- a/python/iceberg/api/expressions/literals.py
+++ b/python/iceberg/api/expressions/literals.py
@@ -18,6 +18,7 @@
 import datetime
 from decimal import (Decimal,
                      ROUND_HALF_UP)
+from typing import Any
 import uuid
 
 import pytz
@@ -72,6 +73,7 @@ class Literals(object):
 
 
 class Literal(object):
+    value: Any
     JAVA_MAX_INT = 2147483647
     JAVA_MIN_INT = -2147483648
     JAVA_MAX_FLOAT = 3.4028235E38

--- a/python/iceberg/api/expressions/projections.py
+++ b/python/iceberg/api/expressions/projections.py
@@ -15,32 +15,81 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from typing import TYPE_CHECKING
 
 from .expressions import Expressions, ExpressionVisitors, RewriteNot
 from .predicate import BoundPredicate, UnboundPredicate
 
+if TYPE_CHECKING:
+    from .expression import Expression
+    from .predicate import Predicate
+    from ..partition_spec import PartitionSpec
 
-def inclusive(spec, case_sensitive=True):
+
+def inclusive(spec: 'PartitionSpec', case_sensitive: bool = True):
+    """
+    Creates an inclusive ProjectionEvaluator for the PartitionSpec, defaulting
+    to case sensitive mode.
+
+    An evaluator is used to project expressions for a table's data rows into expressions on the
+    table's partition values. The evaluator returned by this function is inclusive and will build
+    expressions with the following guarantee: if the original expression matches a row, then the
+    projected expression will match that row's partition.
+
+    Each predicate in the expression is projected using Transform.project(String, BoundPredicate).
+
+    Parameters
+    ----------
+    spec: PartitionSpec
+       a partition spec
+    case_sensitive: boolean
+       whether the Projection should consider case sensitivity on column names or not.
+
+    Returns
+    -------
+    InclusiveProjection
+        an inclusive projection evaluator for the partition spec. Inclusive transform used for each predicate
+    """
     return InclusiveProjection(spec, case_sensitive)
 
 
-def strict(spec):
+def strict(spec: 'PartitionSpec'):
+    """
+    Creates a strict ProjectionEvaluatorfor the PartitionSpec, defaulting to case sensitive mode.
+
+    An evaluator is used to project expressions for a table's data rows into expressions on the
+    table's partition values. The evaluator returned by this function is strict and will build
+    expressions with the following guarantee: if the projected expression matches a partition,
+    then the original expression will match all rows in that partition.
+
+    Each predicate in the expression is projected using Transform.projectStrict(String, BoundPredicate).
+
+    Parameters
+    ----------
+    spec: PartitionSpec
+       a partition spec
+
+    Returns
+    -------
+    StrictProjection
+        a strict projection evaluator for the partition spec
+    """
     return StrictProjection(spec)
 
 
 class ProjectionEvaluator(ExpressionVisitors.ExpressionVisitor):
 
-    def project(self, expr):
+    def project(self, expr: 'Expression'):
         raise NotImplementedError()
 
 
 class BaseProjectionEvaluator(ProjectionEvaluator):
 
-    def __init__(self, spec, case_sensitive=True):
+    def __init__(self, spec: 'PartitionSpec', case_sensitive: bool = True):
         self.spec = spec
         self.case_sensitive = case_sensitive
 
-    def project(self, expr):
+    def project(self, expr: 'Expression') -> 'Expression':
         # projections assume that there are no NOT nodes in the expression tree. to ensure that this
         # is the case, the expression is rewritten to push all NOT nodes down to the expression
         # leaf nodes.
@@ -49,23 +98,26 @@ class BaseProjectionEvaluator(ProjectionEvaluator):
         #
         return ExpressionVisitors.visit(ExpressionVisitors.visit(expr, RewriteNot.get()), self)
 
-    def always_true(self):
+    def always_true(self) -> 'Expression':
         return Expressions.always_true()
 
-    def always_false(self):
+    def always_false(self) -> 'Expression':
         return Expressions.always_false()
 
-    def not_(self, result):
+    def not_(self, result) -> 'Expression':
         raise RuntimeError("[BUG] project called on expression with a not")
 
-    def and_(self, left_result, right_result):
+    def and_(self, left_result: 'Expression', right_result: 'Expression') -> 'Expression':
         return Expressions.and_(left_result, right_result)
 
-    def or_(self, left_result, right_result):
+    def or_(self, left_result: 'Expression', right_result: 'Expression') -> 'Expression':
         return Expressions.or_(left_result, right_result)
 
-    def predicate(self, pred):
-        bound = pred.bind(self.spec.schema.as_struct(), case_sensitive=self.case_sensitive)
+    def predicate(self, pred: 'Predicate') -> 'Expression':
+        if isinstance(pred, UnboundPredicate):
+            bound = pred.bind(self.spec.schema.as_struct(), case_sensitive=self.case_sensitive)
+        else:
+            raise NotImplementedError("No Base implementation for BoundPredicate")
 
         if isinstance(bound, BoundPredicate):
             return self.predicate(bound)
@@ -75,40 +127,47 @@ class BaseProjectionEvaluator(ProjectionEvaluator):
 
 class InclusiveProjection(BaseProjectionEvaluator):
 
-    def __init__(self, spec, case_sensitive=True):
+    def __init__(self, spec: 'PartitionSpec', case_sensitive: bool = True):
         super(InclusiveProjection, self).__init__(spec,
                                                   case_sensitive=case_sensitive)
 
-    def predicate(self, pred):
+    def predicate(self, pred: 'Predicate') -> 'Expression':
         if isinstance(pred, UnboundPredicate):
             return super(InclusiveProjection, self).predicate(pred)
+        parts = self.spec.get_field_by_source_id(pred.ref.field_id)
 
-        part = self.spec.get_field_by_source_id(pred.ref.field_id)
-
-        if part is None:
+        if parts is None:
             return self.always_true()
 
-        result = part.transform.project(part.name, pred)
-        if result is not None:
-            return result
+        projections = [part.transform.project(part.name, pred) for part in parts]
 
-        return self.always_true()
+        result = Expressions.always_true()
+        for projection in [inclusive_projection for inclusive_projection in projections
+                           if inclusive_projection is not None]:
+            result = Expressions.and_(result, projection)
+
+        return result
 
 
 class StrictProjection(BaseProjectionEvaluator):
 
-    def __init__(self, spec):
+    def __init__(self, spec: 'PartitionSpec'):
         super(StrictProjection, self).__init__(spec)
 
-    def predicate(self, pred):
-        part = self.spec.get_field_by_source_id(pred.ref.field_id)
+    def predicate(self, pred: 'Predicate') -> 'Expression':
+        if isinstance(pred, UnboundPredicate):
+            return super(StrictProjection, self).predicate(pred)
 
-        if part is None:
+        parts = self.spec.get_field_by_source_id(pred.ref.field_id)
+
+        if parts is None:
             return self.always_false()
 
-        result = part.transform.project_strict(part.name, pred)
+        projections = [part.transform.project_strict(part.name, pred) for part in parts]
 
-        if result is not None:
-            return result
+        result = Expressions.always_true()
+        for projection in [strict_projection for strict_projection in projections
+                           if strict_projection is not None]:
+            result = Expressions.or_(result, projection)
 
-        return self.always_false()
+        return result

--- a/python/iceberg/api/expressions/residual_evaluator.py
+++ b/python/iceberg/api/expressions/residual_evaluator.py
@@ -15,75 +15,127 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from .expression import Expression
 from .expressions import Expressions, ExpressionVisitors
+from .literals import Literal
 from .predicate import BoundPredicate, Predicate, UnboundPredicate
+from .reference import BoundReference
+from ..partition_spec import PartitionSpec
+from ..struct_like import StructLike
 
 
 class ResidualEvaluator(object):
+    """
+    Finds the residuals for an {@link Expression} the partitions in the given {@link PartitionSpec}.
 
-    def __init__(self, spec, expr):
+    A residual expression is made by partially evaluating an expression using partition values. For
+    example, if a table is partitioned by day(utc_timestamp) and is read with a filter expression
+    utc_timestamp &gt;= a and utc_timestamp &lt;= b, then there are 4 possible residuals expressions
+    for the partition data, d:
+
+
+        + If d > day(a) and d < day(b), the residual is always true
+        + If d == day(a) and d != day(b), the residual is utc_timestamp >= b
+        + if d == day(b) and d != day(a), the residual is utc_timestamp <= b
+        + If d == day(a) == day(b), the residual is utc_timestamp >= a and utc_timestamp <= b
+
+    Partition data is passed using StructLike. Residuals are returned by residualFor(StructLike).
+
+    """
+    @staticmethod
+    def unpartitioned(expr: Expression) -> 'UnpartitionedEvaluator':
+        return UnpartitionedEvaluator(expr)
+
+    @staticmethod
+    def of(spec: PartitionSpec, expr: Expression, case_sensitive=True) -> 'ResidualEvaluator':
+        if len(spec.fields) > 0:
+            return ResidualEvaluator(spec, expr, case_sensitive=case_sensitive)
+        else:
+            return ResidualEvaluator.unpartitioned(expr)
+
+    def __init__(self, spec, expr, case_sensitive=True):
         self._spec = spec
         self._expr = expr
+        self._case_sensitive = case_sensitive
         self.__visitor = None
 
-    def _visitor(self):
+    def _visitor(self) -> 'ResidualVisitor':
         if self.__visitor is None:
-            self.__visitor = ResidualVisitor()
+            self.__visitor = ResidualVisitor(self._spec,
+                                             self._expr,
+                                             self._case_sensitive)
 
         return self.__visitor
 
-    def residual_for(self, partition_data):
+    def residual_for(self, partition_data: StructLike) -> Expression:
+        """
+        Returns a residual expression for the given partition values.
+
+        Parameters
+        ----------
+        partition_data: StructLike
+            partition data values
+
+        Returns
+        -------
+        Expression
+            the residual of this evaluator's expression from the partition values
+        """
         return self._visitor().eval(partition_data)
 
 
 class ResidualVisitor(ExpressionVisitors.BoundExpressionVisitor):
 
-    def __init__(self):
+    def __init__(self, spec, expr, case_sensitive=True):
         self.struct = None
+        self._spec = spec
+        self._expr = expr
+        self._case_sensitive = case_sensitive
 
-    def eval(self, struct):
+    def eval(self, struct: StructLike) -> Expression:
         self.struct = struct
+        return ExpressionVisitors.visit(self._expr, self)
 
-    def always_true(self):
+    def always_true(self) -> Expression:
         return Expressions.always_true()
 
-    def always_false(self):
+    def always_false(self) -> Expression:
         return Expressions.always_false()
 
-    def is_null(self, ref):
+    def is_null(self, ref: BoundReference) -> Expression:
         return self.always_true() if ref.get(self.struct) is None else self.always_false()
 
-    def not_null(self, ref):
+    def not_null(self, ref: BoundReference) -> Expression:
         return self.always_true() if ref.get(self.struct) is not None else self.always_false()
 
-    def lt(self, ref, lit):
+    def lt(self, ref: BoundReference, lit: Literal) -> Expression:
         return self.always_true() if ref.get(self.struct) < lit.value else self.always_false()
 
-    def lt_eq(self, ref, lit):
+    def lt_eq(self, ref: BoundReference, lit: Literal) -> Expression:
         return self.always_true() if ref.get(self.struct) <= lit.value else self.always_false()
 
-    def gt(self, ref, lit):
+    def gt(self, ref: BoundReference, lit: Literal) -> Expression:
         return self.always_true() if ref.get(self.struct) > lit.value else self.always_false()
 
-    def gt_eq(self, ref, lit):
+    def gt_eq(self, ref: BoundReference, lit: Literal) -> Expression:
         return self.always_true() if ref.get(self.struct) >= lit.value else self.always_false()
 
-    def eq(self, ref, lit):
+    def eq(self, ref: BoundReference, lit: Literal) -> Expression:
         return self.always_true() if ref.get(self.struct) == lit.value else self.always_false()
 
-    def not_eq(self, ref, lit):
+    def not_eq(self, ref: BoundReference, lit: Literal) -> Expression:
         return self.always_true() if ref.get(self.struct) != lit.value else self.always_false()
 
-    def not_(self, result):
+    def not_(self, result: Expression) -> Expression:
         return Expressions.not_(result)
 
-    def and_(self, left_result, right_result):
+    def and_(self, left_result: Expression, right_result: Expression) -> Expression:
         return Expressions.and_(left_result, right_result)
 
-    def or_(self, left_result, right_result):
+    def or_(self, left_result: Expression, right_result: Expression) -> Expression:
         return Expressions.or_(left_result, right_result)
 
-    def predicate(self, pred):
+    def predicate(self, pred: Predicate) -> Expression:
         if isinstance(pred, BoundPredicate):
             return self.bound_predicate(pred)
         elif isinstance(pred, UnboundPredicate):
@@ -91,22 +143,30 @@ class ResidualVisitor(ExpressionVisitors.BoundExpressionVisitor):
 
         raise RuntimeError("Invalid predicate argument %s" % pred)
 
-    def bound_predicate(self, pred):
-        part = self.spec.get_field_by_source_id(pred.ref.field_id)
-        if part is None:
+    def bound_predicate(self, pred: BoundPredicate) -> Expression:
+        parts = self._spec.get_field_by_source_id(pred.ref.field_id)
+        if parts is None:
             return pred
 
-        strict_projection = part.transform.project_strict(part.name, pred)
-        if strict_projection is None:
-            bound = strict_projection.bind(self.spec.partition_type())
+        strict_projections = [projection for projection in [part.transform.project_strict(part.name, pred)
+                              for part in parts] if projection is not None]
+
+        if len(strict_projections) == 0:
+            # if there are no strict projections, the predicate must be in the residual
+            return pred
+
+        result = Expressions.always_false()
+        for strict_projection in strict_projections:
+            bound = strict_projection.bind(self._spec.partition_type())
             if isinstance(bound, BoundPredicate):
-                return super(ResidualVisitor, self).predicate(bound)
-            return bound
+                result = Expressions.or_(result, super(ResidualVisitor, self).predicate(bound))
+            else:
+                result = Expressions.or_(result, bound)
 
-        return pred
+        return result
 
-    def unbound_predicate(self, pred):
-        bound = pred.bind(self.spec.schema.as_struct())
+    def unbound_predicate(self, pred: UnboundPredicate) -> Expression:
+        bound = pred.bind(self._spec.schema.as_struct(), case_sensitive=self._case_sensitive)
 
         if isinstance(bound, BoundPredicate):
             bound_residual = self.predicate(bound)
@@ -115,3 +175,14 @@ class ResidualVisitor(ExpressionVisitors.BoundExpressionVisitor):
             return bound_residual
 
         return bound
+
+
+class UnpartitionedEvaluator(ResidualEvaluator):
+
+    def __init__(self, expr):
+        return super(UnpartitionedEvaluator, self).__init__(PartitionSpec.unpartitioned(),
+                                                            expr, case_sensitive=False)
+        self._expr = expr
+
+    def residual_for(self, partition_data):
+        return self._expr

--- a/python/iceberg/api/partition_spec.py
+++ b/python/iceberg/api/partition_spec.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from collections import defaultdict
 from urllib.parse import quote_plus
 
 from iceberg.exceptions import ValidationException
@@ -117,9 +118,9 @@ class PartitionSpec(object):
 
     def lazy_fields_by_source_id(self):
         if self.fields_by_source_id is None:
-            self.fields_by_source_id = dict()
+            self.fields_by_source_id = defaultdict(list)
             for field in self.fields:
-                self.fields_by_source_id[field.source_id] = field
+                self.fields_by_source_id[field.source_id].append(field)
 
         return self.fields_by_source_id
 

--- a/python/tests/api/expressions/conftest.py
+++ b/python/tests/api/expressions/conftest.py
@@ -423,3 +423,21 @@ def inc_man_file():
 @pytest.fixture(scope="session")
 def inc_man_file_ns():
     return TestManifestFile("manifest-list.avro", 1024, 0, int(time.time() * 1000), None, None, None, None)
+
+
+@pytest.fixture(scope="session")
+def residual_spec():
+    inc_schema = Schema(NestedField.required(1, "id", IntegerType.get()),
+                        NestedField.optional(4, "all_nulls", StringType.get()),
+                        NestedField.optional(5, "some_nulls", StringType.get()),
+                        NestedField.optional(6, "no_nulls", StringType.get()),
+                        NestedField.optional(7, "non_part_field", StringType.get())
+                        )
+    return (PartitionSpec.builder_for(inc_schema)
+            .with_spec_id(0)
+            .identity("id")
+            .identity("all_nulls")
+            .identity("some_nulls")
+            .identity("no_nulls")
+            .build()
+            )

--- a/python/tests/api/expressions/test_residual_evaluator.py
+++ b/python/tests/api/expressions/test_residual_evaluator.py
@@ -1,0 +1,77 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from iceberg.api import Schema
+from iceberg.api.expressions import Expressions, ResidualEvaluator
+from iceberg.core import PartitionData
+
+
+def test_unpartitioned():
+    row_filter = Expressions.equal("id", 1)
+    part_data = PartitionData.from_json(Schema().as_struct(), {})
+    evaluator = ResidualEvaluator.unpartitioned(row_filter)
+    assert evaluator.residual_for(part_data) == Expressions.equal("id", 1)
+
+
+def test_no_residual(residual_spec):
+    row_filter = Expressions.equal("id", 1)
+    part_data = PartitionData.from_json(residual_spec.schema.as_struct(), {"id": 1})
+    evaluator = ResidualEvaluator.of(residual_spec, row_filter)
+    assert evaluator.residual_for(part_data) == Expressions.always_true()
+
+
+def test_residual(residual_spec):
+    row_filter = Expressions.and_(Expressions.equal("id", 1),
+                                  Expressions.equal("non_part_field", "test"))
+    part_data = PartitionData.from_json(residual_spec.schema.as_struct(), {"id": 1})
+    evaluator = ResidualEvaluator(residual_spec, row_filter)
+    assert evaluator.residual_for(part_data) == Expressions.equal("non_part_field", "test")
+
+
+def test_is_null_handling(residual_spec):
+    row_filter = Expressions.and_(Expressions.is_null("all_nulls"), Expressions.equal("id", 1))
+
+    part_data = PartitionData.from_json(residual_spec.schema.as_struct(), {"id": 1,
+                                                                           "all_nulls": None,
+                                                                           "some_nulls": "test",
+                                                                           "no_nulls": "test"})
+    evaluator = ResidualEvaluator(residual_spec, row_filter)
+    assert evaluator.residual_for(part_data) == Expressions.always_true()
+
+
+def test_is_not_null_handling(residual_spec):
+    row_filter = Expressions.and_(Expressions.not_null("no_nulls"), Expressions.equal("id", 1))
+
+    part_data = PartitionData.from_json(residual_spec.schema.as_struct(), {"id": 1,
+                                                                           "all_nulls": None,
+                                                                           "some_nulls": "test",
+                                                                           "no_nulls": "test"})
+    evaluator = ResidualEvaluator(residual_spec, row_filter)
+    assert evaluator.residual_for(part_data) == Expressions.always_true()
+
+
+def test_complex(residual_spec):
+    row_filter = Expressions.or_(Expressions.and_(Expressions.equal("non_part_field", "a"),
+                                                  Expressions.equal("id", 1)),
+                                 Expressions.and_(Expressions.equal("non_part_field", "b"),
+                                                  Expressions.not_equal("id", 1)))
+
+    part_data_a = PartitionData.from_json(residual_spec.schema.as_struct(), {"id": 1, "no_nulls": "Test"})
+    part_data_b = PartitionData.from_json(residual_spec.schema.as_struct(), {"id": 2, "no_nulls": "Test"})
+    evaluator = ResidualEvaluator(residual_spec, row_filter)
+    assert evaluator.residual_for(part_data_a) == Expressions.equal("non_part_field", "a")
+    assert evaluator.residual_for(part_data_b) == Expressions.equal("non_part_field", "b")


### PR DESCRIPTION
This completes the ResidualEvaluator implementation.  This is used to pass to the lower level file scanners any residual filters that must be applied at a row level after file level filtering has been applied.  This borrows heavily from the java implementation.

cc: @rymurr 