### PR TITLE
Docs: Fix broken Javadoc link

### DIFF
--- a/site/docs/api.md
+++ b/site/docs/api.md
@@ -25,7 +25,7 @@ Table metadata and operations are accessed through the `Table` interface. This i
 
 ### Table metadata
 
-The [`Table` interface](./javadoc/master/index.html?org/apache/iceberg/Table.html) provides access to the table metadata:
+The [`Table` interface](./javadoc/0.11.1/index.html?org/apache/iceberg/Table.html) provides access to the table metadata:
 
 * `schema` returns the current table [schema](./schemas.md)
 * `spec` returns the current table partition spec
@@ -73,7 +73,7 @@ Use `asOfTime` or `useSnapshot` to configure the table snapshot for time travel 
 
 ### Update operations
 
-`Table` also exposes operations that update the table. These operations use a builder pattern, [`PendingUpdate`](./javadoc/master/index.html?org/apache/iceberg/PendingUpdate.html), that commits when `PendingUpdate#commit` is called.
+`Table` also exposes operations that update the table. These operations use a builder pattern, [`PendingUpdate`](./javadoc/0.11.1/index.html?org/apache/iceberg/PendingUpdate.html), that commits when `PendingUpdate#commit` is called.
 
 For example, updating the table schema is done by calling `updateSchema`, adding updates to the builder, and finally calling `commit` to commit the pending changes to the table:
 
@@ -115,7 +115,7 @@ t.commitTransaction();
 
 ## Types
 
-Iceberg data types are located in the [`org.apache.iceberg.types` package](./javadoc/master/index.html?org/apache/iceberg/types/package-summary.html).
+Iceberg data types are located in the [`org.apache.iceberg.types` package](./javadoc/0.11.1/index.html?org/apache/iceberg/types/package-summary.html).
 
 ### Primitives
 
@@ -157,7 +157,7 @@ ListType list = ListType.ofRequired(1, IntegerType.get());
 
 ## Expressions
 
-Iceberg's expressions are used to configure table scans. To create expressions, use the factory methods in [`Expressions`](./javadoc/master/index.html?org/apache/iceberg/expressions/Expressions.html).
+Iceberg's expressions are used to configure table scans. To create expressions, use the factory methods in [`Expressions`](./javadoc/0.11.1/index.html?org/apache/iceberg/expressions/Expressions.html).
 
 Supported predicate expressions are:
 

--- a/site/docs/flink.md
+++ b/site/docs/flink.md
@@ -357,7 +357,7 @@ stream.print();
 env.execute("Test Iceberg Batch Read");
 ```
 
-There are other options that we could set by Java API, please see the [FlinkSource#Builder](./javadoc/master/org/apache/iceberg/flink/source/FlinkSource.html).
+There are other options that we could set by Java API, please see the [FlinkSource#Builder](./javadoc/0.11.1/org/apache/iceberg/flink/source/FlinkSource.html).
 
 ## Writing with DataStream
 
@@ -421,7 +421,7 @@ RewriteDataFilesActionResult result = Actions.forTable(table)
         .execute();
 ```
 
-For more doc about options of the rewrite files action, please see [RewriteDataFilesAction](./javadoc/master/org/apache/iceberg/flink/actions/RewriteDataFilesAction.html)
+For more doc about options of the rewrite files action, please see [RewriteDataFilesAction](./javadoc/0.11.1/org/apache/iceberg/flink/actions/RewriteDataFilesAction.html)
 
 ## Future improvement.
 

