### PR TITLE
Upgrade mockito version

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueCatalogCommitFailureTest.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueCatalogCommitFailureTest.java
@@ -203,9 +203,9 @@ public class GlueCatalogCommitFailureTest extends GlueTestBase {
                                                  Table table) {
     // Simulate a communication error after a successful commit
     Mockito.doAnswer(i -> {
-      Map<String, String> mapProperties = i.getArgumentAt(1, Map.class);
+      Map<String, String> mapProperties = i.getArgument(1, Map.class);
       realOps.persistGlueTable(
-          i.getArgumentAt(0, software.amazon.awssdk.services.glue.model.Table.class),
+          i.getArgument(0, software.amazon.awssdk.services.glue.model.Table.class),
           mapProperties);
 
       // new metadata location is stored in map property, and used for locking
@@ -242,8 +242,8 @@ public class GlueCatalogCommitFailureTest extends GlueTestBase {
   private void commitAndThrowException(GlueTableOperations realOps, GlueTableOperations spyOps) {
     Mockito.doAnswer(i -> {
       realOps.persistGlueTable(
-          i.getArgumentAt(0, software.amazon.awssdk.services.glue.model.Table.class),
-          i.getArgumentAt(1, Map.class));
+          i.getArgument(0, software.amazon.awssdk.services.glue.model.Table.class),
+          i.getArgument(1, Map.class));
       throw new SdkBaseException("Datacenter on fire");
     }).when(spyOps).persistGlueTable(Matchers.any(), Matchers.anyMap());
   }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
@@ -278,7 +278,7 @@ public class TestHiveCommits extends HiveTableBaseTest {
     // Simulate a communication error after a successful commit
     doAnswer(i -> {
       org.apache.hadoop.hive.metastore.api.Table tbl =
-          i.getArgumentAt(0, org.apache.hadoop.hive.metastore.api.Table.class);
+          i.getArgument(0, org.apache.hadoop.hive.metastore.api.Table.class);
       realOperations.persistTable(tbl, true);
       throw new TException("Datacenter on fire");
     }).when(spyOperations).persistTable(any(), anyBoolean());
@@ -290,7 +290,7 @@ public class TestHiveCommits extends HiveTableBaseTest {
     // Simulate a communication error after a successful commit
     doAnswer(i -> {
       org.apache.hadoop.hive.metastore.api.Table tbl =
-          i.getArgumentAt(0, org.apache.hadoop.hive.metastore.api.Table.class);
+          i.getArgument(0, org.apache.hadoop.hive.metastore.api.Table.class);
       realOperations.persistTable(tbl, true);
       // Simulate lock expiration or removal
       realOperations.doUnlock(lockId.get());

--- a/versions.props
+++ b/versions.props
@@ -25,7 +25,7 @@ io.quarkus:* = 1.13.1.Final
 
 # test deps
 junit:junit = 4.12
-org.mockito:mockito-core = 1.10.19
+org.mockito:mockito-core = 3.7.7
 org.apache.hive:hive-exec = 2.3.8
 org.apache.hive:hive-service = 2.3.8
 org.apache.tez:tez-dag = 0.8.4


### PR DESCRIPTION
Current mockito version (1.x) used by Iceberg is 6+ years old, so upgrading to a newer version (3.x) to take advantage of the latest feature set and any bugfixes. 