### PR TITLE
Build: Remove bintray from repositories.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ import groovy.transform.Memoized
 buildscript {
   repositories {
     gradlePluginPortal()
-    maven { url "https://plugins.gradle.org/m2/" }
   }
   dependencies {
     classpath 'com.github.jengelman.gradle.plugins:shadow:5.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ import groovy.transform.Memoized
 buildscript {
   repositories {
     gradlePluginPortal()
-    maven { url "http://palantir.bintray.com/releases" }
     maven { url "https://plugins.gradle.org/m2/" }
   }
   dependencies {
@@ -63,7 +62,6 @@ allprojects {
   group = "org.apache.iceberg"
   version = getProjectVersion()
   repositories {
-    maven { url  "http://palantir.bintray.com/releases" }
     mavenCentral()
     mavenLocal()
   }


### PR DESCRIPTION
bintray is being sunset. The Palantir plugins can now be found at https://plugins.gradle.org/m2/. Therefore we can remove http://palantir.bintray.com/releases from the repositories.
This relates to https://github.com/apache/iceberg/issues/2462.