### PR TITLE
Core: Fix the NPE while updating event in the context of eventual consistency.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -33,8 +33,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
 class BaseSnapshot implements Snapshot {
-  private static final long INITIAL_SEQUENCE_NUMBER = 0;
-
   private final FileIO io;
   private final long snapshotId;
   private final Long parentId;
@@ -87,7 +85,7 @@ class BaseSnapshot implements Snapshot {
                String operation,
                Map<String, String> summary,
                List<ManifestFile> dataManifests) {
-    this(io, INITIAL_SEQUENCE_NUMBER, snapshotId, parentId, timestampMillis, operation, summary, null);
+    this(io, TableMetadata.INITIAL_SEQUENCE_NUMBER, snapshotId, parentId, timestampMillis, operation, summary, null);
     this.allManifests = dataManifests;
   }
 

--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -33,6 +33,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
 class BaseSnapshot implements Snapshot {
+  private static final long INITIAL_SEQUENCE_NUMBER = 0;
+
   private final FileIO io;
   private final long snapshotId;
   private final Long parentId;
@@ -85,7 +87,7 @@ class BaseSnapshot implements Snapshot {
                String operation,
                Map<String, String> summary,
                List<ManifestFile> dataManifests) {
-    this(io, TableMetadata.INITIAL_SEQUENCE_NUMBER, snapshotId, parentId, timestampMillis, operation, summary, null);
+    this(io, INITIAL_SEQUENCE_NUMBER, snapshotId, parentId, timestampMillis, operation, summary, null);
     this.allManifests = dataManifests;
   }
 

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -399,7 +399,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
     if (justSaved == null) {
       // The snapshot just saved may not be present if the latest metadata couldn't be loaded due to eventual
       // consistency problems in refresh.
-      LOG.warn("Failed to load committed snapshot, leave its sequence number to an invalid number(-1)");
+      LOG.warn("Failed to load committed snapshot: omitting sequence number from notifications");
     } else {
       sequenceNumber = justSaved.sequenceNumber();
     }

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -395,11 +395,11 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
   public Object updateEvent() {
     long snapshotId = snapshotId();
     Snapshot justSaved = ops.refresh().snapshot(snapshotId);
-    long sequenceNumber = 0;
+    long sequenceNumber = TableMetadata.INVALID_SEQUENCE_NUMBER;
     if (justSaved == null) {
       // The snapshot just saved may not be present if the latest metadata couldn't be loaded due to eventual
       // consistency problems in refresh.
-      LOG.warn("Failed to load committed snapshot, leave sequence number to 0");
+      LOG.warn("Failed to load committed snapshot, leave its sequence number to an invalid number(-1)");
     } else {
       sequenceNumber = justSaved.sequenceNumber();
     }

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -40,6 +40,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.iceberg.TableProperties.MANIFEST_MIN_MERGE_COUNT;
 import static org.apache.iceberg.TableProperties.MANIFEST_MIN_MERGE_COUNT_DEFAULT;
@@ -49,6 +51,8 @@ import static org.apache.iceberg.TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED
 import static org.apache.iceberg.TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED_DEFAULT;
 
 abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
+  private static final Logger LOG = LoggerFactory.getLogger(MergingSnapshotProducer.class);
+
   // data is only added in "append" and "overwrite" operations
   private static final Set<String> VALIDATE_ADDED_FILES_OPERATIONS =
       ImmutableSet.of(DataOperations.APPEND, DataOperations.OVERWRITE);
@@ -390,7 +394,16 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
   @Override
   public Object updateEvent() {
     long snapshotId = snapshotId();
-    long sequenceNumber = ops.refresh().snapshot(snapshotId).sequenceNumber();
+    Snapshot justSaved = ops.refresh().snapshot(snapshotId);
+    long sequenceNumber = 0;
+    if( justSaved == null) {
+      // The snapshot just saved may not be present if the latest metadata couldn't be loaded due to eventual
+      // consistency problems in refresh.
+      LOG.warn("Failed to load committed snapshot, leave sequence number to 0");
+    } else {
+      sequenceNumber = justSaved.sequenceNumber();
+    }
+
     return new CreateSnapshotEvent(
         tableName,
         operation(),

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -396,7 +396,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
     long snapshotId = snapshotId();
     Snapshot justSaved = ops.refresh().snapshot(snapshotId);
     long sequenceNumber = 0;
-    if( justSaved == null) {
+    if (justSaved == null) {
       // The snapshot just saved may not be present if the latest metadata couldn't be loaded due to eventual
       // consistency problems in refresh.
       LOG.warn("Failed to load committed snapshot, leave sequence number to 0");

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -48,6 +48,7 @@ import org.apache.iceberg.util.PropertyUtil;
  */
 public class TableMetadata implements Serializable {
   static final long INITIAL_SEQUENCE_NUMBER = 0;
+  static final long INVALID_SEQUENCE_NUMBER = -1;
   static final int DEFAULT_TABLE_FORMAT_VERSION = 1;
   static final int SUPPORTED_TABLE_FORMAT_VERSION = 2;
   static final int INITIAL_SPEC_ID = 0;


### PR DESCRIPTION
We need the same thing as [here](https://github.com/apache/iceberg/blob/83886c87f516afed7e625bed7f5749838217138c/core/src/main/java/org/apache/iceberg/SnapshotProducer.java#L315) in the context of eventual consistency. Otherwise, we hits a NPE like this. We need a fix even though it is a WARN. 
```
timestamp="2021-04-23T22:35:23,938+0000",level="WARN",threadName="pool-1-thread-1",appName="spark-driver",logger="org.apache.iceberg.SnapshotProducer",message="Failed to notify listeners",exception="java.lang.NullPointerException
	at org.apache.iceberg.MergingSnapshotProducer.updateEvent(MergingSnapshotProducer.java:377)
	at org.apache.iceberg.SnapshotProducer.notifyListeners(SnapshotProducer.java:329)
	at org.apache.iceberg.SnapshotProducer.commit(SnapshotProducer.java:324)
	at org.apache.iceberg.spark.source.SparkWrite.commitOperation(SparkWrite.java:236)
```