### PR TITLE
Hive: skip projection pushdown for output tables

### DIFF
--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -56,7 +56,7 @@ import static java.nio.file.attribute.PosixFilePermissions.fromString;
 public class TestHiveMetastore {
 
   private static final String DEFAULT_DATABASE_NAME = "default";
-  private static final int DEFAULT_POOL_SIZE = 10;
+  private static final int DEFAULT_POOL_SIZE = 5;
 
   // create the metastore handlers based on whether we're working with Hive2 or Hive3 dependencies
   // we need to do this because there is a breaking API change between Hive2 and Hive3

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -56,7 +56,7 @@ import static java.nio.file.attribute.PosixFilePermissions.fromString;
 public class TestHiveMetastore {
 
   private static final String DEFAULT_DATABASE_NAME = "default";
-  private static final int DEFAULT_POOL_SIZE = 5;
+  private static final int DEFAULT_POOL_SIZE = 10;
 
   // create the metastore handlers based on whether we're working with Hive2 or Hive3 dependencies
   // we need to do this because there is a breaking API change between Hive2 and Hive3

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
@@ -88,18 +88,24 @@ public class HiveIcebergSerDe extends AbstractSerDe {
       }
     }
 
-    configuration.setBoolean(InputFormatConfig.CASE_SENSITIVE, false);
-    String[] selectedColumns = ColumnProjectionUtils.getReadColumnNames(configuration);
-    // When same table is joined multiple times, it is possible some selected columns are duplicated,
-    // in this case wrong recordStructField position leads wrong value or ArrayIndexOutOfBoundException
-    String[] distinctSelectedColumns = Arrays.stream(selectedColumns).distinct().toArray(String[]::new);
-    Schema projectedSchema = distinctSelectedColumns.length > 0 ?
-            tableSchema.caseInsensitiveSelect(distinctSelectedColumns) : tableSchema;
-    // the input split mapper handles does not belong to this table
-    // it is necessary to ensure projectedSchema equals to tableSchema,
-    // or we cannot find selectOperator's column from inspector
-    if (projectedSchema.columns().size() != distinctSelectedColumns.length) {
+    Schema projectedSchema;
+    if (serDeProperties.get(HiveIcebergStorageHandler.WRITE_KEY) != null) {
+      // when writing out data, we should not do projection pushdown
       projectedSchema = tableSchema;
+    } else {
+      configuration.setBoolean(InputFormatConfig.CASE_SENSITIVE, false);
+      String[] selectedColumns = ColumnProjectionUtils.getReadColumnNames(configuration);
+      // When same table is joined multiple times, it is possible some selected columns are duplicated,
+      // in this case wrong recordStructField position leads wrong value or ArrayIndexOutOfBoundException
+      String[] distinctSelectedColumns = Arrays.stream(selectedColumns).distinct().toArray(String[]::new);
+      projectedSchema = distinctSelectedColumns.length > 0 ?
+              tableSchema.caseInsensitiveSelect(distinctSelectedColumns) : tableSchema;
+      // the input split mapper handles does not belong to this table
+      // it is necessary to ensure projectedSchema equals to tableSchema,
+      // or we cannot find selectOperator's column from inspector
+      if (projectedSchema.columns().size() != distinctSelectedColumns.length) {
+        projectedSchema = tableSchema;
+      }
     }
 
     try {

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -408,7 +408,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     Table table = testTables.createTable(shell, "target_customers",
         HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, fileFormat, ImmutableList.of());
 
-    // Below select from hive_customers should produce: "hive.io.file.readcolumn.names=customer_id,last_name".
+    // Below select from source table should produce: "hive.io.file.readcolumn.names=customer_id,last_name".
     // Inserting into the target table should not fail because first_name is not selected from the source table
     shell.executeStatement("INSERT INTO target_customers SELECT customer_id, 'Sam', last_name FROM source_customers");
 


### PR DESCRIPTION
When inserting data into an Iceberg table from a Hive table, where the source table has the same columns as the target table, the query fails. This is due to the fact that after the SELECT query completes on the source table, the read column values from the source table will be stuck in the config under `hive.io.file.readcolumn.names`, and will be read by the Serde when writing out the data into the target table and therefore will create the wrong objectinspector. To solve this issue, we should skip column projection pushdown for output tables that we write to.