### PR TITLE
Core : remove the UnmodifiableMap

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -22,7 +22,6 @@ package org.apache.iceberg;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -434,7 +433,7 @@ abstract class BaseFile<F>
     if (map != null) {
       Map<K, V> copy = Maps.newHashMapWithExpectedSize(map.size());
       copy.putAll(map);
-      return Collections.unmodifiableMap(copy);
+      return copy;
     }
     return null;
   }


### PR DESCRIPTION
Now, in `BaseFile`, there are some metrics, like `nullValueCounts`, `nanValueCounts` etc, they use `UnmodifiableMap`, resulting in flink serialization problems. For example, the `RewriteDataFilesAction` and streaming read function will failed,the issue is here(#2219 ). I checked some information and found that [spark has similar problems if using kryo.](https://stackoverflow.com/questions/46818293/how-to-set-unmodifiable-collection-serializer-of-kryo-in-spark-code),
so I remove the `UnmodifiableMap`, and I tested that, the `RewriteDataFilesAction` will not throw exception.

what do you think about this ? @rdblue 

