### PR TITLE
Core: Implement HasTableOperations in metadata and txn tables

### DIFF
--- a/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
@@ -40,49 +40,29 @@ import org.apache.iceberg.util.ThreadPools;
  * This table may return duplicate rows.
  */
 public class AllDataFilesTable extends BaseMetadataTable {
-  private final TableOperations ops;
-  private final Table table;
-  private final String name;
 
   AllDataFilesTable(TableOperations ops, Table table) {
     this(ops, table, table.name() + ".all_data_files");
   }
 
   AllDataFilesTable(TableOperations ops, Table table, String name) {
-    this.ops = ops;
-    this.table = table;
-    this.name = name;
-  }
-
-  @Override
-  Table table() {
-    return table;
-  }
-
-  @Override
-  public String name() {
-    return name;
+    super(ops, table, name);
   }
 
   @Override
   public TableScan newScan() {
-    return new AllDataFilesTableScan(ops, table, schema());
+    return new AllDataFilesTableScan(operations(), table(), schema());
   }
 
   @Override
   public Schema schema() {
-    Schema schema = new Schema(DataFile.getType(table.spec().partitionType()).fields());
-    if (table.spec().fields().size() < 1) {
+    Schema schema = new Schema(DataFile.getType(table().spec().partitionType()).fields());
+    if (table().spec().fields().size() < 1) {
       // avoid returning an empty struct, which is not always supported. instead, drop the partition field (id 102)
       return TypeUtil.selectNot(schema, Sets.newHashSet(102));
     } else {
       return schema;
     }
-  }
-
-  @Override
-  String metadataLocation() {
-    return ops.current().metadataFileLocation();
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
@@ -40,49 +40,29 @@ import org.apache.iceberg.util.ThreadPools;
  * use {@link DataFilesTable}.
  */
 public class AllEntriesTable extends BaseMetadataTable {
-  private final TableOperations ops;
-  private final Table table;
-  private final String name;
 
   AllEntriesTable(TableOperations ops, Table table) {
     this(ops, table, table.name() + ".all_entries");
   }
 
   AllEntriesTable(TableOperations ops, Table table, String name) {
-    this.ops = ops;
-    this.table = table;
-    this.name = name;
-  }
-
-  @Override
-  Table table() {
-    return table;
-  }
-
-  @Override
-  public String name() {
-    return name;
+    super(ops, table, name);
   }
 
   @Override
   public TableScan newScan() {
-    return new Scan(ops, table, schema());
+    return new Scan(operations(), table(), schema());
   }
 
   @Override
   public Schema schema() {
-    Schema schema = ManifestEntry.getSchema(table.spec().partitionType());
-    if (table.spec().fields().size() < 1) {
+    Schema schema = ManifestEntry.getSchema(table().spec().partitionType());
+    if (table().spec().fields().size() < 1) {
       // avoid returning an empty struct, which is not always supported. instead, drop the partition field (id 102)
       return TypeUtil.selectNot(schema, Sets.newHashSet(102));
     } else {
       return schema;
     }
-  }
-
-  @Override
-  String metadataLocation() {
-    return ops.current().metadataFileLocation();
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -56,43 +56,22 @@ public class AllManifestsTable extends BaseMetadataTable {
       )))
   );
 
-  private final TableOperations ops;
-  private final Table table;
-  private final String name;
-
   AllManifestsTable(TableOperations ops, Table table) {
     this(ops, table, table.name() + ".all_manifests");
   }
 
   AllManifestsTable(TableOperations ops, Table table, String name) {
-    this.ops = ops;
-    this.table = table;
-    this.name = name;
-  }
-
-  @Override
-  Table table() {
-    return table;
-  }
-
-  @Override
-  public String name() {
-    return name;
+    super(ops, table, name);
   }
 
   @Override
   public TableScan newScan() {
-    return new AllManifestsTableScan(ops, table, MANIFEST_FILE_SCHEMA);
+    return new AllManifestsTableScan(operations(), table(), MANIFEST_FILE_SCHEMA);
   }
 
   @Override
   public Schema schema() {
     return MANIFEST_FILE_SCHEMA;
-  }
-
-  @Override
-  String metadataLocation() {
-    return ops.current().metadataFileLocation();
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -499,7 +499,12 @@ class BaseTransaction implements Transaction {
     }
   }
 
-  public class TransactionTable implements Table {
+  public class TransactionTable implements Table, HasTableOperations {
+
+    @Override
+    public TableOperations operations() {
+      return transactionOps;
+    }
 
     @Override
     public String name() {

--- a/core/src/main/java/org/apache/iceberg/DataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DataFilesTable.java
@@ -32,49 +32,29 @@ import org.apache.iceberg.types.TypeUtil;
  * A {@link Table} implementation that exposes a table's data files as rows.
  */
 public class DataFilesTable extends BaseMetadataTable {
-  private final TableOperations ops;
-  private final Table table;
-  private final String name;
 
   DataFilesTable(TableOperations ops, Table table) {
     this(ops, table, table.name() + ".files");
   }
 
   DataFilesTable(TableOperations ops, Table table, String name) {
-    this.ops = ops;
-    this.table = table;
-    this.name = name;
-  }
-
-  @Override
-  Table table() {
-    return table;
-  }
-
-  @Override
-  public String name() {
-    return name;
+    super(ops, table, name);
   }
 
   @Override
   public TableScan newScan() {
-    return new FilesTableScan(ops, table, schema());
+    return new FilesTableScan(operations(), table(), schema());
   }
 
   @Override
   public Schema schema() {
-    Schema schema = new Schema(DataFile.getType(table.spec().partitionType()).fields());
-    if (table.spec().fields().size() < 1) {
+    Schema schema = new Schema(DataFile.getType(table().spec().partitionType()).fields());
+    if (table().spec().fields().size() < 1) {
       // avoid returning an empty struct, which is not always supported. instead, drop the partition field
       return TypeUtil.selectNot(schema, Sets.newHashSet(DataFile.PARTITION_ID));
     } else {
       return schema;
     }
-  }
-
-  @Override
-  String metadataLocation() {
-    return ops.current().metadataFileLocation();
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/HistoryTable.java
+++ b/core/src/main/java/org/apache/iceberg/HistoryTable.java
@@ -41,33 +41,17 @@ public class HistoryTable extends BaseMetadataTable {
       Types.NestedField.required(4, "is_current_ancestor", Types.BooleanType.get())
   );
 
-  private final TableOperations ops;
-  private final Table table;
-  private final String name;
-
   HistoryTable(TableOperations ops, Table table) {
     this(ops, table, table.name() + ".history");
   }
 
   HistoryTable(TableOperations ops, Table table, String name) {
-    this.ops = ops;
-    this.table = table;
-    this.name = name;
-  }
-
-  @Override
-  Table table() {
-    return table;
-  }
-
-  @Override
-  public String name() {
-    return name;
+    super(ops, table, name);
   }
 
   @Override
   public TableScan newScan() {
-    return new HistoryScan();
+    return new HistoryScan(operations(), table());
   }
 
   @Override
@@ -76,24 +60,20 @@ public class HistoryTable extends BaseMetadataTable {
   }
 
   @Override
-  String metadataLocation() {
-    return ops.current().metadataFileLocation();
-  }
-
-  @Override
   MetadataTableType metadataTableType() {
     return MetadataTableType.HISTORY;
   }
 
   private DataTask task(TableScan scan) {
+    TableOperations ops = operations();
     return StaticDataTask.of(
         ops.io().newInputFile(ops.current().metadataFileLocation()),
         ops.current().snapshotLog(),
-        convertHistoryEntryFunc(table));
+        convertHistoryEntryFunc(table()));
   }
 
   private class HistoryScan extends StaticTableScan {
-    HistoryScan() {
+    HistoryScan(TableOperations ops, Table table) {
       super(ops, table, HISTORY_SCHEMA, HistoryTable.this::task);
     }
 

--- a/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
@@ -37,49 +37,29 @@ import org.apache.iceberg.types.TypeUtil;
  * use {@link DataFilesTable}.
  */
 public class ManifestEntriesTable extends BaseMetadataTable {
-  private final TableOperations ops;
-  private final Table table;
-  private final String name;
 
   ManifestEntriesTable(TableOperations ops, Table table) {
     this(ops, table, table.name() + ".entries");
   }
 
   ManifestEntriesTable(TableOperations ops, Table table, String name) {
-    this.ops = ops;
-    this.table = table;
-    this.name = name;
-  }
-
-  @Override
-  Table table() {
-    return table;
-  }
-
-  @Override
-  public String name() {
-    return name;
+    super(ops, table, name);
   }
 
   @Override
   public TableScan newScan() {
-    return new EntriesTableScan(ops, table, schema());
+    return new EntriesTableScan(operations(), table(), schema());
   }
 
   @Override
   public Schema schema() {
-    Schema schema = ManifestEntry.getSchema(table.spec().partitionType());
-    if (table.spec().fields().size() < 1) {
+    Schema schema = ManifestEntry.getSchema(table().spec().partitionType());
+    if (table().spec().fields().size() < 1) {
       // avoid returning an empty struct, which is not always supported. instead, drop the partition field (id 102)
       return TypeUtil.selectNot(schema, Sets.newHashSet(102));
     } else {
       return schema;
     }
-  }
-
-  @Override
-  String metadataLocation() {
-    return ops.current().metadataFileLocation();
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/ManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestsTable.java
@@ -44,35 +44,20 @@ public class ManifestsTable extends BaseMetadataTable {
       )))
   );
 
-  private final TableOperations ops;
-  private final Table table;
   private final PartitionSpec spec;
-  private final String name;
 
   ManifestsTable(TableOperations ops, Table table) {
     this(ops, table, table.name() + ".manifests");
   }
 
   ManifestsTable(TableOperations ops, Table table, String name) {
-    this.ops = ops;
-    this.table = table;
+    super(ops, table, name);
     this.spec = table.spec();
-    this.name = name;
-  }
-
-  @Override
-  Table table() {
-    return table;
-  }
-
-  @Override
-  public String name() {
-    return name;
   }
 
   @Override
   public TableScan newScan() {
-    return new ManifestsTableScan();
+    return new ManifestsTableScan(operations(), table());
   }
 
   @Override
@@ -81,16 +66,12 @@ public class ManifestsTable extends BaseMetadataTable {
   }
 
   @Override
-  String metadataLocation() {
-    return ops.current().metadataFileLocation();
-  }
-
-  @Override
   MetadataTableType metadataTableType() {
     return MetadataTableType.MANIFESTS;
   }
 
   protected DataTask task(TableScan scan) {
+    TableOperations ops = operations();
     String location = scan.snapshot().manifestListLocation();
     return StaticDataTask.of(
         ops.io().newInputFile(location != null ? location : ops.current().metadataFileLocation()),
@@ -99,7 +80,7 @@ public class ManifestsTable extends BaseMetadataTable {
   }
 
   private class ManifestsTableScan extends StaticTableScan {
-    ManifestsTableScan() {
+    ManifestsTableScan(TableOperations ops, Table table) {
       super(ops, table, SNAPSHOT_SCHEMA, ManifestsTable.this::task);
     }
   }

--- a/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
@@ -38,33 +38,17 @@ public class SnapshotsTable extends BaseMetadataTable {
           Types.MapType.ofRequired(7, 8, Types.StringType.get(), Types.StringType.get()))
   );
 
-  private final TableOperations ops;
-  private final Table table;
-  private final String name;
-
   SnapshotsTable(TableOperations ops, Table table) {
     this(ops, table, table.name() + ".snapshots");
   }
 
   SnapshotsTable(TableOperations ops, Table table, String name) {
-    this.ops = ops;
-    this.table = table;
-    this.name = name;
-  }
-
-  @Override
-  Table table() {
-    return table;
-  }
-
-  @Override
-  public String name() {
-    return name;
+    super(ops, table, name);
   }
 
   @Override
   public TableScan newScan() {
-    return new SnapshotsTableScan();
+    return new SnapshotsTableScan(operations(), table());
   }
 
   @Override
@@ -73,15 +57,11 @@ public class SnapshotsTable extends BaseMetadataTable {
   }
 
   private DataTask task(BaseTableScan scan) {
+    TableOperations ops = operations();
     return StaticDataTask.of(
         ops.io().newInputFile(ops.current().metadataFileLocation()),
         ops.current().snapshots(),
         SnapshotsTable::snapshotToRow);
-  }
-
-  @Override
-  String metadataLocation() {
-    return ops.current().metadataFileLocation();
   }
 
   @Override
@@ -90,7 +70,7 @@ public class SnapshotsTable extends BaseMetadataTable {
   }
 
   private class SnapshotsTableScan extends StaticTableScan {
-    SnapshotsTableScan() {
+    SnapshotsTableScan(TableOperations ops, Table table) {
       super(ops, table, SNAPSHOT_SCHEMA, SnapshotsTable.this::task);
     }
 


### PR DESCRIPTION
This PR implements `HasTableOperations` in metadata and txn tables so that we can leverage it in `SerializedTable` later on.