### PR TITLE
Hive: Add timeout for TestHiveIcebergStorageHandlerWithEngine tests

### DIFF
--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -56,7 +56,7 @@ import static java.nio.file.attribute.PosixFilePermissions.fromString;
 public class TestHiveMetastore {
 
   private static final String DEFAULT_DATABASE_NAME = "default";
-  private static final int DEFAULT_POOL_SIZE = 10;
+  private static final int DEFAULT_POOL_SIZE = 5;
 
   // create the metastore handlers based on whether we're working with Hive2 or Hive3 dependencies
   // we need to do this because there is a breaking API change between Hive2 and Hive3

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveMetastore.java
@@ -56,7 +56,7 @@ import static java.nio.file.attribute.PosixFilePermissions.fromString;
 public class TestHiveMetastore {
 
   private static final String DEFAULT_DATABASE_NAME = "default";
-  private static final int DEFAULT_POOL_SIZE = 5;
+  private static final int DEFAULT_POOL_SIZE = 10;
 
   // create the metastore handlers based on whether we're working with Hive2 or Hive3 dependencies
   // we need to do this because there is a breaking API change between Hive2 and Hive3

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hive.ql.exec.mr.ExecMapper;
 import org.apache.iceberg.FileFormat;
@@ -47,6 +48,7 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -134,6 +136,9 @@ public class TestHiveIcebergStorageHandlerWithEngine {
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
 
+  @Rule
+  public Timeout timeout = new Timeout(40000, TimeUnit.MILLISECONDS);
+
   @BeforeClass
   public static void beforeClass() {
     shell = HiveIcebergStorageHandlerTestUtils.shell();
@@ -160,7 +165,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     ExecMapper.setDone(false);
   }
 
-  @Test(timeout = 40000)
+  @Test
   public void testScanTable() throws IOException {
     testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, fileFormat,
         HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
@@ -175,7 +180,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     Assert.assertArrayEquals(new Object[] {"Alice", 0L}, descRows.get(2));
   }
 
-  @Test(timeout = 40000)
+  @Test
   public void testCBOWithSelectedColumnsNonOverlapJoin() throws IOException {
     shell.setHiveSessionValue("hive.cbo.enable", true);
 
@@ -193,7 +198,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     Assert.assertArrayEquals(new Object[] {102L, 1L, 33.33d, "watch"}, rows.get(2));
   }
 
-  @Test(timeout = 40000)
+  @Test
   public void testDescribeTable() throws IOException {
     testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, fileFormat,
             HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
@@ -207,7 +212,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     }
   }
 
-  @Test(timeout = 40000)
+  @Test
   public void testCBOWithSelectedColumnsOverlapJoin() throws IOException {
     shell.setHiveSessionValue("hive.cbo.enable", true);
     testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, fileFormat,
@@ -226,7 +231,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     Assert.assertArrayEquals(new Object[] {"Alice", 100L}, rows.get(2));
   }
 
-  @Test(timeout = 40000)
+  @Test
   public void testCBOWithSelfJoin() throws IOException {
     shell.setHiveSessionValue("hive.cbo.enable", true);
 
@@ -288,7 +293,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     }
   }
 
-  @Test(timeout = 40000)
+  @Test
   public void testInsert() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
 
@@ -338,7 +343,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
    * Testing map only inserts.
    * @throws IOException If there is an underlying IOException
    */
-  @Test(timeout = 40000)
+  @Test
   public void testInsertFromSelect() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
 
@@ -357,7 +362,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
    * Testing map-reduce inserts.
    * @throws IOException If there is an underlying IOException
    */
-  @Test(timeout = 40000)
+  @Test
   public void testInsertFromSelectWithOrderBy() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
 
@@ -373,7 +378,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     HiveIcebergTestUtils.validateData(table, records, 0);
   }
 
-  @Test(timeout = 40000)
+  @Test
   public void testInsertFromSelectWithProjection() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
 
@@ -392,7 +397,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     HiveIcebergTestUtils.validateData(table, expected, 0);
   }
 
-  @Test(timeout = 40000)
+  @Test
   public void testInsertUsingSourceTableWithSharedColumnsNames() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
 
@@ -417,7 +422,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     HiveIcebergTestUtils.validateData(table, expected, 0);
   }
 
