### PR TITLE
Spark: Add table location to reserved properties so that the table location shows in Spark SQL Properties.

### DIFF
--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -64,7 +64,7 @@ public class SparkTable implements org.apache.spark.sql.connector.catalog.Table,
   private static final Logger LOG = LoggerFactory.getLogger(SparkTable.class);
 
   private static final Set<String> RESERVED_PROPERTIES =
-      Sets.newHashSet("provider", "format", "current-snapshot-id", "location");
+      ImmutableSet.of("provider", "format", "current-snapshot-id", "location");
   private static final Set<TableCapability> CAPABILITIES = ImmutableSet.of(
       TableCapability.BATCH_READ,
       TableCapability.BATCH_WRITE,

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -63,7 +63,8 @@ public class SparkTable implements org.apache.spark.sql.connector.catalog.Table,
 
   private static final Logger LOG = LoggerFactory.getLogger(SparkTable.class);
 
-  private static final Set<String> RESERVED_PROPERTIES = Sets.newHashSet("provider", "format", "current-snapshot-id");
+  private static final Set<String> RESERVED_PROPERTIES =
+      Sets.newHashSet("provider", "format", "current-snapshot-id", "location");
   private static final Set<TableCapability> CAPABILITIES = ImmutableSet.of(
       TableCapability.BATCH_READ,
       TableCapability.BATCH_WRITE,
@@ -138,6 +139,7 @@ public class SparkTable implements org.apache.spark.sql.connector.catalog.Table,
     String currentSnapshotId = icebergTable.currentSnapshot() != null ?
         String.valueOf(icebergTable.currentSnapshot().snapshotId()) : "none";
     propsBuilder.put("current-snapshot-id", currentSnapshotId);
+    propsBuilder.put("location", icebergTable.location());
 
     icebergTable.properties().entrySet().stream()
         .filter(entry -> !RESERVED_PROPERTIES.contains(entry.getKey()))

--- a/spark3/src/test/java/org/apache/iceberg/actions/TestCreateActions.java
+++ b/spark3/src/test/java/org/apache/iceberg/actions/TestCreateActions.java
@@ -459,16 +459,13 @@ public class TestCreateActions extends SparkCatalogTestBase {
     String[] keys = {"provider", "format", "current-snapshot-id", "location"};
 
     for (String entry : keys) {
-      Assert.assertTrue(
-              "Created table missing reserved property " + entry, table.properties().containsKey(entry));
+      Assert.assertTrue("Created table missing reserved property " + entry, table.properties().containsKey(entry));
     }
 
-    Assert.assertEquals("Property value is not the expected value", "iceberg", table.properties().get("provider"));
-    Assert.assertEquals("Property value is not the expected value", "iceberg/parquet",
-        table.properties().get("format"));
-    Assert.assertTrue("Current-snapshot-id doesn't exist",
-        !table.properties().get("current-snapshot-id").equals("none"));
-    Assert.assertTrue("location isn't correct", table.properties().get("location").endsWith(destTableName));
+    Assert.assertEquals("Unexpected provider", "iceberg", table.properties().get("provider"));
+    Assert.assertEquals("Unexpected format", "iceberg/parquet", table.properties().get("format"));
+    Assert.assertNotEquals("No current-snapshot-id found", "none", table.properties().get("current-snapshot-id"));
+    Assert.assertTrue("Location isn't correct", table.properties().get("location").endsWith(destTableName));
   }
 
   @Test

--- a/spark3/src/test/java/org/apache/iceberg/actions/TestCreateActions.java
+++ b/spark3/src/test/java/org/apache/iceberg/actions/TestCreateActions.java
@@ -448,6 +448,30 @@ public class TestCreateActions extends SparkCatalogTestBase {
   }
 
   @Test
+  public void testSparkTableReservedProperties() throws Exception {
+    String destTableName = "iceberg_reserved_properties";
+    String source = sourceName("test_reserved_properties_table");
+    String dest = destName(destTableName);
+    createSourceTable(CREATE_PARQUET, source);
+    assertMigratedFileCount(Actions.snapshot(source, dest), source, dest);
+    SparkTable table = loadTable(dest);
+
+    String[] keys = {"provider", "format", "current-snapshot-id", "location"};
+
+    for (String entry : keys) {
+      Assert.assertTrue(
+              "Created table missing reserved property " + entry, table.properties().containsKey(entry));
+    }
+
+    Assert.assertEquals("Property value is not the expected value", "iceberg", table.properties().get("provider"));
+    Assert.assertEquals("Property value is not the expected value", "iceberg/parquet",
+        table.properties().get("format"));
+    Assert.assertTrue("Current-snapshot-id doesn't exist",
+        !table.properties().get("current-snapshot-id").equals("none"));
+    Assert.assertTrue("location isn't correct", table.properties().get("location").endsWith(destTableName));
+  }
+
+  @Test
   public void testSnapshotDefaultLocation() throws Exception {
     String source = sourceName("test_snapshot_default");
     String dest = destName("iceberg_snapshot_default");


### PR DESCRIPTION
https://github.com/apache/iceberg/issues/2309
A unit test is added. Besides here is the integration test with Apache Spark 3.0.2:
```
spark-sql> describe table extended local.db.table;
21/03/13 00:22:33 INFO BaseMetastoreCatalog: Table loaded by catalog: local.db.table
21/03/13 00:22:35 INFO CodeGenerator: Code generated in 242.060932 ms
21/03/13 00:22:35 INFO CodeGenerator: Code generated in 11.30419 ms
id	bigint
data	string

# Partitioning
Not partitioned

# Detailed Table Information
Name	local.db.table
Location	/Users/yufei/Downloads/spark-3.0.2-bin-hadoop2.7/warehouse/db/table
Provider	iceberg
Owner	yufei
Table Properties	[current-snapshot-id=none,format=iceberg/parquet]
Time taken: 3.503 seconds, Fetched 12 row(s)
21/03/13 00:22:35 INFO SparkSQLCLIDriver: Time taken: 3.503 seconds, Fetched 12 row(s)
```
