### PR TITLE
Spark: Remove softValues for spark2 catalog cache

### DIFF
--- a/spark2/src/main/java/org/apache/iceberg/spark/source/CustomCatalogs.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/CustomCatalogs.java
@@ -39,8 +39,7 @@ import org.apache.spark.SparkConf;
 import org.apache.spark.sql.SparkSession;
 
 public final class CustomCatalogs {
-  private static final Cache<Pair<SparkSession, String>, Catalog> CATALOG_CACHE = Caffeine.newBuilder()
-      .softValues().build();
+  private static final Cache<Pair<SparkSession, String>, Catalog> CATALOG_CACHE = Caffeine.newBuilder().build();
 
   public static final String ICEBERG_DEFAULT_CATALOG = "default_catalog";
   public static final String ICEBERG_CATALOG_PREFIX = "spark.sql.catalog";


### PR DESCRIPTION
As discussed in https://github.com/apache/iceberg/issues/1502, it's possible for a catalog to be prematurely GC'd in Spark 2. The lifecycle of the catalog should match that of the Spark session, and removing `softValues` from the cache should enforce that.