### PR TITLE
SupportsBranches interface and initial impl w/ Nessie

### DIFF
--- a/api/src/main/java/org/apache/iceberg/catalog/Reference.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Reference.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.catalog;
+
+/**
+ * Reference used for SupportsNamespace.
+ *
+ * <p>A reference can be one of three things:
+ * <ul>
+ *   <li>Branch - a pointer to a commit hash that can be modified</li>
+ *   <li>Tag - a pointer to a commit hash that can't be modified</li>
+ *   <li>Hash - a specific commit hash</li>
+ * </ul>
+ *
+ * <p>A reference is either a Hash or a pointer to a hash. A hash is a specific point in the history of a branching
+ * catalog's history. A reference has two components: a name and a hash. The name is the human readable name that points
+ * to a specific hash.
+ *
+ * <p>A Tag cannot be updated or modified. It can be reassigned to another hash only. A hash can't be changed at all. It
+ * is an immutable identifier to a specific point in the branching catalog's history. A branch can be modified, any
+ * catalog which plans to write or modify iceberg tables should set its reference to a branch.
+ */
+public interface Reference {
+
+  /**
+   * the name of this reference.
+   */
+  String name();
+
+  /**
+   * the hash this reference points to.
+   */
+  String hash();
+
+  class Branch implements Reference {
+    private final String name;
+    private final String hash;
+
+    private Branch(String name, String hash) {
+      this.name = name;
+      this.hash = hash;
+    }
+
+    @Override
+    public String name() {
+      return name;
+    }
+
+    @Override
+    public String hash() {
+      return hash;
+    }
+
+    public static Reference of(String name, String base) {
+      return new Branch(name, base);
+    }
+  }
+
+  class Tag implements Reference {
+    private final String name;
+    private final String hash;
+
+    private Tag(String name, String hash) {
+      this.name = name;
+      this.hash = hash;
+    }
+
+    public static Reference of(String name, String base) {
+      return new Tag(name, base);
+    }
+
+    @Override
+    public String name() {
+      return name;
+    }
+
+    @Override
+    public String hash() {
+      return hash;
+    }
+  }
+
+  class Hash implements Reference {
+    private final String hash;
+
+    private Hash(String hash) {
+      this.hash = hash;
+    }
+
+    public static Reference of(String hash) {
+      return new Hash(hash);
+    }
+
+    @Override
+    public String name() {
+      return hash;
+    }
+
+    @Override
+    public String hash() {
+      return hash;
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/catalog/SupportsBranches.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/SupportsBranches.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.catalog;
+
+/**
+ * Catalog methods for working with branches and tags.
+ */
+public interface SupportsBranches {
+
+  /**
+   * Create a {@link Reference.Branch} named 'name' at the default base reference.
+   * @param name name of branch to create.
+   */
+  default void createBranch(String name) {
+    createBranch(name, null);
+  }
+
+  /**
+   * Create a {@link Reference.Branch} named 'name' at the given base reference.
+   * @param name name of branch to create.
+   */
+  default void createBranch(String name, String base) {
+    createReference(Reference.Branch.of(name, base));
+  }
+
+  /**
+   * Create a {@link Reference.Tag} named 'name' at the default base reference.
+   * @param name name of tag to create.
+   */
+  default void createTag(String name) {
+    createTag(name, null);
+  }
+
+  /**
+   * Create a {@link Reference.Tag} named 'name' at the given base reference.
+   * @param name name of tag to create.
+   */
+  default void createTag(String name, String base) {
+    createReference(Reference.Tag.of(name, base));
+  }
+
+  /**
+   * Create a reference as defined in ref.
+   * @param ref name of tag to create
+   * @throws org.apache.iceberg.exceptions.AlreadyExistsException if the reference already exists.
+   * @throws IllegalArgumentException if the hash to create at does not exist.
+   */
+  void createReference(Reference ref);
+
+  /**
+   * List all branches and tags known to this catalog.
+   */
+  Iterable<Reference> listReferences();
+
+  /**
+   * Delete a reference without a safety check. This force deletes the reference.
+   * @param name name of reference to delete.
+   * @throws IllegalArgumentException if the reference does not exist or if the reference name is a Hash.
+   */
+  void deleteReference(String name);
+
+  /**
+   * Delete a reference with a safety check. The hash of ref must be the current hash of ref on the server or the
+   * operation fails.
+   *
+   * @throws IllegalArgumentException if the reference does not exist or if the reference name is a Hash.
+   * @throws IllegalStateException if the reference hash is not up to date.
+   */
+  void deleteReference(Reference ref);
+
+  /**
+   * Sets the current reference of this Catalog.
+   *
+   * <p>All further operations will take place on this Reference unless specified.
+   *
+   * @param name name of reference to set.
+   * @throws IllegalArgumentException if the reference does not exist.
+   */
+  void setCurrentReference(String name);
+
+  /**
+   * Show the current reference of this Catalog.
+   */
+  Reference currentReference();
+
+  /**
+   * Get an arbitrary reference by name. This could be a Hash, Branch or tag.
+   *
+   * @param name name of reference to set.
+   * @throws IllegalArgumentException if the reference does not exist.
+   */
+  Reference referenceByName(String name);
+}

--- a/nessie/src/main/java/org/apache/iceberg/nessie/UpdateableReference.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/UpdateableReference.java
@@ -72,4 +72,8 @@ class UpdateableReference {
   public String getName() {
     return reference.getName();
   }
+
+  Reference getReference() {
+    return reference;
+  }
 }

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestBranchVisibility.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestBranchVisibility.java
@@ -82,10 +82,10 @@ public class TestBranchVisibility extends BaseTestIceberg {
   }
 
   @Test
-  public void testCatalogOnReference() throws NessieNotFoundException {
+  public void testCatalogOnReference() {
     updateSchema(catalog, tableIdentifier1);
     updateSchema(testCatalog, tableIdentifier2);
-    String mainHash = tree.getReferenceByName("main").getHash();
+    String mainHash = catalog.referenceByName("main").hash();
 
     // catalog created with ref points to same catalog as above
     NessieCatalog refCatalog = initCatalog("test");
@@ -97,9 +97,9 @@ public class TestBranchVisibility extends BaseTestIceberg {
   }
 
   @Test
-  public void testCatalogWithTableNames() throws NessieNotFoundException {
+  public void testCatalogWithTableNames() {
     updateSchema(testCatalog, tableIdentifier2);
-    String mainHash = tree.getReferenceByName("main").getHash();
+    String mainHash = catalog.referenceByName("main").hash();
 
     // asking for table@branch gives expected regardless of catalog
     Assert.assertEquals(metadataLocation(catalog, TableIdentifier.of("test-ns", "table1@test")),
@@ -111,7 +111,7 @@ public class TestBranchVisibility extends BaseTestIceberg {
   }
 
   @Test
-  public void testConcurrentChanges() throws NessieNotFoundException {
+  public void testConcurrentChanges() {
     NessieCatalog emptyTestCatalog = initCatalog("test");
     updateSchema(testCatalog, tableIdentifier1);
     // Updating table with out of date hash. We expect this to succeed because of retry despite the conflict.

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
@@ -22,7 +22,6 @@ package org.apache.iceberg.nessie;
 
 import com.dremio.nessie.error.NessieConflictException;
 import com.dremio.nessie.error.NessieNotFoundException;
-import com.dremio.nessie.model.Branch;
 import com.dremio.nessie.model.ContentsKey;
 import com.dremio.nessie.model.IcebergTable;
 import java.io.File;
@@ -46,6 +45,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.catalog.Reference;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.io.FileAppender;
@@ -250,11 +250,11 @@ public class TestNessieTable extends BaseTestIceberg {
   @Test
   public void testFailure() throws NessieNotFoundException, NessieConflictException {
     Table icebergTable = catalog.loadTable(TABLE_IDENTIFIER);
-    Branch branch = (Branch) client.getTreeApi().getReferenceByName(BRANCH);
+    Reference ref = catalog.referenceByName(BRANCH);
 
     IcebergTable table = client.getContentsApi().getContents(KEY, BRANCH).unwrap(IcebergTable.class).get();
 
-    client.getContentsApi().setContents(KEY, branch.getName(), branch.getHash(), "",
+    client.getContentsApi().setContents(KEY, ref.name(), ref.hash(), "",
         IcebergTable.of("dummytable.metadata.json"));
 
     AssertHelpers.assertThrows("Update schema fails with conflict exception, ref not up to date",


### PR DESCRIPTION
As per #1808 this introduces a `SupportsBranches` interface which allows catalogs to support CRUD operations on branches.