### PR TITLE
Spark: Remove deletefiles when expiring snapshots.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/ExpireSnapshots.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ExpireSnapshots.java
@@ -102,6 +102,11 @@ public interface ExpireSnapshots extends Action<ExpireSnapshots, ExpireSnapshots
     long deletedDataFilesCount();
 
     /**
+     * Return the number that deleted delete files.
+     */
+    long deletedDeleteFilesCount();
+
+    /**
      * Returns the number of deleted manifests.
      */
     long deletedManifestsCount();

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -53,8 +53,9 @@ public class AllManifestsTable extends BaseMetadataTable {
           Types.NestedField.required(11, "contains_nan", Types.BooleanType.get()),
           Types.NestedField.optional(12, "lower_bound", Types.StringType.get()),
           Types.NestedField.optional(13, "upper_bound", Types.StringType.get())
-      )))
-  );
+      ))),
+      Types.NestedField.optional(14, "content", Types.IntegerType.get())
+      );
 
   AllManifestsTable(TableOperations ops, Table table) {
     this(ops, table, table.name() + ".all_manifests");

--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -56,6 +56,12 @@ public class ManifestFiles {
         entry -> entry.file().path().toString());
   }
 
+  public static CloseableIterable<String> readDeleteFiles(ManifestFile manifestFile, FileIO io) {
+    return CloseableIterable.transform(
+        readDeleteManifest(manifestFile, io, null).select(ImmutableList.of("file_path")).liveEntries(),
+        entry -> entry.file().path().toString());
+  }
+
   /**
    * Returns a new {@link ManifestReader} for a {@link ManifestFile}.
    * <p>

--- a/core/src/main/java/org/apache/iceberg/ManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestsTable.java
@@ -41,8 +41,9 @@ public class ManifestsTable extends BaseMetadataTable {
           Types.NestedField.required(11, "contains_nan", Types.BooleanType.get()),
           Types.NestedField.optional(12, "lower_bound", Types.StringType.get()),
           Types.NestedField.optional(13, "upper_bound", Types.StringType.get())
-      )))
-  );
+      ))),
+      Types.NestedField.required(14, "content", Types.IntegerType.get())
+      );
 
   private final PartitionSpec spec;
 
@@ -94,8 +95,9 @@ public class ManifestsTable extends BaseMetadataTable {
         manifest.addedFilesCount(),
         manifest.existingFilesCount(),
         manifest.deletedFilesCount(),
-        partitionSummariesToRows(spec, manifest.partitions())
-    );
+        partitionSummariesToRows(spec, manifest.partitions()),
+        manifest.content().id()
+        );
   }
 
   static List<StaticDataTask.Row> partitionSummariesToRows(PartitionSpec spec,

--- a/core/src/main/java/org/apache/iceberg/actions/BaseExpireSnapshotsActionResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseExpireSnapshotsActionResult.java
@@ -22,13 +22,16 @@ package org.apache.iceberg.actions;
 public class BaseExpireSnapshotsActionResult implements ExpireSnapshots.Result {
 
   private final long deletedDataFilesCount;
+  private final long deletedDeleteFilesCount;
   private final long deletedManifestsCount;
   private final long deletedManifestListsCount;
 
   public BaseExpireSnapshotsActionResult(long deletedDataFilesCount,
+                                         long deletedDeleteFilesCount,
                                          long deletedManifestsCount,
                                          long deletedManifestListsCount) {
     this.deletedDataFilesCount = deletedDataFilesCount;
+    this.deletedDeleteFilesCount = deletedDeleteFilesCount;
     this.deletedManifestsCount = deletedManifestsCount;
     this.deletedManifestListsCount = deletedManifestListsCount;
   }
@@ -36,6 +39,11 @@ public class BaseExpireSnapshotsActionResult implements ExpireSnapshots.Result {
   @Override
   public long deletedDataFilesCount() {
     return deletedDataFilesCount;
+  }
+
+  @Override
+  public long deletedDeleteFilesCount() {
+    return deletedDeleteFilesCount;
   }
 
   @Override

--- a/spark/src/main/java/org/apache/iceberg/actions/ExpireSnapshotsActionResult.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/ExpireSnapshotsActionResult.java
@@ -23,24 +23,32 @@ package org.apache.iceberg.actions;
 public class ExpireSnapshotsActionResult {
 
   private final Long dataFilesDeleted;
+  private final Long deleteFilesDeleted;
   private final Long manifestFilesDeleted;
   private final Long manifestListsDeleted;
 
   static ExpireSnapshotsActionResult wrap(ExpireSnapshots.Result result) {
     return new ExpireSnapshotsActionResult(
         result.deletedDataFilesCount(),
+        result.deletedDeleteFilesCount(),
         result.deletedManifestsCount(),
         result.deletedManifestListsCount());
   }
 
-  public ExpireSnapshotsActionResult(Long dataFilesDeleted, Long manifestFilesDeleted, Long manifestListsDeleted) {
+  public ExpireSnapshotsActionResult(Long dataFilesDeleted, Long deleteFilesDeleted,
+                                     Long manifestFilesDeleted, Long manifestListsDeleted) {
     this.dataFilesDeleted = dataFilesDeleted;
+    this.deleteFilesDeleted = deleteFilesDeleted;
     this.manifestFilesDeleted = manifestFilesDeleted;
     this.manifestListsDeleted = manifestListsDeleted;
   }
 
   public Long dataFilesDeleted() {
     return dataFilesDeleted;
+  }
+
+  public Long deleteFiledDeleted() {
+    return  deleteFilesDeleted;
   }
 
   public Long manifestFilesDeleted() {

--- a/spark/src/main/java/org/apache/iceberg/actions/ManifestFileBean.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/ManifestFileBean.java
@@ -27,6 +27,7 @@ public class ManifestFileBean implements ManifestFile {
   private String path = null;
   private Long length = null;
   private Integer partitionSpecId = null;
+  private Integer content = null;
   private Long addedSnapshotId = null;
 
   public String getPath() {
@@ -61,6 +62,14 @@ public class ManifestFileBean implements ManifestFile {
     this.addedSnapshotId = addedSnapshotId;
   }
 
+  public Integer getContent() {
+    return content;
+  }
+
+  public void setContent(Integer content) {
+    this.content = content;
+  }
+
   @Override
   public String path() {
     return path;
@@ -78,7 +87,8 @@ public class ManifestFileBean implements ManifestFile {
 
   @Override
   public ManifestContent content() {
-    return ManifestContent.DATA;
+    return (content != null && content == ManifestContent.DELETES.id()) ?
+      ManifestContent.DELETES : ManifestContent.DATA;
   }
 
   @Override

--- a/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRemoveOrphanFilesSparkAction.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRemoveOrphanFilesSparkAction.java
@@ -146,8 +146,9 @@ public class BaseRemoveOrphanFilesSparkAction
 
   private RemoveOrphanFiles.Result doExecute() {
     Dataset<Row> validDataFileDF = buildValidDataFileDF(table);
+    Dataset<Row> validDeleteFileDF = buildValidDeleteFileDF(table);
     Dataset<Row> validMetadataFileDF = buildValidMetadataFileDF(table, ops);
-    Dataset<Row> validFileDF = validDataFileDF.union(validMetadataFileDF);
+    Dataset<Row> validFileDF = validDataFileDF.union(validDeleteFileDF).union(validMetadataFileDF);
     Dataset<Row> actualFileDF = buildActualFileDF();
 
     Column actualFileName = filenameUDF.apply(actualFileDF.col("file_path"));

--- a/spark/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestExpireSnapshotsAction.java
@@ -122,11 +122,13 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
     return end;
   }
 
-  private void checkExpirationResults(long expectedDatafiles, long expectedManifestsDeleted,
+  private void checkExpirationResults(long expectedDatafiles, long expectedDeletefiles, long expectedManifestsDeleted,
       long expectedManifestListsDeleted, ExpireSnapshotsActionResult results) {
 
     Assert.assertEquals("Incorrect number of manifest files deleted",
         (Long) expectedManifestsDeleted, results.manifestFilesDeleted());
+    Assert.assertEquals("Incorrect number of deletefiles deleted",
+        (Long) expectedDeletefiles, results.deleteFiledDeleted());
     Assert.assertEquals("Incorrect number of datafiles deleted",
         (Long) expectedDatafiles, results.dataFilesDeleted());
     Assert.assertEquals("Incorrect number of manifest lists deleted",
@@ -154,7 +156,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
 
     Assert.assertEquals("Table does not have 1 snapshot after expiration", 1, Iterables.size(table.snapshots()));
 
-    checkExpirationResults(1L, 1L, 2L, results);
+    checkExpirationResults(1L, 0L, 1L, 2L, results);
   }
 
   @Test
@@ -203,7 +205,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
     Assert.assertTrue("FILE_A should be deleted", deletedFiles.contains(FILE_A.path().toString()));
     Assert.assertTrue("FILE_B should be deleted", deletedFiles.contains(FILE_B.path().toString()));
 
-    checkExpirationResults(2L, 3L, 3L, result);
+    checkExpirationResults(2L, 0L, 3L, 3L, result);
   }
 
   @Test
@@ -213,7 +215,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
         .commit();
 
     ExpireSnapshotsActionResult results = Actions.forTable(table).expireSnapshots().execute();
-    checkExpirationResults(0L, 0L, 0L, results);
+    checkExpirationResults(0L, 0L, 0L, 0L, results);
   }
 
   @Test
@@ -236,7 +238,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
 
     long end = rightAfterSnapshot();
     ExpireSnapshotsActionResult results = Actions.forTable(table).expireSnapshots().expireOlderThan(end).execute();
-    checkExpirationResults(1L, 39L, 20L, results);
+    checkExpirationResults(1L, 0L, 39L, 20L, results);
   }
 
   @Test
@@ -297,7 +299,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
     Assert.assertEquals("First snapshot should not present.", null, table.snapshot(firstSnapshotId));
     Assert.assertEquals("Second snapshot should not be present.", null, table.snapshot(secondSnapshotID));
 
-    checkExpirationResults(0L, 0L, 2L, result);
+    checkExpirationResults(0L, 0L, 0L, 2L, result);
   }
 
   @Test
@@ -323,7 +325,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
 
     Assert.assertEquals("Should have two snapshots.", 2, Lists.newArrayList(table.snapshots()).size());
     Assert.assertEquals("First snapshot should not present.", null, table.snapshot(firstSnapshotId));
-    checkExpirationResults(0L, 0L, 1L, result);
+    checkExpirationResults(0L, 0L, 0L, 1L, result);
   }
 
   @Test
@@ -349,7 +351,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
     Assert.assertEquals("Should have two snapshots", 2, Lists.newArrayList(table.snapshots()).size());
     Assert.assertEquals("First snapshot should still present",
         firstSnapshotId, table.snapshot(firstSnapshotId).snapshotId());
-    checkExpirationResults(0L, 0L, 0L, result);
+    checkExpirationResults(0L, 0L, 0L, 0L, result);
   }
 
   @Test
@@ -380,7 +382,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
 
     Assert.assertEquals("Should have three snapshots.", 3, Lists.newArrayList(table.snapshots()).size());
     Assert.assertNotNull("Second snapshot should present.", table.snapshot(secondSnapshot.snapshotId()));
-    checkExpirationResults(0L, 0L, 1L, result);
+    checkExpirationResults(0L,  0L, 0L, 1L, result);
   }
 
   @Test
@@ -425,7 +427,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
 
     Assert.assertEquals("Should have one snapshots.", 1, Lists.newArrayList(table.snapshots()).size());
     Assert.assertNull("Second snapshot should not present.", table.snapshot(secondSnapshot.snapshotId()));
-    checkExpirationResults(0L, 0L, 2L, result);
+    checkExpirationResults(0L,  0L, 0L, 2L, result);
   }
 
   @Test
@@ -455,7 +457,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
 
     Assert.assertEquals("Should have one snapshots.", 1, Lists.newArrayList(table.snapshots()).size());
     Assert.assertNull("Second snapshot should not present.", table.snapshot(secondSnapshot.snapshotId()));
-    checkExpirationResults(0L, 0L, 2L, result);
+    checkExpirationResults(0L,  0L, 0L, 2L, result);
   }
 
   @Test
@@ -493,7 +495,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
         .execute();
 
     Assert.assertTrue("FILE_A should be deleted", deletedFiles.contains(FILE_A.path().toString()));
-    checkExpirationResults(1L, 1L, 2L, result);
+    checkExpirationResults(1L, 0L, 1L, 2L, result);
   }
 
   @Test
@@ -527,7 +529,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
         .execute();
 
     Assert.assertTrue("FILE_A should be deleted", deletedFiles.contains(FILE_A.path().toString()));
-    checkExpirationResults(1L, 1L, 2L, result);
+    checkExpirationResults(1L, 0L, 1L, 2L, result);
   }
 
   /**
@@ -565,7 +567,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
         .expireOlderThan(snapshotB.timestampMillis() + 1)
         .execute();
 
-    checkExpirationResults(1L, 1L, 2L, result);
+    checkExpirationResults(1L, 0L, 1L, 2L, result);
 
     Set<String> expectedDeletes = new HashSet<>();
     expectedDeletes.add(snapshotA.manifestListLocation());
@@ -651,7 +653,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
       });
     });
 
-    checkExpirationResults(1L, 2L, 2L, result);
+    checkExpirationResults(1L, 0L, 2L, 2L, result);
   }
 
   /**
@@ -705,7 +707,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
         Assert.assertFalse(deletedFiles.contains(item.path().toString()));
       });
     });
-    checkExpirationResults(0L, 1L, 1L, firstResult);
+    checkExpirationResults(0L, 0L, 1L, 1L, firstResult);
 
     // Expire all snapshots including cherry-pick
     ExpireSnapshotsActionResult secondResult = Actions.forTable(table).expireSnapshots()
@@ -719,7 +721,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
         Assert.assertFalse(deletedFiles.contains(item.path().toString()));
       });
     });
-    checkExpirationResults(0L, 0L, 2L, secondResult);
+    checkExpirationResults(0L, 0L, 0L, 2L, secondResult);
   }
 
   @Test
@@ -752,7 +754,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
     Assert.assertEquals("Should remove only the expired manifest list location",
         Sets.newHashSet(firstSnapshot.manifestListLocation()), deletedFiles);
 
-    checkExpirationResults(0, 0, 1, result);
+    checkExpirationResults(0, 0L, 0, 1, result);
   }
 
   @Test
@@ -805,7 +807,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
             FILE_A.path()), // deleted
         deletedFiles);
 
-    checkExpirationResults(1, 2, 2, result);
+    checkExpirationResults(1, 0L, 2, 2, result);
   }
 
   @Test
@@ -863,7 +865,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
             FILE_A.path()), // deleted
         deletedFiles);
 
-    checkExpirationResults(1, 1, 2, result);
+    checkExpirationResults(1, 0L, 1, 2, result);
   }
 
   @Test
@@ -918,7 +920,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
             Iterables.getOnlyElement(secondSnapshotManifests).path()), // manifest is no longer referenced
         deletedFiles);
 
-    checkExpirationResults(0, 1, 1, result);
+    checkExpirationResults(0, 0L, 1, 1, result);
   }
 
   @Test
@@ -968,7 +970,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
             FILE_B.path()), // added, but rolled back
         deletedFiles);
 
-    checkExpirationResults(1, 1, 1, result);
+    checkExpirationResults(1, 0L, 1, 1, result);
   }
 
   @Test
@@ -981,7 +983,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
         .deleteWith(deletedFiles::add)
         .execute();
 
-    checkExpirationResults(0, 0, 0, result);
+    checkExpirationResults(0, 0L, 0, 0, result);
   }
 
   @Test
@@ -1053,7 +1055,7 @@ public abstract class TestExpireSnapshotsAction extends SparkTestBase {
     int jobsAfter = spark.sparkContext().dagScheduler().nextJobId().get();
     int totalJobsRun = jobsAfter - jobsBefore;
 
-    checkExpirationResults(1L, 1L, 2L, results);
+    checkExpirationResults(1L, 0L, 1L, 2L, results);
 
     Assert.assertTrue(
         String.format("Expected more than %d jobs when using local iterator, ran %d", SHUFFLE_PARTITIONS, totalJobsRun),

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -717,6 +717,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
                     .set("upper_bound", "1")
                     .build()
                 ))
+            .set("content", manifest.content().id())
             .build()
     );
 
@@ -772,6 +773,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
                     .set("upper_bound", "1")
                     .build()
             ))
+            .set("content", manifest.content().id())
             .build()
     ));
 

--- a/spark3/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
@@ -100,6 +100,7 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
   private InternalRow[] toOutputRows(ExpireSnapshots.Result result) {
     InternalRow row = newInternalRow(
         result.deletedDataFilesCount(),
+        result.deletedDeleteFilesCount(),
         result.deletedManifestsCount(),
         result.deletedManifestListsCount()
     );


### PR DESCRIPTION
When expiring snapshots, the deletefiles should be deleted.