### PR TITLE
[python] Updating Expressions with the Term object used in Predicates

### DIFF
--- a/python/iceberg/api/expressions/__init__.py
+++ b/python/iceberg/api/expressions/__init__.py
@@ -52,7 +52,6 @@ __all__ = ["ABOVE_MAX",
            "Operation",
            "Or",
            "Predicate",
-           "Reference",
            "ResidualEvaluator",
            "strict",
            "StrictMetricsEvaluator",
@@ -103,7 +102,6 @@ from .projections import (inclusive,
                           strict,
                           StrictProjection)
 from .reference import (BoundReference,
-                        NamedReference,
-                        Reference)
+                        NamedReference)
 from .residual_evaluator import ResidualEvaluator
 from .strict_metrics_evaluator import StrictMetricsEvaluator

--- a/python/iceberg/api/expressions/expression.py
+++ b/python/iceberg/api/expressions/expression.py
@@ -43,6 +43,8 @@ class Operation(Enum):
     FALSE = "FALSE"
     IS_NULL = "IS_NULL"
     NOT_NULL = "NOT_NULL"
+    IS_NAN = "IS_NAN"
+    NOT_NAN = "NOT_NAN"
     LT = "LT"
     LT_EQ = "LT_EQ"
     GT = "GT"
@@ -60,6 +62,10 @@ class Operation(Enum):
             return Operation.NOT_NULL
         elif self == Operation.NOT_NULL:
             return Operation.IS_NULL
+        elif self == Operation.IS_NAN:
+            return Operation.NOT_NAN
+        elif self == Operation.NOT_NAN:
+            return Operation.IS_NAN
         elif self == Operation.LT:
             return Operation.GT_EQ
         elif self == Operation.LT_EQ:

--- a/python/iceberg/api/expressions/expressions.py
+++ b/python/iceberg/api/expressions/expressions.py
@@ -75,6 +75,14 @@ class Expressions(object):
         return UnboundPredicate(Operation.NOT_NULL, Expressions.ref(name))
 
     @staticmethod
+    def is_nan(name):
+        return UnboundPredicate(Operation.IS_NAN, Expressions.ref(name))
+
+    @staticmethod
+    def not_nan(name):
+        return UnboundPredicate(Operation.NOT_NAN, Expressions.ref(name))
+
+    @staticmethod
     def less_than(name, value):
         return UnboundPredicate(Operation.LT, Expressions.ref(name), value)
 
@@ -197,6 +205,12 @@ class ExpressionVisitors(object):
         def not_null(self, ref):
             return NotImplementedError()
 
+        def is_nan(self, ref):
+            return NotImplementedError()
+
+        def not_nan(self, ref):
+            return NotImplementedError()
+
         def lt(self, ref, lit):
             return NotImplementedError()
 
@@ -230,6 +244,8 @@ class ExpressionVisitors(object):
                 return self.is_null(pred.ref)
             elif pred.op == Operation.NOT_NULL:
                 return self.not_null(pred.ref)
+            elif pred.op in [Operation.IS_NAN, Operation.NOT_NAN]:
+                raise NotImplementedError("IS_NAN and NOT_NAN not fully implemented for expressions")
             elif pred.op == Operation.LT:
                 return self.lt(pred.ref, pred.lit)
             elif pred.op == Operation.LT_EQ:

--- a/python/iceberg/api/expressions/inclusive_metrics_evaluator.py
+++ b/python/iceberg/api/expressions/inclusive_metrics_evaluator.py
@@ -81,7 +81,7 @@ class MetricsEvalVisitor(ExpressionVisitors.BoundExpressionVisitor):
         return left_result or right_result
 
     def is_null(self, ref):
-        id = ref.field_id
+        id = ref.field.field_id
 
         if self.struct.field(id=id) is None:
             raise RuntimeError("Cannot filter by nested column: %s" % self.schema.find_field(id))
@@ -92,7 +92,7 @@ class MetricsEvalVisitor(ExpressionVisitors.BoundExpressionVisitor):
         return MetricsEvalVisitor.ROWS_MIGHT_MATCH
 
     def not_null(self, ref):
