### PR TITLE
AWS: Remove S3URI usage from public constructors

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -75,12 +75,12 @@ public class S3FileIO implements FileIO {
 
   @Override
   public InputFile newInputFile(String path) {
-    return new S3InputFile(client(), new S3URI(path), awsProperties);
+    return new S3InputFile(client(), path, awsProperties);
   }
 
   @Override
   public OutputFile newOutputFile(String path) {
-    return new S3OutputFile(client(), new S3URI(path), awsProperties);
+    return new S3OutputFile(client(), path, awsProperties);
   }
 
   @Override

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -75,12 +75,12 @@ public class S3FileIO implements FileIO {
 
   @Override
   public InputFile newInputFile(String path) {
-    return new S3InputFile(client(), path, awsProperties);
+    return S3InputFile.fromLocation(path, client(), awsProperties);
   }
 
   @Override
   public OutputFile newOutputFile(String path) {
-    return new S3OutputFile(client(), path, awsProperties);
+    return S3OutputFile.fromLocation(path, client(), awsProperties);
   }
 
   @Override

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputFile.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputFile.java
@@ -25,11 +25,15 @@ import org.apache.iceberg.io.SeekableInputStream;
 import software.amazon.awssdk.services.s3.S3Client;
 
 public class S3InputFile extends BaseS3File implements InputFile {
-  public S3InputFile(S3Client client, S3URI uri) {
+  public S3InputFile(S3Client client, String uri) {
     this(client, uri, new AwsProperties());
   }
 
-  public S3InputFile(S3Client client, S3URI uri, AwsProperties awsProperties) {
+  public S3InputFile(S3Client client, String uri, AwsProperties awsProperties) {
+    super(client, new S3URI(uri), awsProperties);
+  }
+
+  S3InputFile(S3Client client, S3URI uri, AwsProperties awsProperties) {
     super(client, uri, awsProperties);
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputFile.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputFile.java
@@ -25,12 +25,12 @@ import org.apache.iceberg.io.SeekableInputStream;
 import software.amazon.awssdk.services.s3.S3Client;
 
 public class S3InputFile extends BaseS3File implements InputFile {
-  public S3InputFile(S3Client client, String uri) {
-    this(client, uri, new AwsProperties());
+  public static S3InputFile fromLocation(String location, S3Client client) {
+    return new S3InputFile(client, new S3URI(location), new AwsProperties());
   }
 
-  public S3InputFile(S3Client client, String uri, AwsProperties awsProperties) {
-    super(client, new S3URI(uri), awsProperties);
+  public static S3InputFile fromLocation(String location, S3Client client, AwsProperties awsProperties) {
+    return new S3InputFile(client, new S3URI(location), awsProperties);
   }
 
   S3InputFile(S3Client client, S3URI uri, AwsProperties awsProperties) {

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
@@ -29,12 +29,16 @@ import org.apache.iceberg.io.PositionOutputStream;
 import software.amazon.awssdk.services.s3.S3Client;
 
 public class S3OutputFile extends BaseS3File implements OutputFile {
-  public S3OutputFile(S3Client client, String uri) {
-    this(client, uri, new AwsProperties());
+  public static S3OutputFile fromLocation(String location, S3Client client) {
+    return new S3OutputFile(client, new S3URI(location), new AwsProperties());
   }
 
-  public S3OutputFile(S3Client client, String uri, AwsProperties awsProperties) {
-    super(client, new S3URI(uri), awsProperties);
+  public static S3OutputFile fromLocation(String location, S3Client client, AwsProperties awsProperties) {
+    return new S3OutputFile(client, new S3URI(location), awsProperties);
+  }
+
+  S3OutputFile(S3Client client, S3URI uri, AwsProperties awsProperties) {
+    super(client, uri, awsProperties);
   }
 
   /**

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
@@ -29,12 +29,12 @@ import org.apache.iceberg.io.PositionOutputStream;
 import software.amazon.awssdk.services.s3.S3Client;
 
 public class S3OutputFile extends BaseS3File implements OutputFile {
-  public S3OutputFile(S3Client client, S3URI uri) {
+  public S3OutputFile(S3Client client, String uri) {
     this(client, uri, new AwsProperties());
   }
 
-  public S3OutputFile(S3Client client, S3URI uri, AwsProperties awsProperties) {
-    super(client, uri, awsProperties);
+  public S3OutputFile(S3Client client, String uri, AwsProperties awsProperties) {
+    super(client, new S3URI(uri), awsProperties);
   }
 
   /**

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3URI.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3URI.java
@@ -33,7 +33,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
  * Note: Path-style access is deprecated and not supported by this
  * implementation.
  */
-public class S3URI {
+class S3URI {
   private static final String SCHEME_DELIM = "://";
   private static final String PATH_DELIM = "/";
   private static final String QUERY_DELIM = "\\?";
@@ -53,7 +53,7 @@ public class S3URI {
    *
    * @param location fully qualified URI
    */
-  public S3URI(String location) {
+  S3URI(String location) {
     Preconditions.checkNotNull(location, "Location cannot be null.");
 
     this.location = location;

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3URI.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3URI.java
@@ -33,7 +33,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
  * Note: Path-style access is deprecated and not supported by this
  * implementation.
  */
-class S3URI {
+public class S3URI {
   private static final String SCHEME_DELIM = "://";
   private static final String PATH_DELIM = "/";
   private static final String QUERY_DELIM = "\\?";
@@ -53,7 +53,7 @@ class S3URI {
    *
    * @param location fully qualified URI
    */
-  S3URI(String location) {
+  public S3URI(String location) {
     Preconditions.checkNotNull(location, "Location cannot be null.");
 
     this.location = location;


### PR DESCRIPTION
While `S3InputFile` and `S3OutputFile` are public, in order to build a custom `FileIO` using them, `S3URI` needs to be public like the rest of the arguments in their public constructors.

PTAL @danielcweeks @jackye1995 - Thanks!