### PR TITLE
Reduce boxing in ParquetValueReaders.StructReader

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
@@ -239,10 +239,10 @@ public abstract class BaseParquetReaders<T> {
             if (expected.typeId() == org.apache.iceberg.types.Type.TypeID.LONG) {
               return new ParquetValueReaders.IntAsLongReader(desc);
             } else {
-              return new ParquetValueReaders.UnboxedReader<>(desc);
+              return new ParquetValueReaders.IntReader(desc);
             }
           case INT_64:
-            return new ParquetValueReaders.UnboxedReader<>(desc);
+            return new ParquetValueReaders.LongReader(desc);
           case DATE:
             return new DateReader(desc);
           case TIMESTAMP_MICROS:
@@ -294,18 +294,20 @@ public abstract class BaseParquetReaders<T> {
           if (expected != null && expected.typeId() == org.apache.iceberg.types.Type.TypeID.LONG) {
             return new ParquetValueReaders.IntAsLongReader(desc);
           } else {
-            return new ParquetValueReaders.UnboxedReader<>(desc);
+            return new ParquetValueReaders.IntReader(desc);
           }
         case FLOAT:
           if (expected != null && expected.typeId() == org.apache.iceberg.types.Type.TypeID.DOUBLE) {
             return new ParquetValueReaders.FloatAsDoubleReader(desc);
           } else {
-            return new ParquetValueReaders.UnboxedReader<>(desc);
+            return new ParquetValueReaders.FloatReader(desc);
           }
         case BOOLEAN:
+          return new ParquetValueReaders.BooleanReader(desc);
         case INT64:
+          return new ParquetValueReaders.LongReader(desc);
         case DOUBLE:
-          return new ParquetValueReaders.UnboxedReader<>(desc);
+          return new ParquetValueReaders.DoubleReader(desc);
         case INT96:
           // Impala & Spark used to write timestamps as INT96 without a logical type. For backwards
           // compatibility we try to read INT96 as timestamps.

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReader.java
@@ -30,4 +30,49 @@ public interface ParquetValueReader<T> {
   List<TripleIterator<?>> columns();
 
   void setPageSource(PageReadStore pageStore, long rowPosition);
+
+  interface OfBoolean extends ParquetValueReader<Boolean> {
+    @Override
+    default Boolean read(Boolean ignored) {
+      return readBoolean();
+    }
+
+    boolean readBoolean();
+  }
+
+  interface OfInt extends ParquetValueReader<Integer> {
+    @Override
+    default Integer read(Integer ignored) {
+      return readInteger();
+    }
+
+    int readInteger();
+  }
+
+  interface OfLong extends ParquetValueReader<Long> {
+    @Override
+    default Long read(Long ignored) {
+      return readLong();
+    }
+
+    long readLong();
+  }
+
+  interface OfFloat extends ParquetValueReader<Float> {
+    @Override
+    default Float read(Float ignored) {
+      return readFloat();
+    }
+
+    float readFloat();
+  }
+
+  interface OfDouble extends ParquetValueReader<Double> {
+    @Override
+    default Double read(Double ignored) {
+      return readDouble();
+    }
+
+    double readDouble();
+  }
 }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
@@ -306,6 +306,7 @@ public class ParquetValueReaders {
     public IntAsLongReader(ColumnDescriptor desc) {
       super(desc);
     }
+
     @Override
     public long readLong() {
       return column.nextInteger();
@@ -316,6 +317,7 @@ public class ParquetValueReaders {
     public FloatAsDoubleReader(ColumnDescriptor desc) {
       super(desc);
     }
+
     @Override
     public double readDouble() {
       return column.nextFloat();


### PR DESCRIPTION
`UnboxedReader` conflates two things: 1) the source type of the column. 2) the target type. You can't distinguish between its methods as to which one should the client code use. In a later PR I will migrate other usages of `UnboxedReader`.