### PR TITLE
Docs: Show the correct default value of write.target-file-size-bytes.

### DIFF
--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -45,7 +45,7 @@ Iceberg tables support table properties to configure table behavior, like the de
 | write.metadata.compression-codec   | none               | Metadata compression codec; none or gzip           |
 | write.metadata.metrics.default     | truncate(16)       | Default metrics mode for all columns in the table; none, counts, truncate(length), or full |
 | write.metadata.metrics.column.col1 | (not set)          | Metrics mode for column 'col1' to allow per-column tuning; none, counts, truncate(length), or full |
-| write.target-file-size-bytes       | Long.MAX_VALUE     | Controls the size of files generated to target about this many bytes |
+| write.target-file-size-bytes       | 536870912 (512 MB) | Controls the size of files generated to target about this many bytes |
 | write.distribution-mode            | none               | Defines distribution of write data: __none__: don't shuffle rows; __hash__: hash distribute by partition key ; __range__: range distribute by partition key or sort key if table has an SortOrder |
 | write.wap.enabled                  | false              | Enables write-audit-publish writes |
 | write.summary.partition-limit      | 0                  | Includes partition-level summary stats in snapshot summaries if the changed partition count is less than this limit |


### PR DESCRIPTION
https://iceberg.apache.org/configuration/ still shows default value of write.target-file-size-bytes is Long.MAX_VALUE, which has been changed to 512M after the change "Core: Change default write.target-file-size-bytes to 512 MB (#2220)".