### PR TITLE
Core: add checkShouldKeep for DeleteFilter

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/CheckIterator.java
+++ b/api/src/main/java/org/apache/iceberg/io/CheckIterator.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+/**
+ * An Iterator of {@link Optional} that checks a predicate for each item based on another Iterator.
+ * If predicate is true, the optional item has content, otherwise the optional is empty.
+ *
+ * @param <T> the type of objects of the dependent Iterator
+ */
+public abstract class CheckIterator<T> implements CloseableIterator<Optional<T>> {
+  private final Iterator<T> items;
+  private boolean closed;
+
+  protected CheckIterator(Iterator<T> items) {
+    this.items = items;
+    this.closed = false;
+  }
+
+  protected abstract boolean check(T item);
+
+  @Override
+  public boolean hasNext() {
+    boolean itemsHasNext = items.hasNext();
+    if (!itemsHasNext) {
+      close();
+    }
+
+    return !closed && itemsHasNext;
+  }
+
+  @Override
+  public Optional<T> next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+
+    T item = items.next();
+    return check(item) ? Optional.ofNullable(item) : Optional.empty();
+  }
+
+  @Override
+  public void close() {
+    if (!closed) {
+      try {
+        ((Closeable) items).close();
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
+
+      this.closed = true;
+    }
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/io/TestCheckIterator.java
+++ b/api/src/test/java/org/apache/iceberg/io/TestCheckIterator.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io;
+
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestCheckIterator {
+
+  @Test
+  public void testIteration() {
+    CheckIterator<Integer> checkEvenIterator = new CheckIterator<Integer>(
+        CloseableIterable.withNoopClose(IntStream.range(0, 5).boxed().collect(Collectors.toList())).iterator()) {
+      @Override
+      protected boolean check(Integer item) {
+        return (item % 2) == 0;
+      }
+    };
+
+    for (int i = 0; i < 5; i++) {
+      Assert.assertTrue(checkEvenIterator.hasNext());
+      Optional<Integer> next = checkEvenIterator.next();
+      if (i % 2 == 0) {
+        Assert.assertTrue(next.isPresent());
+      } else {
+        Assert.assertFalse(next.isPresent());
+      }
+    }
+
+    Assert.assertFalse(checkEvenIterator.hasNext());
+  }
+}

--- a/data/src/test/java/org/apache/iceberg/data/TestGenericDeleteFilter.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestGenericDeleteFilter.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.data;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.TestTables;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.Pair;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestGenericDeleteFilter {
+
+  public static final Schema SCHEMA = new Schema(
+      Types.NestedField.required(1, "id", Types.IntegerType.get()),
+      Types.NestedField.required(2, "data", Types.StringType.get())
+  );
+
+  public static final PartitionSpec SPEC = PartitionSpec.builderFor(SCHEMA)
+      .bucket("data", 16)
+      .build();
+
+  public static final String TABLE_NAME = "test";
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  private Table table;
+  private List<Record> records;
+  private DataFile dataFile;
+
+  @Before
+  public void before() throws Exception {
+    File tableDir = temp.newFolder();
+    Assert.assertTrue(tableDir.delete());
+    this.table = TestTables.create(tableDir, TABLE_NAME, SCHEMA, SPEC, 2);
+    this.records = Lists.newArrayList();
+
+    GenericRecord record = GenericRecord.create(table.schema());
+    records.add(record.copy("id", 29, "data", "a"));
+    records.add(record.copy("id", 43, "data", "b"));
+    records.add(record.copy("id", 61, "data", "c"));
+    records.add(record.copy("id", 89, "data", "d"));
+    records.add(record.copy("id", 100, "data", "e"));
+    records.add(record.copy("id", 121, "data", "f"));
+    records.add(record.copy("id", 122, "data", "g"));
+
+    this.dataFile = FileHelpers.writeDataFile(table, Files.localOutput(temp.newFile()), TestHelpers.Row.of(0), records);
+
+    table.newAppend()
+        .appendFile(dataFile)
+        .commit();
+  }
+
+  @After
+  public void cleanup() throws IOException {
+    TestTables.clearTables();
+  }
+
+  @Test
+  public void testCheckShouldKeep() throws Exception {
+    Schema dataSchema = table.schema().select("data");
+    Record dataDelete = GenericRecord.create(dataSchema);
+    List<Record> dataDeletes = Lists.newArrayList(
+        dataDelete.copy("data", "a"), // id = 29
+        dataDelete.copy("data", "d"), // id = 89
+        dataDelete.copy("data", "g") // id = 122
+    );
+
+    DeleteFile eqDeletes = FileHelpers.writeDeleteFile(
+        table, Files.localOutput(temp.newFile()), TestHelpers.Row.of(0), dataDeletes, dataSchema);
+
+    List<Pair<CharSequence, Long>> deletes = Lists.newArrayList(
+        Pair.of(dataFile.path(), 3L), // id = 89
+        Pair.of(dataFile.path(), 5L) // id = 121
+    );
+
+    Pair<DeleteFile, Set<CharSequence>> posDeletes = FileHelpers.writeDeleteFile(
+        table, Files.localOutput(temp.newFile()), TestHelpers.Row.of(0), deletes);
+
+    table.newRowDelta()
+        .addDeletes(eqDeletes)
+        .addDeletes(posDeletes.first())
+        .validateDataFilesExist(posDeletes.second())
+        .commit();
+
+    Set<Integer> deletedRows = Sets.newHashSet(29, 89, 121, 122);
+    // we know there is only a single data file
+    FileScanTask task = table.newScan().planFiles().iterator().next();
+    GenericDeleteFilter deleteFilter = new GenericDeleteFilter(table.io(), task, SCHEMA, dataSchema);
+
+    List<Record> recordInputs = Lists.newArrayList();
+
+    int idx = 0;
+    for (Record record : records) {
+      Record r2 = GenericRecord.create(deleteFilter.requiredSchema());
+      r2.set(0, record.getField("data"));
+      r2.set(1, (long) idx);
+      idx++;
+      recordInputs.add(r2);
+    }
+
+    CloseableIterator<Boolean> shouldKeep = deleteFilter.checkShouldKeep(
+        CloseableIterable.withNoopClose(recordInputs)).iterator();
+    for (Record record : records) {
+      Assert.assertTrue(shouldKeep.hasNext());
+      boolean shouldKeepRecord = shouldKeep.next();
+      if (deletedRows.contains((int) record.getField("id"))) {
+        Assert.assertFalse(shouldKeepRecord);
+      } else {
+        Assert.assertTrue(shouldKeepRecord);
+      }
+    }
+
+    Assert.assertFalse(shouldKeep.hasNext());
+  }
+}


### PR DESCRIPTION
@rdblue @openinx @chenjunjiedada 

This is a bit related to #2372, but instead of adding a delete marker for each row, this PR directly adds a `CloseableIterable<Boolean> checkShouldKeep(CloseableIterable<T> records)` method that returns an iterable of booleans to indicate if each record should be kept or not.

This is primarily to accommodate the usage of `DeleteFilter` in Trino, where records are supplied in batch through `Page`s, unlike the Flink and Spark cases where there is an explicit row level representation like `InternalRow` and `RowData`.

For the Trino case, page is a more column oriented data structure consists of one `Block` per column, and each `Block` is an array of raw data. So a row in a page is a `page.getPosition(index)`, which is basically a bunch of raw data scattered in all the blocks. (this is probably an overly simplified explanation but should be enough context here)

So in the delete case, instead of using the `CloseableIterable<T> filter(CloseableIterable<T> records)` method and get all the rows that are remaining, I find it much more efficient to know for each row, if it is deleted or not. With that information, I can simply reuse the same `Page` with only the positions that are not deleted, instead of filtering each row and reformulating a page with filtered rows. There is a method `page.getPositions(positionArray, ...)` which serves exactly this purpose.

The work for delete marker seems to be more oriented to generating the "deleted or not" information after performing the filtering and presenting this information to the end data frame requester. But this change would be used for a lower level query engine data reader.

