### PR TITLE
Spark: Abort changes in migrate action only if staging was successful 

### DIFF
--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMigrateTableProcedure.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.Map;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.spark.sql.AnalysisException;
 import org.junit.After;
@@ -97,6 +98,21 @@ public class TestMigrateTableProcedure extends SparkExtensionsTestBase {
         sql("SELECT * FROM %s ORDER BY id", tableName));
 
     sql("DROP TABLE %s", tableName + "_BACKUP_");
+  }
+
+  @Test
+  public void testMigrateWithInvalidMetricsConfig() throws IOException {
+    Assume.assumeTrue(catalogName.equals("spark_catalog"));
+
+    String location = temp.newFolder().toString();
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet LOCATION '%s'", tableName, location);
+
+    AssertHelpers.assertThrows("Should reject invalid metrics config",
+        ValidationException.class, "Invalid metrics config",
+        () -> {
+          String props = "map('write.metadata.metrics.column.x', 'X')";
+          sql("CALL %s.system.migrate('%s', %s)", catalogName, tableName, props);
+        });
   }
 
   @Test

--- a/spark3/src/main/java/org/apache/iceberg/actions/Spark3MigrateAction.java
+++ b/spark3/src/main/java/org/apache/iceberg/actions/Spark3MigrateAction.java
@@ -100,10 +100,12 @@ public class Spark3MigrateAction extends Spark3CreateAction {
               "exists. The backup can be found with the name '{}'", backupIdentifier, taeException);
         }
 
-        try {
-          stagedTable.abortStagedChanges();
-        } catch (Exception abortException) {
-          LOG.error("Cannot abort staged changes", abortException);
+        if (stagedTable != null) {
+          try {
+            stagedTable.abortStagedChanges();
+          } catch (Exception abortException) {
+            LOG.error("Cannot abort staged changes", abortException);
+          }
         }
       }
     }


### PR DESCRIPTION
This PR makes sure we don't call `abortStagedChanges` if `stagedTable` is null.