### PR TITLE
Spark: Fix MergeInto when Source and Target are SinglePartition Distr…

### DIFF
--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DynamicFileFilterExec.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DynamicFileFilterExec.scala
@@ -48,8 +48,32 @@ abstract class DynamicFileFilterExecBase(
   override def outputOrdering: Seq[SortOrder] = scanExec.outputOrdering
   override def supportsColumnar: Boolean = scanExec.supportsColumnar
 
-  override protected def doExecute(): RDD[InternalRow] = scanExec.execute()
-  override protected def doExecuteColumnar(): RDD[ColumnarBatch] = scanExec.executeColumnar()
+  /*
+  If both target and source have the same partitioning we can have a problem here if our filter exec actually
+  changes the partition. Currently this can only occur in the SinglePartition distribution is in use which only
+  happens if both the target and source have a single partition, but if it does we have the potential of eliminating
+  the only partition in the target. If there are no partitions in the target then we will throw an exception because
+  the partitioning was assumed to be the same 1 partition in source and target. We fix this by making sure that
+  we always return at least 1 empty partition, in the future we may need to handle more complicated partitioner
+  scenarios.
+   */
+
+  override protected def doExecute(): RDD[InternalRow] = {
+    val result = scanExec.execute()
+    if (result.partitions.length == 0) {
+      sparkContext.parallelize(Array.empty[InternalRow], 1)
+    } else {
+      result
+    }
+  }
+  override protected def doExecuteColumnar(): RDD[ColumnarBatch] = {
+    val result = scanExec.executeColumnar()
+    if (result.partitions.length == 0) {
+      sparkContext.parallelize(Array.empty[ColumnarBatch], 1)
+    } else {
+      result
+    }
+  }
 
   override def simpleString(maxFields: Int): String = {
     s"DynamicFileFilterExec${truncatedString(output, "[", ", ", "]", maxFields)}"

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DynamicFileFilterExec.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DynamicFileFilterExec.scala
@@ -50,12 +50,12 @@ abstract class DynamicFileFilterExecBase(
 
   /*
   If both target and source have the same partitioning we can have a problem here if our filter exec actually
-  changes the partition. Currently this can only occur in the SinglePartition distribution is in use which only
-  happens if both the target and source have a single partition, but if it does we have the potential of eliminating
-  the only partition in the target. If there are no partitions in the target then we will throw an exception because
-  the partitioning was assumed to be the same 1 partition in source and target. We fix this by making sure that
-  we always return at least 1 empty partition, in the future we may need to handle more complicated partitioner
-  scenarios.
+  changes the output partitioning of the node. Currently this can only occur in the SinglePartition distribution is
+  in use which only happens if both the target and source have a single partition, but if it does we have the potential
+  of eliminating the only partition in the target. If there are no partitions in the target then we will throw an
+  exception because the partitioning was assumed to be the same 1 partition in source and target. We fix this by making
+  sure that we always return at least 1 empty partition, in the future we may need to handle more complicated
+  partitioner scenarios.
    */
 
   override protected def doExecute(): RDD[InternalRow] = {

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -55,7 +55,6 @@ import static org.apache.iceberg.TableProperties.MERGE_ISOLATION_LEVEL;
 import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.SPLIT_SIZE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE;
-import static org.apache.spark.sql.functions.column;
 import static org.apache.spark.sql.functions.lit;
 
 public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
@@ -1446,11 +1445,11 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     createAndInitTable("id INT", "{\"id\": -1}");
 
     // Coalesce forces our source into a SinglePartition distribution
-    spark.range(0,5).coalesce(1).createOrReplaceTempView("source");
+    spark.range(0, 5).coalesce(1).createOrReplaceTempView("source");
 
-    sql("MERGE INTO %s t USING source s ON t.id = s.id "
-            + "WHEN MATCHED THEN UPDATE SET *"
-            + "WHEN NOT MATCHED THEN INSERT *",
+    sql("MERGE INTO %s t USING source s ON t.id = s.id " +
+            "WHEN MATCHED THEN UPDATE SET *" +
+            "WHEN NOT MATCHED THEN INSERT *",
         tableName);
 
     ImmutableList<Object[]> expectedRows = ImmutableList.of(


### PR DESCRIPTION
…ibuted

Previously there was an exception when both the source and target of a MERGE INTO
command shared the same distribution, causing an join without an exchange but
partitioning was changed by DynamicFileFilterExec. This could only happen
if both the target and source happend to have a single partition
and were repesented with the distribution SinglePartition. If the filter removes
the partition from the target then there is an unbalance between the number of
partitions but the exchange is also missing. This situation breaks the join.

 We do not currently expose any other distribution information so in most cases
the source and target will return unknown distribution which avoids this problem.
In those situations an exchange always follows the DynamicFileFilterExec which makes
sure the number of partitions always matches for the join.