### PR TITLE
Core: update schema constructor callers to include fresh identifier

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Schema.java
+++ b/api/src/main/java/org/apache/iceberg/Schema.java
@@ -210,6 +210,16 @@ public class Schema implements Serializable {
   }
 
   /**
+   * Returns the set of identifier field names.
+   */
+  public Set<String> identifierFieldNames() {
+    return identifierFieldIds()
+            .stream()
+            .map(id -> findField(id).name())
+            .collect(Collectors.toSet());
+  }
+
+  /**
    * Returns the {@link Type} of a sub-field identified by the field name.
    *
    * @param name a field name

--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -197,8 +197,7 @@ public class TypeUtil {
    */
   public static Set<Integer> refreshIdentifierFields(Types.StructType freshSchema, Schema baseSchema) {
     Map<String, Integer> nameToId = TypeUtil.indexByName(freshSchema);
-    Set<String> identifierFieldNames = baseSchema.identifierFieldNames();
-    return identifierFieldNames.stream()
+    return baseSchema.identifierFieldNames().stream()
             .map(nameToId::get)
             .filter(Objects::nonNull)
             .collect(Collectors.toSet());

--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -179,8 +179,8 @@ public class TypeUtil {
    */
   public static Schema assignFreshIds(Schema schema, Schema baseSchema, NextID nextId) {
     Types.StructType struct = TypeUtil
-            .visit(schema.asStruct(), new AssignFreshIds(schema, baseSchema, nextId))
-            .asStructType();
+        .visit(schema.asStruct(), new AssignFreshIds(schema, baseSchema, nextId))
+        .asStructType();
     return new Schema(struct.fields(), refreshIdentifierFields(struct, schema));
   }
 
@@ -188,7 +188,7 @@ public class TypeUtil {
    * Get the identifier fields in the fresh schema based on the identifier fields in the base schema.
    * @param freshSchema fresh schema
    * @param baseSchema base schema
-   * @return idnetifier fields in the fresh schema
+   * @return identifier fields in the fresh schema
    */
   public static Set<Integer> refreshIdentifierFields(Types.StructType freshSchema, Schema baseSchema) {
     Map<String, Integer> nameToId = TypeUtil.indexByName(freshSchema);

--- a/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
@@ -21,6 +21,8 @@
 package org.apache.iceberg.types;
 
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -40,6 +42,25 @@ public class TestTypeUtil {
     );
     final Schema actualSchema = TypeUtil.reassignIds(schema, sourceSchema);
     Assert.assertEquals(sourceSchema.asStruct(), actualSchema.asStruct());
+  }
+
+  @Test
+  public void testReassignIdsWithIdentifier() {
+    Schema schema = new Schema(
+        Lists.newArrayList(
+            required(0, "a", Types.IntegerType.get()),
+            required(1, "A", Types.IntegerType.get())),
+        Sets.newHashSet(0)
+    );
+    Schema sourceSchema = new Schema(
+        Lists.newArrayList(
+            required(1, "a", Types.IntegerType.get()),
+            required(2, "A", Types.IntegerType.get())),
+        Sets.newHashSet(1)
+    );
+    final Schema actualSchema = TypeUtil.reassignIds(schema, sourceSchema);
+    Assert.assertEquals(sourceSchema.asStruct(), actualSchema.asStruct());
+    Assert.assertEquals(sourceSchema.identifierFieldIds(), actualSchema.identifierFieldIds());
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
@@ -63,6 +63,25 @@ public class TestTypeUtil {
     Assert.assertEquals(sourceSchema.identifierFieldIds(), actualSchema.identifierFieldIds());
   }
 
+  @Test
+  public void testAssignIncreasingFreshIdWithIdentifier() {
+    Schema schema = new Schema(
+        Lists.newArrayList(
+            required(10, "a", Types.IntegerType.get()),
+            required(11, "A", Types.IntegerType.get())),
+        Sets.newHashSet(10)
+    );
+    Schema sourceSchema = new Schema(
+        Lists.newArrayList(
+            required(1, "a", Types.IntegerType.get()),
+            required(2, "A", Types.IntegerType.get())),
+        Sets.newHashSet(1)
+    );
+    final Schema actualSchema = TypeUtil.assignIncreasingFreshIds(schema);
+    Assert.assertEquals(sourceSchema.asStruct(), actualSchema.asStruct());
+    Assert.assertEquals(sourceSchema.identifierFieldIds(), actualSchema.identifierFieldIds());
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void testReassignIdsIllegalArgumentException() {
     Schema schema = new Schema(

--- a/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
@@ -60,7 +60,8 @@ public class TestTypeUtil {
     );
     final Schema actualSchema = TypeUtil.reassignIds(schema, sourceSchema);
     Assert.assertEquals(sourceSchema.asStruct(), actualSchema.asStruct());
-    Assert.assertEquals(sourceSchema.identifierFieldIds(), actualSchema.identifierFieldIds());
+    Assert.assertEquals("identifier field ID should change based on source schema",
+        sourceSchema.identifierFieldIds(), actualSchema.identifierFieldIds());
   }
 
   @Test
@@ -71,15 +72,35 @@ public class TestTypeUtil {
             required(11, "A", Types.IntegerType.get())),
         Sets.newHashSet(10)
     );
-    Schema sourceSchema = new Schema(
+    Schema expectedSchema = new Schema(
         Lists.newArrayList(
             required(1, "a", Types.IntegerType.get()),
             required(2, "A", Types.IntegerType.get())),
         Sets.newHashSet(1)
     );
     final Schema actualSchema = TypeUtil.assignIncreasingFreshIds(schema);
+    Assert.assertEquals(expectedSchema.asStruct(), actualSchema.asStruct());
+    Assert.assertEquals("identifier field ID should change based on source schema",
+        expectedSchema.identifierFieldIds(), actualSchema.identifierFieldIds());
+  }
+
+  @Test
+  public void testAssignIncreasingFreshIdNewIdentifier() {
+    Schema schema = new Schema(
+        Lists.newArrayList(
+            required(10, "a", Types.IntegerType.get()),
+            required(11, "A", Types.IntegerType.get())),
+        Sets.newHashSet(10)
+    );
+    Schema sourceSchema = new Schema(
+        Lists.newArrayList(
+            required(1, "a", Types.IntegerType.get()),
+            required(2, "A", Types.IntegerType.get()))
+    );
+    final Schema actualSchema = TypeUtil.reassignIds(schema, sourceSchema);
     Assert.assertEquals(sourceSchema.asStruct(), actualSchema.asStruct());
-    Assert.assertEquals(sourceSchema.identifierFieldIds(), actualSchema.identifierFieldIds());
+    Assert.assertEquals("source schema missing identifier should not impact refreshing new identifier",
+        Sets.newHashSet(sourceSchema.findField("a").fieldId()), actualSchema.identifierFieldIds());
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.iceberg.mapping.MappingUtil;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.mapping.NameMappingParser;
@@ -85,9 +84,7 @@ class SchemaUpdate implements UpdateSchema {
     this.schema = schema;
     this.lastColumnId = lastColumnId;
     this.idToParent = Maps.newHashMap(TypeUtil.indexParents(schema.asStruct()));
-    this.identifierFieldNames = schema.identifierFieldIds().stream()
-        .map(id -> schema.findField(id).name())
-        .collect(Collectors.toSet());
+    this.identifierFieldNames = schema.identifierFieldNames();
   }
 
   @Override

--- a/core/src/test/java/org/apache/iceberg/TestCreateTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestCreateTransaction.java
@@ -22,14 +22,18 @@ package org.apache.iceberg;
 import java.io.File;
 import java.io.IOException;
 import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import static org.apache.iceberg.PartitionSpec.unpartitioned;
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
 
 @RunWith(Parameterized.class)
 public class TestCreateTransaction extends TableTestBase {
@@ -65,6 +69,48 @@ public class TestCreateTransaction extends TableTestBase {
 
     Assert.assertEquals("Table schema should match with reassigned IDs",
         TypeUtil.assignIncreasingFreshIds(SCHEMA).asStruct(), meta.schema().asStruct());
+    Assert.assertEquals("Table spec should match", unpartitioned(), meta.spec());
+    Assert.assertEquals("Table should not have any snapshots", 0, meta.snapshots().size());
+  }
+
+  @Test
+  public void testCreateTransactionAndUpdateSchema() throws IOException {
+    File tableDir = temp.newFolder();
+    Assert.assertTrue(tableDir.delete());
+
+    Transaction txn = TestTables.beginCreate(tableDir, "test_create", SCHEMA, unpartitioned());
+
+    Assert.assertNull("Starting a create transaction should not commit metadata",
+        TestTables.readMetadata("test_create"));
+    Assert.assertNull("Should have no metadata version",
+        TestTables.metadataVersion("test_create"));
+
+    txn.updateSchema()
+        .addColumn("col", Types.StringType.get())
+        .setIdentifierFields("id", "col")
+        .commit();
+
+    txn.commitTransaction();
+
+    TableMetadata meta = TestTables.readMetadata("test_create");
+    Assert.assertNotNull("Table metadata should be created after transaction commits", meta);
+    Assert.assertEquals("Should have metadata version 0",
+        0, (int) TestTables.metadataVersion("test_create"));
+    Assert.assertEquals("Should have 0 manifest files",
+        0, listManifestFiles(tableDir).size());
+
+    Schema resultSchema = new Schema(
+        Lists.newArrayList(
+            required(1, "id", Types.IntegerType.get()),
+            required(2, "data", Types.StringType.get()),
+            optional(3, "col", Types.StringType.get())),
+        Sets.newHashSet(1, 3)
+    );
+
+    Assert.assertEquals("Table schema should match with reassigned IDs",
+        resultSchema.asStruct(), meta.schema().asStruct());
+    Assert.assertEquals("Table schema identifier should match",
+        resultSchema.identifierFieldIds(), meta.schema().identifierFieldIds());
     Assert.assertEquals("Table spec should match", unpartitioned(), meta.spec());
     Assert.assertEquals("Table should not have any snapshots", 0, meta.snapshots().size());
   }


### PR DESCRIPTION
fixes #2528 

Allow callers of the schema constructor to take in identifier information and refresh the identifier field IDs if necessary.

This mostly applies to schema update related code paths. The following 2 cases will continue to use the existing constructor without identifier:

1. callers that are coverting from a file format schema or an engine schema except Flink, because they do not have a primary key-like concept.
    1. I assume @openinx will do all necessary changes in Flink through #2410. 
    2. I will do another PR for Spark with SQL extension added.
2. callers that are converting schema for query transformation purpose such as `select`, `join`, file projection, etc., because identifier is not well-defined for those transformed schemas.