### PR TITLE
Docs: Add release notes for 0.11.1 and update references

### DIFF
--- a/site/docs/javadoc/index.html
+++ b/site/docs/javadoc/index.html
@@ -1,9 +1,9 @@
 <html xmlns="http://www.w3.org/1999/xhtml">    
   <head>      
     <title>Iceberg Javadoc Redirect</title>      
-    <meta http-equiv="refresh" content="0;URL='/javadoc/0.11.0/'" />
+    <meta http-equiv="refresh" content="0;URL='/javadoc/0.11.1/'" />
   </head>    
   <body> 
-    <p>Redirecting to Javadoc for the 0.11.0 release: <a href="/javadoc/0.11.0/">/javadoc/0.11.0</a>.</p>
+    <p>Redirecting to Javadoc for the 0.11.1 release: <a href="/javadoc/0.11.1/">/javadoc/0.11.1</a>.</p>
   </body>  
 </html>

--- a/site/docs/releases.md
+++ b/site/docs/releases.md
@@ -57,6 +57,19 @@ To add a dependency on Iceberg in Maven, add the following to your `pom.xml`:
 </dependencies>
 ```
 
+## 0.11.1 release notes
+
+Important bug fixes:
+
+* [\#2367](https://github.com/apache/iceberg/pull/2367) prohibits deleting data files when tables are dropped if GC is disabled.
+* [\#2196](https://github.com/apache/iceberg/pull/2196) fixes data loss after compaction when large files are split into multiple parts and only some parts are combined with other files.
+* [\#2232](https://github.com/apache/iceberg/pull/2232) fixes row group filters with promoted types in Parquet.
+* [\#2267](https://github.com/apache/iceberg/pull/2267) avoids listing non-Iceberg tables in Glue.
+* [\#2254](https://github.com/apache/iceberg/pull/2254) fixes predicate pushdown for Date in Hive.
+* [\#2126](https://github.com/apache/iceberg/pull/2126) fixes writing of Date, Decimal, Time, UUID types in Hive.
+* [\#2241](https://github.com/apache/iceberg/pull/2241) fixes vectorized ORC reads with metadata columns in Spark.
+* [\#2154](https://github.com/apache/iceberg/pull/2154) refreshes the relation cache in DELETE and MERGE operations in Spark.
+
 ## 0.11.0 release notes
 
 High-level features:


### PR DESCRIPTION
This PR adds already deployed release notes for 0.11.1 and updates references to refer to 0.11.1 instead of 0.11.0.