-  @Test(timeout = 40000)
+  @Test
   public void testInsertFromJoiningTwoIcebergTables() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
 
@@ -436,7 +441,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     HiveIcebergTestUtils.validateData(table, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 0);
   }
 
-  @Test(timeout = 40000)
+  @Test
   public void testWriteArrayOfPrimitivesInTable() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
     Schema schema = new Schema(required(1, "id", Types.LongType.get()),
@@ -446,7 +451,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     testComplexTypeWrite(schema, records);
   }
 
-  @Test(timeout = 40000)
+  @Test
   public void testWriteArrayOfArraysInTable() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
     Schema schema =
@@ -458,7 +463,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     testComplexTypeWrite(schema, records);
   }
 
-  @Test(timeout = 40000)
+  @Test
   public void testWriteArrayOfMapsInTable() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
     Schema schema =
@@ -470,7 +475,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     testComplexTypeWrite(schema, records);
   }
 
-  @Test(timeout = 40000)
+  @Test
   public void testWriteArrayOfStructsInTable() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
     Schema schema =
@@ -482,7 +487,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     testComplexTypeWrite(schema, records);
   }
 
-  @Test(timeout = 40000)
+  @Test
   public void testWriteMapOfPrimitivesInTable() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
     Schema schema = new Schema(required(1, "id", Types.LongType.get()),
@@ -492,7 +497,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     testComplexTypeWrite(schema, records);
   }
 
-  @Test(timeout = 40000)
+  @Test
   public void testWriteMapOfArraysInTable() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
     Schema schema = new Schema(required(1, "id", Types.LongType.get()),
@@ -503,7 +508,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     testComplexTypeWrite(schema, records);
   }
 
-  @Test(timeout = 40000)
+  @Test
   public void testWriteMapOfMapsInTable() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
     Schema schema = new Schema(required(1, "id", Types.LongType.get()),
@@ -513,7 +518,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     testComplexTypeWrite(schema, records);
   }
 
-  @Test(timeout = 40000)
+  @Test
   public void testWriteMapOfStructsInTable() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
     Schema schema = new Schema(required(1, "id", Types.LongType.get()),
@@ -525,7 +530,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     testComplexTypeWrite(schema, records);
   }
 
-  @Test(timeout = 40000)
+  @Test
   public void testWriteStructOfPrimitivesInTable() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
     Schema schema = new Schema(required(1, "id", Types.LongType.get()),
@@ -536,7 +541,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     testComplexTypeWrite(schema, records);
   }
 
-  @Test(timeout = 40000)
+  @Test
   public void testWriteStructOfArraysInTable() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
     Schema schema = new Schema(required(1, "id", Types.LongType.get()),
@@ -548,7 +553,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     testComplexTypeWrite(schema, records);
   }
 
-  @Test(timeout = 40000)
+  @Test
   public void testWriteStructOfMapsInTable() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
     Schema schema = new Schema(required(1, "id", Types.LongType.get()),
@@ -561,7 +566,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     testComplexTypeWrite(schema, records);
   }
 
-  @Test(timeout = 40000)
+  @Test
   public void testWriteStructOfStructsInTable() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
     Schema schema = new Schema(required(1, "id", Types.LongType.get()),
@@ -572,7 +577,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     testComplexTypeWrite(schema, records);
   }
 
-  @Test(timeout = 40000)
+  @Test
   public void testPartitionedWrite() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
 
@@ -588,7 +593,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     HiveIcebergTestUtils.validateData(table, records, 0);
   }
 
-  @Test(timeout = 40000)
+  @Test
   public void testIdentityPartitionedWrite() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
 
@@ -604,7 +609,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     HiveIcebergTestUtils.validateData(table, records, 0);
   }
 
-  @Test(timeout = 40000)
+  @Test
   public void testMultilevelIdentityPartitionedWrite() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
 
@@ -621,7 +626,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     HiveIcebergTestUtils.validateData(table, records, 0);
   }
 
-  @Test(timeout = 40000)
+  @Test
   public void testMultiTableInsert() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -160,7 +160,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     ExecMapper.setDone(false);
   }
 
