### PR TITLE
make GetProjectedIds able to handle empty struct

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/GetProjectedIds.java
+++ b/api/src/main/java/org/apache/iceberg/types/GetProjectedIds.java
@@ -34,6 +34,11 @@ class GetProjectedIds extends TypeUtil.SchemaVisitor<Set<Integer>> {
 
   @Override
   public Set<Integer> struct(Types.StructType struct, List<Set<Integer>> fieldResults) {
+    // if the struct is an empty struct, we should consider itself as 'internal', thus including its id.
+    if (struct.fields().size() == 0) {
+      // since returning null is signaling the call to field() to add the field ID, we return null here.
+      return null;
+    }
     return fieldIds;
   }
 

--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 
 public class TypeUtil {
 
@@ -83,7 +84,11 @@ public class TypeUtil {
   }
 
   private static Set<Integer> getIdsInternal(Type type) {
-    return visit(type, new GetProjectedIds());
+    Set<Integer> res = visit(type, new GetProjectedIds());
+    if (res == null) {
+      return Sets.newHashSet();
+    }
+    return res;
   }
 
   public static Types.StructType selectNot(Types.StructType struct, Set<Integer> fieldIds) {

--- a/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
@@ -20,10 +20,13 @@
 
 package org.apache.iceberg.types;
 
+import java.util.Collections;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 
@@ -66,5 +69,26 @@ public class TestTypeUtil {
         );
 
     TypeUtil.indexByName(Types.StructType.of(nestedType));
+  }
+
+  @Test
+  public void testSelectNot() {
+    // iceberg schema which has an empty struct column.
+    Schema schema = new Schema(
+            required(1, "a", Types.IntegerType.get()),
+            optional(2, "b", Types.StructType.of(
+                    required(3, "c", Types.StringType.get()),
+                    optional(4, "d", Types.StructType.of(Collections.emptyList()))))
+    );
+    Schema filteredSchema = TypeUtil.selectNot(schema, ImmutableSet.of());
+    Assert.assertEquals(schema.toString(), filteredSchema.toString());
+
+    filteredSchema = TypeUtil.selectNot(schema, ImmutableSet.of(4));
+    Schema expected = new Schema(
+            required(1, "a", Types.IntegerType.get()),
+            optional(2, "b", Types.StructType.of(
+                    required(3, "c", Types.StringType.get())))
+    );
+    Assert.assertEquals(expected.toString(), filteredSchema.toString());
   }
 }


### PR DESCRIPTION
In our production, we encounter a table with an empty struct in its schema (the table is ORC format but I think both iceberg and ORC somehow doesn't forbid the creation of table/schema with empty struct), and when we try to read this table, iceberg internally throws away the empty struct in the expected schema, thus the read builder doesn't build the correct number of readers (basically it lacks the reader for the empty struct field).

This fix is to let iceberg not throw away the empty struct field, making it able to read tables with such corner case schemas.