### PR TITLE
Support for PartitionStatsFile in each snapshot 

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Snapshot.java
+++ b/api/src/main/java/org/apache/iceberg/Snapshot.java
@@ -126,4 +126,12 @@ public interface Snapshot extends Serializable {
    * @return the location of the manifest list for this Snapshot
    */
   String manifestListLocation();
+
+  /**
+   * Return a PartitionStatsFile Location map for this snapshot.
+   * Key: SpecId, Value: PartitionStatsFile Location for Partition Specification defined by this SpecId
+   *
+   * @return PartitionStatsFile Location map.
+   */
+  Map<Integer, String> partitionStatsFiles();
 }

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -22,6 +22,7 @@ package org.apache.iceberg;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -187,6 +188,13 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests> imp
     apply.addAll(base.currentSnapshot().deleteManifests());
 
     return apply;
+  }
+
+  @Override
+  protected Map<Integer, String> updatePartitionStats() {
+    /* This is only rewrite of manifest files. We are not adding/removing any new data file.
+    So should not update any partition stats. returning empty map */
+    return new HashMap<>();
   }
 
   private boolean requiresRewrite(Set<ManifestFile> currentManifests) {

--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -43,6 +43,7 @@ class BaseSnapshot implements Snapshot {
   private final String manifestListLocation;
   private final String operation;
   private final Map<String, String> summary;
+  private final Map<Integer, String> partitionStatsFiles;
 
   // lazily initialized
   private transient List<ManifestFile> allManifests = null;
@@ -56,10 +57,10 @@ class BaseSnapshot implements Snapshot {
    */
   BaseSnapshot(FileIO io,
                long snapshotId,
-               String... manifestFiles) {
+               Map<Integer, String> partitionStatsFiles, String... manifestFiles) {
     this(io, snapshotId, null, System.currentTimeMillis(), null, null,
         Lists.transform(Arrays.asList(manifestFiles),
-            path -> new GenericManifestFile(io.newInputFile(path), 0)));
+            path -> new GenericManifestFile(io.newInputFile(path), 0)), partitionStatsFiles);
   }
 
   BaseSnapshot(FileIO io,
@@ -69,7 +70,7 @@ class BaseSnapshot implements Snapshot {
                long timestampMillis,
                String operation,
                Map<String, String> summary,
-               String manifestList) {
+               String manifestList, Map<Integer, String> partitionStatsFiles) {
     this.io = io;
     this.sequenceNumber = sequenceNumber;
     this.snapshotId = snapshotId;
@@ -78,6 +79,7 @@ class BaseSnapshot implements Snapshot {
     this.operation = operation;
     this.summary = summary;
     this.manifestListLocation = manifestList;
+    this.partitionStatsFiles = partitionStatsFiles;
   }
 
   BaseSnapshot(FileIO io,
@@ -86,8 +88,9 @@ class BaseSnapshot implements Snapshot {
                long timestampMillis,
                String operation,
                Map<String, String> summary,
-               List<ManifestFile> dataManifests) {
-    this(io, INITIAL_SEQUENCE_NUMBER, snapshotId, parentId, timestampMillis, operation, summary, null);
+               List<ManifestFile> dataManifests, Map<Integer, String> partitionStatsFiles) {
+    this(io, INITIAL_SEQUENCE_NUMBER, snapshotId, parentId, timestampMillis, operation, summary, null,
+        partitionStatsFiles);
     this.allManifests = dataManifests;
   }
 
@@ -178,6 +181,11 @@ class BaseSnapshot implements Snapshot {
   @Override
   public String manifestListLocation() {
     return manifestListLocation;
+  }
+
+  @Override
+  public Map<Integer, String> partitionStatsFiles() {
+    return partitionStatsFiles;
   }
 
   private void cacheChanges() {

--- a/core/src/main/java/org/apache/iceberg/GenericPartitionStatsEntry.java
+++ b/core/src/main/java/org/apache/iceberg/GenericPartitionStatsEntry.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.io.Serializable;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.specific.SpecificData;
+import org.apache.iceberg.avro.AvroSchemaUtil;
+
+public class GenericPartitionStatsEntry implements PartitionStatsEntry, StructLike, IndexedRecord,
+    SpecificData.SchemaConstructable, Serializable {
+
+  enum PartitionStatsCol {
+    PARTITION_DATA(0),
+    FILE_COUNT(1),
+    ROW_COUNT(2);
+
+    private final int id;
+
+    PartitionStatsCol(int id) {
+      this.id = id;
+    }
+
+    public int id() {
+      return id;
+    }
+  }
+
+  private final org.apache.avro.Schema schema;
+  private PartitionData partitionData = null;
+  private int fileCount;
+  private long rowCount;
+
+  GenericPartitionStatsEntry(org.apache.avro.Schema schema) {
+    this.schema = schema;
+  }
+
+  public GenericPartitionStatsEntry(PartitionData partitionData, int fileCount, long rowCount) {
+    this.schema = AvroSchemaUtil.convert(PartitionStatsEntry.getSchema(partitionData.getPartitionType()),
+        "partitionStatsEntry");
+    this.partitionData = partitionData;
+    this.fileCount = fileCount;
+    this.rowCount = rowCount;
+  }
+
+  @Override
+  public void put(int i, Object v) {
+    switch (PartitionStatsCol.values()[i]) {
+      case PARTITION_DATA:
+        this.partitionData = (PartitionData) v;
+        return;
+      case FILE_COUNT:
+        this.fileCount = (Integer) v;
+        return;
+      case ROW_COUNT:
+        this.rowCount = (Long) v;
+        return;
+      default:
+    }
+  }
+
+  @Override
+  public Object get(int i) {
+    switch (i) {
+      case 0:
+        return partitionData;
+      case 1:
+        return rowCount;
+      case 2:
+        return fileCount;
+      default:
+        throw new UnsupportedOperationException("Unknown field ordinal: " + i);
+    }
+  }
+
+  @Override
+  public Schema getSchema() {
+    return schema;
+  }
+
+  @Override
+  public StructLike getPartition() {
+    return partitionData;
+  }
+
+  @Override
+  public int getFileCount() {
+    return fileCount;
+  }
+
+  @Override
+  public long getRowCount() {
+    return rowCount;
+  }
+
+  @Override
+  public int size() {
+    return 3;
+  }
+
+  @Override
+  public <T> T get(int pos, Class<T> javaClass) {
+    return javaClass.cast(get(pos));
+  }
+
+  @Override
+  public <T> void set(int pos, T value) {
+    put(pos, value);
+  }
+
+  @Override
+  public String toString() {
+    return "GenericPartitionStatsEntry{" +
+        "partitionData=" + partitionData +
+        ", fileCount=" + fileCount +
+        ", rowCount=" + rowCount +
+        '}';
+  }
+
+
+}

--- a/core/src/main/java/org/apache/iceberg/PartitionStats.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionStats.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.avro.Avro;
+import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+/**
+ * Utility class for partition stats file
+ */
+public class PartitionStats {
+
+  private PartitionStats() {
+  }
+
+  static List<PartitionStatsEntry> read(InputFile partitionStats, int specID, Map<Integer, PartitionSpec> specsById) {
+    Schema fileSchema;
+    try (CloseableIterable<PartitionStatsEntry> files = Avro.read(partitionStats)
+        .rename("partitionStats_file", GenericPartitionStatsEntry.class.getName())
+        .rename("partition", PartitionData.class.getName())
+        .rename("r600", PartitionData.class.getName())
+        .classLoader(GenericPartitionStatsEntry.class.getClassLoader())
+        .project(PartitionStatsEntry.getSchema(specsById.get(specID).partitionType()))
+        .reuseContainers(false)
+        .build()) {
+      return Lists.newLinkedList(files);
+    } catch (IOException e) {
+      throw new RuntimeIOException(e, "Cannot read manifest list file: %s", partitionStats.location());
+    }
+  }
+
+  static PartitionStatsWriter write(PartitionSpec spec, OutputFile outputFile) {
+    return new PartitionStatsWriter.V2Writer(spec, outputFile);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/PartitionStatsEntry.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionStatsEntry.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import org.apache.iceberg.types.Types;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+public interface PartitionStatsEntry {
+
+  int PARTITION_ID = 600;
+  String PARTITION_NAME = "partition";
+  String PARTITION_DOC = "Partition data tuple, schema based on the partition spec";
+  Types.NestedField FILE_COUNT = required(601, "file_count", Types.IntegerType.get(),
+      "Number of records in this partition");
+  Types.NestedField ROW_COUNT = required(602, "row_count", Types.LongType.get(),
+      "Number of records in this partition");
+
+  static Types.StructType getType(Types.StructType partitionType) {
+    return Types.StructType.of(
+        required(PARTITION_ID, PARTITION_NAME, partitionType, PARTITION_DOC),
+        FILE_COUNT,
+        ROW_COUNT
+    );
+  }
+
+  static Schema getSchema(Types.StructType partitionType) {
+    return new Schema(required(PARTITION_ID, PARTITION_NAME, partitionType, PARTITION_DOC), FILE_COUNT, ROW_COUNT);
+  }
+
+  /**
+   * Returns partition for this file as a {@link StructLike}.
+   */
+  StructLike getPartition();
+
+  /**
+   * Returns the number of records in the partition.
+   */
+  int getFileCount();
+
+  /**
+   * Returns the number of records in the partition.
+   */
+  long getRowCount();
+}

--- a/core/src/main/java/org/apache/iceberg/PartitionStatsMap.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionStatsMap.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+
+/**
+ * ParitionStatsMap: Instance of this class holds updated delta information, this can be used for both delete and
+ * inserts.
+ */
+public class PartitionStatsMap {
+  private final Map<Integer, PartitionSpec> specsById;
+
+  private Map<Integer, PartitionsTable.PartitionMap> partitionSpecMap = Maps.newHashMap();
+  private Set<Integer> partitionSpecUpdated = new HashSet<>();
+
+  public PartitionStatsMap(Map<Integer, PartitionSpec> specsById) {
+    this.specsById = specsById;
+  }
+
+  synchronized void put(DataFile dataFile) {
+    int partitionSpecId = dataFile.specId();
+    PartitionData pd = (PartitionData) dataFile.partition();
+    PartitionsTable.PartitionMap existingPartitionMap = partitionSpecMap.get(partitionSpecId);
+    if (Objects.isNull(existingPartitionMap)) {
+      partitionSpecUpdated.add(partitionSpecId);
+      PartitionsTable.PartitionMap newPartitionMap = new PartitionsTable.PartitionMap(
+          specsById.get(partitionSpecId).partitionType()
+      );
+      partitionSpecMap.put(partitionSpecId, newPartitionMap);
+      newPartitionMap.get(pd.copy()).update(dataFile);
+    } else {
+      existingPartitionMap.get(pd.copy()).update(dataFile);
+    }
+  }
+
+  Set<Integer> getAllUpdatedPartitionSpec() {
+    return partitionSpecUpdated;
+  }
+
+  Iterable<PartitionsTable.Partition> getPartitionDataStats(Integer partitionSpecId) {
+    return partitionSpecMap.get(partitionSpecId).all();
+  }
+
+  PartitionsTable.PartitionMap getPartitionMap(Integer partitionSpecId) {
+    return partitionSpecMap.get(partitionSpecId);
+  }
+
+  PartitionsTable.PartitionMap getEmptyPartitionMap(Integer partitionSpecId) {
+    return new PartitionsTable.PartitionMap(specsById.get(partitionSpecId).partitionType());
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/PartitionStatsWriter.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionStatsWriter.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.io.IOException;
+import org.apache.iceberg.avro.Avro;
+import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.io.OutputFile;
+
+abstract class PartitionStatsWriter implements FileAppender<PartitionStatsEntry> {
+  private final FileAppender<PartitionStatsEntry> writer;
+
+  protected PartitionStatsWriter(PartitionSpec spec, OutputFile file) {
+    this.writer = newAppender(spec, file);
+  }
+
+  @Override
+  public void add(PartitionStatsEntry datum) {
+    writer.add(prepare(datum));
+  }
+
+  @Override
+  public Metrics metrics() {
+    return writer.metrics();
+  }
+
+  @Override
+  public long length() {
+    return writer.length();
+  }
+
+  @Override
+  public void close() throws IOException {
+    writer.close();
+  }
+
+  protected abstract PartitionStatsEntry prepare(PartitionStatsEntry entry);
+
+  protected abstract FileAppender<PartitionStatsEntry> newAppender(PartitionSpec spec, OutputFile outputFile);
+
+  static class V2Writer extends PartitionStatsWriter {
+    private final V2Metadata.IndexedPartitionStatsEntry entryWrapper;
+
+    V2Writer(PartitionSpec spec, OutputFile file) {
+      super(spec, file);
+      this.entryWrapper = new V2Metadata.IndexedPartitionStatsEntry(spec.partitionType());
+    }
+
+    @Override
+    protected PartitionStatsEntry prepare(PartitionStatsEntry entry) {
+      return entryWrapper.wrap(entry);
+    }
+
+    @Override
+    protected FileAppender<PartitionStatsEntry> newAppender(PartitionSpec spec, OutputFile outputFile) {
+      try {
+        return Avro.write(outputFile)
+            .schema(PartitionStatsEntry.getSchema(spec.partitionType()))
+            .named("partitionStats_file")
+            .meta("schema", SchemaParser.toJson(spec.schema()))
+            .meta("partition-spec", PartitionSpecParser.toJsonFields(spec))
+            .meta("partition-spec-id", String.valueOf(spec.specId()))
+            .meta("format-version", "2")
+            .overwrite()
+            .build();
+      } catch (IOException e) {
+        throw new RuntimeIOException(e, "Failed to create manifest writer for path: %s", outputFile);
+      }
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/V2Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V2Metadata.java
@@ -513,4 +513,62 @@ class V2Metadata {
       throw new UnsupportedOperationException("Cannot copy IndexedDataFile wrapper");
     }
   }
+
+  /**
+   * Wrapper used to write PartitionStats entry to v2 metadata.
+   */
+  static class IndexedPartitionStatsEntry<F> implements PartitionStatsEntry, IndexedRecord {
+    private final org.apache.avro.Schema avroSchema;
+    private final IndexedStructLike partitionWrapper;
+    private PartitionStatsEntry wrapped = null;
+
+    IndexedPartitionStatsEntry(Types.StructType partitionType) {
+      this.avroSchema = AvroSchemaUtil.convert(fileType(partitionType), "partitionStats_file");
+      this.partitionWrapper = new IndexedStructLike(avroSchema.getField("partition").schema());
+    }
+
+    @SuppressWarnings("unchecked")
+    PartitionStatsEntry wrap(PartitionStatsEntry partitionStatsEntry) {
+      this.wrapped = partitionStatsEntry;
+      return this;
+    }
+
+    @Override
+    public org.apache.avro.Schema getSchema() {
+      return avroSchema;
+    }
+
+    @Override
+    public Object get(int pos) {
+      switch (pos) {
+        case 0:
+          return partitionWrapper.wrap(wrapped.getPartition());
+        case 1:
+          return wrapped.getFileCount();
+        case 2:
+          return wrapped.getRowCount();
+      }
+      throw new IllegalArgumentException("Unknown field ordinal: " + pos);
+    }
+
+    @Override
+    public void put(int i, Object v) {
+      throw new UnsupportedOperationException("Cannot read into IndexedPartitionStatsFile");
+    }
+
+    @Override
+    public StructLike getPartition() {
+      return wrapped.getPartition();
+    }
+
+    @Override
+    public int getFileCount() {
+      return wrapped.getFileCount();
+    }
+
+    @Override
+    public long getRowCount() {
+      return wrapped.getRowCount();
+    }
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TableTestBase.java
@@ -140,7 +140,9 @@ public class TableTestBase {
 
   List<File> listManifestFiles(File tableDirToList) {
     return Lists.newArrayList(new File(tableDirToList, "metadata").listFiles((dir, name) ->
-        !name.startsWith("snap") && Files.getFileExtension(name).equalsIgnoreCase("avro")));
+        !name.startsWith("snap") &&
+            !name.startsWith("partitionStats") &&
+            Files.getFileExtension(name).equalsIgnoreCase("avro")));
   }
 
   protected TestTables.TestTable create(Schema schema, PartitionSpec spec) {

--- a/core/src/test/java/org/apache/iceberg/TestPartitionStatsMap.java
+++ b/core/src/test/java/org/apache/iceberg/TestPartitionStatsMap.java
@@ -1,0 +1,459 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.InputFile;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestPartitionStatsMap extends TableTestBase {
+  public TestPartitionStatsMap(int formatVersion) {
+    super(formatVersion);
+  }
+
+  @Parameterized.Parameters(name = "formatVersion = {0}")
+  public static Object[] parameters() {
+    return new Object[]{1, 2};
+  }
+
+  @Test
+  public void testAppendFilesInSingleTransaction() {
+    DataFile file1 = DataFiles.builder(SPEC)
+        .withPath("/path/to/data-0.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+        .withRecordCount(7)
+        .build();
+
+    DataFile file2 = DataFiles.builder(SPEC)
+        .withPath("/path/to/data-0.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+        .withRecordCount(9)
+        .build();
+
+    DataFile file3 = DataFiles.builder(SPEC)
+        .withPath("/path/to/data-a.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+        .withRecordCount(17)
+        .build();
+
+    table.newAppend()
+        .appendFile(file1)
+        .appendFile(file2)
+        .appendFile(file3)
+        .commit();
+
+    Snapshot committedSnapshot = table.currentSnapshot();
+    Map statsFileMap = committedSnapshot.partitionStatsFiles();
+    Assert.assertEquals(1, statsFileMap.size());
+    String loc = (String) statsFileMap.get(0);
+    List<PartitionStatsEntry> ls = getOldPartitionStatsBySpec(loc, 0);
+    Assert.assertEquals(33, ls.get(0).getRowCount());
+    Assert.assertEquals(3, ls.get(0).getFileCount());
+  }
+
+  @Test
+  public void testAppendFilesDifferentPartitions() {
+
+    DataFile file1 = DataFiles.builder(SPEC)
+        .withPath("/path/to/data-0.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+        .withRecordCount(7)
+        .build();
+
+    DataFile file2 = DataFiles.builder(SPEC)
+        .withPath("/path/to/data-0.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+        .withRecordCount(9)
+        .build();
+
+    DataFile file3 = DataFiles.builder(SPEC)
+        .withPath("/path/to/data-3.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=3") // easy way to set partition data for now
+        .withRecordCount(17)
+        .build();
+
+    table.newAppend()
+        .appendFile(file1)
+        .appendFile(file2)
+        .appendFile(file3)
+        .commit();
+
+    Snapshot committedSnapshot = table.currentSnapshot();
+    Map statsFileMap = committedSnapshot.partitionStatsFiles();
+    Assert.assertEquals(1, statsFileMap.size());
+    String loc = (String) statsFileMap.get(0);
+    List<PartitionStatsEntry> statsEntries = getOldPartitionStatsBySpec(loc, 0);
+    Assert.assertEquals(2, statsEntries.size());
+
+    for (PartitionStatsEntry partitionStatsEntry : statsEntries) {
+      PartitionData pd = (PartitionData) partitionStatsEntry.getPartition();
+      if (pd.get(0).equals(0)) {
+        Assert.assertEquals(2, partitionStatsEntry.getFileCount());
+        Assert.assertEquals(16, partitionStatsEntry.getRowCount());
+      } else if (pd.get(0).equals(3)) {
+        Assert.assertEquals(1, partitionStatsEntry.getFileCount());
+        Assert.assertEquals(17, partitionStatsEntry.getRowCount());
+      }
+    }
+  }
+
+  @Test
+  public void testAppendFilesAcrossTransaction() {
+    DataFile file1 = DataFiles.builder(SPEC)
+        .withPath("/path/to/data-0.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+        .withRecordCount(7)
+        .build();
+
+    DataFile file2 = DataFiles.builder(SPEC)
+        .withPath("/path/to/data-0.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+        .withRecordCount(9)
+        .build();
+
+    DataFile file3 = DataFiles.builder(SPEC)
+        .withPath("/path/to/data-3.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=3") // easy way to set partition data for now
+        .withRecordCount(17)
+        .build();
+
+    table.newAppend()
+        .appendFile(file1)
+        .appendFile(file2)
+        .appendFile(file3)
+        .commit();
+
+    DataFile file4 = DataFiles.builder(SPEC)
+        .withPath("/path/to/data-0.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+        .withRecordCount(100)
+        .build();
+
+    DataFile file5 = DataFiles.builder(SPEC)
+        .withPath("/path/to/data-0.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+        .withRecordCount(3)
+        .build();
+
+    DataFile file6 = DataFiles.builder(SPEC)
+        .withPath("/path/to/data-3.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=3") // easy way to set partition data for now
+        .withRecordCount(500)
+        .build();
+
+    table.newAppend()
+        .appendFile(file4)
+        .appendFile(file5)
+        .appendFile(file6)
+        .commit();
+
+    Snapshot committedSnapshot = table.currentSnapshot();
+    Map statsFileMap = committedSnapshot.partitionStatsFiles();
+    Assert.assertEquals(1, statsFileMap.size());
+    String loc = (String) statsFileMap.get(0);
+    List<PartitionStatsEntry> statsEntries = getOldPartitionStatsBySpec(loc, 0);
+    Assert.assertEquals(2, statsEntries.size());
+
+    for (PartitionStatsEntry partitionStatsEntry : statsEntries) {
+      PartitionData pd = (PartitionData) partitionStatsEntry.getPartition();
+      if (pd.get(0).equals(0)) {
+        Assert.assertEquals(4, partitionStatsEntry.getFileCount());
+        Assert.assertEquals(119, partitionStatsEntry.getRowCount());
+      } else if (pd.get(0).equals(3)) {
+        Assert.assertEquals(2, partitionStatsEntry.getFileCount());
+        Assert.assertEquals(517, partitionStatsEntry.getRowCount());
+      }
+    }
+  }
+
+  @Test
+  public void testAppendFilesUpdatedPartitionSpec() {
+    DataFile file1 = DataFiles.builder(SPEC)
+        .withPath("/path/to/data-0.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+        .withRecordCount(7)
+        .build();
+
+    DataFile file2 = DataFiles.builder(SPEC)
+        .withPath("/path/to/data-0.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+        .withRecordCount(9)
+        .build();
+
+    DataFile file3 = DataFiles.builder(SPEC)
+        .withPath("/path/to/data-a.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+        .withRecordCount(17)
+        .build();
+
+    table.newAppend()
+        .appendFile(file1)
+        .appendFile(file2)
+        .appendFile(file3)
+        .commit();
+
+    table.updateSpec().addField("id").commit();
+
+    DataFile file4 = DataFiles.builder(table.spec())
+        .withPath("/path/to/data-31.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=3/id=1")
+        .withRecordCount(21)
+        .build();
+
+    DataFile file5 = DataFiles.builder(table.spec())
+        .withPath("/path/to/data-0-31.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=3/id=1")
+        .withRecordCount(12)
+        .build();
+
+    DataFile file6 = DataFiles.builder(table.spec())
+        .withPath("/path/to/data-0-31.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=3/id=2")
+        .withRecordCount(80)
+        .build();
+
+    DataFile file7 = DataFiles.builder(table.spec())
+        .withPath("/path/to/data-0-31.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=3/id=2")
+        .withRecordCount(5)
+        .build();
+
+
+    table.newAppend()
+        .appendFile(file4)
+        .appendFile(file5)
+        .commit();
+
+    table.newAppend()
+        .appendFile(file6)
+        .commit();
+
+    table.newAppend()
+        .appendFile(file7)
+        .commit();
+
+    Snapshot committedSnapshot = table.currentSnapshot();
+    Map statsFileMap = committedSnapshot.partitionStatsFiles();
+    Assert.assertEquals(2, statsFileMap.size());
+
+    String loc = (String) statsFileMap.get(table.spec().specId());
+    List<PartitionStatsEntry> statsEntries = getOldPartitionStatsBySpec(loc, table.spec().specId());
+    Assert.assertEquals(2, statsEntries.size());
+
+    for (PartitionStatsEntry partitionStatsEntry : statsEntries) {
+      PartitionData pd = (PartitionData) partitionStatsEntry.getPartition();
+      if (pd.get(1).equals(1)) {
+        Assert.assertEquals(2, partitionStatsEntry.getFileCount());
+        Assert.assertEquals(33, partitionStatsEntry.getRowCount());
+      } else if (pd.get(1).equals(2)) {
+        Assert.assertEquals(2, partitionStatsEntry.getFileCount());
+        Assert.assertEquals(85, partitionStatsEntry.getRowCount());
+      }
+    }
+  }
+
+  @Test
+  public void testDeleteFilesPartitionStats() {
+    DataFile file1 = DataFiles.builder(SPEC)
+        .withPath("/path/to/data-1.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+        .withRecordCount(7)
+        .build();
+
+    DataFile file2 = DataFiles.builder(SPEC)
+        .withPath("/path/to/data-2.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+        .withRecordCount(9)
+        .build();
+
+    DataFile file3 = DataFiles.builder(SPEC)
+        .withPath("/path/to/data-3.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=3") // easy way to set partition data for now
+        .withRecordCount(17)
+        .build();
+
+    DataFile file4 = DataFiles.builder(SPEC)
+        .withPath("/path/to/data-4.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=3") // easy way to set partition data for now
+        .withRecordCount(5)
+        .build();
+
+    table.newAppend()
+        .appendFile(file1)
+        .appendFile(file2)
+        .appendFile(file3)
+        .appendFile(file4)
+        .commit();
+
+    table.newDelete()
+        .deleteFile(file2)
+        .deleteFile(file3)
+        .commit();
+
+    Snapshot committedSnapshot = table.currentSnapshot();
+    Map statsFileMap = committedSnapshot.partitionStatsFiles();
+    Assert.assertEquals(1, statsFileMap.size());
+    String loc = (String) statsFileMap.get(0);
+    List<PartitionStatsEntry> statsEntries = getOldPartitionStatsBySpec(loc, 0);
+    Assert.assertEquals(2, statsEntries.size());
+
+    for (PartitionStatsEntry partitionStatsEntry : statsEntries) {
+      PartitionData pd = (PartitionData) partitionStatsEntry.getPartition();
+      if (pd.get(0).equals(0)) {
+        Assert.assertEquals(1, partitionStatsEntry.getFileCount());
+        Assert.assertEquals(7, partitionStatsEntry.getRowCount());
+      } else if (pd.get(0).equals(3)) {
+        Assert.assertEquals(1, partitionStatsEntry.getFileCount());
+        Assert.assertEquals(5, partitionStatsEntry.getRowCount());
+      }
+    }
+  }
+
+  @Test
+  public void testDeleteFilesAll() {
+    DataFile file1 = DataFiles.builder(SPEC)
+        .withPath("/path/to/data-1.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+        .withRecordCount(7)
+        .build();
+
+    DataFile file2 = DataFiles.builder(SPEC)
+        .withPath("/path/to/data-2.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+        .withRecordCount(9)
+        .build();
+
+    DataFile file3 = DataFiles.builder(SPEC)
+        .withPath("/path/to/data-3.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+        .withRecordCount(17)
+        .build();
+
+    table.newAppend()
+        .appendFile(file1)
+        .appendFile(file2)
+        .appendFile(file3)
+        .commit();
+
+    table.updateSpec().addField("id").commit();
+
+    DataFile file4 = DataFiles.builder(table.spec())
+        .withPath("/path/to/data-4.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=3/id=1")
+        .withRecordCount(21)
+        .build();
+
+    DataFile file5 = DataFiles.builder(table.spec())
+        .withPath("/path/to/data-5.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=3/id=1")
+        .withRecordCount(12)
+        .build();
+
+    DataFile file6 = DataFiles.builder(table.spec())
+        .withPath("/path/to/data-6.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=3/id=2")
+        .withRecordCount(80)
+        .build();
+
+    DataFile file7 = DataFiles.builder(table.spec())
+        .withPath("/path/to/data-7.parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=3/id=2")
+        .withRecordCount(5)
+        .build();
+
+    table.newAppend()
+        .appendFile(file4)
+        .appendFile(file5)
+        .commit();
+
+    table.newAppend()
+        .appendFile(file6)
+        .commit();
+
+    table.newAppend()
+        .appendFile(file7)
+        .commit();
+
+    table.newDelete()
+        .deleteFromRowFilter(Expressions.alwaysTrue())
+        .commit();
+
+    Snapshot committedSnapshot = table.currentSnapshot();
+    Map statsFileMap = committedSnapshot.partitionStatsFiles();
+    Assert.assertEquals(2, statsFileMap.size());
+
+    String loc = (String) statsFileMap.get(table.spec().specId());
+    List<PartitionStatsEntry> statsEntries = getOldPartitionStatsBySpec(loc, table.spec().specId());
+    Assert.assertEquals(2, statsEntries.size());
+
+    for (PartitionStatsEntry partitionStatsEntry : statsEntries) {
+      PartitionData pd = (PartitionData) partitionStatsEntry.getPartition();
+      if (pd.get(1).equals(1)) {
+        Assert.assertEquals(0, partitionStatsEntry.getFileCount());
+        Assert.assertEquals(0, partitionStatsEntry.getRowCount());
+      } else if (pd.get(1).equals(2)) {
+        Assert.assertEquals(0, partitionStatsEntry.getFileCount());
+        Assert.assertEquals(0, partitionStatsEntry.getRowCount());
+      }
+    }
+  }
+
+  protected List<PartitionStatsEntry> getOldPartitionStatsBySpec(String location, int specID) {
+    InputFile inpf = table.ops().io().newInputFile(location);
+    return PartitionStats.read(inpf, specID, table.specs());
+  }
+
+}

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -40,7 +41,7 @@ public class TestSnapshotJson {
   @Test
   public void testJsonConversion() {
     Snapshot expected = new BaseSnapshot(ops.io(), System.currentTimeMillis(),
-        "file:/tmp/manifest1.avro", "file:/tmp/manifest2.avro");
+        new HashMap<>(), "file:/tmp/manifest1.avro", "file:/tmp/manifest2.avro");
     String json = SnapshotParser.toJson(expected);
     Snapshot snapshot = SnapshotParser.fromJson(ops.io(), json);
 
@@ -62,7 +63,7 @@ public class TestSnapshotJson {
 
     Snapshot expected = new BaseSnapshot(ops.io(), id, parentId, System.currentTimeMillis(),
         DataOperations.REPLACE, ImmutableMap.of("files-added", "4", "files-deleted", "100"),
-        manifests);
+        manifests, new HashMap<>());
 
     String json = SnapshotParser.toJson(expected);
     Snapshot snapshot = SnapshotParser.fromJson(ops.io(), json);
@@ -102,9 +103,11 @@ public class TestSnapshotJson {
     }
 
     Snapshot expected = new BaseSnapshot(
-        ops.io(), id, 34, parentId, System.currentTimeMillis(), null, null, localInput(manifestList).location());
+        ops.io(), id, 34, parentId, System.currentTimeMillis(), null, null, localInput(manifestList).location(),
+        new HashMap<>());
     Snapshot inMemory = new BaseSnapshot(
-        ops.io(), id, parentId, expected.timestampMillis(), null, null, manifests);
+        ops.io(), id, parentId, expected.timestampMillis(), null, null, manifests,
+        new HashMap<>());
 
     Assert.assertEquals("Files should match in memory list",
         inMemory.allManifests(), expected.allManifests());

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -28,6 +28,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -87,13 +88,20 @@ public class TestTableMetadata {
   @Test
   public void testJsonConversion() throws Exception {
     long previousSnapshotId = System.currentTimeMillis() - new Random(1234).nextInt(3600);
+    Map<Integer, String> partitionStatsFileMap = new HashMap<>();
+    partitionStatsFileMap.put(0, "Dummy Loc0");
+    partitionStatsFileMap.put(1, "Dummy Loc1");
+    partitionStatsFileMap.put(2, "Dummy Loc2");
+    partitionStatsFileMap.put(3, "Dummy Loc3");
+    partitionStatsFileMap.put(4, "Dummy Loc4");
+
     Snapshot previousSnapshot = new BaseSnapshot(
         ops.io(), previousSnapshotId, null, previousSnapshotId, null, null, ImmutableList.of(
-        new GenericManifestFile(localInput("file:/tmp/manfiest.1.avro"), SPEC_5.specId())));
+        new GenericManifestFile(localInput("file:/tmp/manfiest.1.avro"), SPEC_5.specId())), new HashMap<>());
     long currentSnapshotId = System.currentTimeMillis();
     Snapshot currentSnapshot = new BaseSnapshot(
         ops.io(), currentSnapshotId, previousSnapshotId, currentSnapshotId, null, null, ImmutableList.of(
-        new GenericManifestFile(localInput("file:/tmp/manfiest.2.avro"), SPEC_5.specId())));
+        new GenericManifestFile(localInput("file:/tmp/manfiest.2.avro"), SPEC_5.specId())), partitionStatsFileMap);
 
     List<HistoryEntry> snapshotLog = ImmutableList.<HistoryEntry>builder()
         .add(new SnapshotLogEntry(previousSnapshot.timestampMillis(), previousSnapshot.snapshotId()))
@@ -152,11 +160,11 @@ public class TestTableMetadata {
     long previousSnapshotId = System.currentTimeMillis() - new Random(1234).nextInt(3600);
     Snapshot previousSnapshot = new BaseSnapshot(
         ops.io(), previousSnapshotId, null, previousSnapshotId, null, null, ImmutableList.of(
-        new GenericManifestFile(localInput("file:/tmp/manfiest.1.avro"), spec.specId())));
+        new GenericManifestFile(localInput("file:/tmp/manfiest.1.avro"), spec.specId())), new HashMap<>());
     long currentSnapshotId = System.currentTimeMillis();
     Snapshot currentSnapshot = new BaseSnapshot(
         ops.io(), currentSnapshotId, previousSnapshotId, currentSnapshotId, null, null, ImmutableList.of(
-        new GenericManifestFile(localInput("file:/tmp/manfiest.2.avro"), spec.specId())));
+        new GenericManifestFile(localInput("file:/tmp/manfiest.2.avro"), spec.specId())), new HashMap<>());
 
     TableMetadata expected = new TableMetadata(null, 1, null, TEST_LOCATION,
         0, System.currentTimeMillis(), 3, TEST_SCHEMA, 6, ImmutableList.of(spec),
@@ -256,11 +264,11 @@ public class TestTableMetadata {
     long previousSnapshotId = System.currentTimeMillis() - new Random(1234).nextInt(3600);
     Snapshot previousSnapshot = new BaseSnapshot(
         ops.io(), previousSnapshotId, null, previousSnapshotId, null, null, ImmutableList.of(
-        new GenericManifestFile(localInput("file:/tmp/manfiest.1.avro"), SPEC_5.specId())));
+        new GenericManifestFile(localInput("file:/tmp/manfiest.1.avro"), SPEC_5.specId())), new HashMap<>());
     long currentSnapshotId = System.currentTimeMillis();
     Snapshot currentSnapshot = new BaseSnapshot(
         ops.io(), currentSnapshotId, previousSnapshotId, currentSnapshotId, null, null, ImmutableList.of(
-        new GenericManifestFile(localInput("file:/tmp/manfiest.2.avro"), SPEC_5.specId())));
+        new GenericManifestFile(localInput("file:/tmp/manfiest.2.avro"), SPEC_5.specId())), new HashMap<>());
 
     List<HistoryEntry> reversedSnapshotLog = Lists.newArrayList();
     long currentTimestamp = System.currentTimeMillis();
@@ -286,11 +294,11 @@ public class TestTableMetadata {
     long previousSnapshotId = System.currentTimeMillis() - new Random(1234).nextInt(3600);
     Snapshot previousSnapshot = new BaseSnapshot(
         ops.io(), previousSnapshotId, null, previousSnapshotId, null, null, ImmutableList.of(
-        new GenericManifestFile(localInput("file:/tmp/manfiest.1.avro"), SPEC_5.specId())));
+        new GenericManifestFile(localInput("file:/tmp/manfiest.1.avro"), SPEC_5.specId())), new HashMap<>());
     long currentSnapshotId = System.currentTimeMillis();
     Snapshot currentSnapshot = new BaseSnapshot(
         ops.io(), currentSnapshotId, previousSnapshotId, currentSnapshotId, null, null, ImmutableList.of(
-        new GenericManifestFile(localInput("file:/tmp/manfiest.2.avro"), SPEC_5.specId())));
+        new GenericManifestFile(localInput("file:/tmp/manfiest.2.avro"), SPEC_5.specId())), new HashMap<>());
 
     List<HistoryEntry> reversedSnapshotLog = Lists.newArrayList();
     long currentTimestamp = System.currentTimeMillis();
@@ -325,11 +333,11 @@ public class TestTableMetadata {
     long previousSnapshotId = System.currentTimeMillis() - new Random(1234).nextInt(3600);
     Snapshot previousSnapshot = new BaseSnapshot(
         ops.io(), previousSnapshotId, null, previousSnapshotId, null, null, ImmutableList.of(
-        new GenericManifestFile(localInput("file:/tmp/manfiest.1.avro"), SPEC_5.specId())));
+        new GenericManifestFile(localInput("file:/tmp/manfiest.1.avro"), SPEC_5.specId())), new HashMap<>());
     long currentSnapshotId = System.currentTimeMillis();
     Snapshot currentSnapshot = new BaseSnapshot(
         ops.io(), currentSnapshotId, previousSnapshotId, currentSnapshotId, null, null, ImmutableList.of(
-        new GenericManifestFile(localInput("file:/tmp/manfiest.2.avro"), SPEC_5.specId())));
+        new GenericManifestFile(localInput("file:/tmp/manfiest.2.avro"), SPEC_5.specId())), new HashMap<>());
 
     List<HistoryEntry> reversedSnapshotLog = Lists.newArrayList();
     long currentTimestamp = System.currentTimeMillis();
@@ -376,11 +384,11 @@ public class TestTableMetadata {
     long previousSnapshotId = System.currentTimeMillis() - new Random(1234).nextInt(3600);
     Snapshot previousSnapshot = new BaseSnapshot(
         ops.io(), previousSnapshotId, null, previousSnapshotId, null, null, ImmutableList.of(
-        new GenericManifestFile(localInput("file:/tmp/manfiest.1.avro"), SPEC_5.specId())));
+        new GenericManifestFile(localInput("file:/tmp/manfiest.1.avro"), SPEC_5.specId())), new HashMap<>());
     long currentSnapshotId = System.currentTimeMillis();
     Snapshot currentSnapshot = new BaseSnapshot(
         ops.io(), currentSnapshotId, previousSnapshotId, currentSnapshotId, null, null, ImmutableList.of(
-        new GenericManifestFile(localInput("file:/tmp/manfiest.2.avro"), SPEC_5.specId())));
+        new GenericManifestFile(localInput("file:/tmp/manfiest.2.avro"), SPEC_5.specId())), new HashMap<>());
 
     List<HistoryEntry> reversedSnapshotLog = Lists.newArrayList();
     long currentTimestamp = System.currentTimeMillis();

--- a/core/src/test/java/org/apache/iceberg/hadoop/HadoopTableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/HadoopTableTestBase.java
@@ -120,7 +120,9 @@ public class HadoopTableTestBase {
 
   List<File> listManifestFiles() {
     return Lists.newArrayList(metadataDir.listFiles((dir, name) ->
-        !name.startsWith("snap") && Files.getFileExtension(name).equalsIgnoreCase("avro")));
+        !name.startsWith("snap") &&
+            !name.startsWith("partitionStats") &&
+            Files.getFileExtension(name).equalsIgnoreCase("avro")));
   }
 
   List<File> listMetadataJsonFiles() {


### PR DESCRIPTION
This PR is contains implementation PartitionStatsFile. issue : #1833
 
Within each snapshot we will have "partition-stats-files" map which points to partition stats file location for each partition spec in this snapshot.
Schema of partitionstatsfile :
1. partition: This is a list of values for each partition column. PartitionData tuple based on partition specification.
2. file_count (int): Number of data files in this partition
3. row_count(long): Number of rows in table in this partition
See TestPartitionStatsMap.java which tests possible scenarios