### PR TITLE
Update context conditions  

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MicroBatches.java
+++ b/core/src/main/java/org/apache/iceberg/MicroBatches.java
@@ -242,7 +242,7 @@ public class MicroBatches {
       ManifestGroup manifestGroup = new ManifestGroup(io, ImmutableList.of(manifestFile))
           .specsById(specsById)
           .caseSensitive(caseSensitive);
-      if (scanAllFiles) {
+      if (!scanAllFiles) {
         manifestGroup = manifestGroup
             .filterManifestEntries(entry ->
                 entry.snapshotId() == snapshot.snapshotId() && entry.status() == ManifestEntry.Status.ADDED)


### PR DESCRIPTION
Param scanAllFiles Used to check whether all the data files should be processed, or only added files.Here we should replace  scanAllFiles to  !scanAllFiles.