### PR TITLE
Core/Hive: Introduce total-files-size snapshot metric and populate HMS

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -218,12 +218,15 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
       }
     } else {
       // if there was no previous snapshot, default the summary to start totals at 0
-      previousSummary = ImmutableMap.of(
-          SnapshotSummary.TOTAL_RECORDS_PROP, "0",
-          SnapshotSummary.TOTAL_DATA_FILES_PROP, "0",
-          SnapshotSummary.TOTAL_DELETE_FILES_PROP, "0",
-          SnapshotSummary.TOTAL_POS_DELETES_PROP, "0",
-          SnapshotSummary.TOTAL_EQ_DELETES_PROP, "0");
+      ImmutableMap.Builder<String, String> summaryBuilder = ImmutableMap.builder();
+      summaryBuilder
+          .put(SnapshotSummary.TOTAL_RECORDS_PROP, "0")
+          .put(SnapshotSummary.TOTAL_FILE_SIZE_PROP, "0")
+          .put(SnapshotSummary.TOTAL_DATA_FILES_PROP, "0")
+          .put(SnapshotSummary.TOTAL_DELETE_FILES_PROP, "0")
+          .put(SnapshotSummary.TOTAL_POS_DELETES_PROP, "0")
+          .put(SnapshotSummary.TOTAL_EQ_DELETES_PROP, "0");
+      previousSummary = summaryBuilder.build();
     }
 
     ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
@@ -234,6 +237,9 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
     updateTotal(
         builder, previousSummary, SnapshotSummary.TOTAL_RECORDS_PROP,
         summary, SnapshotSummary.ADDED_RECORDS_PROP, SnapshotSummary.DELETED_RECORDS_PROP);
+    updateTotal(
+        builder, previousSummary, SnapshotSummary.TOTAL_FILE_SIZE_PROP,
+        summary, SnapshotSummary.ADDED_FILE_SIZE_PROP, SnapshotSummary.REMOVED_FILE_SIZE_PROP);
     updateTotal(
         builder, previousSummary, SnapshotSummary.TOTAL_DATA_FILES_PROP,
         summary, SnapshotSummary.ADDED_FILES_PROP, SnapshotSummary.DELETED_FILES_PROP);

--- a/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
@@ -38,6 +38,7 @@ public class SnapshotSummary {
   public static final String TOTAL_RECORDS_PROP = "total-records";
   public static final String ADDED_FILE_SIZE_PROP = "added-files-size";
   public static final String REMOVED_FILE_SIZE_PROP = "removed-files-size";
+  public static final String TOTAL_FILE_SIZE_PROP = "total-files-size";
   public static final String ADDED_POS_DELETES_PROP = "added-position-deletes";
   public static final String REMOVED_POS_DELETES_PROP = "removed-position-deletes";
   public static final String TOTAL_POS_DELETES_PROP = "total-position-deletes";

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotSummary.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotSummary.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestSnapshotSummary extends TableTestBase {
+  public TestSnapshotSummary(int formatVersion) {
+    super(formatVersion);
+  }
+
+  @Parameterized.Parameters(name = "formatVersion = {0}")
+  public static Object[] parameters() {
+    return new Object[] { 1, 2 };
+  }
+
+  @Test
+  public void testFileSizeSummary() {
+    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+
+    // fast append
+    table.newFastAppend()
+        .appendFile(FILE_A)
+        .commit();
+    Map<String, String> summary = table.currentSnapshot().summary();
+    Assert.assertEquals("10", summary.get(SnapshotSummary.ADDED_FILE_SIZE_PROP));
+    Assert.assertNull(summary.get(SnapshotSummary.REMOVED_FILE_SIZE_PROP));
+    Assert.assertEquals("10", summary.get(SnapshotSummary.TOTAL_FILE_SIZE_PROP));
+
+    // merge append
+    table.newAppend()
+        .appendFile(FILE_B)
+        .commit();
+    summary = table.currentSnapshot().summary();
+    Assert.assertEquals("10", summary.get(SnapshotSummary.ADDED_FILE_SIZE_PROP));
+    Assert.assertNull(summary.get(SnapshotSummary.REMOVED_FILE_SIZE_PROP));
+    Assert.assertEquals("20", summary.get(SnapshotSummary.TOTAL_FILE_SIZE_PROP));
+
+    table.newOverwrite()
+        .deleteFile(FILE_A)
+        .deleteFile(FILE_B)
+        .addFile(FILE_C)
+        .addFile(FILE_D)
+        .addFile(FILE_D)
+        .commit();
+    summary = table.currentSnapshot().summary();
+    Assert.assertEquals("30", summary.get(SnapshotSummary.ADDED_FILE_SIZE_PROP));
+    Assert.assertEquals("20", summary.get(SnapshotSummary.REMOVED_FILE_SIZE_PROP));
+    Assert.assertEquals("30", summary.get(SnapshotSummary.TOTAL_FILE_SIZE_PROP));
+
+    table.newDelete()
+        .deleteFile(FILE_C)
+        .deleteFile(FILE_D)
+        .commit();
+    summary = table.currentSnapshot().summary();
+    Assert.assertNull(summary.get(SnapshotSummary.ADDED_FILE_SIZE_PROP));
+    Assert.assertEquals("20", summary.get(SnapshotSummary.REMOVED_FILE_SIZE_PROP));
+    Assert.assertEquals("10", summary.get(SnapshotSummary.TOTAL_FILE_SIZE_PROP));
+  }
+}

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -306,8 +306,6 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     parameters.put(StatsSetupConst.NUM_FILES, summary.getOrDefault(SnapshotSummary.TOTAL_DATA_FILES_PROP, "0"));
     parameters.put(StatsSetupConst.ROW_COUNT, summary.getOrDefault(SnapshotSummary.TOTAL_RECORDS_PROP, "0"));
     parameters.put(StatsSetupConst.TOTAL_SIZE, summary.getOrDefault(SnapshotSummary.TOTAL_FILE_SIZE_PROP, "0"));
-    // we don't have the uncompressed file sizes, so we use the totalSize (size on disk) as an estimate for rawDataSize
-    parameters.put(StatsSetupConst.RAW_DATA_SIZE, summary.getOrDefault(SnapshotSummary.TOTAL_FILE_SIZE_PROP, "0"));
 
     tbl.setParameters(parameters);
   }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -303,9 +303,15 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     }
 
     // Set the basic statistics
