### PR TITLE
Hive: Push Iceberg table property values to HMS table properties

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -186,7 +186,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
             baseMetadataLocation, metadataLocation, database, tableName);
       }
 
-      setParameters(newMetadataLocation, tbl, hiveEngineEnabled);
+      setParameters(newMetadataLocation, tbl, metadata, hiveEngineEnabled);
 
       persistTable(tbl, updateHiveTable);
       threw = false;
@@ -257,12 +257,15 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     return newTable;
   }
 
-  private void setParameters(String newMetadataLocation, Table tbl, boolean hiveEngineEnabled) {
+  private void setParameters(String newMetadataLocation, Table tbl, TableMetadata meta, boolean hiveEngineEnabled) {
     Map<String, String> parameters = tbl.getParameters();
 
     if (parameters == null) {
       parameters = new HashMap<>();
     }
+
+    // push all Iceberg table properties into HMS
+    meta.properties().forEach(parameters::put);
 
     parameters.put(TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE.toUpperCase(Locale.ENGLISH));
     parameters.put(METADATA_LOCATION_PROP, newMetadataLocation);

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -186,7 +186,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
             baseMetadataLocation, metadataLocation, database, tableName);
       }
 
-      setParameters(newMetadataLocation, tbl, metadata, hiveEngineEnabled);
+      setHmsTableParameters(newMetadataLocation, tbl, metadata.properties(), hiveEngineEnabled);
 
       persistTable(tbl, updateHiveTable);
       threw = false;
@@ -257,7 +257,8 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     return newTable;
   }
 
