### PR TITLE
Core: Fix NPE caused by Unboxing a Null in ManifestFileUtil (#2492)

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/ManifestFileUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/ManifestFileUtil.java
@@ -42,7 +42,7 @@ public class ManifestFileUtil {
     private final T lowerBound;
     private final T upperBound;
     private final boolean containsNull;
-    private final Boolean containsNaN;
+    private final boolean containsNaN;
 
     @SuppressWarnings("unchecked")
     FieldSummary(Type.PrimitiveType primitive, ManifestFile.PartitionFieldSummary summary) {
@@ -51,7 +51,7 @@ public class ManifestFileUtil {
       this.lowerBound = Conversions.fromByteBuffer(primitive, summary.lowerBound());
       this.upperBound = Conversions.fromByteBuffer(primitive, summary.upperBound());
       this.containsNull = summary.containsNull();
-      this.containsNaN = summary.containsNaN();
+      this.containsNaN = summary.containsNaN() == null ? true : summary.containsNaN();
     }
 
     boolean canContain(Object value) {
@@ -60,7 +60,7 @@ public class ManifestFileUtil {
       }
 
       if (NaNUtil.isNaN(value)) {
-        return containsNaN == null ? true : containsNaN;
+        return containsNaN;
       }
 
       // if lower bound is null, then there are no non-null values

--- a/core/src/main/java/org/apache/iceberg/util/ManifestFileUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/ManifestFileUtil.java
@@ -42,7 +42,7 @@ public class ManifestFileUtil {
     private final T lowerBound;
     private final T upperBound;
     private final boolean containsNull;
-    private final boolean containsNaN;
+    private final Boolean containsNaN;
 
     @SuppressWarnings("unchecked")
     FieldSummary(Type.PrimitiveType primitive, ManifestFile.PartitionFieldSummary summary) {
@@ -60,7 +60,7 @@ public class ManifestFileUtil {
       }
 
       if (NaNUtil.isNaN(value)) {
-        return containsNaN;
+        return containsNaN == null ? true : containsNaN;
       }
 
       // if lower bound is null, then there are no non-null values


### PR DESCRIPTION
Previously the boxed value of contains NaN would be null if the table
was made before NaN stats were implemented. This leads to an NPE when
being unboxed. To fix this we use the Boxed boolean and on null report
"true" since we do not know if the partition contains any NaN values. In
addition we move this below the "allValuesNull" check just in case that
would have allowed us to ignore the manifest since the values are all null.

Fixes (#2492 )