### PR TITLE
Hive: Fix schema projection issue on Tez

### DIFF
--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSerDe.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSerDe.java
@@ -25,9 +25,11 @@ import java.util.Properties;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.iceberg.mr.hive.serde.objectinspector.IcebergObjectInspector;
 import org.apache.iceberg.mr.mapred.Container;
 import org.apache.iceberg.types.Types;
@@ -65,8 +67,15 @@ public class TestHiveIcebergSerDe {
   }
 
   @Test
-  public void testDeserialize() {
+  public void testDeserialize() throws SerDeException {
     HiveIcebergSerDe serDe = new HiveIcebergSerDe();
+
+    Configuration conf = new Configuration();
+
+    Properties properties = new Properties();
+    properties.setProperty(InputFormatConfig.TABLE_SCHEMA, SchemaParser.toJson(schema));
+
+    serDe.initialize(conf, properties);
 
     Record record = RandomGenericData.generate(schema, 1, 0).get(0);
     Container<Record> container = new Container<>();

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -171,12 +171,12 @@ public class TestHiveIcebergStorageHandlerWithEngine {
 
     // Adding the ORDER BY clause will cause Hive to spawn a local MR job this time.
     List<Object[]> descRows =
-        shell.executeStatement("SELECT first_name, customer_id FROM default.customers ORDER BY customer_id DESC");
+        shell.executeStatement("SELECT last_name, customer_id FROM default.customers ORDER BY customer_id DESC");
 
     Assert.assertEquals(3, descRows.size());
-    Assert.assertArrayEquals(new Object[] {"Trudy", 2L}, descRows.get(0));
-    Assert.assertArrayEquals(new Object[] {"Bob", 1L}, descRows.get(1));
-    Assert.assertArrayEquals(new Object[] {"Alice", 0L}, descRows.get(2));
+    Assert.assertArrayEquals(new Object[] {"Pink", 2L}, descRows.get(0));
+    Assert.assertArrayEquals(new Object[] {"Green", 1L}, descRows.get(1));
+    Assert.assertArrayEquals(new Object[] {"Brown", 0L}, descRows.get(2));
   }
 
   @Test


### PR DESCRIPTION
With [this](https://github.com/apache/hive/blob/113f6af7528f016bf821f7a746bad496cc93f834/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/MapRecordProcessor.java#L173-L181), `hive.io.file.readcolumn.names` is not overlayed from  `HiveInputforma.jobConf` to `MapOperator.jobConf`. `MapOperator.jobConf` does not has corresponding projection columns, when `HiveIcebergSerde` is initialized, inspector contains all table fields is created.

Due to wrong inspector, `ArrayIndexOutOfBoundsException` will be raised when partial fields are selected.

This also fix vectorization read issue in https://github.com/apache/iceberg/issues/2120

