### PR TITLE
Core: Support rewriting delete files.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/RewriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteFiles.java
@@ -52,7 +52,7 @@ public interface RewriteFiles extends SnapshotUpdate<RewriteFiles> {
   }
 
   /**
-   * Add a rewrite that replaces one set of files with another set that contains the same data (format v2).
+   * Add a rewrite that replaces one set of files with another set that contains the same data.
    *
    * @param dataFilesToDelete   data files that will be replaced (deleted).
    * @param deleteFilesToDelete delete files that will be replaced (deleted).

--- a/api/src/main/java/org/apache/iceberg/RewriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteFiles.java
@@ -36,7 +36,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
  */
 public interface RewriteFiles extends SnapshotUpdate<RewriteFiles> {
   /**
-   * Add a rewrite that replaces one set of files with another set that contains the same data.
+   * Add a rewrite that replaces one set of data files with another set that contains the same data.
    *
    * @param filesToDelete files that will be replaced (deleted), cannot be null or empty.
    * @param filesToAdd    files that will be added, cannot be null or empty.
@@ -52,7 +52,7 @@ public interface RewriteFiles extends SnapshotUpdate<RewriteFiles> {
   }
 
   /**
-   * Add a rewrite that replaces one set of files with another set that contains the same data.
+   * Add a rewrite that replaces one set of files with another set that contains the same data (format v2).
    *
    * @param dataFilesToDelete   data files that will be replaced (deleted).
    * @param deleteFilesToDelete delete files that will be replaced (deleted).

--- a/api/src/main/java/org/apache/iceberg/RewriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteFiles.java
@@ -19,14 +19,9 @@
 
 package org.apache.iceberg;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 
 /**
  * API for replacing files in a table.
@@ -49,81 +44,22 @@ public interface RewriteFiles extends SnapshotUpdate<RewriteFiles> {
    */
   default RewriteFiles rewriteFiles(Set<DataFile> filesToDelete, Set<DataFile> filesToAdd) {
     return rewriteFiles(
-        FileSet.ofDataFiles(filesToDelete),
-        FileSet.ofDataFiles(filesToAdd)
+        filesToDelete,
+        ImmutableSet.of(),
+        filesToAdd,
+        ImmutableSet.of()
     );
   }
 
   /**
    * Add a rewrite that replaces one set of files with another set that contains the same data.
    *
-   * @param filesToDelete files that will be replaced (deleted), cannot be null empty.
-   * @param filesToAdd    files that will be added, cannot be null or empty.
+   * @param dataFilesToDelete   data files that will be replaced (deleted).
+   * @param deleteFilesToDelete delete files that will be replaced (deleted).
+   * @param dataFilesToAdd      data files that will be added.
+   * @param deleteFilesToAdd    delete files that will be added.
    * @return this for method chaining.
    */
-  RewriteFiles rewriteFiles(FileSet filesToDelete, FileSet filesToAdd);
-
-  class FileSet {
-    private final Set<DataFile> dataFiles = Sets.newHashSet();
-    private final Set<DeleteFile> deleteFiles = Sets.newHashSet();
-
-    public static FileSet ofDataFiles(DataFile... dataFiles) {
-      return new FileSet(dataFiles, new DeleteFile[0]);
-    }
-
-    public static FileSet ofDataFiles(Iterable<DataFile> dataFiles) {
-      return new FileSet(dataFiles, ImmutableSet.of());
-    }
-
-    public static FileSet ofDeleteFiles(Iterable<DeleteFile> deleteFiles) {
-      return new FileSet(ImmutableSet.of(), deleteFiles);
-    }
-
-    public static FileSet ofDeleteFiles(DeleteFile... deleteFiles) {
-      return new FileSet(new DataFile[0], deleteFiles);
-    }
-
-    public static FileSet of(Iterable<DataFile> dataFiles, Iterable<DeleteFile> deleteFiles) {
-      return new FileSet(dataFiles, deleteFiles);
-    }
-
-    public static FileSet of(ContentFile<?>... files) {
-      List<DataFile> dataFiles = Lists.newArrayList();
-      List<DeleteFile> deleteFiles = Lists.newArrayList();
-
-      for (ContentFile<?> file : files) {
-        if (file instanceof DataFile) {
-          dataFiles.add((DataFile) file);
-        } else if (file instanceof DeleteFile) {
-          deleteFiles.add((DeleteFile) file);
-        } else {
-          throw new IllegalArgumentException("Unknown content file: " + file);
-        }
-      }
-
-      return new FileSet(dataFiles, deleteFiles);
-    }
-
-    private FileSet(DataFile[] dataFiles, DeleteFile[] deleteFiles) {
-      Collections.addAll(this.dataFiles, dataFiles);
-      Collections.addAll(this.deleteFiles, deleteFiles);
-    }
-
-    private FileSet(Iterable<DataFile> dataFiles, Iterable<DeleteFile> deleteFiles) {
-      Iterables.addAll(this.dataFiles, dataFiles);
-      Iterables.addAll(this.deleteFiles, deleteFiles);
-    }
-
-    public Set<DataFile> dataFiles() {
-      return dataFiles;
-    }
-
-    public Set<DeleteFile> deleteFiles() {
-      return deleteFiles;
-    }
-
-    public boolean isEmpty() {
-      return dataFiles.isEmpty() && deleteFiles.isEmpty();
-    }
-  }
+  RewriteFiles rewriteFiles(Set<DataFile> dataFilesToDelete, Set<DeleteFile> deleteFilesToDelete,
+                            Set<DataFile> dataFilesToAdd, Set<DeleteFile> deleteFilesToAdd);
 }

