### PR TITLE
Handle metrics during schema transformation

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetricsConfig.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsConfig.java
@@ -47,9 +47,9 @@ public class MetricsConfig implements Serializable {
     return spec;
   }
 
-  public static Map<String, String> updateProperties(Map<String, String> props, List<String> deletes,
-                                                     Map<String, String> renames) {
-    if (!props.keySet().stream().anyMatch(key -> key.startsWith(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX))) {
+  public static Map<String, String> updateProperties(Map<String, String> props, List<String> deletedColumns,
+                                                     Map<String, String> renamedColumns) {
+    if (props.keySet().stream().noneMatch(key -> key.startsWith(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX))) {
       return props;
     } else {
       Map<String, String> updatedProperties = Maps.newHashMap();
@@ -57,11 +57,12 @@ public class MetricsConfig implements Serializable {
       props.keySet().forEach(key -> {
         if (key.startsWith(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX)) {
           String columnAlias = key.replaceFirst(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX, "");
-          if (renames.get(columnAlias) != null) {
+          if (renamedColumns.get(columnAlias) != null) {
             // The name has changed.
-            String newKey = TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + renames.get(columnAlias);
+            String newKey = TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX +
+                renamedColumns.get(columnAlias);
             updatedProperties.put(newKey, props.get(key));
-          } else if (!deletes.contains(columnAlias)) {
+          } else if (!deletedColumns.contains(columnAlias)) {
             // Copy over the original
             updatedProperties.put(key, props.get(key));
           }

--- a/core/src/main/java/org/apache/iceberg/MetricsConfig.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsConfig.java
@@ -117,8 +117,4 @@ public class MetricsConfig implements Serializable {
   public MetricsMode columnMode(String columnAlias) {
     return columnModes.getOrDefault(columnAlias, defaultMode);
   }
-
-  public boolean allDefault() {
-    return columnModes.isEmpty();
-  }
 }

--- a/core/src/main/java/org/apache/iceberg/MetricsConfig.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsConfig.java
@@ -54,19 +54,18 @@ public class MetricsConfig implements Serializable {
     } else {
       Map<String, String> updatedProperties = Maps.newHashMap();
       // Put all of the non metrics columns we aren't modifying
-      props.keySet().stream().forEach(key -> {
+      props.keySet().forEach(key -> {
         if (key.startsWith(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX)) {
           String columnAlias = key.replaceFirst(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX, "");
-          if (deletes.contains(columnAlias)) {
-            // Drop the key by not copying it
-          } else if (renames.get(columnAlias) != null) {
+          if (renames.get(columnAlias) != null) {
             // The name has changed.
             String newKey = TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + renames.get(columnAlias);
             updatedProperties.put(newKey, props.get(key));
-          } else {
-            // We didn't modify it in a way we care about
+          } else if (!deletes.contains(columnAlias)) {
+            // Copy over the original
             updatedProperties.put(key, props.get(key));
           }
+          // Implicit drop if deleted
         } else {
           // Not a metric property
           updatedProperties.put(key, props.get(key));

--- a/core/src/main/java/org/apache/iceberg/MetricsConfig.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsConfig.java
@@ -46,6 +46,14 @@ public class MetricsConfig implements Serializable {
     return spec;
   }
 
+  public static void resolveMetricsColumns(Map<String, String> props, Schema schema) {
+    props.keySet().stream()
+        .filter(key -> key.startsWith(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX))
+        .forEach(key -> {
+          String columnAlias = key.replaceFirst(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX, "");
+
+  }
+
   public static MetricsConfig fromProperties(Map<String, String> props) {
     MetricsConfig spec = new MetricsConfig();
     String defaultModeAsString = props.getOrDefault(DEFAULT_WRITE_METRICS_MODE, DEFAULT_WRITE_METRICS_MODE_DEFAULT);

--- a/core/src/main/java/org/apache/iceberg/MetricsConfig.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsConfig.java
@@ -49,7 +49,7 @@ public class MetricsConfig implements Serializable {
   }
 
   static Map<String, String> updateProperties(Map<String, String> props, List<String> deletedColumns,
-                                                     Map<String, String> renamedColumns) {
+                                              Map<String, String> renamedColumns) {
     if (props.keySet().stream().noneMatch(key -> key.startsWith(METRICS_MODE_COLUMN_CONF_PREFIX))) {
       return props;
     } else {

--- a/core/src/main/java/org/apache/iceberg/MetricsConfig.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsConfig.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import static org.apache.iceberg.TableProperties.DEFAULT_WRITE_METRICS_MODE;
 import static org.apache.iceberg.TableProperties.DEFAULT_WRITE_METRICS_MODE_DEFAULT;
+import static org.apache.iceberg.TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX;
 
 public class MetricsConfig implements Serializable {
 
@@ -49,18 +50,17 @@ public class MetricsConfig implements Serializable {
 
   public static Map<String, String> updateProperties(Map<String, String> props, List<String> deletedColumns,
                                                      Map<String, String> renamedColumns) {
-    if (props.keySet().stream().noneMatch(key -> key.startsWith(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX))) {
+    if (props.keySet().stream().noneMatch(key -> key.startsWith(METRICS_MODE_COLUMN_CONF_PREFIX))) {
       return props;
     } else {
       Map<String, String> updatedProperties = Maps.newHashMap();
       // Put all of the non metrics columns we aren't modifying
       props.keySet().forEach(key -> {
-        if (key.startsWith(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX)) {
-          String columnAlias = key.replaceFirst(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX, "");
+        if (key.startsWith(METRICS_MODE_COLUMN_CONF_PREFIX)) {
+          String columnAlias = key.replaceFirst(METRICS_MODE_COLUMN_CONF_PREFIX, "");
           if (renamedColumns.get(columnAlias) != null) {
             // The name has changed.
-            String newKey = TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX +
-                renamedColumns.get(columnAlias);
+            String newKey = METRICS_MODE_COLUMN_CONF_PREFIX + renamedColumns.get(columnAlias);
             updatedProperties.put(newKey, props.get(key));
           } else if (!deletedColumns.contains(columnAlias)) {
             // Copy over the original
@@ -88,9 +88,9 @@ public class MetricsConfig implements Serializable {
     }
 
     props.keySet().stream()
-        .filter(key -> key.startsWith(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX))
+        .filter(key -> key.startsWith(METRICS_MODE_COLUMN_CONF_PREFIX))
         .forEach(key -> {
-          String columnAlias = key.replaceFirst(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX, "");
+          String columnAlias = key.replaceFirst(METRICS_MODE_COLUMN_CONF_PREFIX, "");
           MetricsMode mode;
           try {
             mode = MetricsModes.fromString(props.get(key));
@@ -110,7 +110,7 @@ public class MetricsConfig implements Serializable {
       ValidationException.check(
           schema.findField(column) != null,
           "Invalid metrics config, could not find column %s from table prop %s in schema %s",
-          column, TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + column, schema);
+          column, METRICS_MODE_COLUMN_CONF_PREFIX + column, schema);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/MetricsConfig.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsConfig.java
@@ -48,7 +48,7 @@ public class MetricsConfig implements Serializable {
     return spec;
   }
 
-  public static Map<String, String> updateProperties(Map<String, String> props, List<String> deletedColumns,
+  static Map<String, String> updateProperties(Map<String, String> props, List<String> deletedColumns,
                                                      Map<String, String> renamedColumns) {
     if (props.keySet().stream().noneMatch(key -> key.startsWith(METRICS_MODE_COLUMN_CONF_PREFIX))) {
       return props;

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -419,12 +419,11 @@ class SchemaUpdate implements UpdateSchema {
     if (base != null && base.properties() != null) {
       Schema newSchema = metadata.schema();
       List<String> deletedColumns = deletes.stream()
-          .map(i -> schema.findColumnName(i))
+          .map(schema::findColumnName)
           .collect(Collectors.toList());
       Map<String, String> renamedColumns = updates.keySet().stream()
-          .filter(i -> !schema.findColumnName(i).equals(newSchema.findColumnName(i)))
-          .collect(
-            Collectors.toMap(i -> schema.findColumnName(i), i -> newSchema.findColumnName(i)));
+          .filter(id -> !schema.findColumnName(id).equals(newSchema.findColumnName(id)))
+          .collect(Collectors.toMap(schema::findColumnName, newSchema::findColumnName));
       Map<String, String> updatedProperties = MetricsConfig.updateProperties(
           newMetadata.properties(), deletedColumns, renamedColumns);
       newMetadata = newMetadata.replaceProperties(updatedProperties);

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -417,7 +417,7 @@ class SchemaUpdate implements UpdateSchema {
 
     // Transform the metrics if they exist
     if (base != null && base.properties() != null) {
-      Schema newSchema = metadata.schema();
+      Schema newSchema = newMetadata.schema();
       List<String> deletedColumns = deletes.stream()
           .map(schema::findColumnName)
           .collect(Collectors.toList());

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.iceberg.mapping.MappingUtil;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.mapping.NameMappingParser;

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -394,12 +394,12 @@ class SchemaUpdate implements UpdateSchema {
   }
 
   private TableMetadata applyChangesToMetadata(TableMetadata metadata) {
-    String existingMappingJson = metadata.property(TableProperties.DEFAULT_NAME_MAPPING, null);
+    String mappingJson = metadata.property(TableProperties.DEFAULT_NAME_MAPPING, null);
     TableMetadata newMetadata = metadata;
-    if (existingMappingJson != null) {
+    if (mappingJson != null) {
       try {
         // parse and update the mapping
-        NameMapping mapping = NameMappingParser.fromJson(existingMappingJson);
+        NameMapping mapping = NameMappingParser.fromJson(mappingJson);
         NameMapping updated = MappingUtil.update(mapping, updates, adds);
 
         // replace the table property
@@ -411,7 +411,7 @@ class SchemaUpdate implements UpdateSchema {
 
       } catch (RuntimeException e) {
         // log the error, but do not fail the update
-        LOG.warn("Failed to update external schema mapping: {}", existingMappingJson, e);
+        LOG.warn("Failed to update external schema mapping: {}", mappingJson, e);
       }
     }
 

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -124,7 +124,6 @@ public class TableProperties {
   public static final boolean METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT = false;
 
   public static final String METRICS_MODE_COLUMN_CONF_PREFIX = "write.metadata.metrics.column.";
-  public static final String METRICS_MODE_COLUMN_REF_CONF_PREFIX = "write.metadata.metrics.column-ref.";
   public static final String DEFAULT_WRITE_METRICS_MODE = "write.metadata.metrics.default";
   public static final String DEFAULT_WRITE_METRICS_MODE_DEFAULT = "truncate(16)";
 

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -124,6 +124,7 @@ public class TableProperties {
   public static final boolean METADATA_DELETE_AFTER_COMMIT_ENABLED_DEFAULT = false;
 
   public static final String METRICS_MODE_COLUMN_CONF_PREFIX = "write.metadata.metrics.column.";
+  public static final String METRICS_MODE_COLUMN_REF_CONF_PREFIX = "write.metadata.metrics.column-ref.";
   public static final String DEFAULT_WRITE_METRICS_MODE = "write.metadata.metrics.default";
   public static final String DEFAULT_WRITE_METRICS_MODE_DEFAULT = "truncate(16)";
 

--- a/core/src/test/java/org/apache/iceberg/TestSchemaAndMappingUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaAndMappingUpdate.java
@@ -178,9 +178,22 @@ public class TestSchemaAndMappingUpdate extends TableTestBase {
 
     // Re-naming a column with metrics succeeds;
     table.updateSchema().renameColumn("id", "bloop").commit();
+    Assert.assertNotNull(
+        "Make sure the metrics config now has bloop",
+        table.properties().get(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "bloop"));
+    Assert.assertNull(
+        "Make sure the metrics config no longer has id",
+        table.properties().get(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "id"));
 
     // Deleting a column with metrics succeeds
     table.updateSchema().deleteColumn("bloop").commit();
+    // Make sure no more reference to bloop in the metrics config
+    Assert.assertNull(
+        "Make sure the metrics config no longer has id",
+        table.properties().get(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "id"));
+    Assert.assertNull(
+        "Make sure the metrics config no longer has bloop",
+        table.properties().get(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "bloop"));
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestSchemaAndMappingUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaAndMappingUpdate.java
@@ -176,20 +176,11 @@ public class TestSchemaAndMappingUpdate extends TableTestBase {
               .set("write.metadata.metrics.column.ids", "full")
               .commit());
 
-    AssertHelpers.assertThrows(
-        "Deleting a column with metrics fails",
-        ValidationException.class,
-        null,
-        () ->
-          table.updateSchema()
-              .deleteColumn("id")
-              .commit());
+    // Re-naming a column with metrics succeeds;
+    table.updateSchema().renameColumn("id", "bloop").commit();
 
-    String updatedJson = table.properties().get(TableProperties.DEFAULT_NAME_MAPPING);
-    NameMapping updated = NameMappingParser.fromJson(updatedJson);
-
-    // should not change the mapping
-    validateUnchanged(mapping, updated);
+    // Deleting a column with metrics succeeds
+    table.updateSchema().deleteColumn("bloop").commit();
   }
 
   @Test


### PR DESCRIPTION
This is for #2079, when we transform the schema we should update the metrics as well automatically.
Longer term we may wish to consider also migrating the metrics to column references, but either way for backwards compatibility we should preserve the name based fields.