### PR TITLE
Improve HadoopCatalog performance/scalability #2124

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -184,7 +184,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
     // still a namespace.
     try {
       return fs.listStatus(metadataPath, TABLE_FILTER).length >= 1;
-    } catch (FileNotFoundException  e) {
+    } catch (FileNotFoundException e) {
       return false;
     } catch (IOException e) {
       if (shouldSuppressPermissionError(e)) {

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -29,8 +29,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -173,8 +173,9 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
 
   private boolean shouldSuppressPermissionError(IOException ioException) {
     if (suppressPermissionError) {
-      return ioException instanceof AccessDeniedException
-              || (ioException.getMessage() != null && ioException.getMessage().contains("AuthorizationPermissionMismatch"));
+      return ioException instanceof AccessDeniedException ||
+              (ioException.getMessage() != null &&
+                      ioException.getMessage().contains("AuthorizationPermissionMismatch"));
     }
     return false;
   }
@@ -226,13 +227,13 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
       }
       RemoteIterator<FileStatus> it = fs.listStatusIterator(nsPath);
       while (it.hasNext()) {
-        FileStatus s = it.next();
-        if (!s.isDirectory()) {
+        FileStatus status = it.next();
+        if (!status.isDirectory()) {
           // Ignore the path which is not a directory.
           continue;
         }
 
-        Path path = s.getPath();
+        Path path = status.getPath();
         if (isTableDir(path)) {
           TableIdentifier tblIdent = TableIdentifier.of(namespace, path.getName());
           tblIdents.add(tblIdent);

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCatalog.java
@@ -262,13 +262,13 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
 
     List<TableIdentifier> tbls1 = catalog.listTables(Namespace.of("db"));
     Set<String> tblSet = Sets.newHashSet(tbls1.stream().map(t -> t.name()).iterator());
-    Assert.assertEquals(tblSet.size(), 2);
+    Assert.assertEquals(2, tblSet.size());
     Assert.assertTrue(tblSet.contains("tbl1"));
     Assert.assertTrue(tblSet.contains("tbl2"));
 
     List<TableIdentifier> tbls2 = catalog.listTables(Namespace.of("db", "ns1"));
-    Assert.assertEquals(tbls2.size(), 1);
-    Assert.assertTrue(tbls2.get(0).name().equals("tbl3"));
+    Assert.assertEquals("table identifiers", 1, tbls2.size());
+    Assert.assertEquals("table name", "tbl3", tbls2.get(0).name());
 
     AssertHelpers.assertThrows("should throw exception", NoSuchNamespaceException.class,
         "Namespace does not exist: ", () -> {
@@ -337,24 +337,24 @@ public class TestHadoopCatalog extends HadoopTableTestBase {
 
     List<Namespace> nsp1 = catalog.listNamespaces(Namespace.of("db"));
     Set<String> tblSet = Sets.newHashSet(nsp1.stream().map(t -> t.toString()).iterator());
-    Assert.assertEquals(tblSet.size(), 3);
+    Assert.assertEquals(3, tblSet.size());
     Assert.assertTrue(tblSet.contains("db.ns1"));
     Assert.assertTrue(tblSet.contains("db.ns2"));
     Assert.assertTrue(tblSet.contains("db.ns3"));
 
     List<Namespace> nsp2 = catalog.listNamespaces(Namespace.of("db", "ns1"));
-    Assert.assertEquals(nsp2.size(), 1);
+    Assert.assertEquals(1, nsp2.size());
     Assert.assertTrue(nsp2.get(0).toString().equals("db.ns1.ns2"));
 
     List<Namespace> nsp3 = catalog.listNamespaces();
     Set<String> tblSet2 = Sets.newHashSet(nsp3.stream().map(t -> t.toString()).iterator());
-    Assert.assertEquals(tblSet2.size(), 2);
+    Assert.assertEquals(2, tblSet2.size());
     Assert.assertTrue(tblSet2.contains("db"));
     Assert.assertTrue(tblSet2.contains("db2"));
 
     List<Namespace> nsp4 = catalog.listNamespaces();
     Set<String> tblSet3 = Sets.newHashSet(nsp4.stream().map(t -> t.toString()).iterator());
-    Assert.assertEquals(tblSet3.size(), 2);
+    Assert.assertEquals(2, tblSet3.size());
     Assert.assertTrue(tblSet3.contains("db"));
     Assert.assertTrue(tblSet3.contains("db2"));
 


### PR DESCRIPTION
Move to RemoteIterator for scanning directories.
It's not as elegant as using the java8 streaming, but it works with
the prefetching that the s3a and (soon) abfs connectors do, as well
as bailing out more efficiently.

Because each directory is probed with its own getFileStatus and list calls, the overhead of the outer list could be entirely swallowed by those inner probes -at least if there is >1 page of results in the listing *and* the implementation is prefetching. 

Also added check for access errors to also look for AccessDeniedException; that's to support other filesystems and to prepare for HADOOP-15710