-        id = ref.field_id
+        id = ref.field.field_id
 
         if self.struct.field(id=id) is None:
             raise RuntimeError("Cannot filter by nested column: %s" % self.schema.find_field(id))
@@ -104,7 +104,7 @@ class MetricsEvalVisitor(ExpressionVisitors.BoundExpressionVisitor):
         return MetricsEvalVisitor.ROWS_MIGHT_MATCH
 
     def lt(self, ref, lit):
-        id = ref.field_id
+        id = ref.field.field_id
         field = self.struct.field(id=id)
 
         if field is None:
@@ -118,7 +118,7 @@ class MetricsEvalVisitor(ExpressionVisitors.BoundExpressionVisitor):
         return MetricsEvalVisitor.ROWS_MIGHT_MATCH
 
     def lt_eq(self, ref, lit):
-        id = ref.field_id
+        id = ref.field.field_id
         field = self.struct.field(id=id)
 
         if field is None:
@@ -132,7 +132,7 @@ class MetricsEvalVisitor(ExpressionVisitors.BoundExpressionVisitor):
         return MetricsEvalVisitor.ROWS_MIGHT_MATCH
 
     def gt(self, ref, lit):
-        id = ref.field_id
+        id = ref.field.field_id
         field = self.struct.field(id=id)
 
         if field is None:
@@ -146,7 +146,7 @@ class MetricsEvalVisitor(ExpressionVisitors.BoundExpressionVisitor):
         return MetricsEvalVisitor.ROWS_MIGHT_MATCH
 
     def gt_eq(self, ref, lit):
-        id = ref.field_id
+        id = ref.field.field_id
         field = self.struct.field(id=id)
 
         if field is None:
@@ -160,7 +160,7 @@ class MetricsEvalVisitor(ExpressionVisitors.BoundExpressionVisitor):
         return MetricsEvalVisitor.ROWS_MIGHT_MATCH
 
     def eq(self, ref, lit):
-        id = ref.field_id
+        id = ref.field.field_id
         field = self.struct.field(id=id)
 
         if field is None:

--- a/python/iceberg/api/expressions/predicate.py
+++ b/python/iceberg/api/expressions/predicate.py
@@ -15,23 +15,40 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from __future__ import annotations
+
+from math import isnan
+from typing import Any, List, Optional, TYPE_CHECKING, Union
+
 from iceberg.exceptions import ValidationException
 
 from .expression import (Expression,
-                         FALSE,
-                         Operation,
-                         TRUE)
-from .literals import (Literal,
+                         Operation)
+from .literals import (BaseLiteral,
                        Literals)
-from .reference import BoundReference
+from .term import BoundTerm, UnboundTerm
+from ..types import TypeID
+
+if TYPE_CHECKING:
+    from iceberg.api import StructLike
 
 
 class Predicate(Expression):
 
-    def __init__(self, op, ref, lit):
-        self.op = op
-        self.ref = ref
-        self.lit = lit
+    def __init__(self, op: Operation, term: Union[BoundTerm, UnboundTerm]):
+        if term is None:
+            raise ValueError("Term cannot be None")
+
+        self.op: Operation = op
+        self.term: Union[BoundTerm, UnboundTerm] = term
+
+    @property
+    def ref(self):
+        return self.term.ref
+
+    @property
+    def lit(self):
+        raise NotImplementedError("Not Implemented for base class")
 
     def __eq__(self, other):
         if id(self) == id(other):
@@ -70,72 +87,209 @@ class Predicate(Expression):
 
 class BoundPredicate(Predicate):
 
-    def __init__(self, op, ref, lit=None):
-        super(BoundPredicate, self).__init__(op, ref, lit)
+    def __init__(self, op: Operation, term: BoundTerm, lit: BaseLiteral = None, literals: List[BaseLiteral] = None,
+                 is_unary_predicate: bool = False, is_literal_predicate: bool = False,
+                 is_set_predicate: bool = False):
+        self.is_unary_predicate = is_unary_predicate
+        self.is_literal_predicate = is_literal_predicate
+        self.is_set_predicate = is_set_predicate
 
