### PR TITLE
Core : fix bugs in RewriteDataFilesAction when datafile size greater than  targetFileSize

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.DataFile;
@@ -215,7 +216,7 @@ public abstract class BaseRewriteDataFilesAction<ThisT>
 
     Map<StructLikeWrapper, Collection<FileScanTask>> groupedTasks = groupTasksByPartition(fileScanTasks.iterator());
     Map<StructLikeWrapper, Collection<FileScanTask>> filteredGroupedTasks = groupedTasks.entrySet().stream()
-        .filter(kv -> kv.getValue().size() > 1)
+        .filter(kv -> kv.getValue().size() > 1 || isSingleBigFile(kv))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     // Nothing to rewrite if there's only one DataFile in each partition.
@@ -238,12 +239,13 @@ public abstract class BaseRewriteDataFilesAction<ThisT>
     }
 
     List<DataFile> addedDataFiles = rewriteDataForTasks(combinedScanTasks);
-    List<DataFile> currentDataFiles = combinedScanTasks.stream()
+    Set<DataFile> currentDataFiles = combinedScanTasks.stream()
         .flatMap(tasks -> tasks.files().stream().map(FileScanTask::file))
-        .collect(Collectors.toList());
-    replaceDataFiles(currentDataFiles, addedDataFiles);
+        .collect(Collectors.toSet());
+    List<DataFile> deletedDataFiles = Lists.newArrayList(currentDataFiles.iterator());
 
-    return new RewriteDataFilesActionResult(currentDataFiles, addedDataFiles);
+    replaceDataFiles(deletedDataFiles, addedDataFiles);
+    return new RewriteDataFilesActionResult(deletedDataFiles, addedDataFiles);
   }
 
 
@@ -275,6 +277,15 @@ public abstract class BaseRewriteDataFilesAction<ThisT>
           .run(fileIO::deleteFile);
       throw e;
     }
