### PR TITLE
Spark: Add more tests for action alignment in MERGE

### DIFF
--- a/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -110,6 +110,10 @@ public abstract class SparkTestBase {
           Object value = row.get(pos);
           if (value instanceof Row) {
             return toJava((Row) value);
+          } else if (value instanceof scala.collection.Seq) {
+            return row.getList(pos);
+          } else if (value instanceof scala.collection.Map) {
+            return row.getJavaMap(pos);
           } else {
             return value;
           }
@@ -146,11 +150,12 @@ public abstract class SparkTestBase {
     Assert.assertEquals("Number of columns should match", expectedRow.length, actualRow.length);
     for (int col = 0; col < actualRow.length; col += 1) {
       Object expectedValue = expectedRow[col];
+      Object actualValue = actualRow[col];
       if (expectedValue != null && expectedValue.getClass().isArray()) {
         String newContext = String.format("%s (nested col %d)", context, col + 1);
-        assertEquals(newContext, (Object[]) expectedValue, (Object[]) actualRow[col]);
+        assertEquals(newContext, (Object[]) expectedValue, (Object[]) actualValue);
       } else if (expectedValue != ANY) {
-        Assert.assertEquals(context + " contents should match", expectedValue, actualRow[col]);
+        Assert.assertEquals(context + " contents should match", expectedValue, actualValue);
       }
     }
   }

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -50,10 +50,10 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
 
   @Test
   public void testMergeAlignsUpdateAndInsertActions() {
-    createAndInitTable("id INT, a INT, b STRING", "{ \"id\": 1, \"a\": 2, \"b\": \"3\" }");
+    createAndInitTable("id INT, a INT, b STRING", "{ \"id\": 1, \"a\": 2, \"b\": \"str\" }");
     createOrReplaceView("source",
-        "{ \"id\": 1, \"c1\": -2, \"c2\": \"-3\" }\n" +
-        "{ \"id\": 2, \"c1\": -20, \"c2\": \"-30\" }");
+        "{ \"id\": 1, \"c1\": -2, \"c2\": \"new_str_1\" }\n" +
+        "{ \"id\": 2, \"c1\": -20, \"c2\": \"new_str_2\" }");
 
     sql("MERGE INTO %s t USING source " +
         "ON t.id == source.id " +
@@ -63,7 +63,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
         "  INSERT (b, a, id) VALUES (c2, c1, id)", tableName);
 
     assertEquals("Output should match",
-        ImmutableList.of(row(1, -2, "-3"), row(2, -20, "-30")),
+        ImmutableList.of(row(1, -2, "new_str_1"), row(2, -20, "new_str_2")),
         sql("SELECT * FROM %s ORDER BY id", tableName));
   }
 
