### PR TITLE
Core: Optimize SerializableMap

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ArrayUtil;
 import org.apache.iceberg.util.ByteBuffers;
+import org.apache.iceberg.util.SerializableMap;
 
 /**
  * Base class for both {@link DataFile} and {@link DeleteFile}.

--- a/core/src/main/java/org/apache/iceberg/util/SerializableMap.java
+++ b/core/src/main/java/org/apache/iceberg/util/SerializableMap.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.iceberg;
+package org.apache.iceberg.util;
 
 import java.io.Serializable;
 import java.util.Collection;
@@ -29,7 +29,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 public class SerializableMap<K, V> implements Map<K, V>, Serializable {
 
   private final Map<K, V> copiedMap;
-  private Map<K, V> immutableMap;
+  private transient volatile Map<K, V> immutableMap;
 
   SerializableMap() {
     this.copiedMap = Maps.newHashMap();
@@ -46,7 +46,11 @@ public class SerializableMap<K, V> implements Map<K, V>, Serializable {
 
   public Map<K, V> immutableMap() {
     if (immutableMap == null) {
-      immutableMap = Collections.unmodifiableMap(copiedMap);
+      synchronized (this) {
+        if (immutableMap == null) {
+          immutableMap = Collections.unmodifiableMap(copiedMap);
+        }
+      }
     }
 
     return immutableMap;


### PR DESCRIPTION
This PR makes `immutableMap` transient in `SerializableMap` to avoid serializing two maps using Java serialization. Also, it moves the map to the util package, where we have our `SerializableSupplier` and other related classes.