### PR TITLE
[BUILD] Relocate Antlr4 in spark3 runtime module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -867,7 +867,6 @@ if (jdkVersion == '8') {
     dependencies {
       compile project(':iceberg-spark2')
       compile project(':iceberg-aws')
-      compile 'org.apache.spark:spark-hive_2.11'
       compile(project(':iceberg-nessie')) {
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
       }
@@ -1020,7 +1019,6 @@ project(':iceberg-spark3-runtime') {
     compile project(':iceberg-spark3')
     compile project(':iceberg-spark3-extensions')
     compile project(':iceberg-aws')
-    compile 'org.apache.spark:spark-hive_2.11'
     compile(project(':iceberg-nessie')) {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }
@@ -1041,6 +1039,7 @@ project(':iceberg-spark3-runtime') {
     relocate 'com.google', 'org.apache.iceberg.shaded.com.google'
     relocate 'com.fasterxml', 'org.apache.iceberg.shaded.com.fasterxml'
     relocate 'com.github.benmanes', 'org.apache.iceberg.shaded.com.github.benmanes'
+    relocate 'org.antlr.v4.runtime', 'org.apache.iceberg.shaded.org.antlr.v4.runtime'
     relocate 'org.checkerframework', 'org.apache.iceberg.shaded.org.checkerframework'
     relocate 'org.apache.avro', 'org.apache.iceberg.shaded.org.apache.avro'
     relocate 'avro.shaded', 'org.apache.iceberg.shaded.org.apache.avro.shaded'

--- a/build.gradle
+++ b/build.gradle
@@ -867,6 +867,7 @@ if (jdkVersion == '8') {
     dependencies {
       compile project(':iceberg-spark2')
       compile project(':iceberg-aws')
+      compile 'org.apache.spark:spark-hive_2.11'
       compile(project(':iceberg-nessie')) {
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
       }
@@ -1019,6 +1020,7 @@ project(':iceberg-spark3-runtime') {
     compile project(':iceberg-spark3')
     compile project(':iceberg-spark3-extensions')
     compile project(':iceberg-aws')
+    compile 'org.apache.spark:spark-hive_2.11'
     compile(project(':iceberg-nessie')) {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }


### PR DESCRIPTION
As [suggested](https://github.com/apache/iceberg/pull/2296#issuecomment-797085585) by @aokolnychyi , we need to shade the runtime antlr4 dep and be independent from Spark.