### PR TITLE
Core: Apply encryption basics to writers and readers

### DIFF
--- a/core/src/main/java/org/apache/iceberg/io/FileAppenderFactory.java
+++ b/core/src/main/java/org/apache/iceberg/io/FileAppenderFactory.java
@@ -41,6 +41,11 @@ public interface FileAppenderFactory<T> {
    */
   FileAppender<T> newAppender(OutputFile outputFile, FileFormat fileFormat);
 
+  // TODO document this, or change the previous function
+  default FileAppender<T> newAppender(EncryptedOutputFile outputFile, FileFormat fileFormat) {
+    return null;
+  }
+
   /**
    * Create a new {@link DataWriter}.
    *

--- a/data/src/main/java/org/apache/iceberg/data/GenericAppenderFactory.java
+++ b/data/src/main/java/org/apache/iceberg/data/GenericAppenderFactory.java
@@ -34,7 +34,7 @@ import org.apache.iceberg.data.parquet.GenericParquetWriter;
 import org.apache.iceberg.deletes.EqualityDeleteWriter;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
-import org.apache.iceberg.encryption.NativeFileEncryptParams;
+import org.apache.iceberg.encryption.NativeFileCryptoParameters;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.FileAppenderFactory;
 import org.apache.iceberg.io.OutputFile;
@@ -91,7 +91,7 @@ public class GenericAppenderFactory implements FileAppenderFactory<Record> {
 
   @Override
   public FileAppender<Record> newAppender(EncryptedOutputFile outputFile, FileFormat fileFormat) {
-    NativeFileEncryptParams nativeEncryption = null;
+    NativeFileCryptoParameters nativeEncryption = null;
     if (outputFile.useNativeEncryption()) {
       nativeEncryption = outputFile.nativeEncryptionParameters();
     }
@@ -100,7 +100,7 @@ public class GenericAppenderFactory implements FileAppenderFactory<Record> {
   }
 
   private FileAppender<Record> newAppender(OutputFile outputFile,
-                                           NativeFileEncryptParams nativeEncryption,
+                                           NativeFileCryptoParameters nativeEncryption,
                                            FileFormat fileFormat) {
     MetricsConfig metricsConfig = MetricsConfig.fromProperties(config);
     try {
@@ -157,7 +157,7 @@ public class GenericAppenderFactory implements FileAppenderFactory<Record> {
     Preconditions.checkNotNull(eqDeleteRowSchema,
         "Equality delete row schema shouldn't be null when creating equality-delete writer");
 
-    NativeFileEncryptParams nativeEncryption = null;
+    NativeFileCryptoParameters nativeEncryption = null;
     if (file.useNativeEncryption()) {
       nativeEncryption = file.nativeEncryptionParameters();
     }
@@ -204,7 +204,7 @@ public class GenericAppenderFactory implements FileAppenderFactory<Record> {
   public PositionDeleteWriter<Record> newPosDeleteWriter(EncryptedOutputFile file, FileFormat format,
                                                          StructLike partition) {
     MetricsConfig metricsConfig = MetricsConfig.fromProperties(config);
-    NativeFileEncryptParams nativeEncryption = null;
+    NativeFileCryptoParameters nativeEncryption = null;
     if (file.useNativeEncryption()) {
       nativeEncryption = file.nativeEncryptionParameters();
     }

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkAppenderFactory.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkAppenderFactory.java
@@ -35,7 +35,7 @@ import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.deletes.EqualityDeleteWriter;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
-import org.apache.iceberg.encryption.NativeFileEncryptParams;
+import org.apache.iceberg.encryption.NativeFileCryptoParameters;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.data.FlinkAvroWriter;
 import org.apache.iceberg.flink.data.FlinkOrcWriter;
@@ -100,7 +100,7 @@ public class FlinkAppenderFactory implements FileAppenderFactory<RowData>, Seria
 
   @Override
   public FileAppender<RowData> newAppender(EncryptedOutputFile outputFile, FileFormat format) {
-    NativeFileEncryptParams nativeEncryption = null;
+    NativeFileCryptoParameters nativeEncryption = null;
     if (outputFile.useNativeEncryption()) {
       nativeEncryption = outputFile.nativeEncryptionParameters();
     }
@@ -109,7 +109,7 @@ public class FlinkAppenderFactory implements FileAppenderFactory<RowData>, Seria
   }
 
   private FileAppender<RowData> newAppender(OutputFile outputFile,
-                                            NativeFileEncryptParams nativeEncryption,
+                                            NativeFileCryptoParameters nativeEncryption,
                                             FileFormat format) {
     MetricsConfig metricsConfig = MetricsConfig.fromProperties(props);
     try {
@@ -166,7 +166,7 @@ public class FlinkAppenderFactory implements FileAppenderFactory<RowData>, Seria
         "Equality delete row schema shouldn't be null when creating equality-delete writer");
 
     MetricsConfig metricsConfig = MetricsConfig.fromProperties(props);
-    NativeFileEncryptParams nativeEncryption = null;
+    NativeFileCryptoParameters nativeEncryption = null;
     if (outputFile.useNativeEncryption()) {
       nativeEncryption = outputFile.nativeEncryptionParameters();
     }
@@ -211,7 +211,7 @@ public class FlinkAppenderFactory implements FileAppenderFactory<RowData>, Seria
   public PositionDeleteWriter<RowData> newPosDeleteWriter(EncryptedOutputFile outputFile, FileFormat format,
                                                           StructLike partition) {
     MetricsConfig metricsConfig = MetricsConfig.fromProperties(props);
-    NativeFileEncryptParams nativeEncryption = null;
+    NativeFileCryptoParameters nativeEncryption = null;
     if (outputFile.useNativeEncryption()) {
       nativeEncryption = outputFile.nativeEncryptionParameters();
     }

--- a/spark/src/main/java/org/apache/iceberg/spark/source/SparkAppenderFactory.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/SparkAppenderFactory.java
@@ -32,7 +32,7 @@ import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.deletes.EqualityDeleteWriter;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
-import org.apache.iceberg.encryption.NativeFileEncryptParams;
+import org.apache.iceberg.encryption.NativeFileCryptoParameters;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.DataWriter;
 import org.apache.iceberg.io.DeleteSchemaUtil;
@@ -155,7 +155,7 @@ class SparkAppenderFactory implements FileAppenderFactory<InternalRow> {
 
   @Override
   public FileAppender<InternalRow> newAppender(EncryptedOutputFile file, FileFormat fileFormat) {
-    NativeFileEncryptParams nativeEncryption = null;
+    NativeFileCryptoParameters nativeEncryption = null;
     if (file.useNativeEncryption()) {
       nativeEncryption = file.nativeEncryptionParameters();
     }
@@ -164,7 +164,7 @@ class SparkAppenderFactory implements FileAppenderFactory<InternalRow> {
   }
 
   private FileAppender<InternalRow> newAppender(OutputFile file,
-                                                NativeFileEncryptParams nativeEncryption,
+                                                NativeFileCryptoParameters nativeEncryption,
                                                 FileFormat fileFormat) {
     MetricsConfig metricsConfig = MetricsConfig.fromProperties(properties);
     try {
@@ -217,7 +217,8 @@ class SparkAppenderFactory implements FileAppenderFactory<InternalRow> {
         "Equality field ids shouldn't be null or empty when creating equality-delete writer");
     Preconditions.checkNotNull(eqDeleteRowSchema,
         "Equality delete row schema shouldn't be null when creating equality-delete writer");
-    NativeFileEncryptParams nativeEncryption = null;
+
+    NativeFileCryptoParameters nativeEncryption = null;
     if (file.useNativeEncryption()) {
       nativeEncryption = file.nativeEncryptionParameters();
     }
@@ -259,10 +260,11 @@ class SparkAppenderFactory implements FileAppenderFactory<InternalRow> {
   @Override
   public PositionDeleteWriter<InternalRow> newPosDeleteWriter(EncryptedOutputFile file, FileFormat format,
                                                               StructLike partition) {
-    NativeFileEncryptParams nativeEncryption = null;
+    NativeFileCryptoParameters nativeEncryption = null;
     if (file.useNativeEncryption()) {
       nativeEncryption = file.nativeEncryptionParameters();
     }
+
     try {
       switch (format) {
         case PARQUET:


### PR DESCRIPTION
A set of fresh data encryption keys is generated for each data file (in formats that support native encryption). The data keys are wrapped centrally (eg in the driver), potentially via KMS interaction, and stored in the manifest key_metadata entry for this data file. The data keys are delivered via NativeFileEncryptParams objects (see #2638) to the workers that perform data file writing/encryption.

@rdblue @jackye1995 @RussellSpitzer @flyrain @aokolnychyi