### PR TITLE
Spark: add extension to spark 3 runtime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1015,6 +1015,7 @@ project(':iceberg-spark3-runtime') {
 
   dependencies {
     compile project(':iceberg-spark3')
+    compile project(':iceberg-spark3-extensions')
     compile project(':iceberg-aws')
     compile 'org.apache.spark:spark-hive_2.11'
     compile(project(':iceberg-nessie')) {

--- a/site/docs/spark.md
+++ b/site/docs/spark.md
@@ -35,6 +35,8 @@ Iceberg uses Apache Spark's DataSourceV2 API for data source and catalog impleme
 | [DataFrame CTAS and RTAS](#creating-tables)      | ✔️        |            |                                                |
 | [Metadata tables](#inspecting-tables)            | ✔️        | ✔️          |                                                |
 
+To enable Iceberg SQL extensions, set Spark configuration `spark.sql.extensions` as `org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions`. 
+
 ## Configuring catalogs
 
 Spark 3.0 adds an API to plug in table catalogs that are used to load, create, and manage Iceberg tables. Spark catalogs are configured by setting [Spark properties](./configuration.md#catalogs) under `spark.sql.catalog`.

--- a/spark3-runtime/LICENSE
+++ b/spark3-runtime/LICENSE
@@ -587,3 +587,26 @@ Copyright: 2020 Dremio Corporation.
 Home page: https://projectnessie.org/
 License: http://www.apache.org/licenses/LICENSE-2.0
 
+--------------------------------------------------------------------------------
+
+This product includes code from Apache Spark.
+
+* dev/check-license script
+* vectorized reading of definition levels in BaseVectorizedParquetValuesReader.java
+* portions of the extensions parser
+* casting logic in AssignmentAlignmentSupport
+* implementation of SetAccumulator.
+
+Copyright: 2011-2018 The Apache Software Foundation
+Home page: https://spark.apache.org/
+License: https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product includes code from Delta Lake.
+
+* AssignmentAlignmentSupport is an independent development but UpdateExpressionsSupport in Delta was used as a reference.
+
+Copyright: 2020 The Delta Lake Project Authors.
+Home page: https://delta.io/
+License: https://www.apache.org/licenses/LICENSE-2.0

--- a/spark3-runtime/LICENSE
+++ b/spark3-runtime/LICENSE
@@ -591,7 +591,6 @@ License: http://www.apache.org/licenses/LICENSE-2.0
 
 This product includes code from Apache Spark.
 
-* dev/check-license script
 * vectorized reading of definition levels in BaseVectorizedParquetValuesReader.java
 * portions of the extensions parser
 * casting logic in AssignmentAlignmentSupport


### PR DESCRIPTION
tested with AWS EMR:

```
spark-sql> ALTER TABLE prod.db8.sample3 ADD PARTITION FIELD bucket(id,16);
21/01/21 01:06:46 INFO BaseMetastoreTableOperations: Refreshing table metadata from new version: s3://iceberg-test-yzhaoqin/db8.db/sample3/metadata/00001-60f23197-414e-49a8-97e3-00ea40297412.metadata.json
21/01/21 01:06:58 INFO BaseMetastoreTableOperations: Successfully committed to table prod.db8.sample3 in 11492 ms
Time taken: 11.693 seconds
21/01/21 01:06:58 INFO SparkSQLCLIDriver: Time taken: 11.693 seconds
```