-    def negate(self):
-        return BoundPredicate(self.op.negate(), self.ref, self.lit)
+        super(BoundPredicate, self).__init__(op, term)
+        ValidationException.check(sum([is_unary_predicate, is_literal_predicate, is_set_predicate]) == 1,
+                                  "Only a single predicate type may be set: %s=%s, %s=%s, %s=%s",
+                                  ("is_unary_predicate", is_unary_predicate,
+                                   "is_literal_predicate", is_literal_predicate,
+                                   "is_set_predicate", is_set_predicate))
+
+        self._literals: Optional[List[BaseLiteral]] = None
+        if self.is_unary_predicate:
+            ValidationException.check(lit is None, "Unary Predicates may not have a literal", ())
+
+        elif self.is_literal_predicate:
+            ValidationException.check(lit is not None, "Literal Predicates must have a literal set", ())
+            self._literals = [lit]  # type: ignore
+
+        elif self.is_set_predicate:
+            ValidationException.check(literals is not None, "Set Predicates must have literals set", ())
+            self._literals = literals
+        else:
+            raise ValueError(f"Unable to instantiate {op} -> (lit={lit}, literal={literals}")
+
+    @property
+    def lit(self) -> Optional[BaseLiteral]:
+        if self._literals is None or len(self._literals) == 0:
+            return None
+        return self._literals[0]
+
+    def eval(self, struct: StructLike) -> bool:
+        ValidationException.check(isinstance(self.term, BoundTerm), "Term must be bound to eval: %s", (self.term))
+        return self.test(self.term.eval(struct))  # type: ignore
+
+    def test(self, struct: StructLike = None, value: Any = None) -> bool:
+        ValidationException.check(struct is None or value is None, "Either struct or value must be none", ())
+        if struct is not None:
+            ValidationException.check(isinstance(self.term, BoundTerm), "Term must be bound to eval: %s", (self.term))
+            return self.test(value=self.term.eval(struct))  # type: ignore
+        else:
+            if self.is_unary_predicate:
+                return self.test_unary_predicate(value)
+            elif self.is_literal_predicate:
+                return self.test_literal_predicate(value)
+            else:
+                return self.test_set_predicate(value)
+
+    def test_unary_predicate(self, value: Any) -> bool:
+
+        if self.op == Operation.IS_NULL:
+            return value is None
+        elif self.op == Operation.NOT_NULL:
+            return value is not None
+        elif self.op == Operation.IS_NAN:
+            return isnan(value)
+        elif self.op == Operation.NOT_NAN:
+            return not isnan(value)
+        else:
+            raise ValueError(f"{self.op} is not a valid unary predicate")
+
+    def test_literal_predicate(self, value: Any) -> bool:
+        if self.lit is None:
+            raise ValidationException("Literal must not be none", ())
+
+        if self.op == Operation.LT:
+            return value < self.lit.value
+        elif self.op == Operation.LT_EQ:
+            return value <= self.lit.value
+        elif self.op == Operation.GT:
+            return value > self.lit.value
+        elif self.op == Operation.GT_EQ:
+            return value >= self.lit.value
+        elif self.op == Operation.EQ:
+            return value == self.lit.value
+        elif self.op == Operation.NOT_EQ:
+            return value != self.lit.value
+        else:
+            raise ValueError(f"{self.op} is not a valid literal predicate")
+
+    def test_set_predicate(self, value: Any) -> bool:
+        if self._literals is None:
+            raise ValidationException("Literals must not be none", ())
+
+        if self.op == Operation.IN:
+            return value in self._literals
+        elif self.op == Operation.NOT_IN:
+            return value not in self._literals
+        else:
+            raise ValueError(f"{self.op} is not a valid set predicate")
 
 
 class UnboundPredicate(Predicate):
 