@@ -71,7 +71,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
   public void testMergeUpdatesNestedStructFields() {
     createAndInitTable("id INT, s STRUCT<c1:INT,c2:STRUCT<a:ARRAY<INT>,m:MAP<STRING, STRING>>>",
         "{ \"id\": 1, \"s\": { \"c1\": 2, \"c2\": { \"a\": [1,2], \"m\": { \"a\": \"b\"} } } } }");
-    createOrReplaceView("source", "{ \"id\": 1, \"c1\": -2, \"c2\": \"-3\" }");
+    createOrReplaceView("source", "{ \"id\": 1, \"c1\": -2 }");
 
     // update primitive, array, map columns inside a struct
     sql("MERGE INTO %s t USING source " +

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -48,8 +48,77 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     sql("DROP TABLE IF EXISTS source");
   }
 
-  // TODO: tests for reordering when operations succeed (both insert and update actions)
-  // TODO: tests for subqueries in conditions
+  @Test
+  public void testMergeAlignsUpdateAndInsertActions() {
+    createAndInitTable("id INT, a INT, b STRING", "{ \"id\": 1, \"a\": 2, \"b\": \"3\" }");
+    createOrReplaceView("source",
+        "{ \"id\": 1, \"c1\": -2, \"c2\": \"-3\" }\n" +
+        "{ \"id\": 2, \"c1\": -20, \"c2\": \"-30\" }");
+
+    sql("MERGE INTO %s t USING source " +
+        "ON t.id == source.id " +
+        "WHEN MATCHED THEN " +
+        "  UPDATE SET b = c2, a = c1, t.id = source.id " +
+        "WHEN NOT MATCHED THEN " +
+        "  INSERT (b, a, id) VALUES (c2, c1, id)", tableName);
+
+    assertEquals("Output should match",
+        ImmutableList.of(row(1, -2, "-3"), row(2, -20, "-30")),
+        sql("SELECT * FROM %s ORDER BY id", tableName));
+  }
+
+  @Test
+  public void testMergeUpdatesNestedStructFields() {
+    createAndInitTable("id INT, s STRUCT<c1:INT,c2:STRUCT<a:ARRAY<INT>,m:MAP<STRING, STRING>>>",
+        "{ \"id\": 1, \"s\": { \"c1\": 2, \"c2\": { \"a\": [1,2], \"m\": { \"a\": \"b\"} } } } }");
+    createOrReplaceView("source", "{ \"id\": 1, \"c1\": -2, \"c2\": \"-3\" }");
+
+    // update primitive, array, map columns inside a struct
+    sql("MERGE INTO %s t USING source " +
+        "ON t.id == source.id " +
+        "WHEN MATCHED THEN " +
+        "  UPDATE SET t.s.c1 = source.c1, t.s.c2.a = array(-1, -2), t.s.c2.m = map('k', 'v')", tableName);
+
+    assertEquals("Output should match",
+        ImmutableList.of(row(1, row(-2, row(ImmutableList.of(-1, -2), ImmutableMap.of("k", "v"))))),
+        sql("SELECT * FROM %s ORDER BY id", tableName));
+
+    // set primitive, array, map columns to NULL (proper casts should be in place)
+    sql("MERGE INTO %s t USING source " +
+        "ON t.id == source.id " +
+        "WHEN MATCHED THEN " +
+        "  UPDATE SET t.s.c1 = NULL, t.s.c2 = NULL", tableName);
+
+    assertEquals("Output should match",
+        ImmutableList.of(row(1, row(null, null))),
+        sql("SELECT * FROM %s ORDER BY id", tableName));
+
+    // update all fields in a struct
+    sql("MERGE INTO %s t USING source " +
+        "ON t.id == source.id " +
+        "WHEN MATCHED THEN " +
+        "  UPDATE SET t.s = named_struct('c1', 100, 'c2', named_struct('a', array(1), 'm', map('x', 'y')))", tableName);
+
+    assertEquals("Output should match",
+        ImmutableList.of(row(1, row(100, row(ImmutableList.of(1), ImmutableMap.of("x", "y"))))),
+        sql("SELECT * FROM %s ORDER BY id", tableName));
+  }
+
+  @Test
+  public void testMergeWithInferredCasts() {
+    createAndInitTable("id INT, s STRING", "{ \"id\": 1, \"s\": \"value\" }");
+    createOrReplaceView("source", "{ \"id\": 1, \"c1\": -2}");
+
+    // -2 in source should be casted to "-2" in target
+    sql("MERGE INTO %s t USING source " +
+        "ON t.id == source.id " +
+        "WHEN MATCHED THEN " +
+        "  UPDATE SET t.s = source.c1", tableName);
+
+    assertEquals("Output should match",
+        ImmutableList.of(row(1, "-2")),
+        sql("SELECT * FROM %s ORDER BY id", tableName));
+  }
 
   @Test
   public void testMergeModifiesNullStruct() {


### PR DESCRIPTION
This PR adds more tests for `AssignmentAlignmentSupport` that previously required an actual implementation of MERGE.