-  @Test
+  @Test(timeout = 40000)
   public void testScanTable() throws IOException {
     testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, fileFormat,
         HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
@@ -175,7 +175,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     Assert.assertArrayEquals(new Object[] {"Alice", 0L}, descRows.get(2));
   }
 
-  @Test
+  @Test(timeout = 40000)
   public void testCBOWithSelectedColumnsNonOverlapJoin() throws IOException {
     shell.setHiveSessionValue("hive.cbo.enable", true);
 
@@ -193,7 +193,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     Assert.assertArrayEquals(new Object[] {102L, 1L, 33.33d, "watch"}, rows.get(2));
   }
 
-  @Test
+  @Test(timeout = 40000)
   public void testDescribeTable() throws IOException {
     testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, fileFormat,
             HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
@@ -207,7 +207,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     }
   }
 
-  @Test
+  @Test(timeout = 40000)
   public void testCBOWithSelectedColumnsOverlapJoin() throws IOException {
     shell.setHiveSessionValue("hive.cbo.enable", true);
     testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, fileFormat,
@@ -226,7 +226,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     Assert.assertArrayEquals(new Object[] {"Alice", 100L}, rows.get(2));
   }
 
-  @Test
+  @Test(timeout = 40000)
   public void testCBOWithSelfJoin() throws IOException {
     shell.setHiveSessionValue("hive.cbo.enable", true);
 
@@ -243,7 +243,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     Assert.assertArrayEquals(new Object[] {102L, 1L, 33.33d}, rows.get(2));
   }
 
-  @Test
+  @Test(timeout = 100000)
   public void testJoinTablesSupportedTypes() throws IOException {
     for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
       Type type = SUPPORTED_TYPES.get(i);
@@ -266,7 +266,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     }
   }
 
-  @Test
+  @Test(timeout = 100000)
   public void testSelectDistinctFromTable() throws IOException {
     for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
       Type type = SUPPORTED_TYPES.get(i);
@@ -288,7 +288,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     }
   }
 
-  @Test
+  @Test(timeout = 40000)
   public void testInsert() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
 
@@ -309,7 +309,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     HiveIcebergTestUtils.validateData(table, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 0);
   }
 
-  @Test
+  @Test(timeout = 100000)
   public void testInsertSupportedTypes() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
     for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
@@ -338,7 +338,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
    * Testing map only inserts.
    * @throws IOException If there is an underlying IOException
    */
-  @Test
+  @Test(timeout = 40000)
   public void testInsertFromSelect() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
 
@@ -357,7 +357,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
    * Testing map-reduce inserts.
    * @throws IOException If there is an underlying IOException
    */
-  @Test
+  @Test(timeout = 40000)
   public void testInsertFromSelectWithOrderBy() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
 
@@ -373,7 +373,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     HiveIcebergTestUtils.validateData(table, records, 0);
   }
 
-  @Test
+  @Test(timeout = 40000)
   public void testInsertFromSelectWithProjection() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
 
@@ -392,7 +392,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     HiveIcebergTestUtils.validateData(table, expected, 0);
   }
 
-  @Test
+  @Test(timeout = 40000)
   public void testInsertUsingSourceTableWithSharedColumnsNames() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
 
@@ -417,7 +417,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     HiveIcebergTestUtils.validateData(table, expected, 0);
   }
 
-  @Test
+  @Test(timeout = 40000)
   public void testInsertFromJoiningTwoIcebergTables() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
 
@@ -436,7 +436,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     HiveIcebergTestUtils.validateData(table, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 0);
   }
 
-  @Test
+  @Test(timeout = 40000)
   public void testWriteArrayOfPrimitivesInTable() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
     Schema schema = new Schema(required(1, "id", Types.LongType.get()),
@@ -446,7 +446,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     testComplexTypeWrite(schema, records);
   }
 
-  @Test
+  @Test(timeout = 40000)
   public void testWriteArrayOfArraysInTable() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
     Schema schema =
@@ -458,7 +458,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     testComplexTypeWrite(schema, records);
   }
 
-  @Test
+  @Test(timeout = 40000)
   public void testWriteArrayOfMapsInTable() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
     Schema schema =
@@ -470,7 +470,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     testComplexTypeWrite(schema, records);
   }
 
