### PR TITLE
Hive: CachedClientPool connection leak

### DIFF
--- a/baseline.gradle
+++ b/baseline.gradle
@@ -79,6 +79,8 @@ subprojects {
           '-Xep:StrictUnusedVariable:OFF',
           '-Xep:TypeParameterShadowing:OFF',
           '-Xep:TypeParameterUnusedInFormals:OFF',
+           // allowed use Runtime#addShutdownHook.
+          '-Xep:ShutdownHook:OFF',
       )
     }
   }

--- a/core/src/main/java/org/apache/iceberg/ClientPoolImpl.java
+++ b/core/src/main/java/org/apache/iceberg/ClientPoolImpl.java
@@ -24,8 +24,6 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,12 +38,9 @@ public abstract class ClientPoolImpl<C, E extends Exception> implements Closeabl
   private volatile int currentSize;
   private boolean closed;
 
-  @VisibleForTesting
-  public static volatile AtomicInteger openCount = new AtomicInteger(0);
-  @VisibleForTesting
-  public static volatile AtomicInteger closeCount = new AtomicInteger(0);
-  @VisibleForTesting
-  public static final String currentProcessUUID = UUID.randomUUID().toString();
+  private static volatile AtomicInteger openCount = new AtomicInteger(0);
+  private static volatile AtomicInteger closeCount = new AtomicInteger(0);
+  private static final String currentProcessUUID = UUID.randomUUID().toString();
 
   public ClientPoolImpl(int poolSize, Class<? extends E> reconnectExc) {
     this.poolSize = poolSize;
@@ -152,5 +147,13 @@ public abstract class ClientPoolImpl<C, E extends Exception> implements Closeabl
 
   public int poolSize() {
     return poolSize;
+  }
+
+  public static AtomicInteger openCount() {
+    return openCount;
+  }
+
+  public static AtomicInteger closeCount() {
+    return closeCount;
   }
 }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalogLeak.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalogLeak.java
@@ -1,77 +1,89 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.iceberg.hive;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import org.apache.iceberg.ClientPoolImpl;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.types.Types;
-import org.junit.Test;
 import org.junit.Assert;
-
-import java.util.ArrayList;
-import java.util.concurrent.*;
+import org.junit.Test;
 
 public class TestHiveCatalogLeak extends HiveMetastoreTest {
-    @Test
-    public void testHmsClientLeak() {
-        connectHMSSimulator();
+  @Test
+  public void testHmsClientLeak() {
+    // Do something to create some connections.
+    connectHMSSimulator();
 
-        // Before cache cleanup, some clients may not be closed.
-        Assert.assertNotEquals(String.format("open count %s , close count %s , all clients have been closed.",
-                ClientPoolImpl.openCount.get(), ClientPoolImpl.closeCount.get()),
-                ClientPoolImpl.openCount.get(), ClientPoolImpl.closeCount.get());
+    // Before cache cleanup, some clients may not be closed.
+    Assert.assertNotEquals(String.format("open count %s , close count %s , all clients have been closed.",
+        ClientPoolImpl.openCount().get(), ClientPoolImpl.closeCount().get()),
+        ClientPoolImpl.openCount().get(), ClientPoolImpl.closeCount().get());
 
-        CachedClientPool.cleanupCache();
+    // Cleanup cache
+    CachedClientPool.cleanupCache();
+    // Cleanup cache is async, so we should wait some time
+    waitingForCleanup();
 
-        // Cleanup cache is async, so we should wait some time
-        long startTime = System.currentTimeMillis();
-        while((ClientPoolImpl.openCount.get() != ClientPoolImpl.closeCount.get())
-                && (startTime + 18000) > System.currentTimeMillis()) {
-            try {
-                Thread.sleep(1000);
-            } catch (Exception e) {
-                // do nothing
-            }
-        }
+    // After cache cleanup, all clients are closed.
+    Assert.assertEquals(String.format("open count %s , close count %s , some clients may not be closed.",
+        ClientPoolImpl.openCount().get(), ClientPoolImpl.closeCount().get()),
+        ClientPoolImpl.openCount().get(), ClientPoolImpl.closeCount().get());
+  }
 
-        // After cache cleanup, all clients are closed.
-        Assert.assertEquals(String.format("open count %s , close count %s , some clients may not be closed.",
-                ClientPoolImpl.openCount.get(), ClientPoolImpl.closeCount.get()),
-                ClientPoolImpl.openCount.get(), ClientPoolImpl.closeCount.get());
+  private void connectHMSSimulator() {
+    ExecutorService executorService = Executors.newFixedThreadPool(100);
+    List<Future<?>> futures = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      int finalI = i;
+      Future<?> future = executorService.submit(() -> {
+        TableIdentifier name = TableIdentifier.of("hivedb", "iceberg_test_" + finalI);
+        Schema schema = new Schema(Types.NestedField.required(1, "c1", Types.IntegerType.get()));
+        catalog.createTable(name, schema);
+      });
+      futures.add(future);
     }
-
-    private void connectHMSSimulator() {
-        ExecutorService executorService = Executors.newFixedThreadPool(100);
-        ArrayList<Future<?>> futures = new ArrayList<>();
-        for (int i = 0; i < 10; i++) {
-            int finalI = i;
-            Future<?> future = executorService.submit(() -> {
-                TableIdentifier name = TableIdentifier.of("hivedb", "iceberg_test_" + finalI);
-                Schema schema = new Schema(Types.NestedField.required(1, "c1", Types.IntegerType.get()));
-                catalog.createTable(name, schema);
-            });
-            futures.add(future);
-        }
-        for (Future<?> future : futures) {
-            try {
-                future.get();
-            } catch (Exception e) {
-                // do nothing
-            }
-        }
-        executorService.shutdown();
+    for (Future<?> future : futures) {
+      try {
+        future.get();
+      } catch (Exception e) {
+        // do nothing
+      }
     }
+    executorService.shutdown();
+  }
+
+  private void waitingForCleanup() {
+    long startTime = System.currentTimeMillis();
+    while ((ClientPoolImpl.openCount().get() != ClientPoolImpl.closeCount().get()) &&
+        (startTime + 18000) > System.currentTimeMillis()) {
+      try {
+        Thread.sleep(1000);
+      } catch (Exception e) {
+        // do nothing
+      }
+    }
+  }
 }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalogLeak.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalogLeak.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.hive;
+
+import com.sun.tools.javac.util.Assert;
+import org.apache.iceberg.ClientPoolImpl;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.types.Types;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.concurrent.*;
+
+public class TestHiveCatalogLeak extends HiveMetastoreTest {
+    @Test
+    public void testHmsClientLeak() {
+        connectHMSSimulator();
+
+        // Before cache cleanup, some clients may not be closed.
+        Assert.check(ClientPoolImpl.openCount.get() != ClientPoolImpl.closeCount.get(),
+                String.format("open count %s , close count %s , all clients have been closed.",
+                        ClientPoolImpl.openCount.get(), ClientPoolImpl.closeCount.get()));
+
+        CachedClientPool.cleanupCache();
+
+        // Cleanup cache is async, so we should wait some time
+        long startTime = System.currentTimeMillis();
+        while((ClientPoolImpl.openCount.get() != ClientPoolImpl.closeCount.get())
+                && (startTime + 18000) > System.currentTimeMillis()) {
+            try {
+                Thread.sleep(1000);
+            } catch (Exception e) {
+                // do nothing
+            }
+        }
+
+        // After cache cleanup, all clients are closed.
+        Assert.check(ClientPoolImpl.openCount.get() == ClientPoolImpl.closeCount.get(),
+                String.format("open count %s , close count %s , some clients may not be closed.",
+                        ClientPoolImpl.openCount.get(), ClientPoolImpl.closeCount.get()));
+    }
+
+    private void connectHMSSimulator() {
+        ExecutorService executorService = Executors.newFixedThreadPool(100);
+        ArrayList<Future<?>> futures = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            int finalI = i;
+            Future<?> future = executorService.submit(() -> {
+                TableIdentifier name = TableIdentifier.of("hivedb", "iceberg_test_" + finalI);
+                Schema schema = new Schema(Types.NestedField.required(1, "c1", Types.IntegerType.get()));
+                catalog.createTable(name, schema);
+            });
+            futures.add(future);
+        }
+        for (Future<?> future : futures) {
+            try {
+                future.get();
+            } catch (Exception e) {
+                // do nothing
+            }
+        }
+        executorService.shutdown();
+    }
+}

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalogLeak.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalogLeak.java
@@ -14,12 +14,12 @@
 
 package org.apache.iceberg.hive;
 
