### PR TITLE
Core: add API for table metadata file encryption

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Table.java
+++ b/api/src/main/java/org/apache/iceberg/Table.java
@@ -22,6 +22,7 @@ package org.apache.iceberg;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.encryption.TableMetadataEncryptionManager;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 
@@ -274,6 +275,11 @@ public interface Table {
    * Returns an {@link org.apache.iceberg.encryption.EncryptionManager} to encrypt and decrypt data files.
    */
   EncryptionManager encryption();
+
+  /**
+   * Returns an {@link TableMetadataEncryptionManager} to encrypt and decrypt table metadata files.
+   */
+  TableMetadataEncryptionManager metadataEncryption();
 
   /**
    * Returns a {@link LocationProvider} to provide locations for new data files.

--- a/api/src/main/java/org/apache/iceberg/encryption/TableMetadataEncryptionManager.java
+++ b/api/src/main/java/org/apache/iceberg/encryption/TableMetadataEncryptionManager.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.encryption;
+
+import java.io.Serializable;
+import java.util.Map;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+
+/**
+ * An encryption manager to handle top level table metadata file encryption.
+ * <p>
+ * Unlike other Iceberg metadata such as manifest list and manifest,
+ * because table metadata is the top level Iceberg metadata,
+ * we do not leverage any other file to store its encryption information.
+ * Therefore, this encryption manager assumes all encryption metadata are externally managed,
+ * and directly transforms the file to its encrypting or decrypting form.
+ */
+public interface TableMetadataEncryptionManager extends Serializable {
+
+  /**
+   * Decrypt a table metadata file.
+   * @param encrypted encrypted input file
+   * @return decrypting input file
+   */
+  InputFile decrypt(InputFile encrypted);
+
+  /**
+   * Encrypt a table metadata file.
+   * @param rawOutput raw output file
+   * @return encrypting output file
+   */
+  OutputFile encrypt(OutputFile rawOutput);
+
+  /**
+   * Initialize the encryption manager from catalog properties.
+   * @param properties catalog properties
+   */
+  default void initialize(Map<String, String> properties) {
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -23,6 +23,7 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.encryption.TableMetadataEncryptionManager;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -76,6 +77,11 @@ abstract class BaseMetadataTable implements Table, HasTableOperations, Serializa
   @Override
   public EncryptionManager encryption() {
     return table().encryption();
+  }
+
+  @Override
+  public TableMetadataEncryptionManager metadataEncryption() {
+    return table().metadataEncryption();
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTable.java
@@ -23,6 +23,7 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.encryption.TableMetadataEncryptionManager;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 
@@ -212,6 +213,11 @@ public class BaseTable implements Table, HasTableOperations, Serializable {
   @Override
   public EncryptionManager encryption() {
     return operations().encryption();
+  }
+
+  @Override
+  public TableMetadataEncryptionManager metadataEncryption() {
+    return operations().metadataEncryption();
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.encryption.TableMetadataEncryptionManager;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.io.FileIO;
@@ -669,6 +670,11 @@ class BaseTransaction implements Transaction {
     @Override
     public EncryptionManager encryption() {
       return transactionOps.encryption();
+    }
+
+    @Override
+    public TableMetadataEncryptionManager metadataEncryption() {
+      return transactionOps.metadataEncryption();
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -55,4 +55,6 @@ public class CatalogProperties {
 
   public static final String LOCK_TABLE = "lock.table";
 
+  public static final String ENCRYPTION_TABLE_METADATA_MANAGER_IMPL = "encryption.table-metadata.manager-impl";
+
 }

--- a/core/src/main/java/org/apache/iceberg/SerializableTable.java
+++ b/core/src/main/java/org/apache/iceberg/SerializableTable.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.encryption.TableMetadataEncryptionManager;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
@@ -58,6 +59,7 @@ public class SerializableTable implements Table, Serializable {
   private final String sortOrderAsJson;
   private final FileIO io;
   private final EncryptionManager encryption;
+  private final TableMetadataEncryptionManager metadataEncryption;
   private final LocationProvider locationProvider;
 
   private transient volatile Table lazyTable = null;
@@ -75,6 +77,7 @@ public class SerializableTable implements Table, Serializable {
     this.sortOrderAsJson = SortOrderParser.toJson(table.sortOrder());
     this.io = fileIO(table);
     this.encryption = table.encryption();
+    this.metadataEncryption = table.metadataEncryption();
     this.locationProvider = table.locationProvider();
   }
 
@@ -119,7 +122,8 @@ public class SerializableTable implements Table, Serializable {
             throw new UnsupportedOperationException("Cannot load metadata: metadata file location is null");
           }
 
-          TableOperations ops = new StaticTableOperations(metadataFileLocation, io, locationProvider);
+          TableOperations ops = new StaticTableOperations(metadataFileLocation, io,
+              metadataEncryption, locationProvider);
           this.lazyTable = newTable(ops, name);
         }
       }
@@ -213,6 +217,11 @@ public class SerializableTable implements Table, Serializable {
   @Override
   public EncryptionManager encryption() {
     return encryption;
+  }
+
+  @Override
+  public TableMetadataEncryptionManager metadataEncryption() {
+    return metadataEncryption;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/StaticTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/StaticTableOperations.java
@@ -20,6 +20,8 @@
 
 package org.apache.iceberg;
 
+import org.apache.iceberg.encryption.TableMetadataEncryptionManager;
+import org.apache.iceberg.encryption.TableMetadataEncryptionManagers;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 
@@ -32,17 +34,31 @@ public class StaticTableOperations implements TableOperations {
   private TableMetadata staticMetadata;
   private final String metadataFileLocation;
   private final FileIO io;
+  private final TableMetadataEncryptionManager metadataEncryption;
   private final LocationProvider locationProvider;
+
+  /**
+   * @deprecated please use {@link #StaticTableOperations(String, FileIO, TableMetadataEncryptionManager)}
+   */
+  @Deprecated
+  public StaticTableOperations(String metadataFileLocation, FileIO io) {
+    this(metadataFileLocation, io, TableMetadataEncryptionManagers.plainText());
+  }
 
   /**
    * Creates a StaticTableOperations tied to a specific static version of the TableMetadata
    */
-  public StaticTableOperations(String metadataFileLocation, FileIO io) {
-    this(metadataFileLocation, io, null);
+  public StaticTableOperations(String metadataFileLocation, FileIO io,
+                               TableMetadataEncryptionManager metadataEncryption) {
+    this(metadataFileLocation, io, metadataEncryption, null);
   }
 
-  public StaticTableOperations(String metadataFileLocation, FileIO io, LocationProvider locationProvider) {
+
+  public StaticTableOperations(String metadataFileLocation, FileIO io,
+                               TableMetadataEncryptionManager metadataEncryption,
+                               LocationProvider locationProvider) {
     this.io = io;
+    this.metadataEncryption = metadataEncryption;
     this.metadataFileLocation = metadataFileLocation;
     this.locationProvider = locationProvider;
   }
@@ -50,7 +66,7 @@ public class StaticTableOperations implements TableOperations {
   @Override
   public TableMetadata current() {
     if (staticMetadata == null) {
-      staticMetadata = TableMetadataParser.read(io, metadataFileLocation);
+      staticMetadata = TableMetadataParser.read(io, metadataEncryption, metadataFileLocation);
     }
     return staticMetadata;
   }

--- a/core/src/main/java/org/apache/iceberg/TableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/TableOperations.java
@@ -22,6 +22,8 @@ package org.apache.iceberg;
 import java.util.UUID;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.encryption.PlaintextEncryptionManager;
+import org.apache.iceberg.encryption.TableMetadataEncryptionManager;
+import org.apache.iceberg.encryption.TableMetadataEncryptionManagers;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 
@@ -75,6 +77,14 @@ public interface TableOperations {
    */
   default EncryptionManager encryption() {
     return new PlaintextEncryptionManager();
+  }
+
+  /**
+   * Returns a {@link org.apache.iceberg.encryption.TableMetadataEncryptionManager}
+   * to encrypt and decrypt table metadata files.
+   */
+  default TableMetadataEncryptionManager metadataEncryption() {
+    return TableMetadataEncryptionManagers.plainText();
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/encryption/TableMetadataEncryptionManagers.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/TableMetadataEncryptionManagers.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.encryption;
+
+import java.util.Map;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.common.DynConstructors;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Factory to get {@link TableMetadataEncryptionManager} instance.
+ */
+public class TableMetadataEncryptionManagers {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TableMetadataEncryptionManagers.class);
+
+  private static final TableMetadataEncryptionManager PLAINTEXT_TABLE_METADATA_ENCRYPTION_MANAGER =
+      new PlaintextTableMetadataEncryptionManager();
+
+  private TableMetadataEncryptionManagers() {
+  }
+
+  /**
+   * Returns a default plaintext encryption manager.
+   */
+  public static TableMetadataEncryptionManager plainText() {
+    return PLAINTEXT_TABLE_METADATA_ENCRYPTION_MANAGER;
+  }
+
+  /**
+   * Load a {@link TableMetadataEncryptionManager} implementation.
+   * <p>
+   * A custom implementation can be loaded through {@link CatalogProperties#ENCRYPTION_TABLE_METADATA_MANAGER_IMPL}.
+   * If custom implementation is not set, default plaintext manager is used.
+   * A custom implementation must have a no-arg constructor, and implement method
+   * {@link TableMetadataEncryptionManager#initialize(Map)} to initialize from catalog properties.
+   *
+   * @param properties catalog properties
+   * @return TableMetadataEncryptionManager implementation
+   * @throws IllegalArgumentException if class path not found or
+   *  right constructor not found or
+   *  the loaded class cannot be casted to the given interface type
+   */
+  public static TableMetadataEncryptionManager load(Map<String, String> properties) {
+    String impl = properties.get(CatalogProperties.ENCRYPTION_TABLE_METADATA_MANAGER_IMPL);
+    if (impl == null) {
+      return plainText();
+    }
+
+    LOG.info("Loading custom TableMetadataEncryptionManager implementation: {}", impl);
+    DynConstructors.Ctor<TableMetadataEncryptionManager> ctor;
+    try {
+      ctor = DynConstructors.builder(TableMetadataEncryptionManager.class).impl(impl).buildChecked();
+    } catch (NoSuchMethodException e) {
+      throw new IllegalArgumentException(String.format(
+          "Cannot initialize TableMetadataEncryptionManager, missing no-arg constructor: %s", impl), e);
+    }
+
+    TableMetadataEncryptionManager tableMetadataEncryptionManager;
+    try {
+      tableMetadataEncryptionManager = ctor.newInstance();
+    } catch (ClassCastException e) {
+      throw new IllegalArgumentException(
+          String.format("Cannot initialize TableMetadataEncryptionManager, " +
+              "%s does not implement TableMetadataEncryptionManager.", impl), e);
+    }
+
+    tableMetadataEncryptionManager.initialize(properties);
+    return tableMetadataEncryptionManager;
+  }
+
+  static class PlaintextTableMetadataEncryptionManager implements TableMetadataEncryptionManager {
+
+    @Override
+    public InputFile decrypt(InputFile encrypted) {
+      return encrypted;
+    }
+
+    @Override
+    public OutputFile encrypt(OutputFile rawOutput) {
+      return rawOutput;
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -90,7 +90,8 @@ public class HadoopTableOperations implements TableOperations {
     // update if the current version is out of date
     if (version == null || version != newVersion) {
       this.version = newVersion;
-      this.currentMetadata = checkUUID(currentMetadata, TableMetadataParser.read(io(), metadataFile));
+      this.currentMetadata = checkUUID(currentMetadata,
+          TableMetadataParser.read(io(), metadataEncryption(), metadataFile));
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTables.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTables.java
@@ -40,6 +40,7 @@ import org.apache.iceberg.Tables;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.Transactions;
 import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.encryption.TableMetadataEncryptionManagers;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
@@ -192,7 +193,7 @@ public class HadoopTables implements Tables, Configurable {
   @VisibleForTesting
   TableOperations newTableOps(String location) {
     if (location.contains(METADATA_JSON)) {
-      return new StaticTableOperations(location, new HadoopFileIO(conf));
+      return new StaticTableOperations(location, new HadoopFileIO(conf), TableMetadataEncryptionManagers.plainText());
     } else {
       return new HadoopTableOperations(new Path(location), new HadoopFileIO(conf), conf);
     }

--- a/spark/src/main/java/org/apache/iceberg/spark/actions/BaseExpireSnapshotsSparkAction.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/actions/BaseExpireSnapshotsSparkAction.java
@@ -225,7 +225,7 @@ public class BaseExpireSnapshotsSparkAction
   }
 
   private Dataset<Row> buildValidFileDF(TableMetadata metadata) {
-    Table staticTable = newStaticTable(metadata, this.table.io());
+    Table staticTable = newStaticTable(metadata, this.table.io(), this.table.metadataEncryption());
     return appendTypeString(buildValidDataFileDF(staticTable), DATA_FILE)
         .union(appendTypeString(buildManifestFileDF(staticTable), MANIFEST))
         .union(appendTypeString(buildManifestListDF(staticTable), MANIFEST_LIST));

--- a/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.actions.Action;
 import org.apache.iceberg.actions.ManifestFileBean;
 import org.apache.iceberg.common.DynMethods;
+import org.apache.iceberg.encryption.TableMetadataEncryptionManager;
 import org.apache.iceberg.io.ClosingIterator;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -143,9 +144,10 @@ abstract class BaseSparkAction<ThisT, R> implements Action<ThisT, R> {
     return otherMetadataFiles;
   }
 
-  protected Table newStaticTable(TableMetadata metadata, FileIO io) {
+  protected Table newStaticTable(TableMetadata metadata, FileIO io,
+                                 TableMetadataEncryptionManager metadataEncryption) {
     String metadataFileLocation = metadata.metadataFileLocation();
-    StaticTableOperations ops = new StaticTableOperations(metadataFileLocation, io);
+    StaticTableOperations ops = new StaticTableOperations(metadataFileLocation, io, metadataEncryption);
     return new BaseTable(ops, metadataFileLocation);
   }
 


### PR DESCRIPTION
This is a PR based on design doc https://docs.google.com/document/d/1kkcjr9KrlB9QagRX3ToulG_Rf-65NMSlVANheDNzJq4/edit#

It introduces a new set of encryption APIs for table metadata files, so that the entire Iceberg metadata tree is fully encrypted. Because this is the top level of an Iceberg metadata tree, the newly introduced `TableMetadataEncryptionManager` does not need to maintain encryption metadata internally, and will directly produce decrypting/encrypting stream from input/output files.

I will introduce an actual implementation in AWS in another PR.

@rdblue @ggershinsky @shangxinli @andersonm-ibm @yyanyy @johnclara