### PR TITLE
Core: Add a util method to combine tasks by partition

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ContentScanTask.java
+++ b/api/src/main/java/org/apache/iceberg/ContentScanTask.java
@@ -25,7 +25,7 @@ import org.apache.iceberg.expressions.Expression;
  *
  * @param <F> the Java class of the content file
  */
-public interface ContentScanTask<F extends ContentFile<F>> extends ScanTask {
+public interface ContentScanTask<F extends ContentFile<F>> extends ScanTask, PartitionScanTask {
   /**
    * The {@link ContentFile file} to scan.
    *
@@ -33,12 +33,10 @@ public interface ContentScanTask<F extends ContentFile<F>> extends ScanTask {
    */
   F file();
 
-  /**
-   * The {@link PartitionSpec spec} used to store this file.
-   *
-   * @return the partition spec from this file's manifest
-   */
-  PartitionSpec spec();
+  @Override
+  default StructLike partition() {
+    return file().partition();
+  }
 
   /**
    * The starting position of this scan range in the file.

--- a/api/src/main/java/org/apache/iceberg/FileScanTask.java
+++ b/api/src/main/java/org/apache/iceberg/FileScanTask.java
@@ -21,8 +21,7 @@ package org.apache.iceberg;
 import java.util.List;
 
 /** A scan task over a range of bytes in a single data file. */
-public interface FileScanTask
-    extends PartitionScanTask, ContentScanTask<DataFile>, SplittableScanTask<FileScanTask> {
+public interface FileScanTask extends ContentScanTask<DataFile>, SplittableScanTask<FileScanTask> {
   /**
    * A list of {@link DeleteFile delete files} to apply when reading the task's data file.
    *

--- a/api/src/main/java/org/apache/iceberg/FileScanTask.java
+++ b/api/src/main/java/org/apache/iceberg/FileScanTask.java
@@ -48,9 +48,4 @@ public interface FileScanTask extends ContentScanTask<DataFile>, SplittableScanT
   default FileScanTask asFileScanTask() {
     return this;
   }
-
-  @Override
-  default StructLike partition() {
-    return file().partition();
-  }
 }

--- a/api/src/main/java/org/apache/iceberg/PartitionScanTask.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionScanTask.java
@@ -18,40 +18,11 @@
  */
 package org.apache.iceberg;
 
-import java.util.List;
+/** A scan task for data within a particular partition */
+public interface PartitionScanTask extends ScanTask {
+  /** Returns the spec of the partition for this scan task */
+  PartitionSpec spec();
 
-/** A scan task over a range of bytes in a single data file. */
-public interface FileScanTask
-    extends PartitionScanTask, ContentScanTask<DataFile>, SplittableScanTask<FileScanTask> {
-  /**
-   * A list of {@link DeleteFile delete files} to apply when reading the task's data file.
-   *
-   * @return a list of delete files to apply
-   */
-  List<DeleteFile> deletes();
-
-  @Override
-  default long sizeBytes() {
-    return length() + deletes().stream().mapToLong(ContentFile::fileSizeInBytes).sum();
-  }
-
-  @Override
-  default int filesCount() {
-    return 1 + deletes().size();
-  }
-
-  @Override
-  default boolean isFileScanTask() {
-    return true;
-  }
-
-  @Override
-  default FileScanTask asFileScanTask() {
-    return this;
-  }
-
-  @Override
-  default StructLike partition() {
-    return file().partition();
-  }
+  /** Returns the value of the partition for this scan task */
+  StructLike partition();
 }

--- a/api/src/main/java/org/apache/iceberg/util/StructProjection.java
+++ b/api/src/main/java/org/apache/iceberg/util/StructProjection.java
@@ -90,6 +90,13 @@ public class StructProjection implements StructLike {
   private final StructProjection[] nestedProjections;
   private StructLike struct;
 
+  private StructProjection(StructProjection other) {
+    this.type = other.type;
+    this.positionMap = other.positionMap;
+    this.nestedProjections = other.nestedProjections;
+    this.struct = other.struct;
+  }
+
   private StructProjection(StructType structType, StructType projection) {
     this(structType, projection, false);
   }
@@ -169,6 +176,14 @@ public class StructProjection implements StructLike {
   public StructProjection wrap(StructLike newStruct) {
     this.struct = newStruct;
     return this;
+  }
+
+  public StructProjection copy() {
+    return new StructProjection(this);
+  }
+
+  public StructType type() {
+    return type;
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/util/StructProjection.java
+++ b/api/src/main/java/org/apache/iceberg/util/StructProjection.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.util;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.Schema;
@@ -92,8 +93,10 @@ public class StructProjection implements StructLike {
 
   private StructProjection(StructProjection other) {
     this.type = other.type;
-    this.positionMap = other.positionMap;
-    this.nestedProjections = other.nestedProjections;
+    this.positionMap = other.positionMap == null ? null :
+            Arrays.copyOf(other.positionMap, other.positionMap.length);
+    this.nestedProjections = other.nestedProjections == null ? null :
+            Arrays.copyOf(other.nestedProjections, other.nestedProjections.length);
     this.struct = other.struct;
   }
 

--- a/api/src/main/java/org/apache/iceberg/util/StructProjection.java
+++ b/api/src/main/java/org/apache/iceberg/util/StructProjection.java
@@ -179,8 +179,7 @@ public class StructProjection implements StructLike {
   }
 
   public StructProjection copyFor(StructLike newStruct) {
-    return new StructProjection(this.type, this.positionMap, this.nestedProjections)
-        .wrap(newStruct);
+    return new StructProjection(type, positionMap, nestedProjections).wrap(newStruct);
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/util/StructProjection.java
+++ b/api/src/main/java/org/apache/iceberg/util/StructProjection.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.util;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.Schema;
@@ -93,14 +92,8 @@ public class StructProjection implements StructLike {
 
   private StructProjection(StructProjection other) {
     this.type = other.type;
-    this.positionMap =
-        other.positionMap == null
-            ? null
-            : Arrays.copyOf(other.positionMap, other.positionMap.length);
-    this.nestedProjections =
-        other.nestedProjections == null
-            ? null
-            : Arrays.copyOf(other.nestedProjections, other.nestedProjections.length);
+    this.positionMap = other.positionMap;
+    this.nestedProjections = other.nestedProjections;
     this.struct = other.struct;
   }
 
@@ -187,10 +180,6 @@ public class StructProjection implements StructLike {
 
   public StructProjection copy() {
     return new StructProjection(this);
-  }
-
-  public StructType type() {
-    return type;
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/util/StructProjection.java
+++ b/api/src/main/java/org/apache/iceberg/util/StructProjection.java
@@ -93,10 +93,14 @@ public class StructProjection implements StructLike {
 
   private StructProjection(StructProjection other) {
     this.type = other.type;
-    this.positionMap = other.positionMap == null ? null :
-            Arrays.copyOf(other.positionMap, other.positionMap.length);
-    this.nestedProjections = other.nestedProjections == null ? null :
-            Arrays.copyOf(other.nestedProjections, other.nestedProjections.length);
+    this.positionMap =
+        other.positionMap == null
+            ? null
+            : Arrays.copyOf(other.positionMap, other.positionMap.length);
+    this.nestedProjections =
+        other.nestedProjections == null
+            ? null
+            : Arrays.copyOf(other.nestedProjections, other.nestedProjections.length);
     this.struct = other.struct;
   }
 

--- a/api/src/main/java/org/apache/iceberg/util/StructProjection.java
+++ b/api/src/main/java/org/apache/iceberg/util/StructProjection.java
@@ -90,11 +90,11 @@ public class StructProjection implements StructLike {
   private final StructProjection[] nestedProjections;
   private StructLike struct;
 
-  private StructProjection(StructProjection other) {
-    this.type = other.type;
-    this.positionMap = other.positionMap;
-    this.nestedProjections = other.nestedProjections;
-    this.struct = other.struct;
+  private StructProjection(
+      StructType type, int[] positionMap, StructProjection[] nestedProjections) {
+    this.type = type;
+    this.positionMap = positionMap;
+    this.nestedProjections = nestedProjections;
   }
 
   private StructProjection(StructType structType, StructType projection) {
@@ -178,8 +178,9 @@ public class StructProjection implements StructLike {
     return this;
   }
 
-  public StructProjection copy() {
-    return new StructProjection(this);
+  public StructProjection copyFor(StructLike newStruct) {
+    return new StructProjection(this.type, this.positionMap, this.nestedProjections)
+        .wrap(newStruct);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/util/TableScanUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/TableScanUtil.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.util;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -152,7 +151,7 @@ public class TableScanUtil {
     Preconditions.checkArgument(
         openFileCost >= 0, "Invalid file open cost (negative): %s", openFileCost);
 
-    List<T> splitTasks = new ArrayList<>();
+    List<T> splitTasks = Lists.newArrayList();
     for (T task : tasks) {
       if (task instanceof SplittableScanTask<?>) {
         ((SplittableScanTask<? extends T>) task).split(splitSize).forEach(splitTasks::add);
@@ -187,7 +186,7 @@ public class TableScanUtil {
         groupedTasks.asMap().values().stream()
             .map(
                 t -> {
-                  List<BaseScanTaskGroup<T>> taskGroups = new ArrayList<>();
+                  List<BaseScanTaskGroup<T>> taskGroups = Lists.newArrayList();
                   new BinPacking.PackingIterable<>(
                           CloseableIterable.withNoopClose(t), splitSize, lookback, weightFunc, true)
                       .forEach(ts -> taskGroups.add(new BaseScanTaskGroup<>(mergeTasks(ts))));

--- a/core/src/test/java/org/apache/iceberg/MockFileScanTask.java
+++ b/core/src/test/java/org/apache/iceberg/MockFileScanTask.java
@@ -39,6 +39,11 @@ public class MockFileScanTask extends BaseFileScanTask {
     this.length = file.fileSizeInBytes();
   }
 
+  public MockFileScanTask(DataFile file, String schemaString, String specString) {
+    super(file, null, schemaString, specString, null);
+    this.length = file.fileSizeInBytes();
+  }
+
   public static MockFileScanTask mockTask(long length, int sortOrderId) {
     DataFile mockFile = Mockito.mock(DataFile.class);
     Mockito.when(mockFile.fileSizeInBytes()).thenReturn(length);

--- a/core/src/test/java/org/apache/iceberg/util/TestTableScanUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestTableScanUtil.java
@@ -161,8 +161,7 @@ public class TestTableScanUtil {
   @Test
   public void testTaskGroupPlanningByPartition() {
     // When all files belong to the same partition, we should combine them together as long as the
-    // total file
-    // size is <= split size
+    // total file size is <= split size
     List<FileScanTask> tasks =
         ImmutableList.of(
             taskWithPartition(TEST_SCHEMA, SPEC1, PARTITION1, 64),

--- a/core/src/test/java/org/apache/iceberg/util/TestTableScanUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestTableScanUtil.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.BaseCombinedScanTask;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.DataFile;
@@ -229,6 +230,18 @@ public class TestTableScanUtil {
       count += 1;
     }
     Assert.assertEquals(4, count);
+
+    // The following should throw exception since `SPEC2` is not an intersection of partition specs
+    // across all tasks.
+    List<PartitionScanTask> tasks2 =
+        ImmutableList.of(
+            taskWithPartition(SPEC1, PARTITION1, 128), taskWithPartition(SPEC2, PARTITION2, 128));
+
+    AssertHelpers.assertThrows(
+        "Should throw exception",
+        IllegalArgumentException.class,
+        "Cannot find field",
+        () -> TableScanUtil.planTaskGroups(tasks2, 128, 10, 4, SPEC2.partitionType()));
   }
 
   private PartitionScanTask taskWithPartition(


### PR DESCRIPTION
This adds a new method: `TableScanUtil.planTaskGroups`, that allow Iceberg splits combining to only happen within partitions. This is a pre-requisite for Iceberg to start exposing table distribution and ordering spec to Spark in order to enable features such as storage-partitioned join.

A new interface `PartitionScanTask` is also introduced to represent scan tasks whose data come from a single partition. 

