### PR TITLE
Bump Nessie version to 0.5.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ buildscript {
 
 plugins {
   id 'nebula.dependency-recommender' version '9.0.2'
-  id 'org.projectnessie' version '0.4.0'
+  id 'org.projectnessie' version '0.5.1'
 }
 
 try {
@@ -1122,21 +1122,18 @@ project(':iceberg-nessie') {
     compile project(':iceberg-core')
     compile project(path: ':iceberg-bundled-guava', configuration: 'shadow')
     compile "org.projectnessie:nessie-client"
-    quarkusAppRunnerConfig "org.projectnessie:nessie-quarkus:0.4.0"
+
+    // dependency version "recommendation" via nebula.dependency-recommender don't work here "immediately",
+    // so pull the Quarkus + Nessie versions from the root-project
+    def quarkusVersion = rootProject.dependencyRecommendations.getRecommendedVersion("io.quarkus", "quarkus-bom")
+    def nessieVersion = rootProject.dependencyRecommendations.getRecommendedVersion("org.projectnessie", "nessie-quarkus")
+    nessieQuarkusRuntime(enforcedPlatform("io.quarkus:quarkus-bom:${quarkusVersion}"))
+    nessieQuarkusServer "org.projectnessie:nessie-quarkus:${nessieVersion}"
 
     compileOnly "org.apache.hadoop:hadoop-common"
 
     testCompile project(path: ':iceberg-api', configuration: 'testArtifacts')
   }
-  quarkusAppRunnerProperties {
-    props = ["quarkus.http.test-port": 0]
-  }
-  tasks.getByName("quarkus-start")
-          // This is not doing anything with Docker or building a native image, just a quirk of Quarkus since 1.10.
-          .doFirst { System.setProperty("quarkus.native.builder-image", "quay.io/quarkus/ubi-quarkus-native-image:21.0.0-java11") }
-          .dependsOn("compileTestJava")
-  tasks.test.dependsOn("quarkus-start").finalizedBy("quarkus-stop")
-
 }
 
 @Memoized

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.io.FileIO;
 import org.projectnessie.client.NessieClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.Contents;
 import org.projectnessie.model.ContentsKey;
 import org.projectnessie.model.IcebergTable;
@@ -94,9 +95,10 @@ public class NessieTableOperations extends BaseMetastoreTableOperations {
     boolean threw = true;
     try {
       IcebergTable newTable = ImmutableIcebergTable.builder().metadataLocation(newMetadataLocation).build();
-      Operations op = ImmutableOperations.builder().addOperations(Operation.Put.of(key, newTable)).build();
-      client.getTreeApi().commitMultipleOperations(reference.getAsBranch().getName(), reference.getHash(),
-          String.format("iceberg commit%s", applicationId()), op);
+      Operations op = ImmutableOperations.builder().addOperations(Operation.Put.of(key, newTable))
+          .commitMeta(CommitMeta.fromMessage(String.format("iceberg commit%s", applicationId())))
+          .build();
+      client.getTreeApi().commitMultipleOperations(reference.getAsBranch().getName(), reference.getHash(), op);
 
       threw = false;
     } catch (NessieConflictException ex) {

--- a/versions.props
+++ b/versions.props
@@ -19,9 +19,9 @@ org.apache.arrow:arrow-memory-netty = 2.0.0
 com.github.stephenc.findbugs:findbugs-annotations = 1.3.9-1
 software.amazon.awssdk:* = 2.15.7
 org.scala-lang:scala-library = 2.12.10
-org.projectnessie:* = 0.4.0
+org.projectnessie:* = 0.5.1
 javax.ws.rs:javax.ws.rs-api = 2.1.1
-io.quarkus:* = 1.12.1.Final
+io.quarkus:* = 1.13.1.Final
 
 # test deps
 junit:junit = 4.12


### PR DESCRIPTION
* Bump Nessie version to 0.5.1
* Support incremental builds w/ the Nessie-Gradle-Plugin
* Simplify the `:iceberg-nessie` code in `build.gradle`
