### PR TITLE
Clarify preconditions in spark 2 TestCatalog initialization

### DIFF
--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestCatalog.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestCatalog.java
@@ -94,11 +94,11 @@ public class TestCatalog implements Catalog, Configurable {
   public void initialize(String name, Map<String, String> properties) {
     String uri = properties.get(CatalogProperties.URI);
     warehouse = properties.get("warehouse");
-    Preconditions.checkNotNull(uri,
+    Preconditions.checkArgument(uri != null,
         "Cannot initialize TestCatalog. The metastore connection uri must be set.");
     Preconditions.checkArgument(uri.contains("thrift"),
         "Cannot initialize TestCatalog. The metastore connection uri must use thrift as the scheme.");
-    Preconditions.checkNotNull(warehouse,
+    Preconditions.checkArgument(warehouse != null,
         "Cannot initialize TestCatalog. The base path for the catalog's warehouse directory must be set.");
     this.tables = new HadoopTables(conf);
   }

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestCatalog.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestCatalog.java
@@ -95,7 +95,7 @@ public class TestCatalog implements Catalog, Configurable {
     String uri = properties.get(CatalogProperties.URI);
     warehouse = properties.get("warehouse");
     Preconditions.checkArgument(uri != null, "A uri parameter must be set");
-    Preconditions.checkArgument(uri.contains("thrift"), "A ur parameter must be valid");
+    Preconditions.checkArgument(uri.contains("thrift"), "A uri parameter must be valid");
     Preconditions.checkArgument(warehouse != null, "A warehouse parameter must be set");
     this.tables = new HadoopTables(conf);
   }

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestCatalog.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestCatalog.java
@@ -94,9 +94,11 @@ public class TestCatalog implements Catalog, Configurable {
   public void initialize(String name, Map<String, String> properties) {
     String uri = properties.get(CatalogProperties.URI);
     warehouse = properties.get("warehouse");
-    Preconditions.checkArgument(uri != null, "A uri parameter must be set");
-    Preconditions.checkArgument(uri.contains("thrift"), "A uri parameter must be valid");
-    Preconditions.checkArgument(warehouse != null, "A warehouse parameter must be set");
+    Preconditions.checkNotNull(uri, "Cannot initialize TestCatalog, the metastore connection uri must be set");
+    Preconditions.checkArgument(uri.contains("thrift"),
+        "Cannot initialize TestCatalog, the metastore connection uri must use thrift as the scheme");
+    Preconditions.checkNotNull(warehouse != null,
+        "Cannot initialize TestCatalog, a base path for the catalog's warehouse directory must be set");
     this.tables = new HadoopTables(conf);
   }
 

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestCatalog.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestCatalog.java
@@ -98,7 +98,7 @@ public class TestCatalog implements Catalog, Configurable {
         "Cannot initialize TestCatalog. The metastore connection uri must be set.");
     Preconditions.checkArgument(uri.contains("thrift"),
         "Cannot initialize TestCatalog. The metastore connection uri must use thrift as the scheme.");
-    Preconditions.checkNotNull(warehouse != null,
+    Preconditions.checkNotNull(warehouse,
         "Cannot initialize TestCatalog. The base path for the catalog's warehouse directory must be set.");
     this.tables = new HadoopTables(conf);
   }

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestCatalog.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestCatalog.java
@@ -94,11 +94,12 @@ public class TestCatalog implements Catalog, Configurable {
   public void initialize(String name, Map<String, String> properties) {
     String uri = properties.get(CatalogProperties.URI);
     warehouse = properties.get("warehouse");
-    Preconditions.checkNotNull(uri, "Cannot initialize TestCatalog, the metastore connection uri must be set");
+    Preconditions.checkNotNull(uri,
+        "Cannot initialize TestCatalog. The metastore connection uri must be set.");
     Preconditions.checkArgument(uri.contains("thrift"),
-        "Cannot initialize TestCatalog, the metastore connection uri must use thrift as the scheme");
+        "Cannot initialize TestCatalog. The metastore connection uri must use thrift as the scheme.");
     Preconditions.checkNotNull(warehouse != null,
-        "Cannot initialize TestCatalog, a base path for the catalog's warehouse directory must be set");
+        "Cannot initialize TestCatalog. The base path for the catalog's warehouse directory must be set.");
     this.tables = new HadoopTables(conf);
   }
 

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestCustomCatalog.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestCustomCatalog.java
@@ -129,7 +129,7 @@ public class TestCustomCatalog {
 
     Dataset<Row> df = spark.createDataFrame(expected, SimpleRecord.class);
     AssertHelpers.assertThrows("We have not set all properties", IllegalArgumentException.class,
-        "A warehouse parameter must be set", () ->
+        "The base path for the catalog's warehouse directory must be set", () ->
         df.select("id", "data").write()
             .format("iceberg")
             .mode("append")
@@ -168,7 +168,7 @@ public class TestCustomCatalog {
 
     Dataset<Row> df = spark.createDataFrame(expected, SimpleRecord.class);
     AssertHelpers.assertThrows("We have not set all properties", IllegalArgumentException.class,
-        "A warehouse parameter must be set", () ->
+        "The base path for the catalog's warehouse directory must be set", () ->
             df.select("id", "data").write()
                 .format("iceberg")
                 .mode("append")


### PR DESCRIPTION
I came across this minor typo working on a separate issue.

I'd include it in that work to reduce commits, but ultimately I won't need to touch this file in that other PR.

After discussing with Ryan Murr, we've decided to rewrite some of the precondition error messages to be of the standard form `cannot do X, reason. Optionally how to fix`, to be more consistent with the projects guidelines.