### PR TITLE
Refine error message when performing incremental scans on metadata tables

### DIFF
--- a/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
@@ -86,7 +86,7 @@ public class AllDataFilesTable extends BaseMetadataTable {
 
     @Override
     protected String tableType() {
-      return String.valueOf(MetadataTableType.ALL_DATA_FILES);
+      return MetadataTableType.ALL_DATA_FILES.name();
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
@@ -51,7 +51,7 @@ public class AllDataFilesTable extends BaseMetadataTable {
 
   @Override
   public TableScan newScan() {
-    return new AllDataFilesTableScan(operations(), table(), schema());
+    return new AllDataFilesTableScan(operations(), table(), schema(), name());
   }
 
   @Override
@@ -72,21 +72,24 @@ public class AllDataFilesTable extends BaseMetadataTable {
 
   public static class AllDataFilesTableScan extends BaseAllMetadataTableScan {
     private final Schema fileSchema;
+    private final String scannedTableName;
 
-    AllDataFilesTableScan(TableOperations ops, Table table, Schema fileSchema) {
-      super(ops, table, fileSchema);
+    AllDataFilesTableScan(TableOperations ops, Table table, Schema fileSchema, String scannedTableName) {
+      super(ops, table, fileSchema, scannedTableName);
       this.fileSchema = fileSchema;
+      this.scannedTableName = scannedTableName;
     }
 
     private AllDataFilesTableScan(TableOperations ops, Table table, Schema schema, Schema fileSchema,
-                                  TableScanContext context) {
-      super(ops, table, schema, context);
+                                  String scannedTableName, TableScanContext context) {
+      super(ops, table, schema, scannedTableName, context);
       this.fileSchema = fileSchema;
+      this.scannedTableName = scannedTableName;
     }
 
     @Override
     protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      return new AllDataFilesTableScan(ops, table, schema, fileSchema, context);
+      return new AllDataFilesTableScan(ops, table, schema, fileSchema, scannedTableName, context);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
@@ -51,7 +51,7 @@ public class AllDataFilesTable extends BaseMetadataTable {
 
   @Override
   public TableScan newScan() {
-    return new AllDataFilesTableScan(operations(), table(), schema(), name());
+    return new AllDataFilesTableScan(operations(), table(), schema());
   }
 
   @Override
@@ -72,24 +72,26 @@ public class AllDataFilesTable extends BaseMetadataTable {
 
   public static class AllDataFilesTableScan extends BaseAllMetadataTableScan {
     private final Schema fileSchema;
-    private final String scannedTableName;
 
-    AllDataFilesTableScan(TableOperations ops, Table table, Schema fileSchema, String scannedTableName) {
-      super(ops, table, fileSchema, scannedTableName);
+    AllDataFilesTableScan(TableOperations ops, Table table, Schema fileSchema) {
+      super(ops, table, fileSchema);
       this.fileSchema = fileSchema;
-      this.scannedTableName = scannedTableName;
     }
 
     private AllDataFilesTableScan(TableOperations ops, Table table, Schema schema, Schema fileSchema,
-                                  String scannedTableName, TableScanContext context) {
-      super(ops, table, schema, scannedTableName, context);
+                                  TableScanContext context) {
+      super(ops, table, schema, context);
       this.fileSchema = fileSchema;
-      this.scannedTableName = scannedTableName;
+    }
+
+    @Override
+    public String tableType() {
+      return String.valueOf(MetadataTableType.ALL_DATA_FILES);
     }
 
     @Override
     protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      return new AllDataFilesTableScan(ops, table, schema, fileSchema, scannedTableName, context);
+      return new AllDataFilesTableScan(ops, table, schema, fileSchema, context);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
@@ -85,7 +85,7 @@ public class AllDataFilesTable extends BaseMetadataTable {
     }
 
     @Override
-    public String tableType() {
+    protected String tableType() {
       return String.valueOf(MetadataTableType.ALL_DATA_FILES);
     }
 

--- a/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
@@ -51,7 +51,7 @@ public class AllEntriesTable extends BaseMetadataTable {
 
   @Override
   public TableScan newScan() {
-    return new Scan(operations(), table(), schema(), name());
+    return new Scan(operations(), table(), schema());
   }
 
   @Override
@@ -72,22 +72,23 @@ public class AllEntriesTable extends BaseMetadataTable {
 
   private static class Scan extends BaseAllMetadataTableScan {
 
-    private final String scannedTableName;
-
-    Scan(TableOperations ops, Table table, Schema schema, String scannedTableName) {
-      super(ops, table, schema, scannedTableName);
-      this.scannedTableName = scannedTableName;
+    Scan(TableOperations ops, Table table, Schema schema) {
+      super(ops, table, schema);
     }
 
-    private Scan(TableOperations ops, Table table, Schema schema, String scannedTableName, TableScanContext context) {
-      super(ops, table, schema, scannedTableName, context);
-      this.scannedTableName = scannedTableName;
+    private Scan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
+      super(ops, table, schema, context);
     }
 
     @Override
     protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema,
                                        TableScanContext context) {
-      return new Scan(ops, table, schema, scannedTableName, context);
+      return new Scan(ops, table, schema, context);
+    }
+
+    @Override
+    public String tableType() {
+      return String.valueOf(MetadataTableType.ALL_ENTRIES);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
@@ -88,7 +88,7 @@ public class AllEntriesTable extends BaseMetadataTable {
 
     @Override
     protected String tableType() {
-      return String.valueOf(MetadataTableType.ALL_ENTRIES);
+      return MetadataTableType.ALL_ENTRIES.name();
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
@@ -87,7 +87,7 @@ public class AllEntriesTable extends BaseMetadataTable {
     }
 
     @Override
-    public String tableType() {
+    protected String tableType() {
       return String.valueOf(MetadataTableType.ALL_ENTRIES);
     }
 

--- a/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllEntriesTable.java
@@ -51,7 +51,7 @@ public class AllEntriesTable extends BaseMetadataTable {
 
   @Override
   public TableScan newScan() {
-    return new Scan(operations(), table(), schema());
+    return new Scan(operations(), table(), schema(), name());
   }
 
   @Override
@@ -72,18 +72,22 @@ public class AllEntriesTable extends BaseMetadataTable {
 
   private static class Scan extends BaseAllMetadataTableScan {
 
-    Scan(TableOperations ops, Table table, Schema schema) {
-      super(ops, table, schema);
+    private final String scannedTableName;
+
+    Scan(TableOperations ops, Table table, Schema schema, String scannedTableName) {
+      super(ops, table, schema, scannedTableName);
+      this.scannedTableName = scannedTableName;
     }
 
-    private Scan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      super(ops, table, schema, context);
+    private Scan(TableOperations ops, Table table, Schema schema, String scannedTableName, TableScanContext context) {
+      super(ops, table, schema, scannedTableName, context);
+      this.scannedTableName = scannedTableName;
     }
 
     @Override
     protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema,
                                        TableScanContext context) {
-      return new Scan(ops, table, schema, context);
+      return new Scan(ops, table, schema, scannedTableName, context);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -66,7 +66,7 @@ public class AllManifestsTable extends BaseMetadataTable {
 
   @Override
   public TableScan newScan() {
-    return new AllManifestsTableScan(operations(), table(), MANIFEST_FILE_SCHEMA, name());
+    return new AllManifestsTableScan(operations(), table(), MANIFEST_FILE_SCHEMA);
   }
 
   @Override
@@ -81,23 +81,19 @@ public class AllManifestsTable extends BaseMetadataTable {
 
   public static class AllManifestsTableScan extends BaseAllMetadataTableScan {
 
-    private final String scannedTableName;
-
-    AllManifestsTableScan(TableOperations ops, Table table, Schema fileSchema, String scannedTableName) {
-      super(ops, table, fileSchema, scannedTableName);
-      this.scannedTableName = scannedTableName;
+    AllManifestsTableScan(TableOperations ops, Table table, Schema fileSchema) {
+      super(ops, table, fileSchema);
     }
 
-    private AllManifestsTableScan(TableOperations ops, Table table, Schema schema, String scannedTableName,
+    private AllManifestsTableScan(TableOperations ops, Table table, Schema schema,
                                   TableScanContext context) {
-      super(ops, table, schema, scannedTableName, context);
-      this.scannedTableName = scannedTableName;
+      super(ops, table, schema, context);
     }
 
     @Override
     protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema,
                                        TableScanContext context) {
-      return new AllManifestsTableScan(ops, table, schema, scannedTableName, context);
+      return new AllManifestsTableScan(ops, table, schema, context);
     }
 
     @Override
@@ -108,6 +104,11 @@ public class AllManifestsTable extends BaseMetadataTable {
     @Override
     public TableScan asOfTime(long timestampMillis) {
       throw new UnsupportedOperationException("Cannot select snapshot: all_manifests is for all snapshots");
+    }
+
+    @Override
+    public String tableType() {
+      return String.valueOf(MetadataTableType.ALL_MANIFESTS);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -66,7 +66,7 @@ public class AllManifestsTable extends BaseMetadataTable {
 
   @Override
   public TableScan newScan() {
-    return new AllManifestsTableScan(operations(), table(), MANIFEST_FILE_SCHEMA);
+    return new AllManifestsTableScan(operations(), table(), MANIFEST_FILE_SCHEMA, name());
   }
 
   @Override
@@ -81,19 +81,23 @@ public class AllManifestsTable extends BaseMetadataTable {
 
   public static class AllManifestsTableScan extends BaseAllMetadataTableScan {
 
-    AllManifestsTableScan(TableOperations ops, Table table, Schema fileSchema) {
-      super(ops, table, fileSchema);
+    private final String scannedTableName;
+
+    AllManifestsTableScan(TableOperations ops, Table table, Schema fileSchema, String scannedTableName) {
+      super(ops, table, fileSchema, scannedTableName);
+      this.scannedTableName = scannedTableName;
     }
 
-    private AllManifestsTableScan(TableOperations ops, Table table, Schema schema,
+    private AllManifestsTableScan(TableOperations ops, Table table, Schema schema, String scannedTableName,
                                   TableScanContext context) {
-      super(ops, table, schema, context);
+      super(ops, table, schema, scannedTableName, context);
+      this.scannedTableName = scannedTableName;
     }
 
     @Override
     protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema,
                                        TableScanContext context) {
-      return new AllManifestsTableScan(ops, table, schema, context);
+      return new AllManifestsTableScan(ops, table, schema, scannedTableName, context);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -108,7 +108,7 @@ public class AllManifestsTable extends BaseMetadataTable {
 
     @Override
     protected String tableType() {
-      return String.valueOf(MetadataTableType.ALL_MANIFESTS);
+      return MetadataTableType.ALL_MANIFESTS.name();
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -107,7 +107,7 @@ public class AllManifestsTable extends BaseMetadataTable {
     }
 
     @Override
-    public String tableType() {
+    protected String tableType() {
       return String.valueOf(MetadataTableType.ALL_MANIFESTS);
     }
 

--- a/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
@@ -36,7 +36,7 @@ abstract class BaseAllMetadataTableScan extends BaseTableScan {
     super(ops, table, schema, context);
   }
 
-  public abstract String tableType();
+  protected abstract String tableType();
 
   @Override
   public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {

--- a/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
@@ -36,6 +36,12 @@ abstract class BaseAllMetadataTableScan extends BaseTableScan {
     super(ops, table, schema, context);
   }
 
+  /**
+   * Type of scan being performed, such as {@link MetadataTableType#ALL_DATA_FILES} when scanning
+   * a table's {@link org.apache.iceberg.AllDataFilesTable}.
+   * <p>
+   * Used for logging and error messages.
+   */
   protected abstract String tableType();
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
@@ -28,12 +28,29 @@ import org.slf4j.LoggerFactory;
 abstract class BaseAllMetadataTableScan extends BaseTableScan {
   private static final Logger LOG = LoggerFactory.getLogger(BaseAllMetadataTableScan.class);
 
-  BaseAllMetadataTableScan(TableOperations ops, Table table, Schema fileSchema) {
+  private final String scannedTableName;
+
+  BaseAllMetadataTableScan(TableOperations ops, Table table, Schema fileSchema, String scannedTableName) {
     super(ops, table, fileSchema);
+    this.scannedTableName = scannedTableName;
   }
 
-  BaseAllMetadataTableScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
+  BaseAllMetadataTableScan(TableOperations ops, Table table, Schema schema, String scannedTableName,
+                           TableScanContext context) {
     super(ops, table, schema, context);
+    this.scannedTableName = scannedTableName;
+  }
+
+  @Override
+  public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
+    throw new UnsupportedOperationException(
+        String.format("Incremental scan is not supported for metadata table %s", scannedTableName));
+  }
+
+  @Override
+  public TableScan appendsAfter(long fromSnapshotId) {
+    throw new UnsupportedOperationException(
+        String.format("Incremental scan is not supported for metadata table %s", scannedTableName));
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
@@ -47,13 +47,13 @@ abstract class BaseAllMetadataTableScan extends BaseTableScan {
   @Override
   public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
     throw new UnsupportedOperationException(
-        String.format("Incremental scan is not supported for %s scan of table %s", tableType(), table().name()));
+        String.format("Cannot incrementally scan table of type %s", tableType()));
   }
 
   @Override
   public TableScan appendsAfter(long fromSnapshotId) {
     throw new UnsupportedOperationException(
-        String.format("Incremental scan is not supported for %s scan of table %s", tableType(), table().name()));
+        String.format("Cannot incrementally scan table of type %s", tableType()));
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
@@ -28,29 +28,26 @@ import org.slf4j.LoggerFactory;
 abstract class BaseAllMetadataTableScan extends BaseTableScan {
   private static final Logger LOG = LoggerFactory.getLogger(BaseAllMetadataTableScan.class);
 
-  private final String scannedTableName;
-
-  BaseAllMetadataTableScan(TableOperations ops, Table table, Schema fileSchema, String scannedTableName) {
+  BaseAllMetadataTableScan(TableOperations ops, Table table, Schema fileSchema) {
     super(ops, table, fileSchema);
-    this.scannedTableName = scannedTableName;
   }
 
-  BaseAllMetadataTableScan(TableOperations ops, Table table, Schema schema, String scannedTableName,
-                           TableScanContext context) {
+  BaseAllMetadataTableScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
     super(ops, table, schema, context);
-    this.scannedTableName = scannedTableName;
   }
+
+  public abstract String tableType();
 
   @Override
   public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
     throw new UnsupportedOperationException(
-        String.format("Incremental scan is not supported for metadata table %s", scannedTableName));
+        String.format("Incremental scan is not supported for %s scan of table %s", tableType(), table().name()));
   }
 
   @Override
   public TableScan appendsAfter(long fromSnapshotId) {
     throw new UnsupportedOperationException(
-        String.format("Incremental scan is not supported for metadata table %s", scannedTableName));
+        String.format("Incremental scan is not supported for %s scan of table %s", tableType(), table().name()));
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/DataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DataFilesTable.java
@@ -118,7 +118,7 @@ public class DataFilesTable extends BaseMetadataTable {
     }
 
     private String tableType() {
-      return String.valueOf(MetadataTableType.FILES);
+      return MetadataTableType.FILES.name();
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/DataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DataFilesTable.java
@@ -43,7 +43,7 @@ public class DataFilesTable extends BaseMetadataTable {
 
   @Override
   public TableScan newScan() {
-    return new FilesTableScan(operations(), table(), schema());
+    return new FilesTableScan(operations(), table(), schema(), name());
   }
 
   @Override
@@ -64,21 +64,36 @@ public class DataFilesTable extends BaseMetadataTable {
 
   public static class FilesTableScan extends BaseTableScan {
     private final Schema fileSchema;
+    private final String fileTableName;
 
-    FilesTableScan(TableOperations ops, Table table, Schema fileSchema) {
+    FilesTableScan(TableOperations ops, Table table, Schema fileSchema, String fileTableName) {
       super(ops, table, fileSchema);
       this.fileSchema = fileSchema;
+      this.fileTableName = fileTableName;
     }
 
-    private FilesTableScan(TableOperations ops, Table table, Schema schema, Schema fileSchema,
+    private FilesTableScan(TableOperations ops, Table table, Schema schema, Schema fileSchema, String fileTableName,
                            TableScanContext context) {
       super(ops, table, schema, context);
       this.fileSchema = fileSchema;
+      this.fileTableName = fileTableName;
+    }
+
+    @Override
+    public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
+      throw new UnsupportedOperationException(
+          String.format("Incremental scan is not supported for metadata table %s", fileTableName));
+    }
+
+    @Override
+    public TableScan appendsAfter(long fromSnapshotId) {
+      throw new UnsupportedOperationException(
+          String.format("Incremental scan is not supported for metadata table %s", fileTableName));
     }
 
     @Override
     protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      return new FilesTableScan(ops, table, schema, fileSchema, context);
+      return new FilesTableScan(ops, table, schema, fileSchema, fileTableName, context);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/DataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DataFilesTable.java
@@ -79,13 +79,13 @@ public class DataFilesTable extends BaseMetadataTable {
     @Override
     public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
       throw new UnsupportedOperationException(
-          String.format("Incremental scan is not supported for %s scan of table %s", tableType(), table().name()));
+          String.format("Cannot incrementally scan table of type %s", MetadataTableType.FILES.name()));
     }
 
     @Override
     public TableScan appendsAfter(long fromSnapshotId) {
       throw new UnsupportedOperationException(
-              String.format("Incremental scan is not supported for %s scan of table %s", tableType(), table().name()));
+          String.format("Cannot incrementally scan table of type %s", MetadataTableType.FILES.name()));
     }
 
     @Override
@@ -115,10 +115,6 @@ public class DataFilesTable extends BaseMetadataTable {
       // all cases.
       return CloseableIterable.transform(manifests, manifest ->
           new ManifestReadTask(ops.io(), manifest, fileSchema, schemaString, specString, residuals));
-    }
-
-    private String tableType() {
-      return MetadataTableType.FILES.name();
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/DataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DataFilesTable.java
@@ -76,10 +76,6 @@ public class DataFilesTable extends BaseMetadataTable {
       this.fileSchema = fileSchema;
     }
 
-    public String tableType() {
-      return String.valueOf(MetadataTableType.FILES);
-    }
-
     @Override
     public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
       throw new UnsupportedOperationException(
@@ -119,6 +115,10 @@ public class DataFilesTable extends BaseMetadataTable {
       // all cases.
       return CloseableIterable.transform(manifests, manifest ->
           new ManifestReadTask(ops.io(), manifest, fileSchema, schemaString, specString, residuals));
+    }
+
+    private String tableType() {
+      return String.valueOf(MetadataTableType.FILES);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/DataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DataFilesTable.java
@@ -43,7 +43,7 @@ public class DataFilesTable extends BaseMetadataTable {
 
   @Override
   public TableScan newScan() {
-    return new FilesTableScan(operations(), table(), schema(), name());
+    return new FilesTableScan(operations(), table(), schema());
   }
 
   @Override
@@ -64,36 +64,37 @@ public class DataFilesTable extends BaseMetadataTable {
 
   public static class FilesTableScan extends BaseTableScan {
     private final Schema fileSchema;
-    private final String fileTableName;
 
-    FilesTableScan(TableOperations ops, Table table, Schema fileSchema, String fileTableName) {
+    FilesTableScan(TableOperations ops, Table table, Schema fileSchema) {
       super(ops, table, fileSchema);
       this.fileSchema = fileSchema;
-      this.fileTableName = fileTableName;
     }
 
-    private FilesTableScan(TableOperations ops, Table table, Schema schema, Schema fileSchema, String fileTableName,
+    private FilesTableScan(TableOperations ops, Table table, Schema schema, Schema fileSchema,
                            TableScanContext context) {
       super(ops, table, schema, context);
       this.fileSchema = fileSchema;
-      this.fileTableName = fileTableName;
+    }
+
+    public String tableType() {
+      return String.valueOf(MetadataTableType.FILES);
     }
 
     @Override
     public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
       throw new UnsupportedOperationException(
-          String.format("Incremental scan is not supported for metadata table %s", fileTableName));
+          String.format("Incremental scan is not supported for %s scan of table %s", tableType(), table().name()));
     }
 
     @Override
     public TableScan appendsAfter(long fromSnapshotId) {
       throw new UnsupportedOperationException(
-          String.format("Incremental scan is not supported for metadata table %s", fileTableName));
+              String.format("Incremental scan is not supported for %s scan of table %s", tableType(), table().name()));
     }
 
     @Override
     protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      return new FilesTableScan(ops, table, schema, fileSchema, fileTableName, context);
+      return new FilesTableScan(ops, table, schema, fileSchema, context);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/HistoryTable.java
+++ b/core/src/main/java/org/apache/iceberg/HistoryTable.java
@@ -78,14 +78,14 @@ public class HistoryTable extends BaseMetadataTable {
     }
 
     @Override
-    protected String tableType() {
-      return String.valueOf(MetadataTableType.HISTORY);
-    }
-
-    @Override
     public CloseableIterable<FileScanTask> planFiles() {
       // override planFiles to avoid the check for a current snapshot because this metadata table is for all snapshots
       return CloseableIterable.withNoopClose(HistoryTable.this.task(this));
+    }
+
+    @Override
+    protected String tableType() {
+      return String.valueOf(HistoryTable.this.metadataTableType());
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/HistoryTable.java
+++ b/core/src/main/java/org/apache/iceberg/HistoryTable.java
@@ -74,18 +74,13 @@ public class HistoryTable extends BaseMetadataTable {
 
   private class HistoryScan extends StaticTableScan {
     HistoryScan(TableOperations ops, Table table) {
-      super(ops, table, HISTORY_SCHEMA, HistoryTable.this::task);
+      super(ops, table, HISTORY_SCHEMA, HistoryTable.this.metadataTableType().name(), HistoryTable.this::task);
     }
 
     @Override
     public CloseableIterable<FileScanTask> planFiles() {
       // override planFiles to avoid the check for a current snapshot because this metadata table is for all snapshots
       return CloseableIterable.withNoopClose(HistoryTable.this.task(this));
-    }
-
-    @Override
-    protected String tableType() {
-      return HistoryTable.this.metadataTableType().name();
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/HistoryTable.java
+++ b/core/src/main/java/org/apache/iceberg/HistoryTable.java
@@ -74,7 +74,7 @@ public class HistoryTable extends BaseMetadataTable {
 
   private class HistoryScan extends StaticTableScan {
     HistoryScan(TableOperations ops, Table table) {
-      super(ops, table, HISTORY_SCHEMA, HistoryTable.this::task);
+      super(ops, table, HISTORY_SCHEMA, HistoryTable.this.name(), HistoryTable.this::task);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/HistoryTable.java
+++ b/core/src/main/java/org/apache/iceberg/HistoryTable.java
@@ -74,7 +74,12 @@ public class HistoryTable extends BaseMetadataTable {
 
   private class HistoryScan extends StaticTableScan {
     HistoryScan(TableOperations ops, Table table) {
-      super(ops, table, HISTORY_SCHEMA, HistoryTable.this.name(), HistoryTable.this::task);
+      super(ops, table, HISTORY_SCHEMA, HistoryTable.this::task);
+    }
+
+    @Override
+    protected String tableType() {
+      return String.valueOf(MetadataTableType.HISTORY);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/HistoryTable.java
+++ b/core/src/main/java/org/apache/iceberg/HistoryTable.java
@@ -85,7 +85,7 @@ public class HistoryTable extends BaseMetadataTable {
 
     @Override
     protected String tableType() {
-      return String.valueOf(HistoryTable.this.metadataTableType());
+      return HistoryTable.this.metadataTableType().name();
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
@@ -77,10 +77,6 @@ public class ManifestEntriesTable extends BaseMetadataTable {
       super(ops, table, schema, context);
     }
 
-    public String tableType() {
-      return String.valueOf(MetadataTableType.ENTRIES);
-    }
-
     @Override
     public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
       throw new UnsupportedOperationException(
@@ -121,6 +117,10 @@ public class ManifestEntriesTable extends BaseMetadataTable {
       return CloseableIterable.transform(manifests, manifest ->
           new ManifestReadTask(ops.io(), manifest, fileSchema, schemaString, specString, residuals,
               ops.current().specsById()));
+    }
+
+    private String tableType() {
+      return String.valueOf(MetadataTableType.ENTRIES);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
@@ -48,7 +48,7 @@ public class ManifestEntriesTable extends BaseMetadataTable {
 
   @Override
   public TableScan newScan() {
-    return new EntriesTableScan(operations(), table(), schema());
+    return new EntriesTableScan(operations(), table(), schema(), name());
   }
 
   @Override
@@ -69,18 +69,35 @@ public class ManifestEntriesTable extends BaseMetadataTable {
 
   private static class EntriesTableScan extends BaseTableScan {
 
-    EntriesTableScan(TableOperations ops, Table table, Schema schema) {
+    private final String scannedTableName;
+
+    EntriesTableScan(TableOperations ops, Table table, Schema schema, String scannedTableName) {
       super(ops, table, schema);
+      this.scannedTableName = scannedTableName;
     }
 
-    private EntriesTableScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
+    private EntriesTableScan(TableOperations ops, Table table, Schema schema, String scannedTableName,
+                             TableScanContext context) {
       super(ops, table, schema, context);
+      this.scannedTableName = scannedTableName;
+    }
+
+    @Override
+    public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
+      throw new UnsupportedOperationException(
+          String.format("Incremental scan is not supported for metadata table %s", scannedTableName));
+    }
+
+    @Override
+    public TableScan appendsAfter(long fromSnapshotId) {
+      throw new UnsupportedOperationException(
+          String.format("Incremental scan is not supported for metadata table %s", scannedTableName));
     }
 
     @Override
     protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema,
                                        TableScanContext context) {
-      return new EntriesTableScan(ops, table, schema, context);
+      return new EntriesTableScan(ops, table, schema, scannedTableName, context);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
@@ -48,7 +48,7 @@ public class ManifestEntriesTable extends BaseMetadataTable {
 
   @Override
   public TableScan newScan() {
-    return new EntriesTableScan(operations(), table(), schema(), name());
+    return new EntriesTableScan(operations(), table(), schema());
   }
 
   @Override
@@ -69,35 +69,34 @@ public class ManifestEntriesTable extends BaseMetadataTable {
 
   private static class EntriesTableScan extends BaseTableScan {
 
-    private final String scannedTableName;
-
-    EntriesTableScan(TableOperations ops, Table table, Schema schema, String scannedTableName) {
+    EntriesTableScan(TableOperations ops, Table table, Schema schema) {
       super(ops, table, schema);
-      this.scannedTableName = scannedTableName;
     }
 
-    private EntriesTableScan(TableOperations ops, Table table, Schema schema, String scannedTableName,
-                             TableScanContext context) {
+    private EntriesTableScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
       super(ops, table, schema, context);
-      this.scannedTableName = scannedTableName;
+    }
+
+    public String tableType() {
+      return String.valueOf(MetadataTableType.ENTRIES);
     }
 
     @Override
     public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
       throw new UnsupportedOperationException(
-          String.format("Incremental scan is not supported for metadata table %s", scannedTableName));
+          String.format("Incremental scan is not supported for %s scan of table %s", tableType(), table().name()));
     }
 
     @Override
     public TableScan appendsAfter(long fromSnapshotId) {
       throw new UnsupportedOperationException(
-          String.format("Incremental scan is not supported for metadata table %s", scannedTableName));
+          String.format("Incremental scan is not supported for %s scan of table %s", tableType(), table().name()));
     }
 
     @Override
     protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema,
                                        TableScanContext context) {
-      return new EntriesTableScan(ops, table, schema, scannedTableName, context);
+      return new EntriesTableScan(ops, table, schema, context);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
@@ -120,7 +120,7 @@ public class ManifestEntriesTable extends BaseMetadataTable {
     }
 
     private String tableType() {
-      return String.valueOf(MetadataTableType.ENTRIES);
+      return MetadataTableType.ENTRIES.name();
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
@@ -80,13 +80,13 @@ public class ManifestEntriesTable extends BaseMetadataTable {
     @Override
     public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
       throw new UnsupportedOperationException(
-          String.format("Incremental scan is not supported for %s scan of table %s", tableType(), table().name()));
+          String.format("Cannot incrementally scan table of type %s", tableType()));
     }
 
     @Override
     public TableScan appendsAfter(long fromSnapshotId) {
       throw new UnsupportedOperationException(
-          String.format("Incremental scan is not supported for %s scan of table %s", tableType(), table().name()));
+          String.format("Cannot incrementally scan table of type %s", tableType()));
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
@@ -80,13 +80,13 @@ public class ManifestEntriesTable extends BaseMetadataTable {
     @Override
     public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
       throw new UnsupportedOperationException(
-          String.format("Cannot incrementally scan table of type %s", tableType()));
+          String.format("Cannot incrementally scan table of type %s", MetadataTableType.ENTRIES.name()));
     }
 
     @Override
     public TableScan appendsAfter(long fromSnapshotId) {
       throw new UnsupportedOperationException(
-          String.format("Cannot incrementally scan table of type %s", tableType()));
+          String.format("Cannot incrementally scan table of type %s", MetadataTableType.ENTRIES.name()));
     }
 
     @Override
@@ -117,10 +117,6 @@ public class ManifestEntriesTable extends BaseMetadataTable {
       return CloseableIterable.transform(manifests, manifest ->
           new ManifestReadTask(ops.io(), manifest, fileSchema, schemaString, specString, residuals,
               ops.current().specsById()));
-    }
-
-    private String tableType() {
-      return MetadataTableType.ENTRIES.name();
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/ManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestsTable.java
@@ -81,7 +81,12 @@ public class ManifestsTable extends BaseMetadataTable {
 
   private class ManifestsTableScan extends StaticTableScan {
     ManifestsTableScan(TableOperations ops, Table table) {
-      super(ops, table, SNAPSHOT_SCHEMA, ManifestsTable.this.name(), ManifestsTable.this::task);
+      super(ops, table, SNAPSHOT_SCHEMA, ManifestsTable.this::task);
+    }
+
+    @Override
+    public String tableType() {
+      return String.valueOf(ManifestsTable.this.metadataTableType());
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/ManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestsTable.java
@@ -81,7 +81,7 @@ public class ManifestsTable extends BaseMetadataTable {
 
   private class ManifestsTableScan extends StaticTableScan {
     ManifestsTableScan(TableOperations ops, Table table) {
-      super(ops, table, SNAPSHOT_SCHEMA, ManifestsTable.this::task);
+      super(ops, table, SNAPSHOT_SCHEMA, ManifestsTable.this.name(), ManifestsTable.this::task);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/ManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestsTable.java
@@ -86,7 +86,7 @@ public class ManifestsTable extends BaseMetadataTable {
 
     @Override
     protected String tableType() {
-      return String.valueOf(ManifestsTable.this.metadataTableType());
+      return ManifestsTable.this.metadataTableType().name();
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/ManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestsTable.java
@@ -81,12 +81,7 @@ public class ManifestsTable extends BaseMetadataTable {
 
   private class ManifestsTableScan extends StaticTableScan {
     ManifestsTableScan(TableOperations ops, Table table) {
-      super(ops, table, SNAPSHOT_SCHEMA, ManifestsTable.this::task);
-    }
-
-    @Override
-    protected String tableType() {
-      return ManifestsTable.this.metadataTableType().name();
+      super(ops, table, SNAPSHOT_SCHEMA, ManifestsTable.this.metadataTableType().name(), ManifestsTable.this::task);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/ManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestsTable.java
@@ -85,7 +85,7 @@ public class ManifestsTable extends BaseMetadataTable {
     }
 
     @Override
-    public String tableType() {
+    protected String tableType() {
       return String.valueOf(ManifestsTable.this.metadataTableType());
     }
   }

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -97,7 +97,7 @@ public class PartitionsTable extends BaseMetadataTable {
 
   private class PartitionsScan extends StaticTableScan {
     PartitionsScan(TableOperations ops, Table table) {
-      super(ops, table, PartitionsTable.this.schema(), PartitionsTable.this::task);
+      super(ops, table, PartitionsTable.this.schema(), PartitionsTable.this.name(), PartitionsTable.this::task);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -97,7 +97,12 @@ public class PartitionsTable extends BaseMetadataTable {
 
   private class PartitionsScan extends StaticTableScan {
     PartitionsScan(TableOperations ops, Table table) {
-      super(ops, table, PartitionsTable.this.schema(), PartitionsTable.this.name(), PartitionsTable.this::task);
+      super(ops, table, PartitionsTable.this.schema(), PartitionsTable.this::task);
+    }
+
+    @Override
+    public String tableType() {
+      return String.valueOf(PartitionsTable.this.metadataTableType());
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -97,12 +97,8 @@ public class PartitionsTable extends BaseMetadataTable {
 
   private class PartitionsScan extends StaticTableScan {
     PartitionsScan(TableOperations ops, Table table) {
-      super(ops, table, PartitionsTable.this.schema(), PartitionsTable.this::task);
-    }
-
-    @Override
-    protected String tableType() {
-      return PartitionsTable.this.metadataTableType().name();
+      super(ops, table, PartitionsTable.this.schema(), PartitionsTable.this.metadataTableType().name(),
+            PartitionsTable.this::task);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -102,7 +102,7 @@ public class PartitionsTable extends BaseMetadataTable {
 
     @Override
     protected String tableType() {
-      return String.valueOf(PartitionsTable.this.metadataTableType());
+      return PartitionsTable.this.metadataTableType().name();
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -101,7 +101,7 @@ public class PartitionsTable extends BaseMetadataTable {
     }
 
     @Override
-    public String tableType() {
+    protected String tableType() {
       return String.valueOf(PartitionsTable.this.metadataTableType());
     }
   }

--- a/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
@@ -71,18 +71,13 @@ public class SnapshotsTable extends BaseMetadataTable {
 
   private class SnapshotsTableScan extends StaticTableScan {
     SnapshotsTableScan(TableOperations ops, Table table) {
-      super(ops, table, SNAPSHOT_SCHEMA, SnapshotsTable.this::task);
+      super(ops, table, SNAPSHOT_SCHEMA, SnapshotsTable.this.metadataTableType().name(), SnapshotsTable.this::task);
     }
 
     @Override
     public CloseableIterable<FileScanTask> planFiles() {
       // override planFiles to avoid the check for a current snapshot because this metadata table is for all snapshots
       return CloseableIterable.withNoopClose(SnapshotsTable.this.task(this));
-    }
-
-    @Override
-    protected String tableType() {
-      return SnapshotsTable.this.metadataTableType().name();
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
@@ -75,14 +75,14 @@ public class SnapshotsTable extends BaseMetadataTable {
     }
 
     @Override
-    public String tableType() {
-      return String.valueOf(SnapshotsTable.this.metadataTableType());
-    }
-
-    @Override
     public CloseableIterable<FileScanTask> planFiles() {
       // override planFiles to avoid the check for a current snapshot because this metadata table is for all snapshots
       return CloseableIterable.withNoopClose(SnapshotsTable.this.task(this));
+    }
+
+    @Override
+    protected String tableType() {
+      return String.valueOf(SnapshotsTable.this.metadataTableType());
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
@@ -71,7 +71,12 @@ public class SnapshotsTable extends BaseMetadataTable {
 
   private class SnapshotsTableScan extends StaticTableScan {
     SnapshotsTableScan(TableOperations ops, Table table) {
-      super(ops, table, SNAPSHOT_SCHEMA, SnapshotsTable.this.name(), SnapshotsTable.this::task);
+      super(ops, table, SNAPSHOT_SCHEMA, SnapshotsTable.this::task);
+    }
+
+    @Override
+    public String tableType() {
+      return String.valueOf(SnapshotsTable.this.metadataTableType());
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
@@ -71,7 +71,7 @@ public class SnapshotsTable extends BaseMetadataTable {
 
   private class SnapshotsTableScan extends StaticTableScan {
     SnapshotsTableScan(TableOperations ops, Table table) {
-      super(ops, table, SNAPSHOT_SCHEMA, SnapshotsTable.this::task);
+      super(ops, table, SNAPSHOT_SCHEMA, SnapshotsTable.this.name(), SnapshotsTable.this::task);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
@@ -82,7 +82,7 @@ public class SnapshotsTable extends BaseMetadataTable {
 
     @Override
     protected String tableType() {
-      return String.valueOf(SnapshotsTable.this.metadataTableType());
+      return SnapshotsTable.this.metadataTableType().name();
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/StaticTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/StaticTableScan.java
@@ -23,7 +23,7 @@ import java.util.function.Function;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.CloseableIterable;
 
-public class StaticTableScan extends BaseTableScan {
+class StaticTableScan extends BaseTableScan {
   private final Function<StaticTableScan, DataTask> buildTask;
   // Metadata table name that the buildTask that this StaticTableScan will return data for.
   private final String scannedTableName;

--- a/core/src/main/java/org/apache/iceberg/StaticTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/StaticTableScan.java
@@ -23,7 +23,7 @@ import java.util.function.Function;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.CloseableIterable;
 
-class StaticTableScan extends BaseTableScan {
+public class StaticTableScan extends BaseTableScan {
   private final Function<StaticTableScan, DataTask> buildTask;
   // Metadata table name that the buildTask that this StaticTableScan will return data for.
   private final String scannedTableName;

--- a/core/src/main/java/org/apache/iceberg/StaticTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/StaticTableScan.java
@@ -25,16 +25,33 @@ import org.apache.iceberg.io.CloseableIterable;
 
 class StaticTableScan extends BaseTableScan {
   private final Function<StaticTableScan, DataTask> buildTask;
+  // Metadata table name that the buildTask that this StaticTableScan will return data for.
+  private final String scannedTableName;
 
-  StaticTableScan(TableOperations ops, Table table, Schema schema, Function<StaticTableScan, DataTask> buildTask) {
+  StaticTableScan(TableOperations ops, Table table, Schema schema,  String scannedTableName,
+                  Function<StaticTableScan, DataTask> buildTask) {
     super(ops, table, schema);
     this.buildTask = buildTask;
+    this.scannedTableName = scannedTableName;
   }
 
-  private StaticTableScan(TableOperations ops, Table table, Schema schema,
+  private StaticTableScan(TableOperations ops, Table table, Schema schema,  String scannedTableName,
                           Function<StaticTableScan, DataTask> buildTask, TableScanContext context) {
     super(ops, table, schema, context);
     this.buildTask = buildTask;
+    this.scannedTableName = scannedTableName;
+  }
+
+  @Override
+  public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
+    throw new UnsupportedOperationException(
+        String.format("Incremental scan is not supported for metadata table %s", scannedTableName));
+  }
+
+  @Override
+  public TableScan appendsAfter(long fromSnapshotId) {
+    throw new UnsupportedOperationException(
+        String.format("Incremental scan is not supported for metadata table %s", scannedTableName));
   }
 
   @Override
@@ -46,7 +63,7 @@ class StaticTableScan extends BaseTableScan {
   @Override
   protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
     return new StaticTableScan(
-        ops, table, schema, buildTask, context);
+        ops, table, schema, scannedTableName, buildTask, context);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/StaticTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/StaticTableScan.java
@@ -25,39 +25,32 @@ import org.apache.iceberg.io.CloseableIterable;
 
 class StaticTableScan extends BaseTableScan {
   private final Function<StaticTableScan, DataTask> buildTask;
+  private final String tableType;
 
-  StaticTableScan(TableOperations ops, Table table, Schema schema,
+  StaticTableScan(TableOperations ops, Table table, Schema schema, String tableType,
                   Function<StaticTableScan, DataTask> buildTask) {
     super(ops, table, schema);
     this.buildTask = buildTask;
+    this.tableType = tableType;
   }
 
-  private StaticTableScan(TableOperations ops, Table table, Schema schema,
+  private StaticTableScan(TableOperations ops, Table table, Schema schema, String tableType,
                           Function<StaticTableScan, DataTask> buildTask, TableScanContext context) {
     super(ops, table, schema, context);
     this.buildTask = buildTask;
-  }
-
-  /**
-   * Type of scan being performed by the buildTask, such as {@link MetadataTableType#HISTORY} when scanning
-   * a table's {@link org.apache.iceberg.HistoryTable}.
-   * <p>
-   * Used for logging and error messages.
-   */
-  protected String tableType() {
-    return "static";
+    this.tableType = tableType;
   }
 
   @Override
   public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
     throw new UnsupportedOperationException(
-        String.format("Incremental scan is not supported for %s scan of table %s", tableType(), table().name()));
+        String.format("Cannot incrementally scan table of type %s", tableType));
   }
 
   @Override
   public TableScan appendsAfter(long fromSnapshotId) {
     throw new UnsupportedOperationException(
-        String.format("Incremental scan is not supported for %s scan of table %s", tableType(), table().name()));
+        String.format("Cannot incrementally scan table of type %s", tableType));
   }
 
   @Override
@@ -69,7 +62,7 @@ class StaticTableScan extends BaseTableScan {
   @Override
   protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
     return new StaticTableScan(
-        ops, table, schema, buildTask, context);
+        ops, table, schema, tableType, buildTask, context);
   }
 
   @Override

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestStaticTable.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestStaticTable.java
@@ -61,6 +61,15 @@ public class TestStaticTable extends HadoopTableTestBase {
   }
 
   @Test
+  public void testCannotDoIncrementalScanOnHistoryTable() {
+    table.newAppend().appendFile(FILE_A).commit();
+    Table staticTable = getStaticTable(MetadataTableType.HISTORY);
+    AssertHelpers.assertThrows("Cannot perform incremental scan on metadata table", UnsupportedOperationException.class,
+        String.format("Incremental scan is not supported for metadata table %s", staticTable.name()),
+        () -> staticTable.newScan().appendsAfter(1));
+  }
+
+  @Test
   public void testHasSameProperties() {
     table.newAppend().appendFile(FILE_A).commit();
     table.newAppend().appendFile(FILE_B).commit();

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestStaticTable.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestStaticTable.java
@@ -61,12 +61,15 @@ public class TestStaticTable extends HadoopTableTestBase {
   }
 
   @Test
-  public void testCannotDoIncrementalScanOnHistoryTable() {
+  public void testCannotDoIncrementalScanOnMetadataTable() {
     table.newAppend().appendFile(FILE_A).commit();
-    Table staticTable = getStaticTable(MetadataTableType.HISTORY);
-    AssertHelpers.assertThrows("Cannot perform incremental scan on metadata table", UnsupportedOperationException.class,
-        String.format("Incremental scan is not supported for metadata table %s", staticTable.name()),
-        () -> staticTable.newScan().appendsAfter(1));
+    for (MetadataTableType type : MetadataTableType.values()) {
+      Table staticTable = getStaticTable(type);
+      AssertHelpers.assertThrows("Metadata tables do not currently support incremental scans",
+          UnsupportedOperationException.class,
+          String.format("Incremental scan is not supported for metadata table %s", staticTable.name()),
+          () -> staticTable.newScan().appendsAfter(1));
+    }
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestStaticTable.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestStaticTable.java
@@ -66,9 +66,9 @@ public class TestStaticTable extends HadoopTableTestBase {
 
     for (MetadataTableType type : MetadataTableType.values()) {
       Table staticTable = getStaticTable(type);
-      AssertHelpers.assertThrows("Static tables do not currently support incremental scans",
+      AssertHelpers.assertThrows("Static tables do not support incremental scans",
           UnsupportedOperationException.class,
-          String.format("Incremental scan is not supported for %s scan of table %s", type, table.name()),
+          String.format("Cannot incrementally scan table of type %s", type),
           () -> staticTable.newScan().appendsAfter(1));
     }
   }

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestStaticTable.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestStaticTable.java
@@ -63,11 +63,12 @@ public class TestStaticTable extends HadoopTableTestBase {
   @Test
   public void testCannotDoIncrementalScanOnMetadataTable() {
     table.newAppend().appendFile(FILE_A).commit();
+
     for (MetadataTableType type : MetadataTableType.values()) {
       Table staticTable = getStaticTable(type);
-      AssertHelpers.assertThrows("Metadata tables do not currently support incremental scans",
+      AssertHelpers.assertThrows("Static tables do not currently support incremental scans",
           UnsupportedOperationException.class,
-          String.format("Incremental scan is not supported for metadata table %s", staticTable.name()),
+          String.format("Incremental scan is not supported for %s scan of table %s", type, table.name()),
           () -> staticTable.newScan().appendsAfter(1));
     }
   }


### PR DESCRIPTION
Refines the error message given when a user attempts an incremental scan against any of the metadata table scans to include the name of the name of the metadata table that's being scanned.

This also makes it trivial to correct the bug in https://github.com/apache/iceberg/issues/2635

This is to assist users who are testing incremental scans on a table `foo`, and might switch back and forth between querying `foo` and for example `foo.history` (to debug their development). Currently, the error message is just `Incremental scan is not supported`, which is not very clear when switching back and forth during development.

This closes https://github.com/apache/iceberg/issues/2599

cc @RussellSpitzer @aokolnychyi 