### PR TITLE
Allow adding of deleted columns

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -138,7 +138,8 @@ class SchemaUpdate implements UpdateSchema {
       parentId = parentField.fieldId();
       Preconditions.checkArgument(!deletes.contains(parentId),
           "Cannot add to a column that will be deleted: %s", parent);
-      Preconditions.checkArgument(schema.findField(parent + "." + name) == null || deletes.contains(schema.findField(parent + "." + name).fieldId()),
+      Preconditions.checkArgument(schema.findField(parent + "." + name) == null ||
+                      deletes.contains(schema.findField(parent + "." + name).fieldId()),
           "Cannot add column, name already exists and is not being deleted: %s.%s", parent, name);
       fullName = schema.findColumnName(parentId) + "." + name;
     } else {

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -138,11 +138,11 @@ class SchemaUpdate implements UpdateSchema {
       parentId = parentField.fieldId();
       Preconditions.checkArgument(!deletes.contains(parentId),
           "Cannot add to a column that will be deleted: %s", parent);
-      Preconditions.checkArgument(schema.findField(parent + "." + name) == null,
-          "Cannot add column, name already exists: %s.%s", parent, name);
+      Preconditions.checkArgument(schema.findField(parent + "." + name) == null || deletes.contains(schema.findField(parent + "." + name).fieldId()),
+          "Cannot add column, name already exists and is not being deleted: %s.%s", parent, name);
       fullName = schema.findColumnName(parentId) + "." + name;
     } else {
-      Preconditions.checkArgument(schema.findField(name) == null,
+      Preconditions.checkArgument(schema.findField(name) == null || deletes.contains(schema.findField(name).fieldId()),
           "Cannot add column, name already exists: %s", name);
       fullName = name;
     }

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -143,7 +143,7 @@ class SchemaUpdate implements UpdateSchema {
       fullName = schema.findColumnName(parentId) + "." + name;
     } else {
       Preconditions.checkArgument(schema.findField(name) == null || deletes.contains(schema.findField(name).fieldId()),
-          "Cannot add column, name already exists: %s", name);
+          "Cannot add column, name already exists and is not being deleted: %s", name);
       fullName = name;
     }
 

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -136,15 +136,16 @@ class SchemaUpdate implements UpdateSchema {
           parentField.type().isNestedType() && parentField.type().asNestedType().isStructType(),
           "Cannot add to non-struct column: %s: %s", parent, parentField.type());
       parentId = parentField.fieldId();
+      Types.NestedField currentField = schema.findField(parent + "." + name);
       Preconditions.checkArgument(!deletes.contains(parentId),
           "Cannot add to a column that will be deleted: %s", parent);
-      Preconditions.checkArgument(schema.findField(parent + "." + name) == null ||
-                      deletes.contains(schema.findField(parent + "." + name).fieldId()),
-          "Cannot add column, name already exists and is not being deleted: %s.%s", parent, name);
+      Preconditions.checkArgument(currentField == null || deletes.contains(currentField.fieldId()),
+          "Cannot add column, name already exists: %s.%s", parent, name);
       fullName = schema.findColumnName(parentId) + "." + name;
     } else {
-      Preconditions.checkArgument(schema.findField(name) == null || deletes.contains(schema.findField(name).fieldId()),
-          "Cannot add column, name already exists and is not being deleted: %s", name);
+      Types.NestedField currentField = schema.findField(name);
+      Preconditions.checkArgument(currentField == null || deletes.contains(currentField.fieldId()),
+          "Cannot add column, name already exists: %s", name);
       fullName = name;
     }
 

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -488,13 +488,13 @@ public class TestSchemaUpdate {
   @Test
   public void testAddAlreadyExists() {
     AssertHelpers.assertThrows("Should reject column name that already exists",
-        IllegalArgumentException.class, "already exists: preferences.feature1", () -> {
+        IllegalArgumentException.class, "already exists and is not being deleted: preferences.feature1", () -> {
           UpdateSchema update = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID);
           update.addColumn("preferences", "feature1", Types.BooleanType.get());
         }
     );
     AssertHelpers.assertThrows("Should reject column name that already exists",
-        IllegalArgumentException.class, "already exists: preferences", () -> {
+        IllegalArgumentException.class, "already exists and is not being deleted: preferences", () -> {
           UpdateSchema update = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID);
           update.addColumn("preferences", Types.BooleanType.get());
         }

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -501,6 +501,58 @@ public class TestSchemaUpdate {
     );
   }
 
+    @Test
+    public void testDeleteThenAdd() {
+        Schema schema = new Schema(required(1, "id", Types.IntegerType.get()));
+        Schema expected = new Schema(optional(2, "id", Types.IntegerType.get()));
+
+        Schema updated = new SchemaUpdate(schema, 1)
+                .deleteColumn("id")
+                .addColumn("id", optional(2, "id", Types.IntegerType.get()).type())
+                .apply();
+
+        Assert.assertEquals("Should match with added fields", expected.asStruct(), updated.asStruct());
+
+        Schema expectedNested = new Schema(
+                required(1, "id", Types.IntegerType.get()),
+                optional(2, "data", Types.StringType.get()),
+                optional(3, "preferences", Types.StructType.of(
+                        optional(9, "feature2", Types.BooleanType.get()),
+                        optional(24, "feature1", Types.BooleanType.get())
+                ), "struct of named boolean options"),
+                required(4, "locations", Types.MapType.ofRequired(10, 11,
+                        Types.StructType.of(
+                                required(20, "address", Types.StringType.get()),
+                                required(21, "city", Types.StringType.get()),
+                                required(22, "state", Types.StringType.get()),
+                                required(23, "zip", Types.IntegerType.get())
+                        ),
+                        Types.StructType.of(
+                                required(12, "lat", Types.FloatType.get()),
+                                required(13, "long", Types.FloatType.get())
+                        )), "map of address to coordinate"),
+                optional(5, "points", Types.ListType.ofOptional(14,
+                        Types.StructType.of(
+                                required(15, "x", Types.LongType.get()),
+                                required(16, "y", Types.LongType.get())
+                        )), "2-D cartesian points"),
+                required(6, "doubles", Types.ListType.ofRequired(17,
+                        Types.DoubleType.get()
+                )),
+                optional(7, "properties", Types.MapType.ofOptional(18, 19,
+                        Types.StringType.get(),
+                        Types.StringType.get()
+                ), "string map of properties")
+        );
+
+        Schema updatedNested = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
+                .deleteColumn("preferences.feature1")
+                .addColumn("preferences", "feature1", Types.BooleanType.get())
+                .apply();
+
+        Assert.assertEquals("Should match with added fields", expectedNested.asStruct(), updatedNested.asStruct());
+    }
+
   @Test
   public void testDeleteMissingColumn() {
     AssertHelpers.assertThrows("Should reject delete missing column",

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -488,13 +488,13 @@ public class TestSchemaUpdate {
   @Test
   public void testAddAlreadyExists() {
     AssertHelpers.assertThrows("Should reject column name that already exists",
-        IllegalArgumentException.class, "already exists and is not being deleted: preferences.feature1", () -> {
+        IllegalArgumentException.class, "already exists: preferences.feature1", () -> {
           UpdateSchema update = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID);
           update.addColumn("preferences", "feature1", Types.BooleanType.get());
         }
     );
     AssertHelpers.assertThrows("Should reject column name that already exists",
-        IllegalArgumentException.class, "already exists and is not being deleted: preferences", () -> {
+        IllegalArgumentException.class, "already exists: preferences", () -> {
           UpdateSchema update = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID);
           update.addColumn("preferences", Types.BooleanType.get());
         }
@@ -507,48 +507,51 @@ public class TestSchemaUpdate {
     Schema expected = new Schema(optional(2, "id", Types.IntegerType.get()));
 
     Schema updated = new SchemaUpdate(schema, 1)
-            .deleteColumn("id")
-            .addColumn("id", optional(2, "id", Types.IntegerType.get()).type())
-            .apply();
+        .deleteColumn("id")
+        .addColumn("id", optional(2, "id", Types.IntegerType.get()).type())
+        .apply();
 
     Assert.assertEquals("Should match with added fields", expected.asStruct(), updated.asStruct());
+  }
 
+  @Test
+  public void testDeleteThenAddNested() {
     Schema expectedNested = new Schema(
-            required(1, "id", Types.IntegerType.get()),
-            optional(2, "data", Types.StringType.get()),
-            optional(3, "preferences", Types.StructType.of(
-                    optional(9, "feature2", Types.BooleanType.get()),
-                    optional(24, "feature1", Types.BooleanType.get())
-            ), "struct of named boolean options"),
-            required(4, "locations", Types.MapType.ofRequired(10, 11,
-                    Types.StructType.of(
-                            required(20, "address", Types.StringType.get()),
-                            required(21, "city", Types.StringType.get()),
-                            required(22, "state", Types.StringType.get()),
-                            required(23, "zip", Types.IntegerType.get())
-                    ),
-                    Types.StructType.of(
-                            required(12, "lat", Types.FloatType.get()),
-                            required(13, "long", Types.FloatType.get())
-                    )), "map of address to coordinate"),
-            optional(5, "points", Types.ListType.ofOptional(14,
-                    Types.StructType.of(
-                            required(15, "x", Types.LongType.get()),
-                            required(16, "y", Types.LongType.get())
-                    )), "2-D cartesian points"),
-            required(6, "doubles", Types.ListType.ofRequired(17,
-                    Types.DoubleType.get()
-            )),
-            optional(7, "properties", Types.MapType.ofOptional(18, 19,
-                    Types.StringType.get(),
-                    Types.StringType.get()
-            ), "string map of properties")
+        required(1, "id", Types.IntegerType.get()),
+        optional(2, "data", Types.StringType.get()),
+        optional(3, "preferences", Types.StructType.of(
+            optional(9, "feature2", Types.BooleanType.get()),
+            optional(24, "feature1", Types.BooleanType.get())
+        ), "struct of named boolean options"),
+        required(4, "locations", Types.MapType.ofRequired(10, 11,
+            Types.StructType.of(
+                    required(20, "address", Types.StringType.get()),
+                    required(21, "city", Types.StringType.get()),
+                    required(22, "state", Types.StringType.get()),
+                    required(23, "zip", Types.IntegerType.get())
+            ),
+            Types.StructType.of(
+                    required(12, "lat", Types.FloatType.get()),
+                    required(13, "long", Types.FloatType.get())
+            )), "map of address to coordinate"),
+        optional(5, "points", Types.ListType.ofOptional(14,
+            Types.StructType.of(
+                    required(15, "x", Types.LongType.get()),
+                    required(16, "y", Types.LongType.get())
+            )), "2-D cartesian points"),
+        required(6, "doubles", Types.ListType.ofRequired(17,
+            Types.DoubleType.get()
+        )),
+        optional(7, "properties", Types.MapType.ofOptional(18, 19,
+            Types.StringType.get(),
+            Types.StringType.get()
+        ), "string map of properties")
     );
 
     Schema updatedNested = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
-            .deleteColumn("preferences.feature1")
-            .addColumn("preferences", "feature1", Types.BooleanType.get())
-            .apply();
+        .deleteColumn("preferences.feature1")
+        .addColumn("preferences", "feature1", Types.BooleanType.get())
+        .apply();
 
     Assert.assertEquals("Should match with added fields", expectedNested.asStruct(), updatedNested.asStruct());
   }

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -501,57 +501,57 @@ public class TestSchemaUpdate {
     );
   }
 
-    @Test
-    public void testDeleteThenAdd() {
-        Schema schema = new Schema(required(1, "id", Types.IntegerType.get()));
-        Schema expected = new Schema(optional(2, "id", Types.IntegerType.get()));
+  @Test
+  public void testDeleteThenAdd() {
+    Schema schema = new Schema(required(1, "id", Types.IntegerType.get()));
+    Schema expected = new Schema(optional(2, "id", Types.IntegerType.get()));
 
-        Schema updated = new SchemaUpdate(schema, 1)
-                .deleteColumn("id")
-                .addColumn("id", optional(2, "id", Types.IntegerType.get()).type())
-                .apply();
+    Schema updated = new SchemaUpdate(schema, 1)
+            .deleteColumn("id")
+            .addColumn("id", optional(2, "id", Types.IntegerType.get()).type())
+            .apply();
 
-        Assert.assertEquals("Should match with added fields", expected.asStruct(), updated.asStruct());
+    Assert.assertEquals("Should match with added fields", expected.asStruct(), updated.asStruct());
 
-        Schema expectedNested = new Schema(
-                required(1, "id", Types.IntegerType.get()),
-                optional(2, "data", Types.StringType.get()),
-                optional(3, "preferences", Types.StructType.of(
-                        optional(9, "feature2", Types.BooleanType.get()),
-                        optional(24, "feature1", Types.BooleanType.get())
-                ), "struct of named boolean options"),
-                required(4, "locations", Types.MapType.ofRequired(10, 11,
-                        Types.StructType.of(
-                                required(20, "address", Types.StringType.get()),
-                                required(21, "city", Types.StringType.get()),
-                                required(22, "state", Types.StringType.get()),
-                                required(23, "zip", Types.IntegerType.get())
-                        ),
-                        Types.StructType.of(
-                                required(12, "lat", Types.FloatType.get()),
-                                required(13, "long", Types.FloatType.get())
-                        )), "map of address to coordinate"),
-                optional(5, "points", Types.ListType.ofOptional(14,
-                        Types.StructType.of(
-                                required(15, "x", Types.LongType.get()),
-                                required(16, "y", Types.LongType.get())
-                        )), "2-D cartesian points"),
-                required(6, "doubles", Types.ListType.ofRequired(17,
-                        Types.DoubleType.get()
-                )),
-                optional(7, "properties", Types.MapType.ofOptional(18, 19,
-                        Types.StringType.get(),
-                        Types.StringType.get()
-                ), "string map of properties")
-        );
+    Schema expectedNested = new Schema(
+            required(1, "id", Types.IntegerType.get()),
+            optional(2, "data", Types.StringType.get()),
+            optional(3, "preferences", Types.StructType.of(
+                    optional(9, "feature2", Types.BooleanType.get()),
+                    optional(24, "feature1", Types.BooleanType.get())
+            ), "struct of named boolean options"),
+            required(4, "locations", Types.MapType.ofRequired(10, 11,
+                    Types.StructType.of(
+                            required(20, "address", Types.StringType.get()),
+                            required(21, "city", Types.StringType.get()),
+                            required(22, "state", Types.StringType.get()),
+                            required(23, "zip", Types.IntegerType.get())
+                    ),
+                    Types.StructType.of(
+                            required(12, "lat", Types.FloatType.get()),
+                            required(13, "long", Types.FloatType.get())
+                    )), "map of address to coordinate"),
+            optional(5, "points", Types.ListType.ofOptional(14,
+                    Types.StructType.of(
+                            required(15, "x", Types.LongType.get()),
+                            required(16, "y", Types.LongType.get())
+                    )), "2-D cartesian points"),
+            required(6, "doubles", Types.ListType.ofRequired(17,
+                    Types.DoubleType.get()
+            )),
+            optional(7, "properties", Types.MapType.ofOptional(18, 19,
+                    Types.StringType.get(),
+                    Types.StringType.get()
+            ), "string map of properties")
+    );
 
-        Schema updatedNested = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
-                .deleteColumn("preferences.feature1")
-                .addColumn("preferences", "feature1", Types.BooleanType.get())
-                .apply();
+    Schema updatedNested = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
+            .deleteColumn("preferences.feature1")
+            .addColumn("preferences", "feature1", Types.BooleanType.get())
+            .apply();
 
-        Assert.assertEquals("Should match with added fields", expectedNested.asStruct(), updatedNested.asStruct());
-    }
+    Assert.assertEquals("Should match with added fields", expectedNested.asStruct(), updatedNested.asStruct());
+  }
 
   @Test
   public void testDeleteMissingColumn() {


### PR DESCRIPTION
### Description

This PR allows for a `UpdateSchema` sequence to permit adding of a deleted column. 

```java

Schema updatedNested = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
                .deleteColumn("preferences.feature1")
                .addColumn("preferences", "feature1", Types.BooleanType.get())
                .apply();
```

where previously, this was not allowed.

Note this does change the struct ordering of the column, but that's expected. 


### Tests

- [x] unit tests