### PR TITLE
Spark: Handle name mapping assignment errors in snapshot action

### DIFF
--- a/spark3/src/main/java/org/apache/iceberg/actions/Spark3SnapshotAction.java
+++ b/spark3/src/main/java/org/apache/iceberg/actions/Spark3SnapshotAction.java
@@ -59,10 +59,10 @@ public class Spark3SnapshotAction extends Spark3CreateAction implements Snapshot
     Table icebergTable = stagedTable.table();
     // TODO Check table location here against source location
 
-    ensureNameMappingPresent(icebergTable);
-
     boolean threw = true;
     try {
+      ensureNameMappingPresent(icebergTable);
+
       String stagingLocation = getMetadataLocation(icebergTable);
       LOG.info("Beginning snapshot of {} to {} using metadata location {}", sourceTableIdent(), destTableIdent(),
           stagingLocation);


### PR DESCRIPTION
This PR moves `ensureNameMappingPresent` into the try-catch block to ensure we will call abort in case of any errors.