-    def __init__(self, op, named_ref, value=None, lit=None):
-        if value is None and lit is None:
-            super(UnboundPredicate, self).__init__(op, named_ref, None)
-        if isinstance(value, Literal):
+    def __init__(self, op, term, value=None, lit=None, values=None, literals=None):
+        self._literals = None
+        num_set_args = sum([1 for x in [value, lit, values, literals] if x is not None])
+
+        if num_set_args > 1:
+            raise ValueError(f"Only one of value={value}, lit={lit}, values={values}, literals={literals} may be set")
+        super(UnboundPredicate, self).__init__(op, term)
+        if isinstance(value, BaseLiteral):
             lit = value
             value = None
         if value is not None:
-            super(UnboundPredicate, self).__init__(op, named_ref, Literals.from_(value))
+            self._literals = [Literals.from_(value)]
         elif lit is not None:
-            super(UnboundPredicate, self).__init__(op, named_ref, lit)
+            self._literals = [lit]
+        elif values is not None:
+            self._literals = map(Literals.from_, values)
+        elif literals is not None:
+            self._literals = literals
+
+    @property
+    def literals(self):
+        return self._literals
+
+    @property
+    def lit(self):
+        if self.op in [Operation.IN, Operation.NOT_IN]:
+            raise ValueError(f"{self.op} predicate cannot return a literal")
+
+        return None if self.literals is None else self.literals[0]
 
     def negate(self):
-        return UnboundPredicate(self.op.negate(), self.ref, self.lit)
+        return UnboundPredicate(self.op.negate(), self.term, literals=self.literals)
 
-    def bind(self, struct, case_sensitive=True):  # noqa: C901
-        if case_sensitive:
-            field = struct.field(self.ref.name)
-        else:
-            field = struct.case_insensitive_field(self.ref.name.lower())
+    def bind(self, struct, case_sensitive=True):
+        bound = self.term.bind(struct, case_sensitive=case_sensitive)
 
-        ValidationException.check(field is not None,
-                                  "Cannot find field '%s' in struct %s", (self.ref.name, struct))
+        if self.literals is None:
+            return self.bind_unary_operation(bound)
+        elif self.op in [Operation.IN, Operation.NOT_IN]:
+            return self.bind_in_operation(bound)
 
-        if self.lit is None:
-            if self.op == Operation.IS_NULL:
-                if field.is_required:
-                    return FALSE
-                return BoundPredicate(Operation.IS_NULL, BoundReference(struct, field.field_id))
-            elif self.op == Operation.NOT_NULL:
-                if field.is_required:
-                    return TRUE
-                return BoundPredicate(Operation.NOT_NULL, BoundReference(struct, field.field_id))
+        return self.bind_literal_operation(bound)
+
+    def bind_unary_operation(self, bound_term: BoundTerm) -> BoundPredicate:
+        from .expressions import Expressions
+        if self.op == Operation.IS_NULL:
+            if bound_term.ref.field.is_required:
+                return Expressions.always_false()
+            return BoundPredicate(Operation.IS_NULL, bound_term, is_unary_predicate=True)
+        elif self.op == Operation.NOT_NULL:
+            if bound_term.ref.field.is_required:
+                return Expressions.always_true()
+            return BoundPredicate(Operation.NOT_NULL, bound_term, is_unary_predicate=True)
+        elif self.op in [Operation.IS_NAN, Operation.NOT_NAN]:
+            if not self.floating_type(bound_term.ref.type.type_id):
+                raise ValidationException(f"{self.op} cannot be used with a non-floating column", ())
+            return BoundPredicate(self.op, bound_term, is_unary_predicate=True)
+
+        raise ValidationException(f"Operation must be in [IS_NULL, NOT_NULL, IS_NAN, NOT_NAN] was:{self.op}", ())
+
+    def bind_in_operation(self, bound_term):
+        from .expressions import Expressions
+
+        def convert_literal(lit):
+            converted = lit.to(bound_term)
+            ValidationException.check(converted is not None,
+                                      "Invalid Value for conversion to type %s: %s (%s)",
+                                      (bound_term.type, lit, lit.__class__.__name__))
+            return converted
+
+        converted_literals = filter(lambda x: x != Literals.above_max() and x != Literals.below_min(),
+                                    [convert_literal(lit) for lit in self.literals])
+        if len(converted_literals) == 0:
+            return Expressions.always_true() if Operation.NOT_IN else Expressions.always_false()
+        literal_set = set(converted_literals)
+        if len(literal_set) == 1:
+            if self.op == Operation.IN:
+                return BoundPredicate(Operation.EQ, bound_term, literal_set[0])
+            elif self.op == Operation.NOT_IN:
+                return BoundPredicate(Operation.NOT_EQ, bound_term, literal_set[0])
             else:
