### PR TITLE
[CORE] Enforce tableName is implemented in BaseMetastoreTableOperations for logging

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -69,9 +69,7 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
    * catalogName + "." + database + "." + table.
    * @return The full name
    */
-  protected String tableName() {
-    return null;
-  }
+  protected abstract String tableName();
 
   @Override
   public TableMetadata current() {

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
@@ -67,6 +67,11 @@ public class NessieTableOperations extends BaseMetastoreTableOperations {
   }
 
   @Override
+  protected String tableName() {
+    return key.toString();
+  }
+
+  @Override
   protected void doRefresh() {
     try {
       reference.refresh();


### PR DESCRIPTION
Fix null tableName when logging in checkCommitStatus for Nessie tables and enforce tableName is implemented at compile time.

Arguably, `tableName` _might_ be something that we want to make part of the interface for `TableOperations`, but that's a larger discussion.

This will fix the [currently `null` tableName](https://github.com/apache/iceberg/blob/32ce969218b75915cb7396c541bdc19f4ac8bd9f/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java#L72-L74) logs in [`checkCommitStatus`](https://github.com/apache/iceberg/blob/32ce969218b75915cb7396c541bdc19f4ac8bd9f/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java#L274-L311) for Nessie tables, as well as enforce this issue doesn't occur when new catalogs are added if they derive their operations from `BaseMetastoreTableOperations`.

Please let me know if this is not the correct way to get the name from the Nessie table's @rymurr


This closes https://github.com/apache/iceberg/issues/2628