### PR TITLE
Hive: add iceberg-aws to Hive runtime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -646,6 +646,7 @@ project(':iceberg-hive-runtime') {
     compile(project(':iceberg-nessie')) {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }
+    compile project(':iceberg-aws')
   }
   
   shadowJar {

--- a/site/docs/aws.md
+++ b/site/docs/aws.md
@@ -126,6 +126,36 @@ catalogs:
     lock.table: myGlueLockTable
 ```
 
+### Hive
+
+To use AWS module with Hive, you can download the necessary dependencies similar to the Flink example,
+and then add them to the Hive classpath or add the jars at runtime in CLI:
+
+```
+add jar /my/path/to/iceberg-hive-runtime.jar;
+add jar /my/path/to/aws/bundle.jar;
+add jar /my/path/to/aws/url-connection-client.jar;
+```
+
+With those dependencies, you can register a Glue catalog and create external tables in Hive at runtime in CLI by:
+
+```sql
+SET iceberg.engine.hive.enabled=true;
+SET hive.vectorized.execution.enabled=false;
+SET iceberg.catalog.glue.type=custom;
+SET iceberg.catalog.glue.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog;
+SET iceberg.catalog.glue.warehouse=s3://my-bucket/my/key/prefix;
+SET iceberg.catalog.glue.lock-impl=org.apache.iceberg.aws.glue.DynamoLockManager;
+SET iceberg.catalog.glue.lock.table=myGlueLockTable;
+
+-- suppose you have an Iceberg table database_a.table_a created by GlueCatalog
+CREATE EXTERNAL TABLE database_a.table_a
+STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler'
+TBLPROPERTIES ('iceberg.catalog'='glue');
+```
+
+You can also preload the catalog by setting the configurations above in `hive-site.xml`.
+
 ## Glue Catalog
 
 Iceberg enables the use of [AWS Glue](https://aws.amazon.com/glue) as the `Catalog` implementation.


### PR DESCRIPTION
@pvary @yyanyy adding the AWS module to the Hive runtime jar. Verified with EMR 6.3.0 (Hive 3.1.2) that I can create external Glue type table and query successfully:

```
0: jdbc:hive2://localhost:10000> CREATE EXTERNAL TABLE db10.sample234
. . . . . . . . . . . . . . . .> STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler'
. . . . . . . . . . . . . . . .> TBLPROPERTIES ('iceberg.catalog'='glue');
INFO  : Compiling command(queryId=hive_20210503024236_8bdfc3e3-6b80-4731-a5d8-0e7f15026254): CREATE EXTERNAL TABLE db10.sample234
STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler'
TBLPROPERTIES ('iceberg.catalog'='glue')
INFO  : Concurrency mode is disabled, not creating a lock manager
INFO  : Semantic Analysis Completed (retrial = false)
INFO  : Returning Hive schema: Schema(fieldSchemas:null, properties:null)
INFO  : Completed compiling command(queryId=hive_20210503024236_8bdfc3e3-6b80-4731-a5d8-0e7f15026254); Time taken: 0.024 seconds
INFO  : Concurrency mode is disabled, not creating a lock manager
INFO  : Executing command(queryId=hive_20210503024236_8bdfc3e3-6b80-4731-a5d8-0e7f15026254): CREATE EXTERNAL TABLE db10.sample234
STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler'
TBLPROPERTIES ('iceberg.catalog'='glue')
INFO  : Starting task [Stage-0:DDL] in serial mode
INFO  : Completed executing command(queryId=hive_20210503024236_8bdfc3e3-6b80-4731-a5d8-0e7f15026254); Time taken: 0.633 seconds
INFO  : OK
INFO  : Concurrency mode is disabled, not creating a lock manager
No rows affected (0.671 seconds)
0: jdbc:hive2://localhost:10000> SELECT * FROM db10.sample234;
INFO  : Compiling command(queryId=hive_20210503024254_f93f118a-3172-4224-a498-3d291c7a578d): SELECT * FROM db10.sample234
INFO  : Concurrency mode is disabled, not creating a lock manager
INFO  : Semantic Analysis Completed (retrial = false)
INFO  : Returning Hive schema: Schema(fieldSchemas:[FieldSchema(name:sample234.id, type:bigint, comment:null), FieldSchema(name:sample234.data, type:string, comment:null), FieldSchema(name:sample234.category, type:string, comment:null)], properties:null)
INFO  : Completed compiling command(queryId=hive_20210503024254_f93f118a-3172-4224-a498-3d291c7a578d); Time taken: 0.665 seconds
INFO  : Concurrency mode is disabled, not creating a lock manager
INFO  : Executing command(queryId=hive_20210503024254_f93f118a-3172-4224-a498-3d291c7a578d): SELECT * FROM db10.sample234
INFO  : Completed executing command(queryId=hive_20210503024254_f93f118a-3172-4224-a498-3d291c7a578d); Time taken: 0.001 seconds
INFO  : OK
INFO  : Concurrency mode is disabled, not creating a lock manager
+---------------+-----------------+---------------------+
| sample234.id  | sample234.data  | sample234.category  |
+---------------+-----------------+---------------------+
| 1             | a               | c1                  |
| 2             | b               | c2                  |
| 3             | c               | c1                  |
| 1             | a               | c1                  |
| 2             | b               | c2                  |
| 3             | c               | c1                  |
+---------------+-----------------+---------------------+
6 rows selected (2.107 seconds)
```