### PR TITLE
Do not redistribute MERGE INTO rows unless the table is sorted

### DIFF
--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteMergeInto.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteMergeInto.scala
@@ -234,11 +234,13 @@ case class RewriteMergeInto(spark: SparkSession) extends Rule[LogicalPlan] with 
   def buildWritePlan(
      childPlan: LogicalPlan,
      table: Table): LogicalPlan = {
-    val defaultDistributionMode = if (table.asIceberg.table.sortOrder.isUnsorted) {
-      TableProperties.WRITE_DISTRIBUTION_MODE_DEFAULT
-    } else {
-      TableProperties.WRITE_DISTRIBUTION_MODE_RANGE
+    val defaultDistributionMode = table match {
+      case iceberg: SparkTable if !iceberg.table.sortOrder.isUnsorted =>
+        TableProperties.WRITE_DISTRIBUTION_MODE_RANGE
+      case _ =>
+        TableProperties.WRITE_DISTRIBUTION_MODE_DEFAULT
     }
+
     table match {
       case iceTable: SparkTable =>
         val numShufflePartitions = spark.sessionState.conf.numShufflePartitions
@@ -268,16 +270,6 @@ case class RewriteMergeInto(spark: SparkSession) extends Rule[LogicalPlan] with 
         case e: SortOrder => e
         case other =>
           SortOrder(other, Ascending, NullsFirst, Set.empty)
-      }
-    }
-  }
-
-  private implicit class TableHelper(table: Table) {
-    def asIceberg: SparkTable = {
-      table match {
-        case iceberg: SparkTable => iceberg
-        case _ =>
-          throw new IllegalArgumentException(s"$table is not an Iceberg table")
       }
     }
   }


### PR DESCRIPTION
This changes the distribution mode used by default to write the output of MERGE INTO to `none` if the table is unsorted, rather than `range`. Range distribution is expensive because it uses an extra round-robin exchange and has an extra stage to estimate skew. If the sort order of the table is not set, then it is not worth adding the extra stages for the inferred sort order.