### PR TITLE
Spark: Add read.locality.enabled to TableProperties to support disabl…

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -93,6 +93,9 @@ public class TableProperties {
   public static final String LOCALITY_ENABLED = "read.locality.enabled";
   public static final String LOCALITY_ENABLED_DEFAULT = null;
 
+  public static final String LOCALITY_TASK_INITIALIZE_THREADS = "read.locality.task.initialize.threads";
+  public static final int LOCALITY_TASK_INITIALIZE_THREADS_DEFAULT = 1;
+
   public static final String OBJECT_STORE_ENABLED = "write.object-storage.enabled";
   public static final boolean OBJECT_STORE_ENABLED_DEFAULT = false;
 

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -90,6 +90,9 @@ public class TableProperties {
   public static final String ORC_VECTORIZATION_ENABLED = "read.orc.vectorization.enabled";
   public static final boolean ORC_VECTORIZATION_ENABLED_DEFAULT = false;
 
+  public static final String LOCALITY_ENABLED = "read.locality.enabled";
+  public static final String LOCALITY_ENABLED_DEFAULT = null;
+
   public static final String OBJECT_STORE_ENABLED = "write.object-storage.enabled";
   public static final boolean OBJECT_STORE_ENABLED_DEFAULT = false;
 

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java
@@ -48,6 +48,9 @@ public class SparkReadOptions {
   // Overrides the table's read.parquet.vectorization.batch-size
   public static final String VECTORIZATION_BATCH_SIZE = "batch-size";
 
+  // Overrides the table's read.locality.enabled
+  public static final String LOCALITY_ENABLED = "locality";
+
   // Set ID that is used to fetch file scan tasks
   public static final String FILE_SCAN_TASK_SET_ID = "file-scan-task-set-id";
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
@@ -20,21 +20,28 @@
 package org.apache.iceberg.spark;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.transforms.UnknownTransform;
 import org.apache.iceberg.util.Pair;
+import org.apache.iceberg.util.PropertyUtil;
 import org.apache.spark.util.SerializableConfiguration;
 
 public class SparkUtil {
+  private static final Set<String> LOCALITY_WHITELIST_FS = ImmutableSet.of("hdfs");
+
   private SparkUtil() {
   }
 
@@ -99,5 +106,12 @@ public class SparkUtil {
         return Pair.of(catalog, identiferProvider.apply(namespace, name));
       }
     }
+  }
+
+  public static boolean isLocalityEnabledDefault(Map<String, String> tableProperties, String fsScheme) {
+    String tableLocalityProp = PropertyUtil.propertyAsString(tableProperties, TableProperties.LOCALITY_ENABLED,
+        TableProperties.LOCALITY_ENABLED_DEFAULT);
+    return tableLocalityProp == null ? LOCALITY_WHITELIST_FS.contains(fsScheme) :
+        Boolean.parseBoolean(tableLocalityProp);
   }
 }

--- a/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -103,7 +103,6 @@ import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_RANGE;
 
 public class Spark3Util {
 
-  private static final Set<String> LOCALITY_WHITELIST_FS = ImmutableSet.of("hdfs");
   private static final Set<String> RESERVED_PROPERTIES = ImmutableSet.of(
       TableCatalog.PROP_LOCATION, TableCatalog.PROP_PROVIDER);
   private static final Joiner DOT = Joiner.on(".");
@@ -483,11 +482,13 @@ public class Spark3Util {
     return Joiner.on(", ").join(SortOrderVisitor.visit(order, DescribeSortOrderVisitor.INSTANCE));
   }
 
-  public static boolean isLocalityEnabled(FileIO io, String location, CaseInsensitiveStringMap readOptions) {
+  public static boolean isLocalityEnabled(FileIO io, String location, Map<String, String> tableProperties,
+      CaseInsensitiveStringMap readOptions) {
     InputFile in = io.newInputFile(location);
     if (in instanceof HadoopInputFile) {
       String scheme = ((HadoopInputFile) in).getFileSystem().getScheme();
-      return readOptions.getBoolean("locality", LOCALITY_WHITELIST_FS.contains(scheme));
+      return readOptions.getBoolean(
+          SparkReadOptions.LOCALITY_ENABLED, SparkUtil.isLocalityEnabledDefault(tableProperties, scheme));
     }
     return false;
   }

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
@@ -80,7 +80,7 @@ abstract class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
     this.caseSensitive = caseSensitive;
     this.expectedSchema = expectedSchema;
     this.filterExpressions = filters != null ? filters : Collections.emptyList();
-    this.localityPreferred = Spark3Util.isLocalityEnabled(table.io(), table.location(), options);
+    this.localityPreferred = Spark3Util.isLocalityEnabled(table.io(), table.location(), table.properties(), options);
     this.batchSize = Spark3Util.batchSize(table.properties(), options);
     this.options = options;
   }


### PR DESCRIPTION
…e locality for spark-sql

When reading an Iceberg table by spark-sql, I couldn't find a way to disable locality as it is defined as a Spark read option. In our busy cluster, a table of about 8k files took about 15s to get block locations from NN. Both QueryExecution$.prepareForExecution() and QueryExecution.sparkPlan() will get block locations and that's 30 seconds... However, the spark job of my sql only runs about 10 seconds...

So I try to add locality as a table property that it can be disable for spark-sql.

Maybe there is a way to disable locality in spark-sql session? Please inform me, thanks!
I also found it not so elegant to set these runtime read-options as table properties. However, I'm using spark-sql and what could be a better way to apply to this problem? 

I've dumped the wallclock time profiling. We can see the problem lies in SparkBatchScan.planInputPartitions()
![wall-clock](https://user-images.githubusercontent.com/11854435/118424059-fd22e800-b6f8-11eb-9fd1-672ec1e69975.png)