-                raise ValidationException("Operation must be IS_NULL or NOT_NULL", None)
+                raise ValidationException("Operation must be in or not in", ())
 
-        literal = self.lit.to(field.type)
-        if literal is None:
-            raise ValidationException("Invalid value for comparison inclusive type %s: %s (%s)",
-                                      (field.type, self.lit.value, type(self.lit.value)))
-        elif literal == Literals.above_max():
-            if self.op in (Operation.LT,
-                           Operation.LT_EQ,
-                           Operation.NOT_EQ):
-                return TRUE
-            elif self.op in (Operation.GT,
-                             Operation.GT_EQ,
-                             Operation.EQ):
-                return FALSE
+        return BoundPredicate(self.op, bound_term, literals=literal_set, is_set_predicate=True)
 
-        elif literal == Literals.below_min():
-            if self.op in (Operation.LT,
-                           Operation.LT_EQ,
-                           Operation.NOT_EQ):
-                return FALSE
-            elif self.op in (Operation.GT,
-                             Operation.GT_EQ,
-                             Operation.EQ):
-                return TRUE
+    def bind_literal_operation(self, bound_term):
+        from .expressions import Expressions
 
-        return BoundPredicate(self.op, BoundReference(struct, field.field_id), literal)
+        lit = self.lit.to(bound_term.type)
+        ValidationException.check(lit is not None,
+                                  "Invalid Value for conversion to type %s: %s (%s)",
+                                  (bound_term.type, self.lit, self.lit.__class__.__name__))
+
+        if lit == Literals.above_max():
+            if self.op in [Operation.LT, Operation.LT_EQ, Operation.NOT_EQ]:
+                return Expressions.always_true()
+            elif self.op in [Operation.GT, Operation.GT_EQ, Operation.EQ]:
+                return Expressions.always_false()
+        elif lit == Literals.below_min():
+            if self.op in [Operation.LT, Operation.LT_EQ, Operation.NOT_EQ]:
+                return Expressions.always_false()
+            elif self.op in [Operation.GT, Operation.GT_EQ, Operation.EQ]:
+                return Expressions.always_true()
+
+        return BoundPredicate(self.op, bound_term, lit=lit, is_literal_predicate=True)
+
+    @staticmethod
+    def floating_type(type_id: TypeID) -> bool:
+        return type_id in [TypeID.FLOAT, TypeID.DOUBLE]

--- a/python/iceberg/api/expressions/projections.py
+++ b/python/iceberg/api/expressions/projections.py
@@ -83,7 +83,7 @@ class InclusiveProjection(BaseProjectionEvaluator):
         if isinstance(pred, UnboundPredicate):
             return super(InclusiveProjection, self).predicate(pred)
 
-        part = self.spec.get_field_by_source_id(pred.ref.field_id)
+        part = self.spec.get_field_by_source_id(pred.ref.field.field_id)
 
         if part is None:
             return self.always_true()
@@ -101,7 +101,7 @@ class StrictProjection(BaseProjectionEvaluator):
         super(StrictProjection, self).__init__(spec)
 
     def predicate(self, pred):
-        part = self.spec.get_field_by_source_id(pred.ref.field_id)
+        part = self.spec.get_field_by_source_id(pred.ref.field.field_id)
 
         if part is None:
             return self.always_false()

--- a/python/iceberg/api/expressions/strict_metrics_evaluator.py
+++ b/python/iceberg/api/expressions/strict_metrics_evaluator.py
@@ -83,7 +83,7 @@ class StrictMetricsEvaluator(object):
             return left_result or right_result
 
         def is_null(self, ref):
-            id = ref.field_id
+            id = ref.field.field_id
             if self.struct.field(id=id) is None:
                 raise RuntimeError("Cannot filter by nested column: %s" % self.schema.find_field(id))
 
