### PR TITLE
Fix when dropping partition fields for the same source field

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
@@ -290,7 +290,9 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
     ImmutableMap.Builder<Pair<Integer, String>, PartitionField> builder = ImmutableMap.builder();
     List<PartitionField> fields = spec.fields();
     for (PartitionField field : fields) {
-      builder.put(Pair.of(field.sourceId(), field.transform().toString()), field);
+      if (!field.transform().equals(Transforms.alwaysNull())) {
+        builder.put(Pair.of(field.sourceId(), field.transform().toString()), field);
+      }
     }
 
     return builder.build();


### PR DESCRIPTION
For https://github.com/apache/iceberg/issues/2569, fix when dropping partition fields for the same source field more than once
 - skip VoidTransform when indexing specs in BaseUpdatePartitionSpec
 