### PR TITLE
Fix flaky delete test

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -56,6 +56,7 @@ import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.PropertyUtil;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -158,8 +159,8 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable, Supp
       this.conf.set(HiveConf.ConfVars.METASTOREWAREHOUSE.varname, properties.get(CatalogProperties.WAREHOUSE_LOCATION));
     }
 
-    int clientPoolSize = Integer.parseInt(
-        properties.getOrDefault(CatalogProperties.CLIENT_POOL_SIZE, "5"));
+    int clientPoolSize = PropertyUtil.propertyAsInt(properties,
+        CatalogProperties.CLIENT_POOL_SIZE, CatalogProperties.CLIENT_POOL_SIZE_DEFAULT);
     this.clients = new HiveClientPool(clientPoolSize, this.conf);
     this.createStack = Thread.currentThread().getStackTrace();
     this.closed = false;


### PR DESCRIPTION
I think this should fix the Hive metastore errors that have made `TestCopyOnWriteDelete` flaky. I think this was accidentally caused by https://github.com/apache/iceberg/commit/6731211eaf746c6a4abfe71386ef53172a3fc137. That commit stopped using the constructors for the Hive and Hadoop catalogs and started loading them dynamically. It also didn't use the same default pool size, 2, and added a hard-coded 5.

I think the test is flaky because the first Hive catalog test runs with 5 clients and shares the same metastore instance with the later catalog test for `spark_catalog`.