@@ -95,7 +95,7 @@ class StrictMetricsEvaluator(object):
             return StrictMetricsEvaluator.MetricsEvalVisitor.ROWS_MIGHT_NOT_MATCH
 
         def not_null(self, ref):
-            id = ref.field_id
+            id = ref.field.field_id
             if self.struct.field(id=id) is None:
                 raise RuntimeError("Cannot filter by nested column: %s" % self.schema.find_field(id))
 
@@ -106,7 +106,7 @@ class StrictMetricsEvaluator(object):
 
         def lt(self, ref, lit):
             # Rows must match when: <----------Min----Max---X------->
-            id = ref.field_id
+            id = ref.field.field_id
 
             field = self.struct.field(id=id)
 
@@ -122,7 +122,7 @@ class StrictMetricsEvaluator(object):
 
         def lt_eq(self, ref, lit):
             # Rows must match when: <----------Min----Max---X------->
-            id = ref.field_id
+            id = ref.field.field_id
 
             field = self.struct.field(id=id)
 
@@ -138,7 +138,7 @@ class StrictMetricsEvaluator(object):
 
         def gt(self, ref, lit):
             # Rows must match when: <-------X---Min----Max---------->
-            id = ref.field_id
+            id = ref.field.field_id
 
             field = self.struct.field(id=id)
 
@@ -154,7 +154,7 @@ class StrictMetricsEvaluator(object):
 
         def gt_eq(self, ref, lit):
             # Rows must match when: <-------X---Min----Max---------->
-            id = ref.field_id
+            id = ref.field.field_id
 
             field = self.struct.field(id=id)
 
@@ -170,7 +170,7 @@ class StrictMetricsEvaluator(object):
 
         def eq(self, ref, lit):
             # Rows must match when Min == X == Max
-            id = ref.field_id
+            id = ref.field.field_id
 
             field = self.struct.field(id=id)
 
@@ -194,7 +194,7 @@ class StrictMetricsEvaluator(object):
 
         def not_eq(self, ref, lit):
             # Rows must match when X < Min or Max < X because it is not in the range
-            id = ref.field_id
+            id = ref.field.field_id
 
             field = self.struct.field(id=id)
 

--- a/python/iceberg/api/expressions/term.py
+++ b/python/iceberg/api/expressions/term.py
@@ -1,0 +1,73 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+
+from iceberg.api.types import StructType
+
+if TYPE_CHECKING:
+    from iceberg.api import StructLike
+
+
+class Bound(object):
+    def eval(self, struct: StructLike) -> Any:
+        """Evaluate current object against struct"""
+
+
+class Unbound(object):
+    @property
+    def ref(self):
+        """the underlying reference"""
+
+    def bind(self, struct: StructType, case_sensitive: bool = True) -> Bound:
+        """bind the current object based on the given struct and return the Bound object"""
+
+
+class Term(object):
+    @property
+    def ref(self):
+        """Expose the reference for this term"""
+
+    @property
+    def type(self):
+        """accessor for term type """
+
+
+class BoundTerm(Bound, Term):
+
+    @property
+    def ref(self):
+        raise NotImplementedError("Base class does not have implementation")
+
+    @property
+    def type(self):
+        raise NotImplementedError("Base class does not have implementation")
+
+    def eval(self, struct: StructLike):
+        raise NotImplementedError("Base class does not have implementation")
+
+
+class UnboundTerm(Unbound, Term):
+
+    @property
+    def ref(self):
+        raise NotImplementedError("Base class does not have implementation")
+
+    def bind(self, struct: StructType, case_sensitive: bool = True):
+        raise NotImplementedError("Base class does not have implementation")

