### PR TITLE
Core: exclude NaN from upper/lower bound of floating columns in Parquet/ORC

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DoubleFieldMetrics.java
+++ b/core/src/main/java/org/apache/iceberg/DoubleFieldMetrics.java
@@ -26,9 +26,9 @@ package org.apache.iceberg;
  * This wrapper ensures that metrics not being updated by those writers will not be incorrectly used, by throwing
  * exceptions when they are accessed.
  */
-public class FloatFieldMetrics extends FieldMetrics<Float> {
+public class DoubleFieldMetrics extends FieldMetrics<Double> {
 
-  private FloatFieldMetrics(int id, long nanValueCount, Float lowerBound, Float upperBound) {
+  private DoubleFieldMetrics(int id, long nanValueCount, Double lowerBound, Double upperBound) {
     super(id, 0L, 0L, nanValueCount, lowerBound, upperBound);
   }
 
@@ -42,35 +42,31 @@ public class FloatFieldMetrics extends FieldMetrics<Float> {
     throw new IllegalStateException("Shouldn't access this method, as this metric is tracked in file statistics. ");
   }
 
-  public Builder builderFor(int id) {
-    return new Builder(id);
-  }
-
   public static class Builder {
     private final int id;
     private long nanValueCount = 0;
-    private Float lowerBound = null;
-    private Float upperBound = null;
+    private Double lowerBound = null;
+    private Double upperBound = null;
 
     public Builder(int id) {
       this.id = id;
     }
 
-    public void addValue(float value) {
-      if (Float.isNaN(value)) {
+    public void addValue(double value) {
+      if (Double.isNaN(value)) {
         this.nanValueCount++;
       } else {
-        if (lowerBound == null || Float.compare(value, lowerBound) < 0) {
+        if (lowerBound == null || Double.compare(value, lowerBound) < 0) {
           this.lowerBound = value;
         }
-        if (upperBound == null || Float.compare(value, upperBound) > 0) {
+        if (upperBound == null || Double.compare(value, upperBound) > 0) {
           this.upperBound = value;
         }
       }
     }
 
-    public FloatFieldMetrics build() {
-      return new FloatFieldMetrics(id, nanValueCount, lowerBound, upperBound);
+    public DoubleFieldMetrics build() {
+      return new DoubleFieldMetrics(id, nanValueCount, lowerBound, upperBound);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/FieldMetrics.java
+++ b/core/src/main/java/org/apache/iceberg/FieldMetrics.java
@@ -20,25 +20,23 @@
 package org.apache.iceberg;
 
 
-import java.nio.ByteBuffer;
-
 /**
  * Iceberg internally tracked field level metrics.
  */
-public class FieldMetrics {
+public class FieldMetrics<T> {
   private final int id;
   private final long valueCount;
   private final long nullValueCount;
   private final long nanValueCount;
-  private final ByteBuffer lowerBound;
-  private final ByteBuffer upperBound;
+  private final T lowerBound;
+  private final T upperBound;
 
   public FieldMetrics(int id,
                       long valueCount,
                       long nullValueCount,
                       long nanValueCount,
-                      ByteBuffer lowerBound,
-                      ByteBuffer upperBound) {
+                      T lowerBound,
+                      T upperBound) {
     this.id = id;
     this.valueCount = valueCount;
     this.nullValueCount = nullValueCount;
@@ -78,14 +76,14 @@ public class FieldMetrics {
   /**
    * Returns the lower bound value of this field.
    */
-  public ByteBuffer lowerBound() {
+  public T lowerBound() {
     return lowerBound;
   }
 
   /**
    * Returns the upper bound value of this field.
    */
-  public ByteBuffer upperBound() {
+  public T upperBound() {
     return upperBound;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/FieldMetrics.java
+++ b/core/src/main/java/org/apache/iceberg/FieldMetrics.java
@@ -86,4 +86,11 @@ public class FieldMetrics<T> {
   public T upperBound() {
     return upperBound;
   }
+
+  /**
+   * Returns if the metrics has bounds (i.e. there is at least non-null value for this field)
+   */
+  public boolean hasBounds() {
+    return upperBound != null;
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/MetricsUtil.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsUtil.java
@@ -34,7 +34,7 @@ public class MetricsUtil {
    * Construct mapping relationship between column id to NaN value counts from input metrics and metrics config.
    */
   public static Map<Integer, Long> createNanValueCounts(
-      Stream<FieldMetrics> fieldMetrics, MetricsConfig metricsConfig, Schema inputSchema) {
+      Stream<FieldMetrics<?>> fieldMetrics, MetricsConfig metricsConfig, Schema inputSchema) {
     Preconditions.checkNotNull(metricsConfig, "metricsConfig is required");
 
     if (fieldMetrics == null || inputSchema == null) {

--- a/core/src/test/java/org/apache/iceberg/TestMetrics.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetrics.java
@@ -274,7 +274,7 @@ public abstract class TestMetrics {
     assertBounds(6, BinaryType.get(),
         ByteBuffer.wrap("A".getBytes()), ByteBuffer.wrap("A".getBytes()), metrics);
     assertCounts(7, 1L, 0L, 1L, metrics);
-    assertBounds(7, DoubleType.get(), Double.NaN, Double.NaN, metrics);
+    assertBounds(7, DoubleType.get(), null, null, metrics);
   }
 
   private Record buildNestedTestRecord() {
@@ -354,9 +354,9 @@ public abstract class TestMetrics {
     Assert.assertEquals(2L, (long) metrics.recordCount());
     assertCounts(1, 2L, 0L, 2L, metrics);
     assertCounts(2, 2L, 0L, 2L, metrics);
-    // below: current behavior; will be null once NaN is excluded from upper/lower bound
-    assertBounds(1, FloatType.get(), Float.NaN, Float.NaN, metrics);
-    assertBounds(2, DoubleType.get(), Double.NaN, Double.NaN, metrics);
+
+    assertBounds(1, FloatType.get(), null, null, metrics);
+    assertBounds(2, DoubleType.get(), null, null, metrics);
   }
 
   @Test
@@ -367,15 +367,8 @@ public abstract class TestMetrics {
     assertCounts(1, 3L, 0L, 1L, metrics);
     assertCounts(2, 3L, 0L, 1L, metrics);
 
-    // below: current behavior; will be non-NaN values once NaN is excluded from upper/lower bound. ORC and Parquet's
-    // behaviors differ due to their implementation of comparison being different.
-    if (fileFormat() == FileFormat.ORC) {
-      assertBounds(1, FloatType.get(), Float.NaN, Float.NaN, metrics);
-      assertBounds(2, DoubleType.get(), Double.NaN, Double.NaN, metrics);
-    } else {
-      assertBounds(1, FloatType.get(), 1.2F, Float.NaN, metrics);
-      assertBounds(2, DoubleType.get(), 3.4D, Double.NaN, metrics);
-    }
+    assertBounds(1, FloatType.get(), 1.2F, 5.6F, metrics);
+    assertBounds(2, DoubleType.get(), 3.4D, 7.8D, metrics);
   }
 
   @Test
@@ -386,15 +379,8 @@ public abstract class TestMetrics {
     assertCounts(1, 3L, 0L, 1L, metrics);
     assertCounts(2, 3L, 0L, 1L, metrics);
 
-    // below: current behavior; will be non-NaN values once NaN is excluded from upper/lower bound. ORC and Parquet's
-    // behaviors differ due to their implementation of comparison being different.
-    if (fileFormat() == FileFormat.ORC) {
-      assertBounds(1, FloatType.get(), 1.2F, 5.6F, metrics);
-      assertBounds(2, DoubleType.get(), 3.4D, 7.8D, metrics);
-    } else {
-      assertBounds(1, FloatType.get(), 1.2F, Float.NaN, metrics);
-      assertBounds(2, DoubleType.get(), 3.4D, Double.NaN, metrics);
-    }
+    assertBounds(1, FloatType.get(), 1.2F, 5.6F, metrics);
+    assertBounds(2, DoubleType.get(), 3.4D, 7.8D, metrics);
   }
 
   @Test
@@ -405,15 +391,8 @@ public abstract class TestMetrics {
     assertCounts(1, 3L, 0L, 1L, metrics);
     assertCounts(2, 3L, 0L, 1L, metrics);
 
-    // below: current behavior; will be non-NaN values once NaN is excluded from upper/lower bound. ORC and Parquet's
-    // behaviors differ due to their implementation of comparison being different.
-    if (fileFormat() == FileFormat.ORC) {
-      assertBounds(1, FloatType.get(), 1.2F, 5.6F, metrics);
-      assertBounds(2, DoubleType.get(), 3.4D, 7.8D, metrics);
-    } else {
-      assertBounds(1, FloatType.get(), 1.2F, Float.NaN, metrics);
-      assertBounds(2, DoubleType.get(), 3.4D, Double.NaN, metrics);
-    }
+    assertBounds(1, FloatType.get(), 1.2F, 5.6F, metrics);
+    assertBounds(2, DoubleType.get(), 3.4D, 7.8D, metrics);
   }
 
   @Test
@@ -506,7 +485,7 @@ public abstract class TestMetrics {
     assertBounds(6, BinaryType.get(),
         ByteBuffer.wrap("A".getBytes()), ByteBuffer.wrap("A".getBytes()), metrics);
     assertCounts(7, 201L, 0L, 201L, metrics);
-    assertBounds(7, DoubleType.get(), Double.NaN, Double.NaN, metrics);
+    assertBounds(7, DoubleType.get(), null, null, metrics);
   }
 
   @Test
@@ -567,7 +546,7 @@ public abstract class TestMetrics {
     assertBounds(6, Types.BinaryType.get(),
         ByteBuffer.wrap("A".getBytes()), ByteBuffer.wrap("A".getBytes()), metrics);
     assertCounts(7, 1L, 0L, 1L, metrics);
-    assertBounds(7, Types.DoubleType.get(), Double.NaN, Double.NaN, metrics);
+    assertBounds(7, Types.DoubleType.get(), null, null, metrics);
   }
 
   @Test

--- a/data/src/main/java/org/apache/iceberg/data/orc/GenericOrcWriter.java
+++ b/data/src/main/java/org/apache/iceberg/data/orc/GenericOrcWriter.java
@@ -129,7 +129,7 @@ public class GenericOrcWriter implements OrcRowWriter<Record> {
   }
 
   @Override
-  public Stream<FieldMetrics> metrics() {
+  public Stream<FieldMetrics<?>> metrics() {
     return writer.metrics();
   }
 
@@ -160,7 +160,7 @@ public class GenericOrcWriter implements OrcRowWriter<Record> {
     }
 
     @Override
-    public Stream<FieldMetrics> metrics() {
+    public Stream<FieldMetrics<?>> metrics() {
       return writers.stream().flatMap(OrcValueWriter::metrics);
     }
   }

--- a/data/src/main/java/org/apache/iceberg/data/orc/GenericOrcWriters.java
+++ b/data/src/main/java/org/apache/iceberg/data/orc/GenericOrcWriters.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Stream;
+import org.apache.iceberg.DoubleFieldMetrics;
 import org.apache.iceberg.FieldMetrics;
 import org.apache.iceberg.FloatFieldMetrics;
 import org.apache.iceberg.orc.OrcValueWriter;
@@ -219,10 +220,10 @@ public class GenericOrcWriters {
   }
 
   private static class FloatWriter implements OrcValueWriter<Float> {
-    private final FloatFieldMetrics.FloatFieldMetricsContext floatFieldMetricsContext;
+    private final FloatFieldMetrics.Builder floatFieldMetricsBuilder;
 
     private FloatWriter(int id) {
-      this.floatFieldMetricsContext = new FloatFieldMetrics.FloatFieldMetricsContext(id);
+      this.floatFieldMetricsBuilder = new FloatFieldMetrics.Builder(id);
     }
 
     @Override
@@ -233,20 +234,20 @@ public class GenericOrcWriters {
     @Override
     public void nonNullWrite(int rowId, Float data, ColumnVector output) {
       ((DoubleColumnVector) output).vector[rowId] = data;
-      floatFieldMetricsContext.updateMetricsContext(data);
+      floatFieldMetricsBuilder.addValue(data);
     }
 
     @Override
     public Stream<FieldMetrics> metrics() {
-      return Stream.of(floatFieldMetricsContext.buildMetrics());
+      return Stream.of(floatFieldMetricsBuilder.build());
     }
   }
 
   private static class DoubleWriter implements OrcValueWriter<Double> {
-    private final FloatFieldMetrics.DoubleFieldMetricsContext doubleFieldMetricsContext;
+    private final DoubleFieldMetrics.Builder doubleFieldMetricsBuilder;
 
     private DoubleWriter(Integer id) {
-      this.doubleFieldMetricsContext = new FloatFieldMetrics.DoubleFieldMetricsContext(id);
+      this.doubleFieldMetricsBuilder = new DoubleFieldMetrics.Builder(id);
     }
 
     @Override
@@ -257,12 +258,12 @@ public class GenericOrcWriters {
     @Override
     public void nonNullWrite(int rowId, Double data, ColumnVector output) {
       ((DoubleColumnVector) output).vector[rowId] = data;
-      doubleFieldMetricsContext.updateMetricsContext(data);
+      doubleFieldMetricsBuilder.addValue(data);
     }
 
     @Override
     public Stream<FieldMetrics> metrics() {
-      return Stream.of(doubleFieldMetricsContext.buildMetrics());
+      return Stream.of(doubleFieldMetricsBuilder.build());
     }
   }
 

--- a/data/src/main/java/org/apache/iceberg/data/orc/GenericOrcWriters.java
+++ b/data/src/main/java/org/apache/iceberg/data/orc/GenericOrcWriters.java
@@ -219,12 +219,10 @@ public class GenericOrcWriters {
   }
 
   private static class FloatWriter implements OrcValueWriter<Float> {
-    private final int id;
-    private long nanCount;
+    private final FloatFieldMetrics.FloatFieldMetricsContext floatFieldMetricsContext;
 
     private FloatWriter(int id) {
-      this.id = id;
-      this.nanCount = 0;
+      this.floatFieldMetricsContext = new FloatFieldMetrics.FloatFieldMetricsContext(id);
     }
 
     @Override
@@ -235,24 +233,20 @@ public class GenericOrcWriters {
     @Override
     public void nonNullWrite(int rowId, Float data, ColumnVector output) {
       ((DoubleColumnVector) output).vector[rowId] = data;
-      if (Float.isNaN(data)) {
-        nanCount++;
-      }
+      floatFieldMetricsContext.updateMetricsContext(data);
     }
 
     @Override
     public Stream<FieldMetrics> metrics() {
-      return Stream.of(new FloatFieldMetrics(id, nanCount));
+      return Stream.of(floatFieldMetricsContext.buildMetrics());
     }
   }
 
   private static class DoubleWriter implements OrcValueWriter<Double> {
-    private final int id;
-    private long nanCount;
+    private final FloatFieldMetrics.DoubleFieldMetricsContext doubleFieldMetricsContext;
 
     private DoubleWriter(Integer id) {
-      this.id = id;
-      this.nanCount = 0;
+      this.doubleFieldMetricsContext = new FloatFieldMetrics.DoubleFieldMetricsContext(id);
     }
 
     @Override
@@ -263,14 +257,12 @@ public class GenericOrcWriters {
     @Override
     public void nonNullWrite(int rowId, Double data, ColumnVector output) {
       ((DoubleColumnVector) output).vector[rowId] = data;
-      if (Double.isNaN(data)) {
-        nanCount++;
-      }
+      doubleFieldMetricsContext.updateMetricsContext(data);
     }
 
     @Override
     public Stream<FieldMetrics> metrics() {
-      return Stream.of(new FloatFieldMetrics(id, nanCount));
+      return Stream.of(doubleFieldMetricsContext.buildMetrics());
     }
   }
 

--- a/data/src/main/java/org/apache/iceberg/data/orc/GenericOrcWriters.java
+++ b/data/src/main/java/org/apache/iceberg/data/orc/GenericOrcWriters.java
@@ -221,6 +221,7 @@ public class GenericOrcWriters {
 
   private static class FloatWriter implements OrcValueWriter<Float> {
     private final FloatFieldMetrics.Builder floatFieldMetricsBuilder;
+    private long nullValueCount = 0;
 
     private FloatWriter(int id) {
       this.floatFieldMetricsBuilder = new FloatFieldMetrics.Builder(id);
@@ -238,13 +239,23 @@ public class GenericOrcWriters {
     }
 
     @Override
-    public Stream<FieldMetrics> metrics() {
-      return Stream.of(floatFieldMetricsBuilder.build());
+    public void nullWrite() {
+      nullValueCount++;
+    }
+
+    @Override
+    public Stream<FieldMetrics<?>> metrics() {
+      FieldMetrics<Float> metricsWithoutNullCount = floatFieldMetricsBuilder.build();
+      return Stream.of(new FieldMetrics<>(metricsWithoutNullCount.id(),
+          metricsWithoutNullCount.valueCount() + nullValueCount,
+          nullValueCount, metricsWithoutNullCount.nanValueCount(),
+          metricsWithoutNullCount.lowerBound(), metricsWithoutNullCount.upperBound()));
     }
   }
 
   private static class DoubleWriter implements OrcValueWriter<Double> {
     private final DoubleFieldMetrics.Builder doubleFieldMetricsBuilder;
+    private long nullValueCount = 0;
 
     private DoubleWriter(Integer id) {
       this.doubleFieldMetricsBuilder = new DoubleFieldMetrics.Builder(id);
@@ -262,8 +273,17 @@ public class GenericOrcWriters {
     }
 
     @Override
-    public Stream<FieldMetrics> metrics() {
-      return Stream.of(doubleFieldMetricsBuilder.build());
+    public void nullWrite() {
+      nullValueCount++;
+    }
+
+    @Override
+    public Stream<FieldMetrics<?>> metrics() {
+      FieldMetrics<Double> metricsWithoutNullCount = doubleFieldMetricsBuilder.build();
+      return Stream.of(new FieldMetrics<>(metricsWithoutNullCount.id(),
+          metricsWithoutNullCount.valueCount() + nullValueCount,
+          nullValueCount, metricsWithoutNullCount.nanValueCount(),
+          metricsWithoutNullCount.lowerBound(), metricsWithoutNullCount.upperBound()));
     }
   }
 
@@ -462,7 +482,7 @@ public class GenericOrcWriters {
     }
 
     @Override
-    public Stream<FieldMetrics> metrics() {
+    public Stream<FieldMetrics<?>> metrics() {
       return element.metrics();
     }
   }
@@ -506,7 +526,7 @@ public class GenericOrcWriters {
     }
 
     @Override
-    public Stream<FieldMetrics> metrics() {
+    public Stream<FieldMetrics<?>> metrics() {
       return Stream.concat(keyWriter.metrics(), valueWriter.metrics());
     }
   }

--- a/data/src/test/java/org/apache/iceberg/TestMergingMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/TestMergingMetrics.java
@@ -48,7 +48,6 @@ import org.junit.runners.Parameterized;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
-import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 public abstract class TestMergingMetrics<T> {
@@ -190,7 +189,7 @@ public abstract class TestMergingMetrics<T> {
     int actualFieldId = FIELDS_WITH_NAN_COUNT_TO_ID.get(field);
     ByteBuffer byteBuffer = boundMap.get(actualFieldId);
     Type type = SCHEMA.findType(actualFieldId);
-    assertEquals(String.format("Bound value for field %s must match", field.name()),
+    Assert.assertEquals(String.format("Bound value for field %s must match", field.name()),
         expected, byteBuffer == null ? null : Conversions.fromByteBuffer(type, byteBuffer));
   }
 

--- a/data/src/test/java/org/apache/iceberg/TestMergingMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/TestMergingMetrics.java
@@ -19,15 +19,26 @@
 
 package org.apache.iceberg;
 
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.NaNUtil;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,6 +48,7 @@ import org.junit.runners.Parameterized;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 public abstract class TestMergingMetrics<T> {
@@ -105,22 +117,62 @@ public abstract class TestMergingMetrics<T> {
   @Test
   public void verifySingleRecordMetric() throws Exception {
     Record record = GenericRecord.create(SCHEMA);
-    record.setField("id", 3);
-    record.setField("float", Float.NaN); // FLOAT_FIELD - 1
-    record.setField("double", Double.NaN); // DOUBLE_FIELD - 1
-    record.setField("floatlist", ImmutableList.of(3.3F, 2.8F, Float.NaN, -25.1F, Float.NaN)); // FLOAT_LIST - 2
-    record.setField("map1", ImmutableMap.of(Float.NaN, "a", 0F, "b")); // MAP_FIELD_1 - 1
-    record.setField("map2", ImmutableMap.of(
+    record.setField(ID_FIELD.name(), 3);
+    record.setField(FLOAT_FIELD.name(), Float.NaN); // FLOAT_FIELD - 1
+    record.setField(DOUBLE_FIELD.name(), Double.NaN); // DOUBLE_FIELD - 1
+    record.setField(FLOAT_LIST.name(), ImmutableList.of(3.3F, 2.8F, Float.NaN, -25.1F, Float.NaN)); // FLOAT_LIST - 2
+    record.setField(MAP_FIELD_1.name(), ImmutableMap.of(Float.NaN, "a", 0F, "b")); // MAP_FIELD_1 - 1
+    record.setField(MAP_FIELD_2.name(), ImmutableMap.of(
         0, 0D, 1, Double.NaN, 2, 2D, 3, Double.NaN, 4, Double.NaN)); // MAP_FIELD_2 - 3
 
     FileAppender<T> appender = writeAndGetAppender(ImmutableList.of(record));
-    Map<Integer, Long> nanValueCount = appender.metrics().nanValueCounts();
+    Metrics metrics = appender.metrics();
+    Map<Integer, Long> nanValueCount = metrics.nanValueCounts();
+    Map<Integer, ByteBuffer> upperBounds = metrics.upperBounds();
+    Map<Integer, ByteBuffer> lowerBounds = metrics.lowerBounds();
 
     assertNaNCountMatch(1L, nanValueCount, FLOAT_FIELD);
     assertNaNCountMatch(1L, nanValueCount, DOUBLE_FIELD);
     assertNaNCountMatch(2L, nanValueCount, FLOAT_LIST);
     assertNaNCountMatch(1L, nanValueCount, MAP_FIELD_1);
     assertNaNCountMatch(3L, nanValueCount, MAP_FIELD_2);
+
+    assertBoundValueMatch(null, upperBounds, FLOAT_FIELD);
+    assertBoundValueMatch(null, upperBounds, DOUBLE_FIELD);
+    assertBoundValueMatch(3.3F, upperBounds, FLOAT_LIST);
+    assertBoundValueMatch(0F, upperBounds, MAP_FIELD_1);
+    assertBoundValueMatch(2D, upperBounds, MAP_FIELD_2);
+
+    assertBoundValueMatch(null, lowerBounds, FLOAT_FIELD);
+    assertBoundValueMatch(null, lowerBounds, DOUBLE_FIELD);
+    assertBoundValueMatch(-25.1F, lowerBounds, FLOAT_LIST);
+    assertBoundValueMatch(0F, lowerBounds, MAP_FIELD_1);
+    assertBoundValueMatch(0D, lowerBounds, MAP_FIELD_2);
+  }
+
+  @Test
+  public void verifyRandomlyGeneratedRecordsMetric() throws Exception {
+    // too big of the record count will more likely to make all upper/lower bounds +/-infinity,
+    // which makes the tests easier to pass
+    List<Record> recordList = RandomGenericData.generate(SCHEMA, 5, 250L);
+    FileAppender<T> appender = writeAndGetAppender(recordList);
+
+    Map<Types.NestedField, AtomicReference<Number>> expectedUpperBounds = new HashMap<>();
+    Map<Types.NestedField, AtomicReference<Number>> expectedLowerBounds = new HashMap<>();
+    Map<Types.NestedField, AtomicLong> expectedNaNCount = new HashMap<>();
+
+    populateExpectedValues(recordList, expectedUpperBounds, expectedLowerBounds, expectedNaNCount);
+
+    Metrics metrics = appender.metrics();
+    expectedUpperBounds.forEach((key, value) -> assertBoundValueMatch(value.get(), metrics.upperBounds(), key));
+    expectedLowerBounds.forEach((key, value) -> assertBoundValueMatch(value.get(), metrics.lowerBounds(), key));
+    expectedNaNCount.forEach((key, value) -> assertNaNCountMatch(value.get(), metrics.nanValueCounts(), key));
+
+    SCHEMA.columns().stream()
+        .filter(column -> !FIELDS_WITH_NAN_COUNT_TO_ID.containsKey(column))
+        .map(Types.NestedField::fieldId)
+        .forEach(id -> Assert.assertNull("NaN count for field %s should be null",
+            metrics.nanValueCounts().get(id)));
   }
 
   private void assertNaNCountMatch(Long expected, Map<Integer, Long> nanValueCount, Types.NestedField field) {
@@ -129,50 +181,88 @@ public abstract class TestMergingMetrics<T> {
         expected, nanValueCount.get(FIELDS_WITH_NAN_COUNT_TO_ID.get(field)));
   }
 
-  @Test
-  public void verifyRandomlyGeneratedRecordsMetric() throws Exception {
-    List<Record> recordList = RandomGenericData.generate(SCHEMA, 50, 250L);
+  private void assertBoundValueMatch(Number expected, Map<Integer, ByteBuffer> boundMap, Types.NestedField field) {
+    if (field.type().isNestedType() && fileFormat == FileFormat.ORC) {
+      // we don't update floating column bounds values within ORC nested columns
+      return;
+    }
 
-    FileAppender<T> appender = writeAndGetAppender(recordList);
-    Map<Integer, Long> nanValueCount = appender.metrics().nanValueCounts();
-
-    FIELDS_WITH_NAN_COUNT_TO_ID.forEach((key, value) -> Assert.assertEquals(
-        String.format("NaN count for field %s does not match expected", key.name()),
-        getExpectedNaNCount(recordList, key),
-        nanValueCount.get(value)));
-
-    SCHEMA.columns().stream()
-        .filter(column -> !FIELDS_WITH_NAN_COUNT_TO_ID.containsKey(column))
-        .map(Types.NestedField::fieldId)
-        .forEach(id -> Assert.assertNull("NaN count for field %s should be null", nanValueCount.get(id)));
+    int actualFieldId = FIELDS_WITH_NAN_COUNT_TO_ID.get(field);
+    ByteBuffer byteBuffer = boundMap.get(actualFieldId);
+    Type type = SCHEMA.findType(actualFieldId);
+    assertEquals(String.format("Bound value for field %s must match", field.name()),
+        expected, byteBuffer == null ? null : Conversions.fromByteBuffer(type, byteBuffer));
   }
 
-  private Long getExpectedNaNCount(List<Record> expectedRecords, Types.NestedField field) {
-    return expectedRecords.stream()
-        .mapToLong(e -> {
-          Object value = e.getField(field.name());
-          if (value == null) {
-            return 0;
-          }
-          if (FLOAT_FIELD.equals(field)) {
-            return Float.isNaN((Float) value) ? 1 : 0;
-          } else if  (DOUBLE_FIELD.equals(field)) {
-            return Double.isNaN((Double) value) ? 1 : 0;
-          } else if  (FLOAT_LIST.equals(field)) {
-            return ((List<Float>) value).stream()
-                .filter(val -> val != null && Float.isNaN(val))
-                .count();
-          } else if  (MAP_FIELD_1.equals(field)) {
-            return ((Map<Float, ?>) value).keySet().stream()
-                .filter(key -> Float.isNaN(key))
-                .count();
-          } else if  (MAP_FIELD_2.equals(field)) {
-            return ((Map<?, Double>) value).values().stream()
-                .filter(val -> val != null && Double.isNaN(val))
-                .count();
-          } else {
-            throw new RuntimeException("unknown field name for getting expected NaN count: " + field.name());
-          }
-        }).sum();
+  private void populateExpectedValues(List<Record> records,
+                                      Map<Types.NestedField, AtomicReference<Number>> upperBounds,
+                                      Map<Types.NestedField, AtomicReference<Number>> lowerBounds,
+                                      Map<Types.NestedField, AtomicLong> expectedNaNCount) {
+    for (Types.NestedField field : FIELDS_WITH_NAN_COUNT_TO_ID.keySet()) {
+      expectedNaNCount.put(field, new AtomicLong(0));
+    }
+
+    for (Record record : records) {
+      updateExpectedValuePerRecord(upperBounds, lowerBounds, expectedNaNCount,
+          FLOAT_FIELD, (Float) record.getField(FLOAT_FIELD.name()));
+      updateExpectedValuePerRecord(upperBounds, lowerBounds, expectedNaNCount,
+          DOUBLE_FIELD, (Double) record.getField(DOUBLE_FIELD.name()));
+
+      List<Float> floatList = (List<Float>) record.getField(FLOAT_LIST.name());
+      if (floatList != null) {
+        updateExpectedValueFromRecords(upperBounds, lowerBounds, expectedNaNCount, FLOAT_LIST, floatList);
+      }
+
+      Map<Float, ?> map1 = (Map<Float, ?>) record.getField(MAP_FIELD_1.name());
+      if (map1 != null) {
+        updateExpectedValueFromRecords(upperBounds, lowerBounds, expectedNaNCount, MAP_FIELD_1, map1.keySet());
+      }
+
+      Map<?, Double> map2 = (Map<?, Double>) record.getField(MAP_FIELD_2.name());
+      if (map2 != null) {
+        updateExpectedValueFromRecords(upperBounds, lowerBounds, expectedNaNCount, MAP_FIELD_2, map2.values());
+      }
+    }
+  }
+
+  private <T1 extends Number> void updateExpectedValueFromRecords(
+      Map<Types.NestedField, AtomicReference<Number>> upperBounds,
+      Map<Types.NestedField, AtomicReference<Number>> lowerBounds,
+      Map<Types.NestedField, AtomicLong> expectedNaNCount,
+      Types.NestedField key, Collection<T1> vals) {
+    List<Number> nonNullNumbers = vals.stream().filter(v -> !NaNUtil.isNaN(v)).collect(Collectors.toList());
+    Optional<Number> maxOptional = nonNullNumbers.stream().filter(Objects::nonNull)
+        .reduce((v1, v2) -> getMinOrMax(v1, v2, true));
+    Optional<Number> minOptional = nonNullNumbers.stream().filter(Objects::nonNull)
+        .reduce((v1, v2) -> getMinOrMax(v1, v2, false));
+
+    expectedNaNCount.get(key).addAndGet(vals.size() - nonNullNumbers.size());
+    maxOptional.ifPresent(max -> updateBound(key, max, upperBounds, true));
+    minOptional.ifPresent(min -> updateBound(key, min, lowerBounds, false));
+  }
+
+  private void updateExpectedValuePerRecord(Map<Types.NestedField, AtomicReference<Number>> upperBounds,
+                                            Map<Types.NestedField, AtomicReference<Number>> lowerBounds,
+                                            Map<Types.NestedField, AtomicLong> expectedNaNCount,
+                                            Types.NestedField key, Number val) {
+    if (NaNUtil.isNaN(val)) {
+      expectedNaNCount.get(key).incrementAndGet();
+    } else if (val != null) {
+      updateBound(key, val, upperBounds, true);
+      updateBound(key, val, lowerBounds, false);
+    }
+  }
+
+  private void updateBound(
+      Types.NestedField key, Number val, Map<Types.NestedField, AtomicReference<Number>> bounds, boolean isMax) {
+    bounds.computeIfAbsent(key, k -> new AtomicReference<>(val)).updateAndGet(old -> getMinOrMax(old, val, isMax));
+  }
+
+  private Number getMinOrMax(Number val1, Number val2, boolean isMax) {
+    if (val1 instanceof Double) {
+      return isMax ? Double.max((Double) val1, (Double) val2) : Double.min((Double) val1, (Double) val2);
+    } else {
+      return isMax ? Float.max((Float) val1, (Float) val2) : Float.min((Float) val1, (Float) val2);
+    }
   }
 }

--- a/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcWriter.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcWriter.java
@@ -68,7 +68,7 @@ public class FlinkOrcWriter implements OrcRowWriter<RowData> {
   }
 
   @Override
-  public Stream<FieldMetrics> metrics() {
+  public Stream<FieldMetrics<?>> metrics() {
     return writer.metrics();
   }
 

--- a/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcWriters.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcWriters.java
@@ -258,7 +258,7 @@ class FlinkOrcWriters {
     }
 
     @Override
-    public Stream<FieldMetrics> metrics() {
+    public Stream<FieldMetrics<?>> metrics() {
       return elementWriter.metrics();
     }
 
@@ -306,7 +306,7 @@ class FlinkOrcWriters {
     }
 
     @Override
-    public Stream<FieldMetrics> metrics() {
+    public Stream<FieldMetrics<?>> metrics() {
       return Stream.concat(keyWriter.metrics(), valueWriter.metrics());
     }
   }
@@ -344,7 +344,7 @@ class FlinkOrcWriters {
     }
 
     @Override
-    public Stream<FieldMetrics> metrics() {
+    public Stream<FieldMetrics<?>> metrics() {
       return writers.stream().flatMap(OrcValueWriter::metrics);
     }
   }

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
@@ -96,7 +96,7 @@ public class OrcMetrics {
     }
   }
 
-  static Metrics fromWriter(Writer writer, Stream<FieldMetrics> fieldMetricsStream, MetricsConfig metricsConfig) {
+  static Metrics fromWriter(Writer writer, Stream<FieldMetrics<?>> fieldMetricsStream, MetricsConfig metricsConfig) {
     try {
       return buildOrcMetrics(writer.getNumberOfRows(), writer.getSchema(), writer.getStatistics(),
           fieldMetricsStream, metricsConfig, null);
@@ -107,7 +107,7 @@ public class OrcMetrics {
 
   private static Metrics buildOrcMetrics(final long numOfRows, final TypeDescription orcSchema,
                                          final ColumnStatistics[] colStats,
-                                         final Stream<FieldMetrics> fieldMetricsStream,
+                                         final Stream<FieldMetrics<?>> fieldMetricsStream,
                                          final MetricsConfig metricsConfig,
                                          final NameMapping mapping) {
     final TypeDescription orcSchemaWithIds = (!ORCSchemaUtil.hasIds(orcSchema) && mapping != null) ?
@@ -133,7 +133,7 @@ public class OrcMetrics {
     Map<Integer, ByteBuffer> lowerBounds = Maps.newHashMap();
     Map<Integer, ByteBuffer> upperBounds = Maps.newHashMap();
 
-    Map<Integer, FieldMetrics> fieldMetricsMap = Optional.ofNullable(fieldMetricsStream)
+    Map<Integer, FieldMetrics<?>> fieldMetricsMap = Optional.ofNullable(fieldMetricsStream)
         .map(stream -> stream.collect(Collectors.toMap(FieldMetrics::id, Function.identity())))
         .orElseGet(HashMap::new);
 
@@ -188,7 +188,7 @@ public class OrcMetrics {
   }
 
   private static Optional<ByteBuffer> fromOrcMin(Type type, ColumnStatistics columnStats,
-                                                 MetricsMode metricsMode, FieldMetrics fieldMetrics) {
+                                                 MetricsMode metricsMode, FieldMetrics<?> fieldMetrics) {
     Object min = null;
     if (columnStats instanceof IntegerColumnStatistics) {
       min = ((IntegerColumnStatistics) columnStats).getMinimum();
@@ -226,7 +226,7 @@ public class OrcMetrics {
   }
 
   private static Optional<ByteBuffer> fromOrcMax(Type type, ColumnStatistics columnStats,
-                                                 MetricsMode metricsMode, FieldMetrics fieldMetrics) {
+                                                 MetricsMode metricsMode, FieldMetrics<?> fieldMetrics) {
     Object max = null;
     if (columnStats instanceof IntegerColumnStatistics) {
       max = ((IntegerColumnStatistics) columnStats).getMaximum();

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
@@ -22,11 +22,14 @@ package org.apache.iceberg.orc;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.sql.Timestamp;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.FieldMetrics;
@@ -41,6 +44,7 @@ import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.hadoop.HadoopInputFile;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.mapping.NameMapping;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Conversions;
@@ -129,6 +133,10 @@ public class OrcMetrics {
     Map<Integer, ByteBuffer> lowerBounds = Maps.newHashMap();
     Map<Integer, ByteBuffer> upperBounds = Maps.newHashMap();
 
+    Map<Integer, FieldMetrics> fieldMetricsMap = Optional.ofNullable(fieldMetricsStream)
+        .map(stream -> stream.collect(Collectors.toMap(FieldMetrics::id, Function.identity())))
+        .orElseGet(HashMap::new);
+
     for (int i = 0; i < colStats.length; i++) {
       final ColumnStatistics colStat = colStats[i];
       final TypeDescription orcCol = orcSchemaWithIds.findSubtype(i);
@@ -160,10 +168,10 @@ public class OrcMetrics {
 
           if (metricsMode != MetricsModes.Counts.get()) {
             Optional<ByteBuffer> orcMin = (colStat.getNumberOfValues() > 0) ?
-                fromOrcMin(icebergCol.type(), colStat, metricsMode) : Optional.empty();
+                fromOrcMin(icebergCol.type(), colStat, metricsMode, fieldMetricsMap.get(fieldId)) : Optional.empty();
             orcMin.ifPresent(byteBuffer -> lowerBounds.put(icebergCol.fieldId(), byteBuffer));
             Optional<ByteBuffer> orcMax = (colStat.getNumberOfValues() > 0) ?
-                fromOrcMax(icebergCol.type(), colStat, metricsMode) : Optional.empty();
+                fromOrcMax(icebergCol.type(), colStat, metricsMode, fieldMetricsMap.get(fieldId)) : Optional.empty();
             orcMax.ifPresent(byteBuffer -> upperBounds.put(icebergCol.fieldId(), byteBuffer));
           }
         }
@@ -174,13 +182,13 @@ public class OrcMetrics {
         columnSizes,
         valueCounts,
         nullCounts,
-        MetricsUtil.createNanValueCounts(fieldMetricsStream, effectiveMetricsConfig, schema),
+        MetricsUtil.createNanValueCounts(fieldMetricsMap.values().stream(), effectiveMetricsConfig, schema),
         lowerBounds,
         upperBounds);
   }
 
   private static Optional<ByteBuffer> fromOrcMin(Type type, ColumnStatistics columnStats,
-                                                 MetricsMode metricsMode) {
+                                                 MetricsMode metricsMode, FieldMetrics fieldMetrics) {
     Object min = null;
     if (columnStats instanceof IntegerColumnStatistics) {
       min = ((IntegerColumnStatistics) columnStats).getMinimum();
@@ -188,10 +196,11 @@ public class OrcMetrics {
         min = Math.toIntExact((long) min);
       }
     } else if (columnStats instanceof DoubleColumnStatistics) {
-      min = ((DoubleColumnStatistics) columnStats).getMinimum();
-      if (type.typeId() == Type.TypeID.FLOAT) {
-        min = ((Double) min).floatValue();
-      }
+      // since Orc includes NaN for upper/lower bounds of floating point columns, and we don't want this behavior,
+      // we have tracked metrics for such columns ourselves and thus do not need to rely on Orc's column statistics.
+      Preconditions.checkNotNull(fieldMetrics,
+          "[BUG] Float or double type columns should have metrics being tracked by Iceberg Orc writers");
+      min = fieldMetrics.lowerBound();
     } else if (columnStats instanceof StringColumnStatistics) {
       min = ((StringColumnStatistics) columnStats).getMinimum();
     } else if (columnStats instanceof DecimalColumnStatistics) {
@@ -217,7 +226,7 @@ public class OrcMetrics {
   }
 
   private static Optional<ByteBuffer> fromOrcMax(Type type, ColumnStatistics columnStats,
-                                                 MetricsMode metricsMode) {
+                                                 MetricsMode metricsMode, FieldMetrics fieldMetrics) {
     Object max = null;
     if (columnStats instanceof IntegerColumnStatistics) {
       max = ((IntegerColumnStatistics) columnStats).getMaximum();
@@ -225,10 +234,11 @@ public class OrcMetrics {
         max = Math.toIntExact((long) max);
       }
     } else if (columnStats instanceof DoubleColumnStatistics) {
-      max = ((DoubleColumnStatistics) columnStats).getMaximum();
-      if (type.typeId() == Type.TypeID.FLOAT) {
-        max = ((Double) max).floatValue();
-      }
+      // since Orc includes NaN for upper/lower bounds of floating point columns, and we don't want this behavior,
+      // we have tracked metrics for such columns ourselves and thus do not need to rely on Orc's column statistics.
+      Preconditions.checkNotNull(fieldMetrics,
+          "[BUG] Float or double type columns should have metrics being tracked by Iceberg Orc writers");
+      max = fieldMetrics.upperBound();
     } else if (columnStats instanceof StringColumnStatistics) {
       max = ((StringColumnStatistics) columnStats).getMaximum();
     } else if (columnStats instanceof DecimalColumnStatistics) {

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcRowWriter.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcRowWriter.java
@@ -41,7 +41,7 @@ public interface OrcRowWriter<T> {
   /**
    * Returns a stream of {@link FieldMetrics} that this OrcRowWriter keeps track of.
    */
-  default Stream<FieldMetrics> metrics() {
+  default Stream<FieldMetrics<?>> metrics() {
     return Stream.empty();
   }
 }

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcValueWriter.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcValueWriter.java
@@ -38,6 +38,7 @@ public interface OrcValueWriter<T> {
     if (data == null) {
       output.noNulls = false;
       output.isNull[rowId] = true;
+      nullWrite();
     } else {
       output.isNull[rowId] = false;
       nonNullWrite(rowId, data, output);
@@ -46,10 +47,14 @@ public interface OrcValueWriter<T> {
 
   void nonNullWrite(int rowId, T data, ColumnVector output);
 
+  default void nullWrite() {
+    // no op
+  }
+
   /**
    * Returns a stream of {@link FieldMetrics} that this OrcValueWriter keeps track of.
    */
-  default Stream<FieldMetrics> metrics() {
+  default Stream<FieldMetrics<?>> metrics() {
     return Stream.empty();
   }
 }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueWriter.java
@@ -34,7 +34,7 @@ public interface ParquetValueWriter<T> {
   /**
    * Returns a stream of {@link FieldMetrics} that this ParquetValueWriter keeps track of.
    */
-  default Stream<FieldMetrics> metrics() {
+  default Stream<FieldMetrics<?>> metrics() {
     return Stream.empty();
   }
 }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueWriters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueWriters.java
@@ -170,50 +170,44 @@ public class ParquetValueWriters {
   }
 
   private static class FloatWriter extends UnboxedWriter<Float> {
-    private final int id;
-    private long nanCount;
+    private final FloatFieldMetrics.FloatFieldMetricsContext floatFieldMetricsContext;
 
     private FloatWriter(ColumnDescriptor desc) {
       super(desc);
-      this.id = desc.getPrimitiveType().getId().intValue();
-      this.nanCount = 0;
+      int id = desc.getPrimitiveType().getId().intValue();
+      this.floatFieldMetricsContext = new FloatFieldMetrics.FloatFieldMetricsContext(id);
     }
 
     @Override
     public void write(int repetitionLevel, Float value) {
       writeFloat(repetitionLevel, value);
-      if (Float.isNaN(value)) {
-        nanCount++;
-      }
+      floatFieldMetricsContext.updateMetricsContext(value);
     }
 
     @Override
     public Stream<FieldMetrics> metrics() {
-      return Stream.of(new FloatFieldMetrics(id, nanCount));
+      return Stream.of(floatFieldMetricsContext.buildMetrics());
     }
   }
 
   private static class DoubleWriter extends UnboxedWriter<Double> {
-    private final int id;
-    private long nanCount;
+    private final FloatFieldMetrics.DoubleFieldMetricsContext doubleFieldMetricsContext;
 
     private DoubleWriter(ColumnDescriptor desc) {
       super(desc);
-      this.id = desc.getPrimitiveType().getId().intValue();
-      this.nanCount = 0;
+      int id = desc.getPrimitiveType().getId().intValue();
+      this.doubleFieldMetricsContext = new FloatFieldMetrics.DoubleFieldMetricsContext(id);
     }
 
     @Override
     public void write(int repetitionLevel, Double value) {
       writeDouble(repetitionLevel, value);
-      if (Double.isNaN(value)) {
-        nanCount++;
-      }
+      doubleFieldMetricsContext.updateMetricsContext(value);
     }
 
     @Override
     public Stream<FieldMetrics> metrics() {
-      return Stream.of(new FloatFieldMetrics(id, nanCount));
+      return Stream.of(doubleFieldMetricsContext.buildMetrics());
     }
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueWriters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueWriters.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import org.apache.avro.util.Utf8;
+import org.apache.iceberg.DoubleFieldMetrics;
 import org.apache.iceberg.FieldMetrics;
 import org.apache.iceberg.FloatFieldMetrics;
 import org.apache.iceberg.deletes.PositionDelete;
@@ -170,44 +171,44 @@ public class ParquetValueWriters {
   }
 
   private static class FloatWriter extends UnboxedWriter<Float> {
-    private final FloatFieldMetrics.FloatFieldMetricsContext floatFieldMetricsContext;
+    private final FloatFieldMetrics.Builder floatFieldMetricsBuilder;
 
     private FloatWriter(ColumnDescriptor desc) {
       super(desc);
       int id = desc.getPrimitiveType().getId().intValue();
-      this.floatFieldMetricsContext = new FloatFieldMetrics.FloatFieldMetricsContext(id);
+      this.floatFieldMetricsBuilder = new FloatFieldMetrics.Builder(id);
     }
 
     @Override
     public void write(int repetitionLevel, Float value) {
       writeFloat(repetitionLevel, value);
-      floatFieldMetricsContext.updateMetricsContext(value);
+      floatFieldMetricsBuilder.addValue(value);
     }
 
     @Override
     public Stream<FieldMetrics> metrics() {
-      return Stream.of(floatFieldMetricsContext.buildMetrics());
+      return Stream.of(floatFieldMetricsBuilder.build());
     }
   }
 
   private static class DoubleWriter extends UnboxedWriter<Double> {
-    private final FloatFieldMetrics.DoubleFieldMetricsContext doubleFieldMetricsContext;
+    private final DoubleFieldMetrics.Builder doubleFieldMetricsBuilder;
 
     private DoubleWriter(ColumnDescriptor desc) {
       super(desc);
       int id = desc.getPrimitiveType().getId().intValue();
-      this.doubleFieldMetricsContext = new FloatFieldMetrics.DoubleFieldMetricsContext(id);
+      this.doubleFieldMetricsBuilder = new DoubleFieldMetrics.Builder(id);
     }
 
     @Override
     public void write(int repetitionLevel, Double value) {
       writeDouble(repetitionLevel, value);
-      doubleFieldMetricsContext.updateMetricsContext(value);
+      doubleFieldMetricsBuilder.addValue(value);
     }
 
     @Override
     public Stream<FieldMetrics> metrics() {
-      return Stream.of(doubleFieldMetricsContext.buildMetrics());
+      return Stream.of(doubleFieldMetricsBuilder.build());
     }
   }
 

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueWriter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueWriter.java
@@ -53,7 +53,7 @@ interface SparkOrcValueWriter {
    * counters, and only return non-empty stream if the writer writes double or float values either by itself or
    * transitively.
    */
-  default Stream<FieldMetrics> metrics() {
+  default Stream<FieldMetrics<?>> metrics() {
     return Stream.empty();
   }
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueWriters.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueWriters.java
@@ -141,52 +141,42 @@ class SparkOrcValueWriters {
   }
 
   private static class FloatWriter implements SparkOrcValueWriter {
-    private final int id;
-    private long nanCount;
+    private final FloatFieldMetrics.FloatFieldMetricsContext floatFieldMetricsContext;
 
     private FloatWriter(int id) {
-      this.id = id;
-      this.nanCount = 0;
+      this.floatFieldMetricsContext = new FloatFieldMetrics.FloatFieldMetricsContext(id);
     }
 
     @Override
     public void nonNullWrite(int rowId, int column, SpecializedGetters data, ColumnVector output) {
       float floatValue = data.getFloat(column);
       ((DoubleColumnVector) output).vector[rowId] = floatValue;
-
-      if (Float.isNaN(floatValue)) {
-        nanCount++;
-      }
+      floatFieldMetricsContext.updateMetricsContext(floatValue);
     }
 
     @Override
     public Stream<FieldMetrics> metrics() {
-      return Stream.of(new FloatFieldMetrics(id, nanCount));
+      return Stream.of(floatFieldMetricsContext.buildMetrics());
     }
   }
 
   private static class DoubleWriter implements SparkOrcValueWriter {
-    private final int id;
-    private long nanCount;
+    private final FloatFieldMetrics.DoubleFieldMetricsContext doubleFieldMetricsContext;
 
     private DoubleWriter(int id) {
-      this.id = id;
-      this.nanCount = 0;
+      this.doubleFieldMetricsContext = new FloatFieldMetrics.DoubleFieldMetricsContext(id);
     }
 
     @Override
     public void nonNullWrite(int rowId, int column, SpecializedGetters data, ColumnVector output) {
       double doubleValue = data.getDouble(column);
       ((DoubleColumnVector) output).vector[rowId] = doubleValue;
-
-      if (Double.isNaN(doubleValue)) {
-        nanCount++;
-      }
+      doubleFieldMetricsContext.updateMetricsContext(doubleValue);
     }
 
     @Override
     public Stream<FieldMetrics> metrics() {
-      return Stream.of(new FloatFieldMetrics(id, nanCount));
+      return Stream.of(doubleFieldMetricsContext.buildMetrics());
     }
   }
 

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueWriters.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueWriters.java
@@ -156,7 +156,7 @@ class SparkOrcValueWriters {
     }
 
     @Override
-    public Stream<FieldMetrics> metrics() {
+    public Stream<FieldMetrics<?>> metrics() {
       return Stream.of(floatFieldMetricsBuilder.build());
     }
   }
@@ -176,7 +176,7 @@ class SparkOrcValueWriters {
     }
 
     @Override
-    public Stream<FieldMetrics> metrics() {
+    public Stream<FieldMetrics<?>> metrics() {
       return Stream.of(doubleFieldMetricsBuilder.build());
     }
   }
@@ -272,7 +272,7 @@ class SparkOrcValueWriters {
     }
 
     @Override
-    public Stream<FieldMetrics> metrics() {
+    public Stream<FieldMetrics<?>> metrics() {
       return writer.metrics();
     }
   }
@@ -308,7 +308,7 @@ class SparkOrcValueWriters {
     }
 
     @Override
-    public Stream<FieldMetrics> metrics() {
+    public Stream<FieldMetrics<?>> metrics() {
       return Stream.concat(keyWriter.metrics(), valueWriter.metrics());
     }
   }

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueWriters.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcValueWriters.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.spark.data;
 
 import java.util.stream.Stream;
+import org.apache.iceberg.DoubleFieldMetrics;
 import org.apache.iceberg.FieldMetrics;
 import org.apache.iceberg.FloatFieldMetrics;
 import org.apache.orc.storage.common.type.HiveDecimal;
@@ -141,42 +142,42 @@ class SparkOrcValueWriters {
   }
 
   private static class FloatWriter implements SparkOrcValueWriter {
-    private final FloatFieldMetrics.FloatFieldMetricsContext floatFieldMetricsContext;
+    private final FloatFieldMetrics.Builder floatFieldMetricsBuilder;
 
     private FloatWriter(int id) {
-      this.floatFieldMetricsContext = new FloatFieldMetrics.FloatFieldMetricsContext(id);
+      this.floatFieldMetricsBuilder = new FloatFieldMetrics.Builder(id);
     }
 
     @Override
     public void nonNullWrite(int rowId, int column, SpecializedGetters data, ColumnVector output) {
       float floatValue = data.getFloat(column);
       ((DoubleColumnVector) output).vector[rowId] = floatValue;
-      floatFieldMetricsContext.updateMetricsContext(floatValue);
+      floatFieldMetricsBuilder.addValue(floatValue);
     }
 
     @Override
     public Stream<FieldMetrics> metrics() {
-      return Stream.of(floatFieldMetricsContext.buildMetrics());
+      return Stream.of(floatFieldMetricsBuilder.build());
     }
   }
 
   private static class DoubleWriter implements SparkOrcValueWriter {
-    private final FloatFieldMetrics.DoubleFieldMetricsContext doubleFieldMetricsContext;
+    private final DoubleFieldMetrics.Builder doubleFieldMetricsBuilder;
 
     private DoubleWriter(int id) {
-      this.doubleFieldMetricsContext = new FloatFieldMetrics.DoubleFieldMetricsContext(id);
+      this.doubleFieldMetricsBuilder = new DoubleFieldMetrics.Builder(id);
     }
 
     @Override
     public void nonNullWrite(int rowId, int column, SpecializedGetters data, ColumnVector output) {
       double doubleValue = data.getDouble(column);
       ((DoubleColumnVector) output).vector[rowId] = doubleValue;
-      doubleFieldMetricsContext.updateMetricsContext(doubleValue);
+      doubleFieldMetricsBuilder.addValue(doubleValue);
     }
 
     @Override
     public Stream<FieldMetrics> metrics() {
-      return Stream.of(doubleFieldMetricsContext.buildMetrics());
+      return Stream.of(doubleFieldMetricsBuilder.build());
     }
   }
 

--- a/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcWriter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/data/SparkOrcWriter.java
@@ -65,7 +65,7 @@ public class SparkOrcWriter implements OrcRowWriter<InternalRow> {
   }
 
   @Override
-  public Stream<FieldMetrics> metrics() {
+  public Stream<FieldMetrics<?>> metrics() {
     return writer.metrics();
   }
 
@@ -146,7 +146,7 @@ public class SparkOrcWriter implements OrcRowWriter<InternalRow> {
     }
 
     @Override
-    public Stream<FieldMetrics> metrics() {
+    public Stream<FieldMetrics<?>> metrics() {
       return writers.stream().flatMap(SparkOrcValueWriter::metrics);
     }
 


### PR DESCRIPTION
- This PR implements the behavior described in #348, to exclude NaN from upper/lower bound of double/float type columns in parquet/orc. 
- Support for Avro metrics can be found in #1963, and has some overlap with this PR (especially on `FieldMetrics` related classes)