### PR TITLE
Core: add missing tests and comments for sort order

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -195,6 +195,7 @@ public class TableMetadataParser {
 
     generator.writeNumberField(LAST_PARTITION_ID, metadata.lastAssignedPartitionId());
 
+    // write the default order ID and sort order list
     generator.writeNumberField(DEFAULT_SORT_ORDER_ID, metadata.defaultSortOrderId());
     generator.writeArrayFieldStart(SORT_ORDERS);
     for (SortOrder sortOrder : metadata.sortOrders()) {
@@ -202,6 +203,7 @@ public class TableMetadataParser {
     }
     generator.writeEndArray();
 
+    // write properties map
     generator.writeObjectFieldStart(PROPERTIES);
     for (Map.Entry<String, String> keyValue : metadata.properties().entrySet()) {
       generator.writeStringField(keyValue.getKey(), keyValue.getValue());
@@ -347,6 +349,7 @@ public class TableMetadataParser {
       lastAssignedPartitionId = specs.stream().mapToInt(PartitionSpec::lastAssignedFieldId).max().orElse(999);
     }
 
+    // parse the sort orders
     JsonNode sortOrderArray = node.get(SORT_ORDERS);
     List<SortOrder> sortOrders;
     int defaultSortOrderId;
@@ -365,6 +368,7 @@ public class TableMetadataParser {
       defaultSortOrderId = defaultSortOrder.orderId();
     }
 
+    // parse properties map
     Map<String, String> properties = JsonUtil.getStringMap(PROPERTIES, node);
     long currentVersionId = JsonUtil.getLong(CURRENT_SNAPSHOT_ID, node);
     long lastUpdatedMillis = JsonUtil.getLong(LAST_UPDATED_MILLIS, node);

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -137,6 +137,12 @@ public class TestTableMetadata {
         expected.specs(), metadata.specs());
     Assert.assertEquals("lastAssignedFieldId across all PartitionSpecs should match",
         expected.spec().lastAssignedFieldId(), metadata.lastAssignedPartitionId());
+    Assert.assertEquals("Default sort ID should match",
+        expected.defaultSortOrderId(), metadata.defaultSortOrderId());
+    Assert.assertEquals("Sort order should match",
+        expected.sortOrder(), metadata.sortOrder());
+    Assert.assertEquals("Sort order map should match",
+        expected.sortOrders(), metadata.sortOrders());
     Assert.assertEquals("Properties should match",
         expected.properties(), metadata.properties());
     Assert.assertEquals("Snapshot logs should match",


### PR DESCRIPTION
Add missing tests and comments in the table metadata parser related to sort order
@yyanyy 