### PR TITLE
Refactor metadata column projection in merge plans

### DIFF
--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Implicits.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Implicits.scala
@@ -19,9 +19,11 @@
 
 package org.apache.spark.sql.execution.datasources.v2
 
+import org.apache.iceberg.spark.source.SparkScanBuilder
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.iceberg.catalog.SupportsMerge
+import org.apache.spark.sql.connector.read.ScanBuilder
 
 // must be merged with DataSourceV2Implicits in Spark
 object ExtendedDataSourceV2Implicits {
@@ -32,6 +34,17 @@ object ExtendedDataSourceV2Implicits {
           support
         case _ =>
           throw new AnalysisException(s"Table does not support updates and deletes: ${table.name}")
+      }
+    }
+  }
+
+  implicit class ScanBuilderHelper(scanBuilder: ScanBuilder) {
+    def asIceberg: SparkScanBuilder = {
+      scanBuilder match {
+        case iceberg: SparkScanBuilder =>
+          iceberg
+        case _ =>
+          throw new AnalysisException(s"ScanBuilder is not from an Iceberg table: $scanBuilder")
       }
     }
   }

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.spark.source;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -100,6 +101,11 @@ public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
     return Expressions.alwaysTrue();
   }
 
+  public SparkScanBuilder withMetadataColumns(String... metadataColumns) {
+    Collections.addAll(metaColumns, metadataColumns);
+    return this;
+  }
+
   public SparkScanBuilder caseSensitive(boolean isCaseSensitive) {
     this.caseSensitive = isCaseSensitive;
     return this;
@@ -178,9 +184,6 @@ public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
   public Scan buildMergeScan() {
     Broadcast<FileIO> io = lazySparkContext().broadcast(SparkUtil.serializableFileIO(table));
     Broadcast<EncryptionManager> encryption = lazySparkContext().broadcast(table.encryption());
-
-    metaColumns.add(MetadataColumns.FILE_PATH.name());
-    metaColumns.add(MetadataColumns.ROW_POSITION.name());
 
     return new SparkMergeScan(
         table, io, encryption, caseSensitive, ignoreResiduals,


### PR DESCRIPTION
This updates how metadata columns are requested for merge plans. Previously, the merge builder automatically added `_file` and `_pos` metadata columns. But but the left anti join case of `MERGE INTO` uses a non-merge scan. To make the metadata columns available in a more reliable way, this adds `withMetadataColumns` to the Iceberg `ScanBuilder`.

It also adds `ScanBuilderHelper.asIceberg` to get an Iceberg `ScanBuilder` when needed.