### PR TITLE
Tests: Get row collection from flink sql query.

### DIFF
--- a/flink/src/test/java/org/apache/iceberg/flink/FlinkTestBase.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/FlinkTestBase.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.flink;
 
 import java.util.List;
-import java.util.stream.IntStream;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableResult;
@@ -96,15 +95,10 @@ public abstract class FlinkTestBase extends TestBaseUtils {
     return exec(getTableEnv(), query, args);
   }
 
-  protected List<Object[]> sql(String query, Object... args) {
+  protected List<Row> sql(String query, Object... args) {
     TableResult tableResult = exec(query, args);
     try (CloseableIterator<Row> iter = tableResult.collect()) {
-      List<Object[]> results = Lists.newArrayList();
-      while (iter.hasNext()) {
-        Row row = iter.next();
-        results.add(IntStream.range(0, row.getArity()).mapToObj(row::getField).toArray(Object[]::new));
-      }
-      return results;
+      return Lists.newArrayList(iter);
     } catch (Exception e) {
       throw new RuntimeException("Failed to collect table result", e);
     }


### PR DESCRIPTION
Currently,  the  FlinkTestBase#sql will returns a `List<Object[]>`,  which is not friendly to assert the results of flink SQL query because for a record,  we have to build a `Object` array , and then use the `Assert.assertArrayEquals((Object[])result,  expected)` to check the equality.   It's hard to assert the record that read from a table with nested column.

So I recommend to return a `List<Row>`  for the `FlinkTestBase#sql` because the flink's  row have considered the equal logic for nested columns, pls see the [equals](https://github.com/apache/flink/blob/master/flink-core/src/main/java/org/apache/flink/types/Row.java#L405) method.