### PR TITLE
Initial cut of nessie extensions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -973,8 +973,12 @@ project(":iceberg-spark3-extensions") {
   }
 
   dependencies {
-    compileOnly project(':iceberg-spark3')
+    apply plugin: 'org.projectnessie'
 
+    compileOnly project(':iceberg-spark3')
+    compileOnly project(':iceberg-nessie')
+
+    quarkusAppRunnerConfig "org.projectnessie:nessie-quarkus:0.2.1"
     compileOnly "org.scala-lang:scala-library"
     compileOnly("org.apache.spark:spark-hive_2.12") {
       exclude group: 'org.apache.avro', module: 'avro'
@@ -990,6 +994,12 @@ project(":iceberg-spark3-extensions") {
     runtime "org.antlr:antlr4-runtime:4.7.1"
     antlr "org.antlr:antlr4:4.7.1"
   }
+
+  quarkusAppRunnerProperties {
+    props = ["quarkus.http.test-port": 0]
+  }
+  tasks.getByName("quarkus-start").dependsOn("compileTestJava")
+  tasks.test.dependsOn("quarkus-start").finalizedBy("quarkus-stop")
 
   generateGrammarSource {
     maxHeapSize = "64m"

--- a/spark3-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
+++ b/spark3-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
@@ -70,6 +70,7 @@ statement
     | ALTER TABLE multipartIdentifier ADD PARTITION FIELD transform (AS name=identifier)?   #addPartitionField
     | ALTER TABLE multipartIdentifier DROP PARTITION FIELD transform                        #dropPartitionField
     | ALTER TABLE multipartIdentifier WRITE writeSpec                                       #setWriteDistributionAndOrdering
+    | CREATE (BRANCH|TAG) identifier (IN catalog=identifier)? (AS reference=identifier)?    #nessieCreateRef
     ;
 
 writeSpec
@@ -157,8 +158,8 @@ quotedIdentifier
     ;
 
 nonReserved
-    : ADD | ALTER | AS | ASC | BY | CALL | DESC | DROP | FIELD | FIRST | LAST | NULLS | ORDERED | PARTITION | TABLE | WRITE
-    | DISTRIBUTED | LOCALLY | UNORDERED
+    : ADD | ALTER | AS | ASC | BRANCH | BY | CALL | CREATE| DESC | DROP | FIELD | FIRST | IN | LAST | NULLS | ORDERED | PARTITION | TABLE | WRITE
+    | DISTRIBUTED | LOCALLY | TAG | UNORDERED
     | TRUE | FALSE
     | MAP
     ;
@@ -167,19 +168,23 @@ ADD: 'ADD';
 ALTER: 'ALTER';
 AS: 'AS';
 ASC: 'ASC';
+BRANCH: 'BRANCH';
 BY: 'BY';
 CALL: 'CALL';
+CREATE: 'CREATE';
 DESC: 'DESC';
 DISTRIBUTED: 'DISTRIBUTED';
 DROP: 'DROP';
 FIELD: 'FIELD';
 FIRST: 'FIRST';
+IN: 'IN';
 LAST: 'LAST';
 LOCALLY: 'LOCALLY';
 NULLS: 'NULLS';
 ORDERED: 'ORDERED';
 PARTITION: 'PARTITION';
 TABLE: 'TABLE';
+TAG: 'TAG';
 UNORDERED: 'UNORDERED';
 WRITE: 'WRITE';
 

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
@@ -110,7 +110,7 @@ class IcebergSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserI
 
   private def isIcebergCommand(sqlText: String): Boolean = {
     val normalized = sqlText.toLowerCase(Locale.ROOT).trim()
-    normalized.startsWith("call") || (
+    normalized.startsWith("call") || normalized.startsWith("create branch") || normalized.startsWith("create tag") || (
         normalized.startsWith("alter table") && (
             normalized.contains("add partition field") ||
             normalized.contains("drop partition field") ||

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.catalyst.parser.extensions.IcebergSqlExtensionsParse
 import org.apache.spark.sql.catalyst.plans.logical.AddPartitionField
 import org.apache.spark.sql.catalyst.plans.logical.CallArgument
 import org.apache.spark.sql.catalyst.plans.logical.CallStatement
+import org.apache.spark.sql.catalyst.plans.logical.CreateBranchField
 import org.apache.spark.sql.catalyst.plans.logical.DropPartitionField
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.logical.NamedArgument
@@ -78,6 +79,14 @@ class IcebergSqlExtensionsAstBuilder(delegate: ParserInterface) extends IcebergS
     DropPartitionField(
       typedVisit[Seq[String]](ctx.multipartIdentifier),
       typedVisit[Transform](ctx.transform))
+  }
+
+  override def visitNessieCreateRef(ctx: NessieCreateRefContext): CreateBranchField = withOrigin(ctx) {
+    val isBranch = ctx.TAG == null
+    val refName = ctx.identifier(0).getText
+    val catalogName = Option(ctx.catalog).map(x => x.getText)
+    val createdFrom = Option(ctx.reference).map(x => x.getText)
+    CreateBranchField(refName, isBranch, catalogName, createdFrom)
   }
 
   /**

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/CreateBranchField.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/CreateBranchField.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.types.DataTypes
+import org.apache.spark.sql.types.Metadata
+import org.apache.spark.sql.types.StructField
+import org.apache.spark.sql.types.StructType
+
+case class CreateBranchField(branch: String, isBranch: Boolean, catalog: Option[String], reference: Option[String])
+  extends Command {
+
+  override lazy val output: Seq[Attribute] = new StructType(Array[StructField](
+    StructField("refType", DataTypes.StringType, false, Metadata.empty),
+    StructField("name", DataTypes.StringType, false, Metadata.empty),
+    StructField("hash", DataTypes.StringType, false, Metadata.empty))).toAttributes
+
+  override def simpleString(maxFields: Int): String = {
+    s"CreateBranch ${branch}"
+  }
+}

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateBranchExec.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateBranchExec.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import com.dremio.nessie.client.NessieClient
+import com.dremio.nessie.model.Branch
+import com.dremio.nessie.model.ImmutableBranch
+import com.dremio.nessie.model.ImmutableHash
+import com.dremio.nessie.model.ImmutableTag
+import com.dremio.nessie.model.Tag
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.connector.catalog.CatalogPlugin
+import org.apache.spark.unsafe.types.UTF8String
+
+
+case class CreateBranchExec(
+    output: Seq[Attribute],
+    branch: String,
+    currentCatalog: CatalogPlugin,
+    isBranch: Boolean,
+    catalog: Option[String],
+    createdFrom: Option[String]) extends V2CommandExec {
+
+  override protected def run(): Seq[InternalRow] = {
+    val catalogName = catalog.getOrElse(currentCatalog.name)
+    val catalogConf = SparkSession.active.sparkContext.conf.getAllWithPrefix(s"spark.sql.catalog.$catalogName.").toMap
+    val nessieClient = NessieClient.withConfig(x => catalogConf.getOrElse(x.replace("nessie.",""), null))
+    val hash = createdFrom.map(nessieClient.getTreeApi.getReferenceByName)
+      .orElse(Option(nessieClient.getTreeApi.getDefaultBranch)).map(x => x.getHash).orNull
+    val ref = if (isBranch) Branch.of(branch, hash) else Tag.of(branch, hash)
+    nessieClient.getTreeApi.createReference(ref)
+    val branchResult = nessieClient.getTreeApi.getReferenceByName(ref.getName)
+    val refType = branchResult match {
+      case _: ImmutableHash => "Hash"
+      case _: ImmutableBranch => "Branch"
+      case _: ImmutableTag => "Tag"
+    }
+    Seq(InternalRow(UTF8String.fromString(refType), UTF8String.fromString(branchResult.getName),
+      UTF8String.fromString(branchResult.getHash)))
+  }
+
+  override def simpleString(maxFields: Int): String = {
+    s"CreateBranchExec ${catalog.getOrElse(currentCatalog.name())} ${if (isBranch) "BRANCH" else "TAG" } ${branch} " +
+      s"${createdFrom}"
+  }
+}

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Strategy.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Strategy.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.catalyst.expressions.NamedExpression
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical.AddPartitionField
 import org.apache.spark.sql.catalyst.plans.logical.Call
+import org.apache.spark.sql.catalyst.plans.logical.CreateBranchField
 import org.apache.spark.sql.catalyst.plans.logical.DropPartitionField
 import org.apache.spark.sql.catalyst.plans.logical.DynamicFileFilter
 import org.apache.spark.sql.catalyst.plans.logical.DynamicFileFilterWithCardinalityCheck
@@ -88,6 +89,10 @@ case class ExtendedDataSourceV2Strategy(spark: SparkSession) extends Strategy {
 
     case MergeInto(mergeIntoParams, output, child) =>
       MergeIntoExec(mergeIntoParams, output, planLater(child)) :: Nil
+
+    case c @ CreateBranchField(branch, isBranch, catalog, reference) =>
+      CreateBranchExec(c.output, branch, spark.sessionState.catalogManager.currentCatalog, isBranch, catalog,
+        reference) :: Nil
 
     case _ => Nil
   }

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestNessieStatements.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestNessieStatements.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.extensions;
+
+import com.dremio.nessie.client.NessieClient;
+import com.dremio.nessie.error.NessieNotFoundException;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.nessie.NessieCatalog;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.spark.SparkTestBase;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.internal.SQLConf;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestNessieStatements extends SparkTestBase {
+
+  private static NessieCatalog catalog;
+
+  @ClassRule
+  @Rule
+  public static TemporaryFolder temp = new TemporaryFolder();
+  private static String hash;
+
+  private final TableIdentifier tableIdent = TableIdentifier.of("testnamespace", "testtable");
+  private final String catalogName = "nessie";
+  private final String tableName = catalogName + "." + tableIdent;
+
+  @BeforeClass
+  public static void startMetastoreAndSpark()  {
+    File tempFile = null;
+    try {
+      tempFile = temp.newFolder();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    String port = System.getProperty("quarkus.http.test-port", "19120");
+    String path = String.format("http://localhost:%s/api/v1", port);
+
+    SparkTestBase.spark = SparkSession.builder()
+        .master("local[2]")
+        .config("spark.testing", "true")
+        .config(SQLConf.PARTITION_OVERWRITE_MODE().key(), "dynamic")
+        .config("spark.sql.extensions", IcebergSparkSessionExtensions.class.getName())
+        .config("spark.sql.shuffle.partitions", "4")
+        .config("spark.sql.catalog.nessie.url", path)
+        .config("spark.sql.catalog.nessie.ref", "main")
+        .config("spark.sql.catalog.nessie.warehouse", tempFile.toURI().toString())
+        .config("spark.sql.catalog.nessie.catalog-impl", NessieCatalog.class.getName())
+        .config("spark.sql.catalog.nessie", "org.apache.iceberg.spark.SparkCatalog")
+        .enableHiveSupport()
+        .getOrCreate();
+
+    catalog = new NessieCatalog();
+    catalog.setConf(hiveConf);
+    catalog.initialize("nessie", ImmutableMap.of("ref", "main",
+        "url", path, "warehouse", tempFile.toURI().toString()));
+    NessieClient client = NessieClient.none(path);
+    try {
+      hash = client.getTreeApi().getDefaultBranch().getHash();
+    } catch (NessieNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @AfterClass
+  public static void stopMetastoreAndSpark() {
+    if (catalog != null) {
+      catalog.close();
+    }
+    SparkTestBase.catalog = null;
+    spark.stop();
+    SparkTestBase.spark = null;
+  }
+
+  @After
+  public void removeTables() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @Test
+  public void testCreateBranch() {
+    List<Object[]> result = sql("CREATE BRANCH tempBranch IN nessie");
+    assertEquals("created branch", ImmutableList.of(new Object[]{"Branch", "tempBranch", hash}), result);
+
+    result = sql("CREATE TAG tempTag IN nessie");
+    assertEquals("created branch", ImmutableList.of(new Object[]{"Tag", "tempTag", hash}), result);
+
+    result = sql("CREATE BRANCH tempBranch1 IN nessie AS main");
+    assertEquals("created branch", ImmutableList.of(new Object[]{"Branch", "tempBranch1", hash}), result);
+
+    result = sql("CREATE TAG tempTag1 IN nessie AS main");
+    assertEquals("created branch", ImmutableList.of(new Object[]{"Tag", "tempTag1", hash}), result);
+
+    spark.sessionState().catalogManager().setCurrentCatalog("nessie");
+    result = sql("CREATE BRANCH tempBranch2");
+    assertEquals("created branch", ImmutableList.of(new Object[]{"Branch", "tempBranch2", hash}), result);
+
+    result = sql("CREATE TAG tempTag2");
+    assertEquals("created branch", ImmutableList.of(new Object[]{"Tag", "tempTag2", hash}), result);
+
+
+  }
+
+
+}


### PR DESCRIPTION
This is still in early stages but I wanted to get early feedback on it. This implements part of #1808, specifically the create reference commands.

I think the biggest open question is if it should live in the same module as the rest of the extensions or in a new module. I sort of think it should be in its own however there would be a ton of extra boilerplate/duplicate code to make that happen

Left to do:
* clean up tests and `build.gradle`
* add other commands from #1808 
* finalize custom command syntax

cc @shangshengtung 