### PR TITLE
Spark: Remove the shading of org.codehaus.jackson.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -892,8 +892,6 @@ if (jdkVersion == '8') {
       relocate 'com.thoughtworks.paranamer', 'org.apache.iceberg.shaded.com.thoughtworks.paranamer'
       relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'
       relocate 'shaded.parquet', 'org.apache.iceberg.shaded.org.apache.parquet.shaded'
-      // relocate Avro's jackson dependency to share parquet-jackson locations
-      relocate 'org.codehaus.jackson', 'org.apache.iceberg.shaded.org.apache.parquet.shaded.org.codehaus.jackson'
       relocate 'org.apache.orc', 'org.apache.iceberg.shaded.org.apache.orc'
       relocate 'io.airlift', 'org.apache.iceberg.shaded.io.airlift'
       // relocate Arrow and related deps to shade Iceberg specific version
@@ -1064,8 +1062,6 @@ project(':iceberg-spark3-runtime') {
     relocate 'com.thoughtworks.paranamer', 'org.apache.iceberg.shaded.com.thoughtworks.paranamer'
     relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'
     relocate 'shaded.parquet', 'org.apache.iceberg.shaded.org.apache.parquet.shaded'
-    // relocate Avro's jackson dependency to share parquet-jackson locations
-    relocate 'org.codehaus.jackson', 'org.apache.iceberg.shaded.org.apache.parquet.shaded.org.codehaus.jackson'
     relocate 'org.apache.orc', 'org.apache.iceberg.shaded.org.apache.orc'
     relocate 'io.airlift', 'org.apache.iceberg.shaded.io.airlift'
     // relocate Arrow and related deps to shade Iceberg specific version


### PR DESCRIPTION
Iceberg uses the Parquet 1.11.x. Parquet removed all shading of `org.codehaus.jackson` after version 1.3.3 as the following commits show.
1. https://github.com/apache/parquet-mr/commit/9652d97f63a05d410fae941f14d684b8dfcedd44
2. https://github.com/apache/parquet-mr/commit/7def49cdd57d670a87abdf264aef5a461de9610a
3. https://github.com/apache/parquet-mr/commit/5ffaba99e7b10e55df9b49e3401396660e3262a7

Iceberg still assumes `org.codehaus.jackson` is shaded in Parquet, then double shades it. This is not only unnecessary, but also causes problem. Integration with Parquet 1.12 may fail due to this.



