### PR TITLE
Flink: add a catalog() method for FlinkCatalog to exposing iceberg catalog

### DIFF
--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -136,6 +136,10 @@ public class FlinkCatalog extends AbstractCatalog {
     }
   }
 
+  public Catalog catalog() {
+    return icebergCatalog;
+  }
+
   private Namespace toNamespace(String database) {
     String[] namespace = new String[baseNamespace.length + 1];
     System.arraycopy(baseNamespace, 0, namespace, 0, baseNamespace.length);


### PR DESCRIPTION
In some cases, I need to get the iceberg table to do some work, such as `RewriteDataFiles`, or modify table schema. When we use the iceberg table of `HiveCatalog`, we may need to construct the `CatalogLoader` first, then construct the `TableLoader`, and then load the iceberg table. The code is relatively complicated, I personally prefer to use sql as much as possible, so I want to change the `org.apache.iceberg.flink.FlinkCatalog#loadIcebergTable` method to public so that we can easily get the iceberg table through the following code .


```
   StreamTableEnvironment tenv = StreamTableEnvironment.create(env);
    tenv.executeSql(
        "CREATE CATALOG iceberg WITH (\n"
            + "  'type'='iceberg',\n"
            + "  'catalog-type'='hive',"
            + "   'warehouse'='hdfs://localhost/user/hive2/warehouse',\n"
            + "   'uri'='thrift://localhost:9083'"
            + ")");

    FlinkCatalog flinkCatalog = (FlinkCatalog) tenv.getCatalog("iceberg").get();
    Table icebergTable = flinkCatalog.loadIcebergTable(new ObjectPath("iceberg_db", "iceberg_table"));
```