--- a/python/iceberg/api/expressions/transform.py
+++ b/python/iceberg/api/expressions/transform.py
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from .reference import BoundReference, NamedReference
+from .. import StructLike
+from ..transforms import Transform, Transforms
+from ..types import StructType
+from ...exceptions import ValidationException
+
+
+class BoundTransform:
+
+    def __init__(self, ref: BoundReference, transform: Transform):
+        self._ref = ref
+        self._transform = transform
+
+    @property
+    def ref(self):
+        return self._ref
+
+    @property
+    def type(self):
+        return self.transform.get_result_type(self.ref.type)
+
+    @property
+    def transform(self):
+        return self._transform
+
+    def eval(self, struct: StructLike):
+        return self.transform.apply(self.ref.eval(struct))
+
+    def __str__(self):
+        return f"{self.transform}({self.ref})"
+
+
+class UnboundTransform:
+
+    def __init__(self, ref: NamedReference, transform: Transform):
+        self._ref = ref
+        self._transform = transform
+
+    @property
+    def ref(self):
+        return self._ref
+
+    @property
+    def transform(self):
+        return self._transform
+
+    def bind(self, struct: StructType, case_sensitive: bool = True):
+        bound_ref = self.ref.bind(struct, case_sensitive=case_sensitive)
+
+        type_transform = Transforms.from_string(bound_ref.type, str(self.transform))
+        ValidationException.check(type_transform.can_transform(bound_ref.type),
+                                  "Cannot bind: %s cannot transform %s values from '%s'", (self.transform,
+                                                                                           bound_ref.type,
+                                                                                           self.ref.name))
+
+        return BoundTransform(bound_ref, type_transform)
+
+    def __str__(self):
+        return f"{self.transform}({self.ref})"

--- a/python/iceberg/api/schema.py
+++ b/python/iceberg/api/schema.py
@@ -100,11 +100,21 @@ class Schema(object):
             return self.lazy_id_to_field().get(id)
 
         if not id:
-            raise RuntimeError("Invalid Column Name (empty)")
+            raise ValueError("Invalid Column Name (empty)")
 
         id = self.lazy_name_to_id().get(id)
-        if id:
+        if id is not None:
             return self.lazy_id_to_field().get(id)
+
+    def case_insensitive_find_field(self, name):
+        if name is None:
+            raise ValueError("Invalid Column Name (empty)")
+
+        id = self.lazy_lowercase_name_to_id().get(name.lower())
+        if id is not None:
+            return self.lazy_id_to_field().get(id)
+
+        return None
 
     def find_column_name(self, id):
         if isinstance(id, int):

--- a/python/tests/api/expressions/test_evaluator.py
+++ b/python/tests/api/expressions/test_evaluator.py
@@ -17,7 +17,8 @@
 
 
 import iceberg.api.expressions as exp
