### PR TITLE
Spark: Prohibit subqueries in conditions of MERGE operations

### DIFF
--- a/spark3-extensions/src/main/scala/org/apache/iceberg/spark/extensions/IcebergSparkSessionExtensions.scala
+++ b/spark3-extensions/src/main/scala/org/apache/iceberg/spark/extensions/IcebergSparkSessionExtensions.scala
@@ -20,7 +20,7 @@
 package org.apache.iceberg.spark.extensions
 
 import org.apache.spark.sql.SparkSessionExtensions
-import org.apache.spark.sql.catalyst.analysis.{AlignMergeIntoTable, DeleteFromTablePredicateCheck, ProcedureArgumentCoercion, ResolveProcedures}
+import org.apache.spark.sql.catalyst.analysis.{AlignMergeIntoTable, DeleteFromTablePredicateCheck, MergeIntoTablePredicateCheck, ProcedureArgumentCoercion, ResolveProcedures}
 import org.apache.spark.sql.catalyst.optimizer.{OptimizeConditionsInRowLevelOperations, PullupCorrelatedPredicatesInRowLevelOperations, RewriteDelete, RewriteMergeInto}
 import org.apache.spark.sql.catalyst.parser.extensions.IcebergSparkSqlExtensionsParser
 import org.apache.spark.sql.execution.datasources.v2.ExtendedDataSourceV2Strategy
@@ -36,6 +36,7 @@ class IcebergSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
     extensions.injectResolutionRule { _ => ProcedureArgumentCoercion }
     extensions.injectPostHocResolutionRule { spark => AlignMergeIntoTable(spark.sessionState.conf)}
     extensions.injectCheckRule { _ => DeleteFromTablePredicateCheck }
