### PR TITLE
Core: add row key to format v2

### DIFF
--- a/api/src/main/java/org/apache/iceberg/RowKey.java
+++ b/api/src/main/java/org/apache/iceberg/RowKey.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.io.Serializable;
+import java.util.Set;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.Types;
+
+/**
+ * Row key of a table.
+ * <p>
+ * Row key is a definition of table row uniqueness,
+ * similar to the concept of primary key in a relational database system.
+ * A row should be unique in a table based on the values of an unordered set of {@link RowKeyIdentifierField}.
+ * Iceberg itself does not enforce row uniqueness based on this key.
+ * It is leveraged by operations such as streaming upsert.
+ */
+public class RowKey implements Serializable {
+
+  private static final RowKey NOT_IDENTIFIED = new RowKey(new Schema(), Sets.newHashSet());
+
+  private final Schema schema;
+  private final RowKeyIdentifierField[] identifierFields;
+
+  private transient volatile Set<RowKeyIdentifierField> identifierFieldSet;
+
+  private RowKey(Schema schema, Set<RowKeyIdentifierField> identifierFields) {
+    this.schema = schema;
+    this.identifierFields = identifierFields.toArray(new RowKeyIdentifierField[0]);
+  }
+
+  /**
+   * Returns the {@link Schema} referenced by the row key
+   */
+  public Schema schema() {
+    return schema;
+  }
+
+  /**
+   * Return the set of {@link RowKeyIdentifierField} in the row key
+   * <p>
+   * @return the set of fields in the row key
+   */
+  public Set<RowKeyIdentifierField> identifierFields() {
+    return lazyIdentifierFieldSet();
+  }
+
+  private Set<RowKeyIdentifierField> lazyIdentifierFieldSet() {
+    if (identifierFieldSet == null) {
+      synchronized (this) {
+        if (identifierFieldSet == null) {
+          identifierFieldSet = ImmutableSet.copyOf(identifierFields);
+        }
+      }
+    }
+
+    return identifierFieldSet;
+  }
+
+  /**
+   * Returns the default row key that has no field
+   */
+  public static RowKey notIdentified() {
+    return NOT_IDENTIFIED;
+  }
+
+  /**
+   * Returns true if the row key is the default one with no field
+   */
+  public boolean isNotIdentified() {
+    return identifierFields.length < 1;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    } else if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+
+    RowKey that = (RowKey) other;
+    return identifierFields().equals(that.identifierFields());
+  }
+
+  @Override
+  public int hashCode() {
+    return identifierFields().hashCode();
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("[");
+    for (RowKeyIdentifierField field : identifierFields) {
+      sb.append("\n");
+      sb.append("  ").append(field);
+    }
+    if (identifierFields.length > 0) {
+      sb.append("\n");
+    }
+    sb.append("]");
+    return sb.toString();
+  }
+
+  /**
+   * Creates a new {@link Builder row key builder} for the given {@link Schema}.
+   *
+   * @param schema a schema
+   * @return a row key builder for the given schema.
+   */
+  public static Builder builderFor(Schema schema) {
+    return new Builder(schema);
+  }
+
+  /**
+   * A builder to create valid {@link RowKey row key}.
+   * <p>
+   * Call {@link #builderFor(Schema)} to create a new builder.
+   */
+  public static class Builder {
+    private final Schema schema;
+    private final Set<RowKeyIdentifierField> fields = Sets.newHashSet();
+
+    private Builder(Schema schema) {
+      this.schema = schema;
+    }
+
+    public Builder addField(String name) {
+      Types.NestedField column = schema.findField(name);
+      ValidationException.check(column != null, "Cannot find column with name %s in schema %s", name, schema);
+      return addField(column);
+    }
+
+    public Builder addField(int id) {
+      Types.NestedField column = schema.findField(id);
+      ValidationException.check(column != null, "Cannot find column with ID %s in schema %s", id, schema);
+      return addField(column);
+    }
+
+    private Builder addField(Types.NestedField column) {
+      ValidationException.check(column.isRequired(),
+          "Cannot add column %s to row key because it is not a required column in schema %s", column, schema);
+      ValidationException.check(column.type().isPrimitiveType(),
+          "Cannot add column %s to row key because it is not a primitive data type in schema %s", column, schema);
+      fields.add(new RowKeyIdentifierField(column.fieldId()));
+      return this;
+    }
+
+    public RowKey build() {
+      if (fields.size() == 0) {
+        return NOT_IDENTIFIED;
+      }
+
+      return new RowKey(schema, fields);
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/RowKeyIdentifierField.java
+++ b/api/src/main/java/org/apache/iceberg/RowKeyIdentifierField.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * An identifier field in {@link RowKey}
+ * <p>
+ * The field must be:
+ *  1. a required column in the table schema
+ *  2. a primitive type column
+ */
+public class RowKeyIdentifierField implements Serializable {
+
+  private final int sourceId;
+
+  RowKeyIdentifierField(int sourceId) {
+    this.sourceId = sourceId;
+  }
+
+  public int sourceId() {
+    return sourceId;
+  }
+
+  @Override
+  public String toString() {
+    return "(" + sourceId + ")";
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    } else if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+
+    RowKeyIdentifierField that = (RowKeyIdentifierField) other;
+    return sourceId == that.sourceId;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(sourceId);
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/Table.java
+++ b/api/src/main/java/org/apache/iceberg/Table.java
@@ -89,6 +89,13 @@ public interface Table {
   Map<Integer, SortOrder> sortOrders();
 
   /**
+   * Return the {@link RowKey row key} for this table.
+   *
+   * @return this table's row key.
+   */
+  RowKey rowKey();
+
+  /**
    * Return a map of string properties for this table.
    *
    * @return this table's properties map

--- a/api/src/main/java/org/apache/iceberg/Tables.java
+++ b/api/src/main/java/org/apache/iceberg/Tables.java
@@ -46,7 +46,17 @@ public interface Tables {
                        SortOrder order,
                        Map<String, String> properties,
                        String tableIdentifier) {
-    throw new UnsupportedOperationException(this.getClass().getName() + " does not implement create with a sort order");
+    return create(schema, spec, order, RowKey.notIdentified(), properties, tableIdentifier);
+  }
+
+  default Table create(Schema schema,
+                       PartitionSpec spec,
+                       SortOrder order,
+                       RowKey rowKey,
+                       Map<String, String> properties,
+                       String tableIdentifier) {
+    throw new UnsupportedOperationException(this.getClass().getName() +
+        " does not implement create with a sort order and row key");
   }
 
   Table load(String tableIdentifier);

--- a/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Catalog.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.catalog;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.RowKey;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
@@ -359,6 +360,14 @@ public interface Catalog {
      * @return this for method chaining
      */
     TableBuilder withSortOrder(SortOrder sortOrder);
+
+    /**
+     * Sets a row key for the table.
+     *
+     * @param rowKey a row key
+     * @return this for method chaining
+     */
+    TableBuilder withRowKey(RowKey rowKey);
 
     /**
      * Sets a location for the table.

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -37,6 +37,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 abstract class BaseMetadataTable implements Table, HasTableOperations, Serializable {
   private final PartitionSpec spec = PartitionSpec.unpartitioned();
   private final SortOrder sortOrder = SortOrder.unsorted();
+  private final RowKey rowKey = RowKey.notIdentified();
   private final TableOperations ops;
   private final Table table;
   private final String name;
@@ -106,6 +107,11 @@ abstract class BaseMetadataTable implements Table, HasTableOperations, Serializa
   @Override
   public Map<Integer, SortOrder> sortOrders() {
     return ImmutableMap.of(sortOrder.orderId(), sortOrder);
+  }
+
+  @Override
+  public RowKey rowKey() {
+    return rowKey;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTable.java
@@ -90,6 +90,11 @@ public class BaseTable implements Table, HasTableOperations, Serializable {
   }
 
   @Override
+  public RowKey rowKey() {
+    return ops.current().rowKey();
+  }
+
+  @Override
   public Map<String, String> properties() {
     return ops.current().properties();
   }

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -546,6 +546,11 @@ class BaseTransaction implements Transaction {
     }
 
     @Override
+    public RowKey rowKey() {
+      return current.rowKey();
+    }
+
+    @Override
     public Map<String, String> properties() {
       return current.properties();
     }

--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -187,6 +187,12 @@ public class CachingCatalog implements Catalog {
     }
 
     @Override
+    public TableBuilder withRowKey(RowKey rowKey) {
+      innerBuilder.withRowKey(rowKey);
+      return this;
+    }
+
+    @Override
     public TableBuilder withLocation(String location) {
       innerBuilder.withLocation(location);
       return this;

--- a/core/src/main/java/org/apache/iceberg/RowKeyParser.java
+++ b/core/src/main/java/org/apache/iceberg/RowKeyParser.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.UncheckedIOException;
+import java.util.Iterator;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.JsonUtil;
+
+public class RowKeyParser {
+  private static final String FIELDS = "identifier-fields";
+  private static final String SOURCE_ID = "source-id";
+
+  private RowKeyParser() {
+  }
+
+  public static void toJson(RowKey rowKey, JsonGenerator generator) throws IOException {
+    generator.writeStartObject();
+    generator.writeFieldName(FIELDS);
+    toJsonFields(rowKey, generator);
+    generator.writeEndObject();
+  }
+
+  public static String toJson(RowKey rowKey) {
+    return toJson(rowKey, false);
+  }
+
+  public static String toJson(RowKey rowKey, boolean pretty) {
+    try {
+      StringWriter writer = new StringWriter();
+      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
+      if (pretty) {
+        generator.useDefaultPrettyPrinter();
+      }
+      toJson(rowKey, generator);
+      generator.flush();
+      return writer.toString();
+
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private static void toJsonFields(RowKey rowKey, JsonGenerator generator) throws IOException {
+    generator.writeStartArray();
+    for (RowKeyIdentifierField field : rowKey.identifierFields()) {
+      generator.writeStartObject();
+      generator.writeNumberField(SOURCE_ID, field.sourceId());
+      generator.writeEndObject();
+    }
+    generator.writeEndArray();
+  }
+
+  public static RowKey fromJson(Schema schema, String json) {
+    try {
+      return fromJson(schema, JsonUtil.mapper().readValue(json, JsonNode.class));
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  public static RowKey fromJson(Schema schema, JsonNode json) {
+    Preconditions.checkArgument(json.isObject(), "Cannot parse row key from non-object: %s", json);
+    RowKey.Builder builder = RowKey.builderFor(schema);
+    buildFromJsonFields(builder, json.get(FIELDS));
+    return builder.build();
+  }
+
+  private static void buildFromJsonFields(RowKey.Builder builder, JsonNode json) {
+    Preconditions.checkArgument(json != null, "Cannot parse null row key fields");
+    Preconditions.checkArgument(json.isArray(), "Cannot parse row key fields, not an array: %s", json);
+
+    Iterator<JsonNode> elements = json.elements();
+    while (elements.hasNext()) {
+      JsonNode element = elements.next();
+      Preconditions.checkArgument(element.isObject(),
+          "Cannot parse row key field, not an object: %s", element);
+      builder.addField(JsonUtil.getInt(SOURCE_ID, element));
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestRowKey.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowKey.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.stream.Collectors;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.Types;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+@RunWith(Parameterized.class)
+public class TestRowKey {
+
+  private final int formatVersion;
+
+  private static final Schema SCHEMA = new Schema(
+      required(10, "id", Types.IntegerType.get()),
+      required(11, "data", Types.StringType.get()),
+      optional(12, "s", Types.StructType.of(
+          required(13, "id", Types.IntegerType.get())
+      )),
+      optional(14, "map", Types.MapType.ofOptional(
+          15, 16, Types.IntegerType.get(), Types.IntegerType.get()
+      )),
+      required(17, "required_list", Types.ListType.ofOptional(18, Types.StringType.get()))
+  );
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+  private File tableDir = null;
+
+  @Parameterized.Parameters
+  public static Iterable<Object[]> parameters() {
+    return Lists.newArrayList(
+        new Object[] {1},
+        new Object[] {2}
+    );
+  }
+
+  public TestRowKey(int formatVersion) {
+    this.formatVersion = formatVersion;
+  }
+
+  @Before
+  public void setupTableDir() throws IOException {
+    this.tableDir = temp.newFolder();
+  }
+
+  @After
+  public void cleanupTables() {
+    TestTables.clearTables();
+  }
+
+  @Test
+  public void testBuildRowKey() {
+    Assert.assertEquals("Should be able to build row key",
+        RowKey.notIdentified(),
+        RowKey.builderFor(SCHEMA).build());
+  }
+
+  @Test
+  public void testDefaultRowKey() {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    SortOrder order = SortOrder.unsorted();
+    RowKey key = RowKey.notIdentified();
+    TestTables.TestTable table = TestTables.create(tableDir, "test", SCHEMA, spec, order, key, formatVersion);
+    Assert.assertEquals("Expected 1 partition spec", 1, table.specs().size());
+    Assert.assertEquals("Expected 1 sort order", 1, table.sortOrders().size());
+
+    RowKey actualId = table.rowKey();
+    Assert.assertTrue("Row key should be default", actualId.isNotIdentified());
+  }
+
+  @Test
+  public void testFreshKeys() {
+    RowKey key = RowKey.builderFor(SCHEMA).addField("id").addField("data").build();
+    TestTables.TestTable table = TestTables.create(tableDir, "test", SCHEMA,
+        PartitionSpec.unpartitioned(), SortOrder.unsorted(), key, formatVersion);
+
+    RowKey actualKey = table.rowKey();
+    Assert.assertEquals("Row key must have 2 fields", 2, actualKey.identifierFields().size());
+    Assert.assertEquals("Row key must have the expected field",
+        Sets.newHashSet(1, 2),
+        actualKey.identifierFields().stream().map(RowKeyIdentifierField::sourceId).collect(Collectors.toSet()));
+  }
+
+  @Test
+  public void testAddField() {
+    AssertHelpers.assertThrows("Should not allow to add no-existing field",
+        ValidationException.class, "Cannot find column with name data0 in schema",
+        () -> RowKey.builderFor(SCHEMA).addField("data0").build());
+
+    AssertHelpers.assertThrows("Should not allow to add no-existing field",
+        ValidationException.class, "Cannot find column with ID 12345 in schema",
+        () -> RowKey.builderFor(SCHEMA).addField(12345).build());
+
+    AssertHelpers.assertThrows("Should not allow to add optional field",
+        ValidationException.class, "because it is not a required column",
+        () -> RowKey.builderFor(SCHEMA).addField("map").build());
+
+    AssertHelpers.assertThrows("Should not allow to add optional field",
+        ValidationException.class, "because it is not a required column",
+        () -> RowKey.builderFor(SCHEMA).addField(14).build());
+
+    AssertHelpers.assertThrows("Should not allow to add non-primitive field",
+        ValidationException.class, "because it is not a primitive data type",
+        () -> RowKey.builderFor(SCHEMA).addField("required_list").build());
+
+    AssertHelpers.assertThrows("Should not allow to add non-primitive field",
+        ValidationException.class, "because it is not a primitive data type",
+        () -> RowKey.builderFor(SCHEMA).addField(17).build());
+  }
+
+  @Test
+  public void testSameRowKey() {
+    RowKey key1 = RowKey.builderFor(SCHEMA).addField("id").addField("data").build();
+    RowKey key2 = RowKey.builderFor(SCHEMA).addField("data").addField("id").build();
+    Assert.assertEquals("Row key with different order must be equal", key1, key2);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestRowKeyParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowKeyParser.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestRowKeyParser extends TableTestBase {
+
+  @Parameterized.Parameters(name = "format = {0}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+        {1},
+        {2}
+    };
+  }
+
+  public TestRowKeyParser(int formatVersion) {
+    super(formatVersion);
+  }
+
+  @Test
+  public void testToJson() {
+    String expected = "{\"identifier-fields\":[]}";
+    Assert.assertEquals(expected, RowKeyParser.toJson(table.rowKey(), false));
+    Assert.assertEquals(expected, RowKeyParser.toJson(RowKey.notIdentified(), false));
+
+    RowKey id = RowKey.builderFor(table.schema())
+        .addField("id")
+        .addField("data")
+        .build();
+
+    table.ops().commit(table.ops().current(), table.ops().current().updateRowKey(id));
+
+    expected = "{\n" +
+        "  \"identifier-fields\" : [ {\n" +
+        "    \"source-id\" : 1\n" +
+        "  }, {\n" +
+        "    \"source-id\" : 2\n" +
+        "  } ]\n" +
+        "}";
+    Assert.assertEquals(expected, RowKeyParser.toJson(id, true));
+  }
+
+  @Test
+  public void testFromJson() {
+    String expected = "{\n" +
+        "  \"identifier-fields\" : [ {\n" +
+        "    \"source-id\" : 1\n" +
+        "  } ]\n" +
+        "}";
+
+    RowKey expectedId = RowKey.builderFor(table.schema())
+        .addField("id")
+        .build();
+
+    RowKey id = RowKeyParser.fromJson(table.schema(), expected);
+    Assert.assertEquals(expectedId, id);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestSortOrder.java
+++ b/core/src/test/java/org/apache/iceberg/TestSortOrder.java
@@ -118,7 +118,8 @@ public class TestSortOrder {
         .asc("s.id", NULLS_LAST)
         .desc(truncate("data", 10), NULLS_FIRST)
         .build();
-    TestTables.TestTable table = TestTables.create(tableDir, "test", SCHEMA, spec, order, formatVersion);
+    TestTables.TestTable table = TestTables.create(tableDir, "test", SCHEMA, spec, order,
+        RowKey.notIdentified(), formatVersion);
 
     Assert.assertEquals("Expected 1 sort order", 1, table.sortOrders().size());
     Assert.assertTrue("Order ID must be fresh", table.sortOrders().containsKey(TableMetadata.INITIAL_SORT_ORDER_ID));
@@ -282,7 +283,8 @@ public class TestSortOrder {
         .asc("s.id")
         .desc(truncate("data", 10))
         .build();
-    TestTables.TestTable table = TestTables.create(tableDir, "test", SCHEMA, spec, order, formatVersion);
+    TestTables.TestTable table = TestTables.create(tableDir, "test", SCHEMA, spec, order,
+        RowKey.notIdentified(), formatVersion);
 
     table.updateSchema()
         .renameColumn("s.id", "s.id2")
@@ -303,7 +305,8 @@ public class TestSortOrder {
         .asc("s.id")
         .desc(truncate("data", 10))
         .build();
-    TestTables.TestTable table = TestTables.create(tableDir, "test", SCHEMA, spec, order, formatVersion);
+    TestTables.TestTable table = TestTables.create(tableDir, "test", SCHEMA, spec, order,
+        RowKey.notIdentified(), formatVersion);
 
     AssertHelpers.assertThrows("Should reject deletion of sort columns",
         ValidationException.class, "Cannot find source column",

--- a/core/src/test/java/org/apache/iceberg/TestTables.java
+++ b/core/src/test/java/org/apache/iceberg/TestTables.java
@@ -48,52 +48,56 @@ public class TestTables {
   }
 
   public static TestTable create(File temp, String name, Schema schema, PartitionSpec spec, int formatVersion) {
-    return create(temp, name, schema, spec, SortOrder.unsorted(), formatVersion);
+    return create(temp, name, schema, spec, SortOrder.unsorted(), RowKey.notIdentified(), formatVersion);
   }
 
   public static TestTable create(File temp, String name, Schema schema, PartitionSpec spec,
-                                 SortOrder sortOrder, int formatVersion) {
+                                 SortOrder sortOrder, RowKey rowKey, int formatVersion) {
     TestTableOperations ops = new TestTableOperations(name, temp);
     if (ops.current() != null) {
       throw new AlreadyExistsException("Table %s already exists at location: %s", name, temp);
     }
 
-    ops.commit(null, newTableMetadata(schema, spec, sortOrder, temp.toString(), ImmutableMap.of(), formatVersion));
+    ops.commit(null, newTableMetadata(schema, spec, sortOrder, rowKey,
+        temp.toString(), ImmutableMap.of(), formatVersion));
 
     return new TestTable(ops, name);
   }
 
   public static Transaction beginCreate(File temp, String name, Schema schema, PartitionSpec spec) {
-    return beginCreate(temp, name, schema, spec, SortOrder.unsorted());
+    return beginCreate(temp, name, schema, spec, SortOrder.unsorted(), RowKey.notIdentified());
   }
 
   public static Transaction beginCreate(File temp, String name, Schema schema,
-                                        PartitionSpec spec, SortOrder sortOrder) {
+                                        PartitionSpec spec, SortOrder sortOrder, RowKey rowKey) {
     TableOperations ops = new TestTableOperations(name, temp);
     if (ops.current() != null) {
       throw new AlreadyExistsException("Table %s already exists at location: %s", name, temp);
     }
 
-    TableMetadata metadata = newTableMetadata(schema, spec, sortOrder, temp.toString(), ImmutableMap.of(), 1);
+    TableMetadata metadata = newTableMetadata(schema, spec, sortOrder, rowKey,
+        temp.toString(), ImmutableMap.of(), 1);
 
     return Transactions.createTableTransaction(name, ops, metadata);
   }
 
   public static Transaction beginReplace(File temp, String name, Schema schema, PartitionSpec spec) {
-    return beginReplace(temp, name, schema, spec, SortOrder.unsorted(), ImmutableMap.of());
+    return beginReplace(temp, name, schema, spec, SortOrder.unsorted(),
+        RowKey.notIdentified(), ImmutableMap.of());
   }
 
   public static Transaction beginReplace(File temp, String name, Schema schema, PartitionSpec spec,
-                                         SortOrder sortOrder, Map<String, String> properties) {
+                                         SortOrder sortOrder, RowKey rowKey,
+                                         Map<String, String> properties) {
     TestTableOperations ops = new TestTableOperations(name, temp);
     TableMetadata current = ops.current();
 
     TableMetadata metadata;
     if (current != null) {
-      metadata = current.buildReplacement(schema, spec, sortOrder, current.location(), properties);
+      metadata = current.buildReplacement(schema, spec, sortOrder, rowKey, current.location(), properties);
       return Transactions.replaceTableTransaction(name, ops, metadata);
     } else {
-      metadata = newTableMetadata(schema, spec, sortOrder, temp.toString(), properties);
+      metadata = newTableMetadata(schema, spec, sortOrder, rowKey, temp.toString(), properties);
       return Transactions.createTableTransaction(name, ops, metadata);
     }
   }

--- a/core/src/test/java/org/apache/iceberg/util/TestSortOrderUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestSortOrderUtil.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.util;
 import java.io.File;
 import java.io.IOException;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.RowKey;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.TestTables;
@@ -80,7 +81,8 @@ public class TestSortOrderUtil {
         .withOrderId(1)
         .asc("id", NULLS_LAST)
         .build();
-    TestTables.TestTable table = TestTables.create(tableDir, "test", SCHEMA, spec, order, formatVersion);
+    TestTables.TestTable table = TestTables.create(
+        tableDir, "test", SCHEMA, spec, order, RowKey.notIdentified(), formatVersion);
 
     // pass PartitionSpec.unpartitioned() on purpose as it has an empty schema
     SortOrder actualOrder = SortOrderUtil.buildSortOrder(table.schema(), spec, table.sortOrder());

--- a/core/src/test/resources/TableMetadataV2Valid.json
+++ b/core/src/test/resources/TableMetadataV2Valid.json
@@ -80,6 +80,16 @@
       ]
     }
   ],
+  "row-key": {
+    "identifier-fields": [
+      {
+        "source-id": 1
+      },
+      {
+        "source-id": 3
+      }
+    ]
+  },
   "properties": {},
   "current-snapshot-id": -1,
   "snapshots": [],

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
+import org.apache.iceberg.RowKey;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.SortOrder;
@@ -271,12 +272,13 @@ abstract class TestTables {
     }
 
     @Override
-    public Table create(Schema schema, PartitionSpec spec, SortOrder sortOrder,
+    public Table create(Schema schema, PartitionSpec spec, SortOrder sortOrder, RowKey rowKey,
                         Map<String, String> properties, String tableIdentifier) {
       TableIdentifier tableIdent = TableIdentifier.parse(tableIdentifier);
       return catalog.buildTable(tableIdent, schema)
           .withPartitionSpec(spec)
           .withSortOrder(sortOrder)
+          .withRowKey(rowKey)
           .withProperties(properties)
           .create();
     }


### PR DESCRIPTION
This is the continuation for #2010 for adding a concept that describes how a row in a table should be uniquely identified. I have the implementation ready up to the Spark SQL extension to update the row key, and will separate them into multiple PRs for review. This PR should have the same amount of content as what openInx had in the old PR.

This PR adds `RowKey` to the `Table` and `TableMetadata` API, and writes the metadata information as something like:

```json
  ...
  "default-row-key-id": 1,
  "row-keys": [
    {
      "key-id": 3,
      "fields": [
        {
          "source-id": 1
        },
        {
          "source-id": 3
        }
      ]
    }
  ],
  ...
```

I will add reasons behind the namings inline.

@openinx @rdblue @aokolnychyi 