--- a/site/docs/hive.md
+++ b/site/docs/hive.md
@@ -21,7 +21,7 @@
 Iceberg supports the reading of Iceberg tables from [Hive](https://hive.apache.org) by using a [StorageHandler](https://cwiki.apache.org/confluence/display/Hive/StorageHandlers). Please note that only Hive 2.x versions are currently supported.
 
 ### Table creation
-This section explains the various steps needed in order to overlay a Hive table "on top of" an existing Iceberg table. Iceberg tables are created using either a [`Catalog`](./javadoc/master/index.html?org/apache/iceberg/catalog/Catalog.html) or an implementation of the [`Tables`](./javadoc/master/index.html?org/apache/iceberg/Tables.html) interface and Hive needs to be configured accordingly to read data from these different types of table.
+This section explains the various steps needed in order to overlay a Hive table "on top of" an existing Iceberg table. Iceberg tables are created using either a [`Catalog`](./javadoc/0.11.1/index.html?org/apache/iceberg/catalog/Catalog.html) or an implementation of the [`Tables`](./javadoc/0.11.1/index.html?org/apache/iceberg/Tables.html) interface and Hive needs to be configured accordingly to read data from these different types of table.
 
 #### Add the Iceberg Hive Runtime jar file to the Hive classpath
 Regardless of the table type, the `HiveIcebergStorageHandler` and supporting classes need to be made available on Hive's classpath. These are provided by the `iceberg-hive-runtime` jar file. For example, if using the Hive shell, this can be achieved by issuing a statement like so:

--- a/site/docs/java-api-quickstart.md
+++ b/site/docs/java-api-quickstart.md
@@ -19,7 +19,7 @@
 
 ## Create a table
 
-Tables are created using either a [`Catalog`](./javadoc/master/index.html?org/apache/iceberg/catalog/Catalog.html) or an implementation of the [`Tables`](./javadoc/master/index.html?org/apache/iceberg/Tables.html) interface.
+Tables are created using either a [`Catalog`](./javadoc/0.11.1/index.html?org/apache/iceberg/catalog/Catalog.html) or an implementation of the [`Tables`](./javadoc/0.11.1/index.html?org/apache/iceberg/Tables.html) interface.
 
 ### Using a Hive catalog
 

--- a/site/docs/maintenance.md
+++ b/site/docs/maintenance.md
@@ -26,7 +26,7 @@
 
 Each write to an Iceberg table creates a new _snapshot_, or version, of a table. Snapshots can be used for time-travel queries, or the table can be rolled back to any valid snapshot.
 
-Snapshots accumulate until they are expired by the [`expireSnapshots`](./javadoc/master/org/apache/iceberg/Table.html#expireSnapshots--) operation. Regularly expiring snapshots is recommended to delete data files that are no longer needed, and to keep the size of table metadata small.
+Snapshots accumulate until they are expired by the [`expireSnapshots`](./javadoc/0.11.1/org/apache/iceberg/Table.html#expireSnapshots--) operation. Regularly expiring snapshots is recommended to delete data files that are no longer needed, and to keep the size of table metadata small.
 
 This example expires snapshots that are older than 1 day:
 
@@ -38,7 +38,7 @@ table.expireSnapshots()
      .commit();
 ```
 
-See the [`ExpireSnapshots` Javadoc](./javadoc/master/org/apache/iceberg/ExpireSnapshots.html) to see more configuration options.
+See the [`ExpireSnapshots` Javadoc](./javadoc/0.11.1/org/apache/iceberg/ExpireSnapshots.html) to see more configuration options.
 
 There is also a Spark action that can run table expiration in parallel for large tables:
 
@@ -83,7 +83,7 @@ Actions.forTable(table)
     .execute();
 ```
 
-See the [RemoveOrphanFilesAction Javadoc](./javadoc/master/org/apache/iceberg/actions/RemoveOrphanFilesAction.html) to see more configuration options.
+See the [RemoveOrphanFilesAction Javadoc](./javadoc/0.11.1/org/apache/iceberg/actions/RemoveOrphanFilesAction.html) to see more configuration options.
 
 This action may take a long time to finish if you have lots of files in data and metadata directories. It is recommended to execute this periodically, but you may not need to execute this often.
 
@@ -119,7 +119,7 @@ Actions.forTable(table).rewriteDataFiles()
 
 The `files` metadata table is useful for inspecting data file sizes and determining when to compact partitons.
 
-See the [`RewriteDataFilesAction` Javadoc](./javadoc/master/org/apache/iceberg/actions/RewriteDataFilesAction.html) to see more configuration options.
+See the [`RewriteDataFilesAction` Javadoc](./javadoc/0.11.1/org/apache/iceberg/actions/RewriteDataFilesAction.html) to see more configuration options.
 
 ### Rewrite manifests
 
@@ -139,4 +139,4 @@ table.rewriteManifests()
     .commit();
 ```
 
-See the [`RewriteManifestsAction` Javadoc](./javadoc/master/org/apache/iceberg/actions/RewriteManifestsAction.html) to see more configuration options.
+See the [`RewriteManifestsAction` Javadoc](./javadoc/0.11.1/org/apache/iceberg/actions/RewriteManifestsAction.html) to see more configuration options.

--- a/site/docs/spark-procedures.md
+++ b/site/docs/spark-procedures.md
@@ -246,7 +246,7 @@ Rewrite manifests for a table to optimize scan planning.
 
 Data files in manifests are sorted by fields in the partition spec. This procedure runs in parallel using a Spark job.
 
-See the [`RewriteManifestsAction` Javadoc](./javadoc/master/org/apache/iceberg/actions/RewriteManifestsAction.html)
+See the [`RewriteManifestsAction` Javadoc](./javadoc/0.11.1/org/apache/iceberg/actions/RewriteManifestsAction.html)
 to see more configuration options.
 
 **Note** this procedure invalidates all cached Spark plans that reference the affected table.

--- a/site/docs/spec.md
+++ b/site/docs/spec.md
@@ -536,7 +536,7 @@ Each version of table metadata is stored in a metadata folder under the table’
 
 Notes:
 
-1. The file system table scheme is implemented in [HadoopTableOperations](./javadoc/master/index.html?org/apache/iceberg/hadoop/HadoopTableOperations.html).
+1. The file system table scheme is implemented in [HadoopTableOperations](./javadoc/0.11.1/index.html?org/apache/iceberg/hadoop/HadoopTableOperations.html).
 
 #### Metastore Tables
 
@@ -552,7 +552,7 @@ Each version of table metadata is stored in a metadata folder under the table’
 
 Notes:
 
-1. The metastore table scheme is partly implemented in [BaseMetastoreTableOperations](./javadoc/master/index.html?org/apache/iceberg/BaseMetastoreTableOperations.html).
+1. The metastore table scheme is partly implemented in [BaseMetastoreTableOperations](./javadoc/0.11.1/index.html?org/apache/iceberg/BaseMetastoreTableOperations.html).
 
 
 ### Delete Formats


### PR DESCRIPTION
This fix the issue: [#2561](https://github.com/apache/iceberg/issues/2561) 
@openinx  Please help me review, tks~