### PR TITLE
Spark: Remove redundant casts in actions

### DIFF
--- a/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRemoveOrphanFilesSparkAction.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRemoveOrphanFilesSparkAction.java
@@ -235,7 +235,7 @@ public class BaseRemoveOrphanFilesSparkAction
       Broadcast<SerializableConfiguration> conf,
       long olderThanTimestamp) {
 
-    return (FlatMapFunction<Iterator<String>, String>) dirs -> {
+    return dirs -> {
       List<String> subDirs = Lists.newArrayList();
       List<String> files = Lists.newArrayList();
 

--- a/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteManifestsSparkAction.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteManifestsSparkAction.java
@@ -350,7 +350,7 @@ public class BaseRewriteManifestsSparkAction
       Broadcast<FileIO> io, long maxNumManifestEntries, String location,
       int format, PartitionSpec spec, StructType sparkType) {
 
-    return (MapPartitionsFunction<Row, ManifestFile>) rows -> {
+    return rows -> {
       List<Row> rowsAsList = Lists.newArrayList(rows);
 
       if (rowsAsList.isEmpty()) {


### PR DESCRIPTION
This PR removes redundant casts in refactored actions.