### PR TITLE
[#2039] Support default value semantics - API changes

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -252,8 +252,8 @@ public class Types {
         return false;
       }
 
-      TimestampType timestampType = (TimestampType) o;
-      return adjustToUTC == timestampType.adjustToUTC;
+      TimestampType that = (TimestampType) o;
+      return adjustToUTC == that.adjustToUTC;
     }
 
     @Override
@@ -331,8 +331,8 @@ public class Types {
         return false;
       }
 
-      FixedType fixedType = (FixedType) o;
-      return length == fixedType.length;
+      FixedType that = (FixedType) o;
+      return length == that.length;
     }
 
     @Override
@@ -415,42 +415,117 @@ public class Types {
 
   public static class NestedField implements Serializable {
     public static NestedField optional(int id, String name, Type type) {
-      return new NestedField(true, id, name, type, null);
+      return new NestedField(true, id, name, type, null, null);
     }
 
     public static NestedField optional(int id, String name, Type type, String doc) {
-      return new NestedField(true, id, name, type, doc);
+      return new NestedField(true, id, name, type, null, doc);
+    }
+
+    public static NestedField optional(int id, String name, Type type, Object defaultValue, String doc) {
+      return new NestedField(true, id, name, type, defaultValue, doc);
     }
 
     public static NestedField required(int id, String name, Type type) {
-      return new NestedField(false, id, name, type, null);
+      return new NestedField(false, id, name, type, null, null);
     }
 
     public static NestedField required(int id, String name, Type type, String doc) {
-      return new NestedField(false, id, name, type, doc);
+      return new NestedField(false, id, name, type, null, doc);
+    }
+
+    public static NestedField required(int id, String name, Type type, Object defaultValue, String doc) {
+      return new NestedField(false, id, name, type, defaultValue, doc);
     }
 
     public static NestedField of(int id, boolean isOptional, String name, Type type) {
-      return new NestedField(isOptional, id, name, type, null);
+      return new NestedField(isOptional, id, name, type, null, null);
     }
 
     public static NestedField of(int id, boolean isOptional, String name, Type type, String doc) {
-      return new NestedField(isOptional, id, name, type, doc);
+      return new NestedField(isOptional, id, name, type, null, doc);
+    }
+
+    public static NestedField of(int id, boolean isOptional, String name, Type type, Object defaultValue, String doc) {
+      return new NestedField(isOptional, id, name, type, defaultValue, doc);
+    }
+
+    private static void validateDefaultValueForRequiredField(Object defaultValue, String fieldName) {
+      Preconditions.checkArgument(defaultValue != null,
+          "Cannot create NestedField with a null default for the required field: " +  fieldName);
+    }
+
+    private static void validateDefaultValue(Object defaultValue, Type type) {
+      if (defaultValue == null) {
+        return;
+      }
+      switch (type.typeId()) {
+        case STRUCT:
+          Preconditions.checkArgument(defaultValue instanceof Map,
+              "defaultValue should be a Map from fields names to values, for StructType");
+          Map<String, Object> defaultStruct = (Map<String, Object>) defaultValue;
+          if (defaultStruct.isEmpty()) {
+            return;
+          }
+          Preconditions.checkArgument(defaultStruct.size() == type.asStructType().fields().size());
+          for (String fieldName : defaultStruct.keySet()) {
+            NestedField.validateDefaultValue(defaultStruct.get(fieldName), type.asStructType().field(fieldName).type);
+          }
+          break;
+
+        case LIST:
+          Preconditions.checkArgument(defaultValue instanceof List,
+              "defaultValue should be an List of Objects, for ListType");
+          List<Object> defaultList = (List<Object>) defaultValue;
+          if (defaultList.size() == 0) {
+            return;
+          }
+          defaultList.forEach(dv -> NestedField.validateDefaultValue(dv, type.asListType().elementField.type));
+          break;
+
+        case MAP:
+          Preconditions.checkArgument(defaultValue instanceof Map,
+              "defaultValue should be an instance of Map for MapType");
+          Map<Object, Object> defaultMap = (Map<Object, Object>) defaultValue;
+          if (defaultMap.isEmpty()) {
+            return;
+          }
+          for (Map.Entry e : defaultMap.entrySet()) {
+            NestedField.validateDefaultValue(e.getKey(), type.asMapType().keyField.type);
+            NestedField.validateDefaultValue(e.getValue(), type.asMapType().valueField.type);
+          }
+          break;
+
+        case FIXED:
+        case BINARY:
+          Preconditions.checkArgument(defaultValue instanceof byte[],
+              "defaultValue should be an instance of byte[] for TypeId.%s, but defaultValue.class = %s",
+              type.typeId().name(), defaultValue.getClass().getCanonicalName());
+          break;
+
+        default:
+          Preconditions.checkArgument(type.typeId().javaClass().isInstance(defaultValue),
+              "defaultValue should be and instance of %s for TypeId.%s, but defaultValue.class = %s",
+              type.typeId().javaClass(), type.typeId().name(), defaultValue.getClass().getCanonicalName());
+      }
     }
 
     private final boolean isOptional;
     private final int id;
     private final String name;
     private final Type type;
+    private final Object defaultValue;
     private final String doc;
 
-    private NestedField(boolean isOptional, int id, String name, Type type, String doc) {
+    private NestedField(boolean isOptional, int id, String name, Type type, Object defaultValue, String doc) {
       Preconditions.checkNotNull(name, "Name cannot be null");
       Preconditions.checkNotNull(type, "Type cannot be null");
+      validateDefaultValue(defaultValue, type);
       this.isOptional = isOptional;
       this.id = id;
       this.name = name;
       this.type = type;
+      this.defaultValue = defaultValue;
       this.doc = doc;
     }
 
@@ -462,7 +537,7 @@ public class Types {
       if (isOptional) {
         return this;
       }
-      return new NestedField(true, id, name, type, doc);
+      return new NestedField(true, id, name, type, defaultValue, doc);
     }
 
     public boolean isRequired() {
@@ -473,7 +548,15 @@ public class Types {
       if (!isOptional) {
         return this;
       }
-      return new NestedField(false, id, name, type, doc);
+      return new NestedField(false, id, name, type, defaultValue, doc);
+    }
+
+    public boolean hasDefaultValue() {
+      return defaultValue != null;
+    }
+
+    public Object getDefaultValue() {
+      return defaultValue;
     }
 
     public int fieldId() {
@@ -496,6 +579,7 @@ public class Types {
     public String toString() {
       return String.format("%d: %s: %s %s",
           id, name, isOptional ? "optional" : "required", type) +
+          (hasDefaultValue() ? ", default value: " + defaultValue + ", " : "") +
           (doc != null ? " (" + doc + ")" : "");
     }
 
@@ -514,6 +598,8 @@ public class Types {
         return false;
       } else if (!name.equals(that.name)) {
         return false;
+      } else if (!Objects.equals(defaultValue, that.defaultValue)) {
+        return false;
       } else if (!Objects.equals(doc, that.doc)) {
         return false;
       }
@@ -522,7 +608,8 @@ public class Types {
 
     @Override
     public int hashCode() {
-      return Objects.hash(NestedField.class, id, isOptional, name, type);
+      return hasDefaultValue() ? Objects.hash(NestedField.class, id, isOptional, name, type, defaultValue) :
+          Objects.hash(NestedField.class, id, isOptional, name, type);
     }
   }
 
@@ -741,8 +828,8 @@ public class Types {
         return false;
       }
 
-      ListType listType = (ListType) o;
-      return elementField.equals(listType.elementField);
+      ListType that = (ListType) o;
+      return elementField.equals(that.elementField);
     }
 
     @Override
@@ -859,11 +946,11 @@ public class Types {
         return false;
       }
 
-      MapType mapType = (MapType) o;
-      if (!keyField.equals(mapType.keyField)) {
+      MapType that = (MapType) o;
+      if (!keyField.equals(that.keyField)) {
         return false;
       }
-      return valueField.equals(mapType.valueField);
+      return valueField.equals(that.valueField);
     }
 
     @Override

--- a/api/src/test/java/org/apache/iceberg/types/TestDefaultValuesForContainerTypes.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestDefaultValuesForContainerTypes.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.types;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.apache.iceberg.types.Types.NestedField;
+import static org.apache.iceberg.types.Types.StructType;
+
+public class TestDefaultValuesForContainerTypes {
+
+  static NestedField intFieldType;
+  static NestedField stringFieldType;
+  static StructType structType;
+
+  @BeforeClass
+  public static void beforeClass() {
+    intFieldType = NestedField.optional(0, "optionalIntField", Types.IntegerType.get());
+    stringFieldType = NestedField.required(1, "requiredStringField", Types.StringType.get());
+    structType = StructType.of(Arrays.asList(intFieldType, stringFieldType));
+  }
+
+  @Test
+  public void testStructTypeDefault() {
+    Map<String, Object> structDefaultvalue = new HashMap<>();
+    structDefaultvalue.put(intFieldType.name(), Integer.valueOf(1));
+    structDefaultvalue.put(stringFieldType.name(), "two");
+    NestedField structField = NestedField.optional(2, "optionalStructField", structType, structDefaultvalue, "doc");
+    Assert.assertTrue(structField.hasDefaultValue());
+    Assert.assertEquals(structDefaultvalue, structField.getDefaultValue());
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testStructTypeDefaultInvalidFieldsTypes() {
+    Map<String, Object> structDefaultvalue = new HashMap<>();
+    structDefaultvalue.put(intFieldType.name(), "one");
+    structDefaultvalue.put(stringFieldType.name(), "two");
+    NestedField.optional(2, "optionalStructField", structType, structDefaultvalue, "doc");
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testStructTypeDefaultInvalidNumberFields() {
+    Map<String, Object> structDefaultvalue = new HashMap<>();
+    structDefaultvalue.put(intFieldType.name(), Integer.valueOf(1));
+    structDefaultvalue.put(stringFieldType.name(), "two");
+    structDefaultvalue.put("extraFieldName", "three");
+    NestedField.optional(2, "optionalStructField", structType, structDefaultvalue, "doc");
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testStructTypeDefaultInvalidObjectType() {
+    List<Object> structDefaultvalue = new ArrayList<>();
+    structDefaultvalue.add(Integer.valueOf(1));
+    structDefaultvalue.add("two");
+    NestedField.optional(2, "optionalStructField", structType, structDefaultvalue, "doc");
+  }
+}
+

--- a/api/src/test/java/org/apache/iceberg/types/TestDefaultValuesForContainerTypes.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestDefaultValuesForContainerTypes.java
@@ -19,11 +19,11 @@
 
 package org.apache.iceberg.types;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -46,7 +46,7 @@ public class TestDefaultValuesForContainerTypes {
 
   @Test
   public void testStructTypeDefault() {
-    Map<String, Object> structDefaultvalue = new HashMap<>();
+    Map<String, Object> structDefaultvalue = Maps.newHashMap();
     structDefaultvalue.put(intFieldType.name(), Integer.valueOf(1));
     structDefaultvalue.put(stringFieldType.name(), "two");
     NestedField structField = NestedField.optional(2, "optionalStructField", structType, structDefaultvalue, "doc");
@@ -56,7 +56,7 @@ public class TestDefaultValuesForContainerTypes {
 
   @Test (expected = IllegalArgumentException.class)
   public void testStructTypeDefaultInvalidFieldsTypes() {
-    Map<String, Object> structDefaultvalue = new HashMap<>();
+    Map<String, Object> structDefaultvalue = Maps.newHashMap();
     structDefaultvalue.put(intFieldType.name(), "one");
     structDefaultvalue.put(stringFieldType.name(), "two");
     NestedField.optional(2, "optionalStructField", structType, structDefaultvalue, "doc");
@@ -64,7 +64,7 @@ public class TestDefaultValuesForContainerTypes {
 
   @Test (expected = IllegalArgumentException.class)
   public void testStructTypeDefaultInvalidNumberFields() {
-    Map<String, Object> structDefaultvalue = new HashMap<>();
+    Map<String, Object> structDefaultvalue = Maps.newHashMap();
     structDefaultvalue.put(intFieldType.name(), Integer.valueOf(1));
     structDefaultvalue.put(stringFieldType.name(), "two");
     structDefaultvalue.put("extraFieldName", "three");
@@ -73,7 +73,7 @@ public class TestDefaultValuesForContainerTypes {
 
   @Test (expected = IllegalArgumentException.class)
   public void testStructTypeDefaultInvalidObjectType() {
-    List<Object> structDefaultvalue = new ArrayList<>();
+    List<Object> structDefaultvalue = Lists.newArrayList();
     structDefaultvalue.add(Integer.valueOf(1));
     structDefaultvalue.add("two");
     NestedField.optional(2, "optionalStructField", structType, structDefaultvalue, "doc");

--- a/api/src/test/java/org/apache/iceberg/types/TestNestedFieldDefaultValues.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestNestedFieldDefaultValues.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.types;
+
+import org.apache.iceberg.types.Types.NestedField;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+
+public class TestNestedFieldDefaultValues {
+
+  private final int id = 1;
+  private final String fieldName = "fieldName";
+  private final Type fieldType = Types.IntegerType.get();
+  private final String doc = "field doc";
+  private final Integer defaultValue = 100;
+
+  @Test
+  public void testConstructorsValidCases() {
+    // optional-constructors
+    Assert.assertFalse(optional(id, fieldName, fieldType).hasDefaultValue());
+    Assert.assertFalse(optional(id, fieldName, fieldType, doc).hasDefaultValue());
+    NestedField nestedFieldWithDefault = optional(id, fieldName, fieldType, defaultValue, doc);
+    Assert.assertTrue(nestedFieldWithDefault.hasDefaultValue());
+    Assert.assertEquals(defaultValue, nestedFieldWithDefault.getDefaultValue());
+    nestedFieldWithDefault = optional(id, fieldName, fieldType, defaultValue, null);
+    Assert.assertTrue(nestedFieldWithDefault.hasDefaultValue());
+    Assert.assertEquals(defaultValue, nestedFieldWithDefault.getDefaultValue());
+
+    // required-constructors
+    Assert.assertFalse(required(id, fieldName, fieldType).hasDefaultValue());
+    Assert.assertFalse(required(id, fieldName, fieldType, doc).hasDefaultValue());
+    Assert.assertFalse(required(id, fieldName, fieldType, null, doc).hasDefaultValue());
+    nestedFieldWithDefault = required(id, fieldName, fieldType, defaultValue, doc);
+    Assert.assertTrue(nestedFieldWithDefault.hasDefaultValue());
+    Assert.assertEquals(defaultValue, nestedFieldWithDefault.getDefaultValue());
+    nestedFieldWithDefault = required(id, fieldName, fieldType, defaultValue, null);
+    Assert.assertTrue(nestedFieldWithDefault.hasDefaultValue());
+    Assert.assertEquals(defaultValue, nestedFieldWithDefault.getDefaultValue());
+
+    // of-constructors
+    Assert.assertFalse(NestedField.of(id, true, fieldName, fieldType).hasDefaultValue());
+    Assert.assertFalse(NestedField.of(id, true, fieldName, fieldType, doc).hasDefaultValue());
+    nestedFieldWithDefault = NestedField.of(id, true, fieldName, fieldType, defaultValue, doc);
+    Assert.assertTrue(nestedFieldWithDefault.hasDefaultValue());
+    Assert.assertEquals(defaultValue, nestedFieldWithDefault.getDefaultValue());
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testOptionalWithInvalidDefaultValueClass() {
+    // class of default value does not match class of type
+    Long wrongClassDefaultValue = 100L;
+    optional(id, fieldName, fieldType, wrongClassDefaultValue, doc);
+  }
+
+  @Test (expected = IllegalArgumentException.class)
+  public void testReqiredWithInvalidDefaultValueClass() {
+    // class of default value does not match class of type
+    Long wrongClassDefaultValue = 100L;
+    required(id, fieldName, fieldType, wrongClassDefaultValue, doc);
+  }
+}
+

--- a/site/docs/spec.md
+++ b/site/docs/spec.md
@@ -151,6 +151,8 @@ A table's **schema** is a list of named columns. All data types are either primi
 
 For the representations of these types in Avro, ORC, and Parquet file formats, see Appendix A.
 
+Default values for fields are supported, see Neted Types below.
+
 #### Nested Types
 
 A **`struct`** is a tuple of typed values. Each field in the tuple is named and has an integer id that is unique in the table schema. Each field can be either optional or required, meaning that values can (or cannot) be null. Fields may be any type. Fields may have an optional comment or doc string.
@@ -158,6 +160,13 @@ A **`struct`** is a tuple of typed values. Each field in the tuple is named and 
 A **`list`** is a collection of values with some element type. The element field has an integer id that is unique in the table schema. Elements can be either optional or required. Element types may be any type.
 
 A **`map`** is a collection of key-value pairs with a key type and a value type. Both the key field and value field each have an integer id that is unique in the table schema. Map keys are required and map values can be either optional or required. Both map keys and map values may be any type, including nested types.
+
+Iceberg supports default-value semantics for fields of nested types (i.e., struct, list and map). Specifically, a field 
+of a nested type field can have a default value that will be returned upon reading this field, if it is not manifested. 
+The default value can be defined with both required and optional fields. Null default values are allowed with optional
+fields only, and it's behavior is identical to optional fields with no default value, that is a Null is returned upon
+reading this field when it is not manifested.
+
 
 #### Primitive Types
 
@@ -1085,7 +1094,6 @@ This serialization scheme is for storing single values as individual binary valu
 | **`struct`**                 | Not supported                                                                                                |
 | **`list`**                   | Not supported                                                                                                |
 | **`map`**                    | Not supported                                                                                                |
-
 
 ## Appendix E: Format version changes
 


### PR DESCRIPTION
# Summary

Iceberg schema currently does not support default values which imposes a challenge on reading Hive tables written in avro format and have default values (see issue 2039). Specifically, if a field has a non-null default value, it is mapped to a required field - with no default value - in iceberg. Thus, upon reading rows where this field is not manifested, an IllegalArgumentException (Missing required field) will be thrown. Further, default values of nullable fields are lost silently. That is because nullable fields with default values are mapped to optional fields with no default values, and thus null is returned when the field is absent, instead of the default value. This document describes how to support the default values semantics in Iceberg schema to resolve these issues.

# Problem
## Default values are lost
Default values are specified using the Avro schema keyword “default”. For example, the following is an example of an Avro string field with default value “unknown”:

`{"name": "filedName", "type": "string", "default": “unknown”}`

Also, a nullable (optional) avro field can define default value as follows:

`{"name": "fieldName", "type": ["null", "string"], "default": null}`

Please note that nullability is specified via UNION type (i.e., the [“null’, “string”]) and the default value’s type must match the first type in the union. In other words, the following are invalid types:

```
{"name": "fieldName", "type": ["null", "string"], "default": “unnown”}
{"name": "fieldName", "type": ["string", “null”], "default": null}
```

That is, if the default value is of type null, the first type of the field must be the “null”, o.w., if the default value is of type string, the first type of the field must be string.

When converting an avro schema to Iceberg Types, we have 2 cases. If the field is nullable, it maps to an optional NestedField Iceberg type. While if the field is non-nullable, it is mapped to a required NestedField Iceberg type, with no default value, since the NestedFiled does not support default values. In both cases, the default value is lost which leads to a wrong handling of the data when read. In the case of non-nullable fields, error is thrown if the field is not present, whereas in case of null, it goes by as an optional field.
## Where in code this breaks
When reading avro records [AvroSchemaUtils::buildAvroProjections() ](https://github.com/apache/iceberg/blob/aba898b1a2ea15fd091228626b6887a5a72800c0/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java#L103) is invoked, which invokes [BuildAvroProjection.record() ](https://github.com/linkedin/iceberg/blob/14b1d891522cfd111f50531e78ba63b8a60ccf1f/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java#L53) to construct the Iceberge’s record. When reading rows with default values (i.e., the field is not present in the data file), the code path goes to check if this field is optional or not (here). If the field has a null-default value, it is nullable, and is therefore mapped to an optional field and the field is skipped, if otherwise it has a non-null default value, this check throws an exception.

# Solution
## Overview
The fix is simply to add the default value to the [NestedField](https://github.com/linkedin/iceberg/blob/14b1d891522cfd111f50531e78ba63b8a60ccf1f/api/src/main/java/org/apache/iceberg/types/Types.java#L415), and add relevant APIs to copy the default value over when converting from AVRO schema, to use it while reading. In case of non-nullable fields with default values, it is obvious that these need to be modeled as required fields with default values. The default value here can be used in schema evolution, for example if a required field is added. In this case, while reading older data/partitions, the default value will be returned. For nullable fields, with similar reasoning about schema evolution, we should model these fields as optional with default values and use the default value instead of just using null for optional fields. This includes the two cases: (a) if the default value is null (as in: `{"name": "fieldName", "type": ["null", "string"], "default": null}`), and (b) non-null default value( as in: `{"name": "fieldName", "type": ["string", "null"], "default": “defValue”}` ). 
## ORC and Parquet
While Avro support defaults semantics, and Avro libraries can be used to read fields with defaults values, neither ORC nor Parquet formats support default values semantics. It is required, though, to provide consistent behavior and semantics across different file formats, therefore, once default semantics are enabled into Iceberg schema, the ORC and Parquet readers should be modified to handle this properly. Specifically, when reading a field that is not manifested but has a default value, the default value should be used.

# Planned Code Changes

-  FIrst (this) PR: API Changes: An AVRO schema of type record is mapped into Iceberg type: StructType, which consists of an array of NestedField’s. Therefore, to support default values we need to make NestedField default-value aware. This involves adding APIs to create NetedField objects with default values, as well as getting the and checking for the default value.
-  Second PR: schema mapping changes: to copy over default values to Iceberg schema during schema mapping/conversion
- Third PR: Avro Reader changes to use the default value when needed
- Fourth PR: ORC Reader changes
- Fifth PR: Parquet Reader changes 
