### PR TITLE
JCenter is shutting down

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ import groovy.transform.Memoized
 
 buildscript {
   repositories {
-    jcenter()
     gradlePluginPortal()
     maven { url "http://palantir.bintray.com/releases" }
     maven { url "https://plugins.gradle.org/m2/" }


### PR DESCRIPTION
As per: https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

I tested this on a new VM w/ no gradle cache. It looks like the only dependencies on JCenter are gradle plugins. Gradle plugins will be automatically moved off jcenter: https://blog.gradle.org/jcenter-shutdown