### PR TITLE
HiveCatalog and HiveClientPool fixes

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -56,7 +56,6 @@ import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,40 +93,6 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
   public HadoopCatalog(){
   }
 
-  /**
-   * The constructor of the HadoopCatalog. It uses the passed location as its warehouse directory.
-   *
-   * @deprecated please use the no-arg constructor, setConf and initialize to construct the catalog. Will be removed in
-   * v0.12.0
-   * @param name The catalog name
-   * @param conf The Hadoop configuration
-   * @param warehouseLocation The location used as warehouse directory
-   */
-  @Deprecated
-  public HadoopCatalog(String name, Configuration conf, String warehouseLocation) {
-    this(name, conf, warehouseLocation, Maps.newHashMap());
-  }
-
-  /**
-   * The all-arg constructor of the HadoopCatalog.
-   *
-   * @deprecated please use the no-arg constructor, setConf and initialize to construct the catalog. Will be removed in
-   * v0.12.0
-   * @param name The catalog name
-   * @param conf The Hadoop configuration
-   * @param warehouseLocation The location used as warehouse directory
-   * @param properties catalog properties
-   */
-  @Deprecated
-  public HadoopCatalog(String name, Configuration conf, String warehouseLocation, Map<String, String> properties) {
-    Preconditions.checkArgument(warehouseLocation != null && !warehouseLocation.equals(""),
-        "Cannot instantiate hadoop catalog. No location provided for warehouse");
-    setConf(conf);
-    Map<String, String> props = Maps.newHashMap(properties);
-    props.put(CatalogProperties.WAREHOUSE_LOCATION, warehouseLocation);
-    initialize(name, props);
-  }
-
   @Override
   public void initialize(String name, Map<String, String> properties) {
     String inputWarehouseLocation = properties.get(CatalogProperties.WAREHOUSE_LOCATION);
@@ -146,11 +111,16 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
   /**
    * The constructor of the HadoopCatalog. It uses the passed location as its warehouse directory.
    *
+   * @deprecated please use the no-arg constructor, setConf and initialize to construct the catalog. Will be removed in
+   * v0.13.0
+   *
    * @param conf The Hadoop configuration
    * @param warehouseLocation The location used as warehouse directory
    */
+  @Deprecated
   public HadoopCatalog(Configuration conf, String warehouseLocation) {
-    this("hadoop", conf, warehouseLocation);
+    setConf(conf);
+    initialize("hadoop", ImmutableMap.of(CatalogProperties.WAREHOUSE_LOCATION, warehouseLocation));
   }
 
   /**
@@ -158,10 +128,16 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
    * from the passed Hadoop configuration as its default file system, and use the default directory
    * <code>iceberg/warehouse</code> as the warehouse directory.
    *
+   * @deprecated please use the no-arg constructor, setConf and initialize to construct the catalog. Will be removed in
+   * v0.13.0
+   *
    * @param conf The Hadoop configuration
    */
+  @Deprecated
   public HadoopCatalog(Configuration conf) {
-    this("hadoop", conf, conf.get("fs.defaultFS") + "/" + ICEBERG_HADOOP_WAREHOUSE_BASE);
+    setConf(conf);
+    String hadoopWarehouseLocation = conf.get("fs.defaultFS") + "/" + ICEBERG_HADOOP_WAREHOUSE_BASE;
+    initialize("hadoop", ImmutableMap.of(CatalogProperties.WAREHOUSE_LOCATION, hadoopWarehouseLocation));
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -56,6 +56,7 @@ import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -93,6 +94,40 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
   public HadoopCatalog(){
   }
 
+  /**
+   * The constructor of the HadoopCatalog. It uses the passed location as its warehouse directory.
+   *
+   * @deprecated please use the no-arg constructor, setConf and initialize to construct the catalog. Will be removed in
+   * v0.12.0
+   * @param name The catalog name
+   * @param conf The Hadoop configuration
+   * @param warehouseLocation The location used as warehouse directory
+   */
+  @Deprecated
+  public HadoopCatalog(String name, Configuration conf, String warehouseLocation) {
+    this(name, conf, warehouseLocation, Maps.newHashMap());
+  }
+
+  /**
+   * The all-arg constructor of the HadoopCatalog.
+   *
+   * @deprecated please use the no-arg constructor, setConf and initialize to construct the catalog. Will be removed in
+   * v0.12.0
+   * @param name The catalog name
+   * @param conf The Hadoop configuration
+   * @param warehouseLocation The location used as warehouse directory
+   * @param properties catalog properties
+   */
+  @Deprecated
+  public HadoopCatalog(String name, Configuration conf, String warehouseLocation, Map<String, String> properties) {
+    Preconditions.checkArgument(warehouseLocation != null && !warehouseLocation.equals(""),
+        "Cannot instantiate hadoop catalog. No location provided for warehouse");
+    setConf(conf);
+    Map<String, String> props = Maps.newHashMap(properties);
+    props.put(CatalogProperties.WAREHOUSE_LOCATION, warehouseLocation);
+    initialize(name, props);
+  }
+
   @Override
   public void initialize(String name, Map<String, String> properties) {
     String inputWarehouseLocation = properties.get(CatalogProperties.WAREHOUSE_LOCATION);
@@ -111,16 +146,11 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
   /**
    * The constructor of the HadoopCatalog. It uses the passed location as its warehouse directory.
    *
-   * @deprecated please use the no-arg constructor, setConf and initialize to construct the catalog. Will be removed in
-   * v0.13.0
-   *
    * @param conf The Hadoop configuration
    * @param warehouseLocation The location used as warehouse directory
    */
-  @Deprecated
   public HadoopCatalog(Configuration conf, String warehouseLocation) {
-    setConf(conf);
-    initialize("hadoop", ImmutableMap.of(CatalogProperties.WAREHOUSE_LOCATION, warehouseLocation));
+    this("hadoop", conf, warehouseLocation);
   }
 
   /**
@@ -128,16 +158,10 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
    * from the passed Hadoop configuration as its default file system, and use the default directory
    * <code>iceberg/warehouse</code> as the warehouse directory.
    *
-   * @deprecated please use the no-arg constructor, setConf and initialize to construct the catalog. Will be removed in
-   * v0.13.0
-   *
    * @param conf The Hadoop configuration
    */
-  @Deprecated
   public HadoopCatalog(Configuration conf) {
-    setConf(conf);
-    String hadoopWarehouseLocation = conf.get("fs.defaultFS") + "/" + ICEBERG_HADOOP_WAREHOUSE_BASE;
-    initialize("hadoop", ImmutableMap.of(CatalogProperties.WAREHOUSE_LOCATION, hadoopWarehouseLocation));
+    this("hadoop", conf, conf.get("fs.defaultFS") + "/" + ICEBERG_HADOOP_WAREHOUSE_BASE);
   }
 
   @Override

--- a/flink/src/main/java/org/apache/iceberg/flink/CatalogLoader.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/CatalogLoader.java
@@ -76,7 +76,7 @@ public interface CatalogLoader extends Serializable {
 
     @Override
     public Catalog loadCatalog() {
-      return new HadoopCatalog(catalogName, hadoopConf.get(), warehouseLocation, properties);
+      return CatalogUtil.loadCatalog(HadoopCatalog.class.getName(), catalogName, properties, hadoopConf.get());
     }
 
     @Override
@@ -109,7 +109,7 @@ public interface CatalogLoader extends Serializable {
 
     @Override
     public Catalog loadCatalog() {
-      return new HiveCatalog(catalogName, uri, warehouse, clientPoolSize, hadoopConf.get(), properties);
+      return CatalogUtil.loadCatalog(HiveCatalog.class.getName(), catalogName, properties, hadoopConf.get());
     }
 
     @Override

--- a/flink/src/main/java/org/apache/iceberg/flink/CatalogLoader.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/CatalogLoader.java
@@ -76,7 +76,7 @@ public interface CatalogLoader extends Serializable {
 
     @Override
     public Catalog loadCatalog() {
-      return CatalogUtil.loadCatalog(HadoopCatalog.class.getName(), catalogName, properties, hadoopConf.get());
+      return new HadoopCatalog(catalogName, hadoopConf.get(), warehouseLocation, properties);
     }
 
     @Override

--- a/flink/src/test/java/org/apache/iceberg/flink/FlinkTestBase.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/FlinkTestBase.java
@@ -59,8 +59,8 @@ public abstract class FlinkTestBase extends TestBaseUtils {
     FlinkTestBase.metastore = new TestHiveMetastore();
     metastore.start();
     FlinkTestBase.hiveConf = metastore.hiveConf();
-    FlinkTestBase.catalog = (HiveCatalog) CatalogUtil.loadCatalog(HiveCatalog.class.getName(),
-        "hive", ImmutableMap.of(), hiveConf);
+    FlinkTestBase.catalog = (HiveCatalog)
+        CatalogUtil.loadCatalog(HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
   }
 
   @AfterClass

--- a/flink/src/test/java/org/apache/iceberg/flink/FlinkTestBase.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/FlinkTestBase.java
@@ -29,8 +29,10 @@ import org.apache.flink.test.util.TestBaseUtils;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.TestHiveMetastore;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -57,7 +59,8 @@ public abstract class FlinkTestBase extends TestBaseUtils {
     FlinkTestBase.metastore = new TestHiveMetastore();
     metastore.start();
     FlinkTestBase.hiveConf = metastore.hiveConf();
-    FlinkTestBase.catalog = new HiveCatalog(metastore.hiveConf());
+    FlinkTestBase.catalog = (HiveCatalog) CatalogUtil.loadCatalog(HiveCatalog.class.getName(),
+        "hive", ImmutableMap.of(), hiveConf);
   }
 
   @AfterClass

--- a/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkReaderDeletesBase.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkReaderDeletesBase.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.flink.source;
 
-import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.iceberg.BaseTable;

--- a/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkReaderDeletesBase.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkReaderDeletesBase.java
@@ -19,9 +19,11 @@
 
 package org.apache.iceberg.flink.source;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -33,6 +35,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.DeleteReadTests;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.TestHiveMetastore;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -73,7 +76,8 @@ public abstract class TestFlinkReaderDeletesBase extends DeleteReadTests {
     metastore = new TestHiveMetastore();
     metastore.start();
     hiveConf = metastore.hiveConf();
-    catalog = new HiveCatalog(hiveConf);
+    catalog = (HiveCatalog)
+        CatalogUtil.loadCatalog(HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
   }
 
   @AfterClass

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.hive;
 
 import java.io.Closeable;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -78,7 +77,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable, Supp
    * Hive Catalog constructor.
    *
    * @deprecated please use the no-arg constructor, setConf and initialize to construct the catalog. Will be removed in
-   * v0.12.0
+   * v0.13.0
    * @param conf Hadoop Configuration
    */
   @Deprecated
@@ -90,71 +89,6 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable, Supp
     this.createStack = Thread.currentThread().getStackTrace();
     this.closed = false;
     this.fileIO = new HadoopFileIO(conf);
-  }
-
-  /**
-   * Hive Catalog constructor.
-   *
-   * @deprecated please use the no-arg constructor, setConf and initialize to construct the catalog. Will be removed in
-   * v0.12.0
-   * @param name catalog name
-   * @param uri Hive metastore uri
-   * @param clientPoolSize size of client pool
-   * @param conf Hadoop Configuration
-   */
-  @Deprecated
-  public HiveCatalog(String name, String uri, int clientPoolSize, Configuration conf) {
-    this(name, uri, null, clientPoolSize, conf);
-  }
-
-  /**
-   * Hive Catalog constructor.
-   *
-   * @deprecated please use the no-arg constructor, setConf and initialize to construct the catalog. Will be removed in
-   * v0.12.0
-   * @param name catalog name
-   * @param uri Hive metastore uri
-   * @param warehouse location of Hive warehouse
-   * @param clientPoolSize size of client pool
-   * @param conf Hadoop Configuration
-   */
-  @Deprecated
-  public HiveCatalog(String name, String uri, String warehouse, int clientPoolSize, Configuration conf) {
-    this(name, uri, warehouse, clientPoolSize, conf, Maps.newHashMap());
-  }
-
-  /**
-   * Hive Catalog constructor.
-   *
-   * @deprecated please use the no-arg constructor, setConf and initialize to construct the catalog. Will be removed in
-   * v0.12.0
-   * @param name catalog name
-   * @param uri Hive metastore uri
-   * @param warehouse location of Hive warehouse
-   * @param clientPoolSize size of client pool
-   * @param conf Hadoop Configuration
-   * @param properties extra Hive configuration properties
-   */
-  @Deprecated
-  public HiveCatalog(
-      String name,
-      String uri,
-      String warehouse,
-      int clientPoolSize,
-      Configuration conf,
-      Map<String, String> properties) {
-
-    Map<String, String> props = new HashMap<>(properties);
-    if (warehouse != null) {
-      props.put(CatalogProperties.WAREHOUSE_LOCATION, warehouse);
-    }
-    if (uri != null) {
-      props.put(CatalogProperties.URI, uri);
-    }
-    props.put(CatalogProperties.CLIENT_POOL_SIZE, Integer.toString(clientPoolSize));
-
-    setConf(conf);
-    initialize(name, props);
   }
 
   @Override

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -74,9 +74,18 @@ public class HiveCatalog extends BaseMetastoreCatalog implements Closeable, Supp
   public HiveCatalog() {
   }
 
+  /**
+   * Hive Catalog constructor.
+   *
+   * @deprecated please use the no-arg constructor, setConf and initialize to construct the catalog. Will be removed in
+   * v0.12.0
+   * @param conf Hadoop Configuration
+   */
+  @Deprecated
   public HiveCatalog(Configuration conf) {
     this.name = "hive";
-    this.clients = new HiveClientPool(conf);
+    int clientPoolSize = conf.getInt(CatalogProperties.CLIENT_POOL_SIZE, CatalogProperties.CLIENT_POOL_SIZE_DEFAULT);
+    this.clients = new HiveClientPool(clientPoolSize, conf);
     this.conf = conf;
     this.createStack = Thread.currentThread().getStackTrace();
     this.closed = false;

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalogs.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalogs.java
@@ -23,6 +23,8 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 
 public final class HiveCatalogs {
 
@@ -34,6 +36,7 @@ public final class HiveCatalogs {
   public static HiveCatalog loadCatalog(Configuration conf) {
     // metastore URI can be null in local mode
     String metastoreUri = conf.get(HiveConf.ConfVars.METASTOREURIS.varname, "");
-    return CATALOG_CACHE.get(metastoreUri, uri -> new HiveCatalog(conf));
+    return CATALOG_CACHE.get(metastoreUri, uri -> (HiveCatalog) CatalogUtil.loadCatalog(HiveCatalog.class.getName(),
+        "hive", ImmutableMap.of(), conf));
   }
 }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalogs.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalogs.java
@@ -36,7 +36,7 @@ public final class HiveCatalogs {
   public static HiveCatalog loadCatalog(Configuration conf) {
     // metastore URI can be null in local mode
     String metastoreUri = conf.get(HiveConf.ConfVars.METASTOREURIS.varname, "");
-    return CATALOG_CACHE.get(metastoreUri, uri -> (HiveCatalog) CatalogUtil.loadCatalog(HiveCatalog.class.getName(),
-        "hive", ImmutableMap.of(), conf));
+    return CATALOG_CACHE.get(metastoreUri, uri -> (HiveCatalog)
+        CatalogUtil.loadCatalog(HiveCatalog.class.getName(), "hive", ImmutableMap.of(), conf));
   }
 }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveClientPool.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveClientPool.java
@@ -38,10 +38,6 @@ public class HiveClientPool extends ClientPool<HiveMetaStoreClient, TException> 
 
   private final HiveConf hiveConf;
 
-  HiveClientPool(Configuration conf) {
-    this(conf.getInt("iceberg.hive.client-pool-size", 5), conf);
-  }
-
   public HiveClientPool(int poolSize, Configuration conf) {
     super(poolSize, TTransportException.class);
     this.hiveConf = new HiveConf(conf, HiveClientPool.class);

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveMetastoreTest.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveMetastoreTest.java
@@ -23,6 +23,8 @@ import java.util.HashMap;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
@@ -44,7 +46,8 @@ public abstract class HiveMetastoreTest {
     String dbPath = metastore.getDatabasePath(DB_NAME);
     Database db = new Database(DB_NAME, "description", dbPath, new HashMap<>());
     metastoreClient.createDatabase(db);
-    HiveMetastoreTest.catalog = new HiveCatalog(hiveConf);
+    HiveMetastoreTest.catalog = (HiveCatalog) CatalogUtil.loadCatalog(HiveCatalog.class.getName(),
+        "hive", ImmutableMap.of(), hiveConf);
   }
 
   @AfterClass

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveMetastoreTest.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveMetastoreTest.java
@@ -46,8 +46,8 @@ public abstract class HiveMetastoreTest {
     String dbPath = metastore.getDatabasePath(DB_NAME);
     Database db = new Database(DB_NAME, "description", dbPath, new HashMap<>());
     metastoreClient.createDatabase(db);
-    HiveMetastoreTest.catalog = (HiveCatalog) CatalogUtil.loadCatalog(HiveCatalog.class.getName(),
-        "hive", ImmutableMap.of(), hiveConf);
+    HiveMetastoreTest.catalog = (HiveCatalog)
+        CatalogUtil.loadCatalog(HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
   }
 
   @AfterClass

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveTableTest.java
@@ -375,7 +375,7 @@ public class HiveTableTest extends HiveTableBaseTest {
     catalog.dropTable(TABLE_IDENTIFIER);
 
     // Unset in hive-conf
-    hiveConf.unset(ConfigProperties.ENGINE_HIVE_ENABLED);
+    catalog.getConf().unset(ConfigProperties.ENGINE_HIVE_ENABLED);
 
     catalog.createTable(TABLE_IDENTIFIER, schema, PartitionSpec.unpartitioned());
     org.apache.hadoop.hive.metastore.api.Table hmsTable = metastoreClient.getTable(DB_NAME, TABLE_NAME);
@@ -389,7 +389,7 @@ public class HiveTableTest extends HiveTableBaseTest {
     catalog.dropTable(TABLE_IDENTIFIER);
 
     // Enable by hive-conf
-    hiveConf.set(ConfigProperties.ENGINE_HIVE_ENABLED, "true");
+    catalog.getConf().set(ConfigProperties.ENGINE_HIVE_ENABLED, "true");
 
     catalog.createTable(TABLE_IDENTIFIER, schema, PartitionSpec.unpartitioned());
     org.apache.hadoop.hive.metastore.api.Table hmsTable = metastoreClient.getTable(DB_NAME, TABLE_NAME);
@@ -399,7 +399,7 @@ public class HiveTableTest extends HiveTableBaseTest {
     catalog.dropTable(TABLE_IDENTIFIER);
 
     // Disable by hive-conf
-    hiveConf.set(ConfigProperties.ENGINE_HIVE_ENABLED, "false");
+    catalog.getConf().set(ConfigProperties.ENGINE_HIVE_ENABLED, "false");
 
     catalog.createTable(TABLE_IDENTIFIER, schema, PartitionSpec.unpartitioned());
     hmsTable = metastoreClient.getTable(DB_NAME, TABLE_NAME);
@@ -415,7 +415,7 @@ public class HiveTableTest extends HiveTableBaseTest {
     // Enabled by table property - also check that the hive-conf is ignored
     Map<String, String> tableProperties = new HashMap<>();
     tableProperties.put(TableProperties.ENGINE_HIVE_ENABLED, "true");
-    hiveConf.set(ConfigProperties.ENGINE_HIVE_ENABLED, "false");
+    catalog.getConf().set(ConfigProperties.ENGINE_HIVE_ENABLED, "false");
 
     catalog.createTable(TABLE_IDENTIFIER, schema, PartitionSpec.unpartitioned(), tableProperties);
     org.apache.hadoop.hive.metastore.api.Table hmsTable = metastoreClient.getTable(DB_NAME, TABLE_NAME);
@@ -426,7 +426,7 @@ public class HiveTableTest extends HiveTableBaseTest {
 
     // Disabled by table property - also check that the hive-conf is ignored
     tableProperties.put(TableProperties.ENGINE_HIVE_ENABLED, "false");
-    hiveConf.set(ConfigProperties.ENGINE_HIVE_ENABLED, "true");
+    catalog.getConf().set(ConfigProperties.ENGINE_HIVE_ENABLED, "true");
 
     catalog.createTable(TABLE_IDENTIFIER, schema, PartitionSpec.unpartitioned(), tableProperties);
     hmsTable = metastoreClient.getTable(DB_NAME, TABLE_NAME);

--- a/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -64,8 +64,8 @@ public abstract class SparkTestBase {
         .enableHiveSupport()
         .getOrCreate();
 
-    SparkTestBase.catalog = (HiveCatalog) CatalogUtil.loadCatalog(HiveCatalog.class.getName(),
-        "hive", ImmutableMap.of(), hiveConf);
+    SparkTestBase.catalog = (HiveCatalog)
+        CatalogUtil.loadCatalog(HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
 
     try {
       catalog.createNamespace(Namespace.of("default"));

--- a/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -24,11 +24,13 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.TestHiveMetastore;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.spark.sql.Row;
@@ -62,7 +64,8 @@ public abstract class SparkTestBase {
         .enableHiveSupport()
         .getOrCreate();
 
-    SparkTestBase.catalog = new HiveCatalog(spark.sessionState().newHadoopConf());
+    SparkTestBase.catalog = (HiveCatalog) CatalogUtil.loadCatalog(HiveCatalog.class.getName(),
+        "hive", ImmutableMap.of(), hiveConf);
 
     try {
       catalog.createNamespace(Namespace.of("default"));

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.List;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.PartitionSpec;
@@ -40,6 +41,7 @@ import org.apache.iceberg.data.Record;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.TestHiveMetastore;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.SparkStructLike;
 import org.apache.iceberg.types.Types;
@@ -74,7 +76,8 @@ public abstract class TestSparkReaderDeletes extends DeleteReadTests {
         .enableHiveSupport()
         .getOrCreate();
 
-    catalog = new HiveCatalog(spark.sessionState().newHadoopConf());
+    catalog = (HiveCatalog) CatalogUtil.loadCatalog(HiveCatalog.class.getName(),
+        "hive", ImmutableMap.of(), hiveConf);
 
     try {
       catalog.createNamespace(Namespace.of("default"));

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -76,8 +76,8 @@ public abstract class TestSparkReaderDeletes extends DeleteReadTests {
         .enableHiveSupport()
         .getOrCreate();
 
-    catalog = (HiveCatalog) CatalogUtil.loadCatalog(HiveCatalog.class.getName(),
-        "hive", ImmutableMap.of(), hiveConf);
+    catalog = (HiveCatalog)
+        CatalogUtil.loadCatalog(HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
 
     try {
       catalog.createNamespace(Namespace.of("default"));

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkExtensionsTestBase.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkExtensionsTestBase.java
@@ -20,8 +20,10 @@
 package org.apache.iceberg.spark.extensions;
 
 import java.util.Map;
+import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.TestHiveMetastore;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.spark.SparkCatalogTestBase;
 import org.apache.iceberg.spark.SparkTestBase;
 import org.apache.spark.sql.SparkSession;
@@ -52,6 +54,7 @@ public abstract class SparkExtensionsTestBase extends SparkCatalogTestBase {
         .enableHiveSupport()
         .getOrCreate();
 
-    SparkTestBase.catalog = new HiveCatalog(spark.sessionState().newHadoopConf());
+    SparkTestBase.catalog = (HiveCatalog) CatalogUtil.loadCatalog(HiveCatalog.class.getName(),
+        "hive", ImmutableMap.of(), hiveConf);
   }
 }

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkExtensionsTestBase.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkExtensionsTestBase.java
@@ -54,7 +54,7 @@ public abstract class SparkExtensionsTestBase extends SparkCatalogTestBase {
         .enableHiveSupport()
         .getOrCreate();
 
-    SparkTestBase.catalog = (HiveCatalog) CatalogUtil.loadCatalog(HiveCatalog.class.getName(),
-        "hive", ImmutableMap.of(), hiveConf);
+    SparkTestBase.catalog = (HiveCatalog)
+        CatalogUtil.loadCatalog(HiveCatalog.class.getName(), "hive", ImmutableMap.of(), hiveConf);
   }
 }


### PR DESCRIPTION
* remove option to create pool w/o a defined size
* deprecate last no-arg constructor in HiveCatalog
* move tests to use no-arg constructor

**NOTE:** the `HiveCatalog` copies a new Hadoop Configuration which is a breaking change from how the constructor used to work. See `HiveMetastoreTest` changes for ramifications.

As discussed in https://github.com/apache/iceberg/pull/2180#issuecomment-770062242