### PR TITLE
Enable Github Wiki and Project Board features

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -23,6 +23,10 @@ github:
   labels:
     - iceberg
     - apache
+  features:
+    wiki: true
+    issues: true
+    projects: true
 
 notifications:
     commits:      commits@iceberg.apache.org


### PR DESCRIPTION
This patch enables the Wiki and Project Board features for the Iceberg
repository.

Please consult the following links for more information about these
features:

 - [Project Boards](https://docs.github.com/en/issues/organizing-your-work-with-project-boards)
 - [Wikis](https://docs.github.com/en/communities/documenting-your-project-with-wikis/about-wikis)