### PR TITLE
Docs: Add cache-enabled to catalog property list

### DIFF
--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -51,6 +51,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
  *   <li><code>warehouse</code> - the warehouse path (Hadoop catalog only)</li>
  *   <li><code>default-database</code> - a database name to use as the default</li>
  *   <li><code>base-namespace</code> - a base namespace as the prefix for all databases (Hadoop catalog only)</li>
+ *   <li><code>cache-enabled</code> - whether to enable catalog cache</li>
  * </ul>
  * <p>
  * To use a custom catalog that is not a Hive or Hadoop catalog, extend this class and override

--- a/site/docs/flink.md
+++ b/site/docs/flink.md
@@ -196,6 +196,7 @@ CREATE CATALOG hive_catalog WITH (
 * `property-version`: Version number to describe the property version. This property can be used for backwards compatibility in case the property format changes. The current property version is `1`. (Optional)
 * `warehouse`: The Hive warehouse location, users should specify this path if neither set the `hive-conf-dir` to specify a location containing a `hive-site.xml` configuration file nor add a correct `hive-site.xml` to classpath.
 * `hive-conf-dir`: Path to a directory containing a `hive-site.xml` configuration file which will be used to provide custom Hive configuration values. The value of `hive.metastore.warehouse.dir` from `<hive-conf-dir>/hive-site.xml` (or hive configure file from classpath) will be overwrote with the `warehouse` value if setting both `hive-conf-dir` and `warehouse` when creating iceberg catalog.
+* `cache-enabled`: Whether to enable catalog cache, default value is `true`
 
 ### Hadoop catalog
 

--- a/site/docs/spark-configuration.md
+++ b/site/docs/spark-configuration.md
@@ -59,6 +59,7 @@ Both catalogs are configured using properties nested under the catalog name. Com
 | spark.sql.catalog._catalog-name_.default-namespace | default                       | The default current namespace for the catalog |
 | spark.sql.catalog._catalog-name_.uri               | thrift://host:port            | Metastore connect URI; default from `hive-site.xml` |
 | spark.sql.catalog._catalog-name_.warehouse         | hdfs://nn:8020/warehouse/path | Base path for the warehouse directory |
+| spark.sql.catalog._catalog-name_.warehouse.cache-enabled | `true` or `false`             | Whether to enable catalog cache, default value is `true`     |
 
 Additional properties can be found in common [catalog configuration](./configuration.md#catalog-properties).
 

--- a/site/docs/spark-configuration.md
+++ b/site/docs/spark-configuration.md
@@ -59,7 +59,7 @@ Both catalogs are configured using properties nested under the catalog name. Com
 | spark.sql.catalog._catalog-name_.default-namespace | default                       | The default current namespace for the catalog |
 | spark.sql.catalog._catalog-name_.uri               | thrift://host:port            | Metastore connect URI; default from `hive-site.xml` |
 | spark.sql.catalog._catalog-name_.warehouse         | hdfs://nn:8020/warehouse/path | Base path for the warehouse directory |
-| spark.sql.catalog._catalog-name_.warehouse.cache-enabled | `true` or `false`             | Whether to enable catalog cache, default value is `true`     |
+| spark.sql.catalog._catalog-name_.cache-enabled     | `true` or `false`             | Whether to enable catalog cache, default value is `true` |
 
 Additional properties can be found in common [catalog configuration](./configuration.md#catalog-properties).
 

--- a/spark3/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -72,6 +72,7 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  *   <li><code>uri</code> - the Hive Metastore URI (Hive catalog only)</li>
  *   <li><code>warehouse</code> - the warehouse path (Hadoop catalog only)</li>
  *   <li><code>default-namespace</code> - a namespace to use as the default</li>
+ *   <li><code>cache-enabled</code> - whether to enable catalog cache</li>
  * </ul>
  * <p>
  * To use a custom catalog that is not a Hive or Hadoop catalog, extend this class and override


### PR DESCRIPTION
By default the catalog cache is enabled. **In one spark-sql session**, same sql over a changing iceberg table will return the same result even if the table has changed. The reason is that `loadTable` method is cached and we couldn't get latest snapshots of the table. If we turn off the cache, we can always get the latest result within one session.

So I think the `cache-enabled` property should be in the docs as it is an important configuration.