### PR TITLE
Change default write.target-file-size-bytes to 512 MB.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -127,7 +127,7 @@ public class TableProperties {
   public static final String WRITE_AUDIT_PUBLISH_ENABLED_DEFAULT = "false";
 
   public static final String WRITE_TARGET_FILE_SIZE_BYTES = "write.target-file-size-bytes";
-  public static final long WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT = Long.MAX_VALUE;
+  public static final long WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT = 536870912; // 512 MB
 
   public static final String SPARK_WRITE_PARTITIONED_FANOUT_ENABLED = "write.spark.fanout.enabled";
   public static final boolean SPARK_WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT = false;


### PR DESCRIPTION
Hello, we are thinking to change for default "write.target-file-size-bytes" to 512 MB

-- The current default (unbound file sizes) will never take advantage of any predicate push down
-- This number corresponds well with the Parquet default row-group size (4 row groups/file)
-- This will have no impact on ORC file (BaseTaskWriter#shouldRollToNewFile() makes an exception for ORC files)

This will result in different behaviors, so would be good to see what the community thinks, cc @aokolnychyi  
Thank you