### PR TITLE
Flink: Use Namespace in FlinkCatalog.

### DIFF
--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -139,10 +139,10 @@ public class FlinkCatalog extends AbstractCatalog {
   }
 
   private Namespace toNamespace(String database) {
-    List<String> namespaces = Lists.newArrayListWithExpectedSize(baseNamespace.levels().length + 1);
-    Collections.addAll(namespaces, baseNamespace.levels());
-    Collections.addAll(namespaces, database);
-    return Namespace.of(namespaces.toArray(new String[0]));
+    String[] namespace = new String[baseNamespace.levels().length + 1];
+    System.arraycopy(baseNamespace.levels(), 0, namespace, 0, baseNamespace.levels().length);
+    namespace[baseNamespace.levels().length] = database;
+    return Namespace.of(namespace);
   }
 
   TableIdentifier toIdentifier(ObjectPath path) {

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -91,17 +91,15 @@ public class FlinkCatalog extends AbstractCatalog {
 
   private final CatalogLoader catalogLoader;
   private final Catalog icebergCatalog;
-  private final String[] baseNamespace;
+  private final Namespace baseNamespace;
   private final SupportsNamespaces asNamespaceCatalog;
   private final Closeable closeable;
   private final boolean cacheEnabled;
 
-  // TODO - Update baseNamespace to use Namespace class
-  // https://github.com/apache/iceberg/issues/1541
   public FlinkCatalog(
       String catalogName,
       String defaultDatabase,
-      String[] baseNamespace,
+      Namespace baseNamespace,
       CatalogLoader catalogLoader,
       boolean cacheEnabled) {
     super(catalogName, defaultDatabase);
@@ -141,10 +139,10 @@ public class FlinkCatalog extends AbstractCatalog {
   }
 
   private Namespace toNamespace(String database) {
-    String[] namespace = new String[baseNamespace.length + 1];
-    System.arraycopy(baseNamespace, 0, namespace, 0, baseNamespace.length);
-    namespace[baseNamespace.length] = database;
-    return Namespace.of(namespace);
+    List<String> namespaces = Lists.newArrayListWithExpectedSize(baseNamespace.levels().length + 1);
+    Collections.addAll(namespaces, baseNamespace.levels());
+    Collections.addAll(namespaces, database);
+    return Namespace.of(namespaces.toArray(new String[0]));
   }
 
   TableIdentifier toIdentifier(ObjectPath path) {
@@ -157,7 +155,7 @@ public class FlinkCatalog extends AbstractCatalog {
       return Collections.singletonList(getDefaultDatabase());
     }
 
-    return asNamespaceCatalog.listNamespaces(Namespace.of(baseNamespace)).stream()
+    return asNamespaceCatalog.listNamespaces(baseNamespace).stream()
         .map(n -> n.level(n.levels().length - 1))
         .collect(Collectors.toList());
   }

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -120,13 +120,13 @@ public class FlinkCatalogFactory implements CatalogFactory {
   protected Catalog createCatalog(String name, Map<String, String> properties, Configuration hadoopConf) {
     CatalogLoader catalogLoader = createCatalogLoader(name, properties, hadoopConf);
     String defaultDatabase = properties.getOrDefault(DEFAULT_DATABASE, "default");
-    boolean cacheEnabled = Boolean.parseBoolean(properties.getOrDefault(CACHE_ENABLED, "true"));
 
     Namespace baseNamespace = Namespace.empty();
     if (properties.containsKey(BASE_NAMESPACE)) {
       baseNamespace = Namespace.of(properties.get(BASE_NAMESPACE).split("\\."));
     }
 
+    boolean cacheEnabled = Boolean.parseBoolean(properties.getOrDefault(CACHE_ENABLED, "true"));
     return new FlinkCatalog(name, defaultDatabase, baseNamespace, catalogLoader, cacheEnabled);
   }
 

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -33,8 +33,8 @@ import org.apache.flink.table.factories.CatalogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -120,10 +120,13 @@ public class FlinkCatalogFactory implements CatalogFactory {
   protected Catalog createCatalog(String name, Map<String, String> properties, Configuration hadoopConf) {
     CatalogLoader catalogLoader = createCatalogLoader(name, properties, hadoopConf);
     String defaultDatabase = properties.getOrDefault(DEFAULT_DATABASE, "default");
-    String[] baseNamespace = properties.containsKey(BASE_NAMESPACE) ?
-        Splitter.on('.').splitToList(properties.get(BASE_NAMESPACE)).toArray(new String[0]) :
-        new String[0];
     boolean cacheEnabled = Boolean.parseBoolean(properties.getOrDefault(CACHE_ENABLED, "true"));
+
+    Namespace baseNamespace = Namespace.empty();
+    if (properties.containsKey(BASE_NAMESPACE)) {
+      baseNamespace = Namespace.of(properties.get(BASE_NAMESPACE).split("\\."));
+    }
+
     return new FlinkCatalog(name, defaultDatabase, baseNamespace, catalogLoader, cacheEnabled);
   }
 


### PR DESCRIPTION
This address the [comment](https://github.com/apache/iceberg/blob/master/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java#L99) in [FlinkCatalog](https://github.com/apache/iceberg/blob/master/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java)