### PR TITLE
Doc: refactor Hive documentation with catalog loading examples

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/Catalogs.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/Catalogs.java
@@ -45,13 +45,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 /**
  * Class for catalog resolution and accessing the common functions for {@link Catalog} API.
  * <p>
- * Catalog resolution happens in this order:
- * <ol>
- * <li>Custom catalog if specified by {@link InputFormatConfig#CATALOG_CLASS_TEMPLATE}
- * <li>Hadoop or Hive catalog if specified by {@link InputFormatConfig#CATALOG_TYPE_TEMPLATE}
- * or {@link InputFormatConfig#CATALOG}</li>
- * <li>Hadoop Tables
- * </ol>
+ * See {@link Catalogs#getCatalogType(Configuration, String)} for catalog type resolution strategy.
  */
 public final class Catalogs {
 

--- a/mr/src/main/java/org/apache/iceberg/mr/Catalogs.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/Catalogs.java
@@ -48,8 +48,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Streams;
  * Catalog resolution happens in this order:
  * <ol>
  * <li>Custom catalog if specified by {@link InputFormatConfig#CATALOG_CLASS_TEMPLATE}
- * <li>Hadoop or Hive catalog if specified by {@link InputFormatConfig#CATALOG_TYPE_TEMPLATE
- *   or {@link InputFormatConfig#CATALOG}
+ * <li>Hadoop or Hive catalog if specified by {@link InputFormatConfig#CATALOG_TYPE_TEMPLATE}
+ * or {@link InputFormatConfig#CATALOG}</li>
  * <li>Hadoop Tables
  * </ol>
  */

--- a/mr/src/main/java/org/apache/iceberg/mr/Catalogs.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/Catalogs.java
@@ -47,8 +47,9 @@ import org.apache.iceberg.relocated.com.google.common.collect.Streams;
  * <p>
  * Catalog resolution happens in this order:
  * <ol>
- * <li>Custom catalog if specified by {@link InputFormatConfig#CATALOG_LOADER_CLASS}
- * <li>Hadoop or Hive catalog if specified by {@link InputFormatConfig#CATALOG}
+ * <li>Custom catalog if specified by {@link InputFormatConfig#CATALOG_CLASS_TEMPLATE}
+ * <li>Hadoop or Hive catalog if specified by {@link InputFormatConfig#CATALOG_TYPE_TEMPLATE
+ *   or {@link InputFormatConfig#CATALOG}
  * <li>Hadoop Tables
  * </ol>
  */

--- a/mr/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
@@ -49,10 +49,26 @@ public class InputFormatConfig {
   public static final String SERIALIZED_TABLE_PREFIX = "iceberg.mr.serialized.table.";
   public static final String TABLE_CATALOG_PREFIX = "iceberg.mr.table.catalog.";
   public static final String LOCALITY = "iceberg.mr.locality";
+
+  /**
+   * @deprecated please use {@link InputFormatConfig#CATALOG_TYPE_TEMPLATE} to specify the type of a catalog,
+   * and set {@link InputFormatConfig#CATALOG_NAME} in table property.
+   */
+  @Deprecated
   public static final String CATALOG = "iceberg.mr.catalog";
+
+  /**
+   * @deprecated please use {@link InputFormatConfig#CATALOG_WAREHOUSE_TEMPLATE} to specify the warehouse location.
+   */
+  @Deprecated
   public static final String HADOOP_CATALOG_WAREHOUSE_LOCATION = "iceberg.mr.catalog.hadoop.warehouse.location";
+
+  /**
+   * @deprecated please use {@link InputFormatConfig#CATALOG_CLASS_TEMPLATE} to set catalog implementation.
+   */
   @Deprecated
   public static final String CATALOG_LOADER_CLASS = "iceberg.mr.catalog.loader.class";
+
   public static final String SELECTED_COLUMNS = "iceberg.mr.selected.columns";
   public static final String EXTERNAL_TABLE_PURGE = "external.table.purge";
 

--- a/mr/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
@@ -51,6 +51,7 @@ public class InputFormatConfig {
   public static final String LOCALITY = "iceberg.mr.locality";
   public static final String CATALOG = "iceberg.mr.catalog";
   public static final String HADOOP_CATALOG_WAREHOUSE_LOCATION = "iceberg.mr.catalog.hadoop.warehouse.location";
+  @Deprecated
   public static final String CATALOG_LOADER_CLASS = "iceberg.mr.catalog.loader.class";
   public static final String SELECTED_COLUMNS = "iceberg.mr.selected.columns";
   public static final String EXTERNAL_TABLE_PURGE = "external.table.purge";

--- a/site/docs/hive.md
+++ b/site/docs/hive.md
@@ -124,7 +124,7 @@ SET iceberg.catalog.glue.type=custom;
 SET iceberg.catalog.glue.catalog-impl=org.apache.iceberg.aws.GlueCatalog;
 SET iceberg.catalog.glue.warehouse=s3://my-bucket/my/key/prefix;
 SET iceberg.catalog.glue.lock-impl=org.apache.iceberg.aws.glue.DynamoLockManager;
-SET iceberg.catalog.glue.lock.table=myGlueLockTable
+SET iceberg.catalog.glue.lock.table=myGlueLockTable;
 ```
 
 ## DDL Commands
@@ -309,5 +309,5 @@ Here is an example of inserting into multiple tables at once in Hive SQL:
 ```sql
 FROM customers
     INSERT INTO target1 SELECT customer_id, first_name
-    INSERT INTO target2 SELECT last_name, customer_id
+    INSERT INTO target2 SELECT last_name, customer_id;
 ```

--- a/site/docs/hive.md
+++ b/site/docs/hive.md
@@ -176,6 +176,14 @@ CREATE TABLE database_a.table_a (
 ) STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler';
 ```
 
+!!! Note
+    This creates an unpartitioned HMS table, while the underlying Iceberg table is partitioned.
+
+!!! Note
+    Due to the limitation of Hive `PARTITIONED BY` syntax, currently you can only partition by columns, 
+    which is translated to Iceberg identity partition transform.
+    You cannot partition by other Iceberg partition transforms such as `days(timestamp)`.
+
 The following Hive types have direct Iceberg types mapping:
 
 - boolean

--- a/site/docs/hive.md
+++ b/site/docs/hive.md
@@ -235,18 +235,25 @@ Tables can be dropped using the `DROP TABLE` command:
 DROP TABLE [IF EXISTS] table_name [PURGE];
 ```
 
-You can configure global purge behavior through Hadoop configuration:
+You can configure purge behavior through global Hadoop configuration or Hive metastore table properties:
 
 | Config key                  | Default                    | Description                                                     |
 | ----------------------------| ---------------------------| --------------------------------------------------------------- |
 | external.table.purge        | true                       | if all data and metadata should be purged in a table by default |
 
-Each table's default purge behavior can be further configured through table properties:
+Each Iceberg table's default purge behavior can also be configured through Iceberg table properties:
 
 | Property                    | Default                    | Description                                                       |
 | ----------------------------| ---------------------------| ----------------------------------------------------------------- |
 | gc.enabled                  | true                       | if all data and metadata should be purged in the table by default |
 
+When changing `gc.enabled` on the Iceberg table via `UpdateProperties`, `external.table.purge` is also updated on HMS table accordingly.
+When setting `external.table.purge` as a table prop during Hive `CREATE TABLE`, `gc.enabled` is pushed down accordingly to the Iceberg table properties.
+This makes sure that the 2 properties are always consistent at table level between Hive and Iceberg.
+
+!!! Warning
+    Changing `external.table.purge` via Hive `ALTER TABLE SET TBLPROPERTIES` does not update `gc.enabled` on the Iceberg table. 
+    This is a limitation on Hive 3.1.2 because the `HiveMetaHook` doesn't have all the hooks for alter tables yet.
 
 ## Querying with SQL
 

--- a/site/docs/hive.md
+++ b/site/docs/hive.md
@@ -59,6 +59,9 @@ HiveCatalog catalog = new HiveCatalog(hadoopConfiguration);
 catalog.createTable(tableId, schema, spec);
 ```
 
+!!! Warning
+    When using Tez, you also have to disable vectorization for now (`hive.vectorized.execution.enabled=false`)
+
 #### Table property configuration
 
 Alternatively, the property `engine.hive.enabled` can be set to `true` and added to the table properties when creating the Iceberg table. 
@@ -264,9 +267,6 @@ Here are the features highlights for Iceberg Hive read support:
 3. **Hive query engines**: Both the MapReduce and Tez query execution engines are supported.
 
 ### Configurations
-
-!!! Warning
-    When reading with Tez, you also have to disable vectorization for now (`hive.vectorized.execution.enabled=false`)
 
 Here are the Hadoop configurations that one can adjust for the Hive reader:
 

--- a/site/docs/hive.md
+++ b/site/docs/hive.md
@@ -56,7 +56,7 @@ To enable Hive support globally for an application, set `iceberg.engine.hive.ena
 For example, setting this in the `hive-site.xml` loaded by Spark will enable the storage handler for all tables created by Spark.
 
 !!! Warning
-    When using Tez, you also have to disable vectorization for now (`hive.vectorized.execution.enabled=false`)
+    When using Hive with Tez in `0.11.x` releases, you also have to disable vectorization (`hive.vectorized.execution.enabled=false`)
 
 #### Table property configuration
 
@@ -338,29 +338,3 @@ The conversion applies on both creating Iceberg table and writing to Iceberg tab
 | list             | list                    |       |
 | map              | map                     |       |
 | union            |                         | not supported |
-
-### Iceberg type to Hive type
-
-This type conversion table describes how Iceberg types are converted to the Hive types. 
-The conversion applies on reading from Iceberg table via Hive.
-
-| Iceberg                    | Hive                    | Note          |
-|----------------------------|-------------------------|---------------|
-| boolean                    | boolean                 |               |
-| integer                    | integer                 |               |
-| long                       | long                    |               |
-| float                      | float                   |               |
-| double                     | double                  |               |
-| date                       | date                    |               |
-| time                       | string                  |               |
-| timestamp with timezone    | timestamp               |               |
-| timestamp without timezone | timestamp               |               |
-| string                     | string                  |               |
-| uuid                       | string                  |               |
-| fixed                      | binary                  |               |
-| binary                     | binary                  |               |
-| decimal                    | decimal                 |               |
-| struct                     | struct                  |               |
-| list                       | list                    |               |
-| map                        | map                     |               |
-

--- a/site/docs/hive.md
+++ b/site/docs/hive.md
@@ -89,7 +89,7 @@ depending on the table's `iceberg.catalog` configuration:
 3. The table can be loaded using the table's location if `iceberg.catalog` is set to `location_based_table`
 
 For cases 2 and 3 above, users can create an overlay of an Iceberg table using [CREATE EXTERNAL TABLE](#create-external-table) in the Hive metastore,
-so that different table types can work together under the same Hive environment.
+so that different table types can work together in the same Hive environment.
 
 ### Custom Iceberg catalogs
 

--- a/site/docs/hive.md
+++ b/site/docs/hive.md
@@ -32,10 +32,14 @@ Here is the current compatibility matrix for Iceberg Hive support:
 
 ### Loading runtime jar
 
-To enable Iceberg support in Hive, the `HiveIcebergStorageHandler` and supporting classes need to be made available on Hive's classpath. These are provided by the `iceberg-hive-runtime` jar file. For example, if using the Hive shell, this can be achieved by issuing a statement like so:
-```sql
+To enable Iceberg support in Hive, the `HiveIcebergStorageHandler` and supporting classes need to be made available on Hive's classpath. 
+These are provided by the `iceberg-hive-runtime` jar file. 
+For example, if using the Hive shell, this can be achieved by issuing a statement like so:
+
+```
 add jar /path/to/iceberg-hive-runtime.jar;
 ```
+
 There are many others ways to achieve this including adding the jar file to Hive's auxiliary classpath so it is available by default.
 Please refer to Hive's documentation for more information.
 
@@ -43,7 +47,7 @@ Please refer to Hive's documentation for more information.
 
 #### Hadoop configuration
 
-The value `iceberg.engine.hive.enabled` needs to be set to `true` in the Hadoop configuraiton in the environment.
+The value `iceberg.engine.hive.enabled` needs to be set to `true` in the Hadoop configuration in the environment.
 For example, it can be added to the Hive configuration file on the classpath of the application creating or modifying (altering, inserting etc.) the table by modifying the relevant `hive-site.xml`.
 You can also do it programmatically like so:
 
@@ -157,6 +161,7 @@ When `iceberg.catalog` is missing from both table properties and the global Hado
 Iceberg tables created using `HadoopTables` are stored entirely in a directory in a filesystem like HDFS.
 These tables are considered to have no catalog. 
 To indicate that, set `iceberg.catalog` property to `location_based_table`. For example:
+
 ```sql
 CREATE EXTERNAL TABLE table_a 
 STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' 
@@ -262,7 +267,6 @@ Here are the Hadoop configurations that one can adjust for the Hive reader:
 | ---------------------------- | ----------------------- | ------------------------------------------------------ |
 | iceberg.mr.reuse.containers  | false                   | if Avro reader should reuse containers                 |
 | iceberg.mr.case.sensitive    | true                    | if the query is case-sensitive                         |
-
 
 ### SELECT
 

--- a/site/docs/hive.md
+++ b/site/docs/hive.md
@@ -17,113 +17,211 @@
 
 # Hive
 
-## Hive read support
-Iceberg supports the reading of Iceberg tables from [Hive](https://hive.apache.org) by using a [StorageHandler](https://cwiki.apache.org/confluence/display/Hive/StorageHandlers). Please note that only Hive 2.x versions are currently supported.
+Iceberg supports reading and writing Iceberg tables through [Hive](https://hive.apache.org) by using a [StorageHandler](https://cwiki.apache.org/confluence/display/Hive/StorageHandlers).
+Only Hive 2.x versions are currently supported. 
 
-### Table creation
-This section explains the various steps needed in order to overlay a Hive table "on top of" an existing Iceberg table. Iceberg tables are created using either a [`Catalog`](./javadoc/master/index.html?org/apache/iceberg/catalog/Catalog.html) or an implementation of the [`Tables`](./javadoc/master/index.html?org/apache/iceberg/Tables.html) interface and Hive needs to be configured accordingly to read data from these different types of table.
+## Enabling Iceberg support in Hive
 
-#### Add the Iceberg Hive Runtime jar file to the Hive classpath
-Regardless of the table type, the `HiveIcebergStorageHandler` and supporting classes need to be made available on Hive's classpath. These are provided by the `iceberg-hive-runtime` jar file. For example, if using the Hive shell, this can be achieved by issuing a statement like so:
+### Loading runtime jar
+
+To enable Iceberg support in Hive, the `HiveIcebergStorageHandler` and supporting classes need to be made available on Hive's classpath. These are provided by the `iceberg-hive-runtime` jar file. For example, if using the Hive shell, this can be achieved by issuing a statement like so:
 ```sql
 add jar /path/to/iceberg-hive-runtime.jar;
 ```
-There are many others ways to achieve this including adding the jar file to Hive's auxiliary classpath (so it is available by default) - please refer to Hive's documentation for more information.
+There are many others ways to achieve this including adding the jar file to Hive's auxiliary classpath so it is available by default.
+Please refer to Hive's documentation for more information.
 
-#### Using Hadoop Tables
+### Enabling support
+
+#### Hadoop configuration
+
+The value `iceberg.engine.hive.enabled` needs to be set to `true` in the Hadoop configuraiton in the environment.
+For example, it can be added to the Hive configuration file on the classpath of the application creating or modifying (altering, inserting etc.) the table by modifying the relevant `hive-site.xml`.
+You can also do it programmatically like so:
+
+```java
+Configuration hadoopConfiguration = spark.sparkContext().hadoopConfiguration();
+hadoopConfiguration.set(ConfigProperties.ENGINE_HIVE_ENABLED, "true"); // iceberg.engine.hive.enabled=true
+HiveCatalog catalog = new HiveCatalog(hadoopConfiguration);
+...
+catalog.createTable(tableId, schema, spec);
+```
+
+#### Table property configuration
+
+Alternatively, the property `engine.hive.enabled` can be set to `true` and added to the table properties when creating the Iceberg table. 
+Here is an example of doing it programmatically:
+
+```java
+Catalog catalog = ...;
+Map<String, String> tableProperties = Maps.newHashMap();
+tableProperties.put(TableProperties.ENGINE_HIVE_ENABLED, "true"); // engine.hive.enabled=true
+catalog.createTable(tableId, schema, spec, tableProperties);
+```
+
+The table level configuration overwrites the global Hadoop configuration.
+
+## Iceberg and Hive catalog compatibility
+
+### Global Hive catalog
+
+From the Hive engine's perspective, there is only 1 global data catalog, which is the Hive metastore defined in the Hadoop configuration in the runtime environment.
+On contrast, Iceberg supports multiple different data catalog types such as Hive, Hadoop, AWS Glue, and also allow any custom catalog implementations.
+Users might want to read tables in anther catalog through the Hive engine, or perform cross-catalog operations like join.
+
+Iceberg handles this issue in the following way:
+
+1. All tables created by Iceberg's `HiveCatalog` with Hive engine feature enabled are automatically visible by the Hive engine.
+2. For Iceberg tables created in other catalogs, the catalog information is registered through Hadoop configuration.
+A Hive external table overlay needs to be created in the Hive metastore, 
+and the actual catalog name is recorded as a part of the overlay table properties. 
+See [CREATE EXTERNAL TABLE](#create-external-table) section for more details.
+
+### Custom Iceberg catalogs
+
+To globally register different catalogs, set the following Hadoop configurations:
+
+| Config Key                                    | Description                                            |
+| --------------------------------------------- | ------------------------------------------------------ |
+| iceberg.catalog.<catalog_name\>.type           | type of catalog: `hive`,`hadoop` or `custom`           |
+| iceberg.catalog.<catalog_name\>.catalog-impl   | catalog implementation, must not be null if type is `custom` |
+| iceberg.catalog.<catalog_name\>.<key\>         | any config key and value pairs for the catalog         |
+
+Here are some examples using Hive CLI:
+
+Register a `HiveCatalog` called `another_hive`:
+
+```
+SET iceberg.catalog.another_hive.type=hive;
+SET iceberg.catalog.another_hive.uri=thrift://example.com:9083;
+SET iceberg.catalog.another_hive.clients=10;
+SET iceberg.catalog.another_hive.warehouse=hdfs://example.com:8020/warehouse;
+```
+
+Register a `HadoopCatalog` called `hadoop`:
+
+```
+SET iceberg.catalog.hadoop.type=hadoop;
+SET iceberg.catalog.hadoop.warehouse=hdfs://example.com:8020/warehouse;
+```
+
+Register an AWS `GlueCatalog` called `glue`:
+
+```
+SET iceberg.catalog.glue.type=custom;
+SET iceberg.catalog.glue.catalog-impl=org.apache.iceberg.aws.GlueCatalog;
+SET iceberg.catalog.glue.warehouse=s3://my-bucket/my/key/prefix;
+SET iceberg.catalog.glue.lock-impl=org.apache.iceberg.aws.glue.DynamoLockManager;
+SET iceberg.catalog.glue.lock.table=myGlueLockTable
+```
+
+## DDL Commands
+
+### CREATE EXTERNAL TABLE
+
+The `CREATE EXTERNAL TABLE` command is used to overlay a Hive table "on top of" an existing Iceberg table. 
+Iceberg tables are created using either a [`Catalog`](./javadoc/master/index.html?org/apache/iceberg/catalog/Catalog.html),
+or an implementation of the [`Tables`](./javadoc/master/index.html?org/apache/iceberg/Tables.html) interface,
+and Hive needs to be configured accordingly to operate on these different types of table.
+
+#### Path-based Hadoop tables
+
 Iceberg tables created using `HadoopTables` are stored entirely in a directory in a filesystem like HDFS.
+You can use other compute engines or the Java/Python API to create such a table. 
 
-##### Create an Iceberg table
-The first step is to create an Iceberg table using the Spark/Java/Python API and `HadoopTables`. For the purposes of this documentation we will assume that the table is called `table_a` and that the table location is `hdfs://some_path/table_a`.
-
-##### Create a Hive table
+Suppose there is a table `table_a` and the table location is `hdfs://some_path/table_a`. 
 Now overlay a Hive table on top of this Iceberg table by issuing Hive DDL like so:
+
 ```sql
 CREATE EXTERNAL TABLE table_a 
 STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' 
 LOCATION 'hdfs://some_bucket/some_path/table_a';
 ```
 
-#### Query the Iceberg table via Hive
-You should now be able to issue Hive SQL `SELECT` queries using the above table and see the results returned from the underlying Iceberg table.
+#### Hadoop catalog tables
+
+Iceberg tables created using `HadoopCatalog` are stored entirely in a directory in a filesystem like HDFS, 
+similar to the tables created through `HadoopTables`.
+You can use other compute engines or Java/Python API to create such as table. 
+
+Suppose there is a table `table_b` and the table location is `hdfs://some_path/table_b`. 
+
+Now overlay a Hive table on top of this Iceberg table by issuing Hive DDL like so:
+
+```sql
+CREATE EXTERNAL TABLE database_a.table_b
+STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' 
+LOCATION 'hdfs://some_path/table_b'
+TBLPROPERTIES (
+  'iceberg.mr.catalog'='hadoop', 
+  'iceberg.mr.catalog.hadoop.warehouse.location'='hdfs://some_bucket/path_to_hadoop_warehouse'
+);
+```
+
+Note that the Hive database and table name *must* match the values used in the Iceberg `TableIdentifier` when the table was created. 
+
+It is possible to omit either or both of the table properties but instead you will then need to set these when reading from the table.
+Generally it is recommended to set them at table creation time, so you can query tables created by different catalogs. 
+
+#### Hive catalog tables
+
+As described before, tables created by the `HiveCatalog` with Hive engine feature enabled are directly visible by the Hive engine, so there is no need to create an overlay.
+
+#### Custom catalog tables
+
+For a registered catalog, simply specify the catalog name in the statement using table property `iceberg.catalog`.
+For example, the SQL below creates an overlay for a table in the `glue` catalog.
+
+```sql
+CREATE EXTERNAL TABLE database_a.table_c
+STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler'
+TBLPROPERTIES ('iceberg.catalog'='glue');
+```
+
+### DROP TABLE
+
+When dropping the Hive table overlay, one can perform the following configurations:
+
+| Config key                  | Default                    | Description                                            |
+| ----------------------------| ---------------------------| ------------------------------------------------------ |
+| external.table.purge        | true                       | if all data and metadata should be purged in the table  |
+
+## Querying with SQL
+
+Here are the features highlights for Iceberg Hive read support:
+
+1. **Predicate pushdown**: Pushdown of the Hive SQL `WHERE` clause has been implemented so that these filters are used at the Iceberg `TableScan` level as well as by the Parquet and ORC Readers.
+2. **Column projection**: Columns from the Hive SQL `SELECT` clause are projected down to the Iceberg readers to reduce the number of columns read.
+3. **Hive query engines**: Both the MapReduce and Tez query execution engines are supported.
+
+You should now be able to issue Hive SQL `SELECT` queries and see the results returned from the underlying Iceberg table:
+
 ```sql
 SELECT * from table_a;
 ```
 
-#### Using Hive Catalog
-Iceberg tables created using `HiveCatalog` are automatically registered with Hive.
+## Writing with SQL
 
-##### Create an Iceberg table
-The first step is to create an Iceberg table using the Spark/Java/Python API and `HiveCatalog`. For the purposes of this documentation we will assume that the table is called `table_b` and that the table location is `s3://some_path/table_b`. In order for Iceberg to correctly set up the Hive table for querying some configuration values need to be set, the two options for this are described below - you can use either or the other depending on your use case.
+### Configurations
 
-##### Hive Configuration
-The value `iceberg.engine.hive.enabled` needs to be set to `true` and added to the Hive configuration file on the classpath of the application creating or modifying (altering, inserting etc.) the table. This can be done by modifying the relevant `hive-site.xml`. Alternatively this can be done programmatically like so:
-```java
-Configuration hadoopConfiguration = spark.sparkContext().hadoopConfiguration();
-hadoopConfiguration.set(ConfigProperties.ENGINE_HIVE_ENABLED, "true"); //iceberg.engine.hive.enabled=true
-HiveCatalog catalog = new HiveCatalog(hadoopConfiguration);
-...
-catalog.createTable(tableId, schema, spec);
-```
+Here is a table of Hadoop configurations that one can adjust for the Hive writer:
 
-##### Table Property Configuration
-The property `engine.hive.enabled` needs to be set to `true` and added to the table properties when creating the Iceberg table. This can be done like so:
-```java
-    Map<String, String> tableProperties = new HashMap<String, String>();
-    tableProperties.put(TableProperties.ENGINE_HIVE_ENABLED, "true"); //engine.hive.enabled=true
-    catalog.createTable(tableId, schema, spec, tableProperties);
-```
+| Config key                                        | Default                                  | Description                                            |
+| ------------------------------------------------- | ---------------------------------------- | ------------------------------------------------------ |
+| iceberg.mr.output.tables                          | the current table in the job             | a list of tables delimited by `..`                     |
+| iceberg.mr.commit.table.thread.pool.size          | 10                                       | the number of threads of a shared thread pool to execute parallel commits for output tables |
+| iceberg.mr.commit.file.thread.pool.size           | 10                                       | the number of threads of a shared thread pool to execute parallel commits for files in each output table |
 
-#### Query the Iceberg table via Hive
-In order to query a Hive table created by either of the HiveCatalog methods described above you need to first set a Hive configuration value like so:
+### INSERT INTO
+
+Hive supports the standard single-table `INSERT INTO` operation:
+
 ```sql
-SET iceberg.mr.catalog=hive;
-```
-You should now be able to issue Hive SQL `SELECT` queries using the above table and see the results returned from the underlying Iceberg table.
-```sql
-SELECT * from table_b;
+INSERT INTO table_a VALUES ('a', 1);
+INSERT INTO table_a SELECT ...;
 ```
 
-#### Using Hadoop Catalog
-Iceberg tables created using `HadoopCatalog` are stored entirely in a directory in a filesystem like HDFS.
-
-##### Create an Iceberg table
-The first step is to create an Iceberg table using the Spark/Java/Python API and `HadoopCatalog`. For the purposes of this documentation we will assume that the fully qualified table identifier is `database_a.table_c` and that the Hadoop Catalog warehouse location is `hdfs://some_bucket/path_to_hadoop_warehouse`. Iceberg will therefore create the table at the location `hdfs://some_bucket/path_to_hadoop_warehouse/database_a/table_c`.
-
-##### Create a Hive table
-Now overlay a Hive table on top of this Iceberg table by issuing Hive DDL like so:
-```sql
-CREATE EXTERNAL TABLE database_a.table_c 
-STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' 
-LOCATION 'hdfs://some_bucket/path_to_hadoop_warehouse/database_a/table_c'
-TBLPROPERTIES (
-  'iceberg.mr.catalog'='hadoop', 
-  'iceberg.mr.catalog.hadoop.warehouse.location'='hdfs://some_bucket/path_to_hadoop_warehouse')
-;
-```
-Note that the Hive database and table name *must* match the values used in the Iceberg `TableIdentifier` when the table was created. 
-
-It is possible to omit either or both of the table properties but instead you will then need to set these when reading from the table. Generally it is recommended to set them at table creation time so you can query tables created by different catalogs. 
-
-#### Query the Iceberg table via Hive
-You should now be able to issue Hive SQL `SELECT` queries using the above table and see the results returned from the underlying Iceberg table.
-```sql
-SELECT * from database_a.table_c;
-```
-
-### Features
-
-#### Predicate pushdown
-Pushdown of the Hive SQL `WHERE` clause has been implemented so that these filters are used at the Iceberg TableScan level as well as by the Parquet and ORC Readers.
-
-#### Column Projection
-Columns from the Hive SQL `SELECT` clause are projected down to the Iceberg readers to reduce the number of columns read.
-
-#### Hive Query Engines
-Both the Map Reduce and Tez query execution engines are supported.
-
-#### Hive Multi-table inserts
-Multi-table inserts will not be atomic and are committed one table at a time. Partial changes will be visible during the commit process and failures can leave partial changes committed. Changes within a single table will remain atomic.
+Multi-table insert is also supported, but it will not be atomic and are committed one table at a time. Partial changes will be visible during the commit process and failures can leave partial changes committed. Changes within a single table will remain atomic.
 
 Here is an example of inserting into multiple tables at once in Hive SQL:
 ```sql


### PR DESCRIPTION
@pvary, @marton-bod, @lcspinter, @rdblue

As @openinx suggested in #2535, we lack documentation for Hive catalog loading after #2129 is merged. This PR adds examples of loading the catalog and creating tables with custom catalogs. I also reorganized the doc to follow the same structure as Spark and Flink, and added more details for each section.

Also there are some documentations in the code that were not updated so I also fixed those.

The doc changes are quite messy, using the split view to read the updated content might be easier, thanks!