### PR TITLE
Core: change writers constructor to use StructLike

### DIFF
--- a/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
-import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
@@ -100,7 +99,7 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
     private SortedPosDeleteWriter<T> posDeleteWriter;
     private Map<StructLike, PathOffset> insertedRowMap;
 
-    protected BaseEqualityDeltaWriter(PartitionKey partition, Schema schema, Schema deleteSchema) {
+    protected BaseEqualityDeltaWriter(StructLike partition, Schema schema, Schema deleteSchema) {
       Preconditions.checkNotNull(schema, "Iceberg table schema cannot be null.");
       Preconditions.checkNotNull(deleteSchema, "Equality-delete schema cannot be null.");
       this.structProjection = StructProjection.create(schema, deleteSchema);
@@ -222,18 +221,18 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
 
   private abstract class BaseRollingWriter<W extends Closeable> implements Closeable {
     private static final int ROWS_DIVISOR = 1000;
-    private final PartitionKey partitionKey;
+    private final StructLike partitionKey;
 
     private EncryptedOutputFile currentFile = null;
     private W currentWriter = null;
     private long currentRows = 0;
 
-    private BaseRollingWriter(PartitionKey partitionKey) {
+    private BaseRollingWriter(StructLike partitionKey) {
       this.partitionKey = partitionKey;
       openCurrent();
     }
 
-    abstract W newWriter(EncryptedOutputFile file, PartitionKey key);
+    abstract W newWriter(EncryptedOutputFile file, StructLike key);
 
     abstract long length(W writer);
 
@@ -301,12 +300,12 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
   }
 
   protected class RollingFileWriter extends BaseRollingWriter<DataWriter<T>> {
-    public RollingFileWriter(PartitionKey partitionKey) {
+    public RollingFileWriter(StructLike partitionKey) {
       super(partitionKey);
     }
 
     @Override
-    DataWriter<T> newWriter(EncryptedOutputFile file, PartitionKey key) {
+    DataWriter<T> newWriter(EncryptedOutputFile file, StructLike key) {
       return appenderFactory.newDataWriter(file, format, key);
     }
 
@@ -327,12 +326,12 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
   }
 
   protected class RollingEqDeleteWriter extends BaseRollingWriter<EqualityDeleteWriter<T>> {
-    RollingEqDeleteWriter(PartitionKey partitionKey) {
+    RollingEqDeleteWriter(StructLike partitionKey) {
       super(partitionKey);
     }
 
     @Override
-    EqualityDeleteWriter<T> newWriter(EncryptedOutputFile file, PartitionKey key) {
+    EqualityDeleteWriter<T> newWriter(EncryptedOutputFile file, StructLike key) {
       return appenderFactory.newEqDeleteWriter(file, format, key);
     }
 

--- a/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java
@@ -232,7 +232,7 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
       openCurrent();
     }
 
-    abstract W newWriter(EncryptedOutputFile file, StructLike key);
+    abstract W newWriter(EncryptedOutputFile file, StructLike partition);
 
     abstract long length(W writer);
 
@@ -305,8 +305,8 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
     }
 
     @Override
-    DataWriter<T> newWriter(EncryptedOutputFile file, StructLike key) {
-      return appenderFactory.newDataWriter(file, format, key);
+    DataWriter<T> newWriter(EncryptedOutputFile file, StructLike partitionKey) {
+      return appenderFactory.newDataWriter(file, format, partitionKey);
     }
 
     @Override
@@ -331,8 +331,8 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
     }
 
     @Override
-    EqualityDeleteWriter<T> newWriter(EncryptedOutputFile file, StructLike key) {
-      return appenderFactory.newEqDeleteWriter(file, format, key);
+    EqualityDeleteWriter<T> newWriter(EncryptedOutputFile file, StructLike partitionKey) {
+      return appenderFactory.newEqDeleteWriter(file, format, partitionKey);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/io/OutputFileFactory.java
+++ b/core/src/main/java/org/apache/iceberg/io/OutputFileFactory.java
@@ -22,8 +22,8 @@ package org.apache.iceberg.io;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.FileFormat;
-import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.StructLike;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.encryption.EncryptionManager;
 
@@ -99,7 +99,7 @@ public class OutputFileFactory {
   /**
    * Generates EncryptedOutputFile for PartitionedWriter.
    */
-  public EncryptedOutputFile newOutputFile(PartitionKey key) {
+  public EncryptedOutputFile newOutputFile(StructLike key) {
     String newDataLocation = locations.newDataLocation(spec, key, generateFilename());
     OutputFile rawOutputFile = io.newOutputFile(newDataLocation);
     return encryptionManager.encrypt(rawOutputFile);

--- a/core/src/main/java/org/apache/iceberg/io/OutputFileFactory.java
+++ b/core/src/main/java/org/apache/iceberg/io/OutputFileFactory.java
@@ -99,8 +99,8 @@ public class OutputFileFactory {
   /**
    * Generates EncryptedOutputFile for PartitionedWriter.
    */
-  public EncryptedOutputFile newOutputFile(StructLike key) {
-    String newDataLocation = locations.newDataLocation(spec, key, generateFilename());
+  public EncryptedOutputFile newOutputFile(StructLike partition) {
+    String newDataLocation = locations.newDataLocation(spec, partition, generateFilename());
     OutputFile rawOutputFile = io.newOutputFile(newDataLocation);
     return encryptionManager.encrypt(rawOutputFile);
   }

--- a/core/src/main/java/org/apache/iceberg/io/SortedPosDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/SortedPosDeleteWriter.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
-import org.apache.iceberg.PartitionKey;
+import org.apache.iceberg.StructLike;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -48,7 +48,7 @@ class SortedPosDeleteWriter<T> implements Closeable {
   private final FileAppenderFactory<T> appenderFactory;
   private final OutputFileFactory fileFactory;
   private final FileFormat format;
-  private final PartitionKey partition;
+  private final StructLike partition;
   private final long recordsNumThreshold;
 
   private int records = 0;
@@ -56,7 +56,7 @@ class SortedPosDeleteWriter<T> implements Closeable {
   SortedPosDeleteWriter(FileAppenderFactory<T> appenderFactory,
                         OutputFileFactory fileFactory,
                         FileFormat format,
-                        PartitionKey partition,
+                        StructLike partition,
                         long recordsNumThreshold) {
     this.appenderFactory = appenderFactory;
     this.fileFactory = fileFactory;
@@ -68,7 +68,7 @@ class SortedPosDeleteWriter<T> implements Closeable {
   SortedPosDeleteWriter(FileAppenderFactory<T> appenderFactory,
                         OutputFileFactory fileFactory,
                         FileFormat format,
-                        PartitionKey partition) {
+                        StructLike partition) {
     this(appenderFactory, fileFactory, format, partition, DEFAULT_RECORDS_NUM_THRESHOLD);
   }
 


### PR DESCRIPTION
This changes the writers' constructor to accept `StructLike` instead of `PartitionKey`, so that writers could create files using `PartitionData`.