### PR TITLE
Spark: Add an action to rewrite equality deletes

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
@@ -74,4 +74,11 @@ public interface ActionsProvider {
   default DeleteReachableFiles deleteReachableFiles(String metadataLocation) {
     throw new UnsupportedOperationException(this.getClass().getName() + " does not implement deleteReachableFiles");
   }
+
+  /**
+   * Instantiates an action to rewrite deletes.
+   */
+  default RewriteDeletes rewriteDeletes(Table table) {
+    throw new UnsupportedOperationException(this.getClass().getName() + " does not implement rewriteDeletes");
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/actions/RewriteDeletes.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteDeletes.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.actions;
+
+import java.util.Set;
+import org.apache.iceberg.DeleteFile;
+
+public interface RewriteDeletes extends SnapshotUpdate<RewriteDeletes, RewriteDeletes.Result> {
+
+  /**
+   * rewrite the equality deletes.
+   *
+   * @return this for method chaining
+   */
+  RewriteDeletes rewriteEqDeletes();
+
+  /**
+   * rewrite the position deletes.
+   *
+   * @return this for method chaining
+   */
+  RewriteDeletes rewritePosDeletes();
+
+  /**
+   * The action result that contains a summary of the execution.
+   */
+  interface Result {
+    /**
+     * Returns the delete files to rewrite.
+     */
+    Set<DeleteFile> deletedFiles();
+
+    /**
+     * Returns the added delete files.
+     */
+    Set<DeleteFile> addedFiles();
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/actions/RewriteDeletes.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteDeletes.java
@@ -25,18 +25,11 @@ import org.apache.iceberg.DeleteFile;
 public interface RewriteDeletes extends SnapshotUpdate<RewriteDeletes, RewriteDeletes.Result> {
 
   /**
-   * rewrite the equality deletes.
+   * Set the implementation class name of rewrite delete strategy
    *
    * @return this for method chaining
    */
-  RewriteDeletes rewriteEqDeletes();
-
-  /**
-   * rewrite the position deletes.
-   *
-   * @return this for method chaining
-   */
-  RewriteDeletes rewritePosDeletes();
+  RewriteDeletes strategy(String strategyImpl);
 
   /**
    * The action result that contains a summary of the execution.

--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDeletesResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDeletesResult.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.actions;
+
+import java.util.Set;
+import org.apache.iceberg.DeleteFile;
+
+public class BaseRewriteDeletesResult implements RewriteDeletes.Result {
+
+  private final Set<DeleteFile> deletesToReplace;
+  private final Set<DeleteFile> deletesToAdd;
+
+  public BaseRewriteDeletesResult(Set<DeleteFile> deletesToReplace, Set<DeleteFile> deletesToAdd) {
+    this.deletesToReplace = deletesToReplace;
+    this.deletesToAdd = deletesToAdd;
+  }
+
+  @Override
+  public Set<DeleteFile> deletedFiles() {
+    return deletesToReplace;
+  }
+
+  @Override
+  public Set<DeleteFile> addedFiles() {
+    return deletesToAdd;
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/actions/RewriteDeleteStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteDeleteStrategy.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.actions;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.DeleteFile;
@@ -52,7 +51,7 @@ public interface RewriteDeleteStrategy {
    * @param deleteFilesToRewrite a group of files to be rewritten together
    * @return iterable of delete files used to replace the original delete files.
    */
-  Set<DeleteFile> rewriteDeletes(List<DeleteFile> deleteFilesToRewrite);
+  Set<DeleteFile> rewriteDeletes(Set<DeleteFile> deleteFilesToRewrite);
 
   /**
    * Groups file scans into lists which will be processed in a single executable unit. Each group will end up being
@@ -62,7 +61,7 @@ public interface RewriteDeleteStrategy {
    * @param deleteFiles iterable of DeleteFile to be rewritten
    * @return iterable of lists of FileScanTasks which will be processed together
    */
-  Iterable<List<FileScanTask>> planDeleteGroups(Iterable<DeleteFile> deleteFiles);
+  Iterable<Set<DeleteFile>> planDeleteGroups(Iterable<DeleteFile> deleteFiles);
 
   /**
    * Sets options to be used with this strategy

--- a/core/src/main/java/org/apache/iceberg/actions/RewriteDeleteStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteDeleteStrategy.java
@@ -19,9 +19,11 @@
 
 package org.apache.iceberg.actions;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Table;
 
 public interface RewriteDeleteStrategy {
@@ -39,16 +41,28 @@ public interface RewriteDeleteStrategy {
   /**
    * Select the deletes to rewrite.
    *
+   * @param dataFiles iterable of FileScanTasks for data files in a given partition
    * @return iterable of original delete file to be replaced.
    */
-  Iterable<DeleteFile> selectDeletes();
+  Iterable<DeleteFile> selectDeletesToRewrite(Iterable<FileScanTask> dataFiles);
 
   /**
    * Define how to rewrite the deletes.
    *
+   * @param deleteFilesToRewrite a group of files to be rewritten together
    * @return iterable of delete files used to replace the original delete files.
    */
-  Iterable<DeleteFile> rewriteDeletes();
+  Set<DeleteFile> rewriteDeletes(List<DeleteFile> deleteFilesToRewrite);
+
+  /**
+   * Groups file scans into lists which will be processed in a single executable unit. Each group will end up being
+   * committed as an independent set of changes. This creates the jobs which will eventually be run as by the underlying
+   * Action.
+   *
+   * @param deleteFiles iterable of DeleteFile to be rewritten
+   * @return iterable of lists of FileScanTasks which will be processed together
+   */
+  Iterable<List<FileScanTask>> planDeleteGroups(Iterable<DeleteFile> deleteFiles);
 
   /**
    * Sets options to be used with this strategy

--- a/core/src/main/java/org/apache/iceberg/actions/RewriteDeleteStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteDeleteStrategy.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.actions;
+
+import java.util.Map;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.Table;
+
+public interface RewriteDeleteStrategy {
+
+  /**
+   * Returns the table being modified by this rewrite strategy
+   */
+  Table table();
+
+  /**
+   * Select the deletes to rewrite.
+   *
+   * @return iterable of original delete file to be replaced.
+   */
+  Iterable<DeleteFile> selectDeletes();
+
+  /**
+   * Define how to rewrite the deletes.
+   *
+   * @return iterable of delete files used to replace the original delete files.
+   */
+  Iterable<DeleteFile> rewriteDeletes();
+
+  /**
+   * Sets options to be used with this strategy
+   */
+  RewriteDeleteStrategy options(Map<String, String> options);
+}

--- a/core/src/main/java/org/apache/iceberg/actions/RewriteDeleteStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteDeleteStrategy.java
@@ -20,10 +20,16 @@
 package org.apache.iceberg.actions;
 
 import java.util.Map;
+import java.util.Set;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.Table;
 
 public interface RewriteDeleteStrategy {
+
+  /**
+   * Returns the name of this rewrite deletes strategy
+   */
+  String name();
 
   /**
    * Returns the table being modified by this rewrite strategy
@@ -48,4 +54,10 @@ public interface RewriteDeleteStrategy {
    * Sets options to be used with this strategy
    */
   RewriteDeleteStrategy options(Map<String, String> options);
+
+  /**
+   * Returns a set of options which this rewrite strategy can use. This is an allowed-list and any options not
+   * specified here will be rejected at runtime.
+   */
+  Set<String> validOptions();
 }

--- a/core/src/main/java/org/apache/iceberg/io/SortedPosDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/SortedPosDeleteWriter.java
@@ -36,7 +36,7 @@ import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.util.CharSequenceSet;
 import org.apache.iceberg.util.CharSequenceWrapper;
 
-class SortedPosDeleteWriter<T> implements Closeable {
+public class SortedPosDeleteWriter<T> implements Closeable {
   private static final long DEFAULT_RECORDS_NUM_THRESHOLD = 100_000L;
 
   private final Map<CharSequenceWrapper, List<PosRow<T>>> posDeletes = Maps.newHashMap();
@@ -52,11 +52,11 @@ class SortedPosDeleteWriter<T> implements Closeable {
 
   private int records = 0;
 
-  SortedPosDeleteWriter(FileAppenderFactory<T> appenderFactory,
-                        OutputFileFactory fileFactory,
-                        FileFormat format,
-                        StructLike partition,
-                        long recordsNumThreshold) {
+  public SortedPosDeleteWriter(FileAppenderFactory<T> appenderFactory,
+                               OutputFileFactory fileFactory,
+                               FileFormat format,
+                               StructLike partition,
+                               long recordsNumThreshold) {
     this.appenderFactory = appenderFactory;
     this.fileFactory = fileFactory;
     this.format = format;
@@ -64,10 +64,10 @@ class SortedPosDeleteWriter<T> implements Closeable {
     this.recordsNumThreshold = recordsNumThreshold;
   }
 
-  SortedPosDeleteWriter(FileAppenderFactory<T> appenderFactory,
-                        OutputFileFactory fileFactory,
-                        FileFormat format,
-                        StructLike partition) {
+  public SortedPosDeleteWriter(FileAppenderFactory<T> appenderFactory,
+                               OutputFileFactory fileFactory,
+                               FileFormat format,
+                               StructLike partition) {
     this(appenderFactory, fileFactory, format, partition, DEFAULT_RECORDS_NUM_THRESHOLD);
   }
 

--- a/data/src/main/java/org/apache/iceberg/data/GenericDeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/GenericDeleteFilter.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.data;
 
+import java.util.function.Consumer;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
@@ -38,6 +39,16 @@ public class GenericDeleteFilter extends DeleteFilter<Record> {
   @Override
   protected long pos(Record record) {
     return (Long) posAccessor().get(record);
+  }
+
+  @Override
+  protected Consumer<Record> deleteMarker() {
+    return record -> record.set(deleteMarkerIndex(), true);
+  }
+
+  @Override
+  protected boolean isDeletedRow(Record record) {
+    return record.get(deleteMarkerIndex(), Boolean.class);
   }
 
   @Override

--- a/data/src/test/java/org/apache/iceberg/data/DeleteReadTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/DeleteReadTests.java
@@ -62,7 +62,7 @@ public abstract class DeleteReadTests {
   private String tableName = null;
   protected Table table = null;
   private List<Record> records = null;
-  private DataFile dataFile = null;
+  protected DataFile dataFile = null;
 
   @Before
   public void writeTestDataFile() throws IOException {

--- a/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDeletesSparkAction.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDeletesSparkAction.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.actions;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.RewriteFiles;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.actions.BaseRewriteDeletesResult;
+import org.apache.iceberg.actions.RewriteDeletes;
+import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.spark.source.EqualityDeleteRewriter;
+import org.apache.iceberg.util.Pair;
+import org.apache.iceberg.util.PropertyUtil;
+import org.apache.iceberg.util.StructLikeWrapper;
+import org.apache.iceberg.util.TableScanUtil;
+import org.apache.iceberg.util.Tasks;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.broadcast.Broadcast;
+import org.apache.spark.sql.SparkSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BaseRewriteDeletesSparkAction
+    extends BaseSnapshotUpdateSparkAction<RewriteDeletes, RewriteDeletes.Result>
+    implements RewriteDeletes {
+  private static final Logger LOG = LoggerFactory.getLogger(BaseRewriteDeletesSparkAction.class);
+  private final Table table;
+  private final JavaSparkContext sparkContext;
+  private final FileIO fileIO;
+  private final boolean caseSensitive;
+  private final PartitionSpec spec;
+  private final long targetSizeInBytes;
+  private final int splitLookback;
+  private final long splitOpenFileCost;
+  private boolean isRewriteEqDelete;
+  private boolean isRewritePosDelete;
+
+  protected BaseRewriteDeletesSparkAction(SparkSession spark, Table table) {
+    super(spark);
+    this.table = table;
+    this.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
+    this.fileIO = table.io();
+    this.caseSensitive = false;
+    this.spec = table.spec();
+
+    long splitSize = PropertyUtil.propertyAsLong(
+        table.properties(),
+        TableProperties.SPLIT_SIZE,
+        TableProperties.SPLIT_SIZE_DEFAULT);
+    long targetFileSize = PropertyUtil.propertyAsLong(
+        table.properties(),
+        TableProperties.WRITE_TARGET_FILE_SIZE_BYTES,
+        TableProperties.WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT);
+    this.targetSizeInBytes = Math.min(splitSize, targetFileSize);
+
+    this.splitLookback = PropertyUtil.propertyAsInt(
+        table.properties(),
+        TableProperties.SPLIT_LOOKBACK,
+        TableProperties.SPLIT_LOOKBACK_DEFAULT);
+    this.splitOpenFileCost = PropertyUtil.propertyAsLong(
+        table.properties(),
+        TableProperties.SPLIT_OPEN_FILE_COST,
+        TableProperties.SPLIT_OPEN_FILE_COST_DEFAULT);
+  }
+
+  @Override
+  public Result execute() {
+    CloseableIterable<FileScanTask> fileScanTasks = null;
+    try {
+      fileScanTasks = table.newScan()
+          .caseSensitive(caseSensitive)
+          .ignoreResiduals()
+          .planFiles();
+    } finally {
+      try {
+        if (fileScanTasks != null) {
+          fileScanTasks.close();
+        }
+      } catch (IOException ioe) {
+        LOG.warn("Failed to close task iterable", ioe);
+      }
+    }
+    if (!isRewriteEqDelete) {
+      LOG.warn("Only supports rewrite equality deletes currently");
+      return new BaseRewriteDeletesResult(Collections.emptySet(), Collections.emptySet());
+    }
+
+    CloseableIterable<FileScanTask> tasksWithEqDelete = CloseableIterable.filter(fileScanTasks, scan ->
+        scan.deletes().stream().anyMatch(delete -> delete.content().equals(FileContent.EQUALITY_DELETES))
+    );
+
+    Set<DeleteFile> eqDeletes = Sets.newHashSet();
+    tasksWithEqDelete.forEach(task -> {
+      eqDeletes.addAll(task.deletes().stream()
+          .filter(deleteFile -> deleteFile.content().equals(FileContent.EQUALITY_DELETES))
+          .collect(Collectors.toList()));
+    });
+
+    Map<StructLikeWrapper, Collection<FileScanTask>> groupedTasks =
+        TableScanUtil.groupTasksByPartition(spec, tasksWithEqDelete.iterator());
+
+    // Split and combine tasks under each partition
+    List<Pair<StructLike, CombinedScanTask>> combinedScanTasks = groupedTasks.entrySet().stream()
+        .map(entry -> {
+          CloseableIterable<FileScanTask> splitTasks = TableScanUtil.splitFiles(
+              CloseableIterable.withNoopClose(entry.getValue()), targetSizeInBytes);
+          return Pair.of(entry.getKey().get(),
+              TableScanUtil.planTasks(splitTasks, targetSizeInBytes, splitLookback, splitOpenFileCost));
+        })
+        .flatMap(pair -> StreamSupport.stream(CloseableIterable
+            .transform(pair.second(), task -> Pair.of(pair.first(), task)).spliterator(), false)
+        )
+        .collect(Collectors.toList());
+
+    if (!combinedScanTasks.isEmpty()) {
+      JavaRDD<Pair<StructLike, CombinedScanTask>> taskRDD = sparkContext.parallelize(combinedScanTasks,
+          combinedScanTasks.size());
+      Broadcast<FileIO> io = sparkContext.broadcast(table.io());
+      Broadcast<EncryptionManager> encryption = sparkContext.broadcast(table.encryption());
+
+      EqualityDeleteRewriter deleteRewriter = new EqualityDeleteRewriter(table, caseSensitive, io, encryption);
+      List<DeleteFile> posDeletes = deleteRewriter.toPosDeletes(taskRDD);
+
+      if (!eqDeletes.isEmpty()) {
+        rewriteEqualityDeletes(Lists.newArrayList(eqDeletes), posDeletes);
+        return new BaseRewriteDeletesResult(eqDeletes, Sets.newHashSet(posDeletes));
+      }
+    }
+
+    return new BaseRewriteDeletesResult(Collections.emptySet(), Collections.emptySet());
+  }
+
+  @Override
+  public RewriteDeletes rewriteEqDeletes() {
+    this.isRewriteEqDelete = true;
+    return this;
+  }
+
+  @Override
+  public RewriteDeletes rewritePosDeletes() {
+    this.isRewritePosDelete = true;
+    return null;
+  }
+
+  @Override
+  protected RewriteDeletes self() {
+    return this;
+  }
+
+  private void rewriteEqualityDeletes(List<DeleteFile> eqDeletes, List<DeleteFile> posDeletes) {
+    Preconditions.checkArgument(eqDeletes.stream().allMatch(f -> f.content().equals(FileContent.EQUALITY_DELETES)),
+        "The deletes to be converted should be equality deletes");
+    Preconditions.checkArgument(posDeletes.stream().allMatch(f -> f.content().equals(FileContent.POSITION_DELETES)),
+        "The converted deletes should be position deletes");
+    try {
+      RewriteFiles rewriteFiles = table.newRewrite();
+      rewriteFiles.rewriteFiles(ImmutableSet.of(), Sets.newHashSet(eqDeletes), ImmutableSet.of(),
+          Sets.newHashSet(posDeletes));
+      rewriteFiles.commit();
+    } catch (Exception e) {
+      Tasks.foreach(Iterables.transform(posDeletes, f -> f.path().toString()))
+          .noRetry()
+          .suppressFailureWhenFinished()
+          .onFailure((location, exc) -> LOG.warn("Failed to delete: {}", location, exc))
+          .run(fileIO::deleteFile);
+      throw e;
+    }
+  }
+}

--- a/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDeletesSparkAction.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDeletesSparkAction.java
@@ -19,42 +19,21 @@
 
 package org.apache.iceberg.spark.actions;
 
-import java.io.IOException;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
-import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileContent;
-import org.apache.iceberg.FileScanTask;
-import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RewriteFiles;
-import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.actions.BaseRewriteDeletesResult;
+import org.apache.iceberg.actions.RewriteDeleteStrategy;
 import org.apache.iceberg.actions.RewriteDeletes;
-import org.apache.iceberg.encryption.EncryptionManager;
-import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.apache.iceberg.spark.source.EqualityDeleteRewriter;
-import org.apache.iceberg.util.Pair;
-import org.apache.iceberg.util.PropertyUtil;
-import org.apache.iceberg.util.StructLikeWrapper;
-import org.apache.iceberg.util.TableScanUtil;
 import org.apache.iceberg.util.Tasks;
-import org.apache.spark.api.java.JavaRDD;
-import org.apache.spark.api.java.JavaSparkContext;
-import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.sql.SparkSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,106 +43,26 @@ public class BaseRewriteDeletesSparkAction
     implements RewriteDeletes {
   private static final Logger LOG = LoggerFactory.getLogger(BaseRewriteDeletesSparkAction.class);
   private final Table table;
-  private final JavaSparkContext sparkContext;
   private final FileIO fileIO;
-  private final boolean caseSensitive;
-  private final PartitionSpec spec;
-  private final long targetSizeInBytes;
-  private final int splitLookback;
-  private final long splitOpenFileCost;
   private boolean isRewriteEqDelete;
   private boolean isRewritePosDelete;
+  private RewriteDeleteStrategy strategy;
 
   protected BaseRewriteDeletesSparkAction(SparkSession spark, Table table) {
     super(spark);
     this.table = table;
-    this.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
     this.fileIO = table.io();
-    this.caseSensitive = false;
-    this.spec = table.spec();
-
-    long splitSize = PropertyUtil.propertyAsLong(
-        table.properties(),
-        TableProperties.SPLIT_SIZE,
-        TableProperties.SPLIT_SIZE_DEFAULT);
-    long targetFileSize = PropertyUtil.propertyAsLong(
-        table.properties(),
-        TableProperties.WRITE_TARGET_FILE_SIZE_BYTES,
-        TableProperties.WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT);
-    this.targetSizeInBytes = Math.min(splitSize, targetFileSize);
-
-    this.splitLookback = PropertyUtil.propertyAsInt(
-        table.properties(),
-        TableProperties.SPLIT_LOOKBACK,
-        TableProperties.SPLIT_LOOKBACK_DEFAULT);
-    this.splitOpenFileCost = PropertyUtil.propertyAsLong(
-        table.properties(),
-        TableProperties.SPLIT_OPEN_FILE_COST,
-        TableProperties.SPLIT_OPEN_FILE_COST_DEFAULT);
+    this.strategy = new ConvertEqDeletesStrategy(spark, table);
   }
 
   @Override
   public Result execute() {
-    CloseableIterable<FileScanTask> fileScanTasks = null;
-    try {
-      fileScanTasks = table.newScan()
-          .caseSensitive(caseSensitive)
-          .ignoreResiduals()
-          .planFiles();
-    } finally {
-      try {
-        if (fileScanTasks != null) {
-          fileScanTasks.close();
-        }
-      } catch (IOException ioe) {
-        LOG.warn("Failed to close task iterable", ioe);
-      }
-    }
-    if (!isRewriteEqDelete) {
-      LOG.warn("Only supports rewrite equality deletes currently");
-      return new BaseRewriteDeletesResult(Collections.emptySet(), Collections.emptySet());
-    }
+    if (isRewriteEqDelete) {
+      Iterable<DeleteFile> deletesToReplace = strategy.selectDeletes();
+      Iterable<DeleteFile> deletesToAdd = strategy.rewriteDeletes();
+      rewriteEqualityDeletes(Sets.newHashSet(deletesToReplace), Sets.newHashSet(deletesToAdd));
 
-    CloseableIterable<FileScanTask> tasksWithEqDelete = CloseableIterable.filter(fileScanTasks, scan ->
-        scan.deletes().stream().anyMatch(delete -> delete.content().equals(FileContent.EQUALITY_DELETES))
-    );
-
-    Set<DeleteFile> eqDeletes = Sets.newHashSet();
-    tasksWithEqDelete.forEach(task -> {
-      eqDeletes.addAll(task.deletes().stream()
-          .filter(deleteFile -> deleteFile.content().equals(FileContent.EQUALITY_DELETES))
-          .collect(Collectors.toList()));
-    });
-
-    Map<StructLikeWrapper, Collection<FileScanTask>> groupedTasks =
-        TableScanUtil.groupTasksByPartition(spec, tasksWithEqDelete.iterator());
-
-    // Split and combine tasks under each partition
-    List<Pair<StructLike, CombinedScanTask>> combinedScanTasks = groupedTasks.entrySet().stream()
-        .map(entry -> {
-          CloseableIterable<FileScanTask> splitTasks = TableScanUtil.splitFiles(
-              CloseableIterable.withNoopClose(entry.getValue()), targetSizeInBytes);
-          return Pair.of(entry.getKey().get(),
-              TableScanUtil.planTasks(splitTasks, targetSizeInBytes, splitLookback, splitOpenFileCost));
-        })
-        .flatMap(pair -> StreamSupport.stream(CloseableIterable
-            .transform(pair.second(), task -> Pair.of(pair.first(), task)).spliterator(), false)
-        )
-        .collect(Collectors.toList());
-
-    if (!combinedScanTasks.isEmpty()) {
-      JavaRDD<Pair<StructLike, CombinedScanTask>> taskRDD = sparkContext.parallelize(combinedScanTasks,
-          combinedScanTasks.size());
-      Broadcast<FileIO> io = sparkContext.broadcast(table.io());
-      Broadcast<EncryptionManager> encryption = sparkContext.broadcast(table.encryption());
-
-      EqualityDeleteRewriter deleteRewriter = new EqualityDeleteRewriter(table, caseSensitive, io, encryption);
-      List<DeleteFile> posDeletes = deleteRewriter.toPosDeletes(taskRDD);
-
-      if (!eqDeletes.isEmpty()) {
-        rewriteEqualityDeletes(Lists.newArrayList(eqDeletes), posDeletes);
-        return new BaseRewriteDeletesResult(eqDeletes, Sets.newHashSet(posDeletes));
-      }
+      return new BaseRewriteDeletesResult(Sets.newHashSet(deletesToReplace), Sets.newHashSet(deletesToAdd));
     }
 
     return new BaseRewriteDeletesResult(Collections.emptySet(), Collections.emptySet());
@@ -186,7 +85,7 @@ public class BaseRewriteDeletesSparkAction
     return this;
   }
 
-  private void rewriteEqualityDeletes(List<DeleteFile> eqDeletes, List<DeleteFile> posDeletes) {
+  private void rewriteEqualityDeletes(Set<DeleteFile> eqDeletes, Set<DeleteFile> posDeletes) {
     Preconditions.checkArgument(eqDeletes.stream().allMatch(f -> f.content().equals(FileContent.EQUALITY_DELETES)),
         "The deletes to be converted should be equality deletes");
     Preconditions.checkArgument(posDeletes.stream().allMatch(f -> f.content().equals(FileContent.POSITION_DELETES)),

--- a/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDeletesSparkAction.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDeletesSparkAction.java
@@ -55,6 +55,15 @@ public class BaseRewriteDeletesSparkAction
     this.strategy = new ConvertEqDeletesStrategy(spark, table);
   }
 
+  /**
+   * Set the rewrite delete strategy.
+   *
+   * @param newStrategy the strategy for rewrite deletes.
+   */
+  public void setStrategy(RewriteDeleteStrategy newStrategy) {
+    this.strategy = newStrategy;
+  }
+
   @Override
   public Result execute() {
     if (isRewriteEqDelete) {

--- a/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDeletesSparkAction.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDeletesSparkAction.java
@@ -19,20 +19,30 @@
 
 package org.apache.iceberg.spark.actions;
 
+import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.RewriteFiles;
+import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.BaseRewriteDeletesResult;
 import org.apache.iceberg.actions.RewriteDeleteStrategy;
 import org.apache.iceberg.actions.RewriteDeletes;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.util.Tasks;
 import org.apache.spark.sql.SparkSession;
 import org.slf4j.Logger;
@@ -67,7 +77,7 @@ public class BaseRewriteDeletesSparkAction
   @Override
   public Result execute() {
     if (isRewriteEqDelete) {
-      Iterable<DeleteFile> deletesToReplace = strategy.selectDeletes();
+      planFileGroups();
       Iterable<DeleteFile> deletesToAdd = strategy.rewriteDeletes();
       rewriteEqualityDeletes(Sets.newHashSet(deletesToReplace), Sets.newHashSet(deletesToAdd));
 
@@ -92,6 +102,36 @@ public class BaseRewriteDeletesSparkAction
   @Override
   protected RewriteDeletes self() {
     return this;
+  }
+
+  private Map<StructLike, List<List<FileScanTask>>> planFileGroups() {
+    CloseableIterable<FileScanTask> fileScanTasks = table.newScan()
+        .ignoreResiduals()
+        .planFiles();
+
+    try {
+      Map<StructLike, List<FileScanTask>> filesByPartition = Streams.stream(fileScanTasks)
+          .collect(Collectors.groupingBy(task -> task.file().partition()));
+
+      Map<StructLike, List<List<FileScanTask>>> fileGroupsByPartition = Maps.newHashMap();
+
+      filesByPartition.forEach((partition, tasks) -> {
+        Iterable<DeleteFile> filtered = strategy.selectDeletesToRewrite(tasks);
+        Iterable<List<FileScanTask>> groupedTasks = strategy.planDeleteGroups(filtered);
+        List<List<FileScanTask>> fileGroups = ImmutableList.copyOf(groupedTasks);
+        if (fileGroups.size() > 0) {
+          fileGroupsByPartition.put(partition, fileGroups);
+        }
+      });
+
+      return fileGroupsByPartition;
+    } finally {
+      try {
+        fileScanTasks.close();
+      } catch (IOException io) {
+        LOG.error("Cannot properly close file iterable while planning for rewrite", io);
+      }
+    }
   }
 
   private void rewriteEqualityDeletes(Set<DeleteFile> eqDeletes, Set<DeleteFile> posDeletes) {

--- a/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkActions.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkActions.java
@@ -24,6 +24,7 @@ import org.apache.iceberg.actions.ActionsProvider;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
 import org.apache.iceberg.actions.DeleteReachableFiles;
 import org.apache.iceberg.actions.ExpireSnapshots;
+import org.apache.iceberg.actions.RewriteDeletes;
 import org.apache.iceberg.actions.RewriteManifests;
 import org.apache.spark.sql.SparkSession;
 
@@ -57,5 +58,10 @@ abstract class BaseSparkActions implements ActionsProvider {
   @Override
   public DeleteReachableFiles deleteReachableFiles(String metadataLocation) {
     return new BaseDeleteReachableFilesSparkAction(spark, metadataLocation);
+  }
+
+  @Override
+  public RewriteDeletes rewriteDeletes(Table table) {
+    return new BaseRewriteDeletesSparkAction(spark, table);
   }
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/actions/ConvertEqDeletesStrategy.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/actions/ConvertEqDeletesStrategy.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.actions;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.actions.RewriteDeleteStrategy;
+import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.spark.source.EqualityDeleteRewriter;
+import org.apache.iceberg.util.Pair;
+import org.apache.iceberg.util.PropertyUtil;
+import org.apache.iceberg.util.StructLikeWrapper;
+import org.apache.iceberg.util.TableScanUtil;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.broadcast.Broadcast;
+import org.apache.spark.sql.SparkSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConvertEqDeletesStrategy implements RewriteDeleteStrategy {
+  private static final Logger LOG = LoggerFactory.getLogger(ConvertEqDeletesStrategy.class);
+
+  private final Table table;
+  private final long targetSizeInBytes;
+  private final int splitLookback;
+  private final long splitOpenFileCost;
+
+  private CloseableIterable<FileScanTask> tasksWithEqDelete;
+  private Iterable<DeleteFile> deletesToReplace;
+  private final JavaSparkContext sparkContext;
+
+  public ConvertEqDeletesStrategy(SparkSession spark, Table table) {
+    this.table = table;
+    this.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
+    this.targetSizeInBytes = PropertyUtil.propertyAsLong(
+        table.properties(),
+        TableProperties.WRITE_TARGET_FILE_SIZE_BYTES,
+        TableProperties.WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT);
+    this.splitLookback = PropertyUtil.propertyAsInt(
+        table.properties(),
+        TableProperties.SPLIT_LOOKBACK,
+        TableProperties.SPLIT_LOOKBACK_DEFAULT);
+    this.splitOpenFileCost = PropertyUtil.propertyAsLong(
+        table.properties(),
+        TableProperties.SPLIT_OPEN_FILE_COST,
+        TableProperties.SPLIT_OPEN_FILE_COST_DEFAULT);
+  }
+
+  @Override
+  public String name() {
+    return "CONVERT-EQUALITY-DELETES";
+  }
+
+  @Override
+  public Table table() {
+    return table;
+  }
+
+  @Override
+  public Iterable<DeleteFile> selectDeletes() {
+    CloseableIterable<FileScanTask> fileScanTasks = null;
+    try {
+      fileScanTasks = table.newScan()
+          .ignoreResiduals()
+          .planFiles();
+    } finally {
+      try {
+        if (fileScanTasks != null) {
+          fileScanTasks.close();
+        }
+      } catch (IOException ioe) {
+        LOG.warn("Failed to close task iterable", ioe);
+      }
+    }
+
+    tasksWithEqDelete = CloseableIterable.filter(fileScanTasks, scan ->
+        scan.deletes().stream().anyMatch(delete -> delete.content().equals(FileContent.EQUALITY_DELETES))
+    );
+
+    Set<DeleteFile> eqDeletes = Sets.newHashSet();
+    tasksWithEqDelete.forEach(task -> {
+      eqDeletes.addAll(task.deletes().stream()
+          .filter(deleteFile -> deleteFile.content().equals(FileContent.EQUALITY_DELETES))
+          .collect(Collectors.toList()));
+    });
+
+    deletesToReplace = eqDeletes;
+
+    return deletesToReplace;
+  }
+
+  @Override
+  public Iterable<DeleteFile> rewriteDeletes() {
+    Map<StructLikeWrapper, Collection<FileScanTask>> groupedTasks =
+        TableScanUtil.groupTasksByPartition(table.spec(), tasksWithEqDelete.iterator());
+
+    // Split and combine tasks under each partition
+    List<Pair<StructLike, CombinedScanTask>> combinedScanTasks = groupedTasks.entrySet().stream()
+        .map(entry -> {
+          CloseableIterable<FileScanTask> splitTasks = TableScanUtil.splitFiles(
+              CloseableIterable.withNoopClose(entry.getValue()), targetSizeInBytes);
+          return Pair.of(entry.getKey().get(),
+              TableScanUtil.planTasks(splitTasks, targetSizeInBytes, splitLookback, splitOpenFileCost));
+        })
+        .flatMap(pair -> StreamSupport.stream(CloseableIterable
+            .transform(pair.second(), task -> Pair.of(pair.first(), task)).spliterator(), false)
+        )
+        .collect(Collectors.toList());
+
+    if (!combinedScanTasks.isEmpty()) {
+      JavaRDD<Pair<StructLike, CombinedScanTask>> taskRDD = sparkContext.parallelize(combinedScanTasks,
+          combinedScanTasks.size());
+      Broadcast<FileIO> io = sparkContext.broadcast(table.io());
+      Broadcast<EncryptionManager> encryption = sparkContext.broadcast(table.encryption());
+
+      EqualityDeleteRewriter deleteRewriter = new EqualityDeleteRewriter(table, true, io, encryption);
+
+      return deleteRewriter.toPosDeletes(taskRDD);
+    }
+
+    return Lists.newArrayList();
+  }
+
+  public RewriteDeleteStrategy options(Map<String, String> options) {
+    return null;
+  }
+
+  public Set<String> validOptions() {
+    return null;
+  }
+}

--- a/spark/src/main/java/org/apache/iceberg/spark/source/DeleteRowReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/DeleteRowReader.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.spark.source;
 import java.util.Map;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -30,12 +31,15 @@ import org.apache.iceberg.util.PartitionUtil;
 import org.apache.spark.rdd.InputFileBlockHolder;
 import org.apache.spark.sql.catalyst.InternalRow;
 
-public class EqualityDeleteRowReader extends RowDataReader {
+public class DeleteRowReader extends RowDataReader {
   private final Schema expectedSchema;
+  private final FileContent deleteSelector;
 
-  public EqualityDeleteRowReader(CombinedScanTask task, Table table, Schema expectedSchema, boolean caseSensitive) {
-    super(task, table, table.schema(), caseSensitive);
+  public DeleteRowReader(CombinedScanTask task, Table table, Schema expectedSchema,
+                         boolean caseSensitive, FileContent deleteContent) {
+    super(task, table, expectedSchema, caseSensitive);
     this.expectedSchema = expectedSchema;
+    this.deleteSelector = deleteContent;
   }
 
   @Override
@@ -50,6 +54,12 @@ public class EqualityDeleteRowReader extends RowDataReader {
     // update the current file for Spark's filename() function
     InputFileBlockHolder.set(file.path().toString(), task.start(), task.length());
 
-    return matches.findEqualityDeleteRows(open(task, requiredSchema, idToConstant)).iterator();
+    if (deleteSelector == null) {
+      return matches.keepRowsFromDeletes(open(task, requiredSchema, idToConstant)).iterator();
+    } else if (deleteSelector.equals(FileContent.EQUALITY_DELETES)) {
+      return matches.keepRowsFromEqualityDeletes(open(task, requiredSchema, idToConstant)).iterator();
+    } else {
+      return matches.keepRowsFromPosDeletes(open(task, requiredSchema, idToConstant)).iterator();
+    }
   }
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/source/EqualityDeleteRewriter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/EqualityDeleteRewriter.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.LocationProvider;
+import org.apache.iceberg.io.OutputFileFactory;
+import org.apache.iceberg.io.SortedPosDeleteWriter;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.util.Pair;
+import org.apache.iceberg.util.Tasks;
+import org.apache.spark.TaskContext;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.broadcast.Broadcast;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.StructType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class EqualityDeleteRewriter implements Serializable {
+  private static final Logger LOG = LoggerFactory.getLogger(EqualityDeleteRewriter.class);
+  private final PartitionSpec spec;
+  private final Schema schema;
+  private final Broadcast<FileIO> io;
+  private final Broadcast<EncryptionManager> encryptionManager;
+  private final LocationProvider locations;
+  private final boolean caseSensitive;
+  private final FileFormat format;
+  private final Table table;
+
+
+  public EqualityDeleteRewriter(Table table, boolean caseSensitive,
+                                Broadcast<FileIO> io, Broadcast<EncryptionManager> encryptionManager) {
+    this.table = table;
+    this.spec = table.spec();
+    this.schema = table.schema();
+    this.io = io;
+    this.encryptionManager = encryptionManager;
+    this.locations = table.locationProvider();
+    this.caseSensitive = caseSensitive;
+    String formatString = table.properties().getOrDefault(
+        TableProperties.DEFAULT_FILE_FORMAT, TableProperties.DEFAULT_FILE_FORMAT_DEFAULT);
+    this.format = FileFormat.valueOf(formatString.toUpperCase(Locale.ENGLISH));
+  }
+
+  public List<DeleteFile> toPosDeletes(JavaRDD<Pair<StructLike, CombinedScanTask>> taskRDD) {
+    JavaRDD<List<DeleteFile>> dataFilesRDD = taskRDD.map(this::toPosDeletes);
+
+    return dataFilesRDD.collect().stream()
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
+  }
+
+  public List<DeleteFile> toPosDeletes(Pair<StructLike, CombinedScanTask> task) throws Exception {
+    TaskContext context = TaskContext.get();
+    int partitionId = context.partitionId();
+    long taskId = context.taskAttemptId();
+
+    Schema metaSchema = new Schema(MetadataColumns.FILE_PATH, MetadataColumns.ROW_POSITION);
+    Schema expectedSchema = TypeUtil.join(metaSchema, schema);
+
+    DeleteRowReader deleteRowReader = new DeleteRowReader(task.second(), table, expectedSchema, caseSensitive,
+        FileContent.EQUALITY_DELETES);
+
+    StructType structType = SparkSchemaUtil.convert(schema);
+    SparkAppenderFactory appenderFactory = SparkAppenderFactory.builderFor(table, schema, structType)
+        .spec(spec)
+        .build();
+
+    OutputFileFactory fileFactory = new OutputFileFactory(
+        spec, format, locations, io.value(), encryptionManager.value(), partitionId, taskId);
+
+    SortedPosDeleteWriter<InternalRow> posDeleteWriter =
+        new SortedPosDeleteWriter<>(appenderFactory, fileFactory, format, task.first());
+
+    try {
+      while (deleteRowReader.next()) {
+        InternalRow row = deleteRowReader.get();
+        posDeleteWriter.delete(row.getString(0), row.getLong(1));
+      }
+
+      deleteRowReader.close();
+      deleteRowReader = null;
+
+      return Lists.newArrayList(posDeleteWriter.complete());
+
+    } catch (Throwable originalThrowable) {
+      try {
+        LOG.error("Aborting task", originalThrowable);
+        context.markTaskFailed(originalThrowable);
+
+        LOG.error("Aborting commit for partition {} (task {}, attempt {}, stage {}.{})",
+            partitionId, taskId, context.attemptNumber(), context.stageId(), context.stageAttemptNumber());
+        if (deleteRowReader != null) {
+          deleteRowReader.close();
+        }
+
+        // clean up files created by this writer
+        Tasks.foreach(Iterables.concat(posDeleteWriter.complete()))
+            .throwFailureWhenFinished()
+            .noRetry()
+            .run(file -> io.value().deleteFile(file.path().toString()));
+
+        LOG.error("Aborted commit for partition {} (task {}, attempt {}, stage {}.{})",
+            partitionId, taskId, context.taskAttemptId(), context.stageId(), context.stageAttemptNumber());
+
+      } catch (Throwable inner) {
+        if (originalThrowable != inner) {
+          originalThrowable.addSuppressed(inner);
+          LOG.warn("Suppressing exception in catch: {}", inner.getMessage(), inner);
+        }
+      }
+
+      if (originalThrowable instanceof Exception) {
+        throw originalThrowable;
+      } else {
+        throw new RuntimeException(originalThrowable);
+      }
+    }
+  }
+}

--- a/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.spark.source;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataTask;
@@ -221,6 +222,16 @@ class RowDataReader extends BaseDataReader<InternalRow> {
     SparkDeleteFilter(FileScanTask task, Schema tableSchema, Schema requestedSchema) {
       super(task, tableSchema, requestedSchema);
       this.asStructLike = new InternalRowWrapper(SparkSchemaUtil.convert(requiredSchema()));
+    }
+
+    @Override
+    protected Consumer<InternalRow> deleteMarker() {
+      return record -> record.setBoolean(deleteMarkerIndex(), true);
+    }
+
+    @Override
+    protected boolean isDeletedRow(InternalRow row) {
+      return row.getBoolean(deleteMarkerIndex());
     }
 
     @Override

--- a/spark/src/test/java/org/apache/iceberg/actions/TestRewriteDeletesAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestRewriteDeletesAction.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
@@ -106,9 +107,10 @@ public abstract class TestRewriteDeletesAction extends SparkTestBase {
     writeRecords(records2);
     table.refresh();
 
-    RewriteDeletes.Result result = actionsProvider().rewriteDeletes(table).rewriteEqDeletes().execute();
-    Assert.assertTrue("Shouldn't contain equality deletes", result.deletedFiles().isEmpty());
-    Assert.assertTrue("Shouldn't generate position deletes", result.addedFiles().isEmpty());
+    AssertHelpers.assertThrows("should fail execute",
+        IllegalArgumentException.class, "Files to delete cannot be null or empty",
+        () -> actionsProvider().rewriteDeletes(table).rewriteEqDeletes().execute()
+    );
 
     List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
     expectedRecords.addAll(records1);
@@ -170,9 +172,10 @@ public abstract class TestRewriteDeletesAction extends SparkTestBase {
 
     table.newRowDelta().addDeletes(eqDeleteWriter.toDeleteFile()).commit();
 
-    RewriteDeletes.Result result = actionsProvider().rewriteDeletes(table).rewriteEqDeletes().execute();
-    Assert.assertTrue("Shouldn't contain equality deletes", result.deletedFiles().isEmpty());
-    Assert.assertTrue("Shouldn't generate position deletes", result.addedFiles().isEmpty());
+    AssertHelpers.assertThrows("should fail execute",
+        IllegalArgumentException.class, "Files to delete cannot be null or empty",
+        () -> actionsProvider().rewriteDeletes(table).rewriteEqDeletes().execute()
+    );
 
     List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
     expectedRecords.addAll(records1);

--- a/spark/src/test/java/org/apache/iceberg/actions/TestRewriteDeletesAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestRewriteDeletesAction.java
@@ -1,0 +1,448 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.actions;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionKey;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.data.GenericAppenderFactory;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.deletes.EqualityDeleteWriter;
+import org.apache.iceberg.deletes.PositionDeleteWriter;
+import org.apache.iceberg.encryption.EncryptedOutputFile;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.OutputFileFactory;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.spark.SparkTestBase;
+import org.apache.iceberg.spark.source.ThreeColumnRecord;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ArrayUtil;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+
+public abstract class TestRewriteDeletesAction extends SparkTestBase {
+  private static final HadoopTables TABLES = new HadoopTables(new Configuration());
+  private static final Schema SCHEMA = new Schema(
+      optional(1, "c1", Types.IntegerType.get()),
+      optional(2, "c2", Types.StringType.get()),
+      optional(3, "c3", Types.StringType.get())
+  );
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  private String tableLocation = null;
+
+  @Before
+  public void setupTableLocation() throws Exception {
+    File tableDir = temp.newFolder();
+    this.tableLocation = tableDir.toURI().toString();
+  }
+
+  public abstract ActionsProvider actionsProvider();
+
+  @Test
+  public void testRewriteDeletesWithNoEqDeletes() {
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA)
+        .identity("c1")
+        .build();
+    Map<String, String> options = Maps.newHashMap();
+    BaseTable table = (BaseTable) TABLES.create(SCHEMA, spec, options, tableLocation);
+    TableOperations ops = table.operations();
+    ops.commit(ops.current(), ops.current().upgradeToFormatVersion(2));
+
+    List<ThreeColumnRecord> records1 = Lists.newArrayList(
+        new ThreeColumnRecord(1, null, "AAAA"),
+        new ThreeColumnRecord(1, "BBBBBBBBBB", "BBBB")
+    );
+    writeRecords(records1);
+
+    List<ThreeColumnRecord> records2 = Lists.newArrayList(
+        new ThreeColumnRecord(2, "CCCCCCCCCC", "CCCC"),
+        new ThreeColumnRecord(2, "DDDDDDDDDD", "DDDD")
+    );
+    writeRecords(records2);
+    table.refresh();
+
+    RewriteDeletes.Result result = actionsProvider().rewriteDeletes(table).rewriteEqDeletes().execute();
+    Assert.assertTrue("Shouldn't contain equality deletes", result.deletedFiles().isEmpty());
+    Assert.assertTrue("Shouldn't generate position deletes", result.addedFiles().isEmpty());
+
+    List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
+    expectedRecords.addAll(records1);
+    expectedRecords.addAll(records2);
+
+    Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
+    List<ThreeColumnRecord> actualRecords = resultDF.sort("c1", "c2")
+        .as(Encoders.bean(ThreeColumnRecord.class))
+        .collectAsList();
+
+    Assert.assertEquals("Rows must match", expectedRecords, actualRecords);
+  }
+
+  @Test
+  public void testRewriteDeletesWithEqDeletesNoMatch() throws IOException {
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA)
+        .identity("c1")
+        .build();
+    Map<String, String> options = Maps.newHashMap();
+    BaseTable table = (BaseTable) TABLES.create(SCHEMA, spec, options, tableLocation);
+    TableOperations ops = table.operations();
+    ops.commit(ops.current(), ops.current().upgradeToFormatVersion(2));
+
+    List<ThreeColumnRecord> records1 = Lists.newArrayList(
+        new ThreeColumnRecord(1, null, "AAAA"),
+        new ThreeColumnRecord(1, "BBBBBBBBBB", "BBBB")
+    );
+    writeRecords(records1);
+
+    List<ThreeColumnRecord> records2 = Lists.newArrayList(
+        new ThreeColumnRecord(2, "CCCCCCCCCC", "CCCC"),
+        new ThreeColumnRecord(2, "DDDDDDDDDD", "DDDD")
+    );
+    writeRecords(records2);
+    table.refresh();
+
+    OutputFileFactory fileFactory = new OutputFileFactory(table.spec(), FileFormat.PARQUET, table.locationProvider(),
+        table.io(), table.encryption(), 1, 1);
+
+    List<Integer> equalityFieldIds = Lists.newArrayList(table.schema().findField("c3").fieldId());
+    Schema eqDeleteRowSchema = table.schema().select("c3");
+    GenericAppenderFactory appenderFactory = new GenericAppenderFactory(table.schema(), table.spec(),
+        ArrayUtil.toIntArray(equalityFieldIds),
+        eqDeleteRowSchema, null);
+
+    Record partitionRecord = GenericRecord.create(table.schema().select("c1"))
+        .copy(ImmutableMap.of("c1", 1));
+
+    Record record = GenericRecord.create(eqDeleteRowSchema).copy(ImmutableMap.of("c3", "AA"));
+
+    EqualityDeleteWriter<Record> eqDeleteWriter = appenderFactory.newEqDeleteWriter(
+        createEncryptedOutputFile(createPartitionKey(table, partitionRecord),  fileFactory),
+        FileFormat.PARQUET,
+        createPartitionKey(table, partitionRecord));
+
+    try (EqualityDeleteWriter<Record> closeableWriter = eqDeleteWriter) {
+      closeableWriter.delete(record);
+    }
+
+    table.newRowDelta().addDeletes(eqDeleteWriter.toDeleteFile()).commit();
+
+    RewriteDeletes.Result result = actionsProvider().rewriteDeletes(table).rewriteEqDeletes().execute();
+    Assert.assertTrue("Shouldn't contain equality deletes", result.deletedFiles().isEmpty());
+    Assert.assertTrue("Shouldn't generate position deletes", result.addedFiles().isEmpty());
+
+    List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
+    expectedRecords.addAll(records1);
+    expectedRecords.addAll(records2);
+
+    Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
+    List<ThreeColumnRecord> actualRecords = resultDF.sort("c1", "c2")
+        .as(Encoders.bean(ThreeColumnRecord.class))
+        .collectAsList();
+
+    Assert.assertEquals("Rows must match", expectedRecords, actualRecords);
+  }
+
+  @Test
+  public void testRewriteDeletesUnpartitionedTable() throws IOException {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Map<String, String> options = Maps.newHashMap();
+    BaseTable table = (BaseTable) TABLES.create(SCHEMA, spec, options, tableLocation);
+    TableOperations ops = table.operations();
+    ops.commit(ops.current(), ops.current().upgradeToFormatVersion(2));
+
+    List<ThreeColumnRecord> records1 = Lists.newArrayList(
+        new ThreeColumnRecord(1, null, "AAAA"),
+        new ThreeColumnRecord(1, "BBBBBBBBBB", "BBBB")
+    );
+    writeRecords(records1);
+
+    List<ThreeColumnRecord> records2 = Lists.newArrayList(
+        new ThreeColumnRecord(2, "CCCCCCCCCC", "CCCC"),
+        new ThreeColumnRecord(2, "DDDDDDDDDD", "DDDD")
+    );
+    writeRecords(records2);
+
+    table.refresh();
+
+    OutputFileFactory fileFactory = new OutputFileFactory(table.spec(), FileFormat.PARQUET, table.locationProvider(),
+        table.io(), table.encryption(), 1, 1);
+
+    List<Integer> equalityFieldIds = Lists.newArrayList(table.schema().findField("c3").fieldId());
+    Schema eqDeleteRowSchema = table.schema().select("c3");
+    GenericAppenderFactory appenderFactory = new GenericAppenderFactory(table.schema(), table.spec(),
+        ArrayUtil.toIntArray(equalityFieldIds),
+        eqDeleteRowSchema, null);
+
+    Record record = GenericRecord.create(eqDeleteRowSchema).copy(ImmutableMap.of("c3", "AAAA"));
+
+    EqualityDeleteWriter<Record> eqDeleteWriter =  appenderFactory.newEqDeleteWriter(
+        createEncryptedOutputFile(createPartitionKey(table, record),  fileFactory),
+        FileFormat.PARQUET,
+        createPartitionKey(table, record));
+
+    try (EqualityDeleteWriter<Record> closeableWriter = eqDeleteWriter) {
+      closeableWriter.delete(record);
+    }
+
+    table.newRowDelta().addDeletes(eqDeleteWriter.toDeleteFile()).commit();
+
+    actionsProvider().rewriteDeletes(table).rewriteEqDeletes().execute();
+
+    CloseableIterable<FileScanTask> tasks = CloseableIterable.filter(
+        table.newScan().planFiles(), task -> task.deletes().stream()
+            .anyMatch(delete -> delete.content().equals(FileContent.EQUALITY_DELETES))
+    );
+    Assert.assertFalse("Should not contain any equality deletes", tasks.iterator().hasNext());
+
+    List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
+    expectedRecords.add(records1.get(1));
+    expectedRecords.addAll(records2);
+
+    Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
+    List<ThreeColumnRecord> actualRecords = resultDF.sort("c1", "c2")
+        .as(Encoders.bean(ThreeColumnRecord.class))
+        .collectAsList();
+
+    Assert.assertEquals("Rows must match", expectedRecords, actualRecords);
+  }
+
+  @Test
+  public void testRewriteDeletesInPartitionedTable() throws IOException {
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA)
+        .identity("c1")
+        .build();
+    Map<String, String> options = Maps.newHashMap();
+    BaseTable table = (BaseTable) TABLES.create(SCHEMA, spec, options, tableLocation);
+    TableOperations ops = table.operations();
+    ops.commit(ops.current(), ops.current().upgradeToFormatVersion(2));
+
+    List<ThreeColumnRecord> records1 = Lists.newArrayList(
+        new ThreeColumnRecord(1, null, "AAAA"),
+        new ThreeColumnRecord(1, "BBBBBBBBBB", "BBBB")
+    );
+    writeRecords(records1);
+
+    List<ThreeColumnRecord> records2 = Lists.newArrayList(
+        new ThreeColumnRecord(2, "CCCCCCCCCC", "CCCC"),
+        new ThreeColumnRecord(2, "DDDDDDDDDD", "DDDD")
+    );
+    writeRecords(records2);
+    table.refresh();
+
+    OutputFileFactory fileFactory = new OutputFileFactory(table.spec(), FileFormat.PARQUET, table.locationProvider(),
+        table.io(), table.encryption(), 1, 1);
+
+    List<Integer> equalityFieldIds = Lists.newArrayList(table.schema().findField("c3").fieldId());
+    Schema eqDeleteRowSchema = table.schema().select("c3");
+    GenericAppenderFactory appenderFactory = new GenericAppenderFactory(table.schema(), table.spec(),
+        ArrayUtil.toIntArray(equalityFieldIds),
+        eqDeleteRowSchema, null);
+
+    Record partitionRecord = GenericRecord.create(table.schema().select("c1"))
+        .copy(ImmutableMap.of("c1", 1));
+
+    EqualityDeleteWriter<Record> eqDeleteWriter = appenderFactory.newEqDeleteWriter(
+        createEncryptedOutputFile(createPartitionKey(table, partitionRecord),  fileFactory),
+        FileFormat.PARQUET,
+        createPartitionKey(table, partitionRecord));
+
+    Record record = GenericRecord.create(eqDeleteRowSchema).copy(ImmutableMap.of("c3", "AAAA"));
+    try (EqualityDeleteWriter<Record> closeableWriter = eqDeleteWriter) {
+      closeableWriter.delete(record);
+    }
+
+    table.newRowDelta().addDeletes(eqDeleteWriter.toDeleteFile()).commit();
+
+    actionsProvider().rewriteDeletes(table).rewriteEqDeletes().execute();
+
+    CloseableIterable<FileScanTask> tasks = CloseableIterable.filter(
+        table.newScan().planFiles(), task -> task.deletes().stream()
+            .anyMatch(delete -> delete.content().equals(FileContent.EQUALITY_DELETES))
+    );
+    Assert.assertFalse("Should not contain any equality deletes", tasks.iterator().hasNext());
+
+    table.refresh();
+    CloseableIterable<FileScanTask> newTasks = table.newScan().ignoreResiduals().planFiles();
+    List<DeleteFile> deleteFiles = Lists.newArrayList();
+    newTasks.forEach(task -> {
+      deleteFiles.addAll(task.deletes());
+    });
+
+    List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
+    expectedRecords.add(records1.get(1));
+    expectedRecords.addAll(records2);
+
+    Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
+    List<ThreeColumnRecord> actualRecords = resultDF.sort("c1", "c2")
+        .as(Encoders.bean(ThreeColumnRecord.class))
+        .collectAsList();
+
+    Assert.assertEquals("Rows must match", expectedRecords, actualRecords);
+  }
+
+  @Test
+  public void testRewriteDeletesWithDeletes() throws IOException {
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA)
+        .identity("c1")
+        .build();
+    Map<String, String> options = Maps.newHashMap();
+    BaseTable table = (BaseTable) TABLES.create(SCHEMA, spec, options, tableLocation);
+    TableOperations ops = table.operations();
+    ops.commit(ops.current(), ops.current().upgradeToFormatVersion(2));
+
+    List<ThreeColumnRecord> records1 = Lists.newArrayList(
+        new ThreeColumnRecord(1, null, "AAAA"),
+        new ThreeColumnRecord(1, "BBBBBBBBBB", "BBBB")
+    );
+    writeRecords(records1);
+
+    List<ThreeColumnRecord> records2 = Lists.newArrayList(
+        new ThreeColumnRecord(2, "CCCCCCCCCC", "CCCC"),
+        new ThreeColumnRecord(2, "DDDDDDDDDD", "DDDD")
+    );
+    writeRecords(records2);
+
+    List<ThreeColumnRecord> records3 = Lists.newArrayList(
+        new ThreeColumnRecord(3, "EEEEEEEEEE", "EEEE")
+    );
+    writeRecords(records3);
+    table.refresh();
+
+    DataFile fileForPosDelete = table.currentSnapshot().addedFiles().iterator().next();
+
+    OutputFileFactory fileFactory = new OutputFileFactory(table.spec(), FileFormat.PARQUET, table.locationProvider(),
+        table.io(), table.encryption(), 1, 1);
+
+    List<Integer> equalityFieldIds = Lists.newArrayList(table.schema().findField("c3").fieldId());
+    Schema eqDeleteRowSchema = table.schema().select("c3");
+    GenericAppenderFactory appenderFactory = new GenericAppenderFactory(table.schema(), table.spec(),
+        ArrayUtil.toIntArray(equalityFieldIds),
+        eqDeleteRowSchema, null);
+
+    // write equality delete
+    Record partitionRecord = GenericRecord.create(table.schema().select("c1")).copy(ImmutableMap.of("c1", 1));
+    EncryptedOutputFile file = createEncryptedOutputFile(createPartitionKey(table, partitionRecord), fileFactory);
+    EqualityDeleteWriter<Record> eqDeleteWriter = appenderFactory.newEqDeleteWriter(
+        file, FileFormat.PARQUET, createPartitionKey(table, partitionRecord));
+    Record record = GenericRecord.create(eqDeleteRowSchema).copy(ImmutableMap.of("c3", "AAAA"));
+    try (EqualityDeleteWriter<Record> closeableWriter = eqDeleteWriter) {
+      closeableWriter.delete(record);
+    }
+    table.newRowDelta().addDeletes(eqDeleteWriter.toDeleteFile()).commit();
+
+    // write positional delete
+    partitionRecord = partitionRecord.copy(ImmutableMap.of("c1", 3));
+    file = createEncryptedOutputFile(createPartitionKey(table, partitionRecord), fileFactory);
+    PositionDeleteWriter<Record> posDeleteWriter = appenderFactory.newPosDeleteWriter(
+        file, FileFormat.PARQUET, createPartitionKey(table, partitionRecord));
+    posDeleteWriter.delete(fileForPosDelete.path(), 0);
+    posDeleteWriter.close();
+    table.newRowDelta().addDeletes(posDeleteWriter.toDeleteFile()).commit();
+
+    RewriteDeletes.Result result = actionsProvider().rewriteDeletes(table).rewriteEqDeletes().execute();
+    Assert.assertEquals("Should contain one equality delete to delete", 1, result.deletedFiles().size());
+    Assert.assertEquals("Should contain one position delete to add", 1, result.addedFiles().size());
+
+    CloseableIterable<FileScanTask> tasks = CloseableIterable.filter(
+        table.newScan().planFiles(), task -> task.deletes().stream()
+            .anyMatch(delete -> delete.content().equals(FileContent.EQUALITY_DELETES))
+    );
+    Assert.assertFalse("Should not contain any equality deletes", tasks.iterator().hasNext());
+
+    table.refresh();
+    CloseableIterable<FileScanTask> newTasks = table.newScan().ignoreResiduals().planFiles();
+    List<DeleteFile> deleteFiles = Lists.newArrayList();
+    newTasks.forEach(task -> {
+      deleteFiles.addAll(task.deletes());
+    });
+
+    List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
+    expectedRecords.add(records1.get(1));
+    expectedRecords.addAll(records2);
+
+    Dataset<Row> resultDF = spark.read().format("iceberg").load(tableLocation);
+    List<ThreeColumnRecord> actualRecords = resultDF.sort("c1", "c2")
+        .as(Encoders.bean(ThreeColumnRecord.class))
+        .collectAsList();
+
+    Assert.assertEquals("Rows must match", expectedRecords, actualRecords);
+  }
+
+  private void writeRecords(List<ThreeColumnRecord> records) {
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class);
+    writeDF(df);
+  }
+
+  private void writeDF(Dataset<Row> df) {
+    df.select("c1", "c2", "c3")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(tableLocation);
+  }
+
+  private PartitionKey createPartitionKey(Table table, Record record) {
+    if (table.spec().isUnpartitioned()) {
+      return null;
+    }
+
+    PartitionKey partitionKey = new PartitionKey(table.spec(), table.schema());
+    partitionKey.partition(record);
+
+    return partitionKey;
+  }
+
+  private EncryptedOutputFile createEncryptedOutputFile(PartitionKey partition, OutputFileFactory fileFactory) {
+    if (partition == null) {
+      return fileFactory.newOutputFile();
+    } else {
+      return fileFactory.newOutputFile(partition);
+    }
+  }
+
+}
+

--- a/spark/src/test/java/org/apache/iceberg/actions/TestRewriteDeletesAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestRewriteDeletesAction.java
@@ -49,6 +49,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.SparkTestBase;
+import org.apache.iceberg.spark.actions.ConvertEqDeletesStrategy;
 import org.apache.iceberg.spark.source.ThreeColumnRecord;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ArrayUtil;
@@ -109,7 +110,7 @@ public abstract class TestRewriteDeletesAction extends SparkTestBase {
 
     AssertHelpers.assertThrows("should fail execute",
         IllegalArgumentException.class, "Files to delete cannot be null or empty",
-        () -> actionsProvider().rewriteDeletes(table).rewriteEqDeletes().execute()
+        () -> actionsProvider().rewriteDeletes(table).execute()
     );
 
     List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
@@ -174,7 +175,7 @@ public abstract class TestRewriteDeletesAction extends SparkTestBase {
 
     AssertHelpers.assertThrows("should fail execute",
         IllegalArgumentException.class, "Files to delete cannot be null or empty",
-        () -> actionsProvider().rewriteDeletes(table).rewriteEqDeletes().execute()
+        () -> actionsProvider().rewriteDeletes(table).strategy(ConvertEqDeletesStrategy.class.getName()).execute()
     );
 
     List<ThreeColumnRecord> expectedRecords = Lists.newArrayList();
@@ -233,7 +234,7 @@ public abstract class TestRewriteDeletesAction extends SparkTestBase {
 
     table.newRowDelta().addDeletes(eqDeleteWriter.toDeleteFile()).commit();
 
-    actionsProvider().rewriteDeletes(table).rewriteEqDeletes().execute();
+    actionsProvider().rewriteDeletes(table).strategy(ConvertEqDeletesStrategy.class.getName()).execute();
 
     CloseableIterable<FileScanTask> tasks = CloseableIterable.filter(
         table.newScan().planFiles(), task -> task.deletes().stream()
@@ -300,7 +301,7 @@ public abstract class TestRewriteDeletesAction extends SparkTestBase {
 
     table.newRowDelta().addDeletes(eqDeleteWriter.toDeleteFile()).commit();
 
-    actionsProvider().rewriteDeletes(table).rewriteEqDeletes().execute();
+    actionsProvider().rewriteDeletes(table).strategy(ConvertEqDeletesStrategy.class.getName()).execute();
 
     CloseableIterable<FileScanTask> tasks = CloseableIterable.filter(
         table.newScan().planFiles(), task -> task.deletes().stream()
@@ -386,7 +387,7 @@ public abstract class TestRewriteDeletesAction extends SparkTestBase {
     posDeleteWriter.close();
     table.newRowDelta().addDeletes(posDeleteWriter.toDeleteFile()).commit();
 
-    RewriteDeletes.Result result = actionsProvider().rewriteDeletes(table).rewriteEqDeletes().execute();
+    RewriteDeletes.Result result = actionsProvider().rewriteDeletes(table).execute();
     Assert.assertEquals("Should contain one equality delete to delete", 1, result.deletedFiles().size());
     Assert.assertEquals("Should contain one position delete to add", 1, result.addedFiles().size());
 

--- a/spark2/src/test/java/org/apache/iceberg/actions/TestRewriteDeletesAction24.java
+++ b/spark2/src/test/java/org/apache/iceberg/actions/TestRewriteDeletesAction24.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.actions;
+
+import org.apache.iceberg.spark.actions.SparkActions;
+
+public class TestRewriteDeletesAction24 extends TestRewriteDeletesAction {
+  @Override
+  public ActionsProvider actionsProvider() {
+    return SparkActions.get();
+  }
+}

--- a/spark3/src/test/java/org/apache/iceberg/actions/TestRewriteDeletesAction3.java
+++ b/spark3/src/test/java/org/apache/iceberg/actions/TestRewriteDeletesAction3.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.actions;
+
+import org.apache.iceberg.spark.actions.SparkActions;
+
+public class TestRewriteDeletesAction3 extends TestRewriteDeletesAction {
+  @Override
+  public ActionsProvider actionsProvider() {
+    return SparkActions.get();
+  }
+}


### PR DESCRIPTION
This is a sub-PR of #2216, it adds a spark action to replace the equality deletes to position deletes which I think is minor compaction. The logic is:

1. Plan and group the tasks by partition. Current it doesn't consider the filter, we may consider filter, such as partition filter, later.
2. Use the delete matcher to keep rows that match the equality delete set. The rows are projected with file and pos fields.
3. Write the matched rows via position delete writer.
4. Perform the rewrite files to replace equality deletes with position deletes.

This adds an API in RewriteFiles to rewrite equality deletes to position deletes. It should keep the same semantic with the current API that rows must be the same as before as after. This may need some changes when https://github.com/apache/iceberg/pull/2294 get merged. 

There are two following things:
1. Extract the common part and implement Flink action.
2. Clustering the position deletes inside the partition.