### PR TITLE
Ensure snapshot ID is positive

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/TableOperations.java
@@ -117,7 +117,7 @@ public interface TableOperations {
     UUID uuid = UUID.randomUUID();
     long mostSignificantBits = uuid.getMostSignificantBits();
     long leastSignificantBits = uuid.getLeastSignificantBits();
-    return Math.abs(mostSignificantBits ^ leastSignificantBits);
+    return (mostSignificantBits ^ leastSignificantBits) & Long.MAX_VALUE;
   }
 
 }


### PR DESCRIPTION
Per description of https://github.com/apache/iceberg/pull/57, the
snapshot ID is expected to be positive.  In the very unlikely edge case
`Math.abs` can return a negative result, i.e. when argument is
`Long.MIN_VALUE`.