### PR TITLE
Try reverse DNS lookup workaround for Ubunut GitHub runners

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -48,6 +48,7 @@ jobs:
         path: ~/.gradle/caches
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: ${{ runner.os }}-gradle
+    - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
     - run: ./gradlew check -Pquick=true -x javadoc
     - uses: actions/upload-artifact@v2
       if: failure()


### PR DESCRIPTION
See https://github.com/apache/iceberg/pull/2451#issuecomment-819674109
See https://lists.apache.org/thread.html/r40b2da182952f21a3b94696e6f1bf8594e7ff16e1c5979fe8b2d51c8%40%3Cbuilds.apache.org%3E

Fixes #2475