-from iceberg.api.types import (IntegerType,
+from iceberg.api.types import (FloatType,
+                               IntegerType,
                                NestedField,
                                StringType,
                                StructType)
@@ -146,3 +147,15 @@ def test_char_seq_value(row_of):
     evaluator = exp.evaluator.Evaluator(struct, exp.expressions.Expressions.equal("s", "abc"))
     assert evaluator.eval(row_of(("abc",)))
     assert not evaluator.eval(row_of(("abcd",)))
+
+
+def test_nan_errors(row_of):
+    # Placeholder until NaN support is fully implemented
+    struct = StructType.of([NestedField.required(34, "f", FloatType.get())])
+    evaluator = exp.evaluator.Evaluator(struct, exp.expressions.Expressions.is_nan("f"))
+    with raises(NotImplementedError):
+        evaluator.eval(row_of((123.4,)))
+
+    evaluator = exp.evaluator.Evaluator(struct, exp.expressions.Expressions.not_nan("f"))
+    with raises(NotImplementedError):
+        evaluator.eval(row_of((123.4,)))

--- a/python/tests/api/expressions/test_expression_binding.py
+++ b/python/tests/api/expressions/test_expression_binding.py
@@ -83,10 +83,10 @@ def test_and(assert_all_bound, assert_and_unwrap):
 
     left = assert_and_unwrap(and_.left, None)
     # should bind x correctly
-    assert 0 == left.ref.field_id
+    assert 0 == left.ref.field.field_id
     right = assert_and_unwrap(and_.right, None)
     # should bind y correctly
-    assert 1 == right.ref.field_id
+    assert 1 == right.ref.field.field_id
 
 
 def test_or(assert_all_bound, assert_and_unwrap):
@@ -99,10 +99,10 @@ def test_or(assert_all_bound, assert_and_unwrap):
 
     left = assert_and_unwrap(or_.left, None)
     # should bind z correctly
-    assert 2 == left.ref.field_id
+    assert 2 == left.ref.field.field_id
     right = assert_and_unwrap(or_.right, None)
     # should bind y correctly
-    assert 1 == right.ref.field_id
+    assert 1 == right.ref.field.field_id
 
 
 def test_not(assert_all_bound, assert_and_unwrap):
@@ -114,7 +114,7 @@ def test_not(assert_all_bound, assert_and_unwrap):
 
     child = assert_and_unwrap(not_.child, None)
     # should bind x correctly
-    assert 0 == child.ref.field_id
+    assert 0 == child.ref.field.field_id
 
 
 def test_always_true():
@@ -140,4 +140,4 @@ def test_basic_simplification(assert_and_unwrap):
     bound = Binder.bind(STRUCT,
                         Expressions.not_(Expressions.not_(Expressions.less_than("y", 100))))
     pred = assert_and_unwrap(bound, None)
-    assert 1 == pred.ref.field_id
+    assert 1 == pred.ref.field.field_id

--- a/python/tests/api/expressions/test_predicate_binding.py
+++ b/python/tests/api/expressions/test_predicate_binding.py
@@ -39,7 +39,7 @@ def test_multiple_fields(assert_and_unwrap):
     expr = unbound.bind(struct)
 
     bound = assert_and_unwrap(expr)
-    assert 11 == bound.ref.field_id
+    assert 11 == bound.ref.field.field_id
     assert Operation.LT == bound.op
     assert 6 == bound.lit.value
 
@@ -60,7 +60,7 @@ def test_comparison_predicate_binding(op, assert_and_unwrap):
     bound = assert_and_unwrap(unbound.bind(struct))
 
     assert 5 == bound.lit.value
-    assert 14 == bound.ref.field_id
+    assert 14 == bound.ref.field.field_id
     assert op == bound.op
 
 
@@ -70,7 +70,7 @@ def test_literal_converison(op, assert_and_unwrap):
     bound = assert_and_unwrap(unbound.bind(struct))
 
     assert Decimal(12.40).quantize(Decimal(".01")).as_tuple() == bound.lit.value.as_tuple()
-    assert 15 == bound.ref.field_id
+    assert 15 == bound.ref.field.field_id
     assert op == bound.op
 
 
@@ -81,7 +81,7 @@ def test_invalid_conversions(op):
     try:
         unbound.bind(struct)
     except ValidationException as e:
-        assert e.args[0].startswith("Invalid value for comparison inclusive type float: 12.40")
+        assert e.args[0].startswith('Invalid Value for conversion to type float: "12.40" (StringLiteral)')
 
 
 def test_long_to_integer_conversion(assert_and_unwrap):
@@ -179,7 +179,7 @@ def test_is_null(assert_and_unwrap):
     bound = assert_and_unwrap(expr)
 
     assert Operation.IS_NULL == bound.op
-    assert 19 == bound.ref.field_id
+    assert 19 == bound.ref.field.field_id
     assert bound.lit is None
 
     required = StructType.of([NestedField.required(20, "s", StringType.get())])
@@ -192,7 +192,7 @@ def test_not_null(assert_and_unwrap):
     expr = unbound.bind(optional)
     bound = assert_and_unwrap(expr)
     assert Operation.NOT_NULL == bound.op
-    assert 21 == bound.ref.field_id
+    assert 21 == bound.ref.field.field_id
     assert bound.lit is None
 
     required = StructType.of([NestedField.required(22, "s", StringType.get())])


### PR DESCRIPTION
Part 1 of N(?) updating python expressions to move it closer to the current state of the java implementation.  This was motivated following review of some of the changes when I started working on some issues in the ResidualEvaluator and on non-identity partition columns.  

The implementation in java has diverged a lot since the initial python implementation, this and the following commits should help move it back in line.  I expect there may be some back and forth on this because I was a little unsure about how to approach this.  cc: @rymurr Let me know what your thoughts are on it.