### PR TITLE
Spark: Add a test for MERGE modifying a null struct

### DIFF
--- a/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -97,11 +97,24 @@ public abstract class SparkTestBase {
       return ImmutableList.of();
     }
 
-    return rows.stream()
-        .map(row -> IntStream.range(0, row.size())
-            .mapToObj(pos -> row.isNullAt(pos) ? null : row.get(pos))
-            .toArray(Object[]::new)
-        ).collect(Collectors.toList());
+    return rows.stream().map(this::toJava).collect(Collectors.toList());
+  }
+
+  private Object[] toJava(Row row) {
+    return IntStream.range(0, row.size())
+        .mapToObj(pos -> {
+          if (row.isNullAt(pos)) {
+            return null;
+          }
+
+          Object value = row.get(pos);
+          if (value instanceof Row) {
+            return toJava((Row) value);
+          } else {
+            return value;
+          }
+        })
+        .toArray(Object[]::new);
   }
 
   protected Object scalarSql(String query, Object... args) {
@@ -123,10 +136,21 @@ public abstract class SparkTestBase {
       Object[] actual = actualRows.get(row);
       Assert.assertEquals("Number of columns should match", expected.length, actual.length);
       for (int col = 0; col < actualRows.get(row).length; col += 1) {
-        if (expected[col] != ANY) {
-          Assert.assertEquals(context + ": row " + row + " col " + col + " contents should match",
-              expected[col], actual[col]);
-        }
+        String newContext = String.format("%s: row %d col %d", context, row + 1, col + 1);
+        assertEquals(newContext, expected, actual);
+      }
+    }
+  }
+
+  private void assertEquals(String context, Object[] expectedRow, Object[] actualRow) {
+    Assert.assertEquals("Number of columns should match", expectedRow.length, actualRow.length);
+    for (int col = 0; col < actualRow.length; col += 1) {
+      Object expectedValue = expectedRow[col];
+      if (expectedValue != null && expectedValue.getClass().isArray()) {
+        String newContext = String.format("%s (nested col %d)", context, col + 1);
+        assertEquals(newContext, (Object[]) expectedValue, (Object[]) actualRow[col]);
+      } else if (expectedValue != ANY) {
+        Assert.assertEquals(context + " contents should match", expectedValue, actualRow[col]);
       }
     }
   }


### PR DESCRIPTION
This PR adds a test for modifying a null struct in MERGE.