### PR TITLE
Spark: Add table sort-order to reserved table properties

### DIFF
--- a/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.NullOrder;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableProperties;
@@ -478,6 +479,10 @@ public class Spark3Util {
     return TypeUtil.visit(type, DescribeSchemaVisitor.INSTANCE);
   }
 
+  public static String describe(org.apache.iceberg.SortOrder order) {
+    return Joiner.on(", ").join(SortOrderVisitor.visit(order, DescribeSortOrderVisitor.INSTANCE));
+  }
+
   public static boolean isLocalityEnabled(FileIO io, String location, CaseInsensitiveStringMap readOptions) {
     InputFile in = io.newInputFile(location);
     if (in instanceof HadoopInputFile) {
@@ -879,5 +884,60 @@ public class Spark3Util {
     String table = identifier.name();
     Option<String> database = namespace.length == 1 ? Option.apply(namespace[0]) : Option.empty();
     return org.apache.spark.sql.catalyst.TableIdentifier.apply(table, database);
+  }
+
+  private static class DescribeSortOrderVisitor implements SortOrderVisitor<String> {
+    private static final DescribeSortOrderVisitor INSTANCE = new DescribeSortOrderVisitor();
+
+    private DescribeSortOrderVisitor() {
+    }
+
+    @Override
+    public String field(String sourceName, int sourceId,
+                        org.apache.iceberg.SortDirection direction, NullOrder nullOrder) {
+      return String.format("%s %s %s", sourceName, direction, nullOrder);
+    }
+
+    @Override
+    public String bucket(String sourceName, int sourceId, int numBuckets,
+                         org.apache.iceberg.SortDirection direction, NullOrder nullOrder) {
+      return String.format("bucket(%s, %s) %s %s", numBuckets, sourceName, direction, nullOrder);
+    }
+
+    @Override
+    public String truncate(String sourceName, int sourceId, int width,
+                           org.apache.iceberg.SortDirection direction, NullOrder nullOrder) {
+      return String.format("bucket(%s, %s) %s %s", sourceName, width, direction, nullOrder);
+    }
+
+    @Override
+    public String year(String sourceName, int sourceId,
+                       org.apache.iceberg.SortDirection direction, NullOrder nullOrder) {
+      return String.format("years(%s) %s %s", sourceName, direction, nullOrder);
+    }
+
+    @Override
+    public String month(String sourceName, int sourceId,
+                        org.apache.iceberg.SortDirection direction, NullOrder nullOrder) {
+      return String.format("months(%s) %s %s", sourceName, direction, nullOrder);
+    }
+
+    @Override
+    public String day(String sourceName, int sourceId,
+                      org.apache.iceberg.SortDirection direction, NullOrder nullOrder) {
+      return String.format("days(%s) %s %s", sourceName, direction, nullOrder);
+    }
+
+    @Override
+    public String hour(String sourceName, int sourceId,
+                       org.apache.iceberg.SortDirection direction, NullOrder nullOrder) {
+      return String.format("hours(%s) %s %s", sourceName, direction, nullOrder);
+    }
+
+    @Override
+    public String unknown(String sourceName, int sourceId, String transform,
+                          org.apache.iceberg.SortDirection direction, NullOrder nullOrder) {
+      return String.format("%s(%s) %s %s", transform, sourceName, direction, nullOrder);
+    }
   }
 }

--- a/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -907,7 +907,7 @@ public class Spark3Util {
     @Override
     public String truncate(String sourceName, int sourceId, int width,
                            org.apache.iceberg.SortDirection direction, NullOrder nullOrder) {
-      return String.format("bucket(%s, %s) %s %s", sourceName, width, direction, nullOrder);
+      return String.format("truncate(%s, %s) %s %s", sourceName, width, direction, nullOrder);
     }
 
     @Override

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -64,7 +64,7 @@ public class SparkTable implements org.apache.spark.sql.connector.catalog.Table,
   private static final Logger LOG = LoggerFactory.getLogger(SparkTable.class);
 
   private static final Set<String> RESERVED_PROPERTIES =
-      ImmutableSet.of("provider", "format", "current-snapshot-id", "location");
+      ImmutableSet.of("provider", "format", "current-snapshot-id", "location", "sort-order");
   private static final Set<TableCapability> CAPABILITIES = ImmutableSet.of(
       TableCapability.BATCH_READ,
       TableCapability.BATCH_WRITE,
@@ -140,6 +140,10 @@ public class SparkTable implements org.apache.spark.sql.connector.catalog.Table,
         String.valueOf(icebergTable.currentSnapshot().snapshotId()) : "none";
     propsBuilder.put("current-snapshot-id", currentSnapshotId);
     propsBuilder.put("location", icebergTable.location());
+
+    if (!icebergTable.sortOrder().isUnsorted()) {
+      propsBuilder.put("sort-order", Spark3Util.describe(icebergTable.sortOrder()));
+    }
 
     icebergTable.properties().entrySet().stream()
         .filter(entry -> !RESERVED_PROPERTIES.contains(entry.getKey()))

--- a/spark3/src/test/java/org/apache/iceberg/actions/TestCreateActions.java
+++ b/spark3/src/test/java/org/apache/iceberg/actions/TestCreateActions.java
@@ -455,8 +455,10 @@ public class TestCreateActions extends SparkCatalogTestBase {
     createSourceTable(CREATE_PARQUET, source);
     assertMigratedFileCount(Actions.snapshot(source, dest), source, dest);
     SparkTable table = loadTable(dest);
+    // set sort orders
+    table.table().replaceSortOrder().asc("id").desc("data").commit();
 
-    String[] keys = {"provider", "format", "current-snapshot-id", "location"};
+    String[] keys = {"provider", "format", "current-snapshot-id", "location", "sort-order"};
 
     for (String entry : keys) {
       Assert.assertTrue("Created table missing reserved property " + entry, table.properties().containsKey(entry));
@@ -466,6 +468,8 @@ public class TestCreateActions extends SparkCatalogTestBase {
     Assert.assertEquals("Unexpected format", "iceberg/parquet", table.properties().get("format"));
     Assert.assertNotEquals("No current-snapshot-id found", "none", table.properties().get("current-snapshot-id"));
     Assert.assertTrue("Location isn't correct", table.properties().get("location").endsWith(destTableName));
+    Assert.assertEquals("Sort-order isn't correct", "id ASC NULLS FIRST, data DESC NULLS LAST",
+        table.properties().get("sort-order"));
   }
 
   @Test

--- a/spark3/src/test/java/org/apache/iceberg/spark/TestSpark3Util.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/TestSpark3Util.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.SortOrderParser;
+import org.apache.iceberg.types.Types;
+
+import static org.apache.iceberg.NullOrder.NULLS_FIRST;
+import static org.apache.iceberg.NullOrder.NULLS_LAST;
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+public class TestSpark3Util {
+    @Test
+    public void testDescribeSortOrder() {
+      Schema schema = new Schema(
+              required(1, "data", Types.StringType.get()),
+              required(2, "time", Types.TimestampType.withoutZone())
+      );
+
+      Assert.assertEquals("Sort order isn't correct.", "data DESC NULLS FIRST",
+          Spark3Util.describe(buildSortOrder("Identity", schema, 1)));
+      Assert.assertEquals("Sort order isn't correct.", "bucket(1, data) DESC NULLS FIRST",
+          Spark3Util.describe(buildSortOrder("bucket[1]", schema, 1)));
+      Assert.assertEquals("Sort order isn't correct.", "truncate(data, 3) DESC NULLS FIRST",
+          Spark3Util.describe(buildSortOrder("truncate[3]", schema, 1)));
+      Assert.assertEquals("Sort order isn't correct.", "years(time) DESC NULLS FIRST",
+          Spark3Util.describe(buildSortOrder("year", schema, 2)));
+      Assert.assertEquals("Sort order isn't correct.", "months(time) DESC NULLS FIRST",
+          Spark3Util.describe(buildSortOrder("month", schema, 2)));
+      Assert.assertEquals("Sort order isn't correct.", "days(time) DESC NULLS FIRST",
+          Spark3Util.describe(buildSortOrder("day", schema, 2)));
+      Assert.assertEquals("Sort order isn't correct.", "hours(time) DESC NULLS FIRST",
+          Spark3Util.describe(buildSortOrder("hour", schema, 2)));
+      Assert.assertEquals("Sort order isn't correct.", "unknown(data) DESC NULLS FIRST",
+          Spark3Util.describe(buildSortOrder("unknown", schema, 1)));
+
+      // multiple sort orders
+      SortOrder multiOrder = SortOrder.builderFor(schema)
+              .asc("time", NULLS_FIRST)
+              .asc("data", NULLS_LAST)
+              .build();
+      Assert.assertEquals("Sort order isn't correct.", "time ASC NULLS FIRST, data ASC NULLS LAST",
+              Spark3Util.describe(multiOrder));
+    }
+
+    private SortOrder buildSortOrder(String transform, Schema schema, int sourceId) {
+      String jsonString = "{\n" +
+              "  \"order-id\" : 10,\n" +
+              "  \"fields\" : [ {\n" +
+              "    \"transform\" : \"" + transform + "\",\n" +
+              "    \"source-id\" : " + sourceId + ",\n" +
+              "    \"direction\" : \"desc\",\n" +
+              "    \"null-order\" : \"nulls-first\"\n" +
+              "  } ]\n" +
+              "}";
+
+      return SortOrderParser.fromJson(schema, jsonString);
+    }
+}

--- a/spark3/src/test/java/org/apache/iceberg/spark/TestSpark3Util.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/TestSpark3Util.java
@@ -19,62 +19,62 @@
 
 package org.apache.iceberg.spark;
 
-import org.junit.Assert;
-import org.junit.Test;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.SortOrderParser;
 import org.apache.iceberg.types.Types;
+import org.junit.Assert;
+import org.junit.Test;
 
 import static org.apache.iceberg.NullOrder.NULLS_FIRST;
 import static org.apache.iceberg.NullOrder.NULLS_LAST;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class TestSpark3Util {
-    @Test
-    public void testDescribeSortOrder() {
-      Schema schema = new Schema(
-              required(1, "data", Types.StringType.get()),
-              required(2, "time", Types.TimestampType.withoutZone())
-      );
+  @Test
+  public void testDescribeSortOrder() {
+    Schema schema = new Schema(
+            required(1, "data", Types.StringType.get()),
+            required(2, "time", Types.TimestampType.withoutZone())
+    );
 
-      Assert.assertEquals("Sort order isn't correct.", "data DESC NULLS FIRST",
-          Spark3Util.describe(buildSortOrder("Identity", schema, 1)));
-      Assert.assertEquals("Sort order isn't correct.", "bucket(1, data) DESC NULLS FIRST",
-          Spark3Util.describe(buildSortOrder("bucket[1]", schema, 1)));
-      Assert.assertEquals("Sort order isn't correct.", "truncate(data, 3) DESC NULLS FIRST",
-          Spark3Util.describe(buildSortOrder("truncate[3]", schema, 1)));
-      Assert.assertEquals("Sort order isn't correct.", "years(time) DESC NULLS FIRST",
-          Spark3Util.describe(buildSortOrder("year", schema, 2)));
-      Assert.assertEquals("Sort order isn't correct.", "months(time) DESC NULLS FIRST",
-          Spark3Util.describe(buildSortOrder("month", schema, 2)));
-      Assert.assertEquals("Sort order isn't correct.", "days(time) DESC NULLS FIRST",
-          Spark3Util.describe(buildSortOrder("day", schema, 2)));
-      Assert.assertEquals("Sort order isn't correct.", "hours(time) DESC NULLS FIRST",
-          Spark3Util.describe(buildSortOrder("hour", schema, 2)));
-      Assert.assertEquals("Sort order isn't correct.", "unknown(data) DESC NULLS FIRST",
-          Spark3Util.describe(buildSortOrder("unknown", schema, 1)));
+    Assert.assertEquals("Sort order isn't correct.", "data DESC NULLS FIRST",
+        Spark3Util.describe(buildSortOrder("Identity", schema, 1)));
+    Assert.assertEquals("Sort order isn't correct.", "bucket(1, data) DESC NULLS FIRST",
+        Spark3Util.describe(buildSortOrder("bucket[1]", schema, 1)));
+    Assert.assertEquals("Sort order isn't correct.", "truncate(data, 3) DESC NULLS FIRST",
+        Spark3Util.describe(buildSortOrder("truncate[3]", schema, 1)));
+    Assert.assertEquals("Sort order isn't correct.", "years(time) DESC NULLS FIRST",
+        Spark3Util.describe(buildSortOrder("year", schema, 2)));
+    Assert.assertEquals("Sort order isn't correct.", "months(time) DESC NULLS FIRST",
+        Spark3Util.describe(buildSortOrder("month", schema, 2)));
+    Assert.assertEquals("Sort order isn't correct.", "days(time) DESC NULLS FIRST",
+        Spark3Util.describe(buildSortOrder("day", schema, 2)));
+    Assert.assertEquals("Sort order isn't correct.", "hours(time) DESC NULLS FIRST",
+        Spark3Util.describe(buildSortOrder("hour", schema, 2)));
+    Assert.assertEquals("Sort order isn't correct.", "unknown(data) DESC NULLS FIRST",
+        Spark3Util.describe(buildSortOrder("unknown", schema, 1)));
 
-      // multiple sort orders
-      SortOrder multiOrder = SortOrder.builderFor(schema)
-              .asc("time", NULLS_FIRST)
-              .asc("data", NULLS_LAST)
-              .build();
-      Assert.assertEquals("Sort order isn't correct.", "time ASC NULLS FIRST, data ASC NULLS LAST",
-              Spark3Util.describe(multiOrder));
-    }
+    // multiple sort orders
+    SortOrder multiOrder = SortOrder.builderFor(schema)
+            .asc("time", NULLS_FIRST)
+            .asc("data", NULLS_LAST)
+            .build();
+    Assert.assertEquals("Sort order isn't correct.", "time ASC NULLS FIRST, data ASC NULLS LAST",
+            Spark3Util.describe(multiOrder));
+  }
 
-    private SortOrder buildSortOrder(String transform, Schema schema, int sourceId) {
-      String jsonString = "{\n" +
-              "  \"order-id\" : 10,\n" +
-              "  \"fields\" : [ {\n" +
-              "    \"transform\" : \"" + transform + "\",\n" +
-              "    \"source-id\" : " + sourceId + ",\n" +
-              "    \"direction\" : \"desc\",\n" +
-              "    \"null-order\" : \"nulls-first\"\n" +
-              "  } ]\n" +
-              "}";
+  private SortOrder buildSortOrder(String transform, Schema schema, int sourceId) {
+    String jsonString = "{\n" +
+            "  \"order-id\" : 10,\n" +
+            "  \"fields\" : [ {\n" +
+            "    \"transform\" : \"" + transform + "\",\n" +
+            "    \"source-id\" : " + sourceId + ",\n" +
+            "    \"direction\" : \"desc\",\n" +
+            "    \"null-order\" : \"nulls-first\"\n" +
+            "  } ]\n" +
+            "}";
 
-      return SortOrderParser.fromJson(schema, jsonString);
-    }
+    return SortOrderParser.fromJson(schema, jsonString);
+  }
 }


### PR DESCRIPTION
Unit test is added. The integration test is blocked by https://github.com/apache/iceberg/issues/2382.