### PR TITLE
Spark: Introduce companion objects for DELETE and MERGE rewrite rules

### DIFF
--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDelete.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDelete.scala
@@ -42,13 +42,15 @@ import org.apache.spark.sql.catalyst.utils.RewriteRowLevelOperationHelper
 import org.apache.spark.sql.connector.iceberg.catalog.ExtendedSupportsDelete
 import org.apache.spark.sql.execution.datasources.DataSourceStrategy
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.execution.datasources.v2.ExtendedDataSourceV2Implicits
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.BooleanType
 
 // TODO: should be part of early scan push down after the delete condition is optimized
 case class RewriteDelete(spark: SparkSession) extends Rule[LogicalPlan] with RewriteRowLevelOperationHelper {
 
-  import org.apache.spark.sql.execution.datasources.v2.ExtendedDataSourceV2Implicits._
+  import ExtendedDataSourceV2Implicits._
+  import RewriteRowLevelOperationHelper._
 
   override def resolver: Resolver = spark.sessionState.conf.resolver
 

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteMergeInto.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteMergeInto.scala
@@ -55,16 +55,13 @@ import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.iceberg.distributions.OrderedDistribution
 import org.apache.spark.sql.connector.iceberg.write.MergeBuilder
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.execution.datasources.v2.ExtendedDataSourceV2Implicits
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.types.BooleanType
 
 case class RewriteMergeInto(spark: SparkSession) extends Rule[LogicalPlan] with RewriteRowLevelOperationHelper  {
-  private val ROW_FROM_SOURCE = "_row_from_source_"
-  private val ROW_FROM_TARGET = "_row_from_target_"
-  private val TRUE_LITERAL = Literal(true, BooleanType)
-  private val FALSE_LITERAL = Literal(false, BooleanType)
-
-  import org.apache.spark.sql.execution.datasources.v2.ExtendedDataSourceV2Implicits._
+  import ExtendedDataSourceV2Implicits._
+  import RewriteMergeInto._
 
   private val conf: SQLConf = spark.sessionState.conf
   override val resolver: Resolver = conf.resolver
@@ -245,3 +242,9 @@ case class RewriteMergeInto(spark: SparkSession) extends Rule[LogicalPlan] with 
   }
 }
 
+object RewriteMergeInto {
+  private final val ROW_FROM_SOURCE = "_row_from_source_"
+  private final val ROW_FROM_TARGET = "_row_from_target_"
+  private final val TRUE_LITERAL = Literal(true, BooleanType)
+  private final val FALSE_LITERAL = Literal(false, BooleanType)
+}

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/utils/RewriteRowLevelOperationHelper.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/utils/RewriteRowLevelOperationHelper.scala
@@ -49,6 +49,7 @@ import org.apache.spark.sql.connector.read.ScanBuilder
 import org.apache.spark.sql.connector.write.LogicalWriteInfo
 import org.apache.spark.sql.connector.write.LogicalWriteInfoImpl
 import org.apache.spark.sql.execution.datasources.DataSourceStrategy
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Implicits
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2ScanRelation
 import org.apache.spark.sql.execution.datasources.v2.PushDownUtils
@@ -56,17 +57,10 @@ import org.apache.spark.sql.sources
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
-
 trait RewriteRowLevelOperationHelper extends PredicateHelper with Logging {
 
-  import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Implicits._
-
-  protected val FILE_NAME_COL = "_file"
-  protected val ROW_POS_COL = "_pos"
-  // `internal.metrics` prefix ensures the accumulator state is not tracked by Spark UI
-  protected val AFFECTED_FILES_ACC_NAME = "internal.metrics.merge.affectedFiles"
-  protected val AFFECTED_FILES_ACC_ALIAS_NAME = "_affectedFiles_"
-  protected val SUM_ROW_ID_ALIAS_NAME = "_sum_"
+  import DataSourceV2Implicits._
+  import RewriteRowLevelOperationHelper._
 
   def resolver: Resolver
 
@@ -201,4 +195,14 @@ trait RewriteRowLevelOperationHelper extends PredicateHelper with Logging {
       }
     }
   }
+}
+
+object RewriteRowLevelOperationHelper {
+  final val FILE_NAME_COL = "_file"
+  final val ROW_POS_COL = "_pos"
+
+  // `internal.metrics` prefix ensures the accumulator state is not tracked by Spark UI
+  private final val AFFECTED_FILES_ACC_NAME = "internal.metrics.merge.affectedFiles"
+  private final val AFFECTED_FILES_ACC_ALIAS_NAME = "_affectedFiles_"
+  private final val SUM_ROW_ID_ALIAS_NAME = "_sum_"
 }


### PR DESCRIPTION
This PR introduces companion objects for DELETE and MERGE rewrite rules and moves constants there.