### PR TITLE
Flink: Support bucket table.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/transforms/Transforms.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Transforms.java
@@ -39,7 +39,7 @@ public class Transforms {
   private Transforms() {
   }
 
-  private static final Pattern HAS_WIDTH = Pattern.compile("(\\w+)\\[(\\d+)\\]");
+  public static final Pattern HAS_WIDTH = Pattern.compile("(\\w+)\\[(\\d+)\\]");
 
   public static Transform<?, ?> fromString(Type type, String transform) {
     Matcher widthMatcher = HAS_WIDTH.matcher(transform);

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkTableProperties.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkTableProperties.java
@@ -24,7 +24,5 @@ public class FlinkTableProperties {
   private FlinkTableProperties() {
   }
 
-  // As we flink SQL does not support create table with specified buckets, so we use the table properties to specify
-  // the bucket infos. When flink SQL support bucket clause in future, we will deprecate the two properties.
-  public static final String PARTITIONS = "flink.partitions";
+  public static final String PARTITION_BY_PREFIX = "partition.by.";
 }

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkTableProperties.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkTableProperties.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink;
+
+public class FlinkTableProperties {
+
+  private FlinkTableProperties() {
+  }
+
+  // As we flink SQL does not support create table with specified buckets, so we use the table properties to specify
+  // the bucket infos. When flink SQL support bucket clause in future, we will deprecate the two properties.
+  public static final String PARTITIONS = "flink.partitions";
+}

--- a/flink/src/main/java/org/apache/iceberg/flink/PartitionUtil.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/PartitionUtil.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink;
+
+import java.util.Locale;
+import java.util.regex.Matcher;
+import org.apache.flink.util.Preconditions;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.Term;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.transforms.Transform;
+import org.apache.iceberg.transforms.Transforms;
+import org.apache.iceberg.types.Types;
+
+class PartitionUtil {
+
+  private PartitionUtil() {
+  }
+
+  static String partitionPropKey(String colName) {
+    return String.format("%s%s", FlinkTableProperties.PARTITION_BY_PREFIX, colName);
+  }
+
+  static boolean isPartitionField(String propKey) {
+    return propKey != null && propKey.startsWith(FlinkTableProperties.PARTITION_BY_PREFIX);
+  }
+
+  private static String partitionField(String propKey) {
+    if (propKey != null && propKey.startsWith(FlinkTableProperties.PARTITION_BY_PREFIX)) {
+      return propKey.replace(FlinkTableProperties.PARTITION_BY_PREFIX, "");
+    } else {
+      return null;
+    }
+  }
+
+  static void addPartitionField(Schema schema, PartitionSpec.Builder builder, String propKey, String propValue) {
+    String colName = partitionField(propKey);
+    Preconditions.checkNotNull(colName,
+        "Table property '%s' is not an valid partition field property, please use '%s<column-name>'", propKey,
+        FlinkTableProperties.PARTITION_BY_PREFIX);
+
+    Types.NestedField nestedField = schema.findField(colName);
+    Preconditions.checkNotNull(nestedField, "Cannot find field %s in schema: %s", colName, schema);
+
+    Transform<?, ?> transform = Transforms.fromString(nestedField.type(), propValue);
+    String transformString = transform.toString();
+    switch (transformType(transformString)) {
+      case "bucket":
+        builder.bucket(colName, findWidth(transformString));
+        break;
+
+      case "truncate":
+        builder.truncate(colName, findWidth(transformString));
+        break;
+
+      case "identify":
+        builder.identity(colName);
+        break;
+
+      case "year":
+        builder.year(colName);
+        break;
+
+      case "month":
+        builder.month(colName);
+        break;
+
+      case "day":
+        builder.day(colName);
+        break;
+
+      case "hour":
+        builder.hour(colName);
+        break;
+
+      case "void":
+        builder.alwaysNull(colName);
+        break;
+
+      default:
+        throw new IllegalArgumentException(
+            String.format("Unknown transform %s for field %s", transformString, colName));
+    }
+  }
+
+  static Term toIcebergTerm(String colName, Transform<?, ?> transform) {
+    String transformString = transform.toString();
+    switch (transformType(transformString)) {
+      case "bucket":
+        return Expressions.bucket(colName, findWidth(transformString));
+
+      case "truncate":
+        return Expressions.truncate(colName, findWidth(transformString));
+
+      case "identify":
+        return Expressions.ref(colName);
+
+      case "year":
+        return Expressions.year(colName);
+
+      case "month":
+        return Expressions.month(colName);
+
+      case "day":
+        return Expressions.day(colName);
+
+      case "hour":
+        return Expressions.hour(colName);
+
+      default:
+        throw new IllegalArgumentException(String.format("Unknown transform %s", transformString));
+    }
+  }
+
+  private static String transformType(String transformString) {
+    Matcher widthMatcher = Transforms.HAS_WIDTH.matcher(transformString);
+    if (widthMatcher.matches()) {
+      return widthMatcher.group(1);
+    }
+
+    if (transformString.equalsIgnoreCase("identify") ||
+        transformString.equalsIgnoreCase("void") ||
+        transformString.equalsIgnoreCase("year") ||
+        transformString.equalsIgnoreCase("month") ||
+        transformString.equalsIgnoreCase("day") ||
+        transformString.equalsIgnoreCase("hour")) {
+      return transformString.toLowerCase(Locale.ENGLISH);
+    }
+
+    return "unknown";
+  }
+
+  private static int findWidth(String transform) {
+    Matcher widthMatcher = Transforms.HAS_WIDTH.matcher(transform);
+    if (widthMatcher.matches()) {
+      int parsedWidth;
+      try {
+        parsedWidth = Integer.parseInt(widthMatcher.group(2));
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException("Unsupported width for transform: " + transform);
+      }
+      Preconditions.checkArgument(parsedWidth > 0 && parsedWidth < Integer.MAX_VALUE,
+          "Unsupported width for transform: " + transform);
+
+      return parsedWidth;
+    } else {
+      throw new IllegalArgumentException("Cannot parse the width from transform: " + transform);
+    }
+  }
+}

--- a/flink/src/main/java/org/apache/iceberg/flink/PartitionUtil.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/PartitionUtil.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.flink;
 
 import java.util.Locale;
 import java.util.regex.Matcher;
-import org.apache.flink.util.Preconditions;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.Expressions;

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -202,16 +202,13 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
 
   @Test
   public void testBucketTable() {
-    sql("CREATE TABLE tl(id BIGINT, dt STRING) WITH ('%s'='id=bucket[8];dt=bucket[10]')",
-        FlinkTableProperties.PARTITIONS);
+    sql("CREATE TABLE tl(id BIGINT, dt STRING) WITH ('%s'='bucket[8]', '%s'='bucket[10]')",
+        PartitionUtil.partitionPropKey("id"),
+        PartitionUtil.partitionPropKey("dt"));
     Table table = table("tl");
 
-    Schema iSchema = new Schema(
-        Types.NestedField.optional(1, "id", Types.LongType.get()),
-        Types.NestedField.optional(2, "dt", Types.StringType.get())
-    );
     Assert.assertEquals("Should have expected partition spec", table.spec(),
-        PartitionSpec.builderFor(iSchema)
+        PartitionSpec.builderFor(table.schema())
             .withSpecId(table.spec().specId())
             .bucket("id", 8)
             .bucket("dt", 10)
@@ -220,7 +217,7 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
     Assert.assertEquals(Maps.newHashMap(), table.properties());
 
     // Alter the table to new buckets.
-    sql("ALTER TABLE tl SET ('%s'='id=bucket[12]')", FlinkTableProperties.PARTITIONS);
+    sql("ALTER TABLE tl SET ('%s'='bucket[12]')", PartitionUtil.partitionPropKey("id"));
     table = table("tl");
     Assert.assertEquals("Should have the expected partition spec", table.spec(),
         PartitionSpec.builderFor(table.schema())
@@ -232,7 +229,9 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
     Assert.assertEquals(Maps.newHashMap(), table.properties());
 
     // Alter the table to add new field bucket.
-    sql("ALTER TABLE tl SET ('%s'='id=bucket[1];dt=bucket[2]')", FlinkTableProperties.PARTITIONS);
+    sql("ALTER TABLE tl SET ('%s'='bucket[1]', '%s'='bucket[2]')",
+        PartitionUtil.partitionPropKey("id"),
+        PartitionUtil.partitionPropKey("dt"));
     table = table("tl");
     Assert.assertEquals("Should have the expected partition spec", table.spec(),
         PartitionSpec.builderFor(table.schema())


### PR DESCRIPTION
As we apache flink does not support bucket or hidden partition syntax, so we add a flink table property in iceberg table, so that we could bucket the table into specified buckets: 

```java
CREATE TABLE test_iceberg(
   id  INT,
   data STRING
) WITH (
   'flink.partitions'='id=bucket[16];data=bucket[8]'
)
```