### PR TITLE
Spark: Prevent setting sort-order by using "ALTER TABLE ... SET TBLPROPERTIES"

### DIFF
--- a/spark3/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -199,6 +199,9 @@ public class SparkCatalog extends BaseCatalog {
           setSnapshotId = set;
         } else if ("cherry-pick-snapshot-id".equalsIgnoreCase(set.property())) {
           pickSnapshotId = set;
+        } else if ("sort-order".equalsIgnoreCase(set.property())) {
+          throw new UnsupportedOperationException("'sort-order' is a reserved table property. Please use the command " +
+                  "'ALTER TABLE ... WRITE ORDERED BY' to specify it.");
         } else {
           propertyChanges.add(set);
         }

--- a/spark3/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -200,8 +200,8 @@ public class SparkCatalog extends BaseCatalog {
         } else if ("cherry-pick-snapshot-id".equalsIgnoreCase(set.property())) {
           pickSnapshotId = set;
         } else if ("sort-order".equalsIgnoreCase(set.property())) {
-          throw new UnsupportedOperationException("'sort-order' is a reserved table property. Please use the command " +
-                  "'ALTER TABLE ... WRITE ORDERED BY' to specify it.");
+          throw new UnsupportedOperationException("Cannot specify the 'sort-order' because it's a reserved table " +
+              "property. Please use the command 'ALTER TABLE ... WRITE ORDERED BY' to specify write sort-orders.");
         } else {
           propertyChanges.add(set);
         }

--- a/spark3/src/test/java/org/apache/iceberg/spark/sql/TestAlterTable.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/sql/TestAlterTable.java
@@ -220,5 +220,8 @@ public class TestAlterTable extends SparkCatalogTestBase {
 
     Assert.assertNull("Should not have the removed table property",
         validationCatalog.loadTable(tableIdent).properties().get("prop"));
+
+    AssertHelpers.assertThrows("'sort-order' is a reserved property.", UnsupportedOperationException.class,
+        () -> sql("ALTER TABLE %s SET TBLPROPERTIES ('sort-order'='value')", tableName));
   }
 }

--- a/spark3/src/test/java/org/apache/iceberg/spark/sql/TestAlterTable.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/sql/TestAlterTable.java
@@ -221,7 +221,8 @@ public class TestAlterTable extends SparkCatalogTestBase {
     Assert.assertNull("Should not have the removed table property",
         validationCatalog.loadTable(tableIdent).properties().get("prop"));
 
-    AssertHelpers.assertThrows("'sort-order' is a reserved property.", UnsupportedOperationException.class,
+    AssertHelpers.assertThrows("Cannot specify the 'sort-order' because it's a reserved table property",
+        UnsupportedOperationException.class,
         () -> sql("ALTER TABLE %s SET TBLPROPERTIES ('sort-order'='value')", tableName));
   }
 }


### PR DESCRIPTION
A unit test is added.