-  @Test
+  @Test(timeout = 40000)
   public void testWriteArrayOfStructsInTable() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
     Schema schema =
@@ -482,7 +482,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     testComplexTypeWrite(schema, records);
   }
 
-  @Test
+  @Test(timeout = 40000)
   public void testWriteMapOfPrimitivesInTable() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
     Schema schema = new Schema(required(1, "id", Types.LongType.get()),
@@ -492,7 +492,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     testComplexTypeWrite(schema, records);
   }
 
-  @Test
+  @Test(timeout = 40000)
   public void testWriteMapOfArraysInTable() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
     Schema schema = new Schema(required(1, "id", Types.LongType.get()),
@@ -503,7 +503,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     testComplexTypeWrite(schema, records);
   }
 
-  @Test
+  @Test(timeout = 40000)
   public void testWriteMapOfMapsInTable() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
     Schema schema = new Schema(required(1, "id", Types.LongType.get()),
@@ -513,7 +513,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     testComplexTypeWrite(schema, records);
   }
 
-  @Test
+  @Test(timeout = 40000)
   public void testWriteMapOfStructsInTable() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
     Schema schema = new Schema(required(1, "id", Types.LongType.get()),
@@ -525,7 +525,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     testComplexTypeWrite(schema, records);
   }
 
-  @Test
+  @Test(timeout = 40000)
   public void testWriteStructOfPrimitivesInTable() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
     Schema schema = new Schema(required(1, "id", Types.LongType.get()),
@@ -536,7 +536,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     testComplexTypeWrite(schema, records);
   }
 
-  @Test
+  @Test(timeout = 40000)
   public void testWriteStructOfArraysInTable() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
     Schema schema = new Schema(required(1, "id", Types.LongType.get()),
@@ -548,7 +548,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     testComplexTypeWrite(schema, records);
   }
 
-  @Test
+  @Test(timeout = 40000)
   public void testWriteStructOfMapsInTable() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
     Schema schema = new Schema(required(1, "id", Types.LongType.get()),
@@ -561,7 +561,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     testComplexTypeWrite(schema, records);
   }
 
-  @Test
+  @Test(timeout = 40000)
   public void testWriteStructOfStructsInTable() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
     Schema schema = new Schema(required(1, "id", Types.LongType.get()),
@@ -572,7 +572,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     testComplexTypeWrite(schema, records);
   }
 
-  @Test
+  @Test(timeout = 40000)
   public void testPartitionedWrite() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
 
@@ -588,7 +588,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     HiveIcebergTestUtils.validateData(table, records, 0);
   }
 
-  @Test
+  @Test(timeout = 40000)
   public void testIdentityPartitionedWrite() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
 
@@ -604,7 +604,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     HiveIcebergTestUtils.validateData(table, records, 0);
   }
 
-  @Test
+  @Test(timeout = 40000)
   public void testMultilevelIdentityPartitionedWrite() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
 
@@ -621,7 +621,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     HiveIcebergTestUtils.validateData(table, records, 0);
   }
 
-  @Test
+  @Test(timeout = 40000)
   public void testMultiTableInsert() throws IOException {
     Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveShell.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveShell.java
@@ -79,7 +79,7 @@ public class TestHiveShell {
 
   public void start() {
     // Create a copy of the HiveConf for the metastore
-    metastore.start(new HiveConf(hs2Conf));
+    metastore.start(new HiveConf(hs2Conf), 10);
     hs2Conf.setVar(HiveConf.ConfVars.METASTOREURIS, metastore.hiveConf().getVar(HiveConf.ConfVars.METASTOREURIS));
     hs2Conf.setVar(HiveConf.ConfVars.METASTOREWAREHOUSE,
         metastore.hiveConf().getVar(HiveConf.ConfVars.METASTOREWAREHOUSE));


### PR DESCRIPTION
In #2437 we seem to hit an issue where the tests are failing because of resource problems.

Github infra handles the timeouts in this case, but when there is a timeout the logs are not collected.

We should handle the timeouts on the tests itself. This is a good practice and in this case we might be able to squeeze out more information about the problems from the logs.

Used a 40s timeout in most tests (usually they run around 5-10 s on my local machine), and used 100s for longer tests (they run around 20-30 s on my local machine). Let's see how they behave on the CI infra.