### PR TITLE
Spark: Don't distribute records in DELETE if mode is none

### DIFF
--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDelete.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDelete.scala
@@ -19,6 +19,8 @@
 
 package org.apache.spark.sql.catalyst.optimizer
 
+import org.apache.iceberg.DistributionMode
+import org.apache.iceberg.spark.Spark3Util
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.analysis.Resolver
 import org.apache.spark.sql.catalyst.expressions.Ascending
@@ -39,6 +41,7 @@ import org.apache.spark.sql.catalyst.plans.logical.Sort
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.utils.PlanUtils.isIcebergRelation
 import org.apache.spark.sql.catalyst.utils.RewriteRowLevelOperationHelper
+import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.iceberg.catalog.ExtendedSupportsDelete
 import org.apache.spark.sql.execution.datasources.DataSourceStrategy
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
@@ -79,14 +82,25 @@ case class RewriteDelete(spark: SparkSession) extends Rule[LogicalPlan] with Rew
 
   private def buildWritePlan(
       remainingRowsPlan: LogicalPlan,
+      table: Table,
       output: Seq[AttributeReference]): LogicalPlan = {
 
     val fileNameCol = findOutputAttr(remainingRowsPlan.output, FILE_NAME_COL)
     val rowPosCol = findOutputAttr(remainingRowsPlan.output, ROW_POS_COL)
+
+    val icebergTable = Spark3Util.toIcebergTable(table)
+    val distributionMode = Spark3Util.getDistributionMode(icebergTable)
+    val planWithDistribution = distributionMode match {
+      case DistributionMode.NONE =>
+        remainingRowsPlan
+      case _ =>
+        // apply hash partitioning by file if the distribution mode is hash or range
+        val numShufflePartitions = SQLConf.get.numShufflePartitions
+        RepartitionByExpression(Seq(fileNameCol), remainingRowsPlan, numShufflePartitions)
+    }
+
     val order = Seq(SortOrder(fileNameCol, Ascending), SortOrder(rowPosCol, Ascending))
-    val numShufflePartitions = SQLConf.get.numShufflePartitions
-    val repartition = RepartitionByExpression(Seq(fileNameCol), remainingRowsPlan, numShufflePartitions)
-    val sort = Sort(order, global = false, repartition)
+    val sort = Sort(order, global = false, planWithDistribution)
     Project(output, sort)
   }
 

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDelete.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDelete.scala
@@ -76,7 +76,7 @@ case class RewriteDelete(spark: SparkSession) extends Rule[LogicalPlan] with Rew
       val remainingRowsPlan = Filter(remainingRowFilter, scanPlan)
 
       val mergeWrite = mergeBuilder.asWriteBuilder.buildForBatch()
-      val writePlan = buildWritePlan(remainingRowsPlan, r.output)
+      val writePlan = buildWritePlan(remainingRowsPlan, r.table, r.output)
       ReplaceData(r, mergeWrite, writePlan)
   }
 

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDelete.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDelete.scala
@@ -89,7 +89,7 @@ case class RewriteDelete(spark: SparkSession) extends Rule[LogicalPlan] with Rew
     val rowPosCol = findOutputAttr(remainingRowsPlan.output, ROW_POS_COL)
 
     val icebergTable = Spark3Util.toIcebergTable(table)
-    val distributionMode = Spark3Util.getDistributionMode(icebergTable)
+    val distributionMode = Spark3Util.distributionModeFor(icebergTable)
     val planWithDistribution = distributionMode match {
       case DistributionMode.NONE =>
         remainingRowsPlan

--- a/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -288,7 +288,7 @@ public class Spark3Util {
   }
 
   public static Distribution buildRequiredDistribution(org.apache.iceberg.Table table) {
-    DistributionMode distributionMode = getDistributionMode(table);
+    DistributionMode distributionMode = distributionModeFor(table);
     switch (distributionMode) {
       case NONE:
         return Distributions.unspecified();
@@ -320,7 +320,7 @@ public class Spark3Util {
     }
   }
 
-  public static DistributionMode getDistributionMode(org.apache.iceberg.Table table) {
+  public static DistributionMode distributionModeFor(org.apache.iceberg.Table table) {
     boolean isSortedTable = !table.sortOrder().isUnsorted();
     String defaultModeName = isSortedTable ? WRITE_DISTRIBUTION_MODE_RANGE : WRITE_DISTRIBUTION_MODE_DEFAULT;
     String modeName = table.properties().getOrDefault(WRITE_DISTRIBUTION_MODE, defaultModeName);

--- a/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -320,7 +320,7 @@ public class Spark3Util {
     }
   }
 
-  private static DistributionMode getDistributionMode(org.apache.iceberg.Table table) {
+  public static DistributionMode getDistributionMode(org.apache.iceberg.Table table) {
     boolean isSortedTable = !table.sortOrder().isUnsorted();
     String defaultModeName = isSortedTable ? WRITE_DISTRIBUTION_MODE_RANGE : WRITE_DISTRIBUTION_MODE_DEFAULT;
     String modeName = table.properties().getOrDefault(WRITE_DISTRIBUTION_MODE, defaultModeName);


### PR DESCRIPTION
This PR makes DELETE respect the distribution mode set in table properties.