### PR TITLE
Spark3: Disable catalog cache-enabled.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -55,4 +55,7 @@ public class CatalogProperties {
 
   public static final String LOCK_TABLE = "lock.table";
 
+  public static final String CATALOG_CACHE_ENABLED = "cache-enabled";
+  public static final String CATALOG_CACHE_ENABLED_DEFAULT = "false";
+
 }

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -147,9 +147,6 @@ public class TableProperties {
   public static final String SPARK_WRITE_PARTITIONED_FANOUT_ENABLED = "write.spark.fanout.enabled";
   public static final boolean SPARK_WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT = false;
 
-  public static final String SPARK_CATALOG_CACHE_ENABLED = "cache-enabled";
-  public static final String SPARK_CATALOG_CACHE_ENABLED_DEFAULT = "false";
-
   public static final String SNAPSHOT_ID_INHERITANCE_ENABLED = "compatibility.snapshot-id-inheritance.enabled";
   public static final boolean SNAPSHOT_ID_INHERITANCE_ENABLED_DEFAULT = false;
 

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -147,6 +147,9 @@ public class TableProperties {
   public static final String SPARK_WRITE_PARTITIONED_FANOUT_ENABLED = "write.spark.fanout.enabled";
   public static final boolean SPARK_WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT = false;
 
+  public static final String SPARK_CATALOG_CACHE_ENABLED = "cache-enabled";
+  public static final String SPARK_CATALOG_CACHE_ENABLED_DEFAULT = "false";
+
   public static final String SNAPSHOT_ID_INHERITANCE_ENABLED = "compatibility.snapshot-id-inheritance.enabled";
   public static final boolean SNAPSHOT_ID_INHERITANCE_ENABLED_DEFAULT = false;
 

--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -84,7 +84,7 @@ Iceberg catalogs support using catalog properties to configure catalog behaviors
 | warehouse                         | null               | the root path of the data warehouse                    |
 | uri                               | null               | a URI string, such as Hive metastore URI               |
 | clients                           | 2                  | client pool size                                       |
-
+| cache-enabled                     | false              | cache catalog, only works for Spark                    | 
 `HadoopCatalog` and `HiveCatalog` can access the properties in their constructors.
 Any other custom catalog can access the properties by implementing `Catalog.initialize(catalogName, catalogProperties)`.
 The properties can be manually constructed or passed in from a compute engine like Spark or Flink.

--- a/spark3/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CachingCatalog;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -379,7 +380,8 @@ public class SparkCatalog extends BaseCatalog {
 
   @Override
   public final void initialize(String name, CaseInsensitiveStringMap options) {
-    this.cacheEnabled = Boolean.parseBoolean(options.getOrDefault("cache-enabled", "true"));
+    this.cacheEnabled = Boolean.parseBoolean(options.getOrDefault(CatalogProperties.CATALOG_CACHE_ENABLED,
+        CatalogProperties.CATALOG_CACHE_ENABLED_DEFAULT));
     Catalog catalog = buildIcebergCatalog(name, options);
 
     this.catalogName = name;


### PR DESCRIPTION
When I use spark SQL to query the iceberg table, I found it can't read the latest table metadata. When `cache-enabled` is set to true, it will not refresh the table. So I think we should disable the `cache-enabled` by default. 

In this patch, I put the setting to catalog properties.