### PR TITLE
Spark: Optimize insert only case in MERGE

### DIFF
--- a/project/scalastyle_config.xml
+++ b/project/scalastyle_config.xml
@@ -93,11 +93,6 @@
             <parameter name="doubleLineAllowed"><![CDATA[false]]></parameter>
         </parameters>
     </check>
-    <check level="error" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
-        <parameters>
-            <parameter name="maxLength"><![CDATA[100]]></parameter>
-        </parameters>
-    </check>
     <check level="error" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
         <parameters>
             <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteMergeInto.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteMergeInto.scala
@@ -75,14 +75,8 @@ case class RewriteMergeInto(spark: SparkSession) extends Rule[LogicalPlan] with 
 
         val targetTableScan = buildSimpleScanPlan(target, cond)
 
-        val insertAction = notMatchedActions match {
-          case Seq(action: InsertAction) =>
-            action
-          case _ =>
-            throw new AnalysisException("Only insert actions are supported in NOT MATCHED clauses")
-        }
-
         // NOT MATCHED conditions may only refer to columns in source so we can push them down
+        val insertAction = notMatchedActions.head.asInstanceOf[InsertAction]
         val filteredSource = insertAction.condition match {
           case Some(insertCond) => Filter(insertCond, source)
           case None => source

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteMergeInto.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteMergeInto.scala
@@ -23,7 +23,6 @@ import org.apache.iceberg.TableProperties.MERGE_CARDINALITY_CHECK_ENABLED
 import org.apache.iceberg.TableProperties.MERGE_CARDINALITY_CHECK_ENABLED_DEFAULT
 import org.apache.iceberg.spark.Spark3Util
 import org.apache.iceberg.util.PropertyUtil
-import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.analysis.Resolver
 import org.apache.spark.sql.catalyst.expressions.Alias


### PR DESCRIPTION
This PR optimizes the insert only case with a single not matched action (the only case supported by Spark 3.0).