### PR TITLE
Core: move targetSplitSize() to TableScan interface

### DIFF
--- a/api/src/main/java/org/apache/iceberg/TableScan.java
+++ b/api/src/main/java/org/apache/iceberg/TableScan.java
@@ -209,4 +209,8 @@ public interface TableScan {
    */
   boolean isCaseSensitive();
 
+  /**
+   * Returns the target split size for this scan.
+   */
+  long targetSplitSize();
 }

--- a/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
@@ -120,8 +120,8 @@ public class AllDataFilesTable extends BaseMetadataTable {
     }
 
     @Override
-    protected long targetSplitSize(TableOperations ops) {
-      return ops.current().propertyAsLong(
+    public long targetSplitSize() {
+      return tableOps().current().propertyAsLong(
           TableProperties.METADATA_SPLIT_SIZE, TableProperties.METADATA_SPLIT_SIZE_DEFAULT);
     }
 

--- a/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
@@ -107,8 +107,8 @@ public class AllEntriesTable extends BaseMetadataTable {
     }
 
     @Override
-    protected long targetSplitSize(TableOperations ops) {
-      return ops.current().propertyAsLong(
+    public long targetSplitSize() {
+      return tableOps().current().propertyAsLong(
           TableProperties.METADATA_SPLIT_SIZE, TableProperties.METADATA_SPLIT_SIZE_DEFAULT);
     }
 

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -128,8 +128,8 @@ public class AllManifestsTable extends BaseMetadataTable {
     }
 
     @Override
-    protected long targetSplitSize(TableOperations ops) {
-      return ops.current().propertyAsLong(
+    public long targetSplitSize() {
+      return tableOps().current().propertyAsLong(
           TableProperties.METADATA_SPLIT_SIZE, TableProperties.METADATA_SPLIT_SIZE_DEFAULT);
     }
 

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -94,9 +94,6 @@ abstract class BaseTableScan implements TableScan {
   }
 
   @SuppressWarnings("checkstyle:HiddenField")
-  protected abstract long targetSplitSize(TableOperations ops);
-
-  @SuppressWarnings("checkstyle:HiddenField")
   protected abstract TableScan newRefinedScan(
       TableOperations ops, Table table, Schema schema, TableScanContext context);
 
@@ -224,7 +221,7 @@ abstract class BaseTableScan implements TableScan {
     if (options.containsKey(TableProperties.SPLIT_SIZE)) {
       splitSize = Long.parseLong(options.get(TableProperties.SPLIT_SIZE));
     } else {
-      splitSize = targetSplitSize(ops);
+      splitSize = targetSplitSize();
     }
     int lookback;
     if (options.containsKey(TableProperties.SPLIT_LOOKBACK)) {

--- a/core/src/main/java/org/apache/iceberg/DataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DataFilesTable.java
@@ -102,8 +102,8 @@ public class DataFilesTable extends BaseMetadataTable {
     }
 
     @Override
-    protected long targetSplitSize(TableOperations ops) {
-      return ops.current().propertyAsLong(
+    public long targetSplitSize() {
+      return tableOps().current().propertyAsLong(
           TableProperties.METADATA_SPLIT_SIZE, TableProperties.METADATA_SPLIT_SIZE_DEFAULT);
     }
 

--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -90,8 +90,8 @@ public class DataTableScan extends BaseTableScan {
   }
 
   @Override
-  protected long targetSplitSize(TableOperations ops) {
-    return ops.current().propertyAsLong(
+  public long targetSplitSize() {
+    return tableOps().current().propertyAsLong(
         TableProperties.SPLIT_SIZE, TableProperties.SPLIT_SIZE_DEFAULT);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
@@ -104,8 +104,8 @@ public class ManifestEntriesTable extends BaseMetadataTable {
     }
 
     @Override
-    protected long targetSplitSize(TableOperations ops) {
-      return ops.current().propertyAsLong(
+    public long targetSplitSize() {
+      return tableOps().current().propertyAsLong(
           TableProperties.METADATA_SPLIT_SIZE, TableProperties.METADATA_SPLIT_SIZE_DEFAULT);
     }
 

--- a/core/src/main/java/org/apache/iceberg/StaticTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/StaticTableScan.java
@@ -38,8 +38,8 @@ class StaticTableScan extends BaseTableScan {
   }
 
   @Override
-  protected long targetSplitSize(TableOperations ops) {
-    return ops.current().propertyAsLong(
+  public long targetSplitSize() {
+    return tableOps().current().propertyAsLong(
         TableProperties.METADATA_SPLIT_SIZE, TableProperties.METADATA_SPLIT_SIZE_DEFAULT);
   }
 


### PR DESCRIPTION
Currently `targetSplitSize` is a private method in `BaseTableScan`. However, currently both `SparkBatchQueryScan` (from #2276) and `SparkMergeScan` need to know the scan-specific split size when planning tasks. Therefore, this PR moves it to `TableScan` and makes it public. In addition, this removes the parameter `TableOperations` from the method and replaces it with `tableOps()`.