+    extensions.injectCheckRule { _ => MergeIntoTablePredicateCheck }
 
     // optimizer extensions
     // TODO: RewriteDelete should be executed after the operator optimization batch

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/MergeIntoTablePredicateCheck.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/MergeIntoTablePredicateCheck.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.SubqueryExpression
+import org.apache.spark.sql.catalyst.plans.logical.DeleteAction
+import org.apache.spark.sql.catalyst.plans.logical.InsertAction
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.MergeIntoTable
+import org.apache.spark.sql.catalyst.plans.logical.UpdateAction
+
+object MergeIntoTablePredicateCheck extends (LogicalPlan => Unit) {
+
+  override def apply(plan: LogicalPlan): Unit = {
+    plan foreach {
+      case merge: MergeIntoTable =>
+        validateMergeIntoConditions(merge)
+      case _ => // OK
+    }
+  }
+
+  private def validateMergeIntoConditions(merge: MergeIntoTable): Unit = {
+    checkMergeIntoCondition(merge.mergeCondition, "SEARCH")
+    val actions = merge.matchedActions ++ merge.notMatchedActions
+    actions.foreach {
+      case DeleteAction(Some(cond)) => checkMergeIntoCondition(cond, "DELETE")
+      case UpdateAction(Some(cond), _) => checkMergeIntoCondition(cond, "UPDATE")
+      case InsertAction(Some(cond), _) => checkMergeIntoCondition(cond, "INSERT")
+      case _ => // OK
+    }
+  }
+
+  private def checkMergeIntoCondition(cond: Expression, condName: String): Unit = {
+    // Spark already validates the conditions are deterministic and don't contain aggregates
+    if (SubqueryExpression.hasSubquery(cond)) {
+      throw new AnalysisException(
+        s"Subqueries are not supported in $condName conditions of MERGE INTO operation: $cond")
+    }
+  }
+}

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/MergeIntoTablePredicateCheck.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/MergeIntoTablePredicateCheck.scala
@@ -53,7 +53,7 @@ object MergeIntoTablePredicateCheck extends (LogicalPlan => Unit) {
     // Spark already validates the conditions are deterministic and don't contain aggregates
     if (SubqueryExpression.hasSubquery(cond)) {
       throw new AnalysisException(
-        s"Subqueries are not supported in $condName conditions of MERGE INTO operation: $cond")
+        s"Subqueries are not supported in $condName conditions of MERGE operation: ${cond.sql}")
     }
   }
 }

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/MergeIntoTablePredicateCheck.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/MergeIntoTablePredicateCheck.scala
@@ -53,7 +53,8 @@ object MergeIntoTablePredicateCheck extends (LogicalPlan => Unit) {
     // Spark already validates the conditions are deterministic and don't contain aggregates
     if (SubqueryExpression.hasSubquery(cond)) {
       throw new AnalysisException(
-        s"Subqueries are not supported in $condName conditions of MERGE operation: ${cond.sql}")
+        s"Subqueries are not supported in conditions of MERGE operations. " +
+        s"Found a subquery in the $condName condition: ${cond.sql}")
     }
   }
 }

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -327,7 +327,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     createOrReplaceView("source", "{ \"c1\": -100, \"c2\": -200 }");
 
     AssertHelpers.assertThrows("Should complain about subquery expressions",
-        AnalysisException.class, "Subqueries are not supported in SEARCH conditions",
+        AnalysisException.class, "Subqueries are not supported in conditions",
         () -> {
           sql("MERGE INTO %s t USING source s " +
               "ON t.id == s.c1 AND t.id < (SELECT max(c2) FROM source) " +
@@ -336,7 +336,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         });
 
     AssertHelpers.assertThrows("Should complain about subquery expressions",
-        AnalysisException.class, "Subqueries are not supported in UPDATE conditions",
+        AnalysisException.class, "Subqueries are not supported in conditions",
         () -> {
           sql("MERGE INTO %s t USING source s " +
               "ON t.id == s.c1 " +
@@ -345,7 +345,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         });
 
     AssertHelpers.assertThrows("Should complain about subquery expressions",
-        AnalysisException.class, "Subqueries are not supported in DELETE conditions",
+        AnalysisException.class, "Subqueries are not supported in conditions",
         () -> {
           sql("MERGE INTO %s t USING source s " +
               "ON t.id == s.c1 " +
@@ -354,7 +354,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         });
 
     AssertHelpers.assertThrows("Should complain about subquery expressions",
-        AnalysisException.class, "Subqueries are not supported in INSERT conditions",
+        AnalysisException.class, "Subqueries are not supported in conditions",
         () -> {
           sql("MERGE INTO %s t USING source s " +
               "ON t.id == s.c1 " +

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -320,4 +320,46 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
               "  INSERT (id, c) VALUES (1, null)", tableName);
         });
   }
+
+  @Test
+  public void testMergeWithSubqueriesInConditions() {
+    createAndInitTable("id INT, c STRUCT<n1:INT,n2:STRUCT<dn1:INT,dn2:INT>>");
+    createOrReplaceView("source", "{ \"c1\": -100, \"c2\": -200 }");
+
+    AssertHelpers.assertThrows("Should complain about subquery expressions",
+        AnalysisException.class, "Subqueries are not supported in SEARCH conditions",
+        () -> {
+          sql("MERGE INTO %s t USING source s " +
+              "ON t.id == s.c1 AND t.id < (SELECT max(c2) FROM source) " +
+              "WHEN MATCHED THEN " +
+              "  UPDATE SET t.c.n1 = s.c2", tableName);
+        });
+
+    AssertHelpers.assertThrows("Should complain about subquery expressions",
+        AnalysisException.class, "Subqueries are not supported in UPDATE conditions",
+        () -> {
+          sql("MERGE INTO %s t USING source s " +
+              "ON t.id == s.c1 " +
+              "WHEN MATCHED AND t.id < (SELECT max(c2) FROM source) THEN " +
+              "  UPDATE SET t.c.n1 = s.c2", tableName);
+        });
+
+    AssertHelpers.assertThrows("Should complain about subquery expressions",
+        AnalysisException.class, "Subqueries are not supported in DELETE conditions",
+        () -> {
+          sql("MERGE INTO %s t USING source s " +
+              "ON t.id == s.c1 " +
+              "WHEN MATCHED AND t.id NOT IN (SELECT c2 FROM source) THEN " +
+              "  DELETE", tableName);
+        });
+
+    AssertHelpers.assertThrows("Should complain about subquery expressions",
+        AnalysisException.class, "Subqueries are not supported in INSERT conditions",
+        () -> {
+          sql("MERGE INTO %s t USING source s " +
+              "ON t.id == s.c1 " +
+              "WHEN NOT MATCHED AND s.c1 IN (SELECT c2 FROM source) THEN " +
+              "  INSERT (id, c) VALUES (1, null)", tableName);
+        });
+  }
 }


### PR DESCRIPTION
This PR disables subqueries in conditions of MERGE operations until we figure out the best way to support them.