### PR TITLE
Core: DeleteMarker to mark row as deleted

### DIFF
--- a/core/src/main/java/org/apache/iceberg/deletes/DeleteSetter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/DeleteSetter.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.deletes;
+
+public abstract class DeleteSetter<T> {
+
+  private T row;
+
+  protected T row() {
+    return this.row;
+  }
+
+  public DeleteSetter<T> wrap(T newRow) {
+    this.row = newRow;
+    return this;
+  }
+
+  public abstract boolean isDeleted();
+
+  public abstract T setDeleted();
+}

--- a/core/src/main/java/org/apache/iceberg/util/DeleteMarker.java
+++ b/core/src/main/java/org/apache/iceberg/util/DeleteMarker.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import org.apache.iceberg.deletes.DeleteSetter;
+import org.apache.iceberg.io.CloseableIterable;
+
+public abstract class DeleteMarker<T> {
+
+  private final DeleteSetter<T> deleteSetter;
+
+  public DeleteMarker(DeleteSetter<T> deleteSetter) {
+    this.deleteSetter = deleteSetter;
+  }
+
+  protected abstract boolean shouldDelete(T item);
+
+  private Iterable<T> setDeleted(Iterable<T> iterable) {
+    return () -> new InternalIterator(iterable.iterator());
+  }
+
+  public CloseableIterable<T> setDeleted(CloseableIterable<T> iterable) {
+    return CloseableIterable.combine(setDeleted((Iterable<T>) iterable), iterable);
+  }
+
+  private class InternalIterator implements Iterator<T> {
+    private final Iterator<T> iterator;
+
+    private InternalIterator(Iterator<T> iterator) {
+      this.iterator = iterator;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return iterator.hasNext();
+    }
+
+    @Override
+    public T next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+
+      T current = iterator.next();
+
+      deleteSetter.wrap(current);
+      if (!deleteSetter.isDeleted() && shouldDelete(current)) {
+        return deleteSetter.setDeleted();
+      } else {
+        return current;
+      }
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/deletes/TestPositionFilter.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestPositionFilter.java
@@ -111,7 +111,7 @@ public class TestPositionFilter {
 
     CloseableIterable<Long> deletes = CloseableIterable.withNoopClose(Lists.newArrayList(0L, 3L, 4L, 7L, 9L));
 
-    CloseableIterable<StructLike> actual = Deletes.streamingFilter(rows, row -> row.get(0, Long.class), deletes);
+    CloseableIterable<StructLike> actual = Deletes.streamingDeleteMarker(rows, row -> row.get(0, Long.class), deletes);
     Assert.assertEquals("Filter should produce expected rows",
         Lists.newArrayList(1L, 2L, 5L, 6L, 8L),
         Lists.newArrayList(Iterables.transform(actual, row -> row.get(0, Long.class))));
@@ -135,7 +135,7 @@ public class TestPositionFilter {
     CloseableIterable<Long> deletes = CloseableIterable.withNoopClose(
         Lists.newArrayList(0L, 0L, 0L, 3L, 4L, 7L, 7L, 9L, 9L, 9L));
 
-    CloseableIterable<StructLike> actual = Deletes.streamingFilter(rows, row -> row.get(0, Long.class), deletes);
+    CloseableIterable<StructLike> actual = Deletes.streamingDeleteMarker(rows, row -> row.get(0, Long.class), deletes);
     Assert.assertEquals("Filter should produce expected rows",
         Lists.newArrayList(1L, 2L, 5L, 6L, 8L),
         Lists.newArrayList(Iterables.transform(actual, row -> row.get(0, Long.class))));
@@ -153,7 +153,7 @@ public class TestPositionFilter {
 
     CloseableIterable<Long> deletes = CloseableIterable.withNoopClose(Lists.newArrayList(0L, 3L, 4L, 7L, 9L));
 
-    CloseableIterable<StructLike> actual = Deletes.streamingFilter(rows, row -> row.get(0, Long.class), deletes);
+    CloseableIterable<StructLike> actual = Deletes.streamingDeleteMarker(rows, row -> row.get(0, Long.class), deletes);
     Assert.assertEquals("Filter should produce expected rows",
         Lists.newArrayList(2L, 5L, 6L),
         Lists.newArrayList(Iterables.transform(actual, row -> row.get(0, Long.class))));
@@ -189,7 +189,7 @@ public class TestPositionFilter {
         Row.of(9L, "j")
     ));
 
-    CloseableIterable<StructLike> actual = Deletes.streamingFilter(
+    CloseableIterable<StructLike> actual = Deletes.streamingDeleteMarker(
         rows,
         row -> row.get(0, Long.class),
         Deletes.deletePositions("file_a.avro", ImmutableList.of(positionDeletes1, positionDeletes2)));

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkDeleteSetter.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkDeleteSetter.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink;
+
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.UpdatableRowData;
+import org.apache.iceberg.deletes.DeleteSetter;
+
+public class FlinkDeleteSetter extends DeleteSetter<RowData> {
+
+  public FlinkDeleteSetter() {
+  }
+
+  private int deleteColumnIndex() {
+    return 0;
+  }
+
+  @Override
+  public boolean isDeleted() {
+    return row().getBoolean(deleteColumnIndex());
+  }
+
+  @Override
+  public RowData setDeleted() {
+    RowData rowData = this.row();
+
+    int idx = deleteColumnIndex();
+    if (rowData instanceof GenericRowData) {
+      ((GenericRowData) rowData).setField(idx, true);
+    } else if (rowData instanceof UpdatableRowData) {
+      ((UpdatableRowData) rowData).setField(idx, true);
+    } else {
+      throw new UnsupportedOperationException(
+          rowData.getClass() + " does not support set the _deleted column to be true.");
+    }
+
+    return rowData;
+  }
+}

--- a/spark/src/main/java/org/apache/iceberg/spark/source/DeletedRowReader.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/DeletedRowReader.java
@@ -31,11 +31,11 @@ import org.apache.iceberg.util.PartitionUtil;
 import org.apache.spark.rdd.InputFileBlockHolder;
 import org.apache.spark.sql.catalyst.InternalRow;
 
-public class EqualityDeleteRowReader extends RowDataReader {
+public class DeletedRowReader extends RowDataReader {
   private final Schema expectedSchema;
 
-  public EqualityDeleteRowReader(CombinedScanTask task, Schema schema, Schema expectedSchema, String nameMapping,
-                                 FileIO io, EncryptionManager encryptionManager, boolean caseSensitive) {
+  public DeletedRowReader(CombinedScanTask task, Schema schema, Schema expectedSchema, String nameMapping,
+                          FileIO io, EncryptionManager encryptionManager, boolean caseSensitive) {
     super(task, schema, schema, nameMapping, io, encryptionManager, caseSensitive);
     this.expectedSchema = expectedSchema;
   }
@@ -52,6 +52,6 @@ public class EqualityDeleteRowReader extends RowDataReader {
     // update the current file for Spark's filename() function
     InputFileBlockHolder.set(file.path().toString(), task.start(), task.length());
 
-    return matches.findEqualityDeleteRows(open(task, requiredSchema, idToConstant)).iterator();
+    return matches.findDeletedRows(open(task, requiredSchema, idToConstant)).iterator();
   }
 }

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -206,7 +206,7 @@ public abstract class TestSparkReaderDeletes extends DeleteReadTests {
         TableProperties.SPLIT_OPEN_FILE_COST_DEFAULT);
 
     for (CombinedScanTask task : tasks) {
-      try (EqualityDeleteRowReader reader = new EqualityDeleteRowReader(task, table.schema(), table.schema(),
+      try (DeletedRowReader reader = new DeletedRowReader(task, table.schema(), table.schema(),
           table.properties().get(DEFAULT_NAME_MAPPING), table.io(), table.encryption(), false)) {
         while (reader.next()) {
           actualRowSet.add(new InternalRowWrapper(SparkSchemaUtil.convert(table.schema())).wrap(reader.get().copy()));


### PR DESCRIPTION
In this comment https://github.com/apache/iceberg/pull/2372#issuecomment-810092443,  we are trying to implement a new `DeleteMarker` to mark those deleted row as `_deleted=true` in the `Iterable`.  This PR is trying to accomplish that goal ( not finished yet).