+  }
+
+  private boolean isSingleBigFile(Map.Entry<StructLikeWrapper, Collection<FileScanTask>> kv) {
+    if (kv.getValue().size() == 1) {
+      FileScanTask task = kv.getValue().iterator().next();
+      return task.file().fileSizeInBytes() > targetSizeInBytes;
+    }
+
+    return true;
   }
 
   private boolean isPartialFileScan(CombinedScanTask task) {

--- a/spark/src/test/java/org/apache/iceberg/actions/TestRewriteDataFilesAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestRewriteDataFilesAction.java
@@ -319,6 +319,7 @@ public abstract class TestRewriteDataFilesAction extends SparkTestBase {
   public void testRewriteDataFilesForLargeFile() throws AnalysisException {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, "100");
     Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
     Assert.assertNull("Table must be empty", table.currentSnapshot());
 
@@ -347,19 +348,68 @@ public abstract class TestRewriteDataFilesAction extends SparkTestBase {
 
     Actions actions = Actions.forTable(table);
 
-    long targetSizeInBytes = maxSizeFile.fileSizeInBytes() - 10;
+    long targetSizeInBytes = maxSizeFile.fileSizeInBytes() / 2;
     RewriteDataFilesActionResult result = actions
         .rewriteDataFiles()
         .targetSizeInBytes(targetSizeInBytes)
         .splitOpenFileCost(1)
         .execute();
 
-    Assert.assertEquals("Action should delete 4 data files", 4, result.deletedDataFiles().size());
-    Assert.assertEquals("Action should add 2 data files", 2, result.addedDataFiles().size());
+    // 1 big datafile and 2 small datafiles
+    Assert.assertEquals("Action should delete 3 data files", 3, result.deletedDataFiles().size());
+
+    // The 2 small datafiles will be rewrote to 1 datafile, the big datafile will be rewrite to 2 datafiles,
+    // so there are 3 datafiles in total
+    Assert.assertEquals("Action should add 3 data files", 3, result.addedDataFiles().size());
 
     spark.read().format("iceberg").load(tableLocation).createTempView("postRewrite");
     long postRewriteNumRecords = spark.read().format("iceberg").load(tableLocation).count();
     List<Object[]> rewrittenRecords = sql("SELECT * from postRewrite sort by c2");
+
+    Assert.assertEquals(originalNumRecords, postRewriteNumRecords);
+    assertEquals("Rows should be unchanged", originalRecords, rewrittenRecords);
+  }
+
+  @Test
+  public void testRewriteSingleLargeFile() throws AnalysisException {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, "100");
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+    Assert.assertNull("Table must be empty", table.currentSnapshot());
+
+    List<ThreeColumnRecord> records1 = Lists.newArrayList();
+
+    IntStream.range(0, 200000).forEach(i -> records1.add(new ThreeColumnRecord(i, "foo" + i, "bar" + i)));
+    Dataset<Row> df = spark.createDataFrame(records1, ThreeColumnRecord.class).repartition(1);
+    writeDF(df);
+
+    table.refresh();
+
+    CloseableIterable<FileScanTask> tasks = table.newScan().planFiles();
+    List<DataFile> dataFiles = Lists.newArrayList(CloseableIterable.transform(tasks, FileScanTask::file));
+    DataFile maxSizeFile = Collections.max(dataFiles, Comparator.comparingLong(DataFile::fileSizeInBytes));
+    Assert.assertEquals("Should have 1 files before rewrite", 1, dataFiles.size());
+
+    spark.read().format("iceberg").load(tableLocation).createTempView("originSingle");
+    long originalNumRecords = spark.read().format("iceberg").load(tableLocation).count();
+    List<Object[]> originalRecords = sql("SELECT * from originSingle sort by c2");
+
+    Actions actions = Actions.forTable(table);
+
+    long targetSizeInBytes = maxSizeFile.fileSizeInBytes() / 2;
+    RewriteDataFilesActionResult result = actions
+        .rewriteDataFiles()
+        .targetSizeInBytes(targetSizeInBytes)
+        .splitOpenFileCost(1)
+        .execute();
+
+    Assert.assertEquals("Action should delete 1 data files", 1, result.deletedDataFiles().size());
+    Assert.assertEquals("Action should add 2 data files", 2, result.addedDataFiles().size());
+
+    spark.read().format("iceberg").load(tableLocation).createTempView("postRewriteSingle");
+    long postRewriteNumRecords = spark.read().format("iceberg").load(tableLocation).count();
+    List<Object[]> rewrittenRecords = sql("SELECT * from postRewriteSingle sort by c2");
 
     Assert.assertEquals(originalNumRecords, postRewriteNumRecords);
     assertEquals("Rows should be unchanged", originalRecords, rewrittenRecords);

--- a/spark/src/test/java/org/apache/iceberg/actions/TestRewriteDataFilesAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestRewriteDataFilesAction.java
@@ -358,7 +358,7 @@ public abstract class TestRewriteDataFilesAction extends SparkTestBase {
     // 1 big datafile and 2 small datafiles
     Assert.assertEquals("Action should delete 3 data files", 3, result.deletedDataFiles().size());
 
-    // The 2 small datafiles will be rewrote to 1 datafile, the big datafile will be rewrite to 2 datafiles,
+    // The 2 small datafiles will be rewritten to 1 datafile, the big datafile will be rewritten to 2 datafiles,
     // so there are 3 datafiles in total
     Assert.assertEquals("Action should add 3 data files", 3, result.addedDataFiles().size());
 


### PR DESCRIPTION
I found some bugs in RewriteDataFilesAction when the size of datafile is larger than targetFileSize
1. If there is only one datafile which size> targetFileSize in the partition, this datafile will be ignored and will not be rewrite.
2. The test case in [pr 2196](https://github.com/apache/iceberg/pull/2196) has some logical issues.I fix it and add some comments in it.   
3. the deletedDataFiles of the RewriteDataFilesActionResult should be deduplicated

@rdblue @RussellSpitzer @openinx could you help me review it ? thanks