### PR TITLE
Core: Allow building unsorted orders

### DIFF
--- a/api/src/main/java/org/apache/iceberg/SortOrder.java
+++ b/api/src/main/java/org/apache/iceberg/SortOrder.java
@@ -257,15 +257,15 @@ public class SortOrder implements Serializable {
     }
 
     public SortOrder build() {
-      if (orderId != null && orderId == 0 && fields.size() != 0) {
-        throw new IllegalArgumentException("Sort order ID 0 is reserved for unsorted order");
-      }
-      if (fields.size() == 0 && orderId != null && orderId != 0) {
-        throw new IllegalArgumentException("Unsorted order ID must be 0");
+      if (fields.isEmpty()) {
+        if (orderId != null && orderId != 0) {
+          throw new IllegalArgumentException("Unsorted order ID must be 0");
+        }
+        return SortOrder.unsorted();
       }
 
-      if (fields.isEmpty()) {
-        return SortOrder.unsorted();
+      if (orderId != null && orderId == 0) {
+        throw new IllegalArgumentException("Sort order ID 0 is reserved for unsorted order");
       }
 
       // default ID to 1 as 0 is reserved for unsorted order

--- a/api/src/main/java/org/apache/iceberg/SortOrder.java
+++ b/api/src/main/java/org/apache/iceberg/SortOrder.java
@@ -187,8 +187,7 @@ public class SortOrder implements Serializable {
   public static class Builder implements SortOrderBuilder<Builder> {
     private final Schema schema;
     private final List<SortField> fields = Lists.newArrayList();
-    // default ID to 1 as 0 is reserved for unsorted order
-    private int orderId = 1;
+    private Integer orderId = null;
     private boolean caseSensitive = true;
 
     private Builder(Schema schema) {
@@ -258,14 +257,20 @@ public class SortOrder implements Serializable {
     }
 
     public SortOrder build() {
-      if (orderId == 0 && fields.size() != 0) {
+      if (orderId != null && orderId == 0 && fields.size() != 0) {
         throw new IllegalArgumentException("Sort order ID 0 is reserved for unsorted order");
       }
-      if (fields.size() == 0 && orderId != 0) {
+      if (fields.size() == 0 && orderId != null && orderId != 0) {
         throw new IllegalArgumentException("Unsorted order ID must be 0");
       }
 
-      SortOrder sortOrder = new SortOrder(schema, orderId, fields);
+      if (fields.isEmpty()) {
+        return SortOrder.unsorted();
+      }
+
+      // default ID to 1 as 0 is reserved for unsorted order
+      int actualOrderId = orderId != null ? orderId : 1;
+      SortOrder sortOrder = new SortOrder(schema, actualOrderId, fields);
       checkCompatibility(sortOrder, schema);
       return sortOrder;
     }

--- a/core/src/test/java/org/apache/iceberg/TestSortOrder.java
+++ b/core/src/test/java/org/apache/iceberg/TestSortOrder.java
@@ -309,4 +309,10 @@ public class TestSortOrder {
         ValidationException.class, "Cannot find source column",
         () -> table.updateSchema().deleteColumn("s.id").commit());
   }
+
+  @Test
+  public void testEmptySortOrder() {
+    SortOrder order = SortOrder.builderFor(SCHEMA).build();
+    Assert.assertEquals("Order must be unsorted", SortOrder.unsorted(), order);
+  }
 }


### PR DESCRIPTION
This PR allows building empty sort orders. Before that, it was failing with a validation exception.