### PR TITLE
Hive: unify catalog experience across engines

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -45,6 +45,16 @@ import static org.apache.iceberg.TableProperties.GC_ENABLED_DEFAULT;
 
 public class CatalogUtil {
   private static final Logger LOG = LoggerFactory.getLogger(CatalogUtil.class);
+
+  /**
+   * Shortcut catalog property to load a catalog implementation through a short type name,
+   * instead of specifying a full java class through {@link CatalogProperties#CATALOG_IMPL}.
+   * Currently the following type to implementation mappings are supported:
+   * <ul>
+   *   <li>hive: org.apache.iceberg.hive.HiveCatalog</li>
+   *   <li>hadoop: org.apache.iceberg.hadoop.HadoopCatalog</li>
+   * </ul>
+   */
   public static final String ICEBERG_CATALOG_TYPE = "type";
   public static final String ICEBERG_CATALOG_TYPE_HADOOP = "hadoop";
   public static final String ICEBERG_CATALOG_TYPE_HIVE = "hive";
@@ -184,10 +194,22 @@ public class CatalogUtil {
     return catalog;
   }
 
+  /**
+   * Build an Iceberg {@link Catalog} based on a map of catalog properties and optional Hadoop configuration.
+   * <p>
+   * This method examines both the {@link #ICEBERG_CATALOG_TYPE} and {@link CatalogProperties#CATALOG_IMPL} properties
+   * to determine the catalog implementation to load.
+   * If nothing is specified for both properties, Hive catalog will be loaded by default.
+   *
+   * @param name catalog name
+   * @param options catalog properties
+   * @param conf Hadoop configuration
+   * @return initialized catalog
+   */
   public static Catalog buildIcebergCatalog(String name, Map<String, String> options, Configuration conf) {
     String catalogImpl = options.get(CatalogProperties.CATALOG_IMPL);
     if (catalogImpl == null) {
-      String catalogType = options.getOrDefault(ICEBERG_CATALOG_TYPE, ICEBERG_CATALOG_TYPE_HIVE);
+      String catalogType = PropertyUtil.propertyAsString(options, ICEBERG_CATALOG_TYPE, ICEBERG_CATALOG_TYPE_HIVE);
       switch (catalogType.toLowerCase(Locale.ENGLISH)) {
         case ICEBERG_CATALOG_TYPE_HIVE:
           catalogImpl = ICEBERG_CATALOG_HIVE;

--- a/mr/src/main/java/org/apache/iceberg/mr/Catalogs.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/Catalogs.java
@@ -44,7 +44,28 @@ import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 /**
  * Class for catalog resolution and accessing the common functions for {@link Catalog} API.
  * <p>
- * See {@link Catalogs#getCatalogType(Configuration, String)} for catalog type resolution strategy.
+ * If the catalog name is provided, get the catalog type from
+ * {@link InputFormatConfig#catalogTypeConfigKey(String) iceberg.catalog.<code>catalogName</code>.type} config.
+ * <p>
+ * In case the catalog name is {@link #ICEBERG_HADOOP_TABLE_NAME location_based_table},
+ * type is ignored and tables will be loaded using {@link HadoopTables}.
+ * <p>
+ * In case the value of catalog type is null,
+ * {@link InputFormatConfig#catalogClassConfigKey(String) iceberg.catalog.<code>catalogName</code>.catalog-impl} config
+ * is used to determine the catalog implementation class.
+ * <p>
+ * If catalog name is null, get the catalog type from {@link InputFormatConfig#CATALOG iceberg.mr.catalog} config:
+ * <ul>
+ *   <li>hive: HiveCatalog</li>
+ *   <li>location: HadoopTables</li>
+ *   <li>hadoop: HadoopCatalog</li>
+ * </ul>
+ * <p>
+ * In case the value of catalog type is null,
+ * {@link InputFormatConfig#CATALOG_LOADER_CLASS iceberg.mr.catalog.loader.class} is used to determine
+ * the catalog implementation class.
+ * <p>
+ * Note: null catalog name mode is only supported for backwards compatibility. Using it is NOT RECOMMENDED.
  */
 public final class Catalogs {
 
@@ -247,20 +268,8 @@ public final class Catalogs {
   /**
    * Return the catalog type based on the catalog name.
    * <p>
-   * If the catalog name is provided get the catalog type from 'iceberg.catalog.<code>catalogName</code>.type' config.
-   * In case the value of this property is null, null is returned as the catalog type,
-   * and the catalog loader will instead use the 'iceberg.catalog.<code>catalogName</code>.catalog-impl' config
-   * to determine the catalog implementation.
-   * </p>
-   * <p>
-   * If catalog name is null, check the global conf for 'iceberg.mr.catalog' property. If the value of the property is:
-   * <ul>
-   *     <li>null/hive -> Hive Catalog</li>
-   *     <li>location -> Hadoop Table</li>
-   *     <li>hadoop -> Hadoop Catalog</li>
-   *     <li>any other value -> Custom Catalog</li>
-   * </ul>
-   * </p>
+   * See {@link Catalogs} documentation for catalog type resolution strategy.
+   *
    * @param conf global hive configuration
    * @param catalogName name of the catalog
    * @return type of the catalog, can be null

--- a/mr/src/main/java/org/apache/iceberg/mr/Catalogs.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/Catalogs.java
@@ -44,14 +44,12 @@ import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 /**
  * Class for catalog resolution and accessing the common functions for {@link Catalog} API.
  * <p>
- * If the catalog name is provided, get the catalog type from
- * {@link InputFormatConfig#catalogTypeConfigKey(String) iceberg.catalog.<code>catalogName</code>.type} config.
+ * If the catalog name is provided, get the catalog type from iceberg.catalog.<code>catalogName</code>.type config.
  * <p>
  * In case the catalog name is {@link #ICEBERG_HADOOP_TABLE_NAME location_based_table},
  * type is ignored and tables will be loaded using {@link HadoopTables}.
  * <p>
- * In case the value of catalog type is null,
- * {@link InputFormatConfig#catalogClassConfigKey(String) iceberg.catalog.<code>catalogName</code>.catalog-impl} config
+ * In case the value of catalog type is null, iceberg.catalog.<code>catalogName</code>.catalog-impl config
  * is used to determine the catalog implementation class.
  * <p>
  * If catalog name is null, get the catalog type from {@link InputFormatConfig#CATALOG iceberg.mr.catalog} config:
@@ -65,20 +63,16 @@ import org.apache.iceberg.relocated.com.google.common.collect.Streams;
  * {@link InputFormatConfig#CATALOG_LOADER_CLASS iceberg.mr.catalog.loader.class} is used to determine
  * the catalog implementation class.
  * <p>
- * Note: null catalog name mode is only supported for backwards compatibility. Using it is NOT RECOMMENDED.
+ * Note: null catalog name mode is only supported for backwards compatibility. Using this mode is NOT RECOMMENDED.
  */
 public final class Catalogs {
 
   public static final String ICEBERG_DEFAULT_CATALOG_NAME = "default_iceberg";
   public static final String ICEBERG_HADOOP_TABLE_NAME = "location_based_table";
-
-  private static final String HIVE_CATALOG_TYPE = "hive";
-  private static final String HADOOP_CATALOG_TYPE = "hadoop";
-  private static final String NO_CATALOG_TYPE = "no catalog";
-
   public static final String NAME = "name";
   public static final String LOCATION = "location";
 
+  private static final String NO_CATALOG_TYPE = "no catalog";
   private static final Set<String> PROPERTIES_TO_REMOVE =
       ImmutableSet.of(InputFormatConfig.TABLE_SCHEMA, InputFormatConfig.PARTITION_SPEC, LOCATION, NAME,
               InputFormatConfig.CATALOG_NAME);
@@ -286,7 +280,7 @@ public final class Catalogs {
     } else {
       String catalogType = conf.get(InputFormatConfig.CATALOG);
       if (catalogType == null) {
-        return HIVE_CATALOG_TYPE;
+        return CatalogUtil.ICEBERG_CATALOG_TYPE_HIVE;
       } else if (catalogType.equals(LOCATION)) {
         return NO_CATALOG_TYPE;
       } else {

--- a/mr/src/main/java/org/apache/iceberg/mr/Catalogs.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/Catalogs.java
@@ -276,7 +276,8 @@ public final class Catalogs {
    */
   private static String getCatalogType(Configuration conf, String catalogName) {
     if (catalogName != null) {
-      String catalogType = conf.get(InputFormatConfig.catalogTypeConfigKey(catalogName));
+      String catalogType = conf.get(InputFormatConfig.catalogPropertyConfigKey(
+          catalogName, CatalogUtil.ICEBERG_CATALOG_TYPE));
       if (catalogName.equals(ICEBERG_HADOOP_TABLE_NAME)) {
         return NO_CATALOG_TYPE;
       } else {

--- a/mr/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
@@ -21,8 +21,6 @@ package org.apache.iceberg.mr;
 
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.iceberg.CatalogProperties;
-import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -53,19 +51,24 @@ public class InputFormatConfig {
   public static final String LOCALITY = "iceberg.mr.locality";
 
   /**
-   * @deprecated please use {@link #catalogTypeConfigKey(String)} to specify the type of a catalog.
+   * @deprecated please use {@link #catalogPropertyConfigKey(String, String)}
+   * with config key {@link org.apache.iceberg.CatalogUtil#ICEBERG_CATALOG_TYPE} to specify the type of a catalog.
    */
   @Deprecated
   public static final String CATALOG = "iceberg.mr.catalog";
 
   /**
-   * @deprecated please use {@link #catalogWarehouseConfigKey(String)} to specify the warehouse location.
+   * @deprecated please use {@link #catalogPropertyConfigKey(String, String)}
+   * with config key {@link org.apache.iceberg.CatalogProperties#WAREHOUSE_LOCATION}
+   * to specify the warehouse location of a catalog.
    */
   @Deprecated
   public static final String HADOOP_CATALOG_WAREHOUSE_LOCATION = "iceberg.mr.catalog.hadoop.warehouse.location";
 
   /**
-   * @deprecated please use {@link #catalogClassConfigKey(String)} to set catalog implementation.
+   * @deprecated please use {@link #catalogPropertyConfigKey(String, String)}
+   * with config key {@link org.apache.iceberg.CatalogProperties#CATALOG_IMPL}
+   * to specify the implementation of a catalog.
    */
   @Deprecated
   public static final String CATALOG_LOADER_CLASS = "iceberg.mr.catalog.loader.class";
@@ -219,38 +222,11 @@ public class InputFormatConfig {
   }
 
   /**
-   * Shortcut for {@link #catalogPropertyConfigKey(String, String)} with config {@link CatalogUtil#ICEBERG_CATALOG_TYPE}
-   * @param catalogName catalog name
-   * @return Hadoop config key of catalog type for the catalog name
-   */
-  public static String catalogTypeConfigKey(String catalogName) {
-    return catalogPropertyConfigKey(catalogName, CatalogUtil.ICEBERG_CATALOG_TYPE);
-  }
-
-  /**
-   * Shortcut for {@link #catalogPropertyConfigKey(String, String)}
-   * with config {@link CatalogProperties#WAREHOUSE_LOCATION}
-   * @param catalogName catalog name
-   * @return Hadoop config key of catalog warehouse location for the catalog name
-   */
-  public static String catalogWarehouseConfigKey(String catalogName) {
-    return catalogPropertyConfigKey(catalogName, CatalogProperties.WAREHOUSE_LOCATION);
-  }
-
-  /**
-   * Shortcut for {@link #catalogPropertyConfigKey(String, String)} with config {@link CatalogProperties#CATALOG_IMPL}
-   * @param catalogName catalog name
-   * @return Hadoop config key of catalog class for the catalog name
-   */
-  public static String catalogClassConfigKey(String catalogName) {
-    return catalogPropertyConfigKey(catalogName, CatalogProperties.CATALOG_IMPL);
-  }
-
-  /**
    * Get Hadoop config key of a catalog property based on catalog name
    * @param catalogName catalog name
    * @param catalogProperty catalog property, can be any custom property,
-   *                        a commonly used list of properties can be found at {@link CatalogProperties}
+   *                        a commonly used list of properties can be found
+   *                        at {@link org.apache.iceberg.CatalogProperties}
    * @return Hadoop config key of a catalog property for the catalog name
    */
   public static String catalogPropertyConfigKey(String catalogName, String catalogProperty) {

--- a/mr/src/test/java/org/apache/iceberg/mr/TestCatalogs.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestCatalogs.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.Properties;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
@@ -247,7 +248,8 @@ public class TestCatalogs {
   @Test
   public void testLoadCatalogHive() {
     String catalogName = "barCatalog";
-    conf.set(InputFormatConfig.catalogTypeConfigKey(catalogName), CatalogUtil.ICEBERG_CATALOG_TYPE_HIVE);
+    conf.set(InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogUtil.ICEBERG_CATALOG_TYPE),
+        CatalogUtil.ICEBERG_CATALOG_TYPE_HIVE);
     Optional<Catalog> hiveCatalog = Catalogs.loadCatalog(conf, catalogName);
     Assert.assertTrue(hiveCatalog.isPresent());
     Assert.assertTrue(hiveCatalog.get() instanceof HiveCatalog);
@@ -256,8 +258,10 @@ public class TestCatalogs {
   @Test
   public void testLoadCatalogHadoop() {
     String catalogName = "barCatalog";
-    conf.set(InputFormatConfig.catalogTypeConfigKey(catalogName), CatalogUtil.ICEBERG_CATALOG_TYPE_HADOOP);
-    conf.set(InputFormatConfig.catalogWarehouseConfigKey(catalogName), "/tmp/mylocation");
+    conf.set(InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogUtil.ICEBERG_CATALOG_TYPE),
+        CatalogUtil.ICEBERG_CATALOG_TYPE_HADOOP);
+    conf.set(InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogProperties.WAREHOUSE_LOCATION),
+        "/tmp/mylocation");
     Optional<Catalog> hadoopCatalog = Catalogs.loadCatalog(conf, catalogName);
     Assert.assertTrue(hadoopCatalog.isPresent());
     Assert.assertTrue(hadoopCatalog.get() instanceof HadoopCatalog);
@@ -267,7 +271,8 @@ public class TestCatalogs {
   @Test
   public void testLoadCatalogHadoopWithLegacyWarehouseLocation() {
     String catalogName = "barCatalog";
-    conf.set(InputFormatConfig.catalogTypeConfigKey(catalogName), CatalogUtil.ICEBERG_CATALOG_TYPE_HADOOP);
+    conf.set(InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogUtil.ICEBERG_CATALOG_TYPE),
+        CatalogUtil.ICEBERG_CATALOG_TYPE_HADOOP);
     conf.set(InputFormatConfig.HADOOP_CATALOG_WAREHOUSE_LOCATION, "/tmp/mylocation");
     Optional<Catalog> hadoopCatalog = Catalogs.loadCatalog(conf, catalogName);
     Assert.assertTrue(hadoopCatalog.isPresent());
@@ -278,8 +283,10 @@ public class TestCatalogs {
   @Test
   public void testLoadCatalogCustom() {
     String catalogName = "barCatalog";
-    conf.set(InputFormatConfig.catalogClassConfigKey(catalogName), CustomHadoopCatalog.class.getName());
-    conf.set(InputFormatConfig.catalogWarehouseConfigKey(catalogName), "/tmp/mylocation");
+    conf.set(InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogProperties.CATALOG_IMPL),
+        CustomHadoopCatalog.class.getName());
+    conf.set(InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogProperties.WAREHOUSE_LOCATION),
+        "/tmp/mylocation");
     Optional<Catalog> customHadoopCatalog = Catalogs.loadCatalog(conf, catalogName);
     Assert.assertTrue(customHadoopCatalog.isPresent());
     Assert.assertTrue(customHadoopCatalog.get() instanceof CustomHadoopCatalog);
@@ -293,7 +300,7 @@ public class TestCatalogs {
   @Test
   public void testLoadCatalogUnknown() {
     String catalogName = "barCatalog";
-    conf.set(InputFormatConfig.catalogTypeConfigKey(catalogName), "fooType");
+    conf.set(InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogUtil.ICEBERG_CATALOG_TYPE), "fooType");
     AssertHelpers.assertThrows(
         "should complain about catalog not supported", UnsupportedOperationException.class,
         "Unknown catalog type:", () -> Catalogs.loadCatalog(conf, catalogName));
@@ -312,8 +319,10 @@ public class TestCatalogs {
   }
 
   private void setCustomCatalogProperties(String catalogName, String warehouseLocation) {
-    conf.set(InputFormatConfig.catalogWarehouseConfigKey(catalogName), warehouseLocation);
-    conf.set(InputFormatConfig.catalogClassConfigKey(catalogName), CustomHadoopCatalog.class.getName());
+    conf.set(InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogProperties.WAREHOUSE_LOCATION),
+        warehouseLocation);
+    conf.set(InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogProperties.CATALOG_IMPL),
+        CustomHadoopCatalog.class.getName());
     conf.set(InputFormatConfig.CATALOG_NAME, catalogName);
   }
 }

--- a/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
@@ -351,10 +351,9 @@ public class TestIcebergInputFormats {
     String warehouseLocation = temp.newFolder("hadoop_catalog").getAbsolutePath();
     conf.set("warehouse.location", warehouseLocation);
     conf.set(InputFormatConfig.CATALOG_NAME, Catalogs.ICEBERG_DEFAULT_CATALOG_NAME);
-    conf.set(String.format(InputFormatConfig.CATALOG_TYPE_TEMPLATE, Catalogs.ICEBERG_DEFAULT_CATALOG_NAME),
+    conf.set(InputFormatConfig.catalogTypeConfigKey(Catalogs.ICEBERG_DEFAULT_CATALOG_NAME),
             CatalogUtil.ICEBERG_CATALOG_TYPE_HADOOP);
-    conf.set(String.format(InputFormatConfig.CATALOG_WAREHOUSE_TEMPLATE, Catalogs.ICEBERG_DEFAULT_CATALOG_NAME),
-            warehouseLocation);
+    conf.set(InputFormatConfig.catalogWarehouseConfigKey(Catalogs.ICEBERG_DEFAULT_CATALOG_NAME), warehouseLocation);
 
     Catalog catalog = new HadoopCatalog(conf, conf.get("warehouse.location"));
     TableIdentifier identifier = TableIdentifier.of("db", "t");

--- a/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
@@ -351,9 +352,10 @@ public class TestIcebergInputFormats {
     String warehouseLocation = temp.newFolder("hadoop_catalog").getAbsolutePath();
     conf.set("warehouse.location", warehouseLocation);
     conf.set(InputFormatConfig.CATALOG_NAME, Catalogs.ICEBERG_DEFAULT_CATALOG_NAME);
-    conf.set(InputFormatConfig.catalogTypeConfigKey(Catalogs.ICEBERG_DEFAULT_CATALOG_NAME),
-            CatalogUtil.ICEBERG_CATALOG_TYPE_HADOOP);
-    conf.set(InputFormatConfig.catalogWarehouseConfigKey(Catalogs.ICEBERG_DEFAULT_CATALOG_NAME), warehouseLocation);
+    conf.set(InputFormatConfig.catalogPropertyConfigKey(Catalogs.ICEBERG_DEFAULT_CATALOG_NAME,
+        CatalogUtil.ICEBERG_CATALOG_TYPE), CatalogUtil.ICEBERG_CATALOG_TYPE_HADOOP);
+    conf.set(InputFormatConfig.catalogPropertyConfigKey(Catalogs.ICEBERG_DEFAULT_CATALOG_NAME,
+        CatalogProperties.WAREHOUSE_LOCATION), warehouseLocation);
 
     Catalog catalog = new HadoopCatalog(conf, conf.get("warehouse.location"));
     TableIdentifier identifier = TableIdentifier.of("db", "t");

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerLocalScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerLocalScan.java
@@ -37,7 +37,6 @@ import org.apache.iceberg.TestHelpers.Row;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
-import org.apache.iceberg.mr.Catalogs;
 import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.iceberg.mr.TestHelper;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerLocalScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerLocalScan.java
@@ -290,7 +290,7 @@ public class TestHiveIcebergStorageHandlerLocalScan {
         "TBLPROPERTIES ('" + InputFormatConfig.PARTITION_SPEC + "'='" + PartitionSpecParser.toJson(spec) + "', " +
         "'" + InputFormatConfig.TABLE_SCHEMA + "'='" +
         SchemaParser.toJson(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA) + "', "  +
-        "'" + InputFormatConfig.CATALOG_NAME + "'='" + Catalogs.ICEBERG_DEFAULT_CATALOG_NAME + "')";
+        "'" + InputFormatConfig.CATALOG_NAME + "'='" + testTables.catalogName() + "')";
     runCreateAndReadTest(identifier, createSql, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, data);
   }
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -546,7 +546,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
         InputFormatConfig.TABLE_SCHEMA, SchemaParser.toJson(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA),
         InputFormatConfig.PARTITION_SPEC, PartitionSpecParser.toJson(SPEC),
         "custom_property", "initial_val",
-        InputFormatConfig.CATALOG_NAME, Catalogs.ICEBERG_DEFAULT_CATALOG_NAME));
+        InputFormatConfig.CATALOG_NAME, testTables.catalogName()));
 
 
     // Check the Iceberg table parameters

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -166,7 +166,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
         "'" + InputFormatConfig.PARTITION_SPEC + "'='" +
         PartitionSpecParser.toJson(PartitionSpec.unpartitioned()) + "', " +
         "'dummy'='test', " +
-        "'" + InputFormatConfig.CATALOG_NAME + "'='" + Catalogs.ICEBERG_DEFAULT_CATALOG_NAME + "')");
+        "'" + InputFormatConfig.CATALOG_NAME + "'='" + testTables.catalogName() + "')");
 
     // Check the Iceberg table data
     org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);
@@ -248,7 +248,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
         testTables.locationForCreateTableSQL(identifier) +
         "TBLPROPERTIES ('" + InputFormatConfig.TABLE_SCHEMA + "'='" +
         SchemaParser.toJson(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA) + "','" +
-        InputFormatConfig.CATALOG_NAME + "'='" + Catalogs.ICEBERG_DEFAULT_CATALOG_NAME + "')");
+        InputFormatConfig.CATALOG_NAME + "'='" + testTables.catalogName() + "')");
 
     // Check the Iceberg table partition data
     org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);
@@ -266,7 +266,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
         SchemaParser.toJson(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA) + "', " +
         "'" + InputFormatConfig.PARTITION_SPEC + "'='" +
         PartitionSpecParser.toJson(PartitionSpec.unpartitioned()) + "', " +
-        "'" + InputFormatConfig.CATALOG_NAME + "'='" + Catalogs.ICEBERG_DEFAULT_CATALOG_NAME + "')");
+        "'" + InputFormatConfig.CATALOG_NAME + "'='" + testTables.catalogName() + "')");
 
     // Check the Iceberg table partition data
     org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);
@@ -283,7 +283,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
         "TBLPROPERTIES ('" + InputFormatConfig.TABLE_SCHEMA + "'='" +
         SchemaParser.toJson(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA) + "', " +
         "'" + InputFormatConfig.EXTERNAL_TABLE_PURGE + "'='FALSE', " +
-        "'" + InputFormatConfig.CATALOG_NAME + "'='" + Catalogs.ICEBERG_DEFAULT_CATALOG_NAME + "')");
+        "'" + InputFormatConfig.CATALOG_NAME + "'='" + testTables.catalogName() + "')");
 
     org.apache.hadoop.hive.metastore.api.Table hmsTable = shell.metastore().getTable("default", "customers");
     Properties tableProperties = new Properties();
@@ -327,7 +327,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
               "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
               testTables.locationForCreateTableSQL(identifier) +
               "TBLPROPERTIES ('" + InputFormatConfig.TABLE_SCHEMA + "'='WrongSchema'" +
-              ",'" + InputFormatConfig.CATALOG_NAME + "'='" + Catalogs.ICEBERG_DEFAULT_CATALOG_NAME + "')");
+              ",'" + InputFormatConfig.CATALOG_NAME + "'='" + testTables.catalogName() + "')");
         }
     );
 
