### PR TITLE
Doc: Fix broken Flink DataStream snippets

### DIFF
--- a/site/docs/flink.md
+++ b/site/docs/flink.md
@@ -342,12 +342,12 @@ This example will read incremental records which start from snapshot-id '3821550
 
 ```java
 StreamExecutionEnvironment env = StreamExecutionEnvironment.createLocalEnvironment();
-TableLoader tableLoader = TableLoader.fromHadooptable("hdfs://nn:8020/warehouse/path");
+TableLoader tableLoader = TableLoader.fromHadoopTable("hdfs://nn:8020/warehouse/path");
 DataStream<RowData> stream = FlinkSource.forRowData()
      .env(env)
      .tableLoader(loader)
      .streaming(true)
-     .startSnapshotId(3821550127947089987)
+     .startSnapshotId(3821550127947089987L)
      .build();
 
 // Print all records to stdout.
@@ -373,11 +373,10 @@ StreamExecutionEnvironment env = ...;
 
 DataStream<RowData> input = ... ;
 Configuration hadoopConf = new Configuration();
-TableLoader tableLoader = TableLoader.fromHadooptable("hdfs://nn:8020/warehouse/path");
+TableLoader tableLoader = TableLoader.fromHadoopTable("hdfs://nn:8020/warehouse/path", hadoopConf);
 
 FlinkSink.forRowData(input)
     .tableLoader(tableLoader)
-    .hadoopConf(hadoopConf)
     .build();
 
 env.execute("Test Iceberg DataStream");
@@ -394,12 +393,11 @@ StreamExecutionEnvironment env = ...;
 
 DataStream<RowData> input = ... ;
 Configuration hadoopConf = new Configuration();
-TableLoader tableLoader = TableLoader.fromHadooptable("hdfs://nn:8020/warehouse/path");
+TableLoader tableLoader = TableLoader.fromHadoopTable("hdfs://nn:8020/warehouse/path", hadoopConf);
 
 FlinkSink.forRowData(input)
     .tableLoader(tableLoader)
     .overwrite(true)
-    .hadoopConf(hadoopConf)
     .build();
 
 env.execute("Test Iceberg DataStream");
@@ -416,7 +414,7 @@ Iceberg provides API to rewrite small files into large files by submitting flink
 ```java
 import org.apache.iceberg.flink.actions.Actions;
 
-TableLoader tableLoader = TableLoader.fromHadooptable("hdfs://nn:8020/warehouse/path");
+TableLoader tableLoader = TableLoader.fromHadoopTable("hdfs://nn:8020/warehouse/path");
 Table table = tableLoader.loadTable();
 RewriteDataFilesActionResult result = Actions.forTable(table)
         .rewriteDataFiles()


### PR DESCRIPTION
The snippets in Flink section are a bit outdated with some compile errors. This PR fixes the problem.