### PR TITLE
Parquet: Support filter operations on int96 timestamps

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/DateTimeUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/DateTimeUtil.java
@@ -19,6 +19,8 @@
 
 package org.apache.iceberg.util;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -26,8 +28,11 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
+import java.util.concurrent.TimeUnit;
 
 public class DateTimeUtil {
+  public static final long UNIX_EPOCH_JULIAN = 2_440_588L;
+
   private DateTimeUtil() {
   }
 
@@ -72,5 +77,16 @@ public class DateTimeUtil {
 
   public static long microsFromTimestamptz(OffsetDateTime dateTime) {
     return ChronoUnit.MICROS.between(EPOCH, dateTime);
+  }
+
+  public static Instant instantFromInt96(ByteBuffer bytes) {
+    final ByteBuffer byteBuffer = bytes.order(ByteOrder.LITTLE_ENDIAN);
+
+    final long timeOfDayNanos = byteBuffer.getLong();
+    final int julianDay = byteBuffer.getInt();
+
+    return Instant
+        .ofEpochMilli(TimeUnit.DAYS.toMillis(julianDay - UNIX_EPOCH_JULIAN))
+        .plusNanos(timeOfDayNanos);
   }
 }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
@@ -66,7 +66,7 @@ public class ParquetDictionaryRowGroupFilter {
   /**
    * Test whether the dictionaries for a row group may contain records that match the expression.
    *
-   * @param fileSchema schema for the Parquet file
+   * @param fileSchema   schema for the Parquet file
    * @param dictionaries a dictionary page read store
    * @return false if the file cannot contain rows that match the expression, true otherwise.
    */
@@ -408,15 +408,21 @@ public class ParquetDictionaryRowGroupFilter {
         switch (col.getPrimitiveType().getPrimitiveTypeName()) {
           case FIXED_LEN_BYTE_ARRAY: dictSet.add((T) conversion.apply(dict.decodeToBinary(i)));
             break;
-          case BINARY: dictSet.add((T) conversion.apply(dict.decodeToBinary(i)));
+          case BINARY:
+          case INT96:
+            dictSet.add((T) conversion.apply(dict.decodeToBinary(i)));
             break;
-          case INT32: dictSet.add((T) conversion.apply(dict.decodeToInt(i)));
+          case INT32:
+            dictSet.add((T) conversion.apply(dict.decodeToInt(i)));
             break;
-          case INT64: dictSet.add((T) conversion.apply(dict.decodeToLong(i)));
+          case INT64:
+            dictSet.add((T) conversion.apply(dict.decodeToLong(i)));
             break;
-          case FLOAT: dictSet.add((T) conversion.apply(dict.decodeToFloat(i)));
+          case FLOAT:
+            dictSet.add((T) conversion.apply(dict.decodeToFloat(i)));
             break;
-          case DOUBLE: dictSet.add((T) conversion.apply(dict.decodeToDouble(i)));
+          case DOUBLE:
+            dictSet.add((T) conversion.apply(dict.decodeToDouble(i)));
             break;
           default:
             throw new IllegalArgumentException(
@@ -433,5 +439,4 @@ public class ParquetDictionaryRowGroupFilter {
   private static boolean mayContainNull(ColumnChunkMetaData meta) {
     return meta.getStatistics() == null || meta.getStatistics().getNumNulls() != 0;
   }
-
 }


### PR DESCRIPTION
Support filter operations on parquet int96 timestamps. Also:

* Extract int96 to instant conversion into DateTimeUtil
* Several code style fixes (sorry, couldn't get intellij to not apply
  them)

Fixes #2553