### PR TITLE
Spark: Make ignored UPDATE tests deterministic

### DIFF
--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -270,8 +270,8 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
 
     sql("UPDATE %s SET id = 100 WHERE id NOT IN (1, 10)", tableName);
     assertEquals("Should have expected rows",
-        ImmutableList.of(row(100, "hr"), row(100, "hardware"), row(null, "hr")),
-        sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", tableName));
+        ImmutableList.of(row(100, "hardware"), row(100, "hr"), row(null, "hr")),
+        sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST, dep", tableName));
   }
 
   @Test
@@ -652,7 +652,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
 
     sql("UPDATE %s SET id = -1 WHERE id NOT IN (SELECT * FROM updated_id WHERE value IS NOT NULL)", tableName);
     assertEquals("Should have expected rows",
-        ImmutableList.of(row(-1, "hr"), row(-1, "hardware"), row(null, "hr")),
+        ImmutableList.of(row(-1, "hardware"), row(-1, "hr"), row(null, "hr")),
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST, dep", tableName));
 
     sql("UPDATE %s SET id = 5 WHERE id NOT IN (SELECT * FROM updated_id) OR dep IN ('software', 'hr')", tableName);


### PR DESCRIPTION
This PR makes ignored UPDATE tests deterministic.