@@ -349,7 +349,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
                 "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
                 "TBLPROPERTIES ('" + InputFormatConfig.TABLE_SCHEMA + "'='" +
                 SchemaParser.toJson(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA) + "','" +
-                InputFormatConfig.CATALOG_NAME + "'='" + Catalogs.ICEBERG_DEFAULT_CATALOG_NAME + "')");
+                InputFormatConfig.CATALOG_NAME + "'='" + testTables.catalogName() + "')");
           }
       );
     }
@@ -369,7 +369,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
                 "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
                 "TBLPROPERTIES ('" + InputFormatConfig.TABLE_SCHEMA + "'='" +
                 SchemaParser.toJson(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA) + "',' " +
-                InputFormatConfig.CATALOG_NAME + "'='" + Catalogs.ICEBERG_DEFAULT_CATALOG_NAME + "')");
+                InputFormatConfig.CATALOG_NAME + "'='" + testTables.catalogName() + "')");
           }
       );
     } else {

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithMultipleCatalogs.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithMultipleCatalogs.java
@@ -27,7 +27,6 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.Record;
-import org.apache.iceberg.mr.Catalogs;
 import org.apache.iceberg.mr.InputFormatConfig;
 import org.junit.After;
 import org.junit.AfterClass;

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithMultipleCatalogs.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithMultipleCatalogs.java
@@ -116,9 +116,9 @@ public class TestHiveIcebergStorageHandlerWithMultipleCatalogs {
 
   @Test
   public void testJoinTablesFromDifferentCatalogs() throws IOException {
-    createAndAddRecords(testTables1, fileFormat1, TableIdentifier.of("default", "customers1"), table1CatalogName,
+    createAndAddRecords(testTables1, fileFormat1, TableIdentifier.of("default", "customers1"),
         HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-    createAndAddRecords(testTables2, fileFormat2, TableIdentifier.of("default", "customers2"), table2CatalogName,
+    createAndAddRecords(testTables2, fileFormat2, TableIdentifier.of("default", "customers2"),
         HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
 
     List<Object[]> rows = shell.executeStatement("SELECT c2.customer_id, c2.first_name, c2.last_name " +
@@ -130,14 +130,12 @@ public class TestHiveIcebergStorageHandlerWithMultipleCatalogs {
   }
 
   private void createAndAddRecords(TestTables testTables, FileFormat fileFormat, TableIdentifier identifier,
-                                   String catalogName, List<Record> records) throws IOException {
-    String catalogNamePropertyValue = testTables instanceof TestTables.HadoopTestTables ?
-        Catalogs.ICEBERG_HADOOP_TABLE_NAME : catalogName;
+                                   List<Record> records) throws IOException {
     String createSql =
         "CREATE EXTERNAL TABLE " + identifier + " (customer_id BIGINT, first_name STRING, last_name STRING)" +
             " STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
             testTables.locationForCreateTableSQL(identifier) +
-            " TBLPROPERTIES ('" + InputFormatConfig.CATALOG_NAME + "'='" + catalogNamePropertyValue + "')";
+            " TBLPROPERTIES ('" + InputFormatConfig.CATALOG_NAME + "'='" + testTables.catalogName() + "')";
     shell.executeStatement(createSql);
     Table icebergTable = testTables.loadTable(identifier);
     testTables.appendIcebergTable(shell.getHiveConf(), icebergTable, fileFormat, null, records);

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithMultipleCatalogs.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithMultipleCatalogs.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.mr.Catalogs;
 import org.apache.iceberg.mr.InputFormatConfig;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -130,11 +131,13 @@ public class TestHiveIcebergStorageHandlerWithMultipleCatalogs {
 
   private void createAndAddRecords(TestTables testTables, FileFormat fileFormat, TableIdentifier identifier,
                                    String catalogName, List<Record> records) throws IOException {
+    String catalogNamePropertyValue = testTables instanceof TestTables.HadoopTestTables ?
+        Catalogs.ICEBERG_HADOOP_TABLE_NAME : catalogName;
     String createSql =
         "CREATE EXTERNAL TABLE " + identifier + " (customer_id BIGINT, first_name STRING, last_name STRING)" +
             " STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
             testTables.locationForCreateTableSQL(identifier) +
-            " TBLPROPERTIES ('" + InputFormatConfig.CATALOG_NAME + "'='" + catalogName + "')";
+            " TBLPROPERTIES ('" + InputFormatConfig.CATALOG_NAME + "'='" + catalogNamePropertyValue + "')";
     shell.executeStatement(createSql);
     Table icebergTable = testTables.loadTable(identifier);
     testTables.appendIcebergTable(shell.getHiveConf(), icebergTable, fileFormat, null, records);

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
@@ -99,6 +99,10 @@ abstract class TestTables {
     return tables;
   }
 
+  public String catalogName() {
+    return catalog;
+  }
+
   /**
    * The location string needed to be provided for CREATE TABLE ... commands,
    * like "LOCATION 'file:///tmp/warehouse/default/tablename'. Empty ("") if LOCATION is not needed.
@@ -193,7 +197,7 @@ abstract class TestTables {
         "'" + InputFormatConfig.PARTITION_SPEC + "'='" +
         PartitionSpecParser.toJson(spec) + "', " +
         "'" + TableProperties.DEFAULT_FILE_FORMAT + "'='" + fileFormat + "', " +
-        "'" + InputFormatConfig.CATALOG_NAME + "'='" + Catalogs.ICEBERG_DEFAULT_CATALOG_NAME + "')");
+        "'" + InputFormatConfig.CATALOG_NAME + "'='" + catalogName() + "')");
 
     if (records != null && !records.isEmpty()) {
       StringBuilder query = new StringBuilder().append("INSERT INTO " + identifier + " VALUES ");

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
@@ -335,9 +336,9 @@ abstract class TestTables {
     @Override
     public Map<String, String> properties() {
       return ImmutableMap.of(
-              InputFormatConfig.catalogClassConfigKey(catalog),
+              InputFormatConfig.catalogPropertyConfigKey(catalog, CatalogProperties.CATALOG_IMPL),
               TestCatalogs.CustomHadoopCatalog.class.getName(),
-              InputFormatConfig.catalogWarehouseConfigKey(catalog),
+              InputFormatConfig.catalogPropertyConfigKey(catalog, CatalogProperties.WAREHOUSE_LOCATION),
               warehouseLocation
       );
     }
@@ -366,8 +367,10 @@ abstract class TestTables {
     @Override
     public Map<String, String> properties() {
       return ImmutableMap.of(
-              InputFormatConfig.catalogTypeConfigKey(catalog), "hadoop",
-              InputFormatConfig.catalogWarehouseConfigKey(catalog), warehouseLocation
+          InputFormatConfig.catalogPropertyConfigKey(catalog, CatalogUtil.ICEBERG_CATALOG_TYPE),
+          CatalogUtil.ICEBERG_CATALOG_TYPE_HADOOP,
+          InputFormatConfig.catalogPropertyConfigKey(catalog, CatalogProperties.WAREHOUSE_LOCATION),
+          warehouseLocation
       );
     }
 
@@ -417,7 +420,8 @@ abstract class TestTables {
 
     @Override
     public Map<String, String> properties() {
-      return ImmutableMap.of(InputFormatConfig.catalogTypeConfigKey(catalog), "hive");
+      return ImmutableMap.of(InputFormatConfig.catalogPropertyConfigKey(catalog, CatalogUtil.ICEBERG_CATALOG_TYPE),
+          CatalogUtil.ICEBERG_CATALOG_TYPE_HIVE);
     }
 
     @Override

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
@@ -331,10 +331,9 @@ abstract class TestTables {
     @Override
     public Map<String, String> properties() {
       return ImmutableMap.of(
-              String.format(InputFormatConfig.CATALOG_TYPE_TEMPLATE, catalog), "custom",
-              String.format(InputFormatConfig.CATALOG_CLASS_TEMPLATE, catalog),
+              InputFormatConfig.catalogClassConfigKey(catalog),
               TestCatalogs.CustomHadoopCatalog.class.getName(),
-              String.format(InputFormatConfig.CATALOG_WAREHOUSE_TEMPLATE, catalog),
+              InputFormatConfig.catalogWarehouseConfigKey(catalog),
               warehouseLocation
       );
     }
@@ -363,8 +362,8 @@ abstract class TestTables {
     @Override
     public Map<String, String> properties() {
       return ImmutableMap.of(
-              String.format(InputFormatConfig.CATALOG_TYPE_TEMPLATE, catalog), "hadoop",
-              String.format(InputFormatConfig.CATALOG_WAREHOUSE_TEMPLATE, catalog), warehouseLocation
+              InputFormatConfig.catalogTypeConfigKey(catalog), "hadoop",
+              InputFormatConfig.catalogWarehouseConfigKey(catalog), warehouseLocation
       );
     }
 
@@ -414,7 +413,7 @@ abstract class TestTables {
 
     @Override
     public Map<String, String> properties() {
-      return ImmutableMap.of(String.format(InputFormatConfig.CATALOG_TYPE_TEMPLATE, catalog), "hive");
+      return ImmutableMap.of(InputFormatConfig.catalogTypeConfigKey(catalog), "hive");
     }
 
     @Override

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
@@ -373,8 +373,8 @@ abstract class TestTables {
   }
 
   static class HadoopTestTables extends TestTables {
-    HadoopTestTables(Configuration conf, TemporaryFolder temp, String catalogName) {
-      super(new HadoopTables(conf), temp, catalogName);
+    HadoopTestTables(Configuration conf, TemporaryFolder temp) {
+      super(new HadoopTables(conf), temp, Catalogs.ICEBERG_HADOOP_TABLE_NAME);
     }
 
     @Override
@@ -448,7 +448,7 @@ abstract class TestTables {
   enum TestTableType {
     HADOOP_TABLE {
       public TestTables instance(Configuration conf, TemporaryFolder temporaryFolder, String catalogName) {
-        return new HadoopTestTables(conf, temporaryFolder, catalogName);
+        return new HadoopTestTables(conf, temporaryFolder);
       }
     },
     HADOOP_CATALOG {

--- a/site/docs/aws.md
+++ b/site/docs/aws.md
@@ -142,7 +142,6 @@ With those dependencies, you can register a Glue catalog and create external tab
 ```sql
 SET iceberg.engine.hive.enabled=true;
 SET hive.vectorized.execution.enabled=false;
-SET iceberg.catalog.glue.type=custom;
 SET iceberg.catalog.glue.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog;
 SET iceberg.catalog.glue.warehouse=s3://my-bucket/my/key/prefix;
 SET iceberg.catalog.glue.lock-impl=org.apache.iceberg.aws.glue.DynamoLockManager;

--- a/site/docs/hive.md
+++ b/site/docs/hive.md
@@ -98,8 +98,8 @@ To globally register different catalogs, set the following Hadoop configurations
 
 | Config Key                                    | Description                                            |
 | --------------------------------------------- | ------------------------------------------------------ |
-| iceberg.catalog.<catalog_name\>.type          | type of catalog: `hive`,`hadoop` or `custom`             |
-| iceberg.catalog.<catalog_name\>.catalog-impl  | catalog implementation, must not be null if type is `custom` |
+| iceberg.catalog.<catalog_name\>.type          | type of catalog: `hive` or `hadoop`                    |
+| iceberg.catalog.<catalog_name\>.catalog-impl  | catalog implementation, must not be null if type is null |
 | iceberg.catalog.<catalog_name\>.<key\>        | any config key and value pairs for the catalog         |
 
 Here are some examples using Hive CLI:
@@ -123,7 +123,6 @@ SET iceberg.catalog.hadoop.warehouse=hdfs://example.com:8020/warehouse;
 Register an AWS `GlueCatalog` called `glue`:
 
 ```
-SET iceberg.catalog.glue.type=custom;
 SET iceberg.catalog.glue.catalog-impl=org.apache.iceberg.aws.GlueCatalog;
 SET iceberg.catalog.glue.warehouse=s3://my-bucket/my/key/prefix;
 SET iceberg.catalog.glue.lock-impl=org.apache.iceberg.aws.glue.DynamoLockManager;


### PR DESCRIPTION
As discussed in #2544, make Hive catalog experience consistent with Spark and Flink, specifically:
1. when `type` is `null`, look at `catalog-impl`, if that is also `null` then use `HiveCatalog` as default.
2. there is also no need to have templates `CATALOG_WAREHOUSE_TEMPLATE` and `CATALOG_CLASS_TEMPLATE`, because they are unified in `CatalogProperties`.

I also rewrote all the tests to make each test case clear in separated tests instead of a single giant test, please take a look if I missed any edge case in testing.

@pvary @marton-bod @lcspinter @aokolnychyi @rdblue 