### PR TITLE
Core: fix bug that HadoopFileIO cannot be dynamically loaded

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.hadoop;
 
 import java.io.IOException;
+import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -29,9 +30,17 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.util.SerializableSupplier;
 
-public class HadoopFileIO implements FileIO {
+public class HadoopFileIO implements FileIO, Configurable {
 
-  private final SerializableSupplier<Configuration> hadoopConf;
+  private SerializableSupplier<Configuration> hadoopConf;
+
+  /**
+   * Constructor used for dynamic FileIO loading.
+   * <p>
+   * {@link Configuration Hadoop configuration} must be set through {@link HadoopFileIO#setConf(Configuration)}
+   */
+  public HadoopFileIO() {
+  }
 
   public HadoopFileIO(Configuration hadoopConf) {
     this(new SerializableConfiguration(hadoopConf)::get);
@@ -64,5 +73,15 @@ public class HadoopFileIO implements FileIO {
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to delete file: %s", path);
     }
+  }
+
+  @Override
+  public void setConf(Configuration conf) {
+    this.hadoopConf = new SerializableConfiguration(conf)::get;
+  }
+
+  @Override
+  public Configuration getConf() {
+    return hadoopConf.get();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
@@ -121,6 +122,15 @@ public class TestCatalogUtil {
     FileIO fileIO = CatalogUtil.loadFileIO(TestFileIONoArg.class.getName(), properties, null);
     Assert.assertTrue(fileIO instanceof TestFileIONoArg);
     Assert.assertEquals(properties, ((TestFileIONoArg) fileIO).map);
+  }
+
+  @Test
+  public void loadCustomFileIO_hadoopConfigConstructor() {
+    Configuration configuration = new Configuration();
+    configuration.set("key", "val");
+    FileIO fileIO = CatalogUtil.loadFileIO(HadoopFileIO.class.getName(), Maps.newHashMap(), configuration);
+    Assert.assertTrue(fileIO instanceof HadoopFileIO);
+    Assert.assertEquals("val", ((HadoopFileIO) fileIO).conf().get("key"));
   }
 
   @Test


### PR DESCRIPTION
@aokolnychyi this should probably go to 0.11.1

HadoopFileIO currently does not have a no-arg constructor and could not be loaded by the dynamic FileIO loader. But our documentation claims it can be loaded, so we need to fix it asap. There are 2 ways to fix it,
1. add a no-arg constructor to HadoopFileIO, let it implement Configurable, and set configuration in `setConf` method.
2. (current approach in PR) allow the loader to load an implementation that has a constructor taking Hadoop configuration.

To do approach 1, we need to change HadoopFileIO class variable to be not final, and I am a bit hesitated to do that for performance concerns, so I went with approach 2 for now.