### PR TITLE
Core: add key_metadata to ManifestFile spec

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ManifestFile.java
+++ b/api/src/main/java/org/apache/iceberg/ManifestFile.java
@@ -62,14 +62,16 @@ public interface ManifestFile {
   Types.NestedField PARTITION_SUMMARIES = optional(507, "partitions",
       Types.ListType.ofRequired(508, PARTITION_SUMMARY_TYPE),
       "Summary for each partition");
-  // next ID to assign: 519
+  Types.NestedField KEY_METADATA = optional(519, "key_metadata", Types.BinaryType.get(),
+      "Encryption key metadata blob");
+  // next ID to assign: 520
 
   Schema SCHEMA = new Schema(
       PATH, LENGTH, SPEC_ID, MANIFEST_CONTENT,
       SEQUENCE_NUMBER, MIN_SEQUENCE_NUMBER, SNAPSHOT_ID,
       ADDED_FILES_COUNT, EXISTING_FILES_COUNT, DELETED_FILES_COUNT,
       ADDED_ROWS_COUNT, EXISTING_ROWS_COUNT, DELETED_ROWS_COUNT,
-      PARTITION_SUMMARIES);
+      PARTITION_SUMMARIES, KEY_METADATA);
 
   static Schema schema() {
     return SCHEMA;
@@ -178,6 +180,13 @@ public interface ManifestFile {
    * @return a list of partition field summaries, one for each field in the manifest's spec
    */
   List<PartitionFieldSummary> partitions();
+
+  /**
+   * Returns metadata about how this manifest file is encrypted, or null if the file is stored in plain text.
+   */
+  default ByteBuffer keyMetadata() {
+    return null;
+  }
 
   /**
    * Copies this {@link ManifestFile manifest file}. Readers can reuse manifest file instances; use

--- a/api/src/test/java/org/apache/iceberg/TestHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/TestHelpers.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.expressions.BoundSetPredicate;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.ExpressionVisitors;
 import org.apache.iceberg.expressions.UnboundPredicate;
+import org.apache.iceberg.util.ByteBuffers;
 import org.junit.Assert;
 
 public class TestHelpers {
@@ -240,10 +241,11 @@ public class TestHelpers {
     private final Integer deletedFiles;
     private final Long deletedRows;
     private final List<PartitionFieldSummary> partitions;
+    private final byte[] keyMetadata;
 
     public TestManifestFile(String path, long length, int specId, Long snapshotId,
                             Integer addedFiles, Integer existingFiles, Integer deletedFiles,
-                            List<PartitionFieldSummary> partitions) {
+                            List<PartitionFieldSummary> partitions, ByteBuffer keyMetadata) {
       this.path = path;
       this.length = length;
       this.specId = specId;
@@ -256,12 +258,13 @@ public class TestHelpers {
       this.deletedFiles = deletedFiles;
       this.deletedRows = null;
       this.partitions = partitions;
+      this.keyMetadata = ByteBuffers.toByteArray(keyMetadata);
     }
 
     public TestManifestFile(String path, long length, int specId, ManifestContent content, Long snapshotId,
                             Integer addedFiles, Long addedRows, Integer existingFiles,
                             Long existingRows, Integer deletedFiles, Long deletedRows,
-                            List<PartitionFieldSummary> partitions) {
+                            List<PartitionFieldSummary> partitions, ByteBuffer keyMetadata) {
       this.path = path;
       this.length = length;
       this.specId = specId;
@@ -274,6 +277,7 @@ public class TestHelpers {
       this.deletedFiles = deletedFiles;
       this.deletedRows = deletedRows;
       this.partitions = partitions;
+      this.keyMetadata = ByteBuffers.toByteArray(keyMetadata);
     }
 
     @Override
@@ -344,6 +348,11 @@ public class TestHelpers {
     @Override
     public List<PartitionFieldSummary> partitions() {
       return partitions;
+    }
+
+    @Override
+    public ByteBuffer keyMetadata() {
+      return keyMetadata == null ? null : ByteBuffer.wrap(keyMetadata);
     }
 
     @Override

--- a/api/src/test/java/org/apache/iceberg/expressions/TestInclusiveManifestEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestInclusiveManifestEvaluator.java
@@ -91,7 +91,7 @@ public class TestInclusiveManifestEvaluator {
   private static final ByteBuffer STRING_MAX = toByteBuffer(Types.StringType.get(), "z");
 
   private static final ManifestFile NO_STATS = new TestHelpers.TestManifestFile(
-      "manifest-list.avro", 1024, 0, System.currentTimeMillis(), null, null, null, null);
+      "manifest-list.avro", 1024, 0, System.currentTimeMillis(), null, null, null, null, null);
 
   private static final ManifestFile FILE = new TestHelpers.TestManifestFile("manifest-list.avro",
       1024, 0, System.currentTimeMillis(), 5, 10, 0, ImmutableList.of(
@@ -110,7 +110,7 @@ public class TestInclusiveManifestEvaluator {
               toByteBuffer(Types.FloatType.get(), 0F),
               toByteBuffer(Types.FloatType.get(), 20F)),
           new TestHelpers.TestFieldSummary(true, null, null)
-      ));
+      ), null);
 
   @Test
   public void testAllNulls() {

--- a/core/src/main/java/org/apache/iceberg/ManifestWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestWriter.java
@@ -156,7 +156,7 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
     long minSeqNumber = minSequenceNumber != null ? minSequenceNumber : UNASSIGNED_SEQ;
     return new GenericManifestFile(file.location(), writer.length(), specId, content(),
         UNASSIGNED_SEQ, minSeqNumber, snapshotId,
-        addedFiles, addedRows, existingFiles, existingRows, deletedFiles, deletedRows, stats.summaries());
+        addedFiles, addedRows, existingFiles, existingRows, deletedFiles, deletedRows, stats.summaries(), null);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -441,7 +441,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
 
       return new GenericManifestFile(manifest.path(), manifest.length(), manifest.partitionSpecId(),
           ManifestContent.DATA, manifest.sequenceNumber(), manifest.minSequenceNumber(), snapshotId,
-          addedFiles, addedRows, existingFiles, existingRows, deletedFiles, deletedRows, stats.summaries());
+          addedFiles, addedRows, existingFiles, existingRows, deletedFiles, deletedRows, stats.summaries(), null);
 
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to read manifest: %s", manifest.path());

--- a/core/src/main/java/org/apache/iceberg/V2Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V2Metadata.java
@@ -132,6 +132,8 @@ class V2Metadata {
           return wrapped.deletedRowsCount();
         case 13:
           return wrapped.partitions();
+        case 14:
+          return wrapped.keyMetadata();
         default:
           throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
       }
@@ -220,6 +222,11 @@ class V2Metadata {
     @Override
     public List<PartitionFieldSummary> partitions() {
       return wrapped.partitions();
+    }
+
+    @Override
+    public ByteBuffer keyMetadata() {
+      return wrapped.keyMetadata();
     }
 
     @Override

--- a/core/src/test/java/org/apache/iceberg/TestManifestListVersions.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestListVersions.java
@@ -56,16 +56,17 @@ public class TestManifestListVersions {
   private static final int DELETED_FILES = 1;
   private static final long DELETED_ROWS = 22910L;
   private static final List<ManifestFile.PartitionFieldSummary> PARTITION_SUMMARIES = ImmutableList.of();
+  private static final ByteBuffer KEY_METADATA = null;
 
   private static final ManifestFile TEST_MANIFEST = new GenericManifestFile(
       PATH, LENGTH, SPEC_ID, ManifestContent.DATA, SEQ_NUM, MIN_SEQ_NUM, SNAPSHOT_ID,
       ADDED_FILES, ADDED_ROWS, EXISTING_FILES, EXISTING_ROWS, DELETED_FILES, DELETED_ROWS,
-      PARTITION_SUMMARIES);
+      PARTITION_SUMMARIES, KEY_METADATA);
 
   private static final ManifestFile TEST_DELETE_MANIFEST = new GenericManifestFile(
       PATH, LENGTH, SPEC_ID, ManifestContent.DELETES, SEQ_NUM, MIN_SEQ_NUM, SNAPSHOT_ID,
       ADDED_FILES, ADDED_ROWS, EXISTING_FILES, EXISTING_ROWS, DELETED_FILES, DELETED_ROWS,
-      PARTITION_SUMMARIES);
+      PARTITION_SUMMARIES, KEY_METADATA);
 
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
@@ -223,7 +224,7 @@ public class TestManifestListVersions {
     ManifestFile manifest = new GenericManifestFile(
         PATH, LENGTH, SPEC_ID, ManifestContent.DATA, SEQ_NUM, MIN_SEQ_NUM, SNAPSHOT_ID,
         ADDED_FILES, ADDED_ROWS, EXISTING_FILES, EXISTING_ROWS, DELETED_FILES, DELETED_ROWS,
-        partitionFieldSummaries);
+        partitionFieldSummaries, KEY_METADATA);
 
     InputFile manifestList = writeManifestList(manifest, 2);
 

--- a/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
@@ -815,7 +815,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
 
   private ManifestFile createTestingManifestFile(Path manifestPath) {
     return new GenericManifestFile(manifestPath.toAbsolutePath().toString(), manifestPath.toFile().length(), 0,
-        ManifestContent.DATA, 0, 0, 0L, 0, 0, 0, 0, 0, 0, null);
+        ManifestContent.DATA, 0, 0, 0L, 0, 0, 0, 0, 0, 0, null, null);
   }
 
   private List<Path> assertFlinkManifests(int expectedCount) throws IOException {

--- a/spark/src/main/java/org/apache/iceberg/actions/ManifestFileBean.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/ManifestFileBean.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.actions;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 import org.apache.iceberg.ManifestContent;
 import org.apache.iceberg.ManifestFile;
@@ -128,6 +129,11 @@ public class ManifestFileBean implements ManifestFile {
 
   @Override
   public List<PartitionFieldSummary> partitions() {
+    return null;
+  }
+
+  @Override
+  public ByteBuffer keyMetadata() {
     return null;
   }
 


### PR DESCRIPTION
@flyrain @rdblue @ggershinsky 

first step based on draft #2520, simply add `keyMetadata` to the interface and implementations, pass in `null` for any caller.