### PR TITLE
Hive: Fix predicate pushdown for Timestamp.withZone()

### DIFF
--- a/hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampObjectInspectorHive3.java
+++ b/hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampObjectInspectorHive3.java
@@ -55,9 +55,7 @@ public class IcebergTimestampObjectInspectorHive3 extends AbstractPrimitiveJavaO
       return null;
     }
     LocalDateTime time = (LocalDateTime) o;
-    Timestamp timestamp = Timestamp.ofEpochMilli(time.toInstant(ZoneOffset.UTC).toEpochMilli());
-    timestamp.setNanos(time.getNano());
-    return timestamp;
+    return Timestamp.ofEpochMilli(time.toInstant(ZoneOffset.UTC).toEpochMilli(), time.getNano());
   }
 
   @Override

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampWithZoneObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampWithZoneObjectInspector.java
@@ -42,12 +42,13 @@ public class IcebergTimestampWithZoneObjectInspector extends AbstractPrimitiveJa
 
   @Override
   public OffsetDateTime convert(Object o) {
-    return o == null ? null : OffsetDateTime.ofInstant(((Timestamp) o).toInstant(), ZoneOffset.UTC);
+    return o == null ? null : OffsetDateTime.of(((Timestamp) o).toLocalDateTime(), ZoneOffset.UTC);
   }
 
   @Override
   public Timestamp getPrimitiveJavaObject(Object o) {
-    return o == null ? null : Timestamp.from(((OffsetDateTime) o).toInstant());
+    return o == null ? null :
+        Timestamp.valueOf(((OffsetDateTime) o).withOffsetSameInstant(ZoneOffset.UTC).toLocalDateTime());
   }
 
   @Override

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
@@ -32,6 +32,10 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -59,7 +63,9 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.IcebergGenerics;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.hive.MetastoreUtil;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ByteBuffers;
 import org.junit.Assert;
@@ -106,6 +112,13 @@ public class HiveIcebergTestUtils {
               PrimitiveObjectInspectorFactory.writableStringObjectInspector,
               PrimitiveObjectInspectorFactory.writableStringObjectInspector
           ));
