### PR TITLE
[INFRA] Add .out folders to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,11 +12,11 @@ tmp/
 
 # gradle build
 .gradle
+.out/
 build
 dependencies.lock
 **/dependencies.lock
 gradle/
-out
 gradle/wrapper/gradle-wrapper.jar
 
 # rat library install location


### PR DESCRIPTION
I have a number of `.out` folders that are getting in the way of my tab completion when I move around between different folders.

These are generated by gradle, and so I've added them to the .gitignore.

There is an existing entry, `out`, which does not catch these but is listed under the `gradle` section. I've removed it. It was added in a PR that also added some automation for the site, so I built the site locally and clicked around to se if an `out` log was generated but it was not.