### PR TITLE
Hive: Quick fix for broken TestHiveIcebergFilterFactory.testTimestampType test

### DIFF
--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergFilterFactory.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergFilterFactory.java
@@ -23,7 +23,6 @@ import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.LocalDate;
-import java.time.ZoneOffset;
 import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory;
@@ -231,7 +230,7 @@ public class TestHiveIcebergFilterFactory {
   public void testTimestampType() {
     Literal<Long> timestampLiteral = Literal.of("2012-10-02T05:16:17.123456").to(Types.TimestampType.withoutZone());
     long timestampMicros = timestampLiteral.value();
-    Timestamp ts = Timestamp.from(DateTimeUtil.timestampFromMicros(timestampMicros).toInstant(ZoneOffset.UTC));
+    Timestamp ts = Timestamp.valueOf(DateTimeUtil.timestampFromMicros(timestampMicros));
 
     SearchArgument.Builder builder = SearchArgumentFactory.newBuilder();
     SearchArgument arg = builder.startAnd().equals("timestamp", PredicateLeaf.Type.TIMESTAMP, ts).end().build();


### PR DESCRIPTION
#2254 modified how the Timestamp type is handled in `HiveIcebergFilterFactory.microsFromTimestamp` but forgot to update the tests for filter conversion.

The original change (#2254) fixed the Timestamp / Date filters to work not only in UTC timezone but other timezones as well. The change was verified by adding new tests which were testing with multiple timezones, but the original `TestHiveIcebergFilterFactory.testTimestampType` test was checking the base behavior which were originally wrong and fixed in #2254, so we need to change the test too.