### PR TITLE
API: Add a constant for none distribution mode

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -139,9 +139,10 @@ public class TableProperties {
   public static final boolean ENGINE_HIVE_ENABLED_DEFAULT = false;
 
   public static final String WRITE_DISTRIBUTION_MODE = "write.distribution-mode";
-  public static final String WRITE_DISTRIBUTION_MODE_DEFAULT = "none";
+  public static final String WRITE_DISTRIBUTION_MODE_NONE = "none";
   public static final String WRITE_DISTRIBUTION_MODE_HASH = "hash";
   public static final String WRITE_DISTRIBUTION_MODE_RANGE = "range";
+  public static final String WRITE_DISTRIBUTION_MODE_DEFAULT = WRITE_DISTRIBUTION_MODE_NONE;
 
   public static final String GC_ENABLED = "gc.enabled";
   public static final boolean GC_ENABLED_DEFAULT = true;


### PR DESCRIPTION
This PR adds a constant to table properties for the `none` distribution mode.