-  private void setParameters(String newMetadataLocation, Table tbl, TableMetadata meta, boolean hiveEngineEnabled) {
+  private void setHmsTableParameters(String newMetadataLocation, Table tbl, Map<String, String> icebergTableProps,
+      boolean hiveEngineEnabled) {
     Map<String, String> parameters = tbl.getParameters();
 
     if (parameters == null) {
@@ -265,7 +266,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     }
 
     // push all Iceberg table properties into HMS
-    meta.properties().forEach(parameters::put);
+    icebergTableProps.forEach(parameters::put);
 
     parameters.put(TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE.toUpperCase(Locale.ENGLISH));
     parameters.put(METADATA_LOCATION_PROP, newMetadataLocation);

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -38,9 +38,11 @@ import org.apache.hadoop.hive.metastore.HiveMetaStore;
 import org.apache.hadoop.hive.metastore.IHMSHandler;
 import org.apache.hadoop.hive.metastore.RetryingHMSHandler;
 import org.apache.hadoop.hive.metastore.TSetIpAddressProcessor;
+import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.common.DynMethods;
 import org.apache.iceberg.hadoop.Util;
+import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.server.TServer;
 import org.apache.thrift.server.TThreadPoolServer;
@@ -189,6 +191,10 @@ public class TestHiveMetastore {
         fs.delete(fileStatus.getPath(), true);
       }
     }
+  }
+
+  public Table getTable(String dbName, String tableName) throws TException, InterruptedException {
+    return clientPool().run(client -> client.getTable(dbName, tableName));
   }
 
   private TServer newThriftServer(TServerSocket socket, int poolSize, HiveConf conf) throws Exception {

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -156,10 +156,6 @@ public class TestHiveMetastore {
     return hiveConf;
   }
 
-  public HiveClientPool clientPool() {
-    return clientPool;
-  }
-
   public String getDatabasePath(String dbName) {
     File dbDir = new File(hiveLocalDir, dbName + ".db");
     return dbDir.getPath();
@@ -194,7 +190,7 @@ public class TestHiveMetastore {
   }
 
   public Table getTable(String dbName, String tableName) throws TException, InterruptedException {
-    return clientPool().run(client -> client.getTable(dbName, tableName));
+    return clientPool.run(client -> client.getTable(dbName, tableName));
   }
 
   private TServer newThriftServer(TServerSocket socket, int poolSize, HiveConf conf) throws Exception {

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.HiveMetaHook;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
-import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.PartitionSpec;
@@ -51,10 +50,7 @@ import org.slf4j.LoggerFactory;
 public class HiveIcebergMetaHook implements HiveMetaHook {
   private static final Logger LOG = LoggerFactory.getLogger(HiveIcebergMetaHook.class);
   private static final Set<String> PARAMETERS_TO_REMOVE = ImmutableSet
-      .of(InputFormatConfig.TABLE_SCHEMA, InputFormatConfig.PARTITION_SPEC, Catalogs.LOCATION, Catalogs.NAME);
-  private static final Set<String> PROPERTIES_TO_REMOVE = ImmutableSet
-      .of(InputFormatConfig.EXTERNAL_TABLE_PURGE, hive_metastoreConstants.META_TABLE_STORAGE, "EXTERNAL",
-          "bucketing_version");
+      .of(InputFormatConfig.TABLE_SCHEMA, Catalogs.LOCATION, Catalogs.NAME);
 
   private final Configuration conf;
   private Table icebergTable = null;
@@ -199,9 +195,6 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
     if (properties.get(Catalogs.NAME) == null) {
       properties.put(Catalogs.NAME, TableIdentifier.of(hmsTable.getDbName(), hmsTable.getTableName()).toString());
     }
-
-    // Remove creation related properties
-    PROPERTIES_TO_REMOVE.forEach(properties::remove);
 
     return properties;
   }

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -228,11 +228,11 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
   private static PartitionSpec spec(Schema schema, Properties properties,
       org.apache.hadoop.hive.metastore.api.Table hmsTable) {
 
-    if (properties.getProperty(InputFormatConfig.PARTITION_SPEC) != null) {
+    if (hmsTable.getParameters().get(InputFormatConfig.PARTITION_SPEC) != null) {
       Preconditions.checkArgument(!hmsTable.isSetPartitionKeys() || hmsTable.getPartitionKeys().isEmpty(),
           "Provide only one of the following: Hive partition specification, or the " +
               InputFormatConfig.PARTITION_SPEC + " property");
-      return PartitionSpecParser.fromJson(schema, properties.getProperty(InputFormatConfig.PARTITION_SPEC));
+      return PartitionSpecParser.fromJson(schema, hmsTable.getParameters().get(InputFormatConfig.PARTITION_SPEC));
     } else if (hmsTable.isSetPartitionKeys() && !hmsTable.getPartitionKeys().isEmpty()) {
       // If the table is partitioned then generate the identity partition definitions for the Iceberg table
       return HiveSchemaUtil.spec(schema, hmsTable.getPartitionKeys());

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -476,8 +476,8 @@ public class TestHiveIcebergStorageHandlerNoScan {
     for (int i = 0; i < icebergTable.schema().columns().size(); i++) {
       Types.NestedField field = icebergTable.schema().columns().get(i);
       Assert.assertNull(field.doc());
-      Assert.assertArrayEquals(new Object[]{field.name(), HiveSchemaUtil.convert(field.type()).getTypeName(),
-              "from deserializer"}, rows.get(i));
+      Assert.assertArrayEquals(new Object[] {field.name(), HiveSchemaUtil.convert(field.type()).getTypeName(),
+          "from deserializer"}, rows.get(i));
     }
   }
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.StatsSetupConst;
@@ -43,6 +44,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.hive.HiveSchemaUtil;
+import org.apache.iceberg.hive.MetastoreUtil;
 import org.apache.iceberg.mr.Catalogs;
 import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -165,43 +167,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
         icebergTable.schema().asStruct());
     Assert.assertEquals(PartitionSpec.unpartitioned(), icebergTable.spec());
 
-    // Check the HMS table parameters
-    org.apache.hadoop.hive.metastore.api.Table hmsTable =
-        shell.metastore().clientPool().run(client -> client.getTable("default", "customers"));
-
-    Map<String, String> hmsParams = hmsTable.getParameters();
-    IGNORED_PARAMS.forEach(hmsParams::remove);
-
-    // This is only set for HiveCatalog based tables. Check the value, then remove it so the other checks can be general
-    if (Catalogs.hiveCatalog(shell.getHiveConf())) {
-      Assert.assertTrue(hmsParams.get(BaseMetastoreTableOperations.METADATA_LOCATION_PROP)
-          .startsWith(icebergTable.location()));
-      hmsParams.remove(BaseMetastoreTableOperations.METADATA_LOCATION_PROP);
-    }
-
-    // General metadata checks
-    Assert.assertEquals(7, hmsParams.size());
-    Assert.assertEquals("test", hmsParams.get("dummy"));
-    Assert.assertEquals("TRUE", hmsParams.get(InputFormatConfig.EXTERNAL_TABLE_PURGE));
-    Assert.assertEquals("TRUE", hmsParams.get("EXTERNAL"));
-    Assert.assertNotNull(hmsParams.get(hive_metastoreConstants.DDL_TIME));
-    Assert.assertEquals(HiveIcebergStorageHandler.class.getName(),
-        hmsTable.getParameters().get(hive_metastoreConstants.META_TABLE_STORAGE));
-    Assert.assertEquals(BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE.toUpperCase(),
-        hmsTable.getParameters().get(BaseMetastoreTableOperations.TABLE_TYPE_PROP));
-
-    // verify that storage descriptor is filled out with inputformat/outputformat/serde
-    Assert.assertEquals(HiveIcebergInputFormat.class.getName(), hmsTable.getSd().getInputFormat());
-    Assert.assertEquals(HiveIcebergOutputFormat.class.getName(), hmsTable.getSd().getOutputFormat());
-    Assert.assertEquals(HiveIcebergSerDe.class.getName(), hmsTable.getSd().getSerdeInfo().getSerializationLib());
-
     if (!Catalogs.hiveCatalog(shell.getHiveConf())) {
-      Map<String, String> expectedIcebergProperties = new HashMap<>(3);
-      expectedIcebergProperties.put("dummy", "test");
-      expectedIcebergProperties.put("EXTERNAL", "TRUE");
-      expectedIcebergProperties.put("storage_handler", HiveIcebergStorageHandler.class.getName());
-      Assert.assertEquals(expectedIcebergProperties, icebergTable.properties());
-
       shell.executeStatement("DROP TABLE customers");
 
       // Check if the table was really dropped even from the Catalog
@@ -211,15 +177,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
           }
       );
     } else {
-      Map<String, String> expectedIcebergProperties = new HashMap<>(4);
-      expectedIcebergProperties.put("dummy", "test");
-      expectedIcebergProperties.put(TableProperties.ENGINE_HIVE_ENABLED, "true");
-      expectedIcebergProperties.put("EXTERNAL", "TRUE");
-      expectedIcebergProperties.put("storage_handler", HiveIcebergStorageHandler.class.getName());
-      Assert.assertEquals(expectedIcebergProperties, icebergTable.properties());
-
-      // Check the HMS table parameters
-      hmsTable = shell.metastore().clientPool().run(client -> client.getTable("default", "customers"));
+      org.apache.hadoop.hive.metastore.api.Table hmsTable = getHmsTable("default", "customers");
       Path hmsTableLocation = new Path(hmsTable.getSd().getLocation());
 
       // Drop the table
@@ -244,7 +202,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
   }
 
   @Test
-  public void testCreateTableWithoutSpec() throws TException, InterruptedException {
+  public void testCreateTableWithoutSpec() {
     TableIdentifier identifier = TableIdentifier.of("default", "customers");
 
     shell.executeStatement("CREATE EXTERNAL TABLE customers " +
@@ -256,26 +214,10 @@ public class TestHiveIcebergStorageHandlerNoScan {
     // Check the Iceberg table partition data
     org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);
     Assert.assertEquals(PartitionSpec.unpartitioned(), icebergTable.spec());
-
-    // Check the HMS table parameters
-    org.apache.hadoop.hive.metastore.api.Table hmsTable =
-        shell.metastore().clientPool().run(client -> client.getTable("default", "customers"));
-
-    Map<String, String> hmsParams = hmsTable.getParameters();
-    IGNORED_PARAMS.forEach(hmsParams::remove);
-
-    // Just check that the PartitionSpec is not set in the metadata
-    Assert.assertNull(hmsParams.get(InputFormatConfig.PARTITION_SPEC));
-
-    if (Catalogs.hiveCatalog(shell.getHiveConf())) {
-      Assert.assertEquals(6, hmsParams.size());
-    } else {
-      Assert.assertEquals(5, hmsParams.size());
-    }
   }
 
   @Test
-  public void testCreateTableWithUnpartitionedSpec() throws TException, InterruptedException {
+  public void testCreateTableWithUnpartitionedSpec() {
     TableIdentifier identifier = TableIdentifier.of("default", "customers");
 
     // We need the location for HadoopTable based tests only
@@ -290,19 +232,6 @@ public class TestHiveIcebergStorageHandlerNoScan {
     // Check the Iceberg table partition data
     org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);
     Assert.assertEquals(SPEC, icebergTable.spec());
-
-    // Check the HMS table parameters
-    org.apache.hadoop.hive.metastore.api.Table hmsTable =
-        shell.metastore().clientPool().run(client -> client.getTable("default", "customers"));
-
-    Map<String, String> hmsParams = hmsTable.getParameters();
-    IGNORED_PARAMS.forEach(hmsParams::remove);
-
-    if (Catalogs.hiveCatalog(shell.getHiveConf())) {
-      Assert.assertEquals(7, hmsParams.size());
-    } else {
-      Assert.assertEquals(6, hmsParams.size());
-    }
   }
 
   @Test
@@ -323,8 +252,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
       testTables.loadTable(identifier);
     } else {
       // Check the HMS table parameters
-      org.apache.hadoop.hive.metastore.api.Table hmsTable =
-          shell.metastore().clientPool().run(client -> client.getTable("default", "customers"));
+      org.apache.hadoop.hive.metastore.api.Table hmsTable = getHmsTable("default", "customers");
       Path hmsTableLocation = new Path(hmsTable.getSd().getLocation());
 
       // Drop the table
@@ -381,13 +309,12 @@ public class TestHiveIcebergStorageHandlerNoScan {
   }
 
   @Test
-  public void testCreateTableAboveExistingTable() throws TException, IOException, InterruptedException {
+  public void testCreateTableAboveExistingTable() throws IOException {
     // Create the Iceberg table
     testTables.createIcebergTable(shell.getHiveConf(), "customers", COMPLEX_SCHEMA, FileFormat.PARQUET,
         Collections.emptyList());
 
     if (Catalogs.hiveCatalog(shell.getHiveConf())) {
-
       // In HiveCatalog we just expect an exception since the table is already exists
       AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
           "customers already exists", () -> {
@@ -398,24 +325,10 @@ public class TestHiveIcebergStorageHandlerNoScan {
           }
       );
     } else {
+      // With other catalogs, table creation should succeed
       shell.executeStatement("CREATE EXTERNAL TABLE customers " +
           "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
           testTables.locationForCreateTableSQL(TableIdentifier.of("default", "customers")));
-
-      // Check the HMS table parameters
-      org.apache.hadoop.hive.metastore.api.Table hmsTable =
-          shell.metastore().clientPool().run(client -> client.getTable("default", "customers"));
-
-      Map<String, String> hmsParams = hmsTable.getParameters();
-      IGNORED_PARAMS.forEach(hmsParams::remove);
-
-      Assert.assertEquals(4, hmsParams.size());
-      Assert.assertEquals("TRUE", hmsParams.get("EXTERNAL"));
-      Assert.assertNotNull(hmsParams.get(hive_metastoreConstants.DDL_TIME));
-      Assert.assertEquals(HiveIcebergStorageHandler.class.getName(),
-          hmsTable.getParameters().get(hive_metastoreConstants.META_TABLE_STORAGE));
-      Assert.assertEquals(BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE.toUpperCase(),
-          hmsTable.getParameters().get(BaseMetastoreTableOperations.TABLE_TYPE_PROP));
     }
   }
 
@@ -562,8 +475,96 @@ public class TestHiveIcebergStorageHandlerNoScan {
     for (int i = 0; i < icebergTable.schema().columns().size(); i++) {
       Types.NestedField field = icebergTable.schema().columns().get(i);
       Assert.assertNull(field.doc());
-      Assert.assertArrayEquals(new Object[] {field.name(), HiveSchemaUtil.convert(field.type()).getTypeName(),
-          "from deserializer"}, rows.get(i));
+      Assert.assertArrayEquals(new Object[]{field.name(), HiveSchemaUtil.convert(field.type()).getTypeName(),
+              "from deserializer"}, rows.get(i));
     }
+  }
+
+  @Test
+  public void testIcebergAndHmsTableProperties() throws TException, InterruptedException {
+    TableIdentifier identifier = TableIdentifier.of("default", "customers");
+
+    shell.executeStatement(String.format("CREATE EXTERNAL TABLE default.customers " +
+        "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' %s" +
+        "TBLPROPERTIES ('%s'='%s', '%s'='%s', '%s'='%s')",
+        testTables.locationForCreateTableSQL(identifier), // we need the location for HadoopTable based tests only
+        InputFormatConfig.TABLE_SCHEMA, SchemaParser.toJson(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA),
+        InputFormatConfig.PARTITION_SPEC, PartitionSpecParser.toJson(SPEC),
+        "custom_property", "initial_val"));
+
+
+    // Check the Iceberg table parameters
+    org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);
+
+    Map<String, String> expectedIcebergProperties = new HashMap<>();
+    expectedIcebergProperties.put("custom_property", "initial_val");
+    expectedIcebergProperties.put("EXTERNAL", "TRUE");
+    expectedIcebergProperties.put("storage_handler", HiveIcebergStorageHandler.class.getName());
+    if (Catalogs.hiveCatalog(shell.getHiveConf())) {
+      expectedIcebergProperties.put(TableProperties.ENGINE_HIVE_ENABLED, "true");
+    }
+    if (MetastoreUtil.hive3PresentOnClasspath()) {
+      expectedIcebergProperties.put("bucketing_version", "2");
+    }
+    Assert.assertEquals(expectedIcebergProperties, icebergTable.properties());
+
+    // Check the HMS table parameters
+    org.apache.hadoop.hive.metastore.api.Table hmsTable = getHmsTable("default", "customers");
+    Map<String, String> hmsParams = hmsTable.getParameters()
+        .entrySet().stream()
+        .filter(e -> !IGNORED_PARAMS.contains(e.getKey()))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+    if (Catalogs.hiveCatalog(shell.getHiveConf())) {
+      Assert.assertEquals(9, hmsParams.size());
+      Assert.assertEquals("initial_val", hmsParams.get("custom_property"));
+      Assert.assertEquals("TRUE", hmsParams.get(InputFormatConfig.EXTERNAL_TABLE_PURGE));
+      Assert.assertEquals("TRUE", hmsParams.get("EXTERNAL"));
+      Assert.assertEquals("true", hmsParams.get(TableProperties.ENGINE_HIVE_ENABLED));
+      Assert.assertEquals(HiveIcebergStorageHandler.class.getName(),
+          hmsParams.get(hive_metastoreConstants.META_TABLE_STORAGE));
+      Assert.assertEquals(BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE.toUpperCase(),
+          hmsParams.get(BaseMetastoreTableOperations.TABLE_TYPE_PROP));
+      Assert.assertTrue(hmsParams.get(BaseMetastoreTableOperations.METADATA_LOCATION_PROP)
+          .startsWith(icebergTable.location()));
+      Assert.assertNull(hmsParams.get(BaseMetastoreTableOperations.PREVIOUS_METADATA_LOCATION_PROP));
+      Assert.assertNotNull(hmsParams.get(hive_metastoreConstants.DDL_TIME));
+    } else {
+      Assert.assertEquals(7, hmsParams.size());
+      Assert.assertNull(hmsParams.get(TableProperties.ENGINE_HIVE_ENABLED));
+    }
+
+    // Check HMS inputformat/outputformat/serde
+    Assert.assertEquals(HiveIcebergInputFormat.class.getName(), hmsTable.getSd().getInputFormat());
+    Assert.assertEquals(HiveIcebergOutputFormat.class.getName(), hmsTable.getSd().getOutputFormat());
+    Assert.assertEquals(HiveIcebergSerDe.class.getName(), hmsTable.getSd().getSerdeInfo().getSerializationLib());
+
+    // Add two new properties to the Iceberg table and update an existing one
+    icebergTable.updateProperties()
+        .set("new_prop_1", "true")
+        .set("new_prop_2", "false")
+        .set("custom_property", "new_val")
+        .commit();
+
+    // Refresh the HMS table to see if new Iceberg properties got synced into HMS
+    hmsParams = getHmsTable("default", "customers").getParameters()
+        .entrySet().stream()
+        .filter(e -> !IGNORED_PARAMS.contains(e.getKey()))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+    if (Catalogs.hiveCatalog(shell.getHiveConf())) {
+      Assert.assertEquals(12, hmsParams.size()); // 2 newly-added properties + previous_metadata_location prop
+      Assert.assertEquals("true", hmsParams.get("new_prop_1"));
+      Assert.assertEquals("false", hmsParams.get("new_prop_2"));
+      Assert.assertEquals("new_val", hmsParams.get("custom_property"));
+      Assert.assertNotNull(hmsParams.get(BaseMetastoreTableOperations.PREVIOUS_METADATA_LOCATION_PROP));
+    } else {
+      Assert.assertEquals(7, hmsParams.size());
+    }
+  }
+
+  private org.apache.hadoop.hive.metastore.api.Table getHmsTable(String dbName, String tableName)
+      throws TException, InterruptedException {
+    return shell.metastore().clientPool().run(client -> client.getTable(dbName, tableName));
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -180,7 +180,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
     }
 
     // General metadata checks
-    Assert.assertEquals(6, hmsParams.size());
+    Assert.assertEquals(7, hmsParams.size());
     Assert.assertEquals("test", hmsParams.get("dummy"));
     Assert.assertEquals("TRUE", hmsParams.get(InputFormatConfig.EXTERNAL_TABLE_PURGE));
     Assert.assertEquals("TRUE", hmsParams.get("EXTERNAL"));
@@ -196,7 +196,11 @@ public class TestHiveIcebergStorageHandlerNoScan {
     Assert.assertEquals(HiveIcebergSerDe.class.getName(), hmsTable.getSd().getSerdeInfo().getSerializationLib());
 
     if (!Catalogs.hiveCatalog(shell.getHiveConf())) {
-      Assert.assertEquals(Collections.singletonMap("dummy", "test"), icebergTable.properties());
+      Map<String, String> expectedIcebergProperties = new HashMap<>(3);
+      expectedIcebergProperties.put("dummy", "test");
+      expectedIcebergProperties.put("EXTERNAL", "TRUE");
+      expectedIcebergProperties.put("storage_handler", HiveIcebergStorageHandler.class.getName());
+      Assert.assertEquals(expectedIcebergProperties, icebergTable.properties());
 
       shell.executeStatement("DROP TABLE customers");
 
@@ -207,9 +211,11 @@ public class TestHiveIcebergStorageHandlerNoScan {
           }
       );
     } else {
-      Map<String, String> expectedIcebergProperties = new HashMap<>(2);
+      Map<String, String> expectedIcebergProperties = new HashMap<>(4);
       expectedIcebergProperties.put("dummy", "test");
       expectedIcebergProperties.put(TableProperties.ENGINE_HIVE_ENABLED, "true");
+      expectedIcebergProperties.put("EXTERNAL", "TRUE");
+      expectedIcebergProperties.put("storage_handler", HiveIcebergStorageHandler.class.getName());
       Assert.assertEquals(expectedIcebergProperties, icebergTable.properties());
 
       // Check the HMS table parameters
@@ -292,12 +298,10 @@ public class TestHiveIcebergStorageHandlerNoScan {
     Map<String, String> hmsParams = hmsTable.getParameters();
     IGNORED_PARAMS.forEach(hmsParams::remove);
 
-    // Just check that the PartitionSpec is not set in the metadata
-    Assert.assertNull(hmsParams.get(InputFormatConfig.PARTITION_SPEC));
     if (Catalogs.hiveCatalog(shell.getHiveConf())) {
-      Assert.assertEquals(6, hmsParams.size());
+      Assert.assertEquals(7, hmsParams.size());
     } else {
-      Assert.assertEquals(5, hmsParams.size());
+      Assert.assertEquals(6, hmsParams.size());
     }
   }
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -178,7 +178,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
           }
       );
     } else {
-      org.apache.hadoop.hive.metastore.api.Table hmsTable = getHmsTable("default", "customers");
+      org.apache.hadoop.hive.metastore.api.Table hmsTable = shell.metastore().getTable("default", "customers");
       Path hmsTableLocation = new Path(hmsTable.getSd().getLocation());
 
       // Drop the table
@@ -253,7 +253,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
       testTables.loadTable(identifier);
     } else {
       // Check the HMS table parameters
-      org.apache.hadoop.hive.metastore.api.Table hmsTable = getHmsTable("default", "customers");
+      org.apache.hadoop.hive.metastore.api.Table hmsTable = shell.metastore().getTable("default", "customers");
       Path hmsTableLocation = new Path(hmsTable.getSd().getLocation());
 
       // Drop the table
@@ -510,7 +510,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
     Assert.assertEquals(expectedIcebergProperties, icebergTable.properties());
 
     // Check the HMS table parameters
-    org.apache.hadoop.hive.metastore.api.Table hmsTable = getHmsTable("default", "customers");
+    org.apache.hadoop.hive.metastore.api.Table hmsTable = shell.metastore().getTable("default", "customers");
     Map<String, String> hmsParams = hmsTable.getParameters()
         .entrySet().stream()
         .filter(e -> !IGNORED_PARAMS.contains(e.getKey()))
@@ -548,7 +548,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
         .commit();
 
     // Refresh the HMS table to see if new Iceberg properties got synced into HMS
-    hmsParams = getHmsTable("default", "customers").getParameters()
+    hmsParams = shell.metastore().getTable("default", "customers").getParameters()
         .entrySet().stream()
         .filter(e -> !IGNORED_PARAMS.contains(e.getKey()))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
@@ -570,10 +570,5 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
   private String getCurrentSnapshotForHiveCatalogTable(org.apache.iceberg.Table icebergTable) {
     return ((BaseMetastoreTableOperations) ((BaseTable) icebergTable).operations()).currentMetadataLocation();
-  }
-
-  private org.apache.hadoop.hive.metastore.api.Table getHmsTable(String dbName, String tableName)
-      throws TException, InterruptedException {
-    return shell.metastore().clientPool().run(client -> client.getTable(dbName, tableName));
   }
 }


### PR DESCRIPTION
As agreed with the community:

- Iceberg table properties are the canonical source of truth
- HMS table properties should be maintained as much as possible to be in sync with the Iceberg table, but it can only happen on a best effort basis

This PR makes the following changes:

- Ensures that all Iceberg table properties are propagated to the HMS table during `HiveTableOperations` commit
- All HMS table properties are pushed down to Iceberg as well during table creation (except for metadata location and spec props)
- Refactors the various property check assertions scattered throughout various test cases into a single property-focused unit test case

What is left out and should be done in the future:
-  Push property changes occurring via Hive DDL (`ALTER TABLE SET TBLPROPERTIES`) down to Iceberg as well. Currently this can't be done reliably because the `HiveMetaHook` interface only contains a `preAlterTable` method, but no `commitAlterTable` method. We'll need to extend this interface and include the change in an upcoming Hive upstream release.