### PR TITLE
Bump Nessie to version 0.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1103,7 +1103,7 @@ project(':iceberg-nessie') {
     props = ["quarkus.http.test-port": 0]
   }
   tasks.getByName("quarkus-start")
-          // This is not doing anything with Docker or building a native image, just a quirk of in Quarkus since 1.10.
+          // This is not doing anything with Docker or building a native image, just a quirk of Quarkus since 1.10.
           .doFirst { System.setProperty("quarkus.native.builder-image", "quay.io/quarkus/ubi-quarkus-native-image:21.0.0-java11") }
           .dependsOn("compileTestJava")
   tasks.test.dependsOn("quarkus-start").finalizedBy("quarkus-stop")

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ buildscript {
 
 plugins {
   id 'nebula.dependency-recommender' version '9.0.2'
-  id 'org.projectnessie' version '0.3.0'
+  id 'org.projectnessie' version '0.4.0'
 }
 
 try {
@@ -1093,7 +1093,7 @@ project(':iceberg-nessie') {
     compile project(':iceberg-core')
     compile project(path: ':iceberg-bundled-guava', configuration: 'shadow')
     compile "org.projectnessie:nessie-client"
-    quarkusAppRunnerConfig "org.projectnessie:nessie-quarkus:0.2.1"
+    quarkusAppRunnerConfig "org.projectnessie:nessie-quarkus:0.4.0"
 
     compileOnly "org.apache.hadoop:hadoop-common"
 
@@ -1102,7 +1102,10 @@ project(':iceberg-nessie') {
   quarkusAppRunnerProperties {
     props = ["quarkus.http.test-port": 0]
   }
-  tasks.getByName("quarkus-start").dependsOn("compileTestJava")
+  tasks.getByName("quarkus-start")
+          // This is not doing anything with Docker or building a native image, just a quirk of in Quarkus since 1.10.
+          .doFirst { System.setProperty("quarkus.native.builder-image", "quay.io/quarkus/ubi-quarkus-native-image:21.0.0-java11") }
+          .dependsOn("compileTestJava")
   tasks.test.dependsOn("quarkus-start").finalizedBy("quarkus-stop")
 
 }

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
@@ -19,19 +19,6 @@
 
 package org.apache.iceberg.nessie;
 
-import com.dremio.nessie.api.TreeApi;
-import com.dremio.nessie.client.NessieClient;
-import com.dremio.nessie.client.NessieConfigConstants;
-import com.dremio.nessie.error.BaseNessieClientServerException;
-import com.dremio.nessie.error.NessieConflictException;
-import com.dremio.nessie.error.NessieNotFoundException;
-import com.dremio.nessie.model.Contents;
-import com.dremio.nessie.model.IcebergTable;
-import com.dremio.nessie.model.ImmutableDelete;
-import com.dremio.nessie.model.ImmutableOperations;
-import com.dremio.nessie.model.ImmutablePut;
-import com.dremio.nessie.model.Operations;
-import com.dremio.nessie.model.Reference;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -57,6 +44,19 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.util.Tasks;
+import org.projectnessie.api.TreeApi;
+import org.projectnessie.client.NessieClient;
+import org.projectnessie.client.NessieConfigConstants;
+import org.projectnessie.error.BaseNessieClientServerException;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Contents;
+import org.projectnessie.model.IcebergTable;
+import org.projectnessie.model.ImmutableDelete;
+import org.projectnessie.model.ImmutableOperations;
+import org.projectnessie.model.ImmutablePut;
+import org.projectnessie.model.Operations;
+import org.projectnessie.model.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,7 +90,7 @@ public class NessieCatalog extends BaseMetastoreCatalog implements AutoCloseable
     // remove nessie prefix
     final Function<String, String> removePrefix = x -> x.replace("nessie.", "");
 
-    this.client = NessieClient.withConfig(x -> options.get(removePrefix.apply(x)));
+    this.client = NessieClient.builder().fromConfig(x -> options.get(removePrefix.apply(x))).build();
 
     this.warehouseLocation = options.get(CatalogProperties.WAREHOUSE_LOCATION);
     if (warehouseLocation == null) {

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
@@ -19,13 +19,6 @@
 
 package org.apache.iceberg.nessie;
 
-import com.dremio.nessie.client.NessieClient;
-import com.dremio.nessie.error.NessieConflictException;
-import com.dremio.nessie.error.NessieNotFoundException;
-import com.dremio.nessie.model.Contents;
-import com.dremio.nessie.model.ContentsKey;
-import com.dremio.nessie.model.IcebergTable;
-import com.dremio.nessie.model.ImmutableIcebergTable;
 import java.util.Map;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.Snapshot;
@@ -33,6 +26,13 @@ import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.io.FileIO;
+import org.projectnessie.client.NessieClient;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Contents;
+import org.projectnessie.model.ContentsKey;
+import org.projectnessie.model.IcebergTable;
+import org.projectnessie.model.ImmutableIcebergTable;
 
 /**
  * Nessie implementation of Iceberg TableOperations.

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
@@ -19,14 +19,14 @@
 
 package org.apache.iceberg.nessie;
 
-import com.dremio.nessie.model.ContentsKey;
-import com.dremio.nessie.model.EntriesResponse;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.projectnessie.model.ContentsKey;
+import org.projectnessie.model.EntriesResponse;
 
 public final class NessieUtil {
 
@@ -78,7 +78,7 @@ public final class NessieUtil {
     }
     identifiers.add(tableIdentifier.name());
 
-    ContentsKey key = new ContentsKey(identifiers);
+    ContentsKey key = ContentsKey.of(identifiers);
     return key;
   }
 

--- a/nessie/src/main/java/org/apache/iceberg/nessie/UpdateableReference.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/UpdateableReference.java
@@ -19,11 +19,11 @@
 
 package org.apache.iceberg.nessie;
 
-import com.dremio.nessie.api.TreeApi;
-import com.dremio.nessie.error.NessieNotFoundException;
-import com.dremio.nessie.model.Branch;
-import com.dremio.nessie.model.Hash;
-import com.dremio.nessie.model.Reference;
+import org.projectnessie.api.TreeApi;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.Hash;
+import org.projectnessie.model.Reference;
 
 class UpdateableReference {
 

--- a/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
@@ -62,7 +62,7 @@ public abstract class BaseTestIceberg {
   protected ContentsApi contents;
   protected Configuration hadoopConfig;
   protected final String branch;
-  private String path;
+  private String uri;
 
   public BaseTestIceberg(String branch) {
     this.branch = branch;
@@ -82,8 +82,8 @@ public abstract class BaseTestIceberg {
   @Before
   public void beforeEach() throws IOException {
     String port = System.getProperty("quarkus.http.test-port", "19120");
-    path = String.format("http://localhost:%s/api/v1", port);
-    this.client = NessieClient.builder().withUri(path).build();
+    uri = String.format("http://localhost:%s/api/v1", port);
+    this.client = NessieClient.builder().withUri(uri).build();
     tree = client.getTreeApi();
     contents = client.getContentsApi();
 
@@ -103,7 +103,7 @@ public abstract class BaseTestIceberg {
     NessieCatalog newCatalog = new NessieCatalog();
     newCatalog.setConf(hadoopConfig);
     newCatalog.initialize("nessie", ImmutableMap.of("ref", ref,
-        "uri", path,
+        CatalogProperties.URI, uri,
         "auth_type", "NONE",
         CatalogProperties.WAREHOUSE_LOCATION, temp.getRoot().toURI().toString()
         ));

--- a/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
@@ -19,13 +19,6 @@
 
 package org.apache.iceberg.nessie;
 
-import com.dremio.nessie.api.ContentsApi;
-import com.dremio.nessie.api.TreeApi;
-import com.dremio.nessie.client.NessieClient;
-import com.dremio.nessie.error.NessieConflictException;
-import com.dremio.nessie.error.NessieNotFoundException;
-import com.dremio.nessie.model.Branch;
-import com.dremio.nessie.model.Reference;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,6 +37,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
+import org.projectnessie.api.ContentsApi;
+import org.projectnessie.api.TreeApi;
+import org.projectnessie.client.NessieClient;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,7 +83,7 @@ public abstract class BaseTestIceberg {
   public void beforeEach() throws IOException {
     String port = System.getProperty("quarkus.http.test-port", "19120");
     path = String.format("http://localhost:%s/api/v1", port);
-    this.client = NessieClient.none(path);
+    this.client = NessieClient.builder().withUri(path).build();
     tree = client.getTreeApi();
     contents = client.getContentsApi();
 
@@ -103,7 +103,7 @@ public abstract class BaseTestIceberg {
     NessieCatalog newCatalog = new NessieCatalog();
     newCatalog.setConf(hadoopConfig);
     newCatalog.initialize("nessie", ImmutableMap.of("ref", ref,
-        "url", path,
+        "uri", path,
         "auth_type", "NONE",
         CatalogProperties.WAREHOUSE_LOCATION, temp.getRoot().toURI().toString()
         ));

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestBranchVisibility.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestBranchVisibility.java
@@ -19,14 +19,14 @@
 
 package org.apache.iceberg.nessie;
 
-import com.dremio.nessie.error.NessieConflictException;
-import com.dremio.nessie.error.NessieNotFoundException;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.types.Types;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.error.NessieNotFoundException;
 
 public class TestBranchVisibility extends BaseTestIceberg {
 

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
@@ -20,11 +20,6 @@
 package org.apache.iceberg.nessie;
 
 
-import com.dremio.nessie.error.NessieConflictException;
-import com.dremio.nessie.error.NessieNotFoundException;
-import com.dremio.nessie.model.Branch;
-import com.dremio.nessie.model.ContentsKey;
-import com.dremio.nessie.model.IcebergTable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -54,6 +49,11 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.ContentsKey;
+import org.projectnessie.model.IcebergTable;
 
 import static org.apache.iceberg.TableMetadataParser.getFileExtension;
 import static org.apache.iceberg.types.Types.NestedField.optional;
@@ -98,7 +98,7 @@ public class TestNessieTable extends BaseTestIceberg {
     super.afterEach();
   }
 
-  private com.dremio.nessie.model.IcebergTable getTable(ContentsKey key) throws NessieNotFoundException {
+  private org.projectnessie.model.IcebergTable getTable(ContentsKey key) throws NessieNotFoundException {
     return client.getContentsApi()
         .getContents(key, BRANCH)
         .unwrap(IcebergTable.class).get();

--- a/versions.props
+++ b/versions.props
@@ -19,9 +19,9 @@ org.apache.arrow:arrow-memory-netty = 2.0.0
 com.github.stephenc.findbugs:findbugs-annotations = 1.3.9-1
 software.amazon.awssdk:* = 2.15.7
 org.scala-lang:scala-library = 2.12.10
-org.projectnessie:* = 0.3.0
+org.projectnessie:* = 0.4.0
 javax.ws.rs:javax.ws.rs-api = 2.1.1
-io.quarkus:* = 1.9.1.Final
+io.quarkus:* = 1.12.1.Final
 
 # test deps
 junit:junit = 4.12


### PR DESCRIPTION
Contains some "noise" due to the renamed package `com.dremio.nessie` -> `org.projectnessie`.

Implicitly bumps Quarkus to 1.12.1.Final

Quarkus image building requires us to set the system property `quarkus.build.native-image`, which is not particularly
great and should be changed in the future on the Nessie-Quarkus-Gradle-Plugin side. It is a change in the behavior
since Quarkus 1.10 (Nessie 0.3.0 used Quarkus 1.9.1.Final) regarding how the Quarkus platform properties are applied,
which sadly also affects Quarkus builds that do not build a native image. Playing around with applying the Quarkus
bom, as suggested by Quarkus project, in various places (Gradle configs) didn't help here. I suspect, that's some
transitive dependency resolving issue.