-    parameters.put(StatsSetupConst.NUM_FILES, summary.getOrDefault(SnapshotSummary.TOTAL_DATA_FILES_PROP, "0"));
-    parameters.put(StatsSetupConst.ROW_COUNT, summary.getOrDefault(SnapshotSummary.TOTAL_RECORDS_PROP, "0"));
-    parameters.put(StatsSetupConst.TOTAL_SIZE, summary.getOrDefault(SnapshotSummary.TOTAL_FILE_SIZE_PROP, "0"));
+    if (summary.get(SnapshotSummary.TOTAL_DATA_FILES_PROP) != null) {
+      parameters.put(StatsSetupConst.NUM_FILES, summary.get(SnapshotSummary.TOTAL_DATA_FILES_PROP));
+    }
+    if (summary.get(SnapshotSummary.TOTAL_RECORDS_PROP) != null) {
+      parameters.put(StatsSetupConst.ROW_COUNT, summary.get(SnapshotSummary.TOTAL_RECORDS_PROP));
+    }
+    if (summary.get(SnapshotSummary.TOTAL_FILE_SIZE_PROP) != null) {
+      parameters.put(StatsSetupConst.TOTAL_SIZE, summary.get(SnapshotSummary.TOTAL_FILE_SIZE_PROP));
+    }
 
     tbl.setParameters(parameters);
   }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -520,14 +520,11 @@ public class TestHiveIcebergStorageHandlerNoScan {
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     if (Catalogs.hiveCatalog(shell.getHiveConf())) {
-      Assert.assertEquals(12, hmsParams.size());
+      Assert.assertEquals(9, hmsParams.size());
       Assert.assertEquals("initial_val", hmsParams.get("custom_property"));
       Assert.assertEquals("TRUE", hmsParams.get(InputFormatConfig.EXTERNAL_TABLE_PURGE));
       Assert.assertEquals("TRUE", hmsParams.get("EXTERNAL"));
       Assert.assertEquals("true", hmsParams.get(TableProperties.ENGINE_HIVE_ENABLED));
-      Assert.assertEquals("0", hmsParams.get(StatsSetupConst.NUM_FILES));
-      Assert.assertEquals("0", hmsParams.get(StatsSetupConst.ROW_COUNT));
-      Assert.assertEquals("0", hmsParams.get(StatsSetupConst.TOTAL_SIZE));
       Assert.assertEquals(HiveIcebergStorageHandler.class.getName(),
           hmsParams.get(hive_metastoreConstants.META_TABLE_STORAGE));
       Assert.assertEquals(BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE.toUpperCase(),
@@ -560,7 +557,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     if (Catalogs.hiveCatalog(shell.getHiveConf())) {
-      Assert.assertEquals(15, hmsParams.size()); // 2 newly-added properties + previous_metadata_location prop
+      Assert.assertEquals(12, hmsParams.size()); // 2 newly-added properties + previous_metadata_location prop
       Assert.assertEquals("true", hmsParams.get("new_prop_1"));
       Assert.assertEquals("false", hmsParams.get("new_prop_2"));
       Assert.assertEquals("new_val", hmsParams.get("custom_property"));

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -41,8 +41,10 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.data.Record;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.hive.HiveSchemaUtil;
@@ -106,9 +108,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
       ))
   );
 
-  private static final Set<String> IGNORED_PARAMS =
-      ImmutableSet.of("bucketing_version", StatsSetupConst.ROW_COUNT,
-          StatsSetupConst.RAW_DATA_SIZE, StatsSetupConst.TOTAL_SIZE, StatsSetupConst.NUM_FILES, "numFilesErasureCoded");
+  private static final Set<String> IGNORED_PARAMS = ImmutableSet.of("bucketing_version", "numFilesErasureCoded");
 
   @Parameters(name = "catalog={0}")
   public static Collection<Object[]> parameters() {
@@ -485,7 +485,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
   }
 
   @Test
-  public void testIcebergAndHmsTableProperties() throws TException, InterruptedException {
+  public void testIcebergAndHmsTableProperties() throws Exception {
     TableIdentifier identifier = TableIdentifier.of("default", "customers");
 
     shell.executeStatement(String.format("CREATE EXTERNAL TABLE default.customers " +
@@ -520,11 +520,15 @@ public class TestHiveIcebergStorageHandlerNoScan {
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     if (Catalogs.hiveCatalog(shell.getHiveConf())) {
-      Assert.assertEquals(9, hmsParams.size());
+      Assert.assertEquals(13, hmsParams.size());
       Assert.assertEquals("initial_val", hmsParams.get("custom_property"));
       Assert.assertEquals("TRUE", hmsParams.get(InputFormatConfig.EXTERNAL_TABLE_PURGE));
       Assert.assertEquals("TRUE", hmsParams.get("EXTERNAL"));
       Assert.assertEquals("true", hmsParams.get(TableProperties.ENGINE_HIVE_ENABLED));
+      Assert.assertEquals("0", hmsParams.get(StatsSetupConst.NUM_FILES));
+      Assert.assertEquals("0", hmsParams.get(StatsSetupConst.ROW_COUNT));
+      Assert.assertEquals("0", hmsParams.get(StatsSetupConst.TOTAL_SIZE));
+      Assert.assertEquals("0", hmsParams.get(StatsSetupConst.RAW_DATA_SIZE));
       Assert.assertEquals(HiveIcebergStorageHandler.class.getName(),
           hmsParams.get(hive_metastoreConstants.META_TABLE_STORAGE));
       Assert.assertEquals(BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE.toUpperCase(),
@@ -557,7 +561,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     if (Catalogs.hiveCatalog(shell.getHiveConf())) {
-      Assert.assertEquals(12, hmsParams.size()); // 2 newly-added properties + previous_metadata_location prop
+      Assert.assertEquals(16, hmsParams.size()); // 2 newly-added properties + previous_metadata_location prop
       Assert.assertEquals("true", hmsParams.get("new_prop_1"));
       Assert.assertEquals("false", hmsParams.get("new_prop_2"));
       Assert.assertEquals("new_val", hmsParams.get("custom_property"));
@@ -576,13 +580,23 @@ public class TestHiveIcebergStorageHandlerNoScan {
           .remove("custom_property")
           .remove("new_prop_1")
           .commit();
-      hmsParams = shell.metastore().getTable("default", "customers").getParameters()
-          .entrySet().stream()
-          .filter(e -> !IGNORED_PARAMS.contains(e.getKey()))
-          .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+      hmsParams = shell.metastore().getTable("default", "customers").getParameters();
       Assert.assertFalse(hmsParams.containsKey("custom_property"));
       Assert.assertFalse(hmsParams.containsKey("new_prop_1"));
       Assert.assertTrue(hmsParams.containsKey("new_prop_2"));
+    }
+
+    // append some data and check whether HMS stats are aligned with snapshot summary
+    if (Catalogs.hiveCatalog(shell.getHiveConf())) {
+      List<Record> records = HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS;
+      testTables.appendIcebergTable(shell.getHiveConf(), icebergTable, FileFormat.PARQUET, null, records);
+      hmsParams = shell.metastore().getTable("default", "customers").getParameters();
+      Map<String, String> summary = icebergTable.currentSnapshot().summary();
+      Assert.assertEquals(summary.get(SnapshotSummary.TOTAL_DATA_FILES_PROP), hmsParams.get(StatsSetupConst.NUM_FILES));
+      Assert.assertEquals(summary.get(SnapshotSummary.TOTAL_RECORDS_PROP), hmsParams.get(StatsSetupConst.ROW_COUNT));
+      Assert.assertEquals(summary.get(SnapshotSummary.TOTAL_FILE_SIZE_PROP), hmsParams.get(StatsSetupConst.TOTAL_SIZE));
+      Assert.assertEquals(summary.get(SnapshotSummary.TOTAL_FILE_SIZE_PROP),
+          hmsParams.get(StatsSetupConst.RAW_DATA_SIZE));
     }
   }
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -520,7 +520,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     if (Catalogs.hiveCatalog(shell.getHiveConf())) {
-      Assert.assertEquals(13, hmsParams.size());
+      Assert.assertEquals(12, hmsParams.size());
       Assert.assertEquals("initial_val", hmsParams.get("custom_property"));
       Assert.assertEquals("TRUE", hmsParams.get(InputFormatConfig.EXTERNAL_TABLE_PURGE));
       Assert.assertEquals("TRUE", hmsParams.get("EXTERNAL"));
@@ -528,7 +528,6 @@ public class TestHiveIcebergStorageHandlerNoScan {
       Assert.assertEquals("0", hmsParams.get(StatsSetupConst.NUM_FILES));
       Assert.assertEquals("0", hmsParams.get(StatsSetupConst.ROW_COUNT));
       Assert.assertEquals("0", hmsParams.get(StatsSetupConst.TOTAL_SIZE));
-      Assert.assertEquals("0", hmsParams.get(StatsSetupConst.RAW_DATA_SIZE));
       Assert.assertEquals(HiveIcebergStorageHandler.class.getName(),
           hmsParams.get(hive_metastoreConstants.META_TABLE_STORAGE));
       Assert.assertEquals(BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE.toUpperCase(),
@@ -561,7 +560,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     if (Catalogs.hiveCatalog(shell.getHiveConf())) {
-      Assert.assertEquals(16, hmsParams.size()); // 2 newly-added properties + previous_metadata_location prop
+      Assert.assertEquals(15, hmsParams.size()); // 2 newly-added properties + previous_metadata_location prop
       Assert.assertEquals("true", hmsParams.get("new_prop_1"));
       Assert.assertEquals("false", hmsParams.get("new_prop_2"));
       Assert.assertEquals("new_val", hmsParams.get("custom_property"));
@@ -595,8 +594,6 @@ public class TestHiveIcebergStorageHandlerNoScan {
       Assert.assertEquals(summary.get(SnapshotSummary.TOTAL_DATA_FILES_PROP), hmsParams.get(StatsSetupConst.NUM_FILES));
       Assert.assertEquals(summary.get(SnapshotSummary.TOTAL_RECORDS_PROP), hmsParams.get(StatsSetupConst.ROW_COUNT));
       Assert.assertEquals(summary.get(SnapshotSummary.TOTAL_FILE_SIZE_PROP), hmsParams.get(StatsSetupConst.TOTAL_SIZE));
-      Assert.assertEquals(summary.get(SnapshotSummary.TOTAL_FILE_SIZE_PROP),
-          hmsParams.get(StatsSetupConst.RAW_DATA_SIZE));
     }
   }
 


### PR DESCRIPTION
This patch:

- Introduces a new snapshot summary metric for `total-files-size`. It was somehow missing up till now, even though it has its companion metrics `added-files-size` and `removed-files-size`. Introducing this total metric makes it consistent with the other 'metric groups'.
- On HiveTableOperations commit, we should populate the HMS statistics using these snapshot metrics. Having these stats populated makes the Hive read query planning significantly faster. In some cases, @pvary's research showed that it led to 10x+ improvement on query compilation times, since in the absence of HMS stats the Hive query planner will recursively list the data files to gather their sizes first before execution.