### PR TITLE
Doc: Document non-atomicity of Hive multi-table inserts

### DIFF
--- a/site/docs/hive.md
+++ b/site/docs/hive.md
@@ -121,3 +121,11 @@ Columns from the Hive SQL `SELECT` clause are projected down to the Iceberg read
 
 #### Hive Query Engines
 Both the Map Reduce and Tez query execution engines are supported.
+
+#### Hive Multi-table inserts
+It is possible to issue inserts targeting multiple Hive tables backed by Iceberg. The users should be aware that the commits are atomic only on table level, and the commit is not atomic on query level. The commits to Iceberg tables happen 1-by-1, and if one of the commit fails the other writes will not be rolled back. Example:
+```sql
+FROM customers
+    INSERT INTO target1 SELECT customer_id, first_name
+    INSERT INTO target2 SELECT last_name, customer_id
+```

--- a/site/docs/hive.md
+++ b/site/docs/hive.md
@@ -123,7 +123,7 @@ Columns from the Hive SQL `SELECT` clause are projected down to the Iceberg read
 Both the Map Reduce and Tez query execution engines are supported.
 
 #### Hive Multi-table inserts
-Multi-table inserts will not be atomic and are committed one table at a time. Partial changes will be visible during the commit process and failures can leave partial changes committed. Changes within a single table will remain atomic
+Multi-table inserts will not be atomic and are committed one table at a time. Partial changes will be visible during the commit process and failures can leave partial changes committed. Changes within a single table will remain atomic.
 
 Here is an example of inserting into multiple tables at once in Hive SQL:
 ```sql

--- a/site/docs/hive.md
+++ b/site/docs/hive.md
@@ -123,7 +123,9 @@ Columns from the Hive SQL `SELECT` clause are projected down to the Iceberg read
 Both the Map Reduce and Tez query execution engines are supported.
 
 #### Hive Multi-table inserts
-It is possible to issue inserts targeting multiple Hive tables backed by Iceberg. The users should be aware that the commits are atomic only on table level, and the commit is not atomic on query level. The commits to Iceberg tables happen 1-by-1, and if one of the commit fails the other writes will not be rolled back. Example:
+Multi-table inserts will not be atomic and are committed one table at a time. Partial changes will be visible during the commit process and failures can leave partial changes committed. Changes within a single table will remain atomic
+
+Here is an example of inserting into multiple tables at once in Hive SQL:
 ```sql
 FROM customers
     INSERT INTO target1 SELECT customer_id, first_name


### PR DESCRIPTION
As discussed in #2228 we should document that the Hive multi-table inserts are only atomic on table level.

@massdosage, @rdblue, @RussellSpitzer, @jackye1995 could one of you please check my English?

Thanks,
Peter