+
+  public static final DateTimeFormatter timestampWithTZFormatter = new DateTimeFormatterBuilder()
+      .appendPattern("yyyy-MM-dd HH:mm:ss")
+      .appendFraction(ChronoField.MICRO_OF_SECOND, 0, 9, true)
+      .appendLiteral(' ')
+      .appendZoneOrOffsetId()
+      .toFormatter();
 
   private HiveIcebergTestUtils() {
     // Empty constructor for the utility class
@@ -264,5 +277,58 @@ public class HiveIcebergTestUtils {
 
     Assert.assertEquals(dataFileNum, dataFiles.size());
     Assert.assertFalse(new File(HiveIcebergOutputCommitter.generateJobLocation(conf, jobId)).exists());
+  }
+
+  /**
+   * Lazy implementation for checking the the returned results from a SELECT statement are the same than the inserted
+   * values. We expect that the values are inserted using {@link #getStringValueForInsert(Object, Type)}.
+   * <p>
+   * For completeness shake we might want to implement sorting when needed.
+   * @param shell The shell used for executing the query
+   * @param tableName The name of the table to query
+   * @param expected The records we inserted
+   */
+  public static void validateDataWithSql(TestHiveShell shell, String tableName, List<Record> expected) {
+    List<Object[]> actual = shell.executeStatement("SELECT * from " + tableName);
+
+    for (int rowId = 0; rowId < expected.size(); ++rowId) {
+      Record record = expected.get(rowId);
+      Object[] row = actual.get(rowId);
+      Assert.assertEquals(record.size(), row.length);
+      for (int fieldId = 0; fieldId < record.size(); ++fieldId) {
+        Types.NestedField field = record.struct().fields().get(fieldId);
+        String inserted =
+            getStringValueForInsert(record.getField(field.name()), field.type()).replaceAll("'(.*)'", "$1");
+        String returned = row[fieldId].toString();
+        if (field.type().equals(Types.TimestampType.withZone()) && MetastoreUtil.hive3PresentOnClasspath()) {
+          Timestamp timestamp = Timestamp.from(ZonedDateTime.parse(returned, timestampWithTZFormatter).toInstant());
+          returned = timestamp.toString();
+        }
+        Assert.assertEquals(inserted, returned);
+      }
+    }
+  }
+
+  public static String getStringValueForInsert(Object value, Type type) {
+    String template = "\'%s\'";
+    if (type.equals(Types.TimestampType.withoutZone())) {
+      return String.format(template, Timestamp.valueOf((LocalDateTime) value).toString());
+    } else if (type.equals(Types.TimestampType.withZone())) {
+      Timestamp timestamp;
+      // Hive2 stores Timestamps with local TZ, Hive3 stores Timestamps in UTC so we have to insert different timestamp
+      // to get the same expected values in the Iceberg rows. The Hive query should return the same values as inserted
+      // in both cases
+      if (MetastoreUtil.hive3PresentOnClasspath()) {
+        timestamp = Timestamp.from(((OffsetDateTime) value).toInstant());
+      } else {
+        timestamp = Timestamp.valueOf(((OffsetDateTime) value).withOffsetSameInstant(ZoneOffset.UTC).toLocalDateTime());
+      }
+      return String.format(template, timestamp.toString());
+    } else if (type.equals(Types.BooleanType.get())) {
+      // in hive2 boolean type values must not be surrounded in apostrophes. Otherwise the value is translated to true.
+      return value.toString();
+    } else {
+      return String.format(template, value.toString());
+    }
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
@@ -297,9 +297,9 @@ public class HiveIcebergTestUtils {
       Assert.assertEquals(record.size(), row.length);
       for (int fieldId = 0; fieldId < record.size(); ++fieldId) {
         Types.NestedField field = record.struct().fields().get(fieldId);
-        // If there are enclosing quotes then remove them
-        String inserted =
-            getStringValueForInsert(record.getField(field.name()), field.type()).replaceAll("'(.*)'", "$1");
+        String inserted = getStringValueForInsert(record.getField(field.name()), field.type())
+            // If there are enclosing quotes then remove them
+            .replaceAll("'(.*)'", "$1");
         String returned = row[fieldId].toString();
         if (field.type().equals(Types.TimestampType.withZone()) && MetastoreUtil.hive3PresentOnClasspath()) {
           Timestamp timestamp = Timestamp.from(ZonedDateTime.parse(returned, TIMESTAMP_WITH_TZ_FORMATTER).toInstant());

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
@@ -280,10 +280,10 @@ public class HiveIcebergTestUtils {
   }
 
   /**
-   * Lazy implementation for checking that the returned results from a SELECT statement are the same than the inserted
-   * values. We expect that the values are inserted using {@link #getStringValueForInsert(Object, Type)}.
+   * Simplified implementation for checking that the returned results from a SELECT statement are the same than the
+   * inserted values. We expect that the values are inserted using {@link #getStringValueForInsert(Object, Type)}.
    * <p>
-   * For completeness sake we might want to implement sorting when needed.
+   * For the full implementation we might want to add sorting so the check could work for every table/query.
    * @param shell The shell used for executing the query
    * @param tableName The name of the table to query
    * @param expected The records we inserted

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergOutputCommitter.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergOutputCommitter.java
@@ -111,7 +111,7 @@ public class TestHiveIcebergOutputCommitter {
     committer.commitJob(new JobContextImpl(conf, JOB_ID));
 
     HiveIcebergTestUtils.validateFiles(table, conf, JOB_ID, 1);
-    HiveIcebergTestUtils.validateData(table, expected, 0);
+    HiveIcebergTestUtils.validateDataWithIceberg(table, expected, 0);
   }
 
   @Test
@@ -123,7 +123,7 @@ public class TestHiveIcebergOutputCommitter {
     committer.commitJob(new JobContextImpl(conf, JOB_ID));
 
     HiveIcebergTestUtils.validateFiles(table, conf, JOB_ID, 3);
-    HiveIcebergTestUtils.validateData(table, expected, 0);
+    HiveIcebergTestUtils.validateDataWithIceberg(table, expected, 0);
   }
 
   @Test
@@ -135,7 +135,7 @@ public class TestHiveIcebergOutputCommitter {
     committer.commitJob(new JobContextImpl(conf, JOB_ID));
 
     HiveIcebergTestUtils.validateFiles(table, conf, JOB_ID, 2);
-    HiveIcebergTestUtils.validateData(table, expected, 0);
+    HiveIcebergTestUtils.validateDataWithIceberg(table, expected, 0);
   }
 
   @Test
@@ -147,7 +147,7 @@ public class TestHiveIcebergOutputCommitter {
     committer.commitJob(new JobContextImpl(conf, JOB_ID));
 
     HiveIcebergTestUtils.validateFiles(table, conf, JOB_ID, 6);
-    HiveIcebergTestUtils.validateData(table, expected, 0);
+    HiveIcebergTestUtils.validateDataWithIceberg(table, expected, 0);
   }
 
   @Test
@@ -159,19 +159,19 @@ public class TestHiveIcebergOutputCommitter {
     // Write records and abort the tasks
     writeRecords(2, 0, false, true, conf);
     HiveIcebergTestUtils.validateFiles(table, conf, JOB_ID, 0);
-    HiveIcebergTestUtils.validateData(table, Collections.emptyList(), 0);
+    HiveIcebergTestUtils.validateDataWithIceberg(table, Collections.emptyList(), 0);
 
     // Write records but do not abort the tasks
     // The data files remain since we can not identify them but should not be read
     writeRecords(2, 1, false, false, conf);
     HiveIcebergTestUtils.validateFiles(table, conf, JOB_ID, 2);
-    HiveIcebergTestUtils.validateData(table, Collections.emptyList(), 0);
+    HiveIcebergTestUtils.validateDataWithIceberg(table, Collections.emptyList(), 0);
 
     // Write and commit the records
     List<Record> expected = writeRecords(2, 2, true, false, conf);
     committer.commitJob(new JobContextImpl(conf, JOB_ID));
     HiveIcebergTestUtils.validateFiles(table, conf, JOB_ID, 4);
-    HiveIcebergTestUtils.validateData(table, expected, 0);
+    HiveIcebergTestUtils.validateDataWithIceberg(table, expected, 0);
   }
 
   @Test
@@ -183,7 +183,7 @@ public class TestHiveIcebergOutputCommitter {
     committer.abortJob(new JobContextImpl(conf, JOB_ID), JobStatus.State.FAILED);
 
     HiveIcebergTestUtils.validateFiles(table, conf, JOB_ID, 0);
-    HiveIcebergTestUtils.validateData(table, Collections.emptyList(), 0);
+    HiveIcebergTestUtils.validateDataWithIceberg(table, Collections.emptyList(), 0);
   }
 
   @Test

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -306,7 +306,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
 
     shell.executeStatement(query.toString());
 
-    HiveIcebergTestUtils.validateData(table, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 0);
+    HiveIcebergTestUtils.validateDataWithIceberg(table, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 0);
   }
 
   @Test
@@ -331,7 +331,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
       Table table = testTables.createTable(shell, tableName, schema, PartitionSpec.unpartitioned(), fileFormat,
           expected);
 
-      HiveIcebergTestUtils.validateData(table, expected, 0);
+      HiveIcebergTestUtils.validateDataWithIceberg(table, expected, 0);
       HiveIcebergTestUtils.validateDataWithSql(shell, tableName, expected);
     }
   }
@@ -352,7 +352,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     // Check that everything is duplicated as expected
     List<Record> records = new ArrayList<>(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
     records.addAll(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-    HiveIcebergTestUtils.validateData(table, records, 0);
+    HiveIcebergTestUtils.validateDataWithIceberg(table, records, 0);
   }
 
   /**
@@ -372,7 +372,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     // Check that everything is duplicated as expected
     List<Record> records = new ArrayList<>(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
     records.addAll(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-    HiveIcebergTestUtils.validateData(table, records, 0);
+    HiveIcebergTestUtils.validateDataWithIceberg(table, records, 0);
   }
 
   @Test
@@ -391,7 +391,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
         .add(1L, null, "test")
         .build();
 
-    HiveIcebergTestUtils.validateData(table, expected, 0);
+    HiveIcebergTestUtils.validateDataWithIceberg(table, expected, 0);
   }
 
   @Test
@@ -416,7 +416,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
       copy.setField("first_name", "Sam");
       expected.add(copy);
     });
-    HiveIcebergTestUtils.validateData(table, expected, 0);
+    HiveIcebergTestUtils.validateDataWithIceberg(table, expected, 0);
   }
 
   @Test
@@ -435,7 +435,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     shell.executeStatement("INSERT INTO target_customers SELECT a.customer_id, b.first_name, a.last_name FROM " +
             "source_customers_1 a JOIN source_customers_2 b ON a.last_name = b.last_name");
 
-    HiveIcebergTestUtils.validateData(table, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 0);
+    HiveIcebergTestUtils.validateDataWithIceberg(table, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 0);
   }
 
   @Test
@@ -587,7 +587,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     Table table = testTables.createTable(shell, "partitioned_customers",
         HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, fileFormat, records);
 
-    HiveIcebergTestUtils.validateData(table, records, 0);
+    HiveIcebergTestUtils.validateDataWithIceberg(table, records, 0);
   }
 
   @Test
@@ -603,7 +603,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     Table table = testTables.createTable(shell, "partitioned_customers",
         HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, fileFormat, records);
 
-    HiveIcebergTestUtils.validateData(table, records, 0);
+    HiveIcebergTestUtils.validateDataWithIceberg(table, records, 0);
   }
 
   @Test
@@ -620,7 +620,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     Table table = testTables.createTable(shell, "partitioned_customers",
         HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, fileFormat, records);
 
-    HiveIcebergTestUtils.validateData(table, records, 0);
+    HiveIcebergTestUtils.validateDataWithIceberg(table, records, 0);
   }
 
   private void testComplexTypeWrite(Schema schema, List<Record> records) throws IOException {
@@ -631,7 +631,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     shell.executeStatement("CREATE TABLE default." + dummyTableName + "(a int)");
     shell.executeStatement("INSERT INTO TABLE default." + dummyTableName + " VALUES(1)");
     records.forEach(r -> shell.executeStatement(insertQueryForComplexType(tableName, dummyTableName, schema, r)));
-    HiveIcebergTestUtils.validateData(table, records, 0);
+    HiveIcebergTestUtils.validateDataWithIceberg(table, records, 0);
   }
 
   private String insertQueryForComplexType(String tableName, String dummyTableName, Schema schema, Record record) {

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -323,14 +323,16 @@ public class TestHiveIcebergStorageHandlerWithEngine {
         continue;
       }
       String columnName = type.typeId().toString().toLowerCase() + "_column";
+      String tableName = type.typeId().toString().toLowerCase() + "_table_" + i;
 
       Schema schema = new Schema(required(1, "id", Types.LongType.get()), required(2, columnName, type));
       List<Record> expected = TestHelper.generateRandomRecords(schema, 5, 0L);
 
-      Table table = testTables.createTable(shell, type.typeId().toString().toLowerCase() + "_table_" + i,
-          schema, PartitionSpec.unpartitioned(), fileFormat, expected);
+      Table table = testTables.createTable(shell, tableName, schema, PartitionSpec.unpartitioned(), fileFormat,
+          expected);
 
       HiveIcebergTestUtils.validateData(table, expected, 0);
+      HiveIcebergTestUtils.validateDataWithSql(shell, tableName, expected);
     }
   }
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
@@ -22,9 +22,6 @@ package org.apache.iceberg.mr.hive;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.sql.Timestamp;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -54,8 +51,6 @@ import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ObjectArrays;
-import org.apache.iceberg.types.Type;
-import org.apache.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.rules.TemporaryFolder;
 
@@ -186,8 +181,8 @@ abstract class TestTables {
       records.forEach(record -> {
         query.append("(");
         query.append(record.struct().fields().stream()
-                .map(field -> getStringValueForInsert(record.getField(field.name()), field.type()))
-                .collect(Collectors.joining(",")));
+            .map(field -> HiveIcebergTestUtils.getStringValueForInsert(record.getField(field.name()), field.type()))
+            .collect(Collectors.joining(",")));
         query.append("),");
       });
       query.setLength(query.length() - 1);
@@ -403,20 +398,6 @@ abstract class TestTables {
 
   private static String tablePath(TableIdentifier identifier) {
     return "/" + Joiner.on("/").join(identifier.namespace().levels()) + "/" + identifier.name();
-  }
-
-  private String getStringValueForInsert(Object value, Type type) {
-    String template = "\'%s\'";
-    if (type.equals(Types.TimestampType.withoutZone())) {
-      return String.format(template, Timestamp.valueOf((LocalDateTime) value).toString());
-    } else if (type.equals(Types.TimestampType.withZone())) {
-      return String.format(template, Timestamp.from(((OffsetDateTime) value).toInstant()).toString());
-    } else if (type.equals(Types.BooleanType.get())) {
-      // in hive2 boolean type values must not be surrounded in apostrophes. Otherwise the value is translated to true.
-      return value.toString();
-    } else {
-      return String.format(template, value.toString());
-    }
   }
 
   enum TestTableType {

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspector.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/serde/objectinspector/TestIcebergTimestampWithZoneObjectInspector.java
@@ -52,7 +52,7 @@ public class TestIcebergTimestampWithZoneObjectInspector {
 
     LocalDateTime local = LocalDateTime.of(2020, 1, 1, 16, 45, 33, 456000);
     OffsetDateTime offsetDateTime = OffsetDateTime.of(local, ZoneOffset.ofHours(-5));
-    Timestamp ts = Timestamp.from(offsetDateTime.toInstant());
+    Timestamp ts = Timestamp.valueOf(offsetDateTime.withOffsetSameInstant(ZoneOffset.UTC).toLocalDateTime());
 
     Assert.assertEquals(ts, oi.getPrimitiveJavaObject(offsetDateTime));
     Assert.assertEquals(new TimestampWritable(ts), oi.getPrimitiveWritableObject(offsetDateTime));
@@ -66,9 +66,5 @@ public class TestIcebergTimestampWithZoneObjectInspector {
 
     Assert.assertEquals(OffsetDateTime.ofInstant(local.toInstant(ZoneOffset.ofHours(-5)), ZoneOffset.UTC),
             oi.convert(ts));
-
-    Assert.assertEquals(offsetDateTime.withOffsetSameInstant(ZoneOffset.UTC),
-            oi.convert(Timestamp.from(offsetDateTime.toInstant())));
   }
-
 }


### PR DESCRIPTION
During #2254 we postponed to create tests for tables where the column type is timestamp.withZone().
This PR adds them with the appropriate tests.

The premise:
- Hive2 uses sql.Timestamp internally - which is in the LocalTimezone
- Hive3 uses hive.Timestamp internally - which is in UTC
- Iceberg timestamp.withZone() stores the values in OffsetDateTime in UTC

What I have done:
- Fixed the conversions for `IcebergTimestampWithZoneObjectInspector`
- Simplified a code a little bit for `IcebergTimestampObjectInspectorHive3`
- Added the junit tests for `SELECT`
   - Had to  add one more magic setting so the TimeZone is handled correctly
- Added additional check to the existing unit tests to make sure that we get back the same string in SQL as we insert
- Had to change the unit tests for Hive2, so the expected value in the Iceberg record is considers the TimeZone