### PR TITLE
Core: add row identifier to schema

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Schema.java
+++ b/api/src/main/java/org/apache/iceberg/Schema.java
@@ -190,8 +190,10 @@ public class Schema implements Serializable {
    * The set of identifier field IDs.
    * <p>
    * Identifier is a concept similar to primary key in a relational database system.
+   * It consists of a unique set of primitive fields in the schema.
+   * An identifier field must be at root, or nested in a chain of structs (no maps or lists).
    * A row should be unique in a table based on the values of the identifier fields.
-   * However, unlike a primary key, Iceberg identifier differs in the following ways:
+   * However, Iceberg identifier differs from primary key in the following ways:
    * <ul>
    * <li>Iceberg does not enforce the uniqueness of a row based on this identifier information.
    * It is used for operations like upsert to define the default upsert key.</li>
@@ -200,12 +202,6 @@ public class Schema implements Serializable {
    * inside a "user" struct in a schema, field "user.last_name" can be set as a part of the identifier field.</li>
    * </ul>
    * <p>
-   * A field can be used as a part of the identifier only if:
-   * <ul>
-   * <li>its type is primitive</li>
-   * <li>it exists in the current schema, or have been added in this update</li>
-   * <li>it is at root, or nested in a chain of structs (no maps or lists)</li>
-   * </ul>
    *
    * @return the set of identifier field IDs in this schema.
    */

--- a/api/src/main/java/org/apache/iceberg/Schema.java
+++ b/api/src/main/java/org/apache/iceberg/Schema.java
@@ -189,15 +189,22 @@ public class Schema implements Serializable {
   /**
    * The set of identifier field IDs.
    * <p>
-   * Identifier field is a similar concept as primary key in a relational database system.
-   * A row should be unique based on the values of the identifier fields.
-   * However, unlike a primary key, Iceberg identifier field differs in the following ways:
+   * Identifier is a concept similar to primary key in a relational database system.
+   * A row should be unique in a table based on the values of the identifier fields.
+   * However, unlike a primary key, Iceberg identifier differs in the following ways:
    * <ul>
    * <li>Iceberg does not enforce the uniqueness of a row based on this identifier information.
    * It is used for operations like upsert to define the default upsert key.</li>
    * <li>NULL can be used as value of an identifier field. Iceberg ensures null-safe equality check.</li>
    * <li>A nested field in a struct can be used as an identifier. For example, if there is a "last_name" field
-   * inside a "user" struct in a schema, field "user.last_name" can be set as an identifier field.</li>
+   * inside a "user" struct in a schema, field "user.last_name" can be set as a part of the identifier field.</li>
+   * </ul>
+   * <p>
+   * A field can be used as a part of the identifier only if:
+   * <ul>
+   * <li>its type is primitive</li>
+   * <li>it exists in the current schema, or have been added in this update</li>
+   * <li>it is at root, or nested in a chain of structs (no maps or lists)</li>
    * </ul>
    *
    * @return the set of identifier field IDs in this schema.

--- a/api/src/main/java/org/apache/iceberg/Schema.java
+++ b/api/src/main/java/org/apache/iceberg/Schema.java
@@ -186,6 +186,22 @@ public class Schema implements Serializable {
     return struct.fields();
   }
 
+  /**
+   * The set of identifier field IDs.
+   * <p>
+   * Identifier field is a similar concept as primary key in a relational database system.
+   * A row should be unique based on the values of the identifier fields.
+   * However, unlike a primary key, Iceberg identifier field differs in the following ways:
+   * <ul>
+   * <li>Iceberg does not enforce the uniqueness of a row based on this identifier information.
+   * It is used for operations like upsert to define the default upsert key.</li>
+   * <li>NULL can be used as value of an identifier field. Iceberg ensures null-safe equality check.</li>
+   * <li>A nested field in a struct can be used as an identifier. For example, if there is a "last_name" field
+   * inside a "user" struct in a schema, field "user.last_name" can be set as an identifier field.</li>
+   * </ul>
+   *
+   * @return the set of identifier field IDs in this schema.
+   */
   public Set<Integer> identifierFieldIds() {
     return lazyIdentifierFieldIdSet();
   }

--- a/api/src/main/java/org/apache/iceberg/UpdateSchema.java
+++ b/api/src/main/java/org/apache/iceberg/UpdateSchema.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg;
 
+import java.util.Set;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.types.Type;
 
@@ -384,4 +385,21 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
    *                                  with other additions, renames, or updates.
    */
   UpdateSchema unionByNameWith(Schema newSchema);
+
+  /**
+   * Set the identifier fields given a set of column names.
+   * <p>
+   * Identifier field is a similar concept as primary key in a relational database system.
+   * A row should be unique based on the values of the identifier fields.
+   * However, unlike a primary key, Iceberg does not enforce the uniqueness of a row based on this information.
+   * It is used for operations like upsert to define the default upsert key.
+   * <p>
+   * A column in the identifier fields must be of a primitive type.
+   * Each column set in this operation must exist in the current schema to update,
+   * or is added as a part of this update.
+   *
+   * @param names names of the columns to set as identifier fields
+   * @return this for method chaining
+   */
+  UpdateSchema setIdentifierFields(Set<String> names);
 }

--- a/api/src/main/java/org/apache/iceberg/UpdateSchema.java
+++ b/api/src/main/java/org/apache/iceberg/UpdateSchema.java
@@ -389,13 +389,7 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
 
   /**
    * Set the identifier fields given a set of field names.
-   * <p>
-   * A field can be set as an identifier only if:
-   * <ul>
-   * <li>its type is primitive</li>
-   * <li>it exists in the current schema, or have been added in this update</li>
-   * <li>it is at root, or nested in a chain of structs (no maps or lists)</li>
-   * </ul>
+   * See {@link Schema#identifierFieldIds()} to learn more about Iceberg identifier.
    *
    * @param names names of the columns to set as identifier fields
    * @return this for method chaining
@@ -403,7 +397,7 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
   UpdateSchema setIdentifierFields(Set<String> names);
 
   /**
-   * Set the identifier fields given some column names.
+   * Set the identifier fields given some field names.
    * See {@link UpdateSchema#setIdentifierFields(Set)} for more details.
    *
    * @param names names of the columns to set as identifier fields

--- a/api/src/main/java/org/apache/iceberg/UpdateSchema.java
+++ b/api/src/main/java/org/apache/iceberg/UpdateSchema.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 
 import java.util.Set;
 import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Type;
 
 /**
@@ -387,19 +388,28 @@ public interface UpdateSchema extends PendingUpdate<Schema> {
   UpdateSchema unionByNameWith(Schema newSchema);
 
   /**
-   * Set the identifier fields given a set of column names.
+   * Set the identifier fields given a set of field names.
    * <p>
-   * Identifier field is a similar concept as primary key in a relational database system.
-   * A row should be unique based on the values of the identifier fields.
-   * However, unlike a primary key, Iceberg does not enforce the uniqueness of a row based on this information.
-   * It is used for operations like upsert to define the default upsert key.
-   * <p>
-   * A column in the identifier fields must be of a primitive type.
-   * Each column set in this operation must exist in the current schema to update,
-   * or is added as a part of this update.
+   * A field can be set as an identifier only if:
+   * <ul>
+   * <li>its type is primitive</li>
+   * <li>it exists in the current schema, or have been added in this update</li>
+   * <li>it is at root, or nested in a chain of structs (no maps or lists)</li>
+   * </ul>
    *
    * @param names names of the columns to set as identifier fields
    * @return this for method chaining
    */
   UpdateSchema setIdentifierFields(Set<String> names);
+
+  /**
+   * Set the identifier fields given some column names.
+   * See {@link UpdateSchema#setIdentifierFields(Set)} for more details.
+   *
+   * @param names names of the columns to set as identifier fields
+   * @return this for method chaining
+   */
+  default UpdateSchema setIdentifierFields(String... names) {
+    return setIdentifierFields(Sets.newHashSet(names));
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -444,7 +444,7 @@ class SchemaUpdate implements UpdateSchema {
         .visit(schema, new ApplyChanges(deletes, updates, adds, moves))
         .asNestedType().asStructType();
 
-    // validate
+    // validate identifier requirements based on latest schema
     Schema noIdentifierSchema = new Schema(struct.fields());
     Set<Integer> validatedIdentifiers = identifierNames.stream()
         .map(n -> validateIdentifierField(n, noIdentifierSchema))
@@ -473,7 +473,7 @@ class SchemaUpdate implements UpdateSchema {
         validateIdentifierFieldParent(identifierName, parent.fieldId(), idToParent, schema);
       } else {
         throw new IllegalArgumentException(String.format(
-            "Cannot add field %s as an identifier: must not be nested in %s", identifierName, parent));
+            "Cannot add field %s as an identifier field: must not be nested in %s", identifierName, parent));
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -491,7 +491,7 @@ public class TableMetadata implements Serializable {
 
     ImmutableList.Builder<Schema> builder = ImmutableList.<Schema>builder().addAll(schemas);
     if (!schemasById.containsKey(newSchemaId)) {
-      builder.add(new Schema(newSchemaId, newSchema.columns()));
+      builder.add(new Schema(newSchemaId, newSchema.columns(), newSchema.identifierFieldIds()));
     }
 
     return new TableMetadata(null, formatVersion, uuid, location,
@@ -760,7 +760,7 @@ public class TableMetadata implements Serializable {
     ImmutableList.Builder<Schema> schemasBuilder = ImmutableList.<Schema>builder().addAll(schemas);
 
     if (!schemasById.containsKey(freshSchemaId)) {
-      schemasBuilder.add(new Schema(freshSchemaId, freshSchema.columns()));
+      schemasBuilder.add(new Schema(freshSchemaId, freshSchema.columns(), freshSchema.identifierFieldIds()));
     }
 
     return new TableMetadata(null, formatVersion, uuid, newLocation,
@@ -916,7 +916,7 @@ public class TableMetadata implements Serializable {
     // if the schema already exists, use its id; otherwise use the highest id + 1
     int newSchemaId = currentSchemaId;
     for (Schema schema : schemas) {
-      if (schema.asStruct().equals(newSchema.asStruct())) {
+      if (schema.sameSchema(newSchema)) {
         newSchemaId = schema.schemaId();
         break;
       } else if (schema.schemaId() >= newSchemaId) {

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -663,7 +663,6 @@ public class TestTableMetadata {
 
     TableMetadata meta = TableMetadata.newTableMetadata(
         schema, PartitionSpec.unpartitioned(), null, ImmutableMap.of());
-    Assert.assertTrue("Should default to no identifier field", meta.schema().identifierFieldIds().isEmpty());
 
     Schema newSchema = new Schema(
         Lists.newArrayList(Types.NestedField.required(1, "x", Types.StringType.get())),

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -647,6 +647,34 @@ public class TestTableMetadata {
   }
 
   @Test
+  public void testParseSchemaIdentifierFields() throws Exception {
+    String data = readTableMetadataInputFile("TableMetadataV2Valid.json");
+    TableMetadata parsed = TableMetadataParser.fromJson(
+        ops.io(), null, JsonUtil.mapper().readValue(data, JsonNode.class));
+    Assert.assertEquals(Sets.newHashSet(), parsed.schemasById().get(0).identifierFieldIds());
+    Assert.assertEquals(Sets.newHashSet(1, 2), parsed.schemasById().get(1).identifierFieldIds());
+  }
+
+  @Test
+  public void testUpdateSchemaIdentifierFields() {
+    Schema schema = new Schema(
+        Types.NestedField.required(10, "x", Types.StringType.get())
+    );
+
+    TableMetadata meta = TableMetadata.newTableMetadata(
+        schema, PartitionSpec.unpartitioned(), null, ImmutableMap.of());
+    Assert.assertTrue("Should default to no identifier field", meta.schema().identifierFieldIds().isEmpty());
+
+    Schema newSchema = new Schema(
+        Lists.newArrayList(Types.NestedField.required(1, "x", Types.StringType.get())),
+        Sets.newHashSet(1)
+    );
+    TableMetadata newMeta = meta.updateSchema(newSchema, 1);
+    Assert.assertEquals(2, newMeta.schemas().size());
+    Assert.assertEquals(Sets.newHashSet(1), newMeta.schema().identifierFieldIds());
+  }
+
+  @Test
   public void testUpdateSchema() {
     Schema schema = new Schema(0,
         Types.NestedField.required(1, "y", Types.LongType.get(), "comment")

--- a/core/src/test/resources/TableMetadataV2Valid.json
+++ b/core/src/test/resources/TableMetadataV2Valid.json
@@ -22,6 +22,10 @@
     {
       "type": "struct",
       "schema-id": 1,
+      "identifier-field-ids": [
+        1,
+        2
+      ],
       "fields": [
         {
           "id": 1,


### PR DESCRIPTION
Continuation of #2354

@yyanyy @rdblue @openinx @aokolnychyi 

Spec with row identifier:

```
{
      "type": "struct",
      "schema-id": 1,
      "row-identifiers": [
        1,
        2
      ],
      "fields": [
        {
          "id": 1,
          "name": "x",
          "required": true,
          "type": "long"
        },
        {
          "id": 2,
          "name": "y",
          "required": true,
          "type": "long",
          "doc": "comment"
        },
        {
          "id": 3,
          "name": "z",
          "required": true,
          "type": "long"
        }
      ]
    }

```

New Schema toString:

```
table {
  fields {
    1: x: required long
    2: y: required long (comment)
    3: z: required long
  }
  row identifiers { 1,2 }
}
```


Update row identifier rules:
1. row identifier should be added through `UpdateSchema.addRowIdentifier(columnName)`
2. the column added should exist in schema or a part of the newly added columns (to make adding a new primary key a single atomic update)
3. rename, move column should not affect row identifier because it is referencing the field IDs
4. row identifier should be dropped through `UpdateSchema.deleteRowIdentifier(columnName)`
5. it can only drop existing row identifier column
6. a row identifier column cannot be dropped unless it is first dropped in the row identifiers list, to satisfy both use cases (1) user want to actually drop that row identifier column as an atomic update, (2) prevent user from directly dropping that column without knowing the implications

