### PR TITLE
Hive: make sure unlock is called when HiveTableOperations can not acq…

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -353,9 +353,12 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     } finally {
       if (!state.get().equals(LockState.ACQUIRED)) {
         unlock(Optional.of(lockId));
-        throw new CommitFailedException("Could not acquire the lock on %s.%s, " +
-            "lock request ended in state %s", database, tableName, state);
       }
+    }
+
+    if (!state.get().equals(LockState.ACQUIRED)) {
+      throw new CommitFailedException("Could not acquire the lock on %s.%s, " +
+          "lock request ended in state %s", database, tableName, state);
     }
     return lockId;
   }


### PR DESCRIPTION
Currently, there is no way to call `unlock` if `HiveTableOperations.acquireLock` fails at waiting for lock on hive table. This PR aims to try to invoke `unlock` in the finally block.