### PR TITLE
Bump Nessie to 0.8.2 + related changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,6 @@ buildscript {
 
 plugins {
   id 'nebula.dependency-recommender' version '9.0.2'
-  id 'org.projectnessie' version '0.5.1'
 }
 
 try {
@@ -127,6 +126,7 @@ subprojects {
     compile 'com.github.stephenc.findbugs:findbugs-annotations'
 
     testCompile 'org.junit.vintage:junit-vintage-engine'
+    testCompile 'org.junit.jupiter:junit-jupiter-engine'
     testCompile 'org.junit.jupiter:junit-jupiter'
     testCompile 'org.slf4j:slf4j-simple'
     testCompile 'org.mockito:mockito-core'
@@ -1266,19 +1266,18 @@ project(':iceberg-pig') {
 }
 
 project(':iceberg-nessie') {
-  apply plugin: 'org.projectnessie'
+  test {
+    useJUnitPlatform()
+  }
 
   dependencies {
     compile project(':iceberg-core')
     compile project(path: ':iceberg-bundled-guava', configuration: 'shadow')
     compile "org.projectnessie:nessie-client"
 
-    // dependency version "recommendation" via nebula.dependency-recommender don't work here "immediately",
-    // so pull the Quarkus + Nessie versions from the root-project
-    def quarkusVersion = rootProject.dependencyRecommendations.getRecommendedVersion("io.quarkus", "quarkus-bom")
-    def nessieVersion = rootProject.dependencyRecommendations.getRecommendedVersion("org.projectnessie", "nessie-quarkus")
-    nessieQuarkusRuntime(enforcedPlatform("io.quarkus:quarkus-bom:${quarkusVersion}"))
-    nessieQuarkusServer "org.projectnessie:nessie-quarkus:${nessieVersion}"
+    testImplementation "org.projectnessie:nessie-jaxrs-testextension"
+    // Need to "pull in" el-api explicitly :(
+    testImplementation "jakarta.el:jakarta.el-api"
 
     compileOnly "org.apache.hadoop:hadoop-common"
 

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.nessie;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -46,6 +45,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.util.Tasks;
 import org.projectnessie.api.TreeApi;
+import org.projectnessie.api.params.EntriesParams;
 import org.projectnessie.client.NessieClient;
 import org.projectnessie.client.NessieConfigConstants;
 import org.projectnessie.error.BaseNessieClientServerException;
@@ -324,7 +324,8 @@ public class NessieCatalog extends BaseMetastoreCatalog implements AutoCloseable
 
   private IcebergTable table(TableIdentifier tableIdentifier) {
     try {
-      Contents table = client.getContentsApi().getContents(NessieUtil.toKey(tableIdentifier), reference.getHash());
+      Contents table = client.getContentsApi()
+          .getContents(NessieUtil.toKey(tableIdentifier), reference.getName(), reference.getHash());
       return table.unwrap(IcebergTable.class).orElse(null);
     } catch (NessieNotFoundException e) {
       return null;
@@ -353,7 +354,7 @@ public class NessieCatalog extends BaseMetastoreCatalog implements AutoCloseable
   private Stream<TableIdentifier> tableStream(Namespace namespace) {
     try {
       return client.getTreeApi()
-          .getEntries(reference.getHash(), null, null, Collections.emptyList())
+          .getEntries(reference.getName(), EntriesParams.builder().hashOnRef(reference.getHash()).build())
           .getEntries()
           .stream()
           .filter(NessieUtil.namespacePredicate(namespace))

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
@@ -53,6 +53,7 @@ import org.projectnessie.client.http.HttpClientException;
 import org.projectnessie.error.BaseNessieClientServerException;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Branch;
 import org.projectnessie.model.Contents;
 import org.projectnessie.model.IcebergTable;
 import org.projectnessie.model.ImmutableDelete;
@@ -184,8 +185,9 @@ public class NessieCatalog extends BaseMetastoreCatalog implements AutoCloseable
           .throwFailureWhenFinished()
           .onFailure((c, exception) -> refresh())
           .run(c -> {
-            client.getTreeApi().commitMultipleOperations(reference.getAsBranch().getName(), reference.getHash(), c);
-            refresh(); // note: updated to reference.updateReference() with Nessie 0.6
+            Branch branch = client.getTreeApi().commitMultipleOperations(reference.getAsBranch().getName(),
+                reference.getHash(), c);
+            reference.updateReference(branch);
           }, BaseNessieClientServerException.class);
       threw = false;
     } catch (NessieConflictException e) {
@@ -227,8 +229,9 @@ public class NessieCatalog extends BaseMetastoreCatalog implements AutoCloseable
           .throwFailureWhenFinished()
           .onFailure((c, exception) -> refresh())
           .run(c -> {
-            client.getTreeApi().commitMultipleOperations(reference.getAsBranch().getName(), reference.getHash(), c);
-            refresh();
+            Branch branch = client.getTreeApi().commitMultipleOperations(reference.getAsBranch().getName(),
+                reference.getHash(), c);
+            reference.updateReference(branch);
           }, BaseNessieClientServerException.class);
     } catch (NessieNotFoundException e) {
       // important note: the NotFoundException refers to the ref only. If a table was not found it would imply that the

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
@@ -30,6 +30,7 @@ import org.projectnessie.client.NessieClient;
 import org.projectnessie.client.http.HttpClientException;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Branch;
 import org.projectnessie.model.Contents;
 import org.projectnessie.model.ContentsKey;
 import org.projectnessie.model.IcebergTable;
@@ -110,7 +111,9 @@ public class NessieTableOperations extends BaseMetastoreTableOperations {
 
       Operations op = ImmutableOperations.builder().addOperations(Operation.Put.of(key, newTable.build()))
           .commitMeta(NessieUtil.buildCommitMetadata("iceberg commit", catalogOptions)).build();
-      client.getTreeApi().commitMultipleOperations(reference.getAsBranch().getName(), reference.getHash(), op);
+      Branch branch = client.getTreeApi().commitMultipleOperations(reference.getAsBranch().getName(),
+          reference.getHash(), op);
+      reference.updateReference(branch);
 
       delete = false;
     } catch (NessieConflictException ex) {

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
@@ -102,8 +102,13 @@ public class NessieTableOperations extends BaseMetastoreTableOperations {
 
     boolean delete = true;
     try {
-      IcebergTable newTable = ImmutableIcebergTable.builder().metadataLocation(newMetadataLocation).build();
-      Operations op = ImmutableOperations.builder().addOperations(Operation.Put.of(key, newTable))
+      ImmutableIcebergTable.Builder newTable = ImmutableIcebergTable.builder();
+      if (table != null) {
+        newTable.from(table);
+      }
+      newTable.metadataLocation(newMetadataLocation);
+
+      Operations op = ImmutableOperations.builder().addOperations(Operation.Put.of(key, newTable.build()))
           .commitMeta(NessieUtil.buildCommitMetadata("iceberg commit", catalogOptions)).build();
       client.getTreeApi().commitMultipleOperations(reference.getAsBranch().getName(), reference.getHash(), op);
 

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
@@ -80,7 +80,7 @@ public class NessieTableOperations extends BaseMetastoreTableOperations {
     }
     String metadataLocation = null;
     try {
-      Contents contents = client.getContentsApi().getContents(key, reference.getHash());
+      Contents contents = client.getContentsApi().getContents(key, reference.getName(), reference.getHash());
       this.table = contents.unwrap(IcebergTable.class)
           .orElseThrow(() ->
               new IllegalStateException("Cannot refresh iceberg table: " +

--- a/nessie/src/main/java/org/apache/iceberg/nessie/UpdateableReference.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/UpdateableReference.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.nessie;
 
+import java.util.Objects;
 import org.projectnessie.api.TreeApi;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Branch;
@@ -42,6 +43,11 @@ class UpdateableReference {
     Reference oldReference = reference;
     reference = client.getReferenceByName(reference.getName());
     return !oldReference.equals(reference);
+  }
+
+  public void updateReference(Reference ref) {
+    Objects.requireNonNull(ref);
+    this.reference = ref;
   }
 
   public boolean isBranch() {

--- a/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.nessie;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
@@ -33,15 +34,16 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.LongType;
 import org.apache.iceberg.types.Types.StructType;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 import org.projectnessie.api.ContentsApi;
 import org.projectnessie.api.TreeApi;
 import org.projectnessie.client.NessieClient;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.jaxrs.NessieJaxRsExtension;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.Reference;
 import org.slf4j.Logger;
@@ -50,11 +52,13 @@ import org.slf4j.LoggerFactory;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 public abstract class BaseTestIceberg {
+  @RegisterExtension
+  static NessieJaxRsExtension server = new NessieJaxRsExtension();
 
   private static final Logger LOGGER = LoggerFactory.getLogger(BaseTestIceberg.class);
 
-  @Rule
-  public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir
+  public Path temp;
 
   protected NessieCatalog catalog;
   protected NessieClient client;
@@ -79,10 +83,10 @@ public abstract class BaseTestIceberg {
     tree.createReference(Branch.of("main", null));
   }
 
-  @Before
+  @BeforeEach
   public void beforeEach() throws IOException {
     String port = System.getProperty("quarkus.http.test-port", "19120");
-    uri = String.format("http://localhost:%s/api/v1", port);
+    uri = server.getURI().toString();
     this.client = NessieClient.builder().withUri(uri).build();
     tree = client.getTreeApi();
     contents = client.getContentsApi();
@@ -105,7 +109,7 @@ public abstract class BaseTestIceberg {
     newCatalog.initialize("nessie", ImmutableMap.of("ref", ref,
         CatalogProperties.URI, uri,
         "auth_type", "NONE",
-        CatalogProperties.WAREHOUSE_LOCATION, temp.getRoot().toURI().toString()
+        CatalogProperties.WAREHOUSE_LOCATION, temp.toUri().toString()
     ));
     return newCatalog;
   }
@@ -136,7 +140,7 @@ public abstract class BaseTestIceberg {
     tree.createReference(Branch.of(name, hash));
   }
 
-  @After
+  @AfterEach
   public void afterEach() throws Exception {
     catalog.close();
     client.close();

--- a/nessie/src/test/java/org/apache/iceberg/nessie/NessieUtilTest.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/NessieUtilTest.java
@@ -22,7 +22,7 @@ package org.apache.iceberg.nessie;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.projectnessie.model.CommitMeta;
 
 public class NessieUtilTest {

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestBranchVisibility.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestBranchVisibility.java
@@ -79,31 +79,34 @@ public class TestBranchVisibility extends BaseTestIceberg {
   }
 
   @Test
-  public void testCatalogOnReference() throws NessieNotFoundException {
+  public void testCatalogOnReference() {
     updateSchema(catalog, tableIdentifier1);
     updateSchema(testCatalog, tableIdentifier2);
-    String mainHash = tree.getReferenceByName("main").getHash();
 
     // catalog created with ref points to same catalog as above
     NessieCatalog refCatalog = initCatalog("test");
     testCatalogEquality(refCatalog, testCatalog, true, true);
 
     // catalog created with hash points to same catalog as above
-    NessieCatalog refHashCatalog = initCatalog(mainHash);
+    NessieCatalog refHashCatalog = initCatalog("main");
     testCatalogEquality(refHashCatalog, catalog, true, true);
   }
 
   @Test
-  public void testCatalogWithTableNames() throws NessieNotFoundException {
+  public void testCatalogWithTableNames() {
     updateSchema(testCatalog, tableIdentifier2);
-    String mainHash = tree.getReferenceByName("main").getHash();
+
+    String mainName = "main";
 
     // asking for table@branch gives expected regardless of catalog
     Assertions.assertThat(metadataLocation(catalog, TableIdentifier.of("test-ns", "table1@test")))
         .isEqualTo(metadataLocation(testCatalog, tableIdentifier1));
 
-    // asking for table@branch#hash gives expected regardless of catalog
-    Assertions.assertThat(metadataLocation(catalog, TableIdentifier.of("test-ns", "table1@" + mainHash)))
+    // Asking for table@branch gives expected regardless of catalog.
+    // Earlier versions used "table1@" + tree.getReferenceByName("main").getHash() before, but since
+    // Nessie 0.8.2 the branch name became mandatory and specifying a hash within a branch is not
+    // possible.
+    Assertions.assertThat(metadataLocation(catalog, TableIdentifier.of("test-ns", "table1@" + mainName)))
         .isEqualTo(metadataLocation(testCatalog, tableIdentifier1));
   }
 

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestBranchVisibility.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestBranchVisibility.java
@@ -22,9 +22,9 @@ package org.apache.iceberg.nessie;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.types.Types;
 import org.assertj.core.api.Assertions;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 
@@ -39,7 +39,7 @@ public class TestBranchVisibility extends BaseTestIceberg {
     super("main");
   }
 
-  @Before
+  @BeforeEach
   public void before() throws NessieNotFoundException, NessieConflictException {
     createTable(tableIdentifier1, 1); // table 1
     createTable(tableIdentifier2, 1); // table 2
@@ -48,7 +48,7 @@ public class TestBranchVisibility extends BaseTestIceberg {
     testCatalog = initCatalog("test");
   }
 
-  @After
+  @AfterEach
   public void after() throws NessieNotFoundException, NessieConflictException {
     catalog.dropTable(tableIdentifier1);
     catalog.dropTable(tableIdentifier2);

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNamespace.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNamespace.java
@@ -23,7 +23,7 @@ import java.util.List;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestNamespace extends BaseTestIceberg {
   private static final String BRANCH = "test-namespace";

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
@@ -44,9 +44,9 @@ import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.types.Types;
 import org.assertj.core.api.Assertions;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.projectnessie.error.NessieConflictException;
 import org.projectnessie.error.NessieNotFoundException;
 import org.projectnessie.model.Branch;
@@ -78,13 +78,13 @@ public class TestNessieTable extends BaseTestIceberg {
     super(BRANCH);
   }
 
-  @Before
+  @BeforeEach
   public void beforeEach() throws IOException {
     super.beforeEach();
     this.tableLocation = new Path(catalog.createTable(TABLE_IDENTIFIER, schema).location());
   }
 
-  @After
+  @AfterEach
   public void afterEach() throws Exception {
     // drop the table data
     if (tableLocation != null) {
@@ -112,7 +112,7 @@ public class TestNessieTable extends BaseTestIceberg {
     icebergTable.updateSchema().addColumn("mother", Types.LongType.get()).commit();
     IcebergTable table = getTable(KEY);
     // check parameters are in expected state
-    String expected = (temp.getRoot().toURI() + DB_NAME + "/" + tableName).replace("//", "/");
+    String expected = (temp.toUri() + DB_NAME + "/" + tableName).replace("///", "/");
     Assertions.assertThat(getTableLocation(tableName)).isEqualTo(expected);
 
     // Only 1 snapshotFile Should exist and no manifests should exist
@@ -291,7 +291,7 @@ public class TestNessieTable extends BaseTestIceberg {
   }
 
   private String getTableBasePath(String tableName) {
-    String databasePath = temp.getRoot().toString() + "/" + DB_NAME;
+    String databasePath = temp.toString() + "/" + DB_NAME;
     return Paths.get(databasePath, tableName).toAbsolutePath().toString();
   }
 

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestTableReference.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestTableReference.java
@@ -20,7 +20,7 @@
 package org.apache.iceberg.nessie;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestTableReference {
 

--- a/versions.props
+++ b/versions.props
@@ -18,13 +18,11 @@ org.apache.arrow:arrow-memory-netty = 2.0.0
 com.github.stephenc.findbugs:findbugs-annotations = 1.3.9-1
 software.amazon.awssdk:* = 2.15.7
 org.scala-lang:scala-library = 2.12.10
-org.projectnessie:* = 0.5.1
-javax.ws.rs:javax.ws.rs-api = 2.1.1
-io.quarkus:* = 1.13.1.Final
+org.projectnessie:* = 0.8.2
 
 # test deps
 org.junit.vintage:junit-vintage-engine = 5.7.2
-org.junit.jupiter:junit-jupiter = 5.7.2
+org.junit.jupiter:* = 5.7.2
 org.mockito:mockito-core = 3.7.7
 org.apache.hive:hive-exec = 2.3.8
 org.apache.hive:hive-service = 2.3.8


### PR DESCRIPTION
* Bump Nessie to 0.8.2 + replace Gradle plugin with new JUnit extension
  * Replace Gradle plugin with new JUnit extension.
    See [Add JAX-RS tests and add JUnit/Jupyter extension](https://github.com/projectnessie/nessie/pull/1566)

* Apply changes to Iceberg required by API changes in Nessie:
  * [Re-introduce wrapper classes for query params of CommitLog/Entries](https://github.com/projectnessie/nessie/pull/1595)
  * [Server-side commit range filtering](https://github.com/projectnessie/nessie/pull/1596)
  * [Add hashOnRef query param to support time travel on a named ref](https://github.com/projectnessie/nessie/pull/1589)
  * [Only accept NamedRefs in REST API](https://github.com/projectnessie/nessie/pull/1583)

* Bugfix: must send the Contents.id of the existing table
    Nessie's `Contents.id` is a random ID generated when the `Contents.Key` is first used (think:
    CREATE TABLE) and must not be changed. This change addresses a bug in the Iceberg-Nesie code
    that caused a new id for every change.

    Throw `CommitStateUnknownException` for `renameTable` as well
    
    Follow-up of #2515

* Fix race-condition & save one roundtrip to Nessie during "commit"
    
    When commiting a change, the Nessie-API now returns the hash of the commit for the change.
    This returned hash should then be used as the "expected hash" for the next commit.
    
    The previous approach was to commit the change to Nessie and then do another request to
    retrieve the new hash of HEAD.
    
    This old approach is prone to a race condition, namely when another commit happens after
    "this" commit but before retrieving the "new HEAD", so "this" instance would wrongly
    ignore the other commit's changes during conflict checks.
    
    See [Let VersionStore.create()+commit() return the current hash](https://github.com/projectnessie/nessie/pull/1089)