--- a/api/src/main/java/org/apache/iceberg/RewriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteFiles.java
@@ -19,8 +19,14 @@
 
 package org.apache.iceberg;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 
 /**
  * API for replacing files in a table.
@@ -38,8 +44,86 @@ public interface RewriteFiles extends SnapshotUpdate<RewriteFiles> {
    * Add a rewrite that replaces one set of files with another set that contains the same data.
    *
    * @param filesToDelete files that will be replaced (deleted), cannot be null or empty.
-   * @param filesToAdd files that will be added, cannot be null or empty.
+   * @param filesToAdd    files that will be added, cannot be null or empty.
    * @return this for method chaining
    */
-  RewriteFiles rewriteFiles(Set<DataFile> filesToDelete, Set<DataFile> filesToAdd);
+  default RewriteFiles rewriteFiles(Set<DataFile> filesToDelete, Set<DataFile> filesToAdd) {
+    return rewriteFiles(
+        FileSet.ofDataFiles(filesToDelete),
+        FileSet.ofDataFiles(filesToAdd)
+    );
+  }
+
+  /**
+   * Add a rewrite that replaces one set of files with another set that contains the same data.
+   *
+   * @param filesToDelete files that will be replaced (deleted), cannot be null empty.
+   * @param filesToAdd    files that will be added, cannot be null or empty.
+   * @return this for method chaining.
+   */
+  RewriteFiles rewriteFiles(FileSet filesToDelete, FileSet filesToAdd);
+
+  class FileSet {
+    private final Set<DataFile> dataFiles = Sets.newHashSet();
+    private final Set<DeleteFile> deleteFiles = Sets.newHashSet();
+
+    public static FileSet ofDataFiles(DataFile... dataFiles) {
+      return new FileSet(dataFiles, new DeleteFile[0]);
+    }
+
+    public static FileSet ofDataFiles(Iterable<DataFile> dataFiles) {
+      return new FileSet(dataFiles, ImmutableSet.of());
+    }
+
+    public static FileSet ofDeleteFiles(Iterable<DeleteFile> deleteFiles) {
+      return new FileSet(ImmutableSet.of(), deleteFiles);
+    }
+
+    public static FileSet ofDeleteFiles(DeleteFile... deleteFiles) {
+      return new FileSet(new DataFile[0], deleteFiles);
+    }
+
+    public static FileSet of(Iterable<DataFile> dataFiles, Iterable<DeleteFile> deleteFiles) {
+      return new FileSet(dataFiles, deleteFiles);
+    }
+
+    public static FileSet of(ContentFile<?>... files) {
+      List<DataFile> dataFiles = Lists.newArrayList();
+      List<DeleteFile> deleteFiles = Lists.newArrayList();
+
+      for (ContentFile<?> file : files) {
+        if (file instanceof DataFile) {
+          dataFiles.add((DataFile) file);
+        } else if (file instanceof DeleteFile) {
+          deleteFiles.add((DeleteFile) file);
+        } else {
+          throw new IllegalArgumentException("Unknown content file: " + file);
+        }
+      }
+
+      return new FileSet(dataFiles, deleteFiles);
+    }
+
+    private FileSet(DataFile[] dataFiles, DeleteFile[] deleteFiles) {
+      Collections.addAll(this.dataFiles, dataFiles);
+      Collections.addAll(this.deleteFiles, deleteFiles);
+    }
+
+    private FileSet(Iterable<DataFile> dataFiles, Iterable<DeleteFile> deleteFiles) {
+      Iterables.addAll(this.dataFiles, dataFiles);
+      Iterables.addAll(this.deleteFiles, deleteFiles);
+    }
+
+    public Set<DataFile> dataFiles() {
+      return dataFiles;
+    }
+
+    public Set<DeleteFile> deleteFiles() {
+      return deleteFiles;
+    }
+
+    public boolean isEmpty() {
+      return dataFiles.isEmpty() && deleteFiles.isEmpty();
+    }
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg;
 
-import java.util.Set;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements RewriteFiles {
@@ -41,18 +40,26 @@ class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements 
   }
 
   @Override
-  public RewriteFiles rewriteFiles(Set<DataFile> filesToDelete, Set<DataFile> filesToAdd) {
-    Preconditions.checkArgument(filesToDelete != null && !filesToDelete.isEmpty(),
+  public RewriteFiles rewriteFiles(FileSet filesToRemove, FileSet filesToAdd) {
+    Preconditions.checkArgument(filesToRemove != null && !filesToRemove.isEmpty(),
         "Files to delete cannot be null or empty");
     Preconditions.checkArgument(filesToAdd != null && !filesToAdd.isEmpty(),
         "Files to add can not be null or empty");
 
-    for (DataFile toDelete : filesToDelete) {
-      delete(toDelete);
+    for (DataFile dataFileToRemove : filesToRemove.dataFiles()) {
+      delete(dataFileToRemove);
     }
 
-    for (DataFile toAdd : filesToAdd) {
-      add(toAdd);
+    for (DeleteFile deleteFileToRemove : filesToRemove.deleteFiles()) {
+      delete(deleteFileToRemove);
+    }
+
+    for (DataFile dataFileToAdd : filesToAdd.dataFiles()) {
+      add(dataFileToAdd);
+    }
+
+    for (DeleteFile deleteFileToAdd : filesToAdd.deleteFiles()) {
+      add(deleteFileToAdd);
     }
 
     return this;

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
@@ -56,9 +56,9 @@ class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements 
     if (deleteFilesToDelete == null || deleteFilesToDelete.isEmpty()) {
       // When there is no delete files in the rewrite action, data files to add cannot be null or empty.
       Preconditions.checkArgument(dataFilesToAdd != null && dataFilesToAdd.size() > 0,
-          "Data files to add can not be null or empty because there's no delete file to rewrite");
+          "Data files to add can not be null or empty because there's no delete file to be rewritten");
       Preconditions.checkArgument(deleteFilesToAdd == null || deleteFilesToAdd.isEmpty(),
-          "Delete files to add must be null or empty because there's no delete file to rewrite");
+          "Delete files to add must be null or empty because there's no delete file to be rewritten");
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
@@ -42,23 +42,23 @@ class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements 
 
   private void verifyInputAndOutputFiles(Set<DataFile> dataFilesToDelete, Set<DeleteFile> deleteFilesToDelete,
                                          Set<DataFile> dataFilesToAdd, Set<DeleteFile> deleteFilesToAdd) {
-    int filesToDelete = 0;
-    if (dataFilesToDelete != null) {
-      filesToDelete += dataFilesToDelete.size();
-    }
+    Preconditions.checkNotNull(dataFilesToDelete, "Data files to delete can not be null");
+    Preconditions.checkNotNull(deleteFilesToDelete, "Delete files to delete can not be null");
+    Preconditions.checkNotNull(dataFilesToAdd, "Data files to add can not be null");
+    Preconditions.checkNotNull(deleteFilesToAdd, "Delete files to add can not be null");
 
-    if (deleteFilesToDelete != null) {
-      filesToDelete += deleteFilesToDelete.size();
-    }
+    int filesToDelete = 0;
+    filesToDelete += dataFilesToDelete.size();
+    filesToDelete += deleteFilesToDelete.size();
 
     Preconditions.checkArgument(filesToDelete > 0, "Files to delete cannot be null or empty");
 
-    if (deleteFilesToDelete == null || deleteFilesToDelete.isEmpty()) {
+    if (deleteFilesToDelete.isEmpty()) {
       // When there is no delete files in the rewrite action, data files to add cannot be null or empty.
-      Preconditions.checkArgument(dataFilesToAdd != null && dataFilesToAdd.size() > 0,
-          "Data files to add can not be null or empty because there's no delete file to be rewritten");
-      Preconditions.checkArgument(deleteFilesToAdd == null || deleteFilesToAdd.isEmpty(),
-          "Delete files to add must be null or empty because there's no delete file to be rewritten");
+      Preconditions.checkArgument(dataFilesToAdd.size() > 0,
+          "Data files to add can not be empty because there's no delete file to be rewritten");
+      Preconditions.checkArgument(deleteFilesToAdd.isEmpty(),
+          "Delete files to add must be empty because there's no delete file to be rewritten");
     }
   }
 
@@ -67,28 +67,20 @@ class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements 
                                    Set<DataFile> dataFilesToAdd, Set<DeleteFile> deleteFilesToAdd) {
     verifyInputAndOutputFiles(dataFilesToDelete, deleteFilesToDelete, dataFilesToAdd, deleteFilesToAdd);
 
-    if (dataFilesToDelete != null) {
-      for (DataFile dataFile : dataFilesToDelete) {
-        delete(dataFile);
-      }
+    for (DataFile dataFile : dataFilesToDelete) {
+      delete(dataFile);
     }
 
-    if (deleteFilesToDelete != null) {
-      for (DeleteFile deleteFile : deleteFilesToDelete) {
-        delete(deleteFile);
-      }
+    for (DeleteFile deleteFile : deleteFilesToDelete) {
+      delete(deleteFile);
     }
 
-    if (dataFilesToAdd != null) {
-      for (DataFile dataFile : dataFilesToAdd) {
-        add(dataFile);
-      }
+    for (DataFile dataFile : dataFilesToAdd) {
+      add(dataFile);
     }
 
-    if (deleteFilesToAdd != null) {
-      for (DeleteFile deleteFile : deleteFilesToAdd) {
-        add(deleteFile);
-      }
+    for (DeleteFile deleteFile : deleteFilesToAdd) {
+      add(deleteFile);
     }
 
     return this;

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
@@ -40,8 +40,8 @@ class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements 
     return DataOperations.REPLACE;
   }
 
-  private void checkFilesToDelete(Set<DataFile> dataFilesToDelete,
-                                  Set<DeleteFile> deleteFilesToDelete) {
+  private void verifyInputAndOutputFiles(Set<DataFile> dataFilesToDelete, Set<DeleteFile> deleteFilesToDelete,
+                                         Set<DataFile> dataFilesToAdd, Set<DeleteFile> deleteFilesToAdd) {
     int filesToDelete = 0;
     if (dataFilesToDelete != null) {
       filesToDelete += dataFilesToDelete.size();
@@ -52,27 +52,20 @@ class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements 
     }
 
     Preconditions.checkArgument(filesToDelete > 0, "Files to delete cannot be null or empty");
-  }
 
-  private void checkFilesToAdd(Set<DataFile> dataFilesToAdd,
-                               Set<DeleteFile> deleteFilesToAdd) {
-    int filesToAdd = 0;
-    if (dataFilesToAdd != null) {
-      filesToAdd += dataFilesToAdd.size();
+    if (deleteFilesToDelete == null || deleteFilesToDelete.isEmpty()) {
+      // When there is no delete files in the rewrite action, data files to add cannot be null or empty.
+      Preconditions.checkArgument(dataFilesToAdd != null && dataFilesToAdd.size() > 0,
+          "Data files to add can not be null or empty because there's no delete file to rewrite");
+      Preconditions.checkArgument(deleteFilesToAdd == null || deleteFilesToAdd.isEmpty(),
+          "Delete files to add must be null or empty because there's no delete file to rewrite");
     }
-
-    if (deleteFilesToAdd != null) {
-      filesToAdd += deleteFilesToAdd.size();
-    }
-
-    Preconditions.checkArgument(filesToAdd > 0, "Files to add can not be null or empty");
   }
 
   @Override
   public RewriteFiles rewriteFiles(Set<DataFile> dataFilesToDelete, Set<DeleteFile> deleteFilesToDelete,
                                    Set<DataFile> dataFilesToAdd, Set<DeleteFile> deleteFilesToAdd) {
-    checkFilesToDelete(dataFilesToDelete, deleteFilesToDelete);
-    checkFilesToAdd(dataFilesToAdd, deleteFilesToAdd);
+    verifyInputAndOutputFiles(dataFilesToDelete, deleteFilesToDelete, dataFilesToAdd, deleteFilesToAdd);
 
     if (dataFilesToDelete != null) {
       for (DataFile dataFile : dataFilesToDelete) {

--- a/core/src/test/java/org/apache/iceberg/TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TableTestBase.java
@@ -73,6 +73,14 @@ public class TableTestBase {
       .withPartitionPath("data_bucket=0") // easy way to set partition data for now
       .withRecordCount(1)
       .build();
+  // Equality delete files.
+  static final DeleteFile FILE_A2_DELETES = FileMetadata.deleteFileBuilder(SPEC)
+      .ofEqualityDeletes(3)
+      .withPath("/path/to/data-a2-deletes.parquet")
+      .withFileSizeInBytes(10)
+      .withPartitionPath("data_bucket=0")
+      .withRecordCount(1)
+      .build();
   static final DataFile FILE_B = DataFiles.builder(SPEC)
       .withPath("/path/to/data-b.parquet")
       .withFileSizeInBytes(10)

--- a/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
@@ -244,7 +244,7 @@ public class TestRewriteFiles extends TableTestBase {
 
     Assert.assertEquals("Should contain 3 manifest", 3, pending.allManifests().size());
     Assert.assertFalse("Should not contain manifest from initial write",
-        pending.allManifests().containsAll(initialManifests));
+        pending.allManifests().stream().anyMatch(initialManifests::contains));
 
     long pendingId = pending.snapshotId();
     validateManifestEntries(pending.allManifests().get(0),
@@ -432,8 +432,8 @@ public class TestRewriteFiles extends TableTestBase {
 
     TableMetadata metadata = readMetadata();
     List<ManifestFile> committedManifests = Lists.newArrayList(manifest1, manifest2, manifest3);
-    Assert.assertTrue("Should committed the manifests",
-        metadata.currentSnapshot().allManifests().containsAll(committedManifests));
+    Assert.assertEquals("Should committed the manifests",
+        metadata.currentSnapshot().allManifests(), committedManifests);
 
     // As commit success all the manifests added with rewrite should be available.
     Assert.assertEquals("Only 5 manifest should exist", 5, listManifestFiles().size());
@@ -488,8 +488,8 @@ public class TestRewriteFiles extends TableTestBase {
 
     metadata = readMetadata();
     List<ManifestFile> committedManifests = Lists.newArrayList(manifest1, manifest2, manifest3);
-    Assert.assertTrue("Should committed the manifests",
-        metadata.currentSnapshot().allManifests().containsAll(committedManifests));
+    Assert.assertEquals("Should committed the manifests",
+        metadata.currentSnapshot().allManifests(), committedManifests);
 
     // As commit success all the manifests added with rewrite should be available.
     Assert.assertEquals("4 manifests should exist", 4, listManifestFiles().size());

--- a/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
@@ -77,14 +77,14 @@ public class TestRewriteFiles extends TableTestBase {
 
     AssertHelpers.assertThrows("Expected an exception",
         IllegalArgumentException.class,
-        "Data files to add can not be null or empty because there's no delete file to be rewritten",
+        "Data files to add can not be empty because there's no delete file to be rewritten",
         () -> table.newRewrite()
             .rewriteFiles(Sets.newSet(FILE_A), Collections.emptySet())
             .apply());
 
     AssertHelpers.assertThrows("Expected an exception",
         IllegalArgumentException.class,
-        "Data files to add can not be null or empty because there's no delete file to be rewritten",
+        "Data files to add can not be empty because there's no delete file to be rewritten",
         () -> table.newRewrite()
             .rewriteFiles(ImmutableSet.of(FILE_A), ImmutableSet.of(),
                 ImmutableSet.of(), ImmutableSet.of(FILE_A_DELETES))
@@ -92,7 +92,7 @@ public class TestRewriteFiles extends TableTestBase {
 
     AssertHelpers.assertThrows("Expected an exception",
         IllegalArgumentException.class,
-        "Delete files to add must be null or empty because there's no delete file to be rewritten",
+        "Delete files to add must be empty because there's no delete file to be rewritten",
         () -> table.newRewrite()
             .rewriteFiles(ImmutableSet.of(FILE_A), ImmutableSet.of(),
                 ImmutableSet.of(FILE_B), ImmutableSet.of(FILE_B_DELETES))

--- a/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -65,7 +66,8 @@ public class TestRewriteFiles extends TableTestBase {
         ValidationException.class,
         "Missing required files to delete: /path/to/data-a-deletes.parquet",
         () -> table.newRewrite()
-            .rewriteFiles(RewriteFiles.FileSet.of(FILE_A_DELETES), RewriteFiles.FileSet.of(FILE_A, FILE_B_DELETES))
+            .rewriteFiles(ImmutableSet.of(), ImmutableSet.of(FILE_A_DELETES),
+                ImmutableSet.of(FILE_A), ImmutableSet.of(FILE_B_DELETES))
             .commit());
   }
 
@@ -84,14 +86,15 @@ public class TestRewriteFiles extends TableTestBase {
         IllegalArgumentException.class,
         "Files to add can not be null or empty",
         () -> table.newRewrite()
-            .rewriteFiles(RewriteFiles.FileSet.of(FILE_A_DELETES), RewriteFiles.FileSet.of())
+            .rewriteFiles(ImmutableSet.of(), ImmutableSet.of(FILE_A_DELETES), ImmutableSet.of(), ImmutableSet.of())
             .apply());
 
     AssertHelpers.assertThrows("Expected an exception",
         IllegalArgumentException.class,
         "Files to add can not be null or empty",
         () -> table.newRewrite()
-            .rewriteFiles(RewriteFiles.FileSet.of(FILE_A, FILE_A_DELETES), RewriteFiles.FileSet.of())
+            .rewriteFiles(ImmutableSet.of(FILE_A), ImmutableSet.of(FILE_A_DELETES),
+                ImmutableSet.of(), ImmutableSet.of())
             .apply());
   }
 
@@ -110,14 +113,15 @@ public class TestRewriteFiles extends TableTestBase {
         IllegalArgumentException.class,
         "Files to delete cannot be null or empty",
         () -> table.newRewrite()
-            .rewriteFiles(RewriteFiles.FileSet.of(), RewriteFiles.FileSet.of(FILE_A_DELETES))
+            .rewriteFiles(ImmutableSet.of(), ImmutableSet.of(), ImmutableSet.of(), ImmutableSet.of(FILE_A_DELETES))
             .apply());
 
     AssertHelpers.assertThrows("Expected an exception",
         IllegalArgumentException.class,
         "Files to delete cannot be null or empty",
         () -> table.newRewrite()
-            .rewriteFiles(RewriteFiles.FileSet.of(), RewriteFiles.FileSet.of(FILE_A, FILE_A_DELETES))
+            .rewriteFiles(ImmutableSet.of(), ImmutableSet.of(),
+                ImmutableSet.of(FILE_A), ImmutableSet.of(FILE_A_DELETES))
             .apply());
   }
 
@@ -233,7 +237,8 @@ public class TestRewriteFiles extends TableTestBase {
 
     // Rewrite the files.
     Snapshot pending = table.newRewrite()
-        .rewriteFiles(RewriteFiles.FileSet.of(FILE_A, FILE_A_DELETES), RewriteFiles.FileSet.of(FILE_D))
+        .rewriteFiles(ImmutableSet.of(FILE_A), ImmutableSet.of(FILE_A_DELETES),
+            ImmutableSet.of(FILE_D), ImmutableSet.of())
         .apply();
 
     Assert.assertEquals("Should contain 3 manifest", 3, pending.allManifests().size());
@@ -308,7 +313,8 @@ public class TestRewriteFiles extends TableTestBase {
     table.ops().failCommits(5);
 
     RewriteFiles rewrite = table.newRewrite()
-        .rewriteFiles(RewriteFiles.FileSet.of(FILE_A, FILE_A_DELETES, FILE_B_DELETES), RewriteFiles.FileSet.of(FILE_D));
+        .rewriteFiles(ImmutableSet.of(FILE_A), ImmutableSet.of(FILE_A_DELETES, FILE_B_DELETES),
+            ImmutableSet.of(FILE_D), ImmutableSet.of());
     Snapshot pending = rewrite.apply();
 
     Assert.assertEquals("Should produce 3 manifests", 3, pending.allManifests().size());
@@ -392,7 +398,8 @@ public class TestRewriteFiles extends TableTestBase {
     table.ops().failCommits(3);
 
     RewriteFiles rewrite = table.newRewrite()
-        .rewriteFiles(RewriteFiles.FileSet.of(FILE_A, FILE_A_DELETES, FILE_B_DELETES), RewriteFiles.FileSet.of(FILE_D));
+        .rewriteFiles(ImmutableSet.of(FILE_A), ImmutableSet.of(FILE_A_DELETES, FILE_B_DELETES),
+            ImmutableSet.of(FILE_D), ImmutableSet.of());
     Snapshot pending = rewrite.apply();
 
     Assert.assertEquals("Should produce 3 manifests", 3, pending.allManifests().size());

--- a/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
@@ -77,14 +77,14 @@ public class TestRewriteFiles extends TableTestBase {
 
     AssertHelpers.assertThrows("Expected an exception",
         IllegalArgumentException.class,
-        "Data files to add can not be null or empty because there's no delete file to rewrite",
+        "Data files to add can not be null or empty because there's no delete file to be rewritten",
         () -> table.newRewrite()
             .rewriteFiles(Sets.newSet(FILE_A), Collections.emptySet())
             .apply());
 
     AssertHelpers.assertThrows("Expected an exception",
         IllegalArgumentException.class,
-        "Data files to add can not be null or empty because there's no delete file to rewrite",
+        "Data files to add can not be null or empty because there's no delete file to be rewritten",
         () -> table.newRewrite()
             .rewriteFiles(ImmutableSet.of(FILE_A), ImmutableSet.of(),
                 ImmutableSet.of(), ImmutableSet.of(FILE_A_DELETES))
@@ -92,7 +92,7 @@ public class TestRewriteFiles extends TableTestBase {
 
     AssertHelpers.assertThrows("Expected an exception",
         IllegalArgumentException.class,
-        "Delete files to add must be null or empty because there's no delete file to rewrite",
+        "Delete files to add must be null or empty because there's no delete file to be rewritten",
         () -> table.newRewrite()
             .rewriteFiles(ImmutableSet.of(FILE_A), ImmutableSet.of(),
                 ImmutableSet.of(FILE_B), ImmutableSet.of(FILE_B_DELETES))


### PR DESCRIPTION
In iceberg format v2,  we've introduced the row-level delete feature,  which would introduce many delete files ( include positional delete files and insert data files).   Currently the **batch** RewriteAction only works for iceberg format v2, say compacting data files only.  Before expose the format v2 to end users, we need to check whether the common features are OK,   we should provide the ability to rewrite both data files and delete files. 

In this PR,  I'm trying to extend the **RewriteFiles** API to work for both data files and delete files, so that we could implement the format v2's  RewriteFiles Action.