### PR TITLE
Flink: Support create iceberg table with 'connector'='iceberg'

### DIFF
--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -360,6 +360,17 @@ public class FlinkCatalog extends AbstractCatalog {
   @Override
   public void createTable(ObjectPath tablePath, CatalogBaseTable table, boolean ignoreIfExists)
       throws CatalogException, TableAlreadyExistException {
+    if (Objects.equals(table.getOptions().get("connector"), FlinkDynamicTableFactory.FACTORY_IDENTIFIER)) {
+      throw new IllegalArgumentException("Cannot create the table with 'connector'='iceberg' table property in " +
+          "an iceberg catalog, Please create table with 'connector'='iceberg' property in a non-iceberg catalog or " +
+          "create table without 'connector'='iceberg' related properties in an iceberg table.");
+    }
+
+    createIcebergTable(tablePath, table, ignoreIfExists);
+  }
+
+  void createIcebergTable(ObjectPath tablePath, CatalogBaseTable table, boolean ignoreIfExists)
+      throws CatalogException, TableAlreadyExistException {
     validateFlinkTable(table);
 
     Schema icebergSchema = FlinkSchemaUtil.convert(table.getSchema());

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -78,7 +78,7 @@ public class FlinkCatalogFactory implements CatalogFactory {
    * @param hadoopConf Hadoop configuration for catalog
    * @return an Iceberg catalog loader
    */
-  static CatalogLoader createCatalogLoader(String name, Map<String, String> properties, Configuration hadoopConf) {
+  protected CatalogLoader createCatalogLoader(String name, Map<String, String> properties, Configuration hadoopConf) {
     String catalogImpl = properties.get(CatalogProperties.CATALOG_IMPL);
     if (catalogImpl != null) {
       return CatalogLoader.custom(name, properties, hadoopConf, catalogImpl);

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -66,7 +66,7 @@ public class FlinkCatalogFactory implements CatalogFactory {
 
   public static final String HIVE_CONF_DIR = "hive-conf-dir";
   public static final String DEFAULT_DATABASE = "default-database";
-  public static final String DEFAULT_DATABASE_VALUE = "default";
+  public static final String DEFAULT_DATABASE_NAME = "default";
   public static final String BASE_NAMESPACE = "base-namespace";
   public static final String CACHE_ENABLED = "cache-enabled";
 
@@ -78,7 +78,7 @@ public class FlinkCatalogFactory implements CatalogFactory {
    * @param hadoopConf Hadoop configuration for catalog
    * @return an Iceberg catalog loader
    */
-  protected CatalogLoader createCatalogLoader(String name, Map<String, String> properties, Configuration hadoopConf) {
+  static CatalogLoader createCatalogLoader(String name, Map<String, String> properties, Configuration hadoopConf) {
     String catalogImpl = properties.get(CatalogProperties.CATALOG_IMPL);
     if (catalogImpl != null) {
       return CatalogLoader.custom(name, properties, hadoopConf, catalogImpl);
@@ -121,7 +121,7 @@ public class FlinkCatalogFactory implements CatalogFactory {
 
   protected Catalog createCatalog(String name, Map<String, String> properties, Configuration hadoopConf) {
     CatalogLoader catalogLoader = createCatalogLoader(name, properties, hadoopConf);
-    String defaultDatabase = properties.getOrDefault(DEFAULT_DATABASE, DEFAULT_DATABASE_VALUE);
+    String defaultDatabase = properties.getOrDefault(DEFAULT_DATABASE, DEFAULT_DATABASE_NAME);
 
     Namespace baseNamespace = Namespace.empty();
     if (properties.containsKey(BASE_NAMESPACE)) {

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -66,6 +66,7 @@ public class FlinkCatalogFactory implements CatalogFactory {
 
   public static final String HIVE_CONF_DIR = "hive-conf-dir";
   public static final String DEFAULT_DATABASE = "default-database";
+  public static final String DEFAULT_DATABASE_VALUE = "default";
   public static final String BASE_NAMESPACE = "base-namespace";
   public static final String CACHE_ENABLED = "cache-enabled";
 
@@ -77,7 +78,7 @@ public class FlinkCatalogFactory implements CatalogFactory {
    * @param hadoopConf Hadoop configuration for catalog
    * @return an Iceberg catalog loader
    */
-  protected CatalogLoader createCatalogLoader(String name, Map<String, String> properties, Configuration hadoopConf) {
+  static CatalogLoader createCatalogLoader(String name, Map<String, String> properties, Configuration hadoopConf) {
     String catalogImpl = properties.get(CatalogProperties.CATALOG_IMPL);
     if (catalogImpl != null) {
       return CatalogLoader.custom(name, properties, hadoopConf, catalogImpl);
@@ -120,7 +121,7 @@ public class FlinkCatalogFactory implements CatalogFactory {
 
   protected Catalog createCatalog(String name, Map<String, String> properties, Configuration hadoopConf) {
     CatalogLoader catalogLoader = createCatalogLoader(name, properties, hadoopConf);
-    String defaultDatabase = properties.getOrDefault(DEFAULT_DATABASE, "default");
+    String defaultDatabase = properties.getOrDefault(DEFAULT_DATABASE, DEFAULT_DATABASE_VALUE);
 
     Namespace baseNamespace = Namespace.empty();
     if (properties.containsKey(BASE_NAMESPACE)) {

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -44,19 +44,19 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 public class FlinkDynamicTableFactory implements DynamicTableSinkFactory, DynamicTableSourceFactory {
   private static final String FACTORY_IDENTIFIER = "iceberg";
 
-  public static final ConfigOption<String> CATALOG_NAME =
+  private static final ConfigOption<String> CATALOG_NAME =
       ConfigOptions.key("catalog-name")
           .stringType()
           .noDefaultValue()
           .withDescription("Catalog name");
 
-  public static final ConfigOption<String> CATALOG_TYPE =
+  private static final ConfigOption<String> CATALOG_TYPE =
       ConfigOptions.key(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE)
           .stringType()
           .noDefaultValue()
           .withDescription("Catalog type.");
 
-  public static final ConfigOption<String> CATALOG_DATABASE =
+  private static final ConfigOption<String> CATALOG_DATABASE =
       ConfigOptions.key("catalog-database")
           .stringType()
           .defaultValue(FlinkCatalogFactory.DEFAULT_DATABASE_VALUE)
@@ -112,7 +112,7 @@ public class FlinkDynamicTableFactory implements DynamicTableSinkFactory, Dynami
     options.add(CATALOG_TYPE);
     options.add(CATALOG_NAME);
     options.add(CATALOG_DATABASE);
-    return Sets.newHashSet();
+    return options;
   }
 
   @Override
@@ -138,11 +138,7 @@ public class FlinkDynamicTableFactory implements DynamicTableSinkFactory, Dynami
     Preconditions.checkNotNull(catalogDatabase, "Table property '%s' cannot be null", CATALOG_DATABASE.key());
 
     org.apache.hadoop.conf.Configuration hadoopConf = FlinkCatalogFactory.clusterHadoopConf();
-    CatalogLoader catalogLoader = FlinkCatalogFactory.createCatalogLoader(
-        catalogName,
-        tableProps,
-        hadoopConf
-    );
+    CatalogLoader catalogLoader = FlinkCatalogFactory.createCatalogLoader(catalogName, tableProps, hadoopConf);
 
     FlinkCatalogFactory factory = new FlinkCatalogFactory();
     Catalog flinkCatalog = factory.createCatalog(catalogName, tableProps, hadoopConf);
@@ -155,10 +151,7 @@ public class FlinkDynamicTableFactory implements DynamicTableSinkFactory, Dynami
       }
     }
 
-    return TableLoader.fromCatalog(
-        catalogLoader,
-        TableIdentifier.of(catalogDatabase, tableName)
-    );
+    return TableLoader.fromCatalog(catalogLoader, TableIdentifier.of(catalogDatabase, tableName));
   }
 
   private static TableLoader createTableLoader(FlinkCatalog catalog, ObjectPath objectPath) {

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -150,7 +150,7 @@ public class FlinkDynamicTableFactory implements DynamicTableSinkFactory, Dynami
       try {
         flinkCatalog.createDatabase(catalogDatabase, new CatalogDatabaseImpl(Maps.newHashMap(), null), true);
       } catch (DatabaseAlreadyExistException | CatalogException e) {
-        throw new RuntimeException(e);
+        throw new RuntimeException(String.format("Failed to create database %s.%s", catalogName, catalogDatabase), e);
       }
     }
 
@@ -159,7 +159,7 @@ public class FlinkDynamicTableFactory implements DynamicTableSinkFactory, Dynami
       try {
         flinkCatalog.createTable(objectPath, catalogTable, true);
       } catch (TableAlreadyExistException | CatalogException e) {
-        throw new RuntimeException(e);
+        throw new RuntimeException(String.format("Failed to create table %s.%s", catalogName, objectPath), e);
       }
     }
 

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -44,7 +44,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 
 public class FlinkDynamicTableFactory implements DynamicTableSinkFactory, DynamicTableSourceFactory {
-  private static final String FACTORY_IDENTIFIER = "iceberg";
+  static final String FACTORY_IDENTIFIER = "iceberg";
 
   private static final ConfigOption<String> CATALOG_NAME =
       ConfigOptions.key("catalog-name")
@@ -158,7 +158,7 @@ public class FlinkDynamicTableFactory implements DynamicTableSinkFactory, Dynami
     // Create table if not exists in the external catalog.
     if (!flinkCatalog.tableExists(objectPath)) {
       try {
-        flinkCatalog.createTable(objectPath, catalogTable, true);
+        flinkCatalog.createIcebergTable(objectPath, catalogTable, true);
       } catch (TableAlreadyExistException e) {
         throw new AlreadyExistsException(e, "Table %s already exists in the database %s and catalog %s",
             tableName, catalogDatabase, catalogName);

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -19,18 +19,54 @@
 
 package org.apache.iceberg.flink;
 
+import java.util.Map;
 import java.util.Set;
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
+import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.factories.DynamicTableSinkFactory;
 import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.utils.TableSchemaUtils;
+import org.apache.flink.util.Preconditions;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 
 public class FlinkDynamicTableFactory implements DynamicTableSinkFactory, DynamicTableSourceFactory {
+  private static final String FACTORY_IDENTIFIER = "iceberg";
+
+  public static final ConfigOption<String> CATALOG_NAME =
+      ConfigOptions.key("catalog-name")
+          .stringType()
+          .noDefaultValue()
+          .withDescription("Catalog name");
+
+  public static final ConfigOption<String> CATALOG_TYPE =
+      ConfigOptions.key(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE)
+          .stringType()
+          .noDefaultValue()
+          .withDescription("Catalog type.");
+
+  public static final ConfigOption<String> CATALOG_DATABASE =
+      ConfigOptions.key("catalog-database")
+          .stringType()
+          .defaultValue(FlinkCatalogFactory.DEFAULT_DATABASE_VALUE)
+          .withDeprecatedKeys("Catalog database");
+
   private final FlinkCatalog catalog;
+
+  public FlinkDynamicTableFactory() {
+    this.catalog = null;
+  }
 
   public FlinkDynamicTableFactory(FlinkCatalog catalog) {
     this.catalog = catalog;
@@ -38,37 +74,95 @@ public class FlinkDynamicTableFactory implements DynamicTableSinkFactory, Dynami
 
   @Override
   public DynamicTableSource createDynamicTableSource(Context context) {
-    ObjectPath objectPath = context.getObjectIdentifier().toObjectPath();
-    TableLoader tableLoader = createTableLoader(objectPath);
+    ObjectIdentifier objectIdentifier = context.getObjectIdentifier();
+    Map<String, String> tableProps = context.getCatalogTable().getOptions();
+    CatalogTable catalogTable = context.getCatalogTable();
     TableSchema tableSchema = TableSchemaUtils.getPhysicalSchema(context.getCatalogTable().getSchema());
-    return new IcebergTableSource(tableLoader, tableSchema, context.getCatalogTable().getOptions(),
-        context.getConfiguration());
+
+    TableLoader tableLoader;
+    if (catalog != null) {
+      tableLoader = createTableLoader(catalog, objectIdentifier.toObjectPath());
+    } else {
+      tableLoader = createTableLoader(catalogTable, tableProps, objectIdentifier.getObjectName());
+    }
+
+    return new IcebergTableSource(tableLoader, tableSchema, tableProps, context.getConfiguration());
   }
 
   @Override
   public DynamicTableSink createDynamicTableSink(Context context) {
     ObjectPath objectPath = context.getObjectIdentifier().toObjectPath();
-    TableLoader tableLoader = createTableLoader(objectPath);
+    Map<String, String> tableProps = context.getCatalogTable().getOptions();
+    CatalogTable catalogTable = context.getCatalogTable();
     TableSchema tableSchema = TableSchemaUtils.getPhysicalSchema(context.getCatalogTable().getSchema());
+
+    TableLoader tableLoader;
+    if (catalog != null) {
+      tableLoader = createTableLoader(catalog, objectPath);
+    } else {
+      tableLoader = createTableLoader(catalogTable, tableProps, objectPath.getObjectName());
+    }
+
     return new IcebergTableSink(tableLoader, tableSchema);
   }
 
   @Override
   public Set<ConfigOption<?>> requiredOptions() {
-    throw new UnsupportedOperationException("Iceberg Table Factory can not be loaded from Java SPI");
+    Set<ConfigOption<?>> options = Sets.newHashSet();
+    options.add(CATALOG_TYPE);
+    options.add(CATALOG_NAME);
+    options.add(CATALOG_DATABASE);
+    return Sets.newHashSet();
   }
 
   @Override
   public Set<ConfigOption<?>> optionalOptions() {
-    throw new UnsupportedOperationException("Iceberg Table Factory can not be loaded from Java SPI");
+    return Sets.newHashSet();
   }
 
   @Override
   public String factoryIdentifier() {
-    throw new UnsupportedOperationException("Iceberg Table Factory can not be loaded from Java SPI");
+    return FACTORY_IDENTIFIER;
   }
 
-  private TableLoader createTableLoader(ObjectPath objectPath) {
+  private static TableLoader createTableLoader(CatalogBaseTable catalogTable,
+                                               Map<String, String> tableProps,
+                                               String tableName) {
+    Configuration flinkConf = new Configuration();
+    tableProps.forEach(flinkConf::setString);
+
+    String catalogName = flinkConf.getString(CATALOG_NAME);
+    Preconditions.checkNotNull(catalogName, "Table property '%s' cannot be null", CATALOG_NAME.key());
+
+    String catalogDatabase = flinkConf.getString(CATALOG_DATABASE);
+    Preconditions.checkNotNull(catalogDatabase, "Table property '%s' cannot be null", CATALOG_DATABASE.key());
+
+    org.apache.hadoop.conf.Configuration hadoopConf = FlinkCatalogFactory.clusterHadoopConf();
+    CatalogLoader catalogLoader = FlinkCatalogFactory.createCatalogLoader(
+        catalogName,
+        tableProps,
+        hadoopConf
+    );
+
+    FlinkCatalogFactory factory = new FlinkCatalogFactory();
+    Catalog flinkCatalog = factory.createCatalog(catalogName, tableProps, hadoopConf);
+    ObjectPath objectPath = new ObjectPath(catalogDatabase, tableName);
+    if (!flinkCatalog.tableExists(objectPath)) {
+      try {
+        flinkCatalog.createTable(objectPath, catalogTable, true);
+      } catch (TableAlreadyExistException | DatabaseNotExistException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    return TableLoader.fromCatalog(
+        catalogLoader,
+        TableIdentifier.of(catalogDatabase, tableName)
+    );
+  }
+
+  private static TableLoader createTableLoader(FlinkCatalog catalog, ObjectPath objectPath) {
+    Preconditions.checkNotNull(catalog, "Flink catalog cannot be null");
     return TableLoader.fromCatalog(catalog.getCatalogLoader(), catalog.toIdentifier(objectPath));
   }
 }

--- a/flink/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.iceberg.flink.FlinkDynamicTableFactory

--- a/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.apache.iceberg.flink;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TestIcebergConnector extends FlinkTestBase {
+
+  private static TableEnvironment tEnv;
+
+  @Rule
+  public final TemporaryFolder warehouse = new TemporaryFolder();
+
+
+  @BeforeClass
+  public static void beforeClass() {
+    EnvironmentSettings settings = EnvironmentSettings
+        .newInstance()
+        .useBlinkPlanner()
+        .inBatchMode()
+        .build();
+
+    tEnv = TableEnvironment.create(settings);
+    tEnv.getConfig().getConfiguration()
+        .set(CoreOptions.DEFAULT_PARALLELISM, 1)
+        .set(FlinkTableOptions.TABLE_EXEC_ICEBERG_INFER_SOURCE_PARALLELISM, false);
+  }
+
+  @Test
+  public void testHadoopCatalog() {
+    Map<String, String> tableProps = Maps.newHashMap();
+    tableProps.put("connector", "iceberg");
+    tableProps.put("catalog-name", "test-hadoop");
+    tableProps.put("catalog-type", "hadoop");
+    tableProps.put("catalog-database", "local_db");
+    tableProps.put(CatalogProperties.WAREHOUSE_LOCATION, warehouseRoot());
+
+    sql("CREATE TABLE hadoop_table (id BIGINT, data STRING) WITH %s", toWithClause(tableProps));
+    sql("INSERT INTO hadoop_table VALUES (1, 'aaa'), (2, 'bbb'), (3, 'ccc')");
+    Assert.assertEquals("Should have expected rows",
+        Lists.newArrayList(Row.of(1L, "aaa"), Row.of(2L, "bbb"), Row.of(3L, "ccc")),
+        sql("SELECT * FROM hadoop_table"));
+
+    // Drop and create it again.
+    sql("DROP TABLE hadoop_table");
+    sql("CREATE TABLE hadoop_table (id BIGINT, data STRING) WITH %s", toWithClause(tableProps));
+    Assert.assertEquals("Should have expected rows",
+        Lists.newArrayList(Row.of(1L, "aaa"), Row.of(2L, "bbb"), Row.of(3L, "ccc")),
+        sql("SELECT * FROM hadoop_table"));
+
+    sql("DROP TABLE hadoop_table");
+  }
+
+  @Test
+  public void testHiveCatalog() {
+    Map<String, String> tableProps = Maps.newHashMap();
+    tableProps.put("connector", "iceberg");
+    tableProps.put("catalog-name", "test-hive");
+    tableProps.put("catalog-type", "hive");
+    tableProps.put("catalog-database", "default");
+    tableProps.put(CatalogProperties.URI, FlinkCatalogTestBase.getURI(hiveConf));
+    tableProps.put(CatalogProperties.WAREHOUSE_LOCATION, warehouseRoot());
+
+    sql("CREATE TABLE hive_table(id BIGINT, data STRING) WITH %s", FlinkCatalogTestBase.toWithClause(tableProps));
+    sql("INSERT INTO hive_table VALUES (1, 'AAA'), (2, 'BBB'), (3, 'CCC')");
+    Assert.assertEquals("Should have the expected rows",
+        Lists.newArrayList(Row.of(1L, "AAA"), Row.of(2L, "BBB"), Row.of(3L, "CCC")),
+        sql("SELECT * FROM hive_table"));
+
+    // Drop and create it again.
+    sql("DROP TABLE hive_table");
+    sql("CREATE TABLE hive_table (id BIGINT, data STRING) WITH %s", toWithClause(tableProps));
+    Assert.assertEquals("Should have expected rows",
+        Lists.newArrayList(Row.of(1L, "AAA"), Row.of(2L, "BBB"), Row.of(3L, "CCC")),
+        sql("SELECT * FROM hive_table"));
+
+    sql("DROP TABLE hive_table");
+  }
+
+  private String toWithClause(Map<String, String> props) {
+    return FlinkCatalogTestBase.toWithClause(props);
+  }
+
+  private String warehouseRoot() {
+    return String.format("file://%s", warehouse.getRoot().getAbsolutePath());
+  }
+
+  protected List<Row> sql(String query, Object... args) {
+    TableResult tableResult = tEnv.executeSql(String.format(query, args));
+    try {
+      tableResult.await();
+    } catch (InterruptedException | ExecutionException e) {
+      throw new RuntimeException(e);
+    }
+
+    try (CloseableIterator<Row> iter = tableResult.collect()) {
+      return Lists.newArrayList(iter);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to collect table result", e);
+    }
+  }
+}

--- a/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
@@ -154,24 +154,24 @@ public class TestIcebergConnector extends FlinkTestBase {
     tableProps.put(CatalogProperties.URI, FlinkCatalogTestBase.getURI(hiveConf));
     tableProps.put(CatalogProperties.WAREHOUSE_LOCATION, warehouseRoot());
 
-    sql("CREATE TABLE %s(id BIGINT, data STRING) WITH %s", TABLE_NAME, toWithClause(tableProps));
-    sql("INSERT INTO %s VALUES (1, 'AAA'), (2, 'BBB'), (3, 'CCC')", TABLE_NAME);
-    Assert.assertEquals("Should have the expected rows",
-        Lists.newArrayList(Row.of(1L, "AAA"), Row.of(2L, "BBB"), Row.of(3L, "CCC")),
-        sql("SELECT * FROM %s", TABLE_NAME));
-
-    // Drop and create it again.
-    sql("DROP TABLE %s", TABLE_NAME);
-    sql("CREATE TABLE %s (id BIGINT, data STRING) WITH %s", TABLE_NAME, toWithClause(tableProps));
-    Assert.assertEquals("Should have expected rows",
-        Lists.newArrayList(Row.of(1L, "AAA"), Row.of(2L, "BBB"), Row.of(3L, "CCC")),
-        sql("SELECT * FROM %s", TABLE_NAME));
-
-    sql("DROP TABLE %s", TABLE_NAME);
     HiveMetaStoreClient metaStoreClient = new HiveMetaStoreClient(hiveConf);
     try {
-      metaStoreClient.dropTable("default", TABLE_NAME);
+      sql("CREATE TABLE %s(id BIGINT, data STRING) WITH %s", TABLE_NAME, toWithClause(tableProps));
+      sql("INSERT INTO %s VALUES (1, 'AAA'), (2, 'BBB'), (3, 'CCC')", TABLE_NAME);
+      Assert.assertEquals("Should have the expected rows",
+          Lists.newArrayList(Row.of(1L, "AAA"), Row.of(2L, "BBB"), Row.of(3L, "CCC")),
+          sql("SELECT * FROM %s", TABLE_NAME));
+
+      // Drop and create it again.
+      sql("DROP TABLE %s", TABLE_NAME);
+      sql("CREATE TABLE %s (id BIGINT, data STRING) WITH %s", TABLE_NAME, toWithClause(tableProps));
+      Assert.assertEquals("Should have expected rows",
+          Lists.newArrayList(Row.of(1L, "AAA"), Row.of(2L, "BBB"), Row.of(3L, "CCC")),
+          sql("SELECT * FROM %s", TABLE_NAME));
+
+      sql("DROP TABLE %s", TABLE_NAME);
     } finally {
+      metaStoreClient.dropTable("default", TABLE_NAME);
       metaStoreClient.close();
     }
   }
@@ -186,23 +186,22 @@ public class TestIcebergConnector extends FlinkTestBase {
     tableProps.put(CatalogProperties.URI, FlinkCatalogTestBase.getURI(hiveConf));
     tableProps.put(CatalogProperties.WAREHOUSE_LOCATION, warehouseRoot());
 
-    sql("CREATE TABLE %s (id BIGINT, data STRING) WITH %s", TABLE_NAME, toWithClause(tableProps));
-    sql("INSERT INTO %s VALUES (1, 'aaa'), (2, 'bbb'), (3, 'ccc')", TABLE_NAME);
-    Assert.assertEquals("Should have expected rows",
-        Lists.newArrayList(Row.of(1L, "aaa"), Row.of(2L, "bbb"), Row.of(3L, "ccc")),
-        sql("SELECT * FROM %s", TABLE_NAME));
-
-    FlinkCatalogFactory factory = new FlinkCatalogFactory();
-    Catalog catalog = factory.createCatalog("test-hive", tableProps, hiveConf);
-    Assert.assertTrue("Should have created the database", catalog.databaseExists("not_existing_db"));
-    Assert.assertTrue("Should have created the table",
-        catalog.tableExists(new ObjectPath("not_existing_db", TABLE_NAME)));
-
     HiveMetaStoreClient metaStoreClient = new HiveMetaStoreClient(hiveConf);
     try {
+      sql("CREATE TABLE %s (id BIGINT, data STRING) WITH %s", TABLE_NAME, toWithClause(tableProps));
+      sql("INSERT INTO %s VALUES (1, 'aaa'), (2, 'bbb'), (3, 'ccc')", TABLE_NAME);
+      Assert.assertEquals("Should have expected rows",
+          Lists.newArrayList(Row.of(1L, "aaa"), Row.of(2L, "bbb"), Row.of(3L, "ccc")),
+          sql("SELECT * FROM %s", TABLE_NAME));
+
+      FlinkCatalogFactory factory = new FlinkCatalogFactory();
+      Catalog catalog = factory.createCatalog("test-hive", tableProps, hiveConf);
+      Assert.assertTrue("Should have created the database", catalog.databaseExists("not_existing_db"));
+      Assert.assertTrue("Should have created the table",
+          catalog.tableExists(new ObjectPath("not_existing_db", TABLE_NAME)));
+    } finally {
       metaStoreClient.dropTable("not_existing_db", TABLE_NAME);
       metaStoreClient.dropDatabase("not_existing_db");
-    } finally {
       metaStoreClient.close();
     }
   }

--- a/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
@@ -206,7 +206,7 @@ public class TestIcebergConnector extends FlinkTestBase {
           // Set only one parallelism.
           tEnv.getConfig().getConfiguration()
               .set(CoreOptions.DEFAULT_PARALLELISM, 1)
-              .set(FlinkTableOptions.TABLE_EXEC_ICEBERG_INFER_SOURCE_PARALLELISM, false);
+              .set(FlinkConfigOptions.TABLE_EXEC_ICEBERG_INFER_SOURCE_PARALLELISM, false);
         }
       }
     }


### PR DESCRIPTION
This PR is trying to address the issue : https://github.com/apache/iceberg/issues/2572

For people who want to create an iceberg table under hadoop catalog, could use the following sql:

```sql
CREATE TABLE hadoop_table (
  id        BIGINT,
  data   STRING
) WITH (
  'connector' = 'iceberg',
  'catalog-name' = 'hadoop-catalog',
  'catalog-type' = 'hadoop',
  'catalog-database' = 'local_db',
  'warehouse' = 'hdfs://nn:9090/path/to/warehouse'
);
```

If want to create an iceberg table under hive catalog,  we could use the following SQL:

```sql
CREATE TABLE hive_table (
   id      BIGINT,
   data STRING
) WITH (
  'connector' = 'iceberg',
  'catalog-name' = 'hive-catalog',
  'catalog-type' = 'hive',
  'catalog-database' = 'default',
  'uri' = 'thrift://localhost:9093',
  'warehouse' = 'hdfs://nn:9090/path/to/warehouse'
);
```

The flink `CREATE TABLE` with `'connector'='iceberg'` option is actually trying to mapping the underlying iceberg table to an flink table which managed in flink's in-memory catalogs, so in theory if people execute an `ALTER TABLE` or `DROP TABLE` clause, it won't affect the underlying iceberg table.  For the convenience of use,   this PR will try to initialize/create the underlying iceberg table if it does not exist when mapping the flink table from in-memory catalogs to iceberg table,  then people don't need to create the real iceberg table before mapping the flink table to it.