-import com.sun.tools.javac.util.Assert;
 import org.apache.iceberg.ClientPoolImpl;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.types.Types;
 import org.junit.Test;
+import org.junit.Assert;
 
 import java.util.ArrayList;
 import java.util.concurrent.*;
@@ -30,9 +30,9 @@ public class TestHiveCatalogLeak extends HiveMetastoreTest {
         connectHMSSimulator();
 
         // Before cache cleanup, some clients may not be closed.
-        Assert.check(ClientPoolImpl.openCount.get() != ClientPoolImpl.closeCount.get(),
-                String.format("open count %s , close count %s , all clients have been closed.",
-                        ClientPoolImpl.openCount.get(), ClientPoolImpl.closeCount.get()));
+        Assert.assertNotEquals(String.format("open count %s , close count %s , all clients have been closed.",
+                ClientPoolImpl.openCount.get(), ClientPoolImpl.closeCount.get()),
+                ClientPoolImpl.openCount.get(), ClientPoolImpl.closeCount.get());
 
         CachedClientPool.cleanupCache();
 
@@ -48,9 +48,9 @@ public class TestHiveCatalogLeak extends HiveMetastoreTest {
         }
 
         // After cache cleanup, all clients are closed.
-        Assert.check(ClientPoolImpl.openCount.get() == ClientPoolImpl.closeCount.get(),
-                String.format("open count %s , close count %s , some clients may not be closed.",
-                        ClientPoolImpl.openCount.get(), ClientPoolImpl.closeCount.get()));
+        Assert.assertEquals(String.format("open count %s , close count %s , some clients may not be closed.",
+                ClientPoolImpl.openCount.get(), ClientPoolImpl.closeCount.get()),
+                ClientPoolImpl.openCount.get(), ClientPoolImpl.closeCount.get());
     }
 
     private void connectHMSSimulator() {


### PR DESCRIPTION
# What changes were proposed in this pull request?
This pr adds shutdownhook to close the connection in the cache of CachedClientPool before the jvm exit. 

# Why are the changes needed?
ExpireAfterAccess is 5 minutes, this is too long, if the last access time is much less than 5 minutes, the connections in the cache will leak，we should close it.