### PR TITLE
Flink: Support SQL primary key

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Schema.java
+++ b/api/src/main/java/org/apache/iceberg/Schema.java
@@ -88,8 +88,8 @@ public class Schema implements Serializable {
     this(schemaId, columns, null, identifierFieldIds);
   }
 
-  private Schema(int schemaId, List<NestedField> columns, Map<String, Integer> aliases,
-                 Set<Integer> identifierFieldIds) {
+  public Schema(int schemaId, List<NestedField> columns, Map<String, Integer> aliases,
+                Set<Integer> identifierFieldIds) {
     this.schemaId = schemaId;
     this.struct = StructType.of(columns);
     this.aliasToId = aliases != null ? ImmutableBiMap.copyOf(aliases) : null;

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -467,10 +467,6 @@ public class FlinkCatalog extends AbstractCatalog {
     if (!schema.getWatermarkSpecs().isEmpty()) {
       throw new UnsupportedOperationException("Creating table with watermark specs is not supported yet.");
     }
-
-    if (schema.getPrimaryKey().isPresent()) {
-      throw new UnsupportedOperationException("Creating table with primary key is not supported yet.");
-    }
   }
 
   private static PartitionSpec toPartitionSpec(List<String> partitionKeys, Schema icebergSchema) {
@@ -536,7 +532,7 @@ public class FlinkCatalog extends AbstractCatalog {
   }
 
   static CatalogTable toCatalogTable(Table table) {
-    TableSchema schema = FlinkSchemaUtil.toSchema(FlinkSchemaUtil.convert(table.schema()));
+    TableSchema schema = FlinkSchemaUtil.toSchema(table.schema());
     List<String> partitionKeys = toPartitionKeys(table.spec(), table.schema());
 
     // NOTE: We can not create a IcebergCatalogTable extends CatalogTable, because Flink optimizer may use

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkSchemaUtil.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkSchemaUtil.java
@@ -19,12 +19,16 @@
 
 package org.apache.iceberg.flink;
 
+import java.util.List;
+import java.util.Set;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
@@ -61,7 +65,22 @@ public class FlinkSchemaUtil {
     RowType root = (RowType) schemaType;
     Type converted = root.accept(new FlinkTypeToType(root));
 
-    return new Schema(converted.asStructType().fields());
+    Schema iSchema = new Schema(converted.asStructType().fields());
+    return freshIdentifierFieldIds(iSchema, schema);
+  }
+
+  private static Schema freshIdentifierFieldIds(Schema iSchema, TableSchema schema) {
+    // Locate the identifier field id list.
+    Set<Integer> identifierFieldIds = Sets.newHashSet();
+    if (schema.getPrimaryKey().isPresent()) {
+      for (String column : schema.getPrimaryKey().get().getColumns()) {
+        Types.NestedField field = iSchema.findField(column);
+        Preconditions.checkNotNull(field, "Column %s does not found in schema %s", column, iSchema);
+        identifierFieldIds.add(field.fieldId());
+      }
+    }
+
+    return new Schema(iSchema.schemaId(), iSchema.asStruct().fields(), identifierFieldIds);
   }
 
   /**
@@ -83,7 +102,8 @@ public class FlinkSchemaUtil {
     // reassign ids to match the base schema
     Schema schema = TypeUtil.reassignIds(new Schema(struct.fields()), baseSchema);
     // fix types that can't be represented in Flink (UUID)
-    return FlinkFixupTypes.fixup(schema, baseSchema);
+    Schema fixedSchema = FlinkFixupTypes.fixup(schema, baseSchema);
+    return freshIdentifierFieldIds(fixedSchema, flinkSchema);
   }
 
   /**
@@ -119,6 +139,36 @@ public class FlinkSchemaUtil {
     for (RowType.RowField field : rowType.getFields()) {
       builder.field(field.getName(), TypeConversions.fromLogicalToDataType(field.getType()));
     }
+    return builder.build();
+  }
+
+  /**
+   * Convert a {@link Schema} to a {@link TableSchema}.
+   *
+   * @param schema iceberg schema to convert.
+   * @return Flink TableSchema.
+   */
+  public static TableSchema toSchema(Schema schema) {
+    TableSchema.Builder builder = TableSchema.builder();
+
+    // Add columns.
+    for (RowType.RowField field : convert(schema).getFields()) {
+      builder.field(field.getName(), TypeConversions.fromLogicalToDataType(field.getType()));
+    }
+
+    // Add primary key.
+    Set<Integer> identifierFieldIds = schema.identifierFieldIds();
+    if (!identifierFieldIds.isEmpty()) {
+      List<String> columns = Lists.newArrayListWithExpectedSize(identifierFieldIds.size());
+      for (Integer identifierFieldId : identifierFieldIds) {
+        String columnName = schema.findColumnName(identifierFieldId);
+        Preconditions.checkNotNull(columnName, "Cannot find field with id %s in schema %s", identifierFieldId, schema);
+
+        columns.add(columnName);
+      }
+      builder.primaryKey(columns.toArray(new String[0]));
+    }
+
     return builder.build();
   }
 }

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkSchemaUtil.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkSchemaUtil.java
@@ -75,7 +75,8 @@ public class FlinkSchemaUtil {
     if (schema.getPrimaryKey().isPresent()) {
       for (String column : schema.getPrimaryKey().get().getColumns()) {
         Types.NestedField field = iSchema.findField(column);
-        Preconditions.checkNotNull(field, "Column %s does not found in schema %s", column, iSchema);
+        Preconditions.checkNotNull(field,
+            "Cannot find field ID for the primary key column %s in schema %s", column, iSchema);
         identifierFieldIds.add(field.fieldId());
       }
     }

--- a/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
@@ -210,8 +210,17 @@ public class SimpleDataUtil {
 
   public static StructLikeSet actualRowSet(Table table, String... columns) throws IOException {
     table.refresh();
+    return actualRowSet(table, table.currentSnapshot().snapshotId(), columns);
+  }
+
+  public static StructLikeSet actualRowSet(Table table, long snapshotId, String... columns) throws IOException {
+    table.refresh();
     StructLikeSet set = StructLikeSet.create(table.schema().asStruct());
-    try (CloseableIterable<Record> reader = IcebergGenerics.read(table).select(columns).build()) {
+    try (CloseableIterable<Record> reader = IcebergGenerics
+        .read(table)
+        .useSnapshot(snapshotId)
+        .select(columns)
+        .build()) {
       reader.forEach(set::add);
     }
     return set;

--- a/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
@@ -209,16 +209,15 @@ public class SimpleDataUtil {
   }
 
   public static StructLikeSet actualRowSet(Table table, String... columns) throws IOException {
-    table.refresh();
-    return actualRowSet(table, table.currentSnapshot().snapshotId(), columns);
+    return actualRowSet(table, null, columns);
   }
 
-  public static StructLikeSet actualRowSet(Table table, long snapshotId, String... columns) throws IOException {
+  public static StructLikeSet actualRowSet(Table table, Long snapshotId, String... columns) throws IOException {
     table.refresh();
     StructLikeSet set = StructLikeSet.create(table.schema().asStruct());
     try (CloseableIterable<Record> reader = IcebergGenerics
         .read(table)
-        .useSnapshot(snapshotId)
+        .useSnapshot(snapshotId == null ? table.currentSnapshot().snapshotId() : snapshotId)
         .select(columns)
         .build()) {
       reader.forEach(set::add);

--- a/flink/src/test/java/org/apache/iceberg/flink/TestChangeLogTable.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestChangeLogTable.java
@@ -1,0 +1,302 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.apache.flink.types.Row;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.flink.source.BoundedTableFactory;
+import org.apache.iceberg.flink.source.ChangeLogTableTestBase;
+import org.apache.iceberg.relocated.com.google.common.base.Joiner;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.StructLikeSet;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestChangeLogTable extends ChangeLogTableTestBase {
+  private static final Configuration CONF = new Configuration();
+  private static final String SOURCE_TABLE = "default_catalog.default_database.source_change_logs";
+
+  private static final String CATALOG_NAME = "test_catalog";
+  private static final String DATABASE_NAME = "test_db";
+  private static final String TABLE_NAME = "test_table";
+  private static String warehouse;
+
+  private final boolean partitioned;
+
+  @Parameterized.Parameters(name = "PartitionedTable={0}")
+  public static Iterable<Object[]> parameters() {
+    return ImmutableList.of(
+        new Object[] {true},
+        new Object[] {false}
+    );
+  }
+
+  public TestChangeLogTable(boolean partitioned) {
+    this.partitioned = partitioned;
+  }
+
+  @BeforeClass
+  public static void createWarehouse() throws IOException {
+    File warehouseFile = TEMPORARY_FOLDER.newFolder();
+    Assert.assertTrue("The warehouse should be deleted", warehouseFile.delete());
+    warehouse = String.format("file:%s", warehouseFile);
+  }
+
+  @Before
+  public void before() {
+    sql("CREATE CATALOG %s WITH ('type'='iceberg', 'catalog-type'='hadoop', 'warehouse'='%s')",
+        CATALOG_NAME, warehouse);
+    sql("USE CATALOG %s", CATALOG_NAME);
+    sql("CREATE DATABASE %s", DATABASE_NAME);
+    sql("USE %s", DATABASE_NAME);
+  }
+
+  @After
+  @Override
+  public void clean() {
+    sql("DROP TABLE IF EXISTS %s", TABLE_NAME);
+    sql("DROP DATABASE IF EXISTS %s", DATABASE_NAME);
+    sql("DROP CATALOG IF EXISTS %s", CATALOG_NAME);
+    BoundedTableFactory.clearDataSets();
+  }
+
+  @Test
+  public void testSqlChangeLogOnIdKey() throws Exception {
+    List<List<Row>> inputRowsPerCheckpoint = ImmutableList.of(
+        ImmutableList.of(
+            row("+I", 1, "aaa"),
+            row("-D", 1, "aaa"),
+            row("+I", 1, "bbb"),
+            row("+I", 2, "aaa"),
+            row("-D", 2, "aaa"),
+            row("+I", 2, "bbb")
+        ),
+        ImmutableList.of(
+            row("-U", 2, "bbb"),
+            row("+U", 2, "ccc"),
+            row("-D", 2, "ccc"),
+            row("+I", 2, "ddd")
+        ),
+        ImmutableList.of(
+            row("-D", 1, "bbb"),
+            row("+I", 1, "ccc"),
+            row("-D", 1, "ccc"),
+            row("+I", 1, "ddd")
+        )
+    );
+
+    List<List<Record>> expectedRecordsPerCheckpoint = ImmutableList.of(
+        ImmutableList.of(record(1, "bbb"), record(2, "bbb")),
+        ImmutableList.of(record(1, "bbb"), record(2, "ddd")),
+        ImmutableList.of(record(1, "ddd"), record(2, "ddd"))
+    );
+
+    testSqlChangeLog(TABLE_NAME, ImmutableList.of("id"), inputRowsPerCheckpoint,
+        expectedRecordsPerCheckpoint);
+  }
+
+  @Test
+  public void testChangeLogOnDataKey() throws Exception {
+    List<List<Row>> elementsPerCheckpoint = ImmutableList.of(
+        ImmutableList.of(
+            row("+I", 1, "aaa"),
+            row("-D", 1, "aaa"),
+            row("+I", 2, "bbb"),
+            row("+I", 1, "bbb"),
+            row("+I", 2, "aaa")
+        ),
+        ImmutableList.of(
+            row("-U", 2, "aaa"),
+            row("+U", 1, "ccc"),
+            row("+I", 1, "aaa")
+        ),
+        ImmutableList.of(
+            row("-D", 1, "bbb"),
+            row("+I", 2, "aaa"),
+            row("+I", 2, "ccc")
+        )
+    );
+
+    List<List<Record>> expectedRecords = ImmutableList.of(
+        ImmutableList.of(record(1, "bbb"), record(2, "aaa")),
+        ImmutableList.of(record(1, "aaa"), record(1, "bbb"), record(1, "ccc")),
+        ImmutableList.of(record(1, "aaa"), record(1, "ccc"), record(2, "aaa"), record(2, "ccc"))
+    );
+
+    testSqlChangeLog(TABLE_NAME, ImmutableList.of("data"), elementsPerCheckpoint, expectedRecords);
+  }
+
+  @Test
+  public void testChangeLogOnIdDataKey() throws Exception {
+    List<List<Row>> elementsPerCheckpoint = ImmutableList.of(
+        ImmutableList.of(
+            row("+I", 1, "aaa"),
+            row("-D", 1, "aaa"),
+            row("+I", 2, "bbb"),
+            row("+I", 1, "bbb"),
+            row("+I", 2, "aaa")
+        ),
+        ImmutableList.of(
+            row("-U", 2, "aaa"),
+            row("+U", 1, "ccc"),
+            row("+I", 1, "aaa")
+        ),
+        ImmutableList.of(
+            row("-D", 1, "bbb"),
+            row("+I", 2, "aaa")
+        )
+    );
+
+    List<List<Record>> expectedRecords = ImmutableList.of(
+        ImmutableList.of(record(1, "bbb"), record(2, "aaa"), record(2, "bbb")),
+        ImmutableList.of(record(1, "aaa"), record(1, "bbb"), record(1, "ccc"), record(2, "bbb")),
+        ImmutableList.of(record(1, "aaa"), record(1, "ccc"), record(2, "aaa"), record(2, "bbb"))
+    );
+
+    testSqlChangeLog(TABLE_NAME, ImmutableList.of("data", "id"), elementsPerCheckpoint, expectedRecords);
+  }
+
+  @Test
+  public void testPureInsertOnIdKey() throws Exception {
+    List<List<Row>> elementsPerCheckpoint = ImmutableList.of(
+        ImmutableList.of(
+            row("+I", 1, "aaa"),
+            row("+I", 2, "bbb")
+        ),
+        ImmutableList.of(
+            row("+I", 3, "ccc"),
+            row("+I", 4, "ddd")
+        ),
+        ImmutableList.of(
+            row("+I", 5, "eee"),
+            row("+I", 6, "fff")
+        )
+    );
+
+    List<List<Record>> expectedRecords = ImmutableList.of(
+        ImmutableList.of(
+            record(1, "aaa"),
+            record(2, "bbb")
+        ),
+        ImmutableList.of(
+            record(1, "aaa"),
+            record(2, "bbb"),
+            record(3, "ccc"),
+            record(4, "ddd")
+        ),
+        ImmutableList.of(
+            record(1, "aaa"),
+            record(2, "bbb"),
+            record(3, "ccc"),
+            record(4, "ddd"),
+            record(5, "eee"),
+            record(6, "fff")
+        )
+    );
+
+    testSqlChangeLog(TABLE_NAME, ImmutableList.of("data"), elementsPerCheckpoint, expectedRecords);
+  }
+
+  private Record record(int id, String data) {
+    return SimpleDataUtil.createRecord(id, data);
+  }
+
+  private Table createTable(String tableName, List<String> key, boolean isPartitioned) {
+    String partitionByCause = isPartitioned ? "PARTITIONED BY (data)" : "";
+    sql("CREATE TABLE %s(id INT, data VARCHAR, PRIMARY KEY(%s) NOT ENFORCED) %s",
+        tableName, Joiner.on(',').join(key), partitionByCause);
+
+    // Upgrade the iceberg table to format v2.
+    CatalogLoader loader = CatalogLoader.hadoop("my_catalog", CONF, ImmutableMap.of(
+        CatalogProperties.WAREHOUSE_LOCATION, warehouse
+    ));
+    Table table = loader.loadCatalog().loadTable(TableIdentifier.of(DATABASE_NAME, TABLE_NAME));
+    TableOperations ops = ((BaseTable) table).operations();
+    TableMetadata meta = ops.current();
+    ops.commit(meta, meta.upgradeToFormatVersion(2));
+
+    return table;
+  }
+
+  private void testSqlChangeLog(String tableName,
+                                List<String> key,
+                                List<List<Row>> inputRowsPerCheckpoint,
+                                List<List<Record>> expectedRecordsPerCheckpoint) throws Exception {
+    String dataId = BoundedTableFactory.registerDataSet(inputRowsPerCheckpoint);
+    sql("CREATE TABLE %s(id INT NOT NULL, data STRING NOT NULL)" +
+        " WITH ('connector'='BoundedSource', 'data-id'='%s')", SOURCE_TABLE, dataId);
+
+    Assert.assertEquals("Should have the expected rows",
+        listJoin(inputRowsPerCheckpoint),
+        sql("SELECT * FROM %s", SOURCE_TABLE));
+
+    Table table = createTable(tableName, key, partitioned);
+    sql("INSERT INTO %s SELECT * FROM %s", tableName, SOURCE_TABLE);
+
+    table.refresh();
+    List<Snapshot> snapshots = findValidSnapshots(table);
+    int expectedSnapshotNum = expectedRecordsPerCheckpoint.size();
+    Assert.assertEquals("Should have the expected snapshot number", expectedSnapshotNum, snapshots.size());
+
+    for (int i = 0; i < expectedSnapshotNum; i++) {
+      long snapshotId = snapshots.get(i).snapshotId();
+      List<Record> expectedRecords = expectedRecordsPerCheckpoint.get(i);
+      Assert.assertEquals("Should have the expected records for the checkpoint#" + i,
+          expectedRowSet(table, expectedRecords), actualRowSet(table, snapshotId));
+    }
+  }
+
+  private List<Snapshot> findValidSnapshots(Table table) {
+    List<Snapshot> validSnapshots = Lists.newArrayList();
+    for (Snapshot snapshot : table.snapshots()) {
+      if (snapshot.allManifests().stream().anyMatch(m -> snapshot.snapshotId() == m.snapshotId())) {
+        validSnapshots.add(snapshot);
+      }
+    }
+    return validSnapshots;
+  }
+
+  private static StructLikeSet expectedRowSet(Table table, List<Record> records) {
+    return SimpleDataUtil.expectedRowSet(table, records.toArray(new Record[0]));
+  }
+
+  private static StructLikeSet actualRowSet(Table table, long snapshotId) throws IOException {
+    return SimpleDataUtil.actualRowSet(table, snapshotId, "*");
+  }
+}

--- a/flink/src/test/java/org/apache/iceberg/flink/TestChangeLogTable.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestChangeLogTable.java
@@ -100,24 +100,24 @@ public class TestChangeLogTable extends ChangeLogTableTestBase {
   public void testSqlChangeLogOnIdKey() throws Exception {
     List<List<Row>> inputRowsPerCheckpoint = ImmutableList.of(
         ImmutableList.of(
-            row("+I", 1, "aaa"),
-            row("-D", 1, "aaa"),
-            row("+I", 1, "bbb"),
-            row("+I", 2, "aaa"),
-            row("-D", 2, "aaa"),
-            row("+I", 2, "bbb")
+            insertRow(1, "aaa"),
+            deleteRow(1, "aaa"),
+            insertRow(1, "bbb"),
+            insertRow(2, "aaa"),
+            deleteRow(2, "aaa"),
+            insertRow(2, "bbb")
         ),
         ImmutableList.of(
-            row("-U", 2, "bbb"),
-            row("+U", 2, "ccc"),
-            row("-D", 2, "ccc"),
-            row("+I", 2, "ddd")
+            updateBeforeRow(2, "bbb"),
+            updateAfterRow(2, "ccc"),
+            deleteRow(2, "ccc"),
+            insertRow(2, "ddd")
         ),
         ImmutableList.of(
-            row("-D", 1, "bbb"),
-            row("+I", 1, "ccc"),
-            row("-D", 1, "ccc"),
-            row("+I", 1, "ddd")
+            deleteRow(1, "bbb"),
+            insertRow(1, "ccc"),
+            deleteRow(1, "ccc"),
+            insertRow(1, "ddd")
         )
     );
 
@@ -135,21 +135,21 @@ public class TestChangeLogTable extends ChangeLogTableTestBase {
   public void testChangeLogOnDataKey() throws Exception {
     List<List<Row>> elementsPerCheckpoint = ImmutableList.of(
         ImmutableList.of(
-            row("+I", 1, "aaa"),
-            row("-D", 1, "aaa"),
-            row("+I", 2, "bbb"),
-            row("+I", 1, "bbb"),
-            row("+I", 2, "aaa")
+            insertRow(1, "aaa"),
+            deleteRow(1, "aaa"),
+            insertRow(2, "bbb"),
+            insertRow(1, "bbb"),
+            insertRow(2, "aaa")
         ),
         ImmutableList.of(
-            row("-U", 2, "aaa"),
-            row("+U", 1, "ccc"),
-            row("+I", 1, "aaa")
+            updateBeforeRow(2, "aaa"),
+            updateAfterRow(1, "ccc"),
+            insertRow(1, "aaa")
         ),
         ImmutableList.of(
-            row("-D", 1, "bbb"),
-            row("+I", 2, "aaa"),
-            row("+I", 2, "ccc")
+            deleteRow(1, "bbb"),
+            insertRow(2, "aaa"),
+            insertRow(2, "ccc")
         )
     );
 
@@ -166,20 +166,20 @@ public class TestChangeLogTable extends ChangeLogTableTestBase {
   public void testChangeLogOnIdDataKey() throws Exception {
     List<List<Row>> elementsPerCheckpoint = ImmutableList.of(
         ImmutableList.of(
-            row("+I", 1, "aaa"),
-            row("-D", 1, "aaa"),
-            row("+I", 2, "bbb"),
-            row("+I", 1, "bbb"),
-            row("+I", 2, "aaa")
+            insertRow(1, "aaa"),
+            deleteRow(1, "aaa"),
+            insertRow(2, "bbb"),
+            insertRow(1, "bbb"),
+            insertRow(2, "aaa")
         ),
         ImmutableList.of(
-            row("-U", 2, "aaa"),
-            row("+U", 1, "ccc"),
-            row("+I", 1, "aaa")
+            updateBeforeRow(2, "aaa"),
+            updateAfterRow(1, "ccc"),
+            insertRow(1, "aaa")
         ),
         ImmutableList.of(
-            row("-D", 1, "bbb"),
-            row("+I", 2, "aaa")
+            deleteRow(1, "bbb"),
+            insertRow(2, "aaa")
         )
     );
 
@@ -196,16 +196,16 @@ public class TestChangeLogTable extends ChangeLogTableTestBase {
   public void testPureInsertOnIdKey() throws Exception {
     List<List<Row>> elementsPerCheckpoint = ImmutableList.of(
         ImmutableList.of(
-            row("+I", 1, "aaa"),
-            row("+I", 2, "bbb")
+            insertRow(1, "aaa"),
+            insertRow(2, "bbb")
         ),
         ImmutableList.of(
-            row("+I", 3, "ccc"),
-            row("+I", 4, "ddd")
+            insertRow(3, "ccc"),
+            insertRow(4, "ddd")
         ),
         ImmutableList.of(
-            row("+I", 5, "eee"),
-            row("+I", 6, "fff")
+            insertRow(5, "eee"),
+            insertRow(6, "fff")
         )
     );
 

--- a/flink/src/test/java/org/apache/iceberg/flink/TestChangeLogTable.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestChangeLogTable.java
@@ -47,6 +47,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+/**
+ * In this test case, we mainly cover the impact of primary key selection, multiple operations within a single
+ * transaction, and multiple operations between different txn on the correctness of the data.
+ */
 @RunWith(Parameterized.class)
 public class TestChangeLogTable extends ChangeLogTableTestBase {
   private static final Configuration CONF = new Configuration();

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
@@ -298,7 +298,7 @@ public class TestFlinkSchemaUtil {
 
   @Test
   public void testConvertFlinkSchemaWithPrimaryKeys() {
-    Schema iSchema = new Schema(
+    Schema icebergSchema = new Schema(
         Lists.newArrayList(
             Types.NestedField.required(1, "int", Types.IntegerType.get()),
             Types.NestedField.required(2, "string", Types.StringType.get())
@@ -306,7 +306,7 @@ public class TestFlinkSchemaUtil {
         Sets.newHashSet(1, 2)
     );
 
-    TableSchema tableSchema = FlinkSchemaUtil.toSchema(iSchema);
+    TableSchema tableSchema = FlinkSchemaUtil.toSchema(icebergSchema);
     Assert.assertTrue(tableSchema.getPrimaryKey().isPresent());
     Assert.assertEquals(ImmutableSet.of("int", "string"),
         ImmutableSet.copyOf(tableSchema.getPrimaryKey().get().getColumns()));
@@ -314,7 +314,7 @@ public class TestFlinkSchemaUtil {
 
   @Test
   public void testConvertFlinkSchemaWithNestedColumnInPrimaryKeys() {
-    Schema iSchema = new Schema(
+    Schema icebergSchema = new Schema(
         Lists.newArrayList(Types.NestedField.required(1, "struct",
             Types.StructType.of(Types.NestedField.required(2, "inner", Types.LongType.get())))
         ),
@@ -323,6 +323,6 @@ public class TestFlinkSchemaUtil {
     AssertHelpers.assertThrows("Does not support the nested columns in flink schema's primary keys",
         ValidationException.class,
         "Column 'struct.inner' does not exist",
-        () -> FlinkSchemaUtil.toSchema(iSchema));
+        () -> FlinkSchemaUtil.toSchema(icebergSchema));
   }
 }

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
@@ -277,6 +277,26 @@ public class TestFlinkSchemaUtil {
   }
 
   @Test
+  public void testConvertFlinkSchemaBaseOnIcebergSchema() {
+    Schema baseSchema = new Schema(
+        Lists.newArrayList(
+            Types.NestedField.required(101, "int", Types.IntegerType.get()),
+            Types.NestedField.optional(102, "string", Types.StringType.get())
+        ),
+        Sets.newHashSet(101, 102)
+    );
+
+    TableSchema flinkSchema = TableSchema.builder()
+        .field("int", DataTypes.INT().notNull())
+        .field("string", DataTypes.STRING().nullable())
+        .primaryKey("int")
+        .build();
+    Schema convertedSchema = FlinkSchemaUtil.convert(baseSchema, flinkSchema);
+    Assert.assertEquals(baseSchema.asStruct(), convertedSchema.asStruct());
+    Assert.assertEquals(ImmutableSet.of(101), convertedSchema.identifierFieldIds());
+  }
+
+  @Test
   public void testConvertFlinkSchemaWithPrimaryKeys() {
     Schema iSchema = new Schema(
         Lists.newArrayList(

--- a/flink/src/test/java/org/apache/iceberg/flink/source/BoundedTableFactory.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/source/BoundedTableFactory.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.source.DataStreamScanProvider;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.util.DataFormatConverters;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.utils.TableSchemaUtils;
+import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
+import org.apache.iceberg.flink.util.FlinkCompatibilityUtil;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+
+public class BoundedTableFactory implements DynamicTableSourceFactory {
+  private static final AtomicInteger DATA_SET_ID = new AtomicInteger(0);
+  private static final Map<String, List<List<Row>>> DATA_SETS = new HashMap<>();
+
+  private static final ConfigOption<String> DATA_ID = ConfigOptions.key("data-id").stringType().noDefaultValue();
+
+  public static String registerDataSet(List<List<Row>> dataSet) {
+    String dataSetId = String.valueOf(DATA_SET_ID.incrementAndGet());
+    DATA_SETS.put(dataSetId, dataSet);
+    return dataSetId;
+  }
+
+  public static void clearDataSets() {
+    DATA_SETS.clear();
+  }
+
+  @Override
+  public DynamicTableSource createDynamicTableSource(Context context) {
+    TableSchema tableSchema = TableSchemaUtils.getPhysicalSchema(context.getCatalogTable().getSchema());
+
+    Configuration configuration = Configuration.fromMap(context.getCatalogTable().getOptions());
+    String dataId = configuration.getString(DATA_ID);
+    Preconditions.checkArgument(DATA_SETS.containsKey(dataId),
+        "data-id %s does not found in registered data set.", dataId);
+
+    return new BoundedTableSource(DATA_SETS.get(dataId), tableSchema);
+  }
+
+  @Override
+  public String factoryIdentifier() {
+    return "BoundedSource";
+  }
+
+  @Override
+  public Set<ConfigOption<?>> requiredOptions() {
+    return ImmutableSet.of();
+  }
+
+  @Override
+  public Set<ConfigOption<?>> optionalOptions() {
+    return ImmutableSet.of(DATA_ID);
+  }
+
+  private static class BoundedTableSource implements ScanTableSource {
+
+    private final List<List<Row>> elementsPerCheckpoint;
+    private final TableSchema tableSchema;
+
+    private BoundedTableSource(List<List<Row>> elementsPerCheckpoint, TableSchema tableSchema) {
+      this.elementsPerCheckpoint = elementsPerCheckpoint;
+      this.tableSchema = tableSchema;
+    }
+
+    private BoundedTableSource(BoundedTableSource toCopy) {
+      this.elementsPerCheckpoint = toCopy.elementsPerCheckpoint;
+      this.tableSchema = toCopy.tableSchema;
+    }
+
+    @Override
+    public ChangelogMode getChangelogMode() {
+      return ChangelogMode.newBuilder()
+          .addContainedKind(RowKind.INSERT)
+          .addContainedKind(RowKind.DELETE)
+          .addContainedKind(RowKind.UPDATE_BEFORE)
+          .addContainedKind(RowKind.UPDATE_AFTER)
+          .build();
+    }
+
+    @Override
+    public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
+      return new DataStreamScanProvider() {
+        @Override
+        public DataStream<RowData> produceDataStream(StreamExecutionEnvironment env) {
+          SourceFunction<Row> source = new BoundedTestSource<>(elementsPerCheckpoint);
+
+          RowType rowType = (RowType) tableSchema.toRowDataType().getLogicalType();
+          // Converter to convert the Row to RowData.
+          DataFormatConverters.RowConverter rowConverter = new DataFormatConverters
+              .RowConverter(tableSchema.getFieldDataTypes());
+
+          return env.addSource(source, new RowTypeInfo(tableSchema.getFieldTypes()))
+              .map(rowConverter::toInternal, FlinkCompatibilityUtil.toTypeInfo(rowType));
+        }
+
+        @Override
+        public boolean isBounded() {
+          return true;
+        }
+      };
+    }
+
+    @Override
+    public DynamicTableSource copy() {
+      return new BoundedTableSource(this);
+    }
+
+    @Override
+    public String asSummaryString() {
+      return "Bounded test table source";
+    }
+  }
+}

--- a/flink/src/test/java/org/apache/iceberg/flink/source/BoundedTestSource.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/source/BoundedTestSource.java
@@ -23,7 +23,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.apache.flink.runtime.state.CheckpointListener;
+import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 
 /**

--- a/flink/src/test/java/org/apache/iceberg/flink/source/BoundedTestSource.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/source/BoundedTestSource.java
@@ -63,6 +63,12 @@ public final class BoundedTestSource<T> implements SourceFunction<T>, Checkpoint
 
       final int checkpointToAwait;
       synchronized (ctx.getCheckpointLock()) {
+        // Let's say checkpointToAwait = numCheckpointsComplete.get() + delta, in fact the value of delta should not
+        // affect the final table records because we only need to make sure that there will be exactly
+        // elementsPerCheckpoint.size() checkpoints to emit each records buffer from the original elementsPerCheckpoint.
+        // Even if the checkpoints that emitted results are not continuous, the correctness of the data should not be
+        // affected in the end. Setting the delta to be 2 is introducing the variable that produce un-continuous
+        // checkpoints that emit the records buffer from elementsPerCheckpoints.
         checkpointToAwait = numCheckpointsComplete.get() + 2;
         for (T element : elementsPerCheckpoint.get(checkpoint)) {
           ctx.collect(element);

--- a/flink/src/test/java/org/apache/iceberg/flink/source/ChangeLogTableTestBase.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/source/ChangeLogTableTestBase.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.flink.source;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
@@ -28,7 +29,6 @@ import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 import org.apache.iceberg.flink.FlinkTestBase;
 import org.apache.iceberg.flink.MiniClusterResource;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.rules.TestName;
@@ -86,10 +86,8 @@ public class ChangeLogTableTestBase extends FlinkTestBase {
   }
 
   protected static <T> List<T> listJoin(List<List<T>> lists) {
-    List<T> result = Lists.newArrayList();
-    for (List<T> list : lists) {
-      result.addAll(list);
-    }
-    return result;
+    return lists.stream()
+        .flatMap(List::stream)
+        .collect(Collectors.toList());
   }
 }

--- a/flink/src/test/java/org/apache/iceberg/flink/source/ChangeLogTableTestBase.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/source/ChangeLogTableTestBase.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
+import org.apache.iceberg.flink.FlinkTestBase;
+import org.apache.iceberg.flink.MiniClusterResource;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.rules.TestName;
+
+public class ChangeLogTableTestBase extends FlinkTestBase {
+  private volatile TableEnvironment tEnv = null;
+
+  @Rule
+  public TestName name = new TestName();
+
+  @After
+  public void clean() {
+    sql("DROP TABLE IF EXISTS %s", name.getMethodName());
+    BoundedTableFactory.clearDataSets();
+  }
+
+  @Override
+  protected TableEnvironment getTableEnv() {
+    if (tEnv == null) {
+      synchronized (this) {
+        if (tEnv == null) {
+          EnvironmentSettings settings = EnvironmentSettings
+              .newInstance()
+              .useBlinkPlanner()
+              .inStreamingMode()
+              .build();
+
+          StreamExecutionEnvironment env = StreamExecutionEnvironment
+              .getExecutionEnvironment(MiniClusterResource.DISABLE_CLASSLOADER_CHECK_CONFIG)
+              .enableCheckpointing(400)
+              .setMaxParallelism(1)
+              .setParallelism(1);
+
+          tEnv = StreamTableEnvironment.create(env, settings);
+        }
+      }
+    }
+    return tEnv;
+  }
+
+  private static final Map<String, RowKind> ROW_KIND_MAP = ImmutableMap.of(
+      "+I", RowKind.INSERT,
+      "-D", RowKind.DELETE,
+      "-U", RowKind.UPDATE_BEFORE,
+      "+U", RowKind.UPDATE_AFTER);
+
+  protected Row row(String rowKind, int id, String data) {
+    RowKind kind = ROW_KIND_MAP.get(rowKind);
+    if (kind == null) {
+      throw new IllegalArgumentException("Unknown row kind: " + rowKind);
+    }
+
+    return Row.ofKind(kind, id, data);
+  }
+
+  protected static <T> List<T> listJoin(List<List<T>> lists) {
+    List<T> result = Lists.newArrayList();
+    for (List<T> list : lists) {
+      result.addAll(list);
+    }
+    return result;
+  }
+}

--- a/flink/src/test/java/org/apache/iceberg/flink/source/ChangeLogTableTestBase.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/source/ChangeLogTableTestBase.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.flink.source;
 
 import java.util.List;
-import java.util.Map;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
@@ -29,7 +28,6 @@ import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 import org.apache.iceberg.flink.FlinkTestBase;
 import org.apache.iceberg.flink.MiniClusterResource;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.After;
 import org.junit.Rule;
@@ -71,19 +69,20 @@ public class ChangeLogTableTestBase extends FlinkTestBase {
     return tEnv;
   }
 
-  private static final Map<String, RowKind> ROW_KIND_MAP = ImmutableMap.of(
-      "+I", RowKind.INSERT,
-      "-D", RowKind.DELETE,
-      "-U", RowKind.UPDATE_BEFORE,
-      "+U", RowKind.UPDATE_AFTER);
+  protected static Row insertRow(Object... values) {
+    return Row.ofKind(RowKind.INSERT, values);
+  }
 
-  protected Row row(String rowKind, int id, String data) {
-    RowKind kind = ROW_KIND_MAP.get(rowKind);
-    if (kind == null) {
-      throw new IllegalArgumentException("Unknown row kind: " + rowKind);
-    }
+  protected static Row deleteRow(Object... values) {
+    return Row.ofKind(RowKind.DELETE, values);
+  }
 
-    return Row.ofKind(kind, id, data);
+  protected static Row updateBeforeRow(Object... values) {
+    return Row.ofKind(RowKind.UPDATE_BEFORE, values);
+  }
+
+  protected static Row updateAfterRow(Object... values) {
+    return Row.ofKind(RowKind.UPDATE_AFTER, values);
   }
 
   protected static <T> List<T> listJoin(List<List<T>> lists) {

--- a/flink/src/test/java/org/apache/iceberg/flink/source/TestBoundedTableFactory.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/source/TestBoundedTableFactory.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.source;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.apache.flink.types.Row;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Streams;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestBoundedTableFactory extends ChangeLogTableTestBase {
+
+  @Test
+  public void testEmptyDataSet() {
+    String table = name.getMethodName();
+    List<List<Row>> emptyDataSet = ImmutableList.of();
+
+    String dataId = BoundedTableFactory.registerDataSet(emptyDataSet);
+    sql("CREATE TABLE %s(id INT, data STRING) WITH ('connector'='BoundedSource', 'data-id'='%s')", table, dataId);
+
+    Assert.assertEquals("Should have caught empty change log set.", ImmutableList.of(),
+        sql("SELECT * FROM %s", table));
+  }
+
+  @Test
+  public void testBoundedTableFactory() {
+    String table = name.getMethodName();
+    List<List<Row>> dataSet = ImmutableList.of(
+        ImmutableList.of(
+            row("+I", 1, "aaa"),
+            row("-D", 1, "aaa"),
+            row("+I", 1, "bbb"),
+            row("+I", 2, "aaa"),
+            row("-D", 2, "aaa"),
+            row("+I", 2, "bbb")
+        ),
+        ImmutableList.of(
+            row("-U", 2, "bbb"),
+            row("+U", 2, "ccc"),
+            row("-D", 2, "ccc"),
+            row("+I", 2, "ddd")
+        ),
+        ImmutableList.of(
+            row("-D", 1, "bbb"),
+            row("+I", 1, "ccc"),
+            row("-D", 1, "ccc"),
+            row("+I", 1, "ddd")
+        )
+    );
+
+    String dataId = BoundedTableFactory.registerDataSet(dataSet);
+    sql("CREATE TABLE %s(id INT, data STRING) WITH ('connector'='BoundedSource', 'data-id'='%s')", table, dataId);
+
+    List<Row> rowSet = dataSet.stream().flatMap(Streams::stream).collect(Collectors.toList());
+    Assert.assertEquals("Should have the expected change log events.", rowSet, sql("SELECT * FROM %s", table));
+
+    Assert.assertEquals("Should have the expected change log events",
+        rowSet.stream().filter(r -> Objects.equals(r.getField(1), "aaa")).collect(Collectors.toList()),
+        sql("SELECT * FROM %s WHERE data='aaa'", table));
+  }
+}

--- a/flink/src/test/java/org/apache/iceberg/flink/source/TestBoundedTableFactory.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/source/TestBoundedTableFactory.java
@@ -47,24 +47,24 @@ public class TestBoundedTableFactory extends ChangeLogTableTestBase {
     String table = name.getMethodName();
     List<List<Row>> dataSet = ImmutableList.of(
         ImmutableList.of(
-            row("+I", 1, "aaa"),
-            row("-D", 1, "aaa"),
-            row("+I", 1, "bbb"),
-            row("+I", 2, "aaa"),
-            row("-D", 2, "aaa"),
-            row("+I", 2, "bbb")
+            insertRow(1, "aaa"),
+            deleteRow(1, "aaa"),
+            insertRow(1, "bbb"),
+            insertRow(2, "aaa"),
+            deleteRow(2, "aaa"),
+            insertRow(2, "bbb")
         ),
         ImmutableList.of(
-            row("-U", 2, "bbb"),
-            row("+U", 2, "ccc"),
-            row("-D", 2, "ccc"),
-            row("+I", 2, "ddd")
+            updateBeforeRow(2, "bbb"),
+            updateAfterRow(2, "ccc"),
+            deleteRow(2, "ccc"),
+            insertRow(2, "ddd")
         ),
         ImmutableList.of(
-            row("-D", 1, "bbb"),
-            row("+I", 1, "ccc"),
-            row("-D", 1, "ccc"),
-            row("+I", 1, "ddd")
+            deleteRow(1, "bbb"),
+            insertRow(1, "ccc"),
+            deleteRow(1, "ccc"),
+            insertRow(1, "ddd")
         )
     );
 

--- a/flink/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.iceberg.flink.source.BoundedTableFactory


### PR DESCRIPTION
This is built on top of https://github.com/apache/iceberg/pull/2354 


## How to export MySQL CDC into apache iceberg table in flink streaming job ?

### Preparation

As we will define an apache iceberg sink table in flink+hive catalog, so you will need to follow all those steps in [here](https://iceberg.apache.org/flink/#preparation).

Another side, we will define an mysql CDC table in catalog, so we will need to download the flink-sql-connector-mysql-cdc-1.2.0.jar from [here](https://github.com/ververica/flink-cdc-connectors/wiki/Downloads) and put it under the `$FLINK_HOME/lib` directory:

```bash
wget https://repo1.maven.org/maven2/com/alibaba/ververica/flink-sql-connector-mysql-cdc/1.2.0/flink-sql-connector-mysql-cdc-1.2.0.jar
cp flink-sql-connector-mysql-cdc-1.2.0.jar $FLINK_HOME/lib/
```

### Define MySQL source table

You need to start a local mysql server and then enable the binlog (Pls follow the [document](https://dev.mysql.com/doc/refman/5.7/en/replication-howto-masterbaseconfig.html)).  Then create a `test` database in your mysql server and run the `sysbench` tool to initialize your tables: 

```bash
sysbench --threads=10 oltp_common \
    --tables=10 \
    --table-size=10000 \
    --mysql-host=localhost \
    --mysql-user=<your-mysql-user> \
    --mysql-password=<your-mysql-password> \
    --mysql-db=test \
    prepare
```

After that you can see the mysql tables (from `sbtest1` to `sbtest10`) under database `test`.  Next please open you flink sql client by `./bin/sql-client.sh embedded shell` and create a mysql cdc source table: 

```sql
CREATE TABLE sbtest1(
  `id`  INT NOT NULL,
  `k`   INT NOT NULL,
  `c`   CHAR(120) NOT NULL,
  `pad` char(60) NOT NULL 
) WITH (
  'connector' = 'mysql-cdc',
  'hostname' = 'localhost',
  'port' = '3306',
  'username' = '<your-mysql-user>',
  'password' = '<your-mysql-password>',
  'database-name' = 'test',
  'table-name' = 'sbtest1'
);
```

### Define apache iceberg sink table

To create an apache iceberg sink table, you could just execute the flink sql in your flink sql client: 

(For how to configure hive catalog, you may want to read iceberg [document](https://iceberg.apache.org/flink/#creating-catalogs-and-using-catalogs))

```sql
CREATE CATALOG hive_catalog WITH (
   'type'='iceberg',
   'catalog-type'='hive',
   'uri'='thrift://localhost:9083',
   'clients'='5',
   'property-version'='1',
   'warehouse'='file:///Users/openinx/test/iceberg-warehouse'
);
USE hive_catalog;

CREATE DATABASE mysql_db;
USE mysql_db;

CREATE TABLE iceberg_sbtest1(
  `id`  INT NOT NULL,
  `k`   INT NOT NULL,
  `c`   CHAR(120) NOT NULL,
  `pad` char(60) NOT NULL,
  PRIMARY KEY(id) NOT ENFORCED
);
```

### Submit flink streaming job to export change log from MySQL server to iceberg table

```sql
INSERT INTO iceberg_sbtest1 SELECT * FROM default_catalog.default_database.sbtest1 ;
```

Then you could try to write few records into the source mysql table `sbtest1` by `sysbench`:

```bash
sysbench --mysql-host=localhost \
    --mysql-user=<your-mysql-user> \
    --mysql-password=<your-mysql-password>  \
    --mysql-db=test \
    --threads=1 \
    --rate=52 \
    --time=1800 \
    --report-interval=10  \      
    oltp_insert \
    --table_size=60000000 \
    --skip_trx=on \
    run
```

### Verify the records between mysql table and iceberg table: 

At one point of time, we kill the `sysbench` process, and veriy the records.

In mysql table: 

```
mysql> select count(*) from sbtest1 ; 
+----------+
| count(*) |
+----------+
|    54358 |
+----------+
1 row in set (0.01 sec)
```

In iceberg table: 

```
Flink SQL> select count(*) from iceberg_sbtest1;
+--------+
| EXPR$0 |
+--------+
|  54358 |
+--------+
1 row in set
```