### PR TITLE
Flink : update rewrite data file job name

### DIFF
--- a/flink/src/main/java/org/apache/iceberg/flink/actions/RewriteDataFilesAction.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/actions/RewriteDataFilesAction.java
@@ -52,7 +52,11 @@ public class RewriteDataFilesAction extends BaseRewriteDataFilesAction<RewriteDa
     int parallelism = Math.min(size, maxParallelism);
     DataStream<CombinedScanTask> dataStream = env.fromCollection(combinedScanTasks);
     RowDataRewriter rowDataRewriter = new RowDataRewriter(table(), caseSensitive(), fileIO(), encryptionManager());
-    return rowDataRewriter.rewriteDataForTasks(dataStream, parallelism);
+    try {
+      return rowDataRewriter.rewriteDataForTasks(dataStream, parallelism);
+    } catch (Exception e) {
+      throw new RuntimeException("Rewrite data file error.", e);
+    }
   }
 
   @Override


### PR DESCRIPTION
Now, all the job name of the rewrite data file job is `Data Stream Collect`, and it can not be set. 
So we can’t distinguish the running jobs，the purpose of this PR is to set a different  job name for each job