### PR TITLE
Core: add HadoopConfigurable interface to serialize custom FileIO

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SerializableTable.java
+++ b/core/src/main/java/org/apache/iceberg/SerializableTable.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.encryption.EncryptionManager;
-import org.apache.iceberg.hadoop.HadoopFileIO;
+import org.apache.iceberg.hadoop.HadoopConfigurable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -102,13 +102,13 @@ public class SerializableTable implements Table, Serializable {
   }
 
   private FileIO fileIO(Table table) {
-    if (table.io() instanceof HadoopFileIO) {
-      HadoopFileIO hadoopFileIO = (HadoopFileIO) table.io();
-      SerializableConfiguration serializedConf = new SerializableConfiguration(hadoopFileIO.getConf());
-      return new HadoopFileIO(serializedConf::get);
-    } else {
-      return table.io();
+    if (table.io() instanceof HadoopConfigurable) {
+      HadoopConfigurable hadoopConfigurableIO = (HadoopConfigurable) table.io();
+      SerializableConfiguration serializedConf = new SerializableConfiguration(hadoopConfigurableIO.getConf());
+      hadoopConfigurableIO.setConfSupplier(serializedConf::get);
     }
+
+    return table.io();
   }
 
   private Table lazyTable() {

--- a/core/src/main/java/org/apache/iceberg/SerializableTable.java
+++ b/core/src/main/java/org/apache/iceberg/SerializableTable.java
@@ -103,9 +103,7 @@ public class SerializableTable implements Table, Serializable {
 
   private FileIO fileIO(Table table) {
     if (table.io() instanceof HadoopConfigurable) {
-      HadoopConfigurable hadoopConfigurableIO = (HadoopConfigurable) table.io();
-      SerializableConfiguration serializedConf = new SerializableConfiguration(hadoopConfigurableIO.getConf());
-      hadoopConfigurableIO.setConfSupplier(serializedConf::get);
+      ((HadoopConfigurable) table.io()).serializeConfWith(conf -> new SerializableConfiguration(conf)::get);
     }
 
     return table.io();

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopConfigurable.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopConfigurable.java
@@ -19,31 +19,26 @@
 
 package org.apache.iceberg.hadoop;
 
+import java.util.function.Function;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.util.SerializableSupplier;
 
 /**
- * An interface that extends the Hadoop {@link Configurable} interface to
- * offer better serialization support for customizable Iceberg objects
- * such as {@link org.apache.iceberg.io.FileIO}.
+ * An interface that extends the Hadoop {@link Configurable} interface to offer better serialization support for
+ * customizable Iceberg objects such as {@link org.apache.iceberg.io.FileIO}.
  * <p>
- * If an object is serialized and needs to use Hadoop configuration,
- * it is recommend for the object to implement this interface so that
- * a serializable supplier of configuration can be provided instead of
- * an actual Hadoop configuration which is not serializable.
+ * If an object is serialized and needs to use Hadoop configuration, it is recommended for the object to implement
+ * this interface so that a serializable supplier of configuration can be provided instead of an actual Hadoop
+ * configuration which is not serializable.
  */
 public interface HadoopConfigurable extends Configurable {
 
   /**
-   * A serializable object requiring Hadoop configuration in Iceberg must be able to
-   * accept a Hadoop configuration supplier,and use the supplier to get Hadoop configurations.
-   * This ensures that Hadoop configuration can be serialized and passed around works in a distributed environment.
-   * @param confSupplier a serializable supplier of Hadoop configuration
+   * Take a function that serializes Hadoop configuration into a supplier. An implementation is supposed to pass in
+   * its current Hadoop configuration into this function, and the result can be safely serialized for future use.
+   * @param confSerializer A function that takes Hadoop configuration and returns a serializable supplier of it.
    */
-  default void setConfSupplier(SerializableSupplier<Configuration> confSupplier) {
-    throw new UnsupportedOperationException(
-        "Cannot set Hadoop configuration supplier to serialize Hadoop configuration");
-  }
+  void serializeConfWith(Function<Configuration, SerializableSupplier<Configuration>> confSerializer);
 
 }

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopConfigurable.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopConfigurable.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.hadoop;
+
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.util.SerializableSupplier;
+
+/**
+ * An interface that extends the Hadoop {@link Configurable} interface to
+ * offer better serialization support for customizable Iceberg objects
+ * such as {@link org.apache.iceberg.io.FileIO}.
+ * <p>
+ * If an object is serialized and needs to use Hadoop configuration,
+ * it is recommend for the object to implement this interface so that
+ * a serializable supplier of configuration can be provided instead of
+ * an actual Hadoop configuration which is not serializable.
+ */
+public interface HadoopConfigurable extends Configurable {
+
+  /**
+   * A serializable object requiring Hadoop configuration in Iceberg must be able to
+   * accept a Hadoop configuration supplier,and use the supplier to get Hadoop configurations.
+   * This ensures that Hadoop configuration can be serialized and passed around works in a distributed environment.
+   * @param confSupplier a serializable supplier of Hadoop configuration
+   */
+  default void setConfSupplier(SerializableSupplier<Configuration> confSupplier) {
+    throw new UnsupportedOperationException(
+        "Cannot set Hadoop configuration supplier to serialize Hadoop configuration");
+  }
+
+}

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.hadoop;
 
 import java.io.IOException;
-import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -30,7 +29,7 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.util.SerializableSupplier;
 
-public class HadoopFileIO implements FileIO, Configurable {
+public class HadoopFileIO implements FileIO, HadoopConfigurable {
 
   private SerializableSupplier<Configuration> hadoopConf;
 
@@ -83,5 +82,10 @@ public class HadoopFileIO implements FileIO, Configurable {
   @Override
   public Configuration getConf() {
     return hadoopConf.get();
+  }
+
+  @Override
+  public void setConfSupplier(SerializableSupplier<Configuration> confSupplier) {
+    this.hadoopConf = confSupplier;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.hadoop;
 
 import java.io.IOException;
+import java.util.function.Function;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -85,7 +86,7 @@ public class HadoopFileIO implements FileIO, HadoopConfigurable {
   }
 
   @Override
-  public void setConfSupplier(SerializableSupplier<Configuration> confSupplier) {
-    this.hadoopConf = confSupplier;
+  public void serializeConfWith(Function<Configuration, SerializableSupplier<Configuration>> confSerializer) {
+    this.hadoopConf = confSerializer.apply(getConf());
   }
 }

--- a/core/src/main/java/org/apache/iceberg/util/SerializationUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SerializationUtil.java
@@ -27,6 +27,8 @@ import java.io.ObjectOutputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import org.apache.iceberg.hadoop.HadoopConfigurable;
+import org.apache.iceberg.hadoop.SerializableConfiguration;
 
 public class SerializationUtil {
 
@@ -41,6 +43,16 @@ public class SerializationUtil {
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to serialize object", e);
     }
+  }
+
+  public static byte[] serializeToBytesWithHadoopConfig(Object obj) {
+    if (obj instanceof HadoopConfigurable) {
+      HadoopConfigurable configurableObj = (HadoopConfigurable) obj;
+      SerializableConfiguration serializableConf = new SerializableConfiguration(configurableObj.getConf());
+      configurableObj.setConfSupplier(serializableConf::get);
+    }
+
+    return serializeToBytes(obj);
   }
 
   @SuppressWarnings("unchecked")

--- a/core/src/main/java/org/apache/iceberg/util/SerializationUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SerializationUtil.java
@@ -35,7 +35,17 @@ public class SerializationUtil {
   private SerializationUtil() {
   }
 
+  /**
+   * Serialize an object to bytes. If the object implements {@link HadoopConfigurable}, its Hadoop configuration will
+   * be serialized into a {@link SerializableConfiguration}.
+   * @param obj object to serialize
+   * @return serialized bytes
+   */
   public static byte[] serializeToBytes(Object obj) {
+    if (obj instanceof HadoopConfigurable) {
+      ((HadoopConfigurable) obj).serializeConfWith(conf -> new SerializableConfiguration(conf)::get);
+    }
+
     try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
          ObjectOutputStream oos = new ObjectOutputStream(baos)) {
       oos.writeObject(obj);
@@ -43,16 +53,6 @@ public class SerializationUtil {
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to serialize object", e);
     }
-  }
-
-  public static byte[] serializeToBytesWithHadoopConfig(Object obj) {
-    if (obj instanceof HadoopConfigurable) {
-      HadoopConfigurable configurableObj = (HadoopConfigurable) obj;
-      SerializableConfiguration serializableConf = new SerializableConfiguration(configurableObj.getConf());
-      configurableObj.setConfSupplier(serializableConf::get);
-    }
-
-    return serializeToBytes(obj);
   }
 
   @SuppressWarnings("unchecked")

--- a/core/src/main/java/org/apache/iceberg/util/SerializationUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SerializationUtil.java
@@ -27,6 +27,8 @@ import java.io.ObjectOutputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.function.Function;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.hadoop.HadoopConfigurable;
 import org.apache.iceberg.hadoop.SerializableConfiguration;
 
@@ -42,8 +44,20 @@ public class SerializationUtil {
    * @return serialized bytes
    */
   public static byte[] serializeToBytes(Object obj) {
+    return serializeToBytes(obj, conf -> new SerializableConfiguration(conf)::get);
+  }
+
+  /**
+   * Serialize an object to bytes. If the object implements {@link HadoopConfigurable}, the confSerializer will be used
+   * to serialize Hadoop configuration used by the object.
+   * @param obj object to serialize
+   * @param confSerializer serializer for the Hadoop configuration
+   * @return serialized bytes
+   */
+  public static byte[] serializeToBytes(Object obj,
+                                        Function<Configuration, SerializableSupplier<Configuration>> confSerializer) {
     if (obj instanceof HadoopConfigurable) {
-      ((HadoopConfigurable) obj).serializeConfWith(conf -> new SerializableConfiguration(conf)::get);
+      ((HadoopConfigurable) obj).serializeConfWith(confSerializer);
     }
 
     try (ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergSplit.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergSplit.java
@@ -27,8 +27,6 @@ import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.encryption.EncryptionManager;
-import org.apache.iceberg.hadoop.HadoopFileIO;
-import org.apache.iceberg.hadoop.SerializableConfiguration;
 import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.mr.InputFormatConfig;
@@ -92,17 +90,11 @@ public class IcebergSplit extends InputSplit implements org.apache.hadoop.mapred
     out.writeInt(data.length);
     out.write(data);
 
-    byte[] ioData;
-    if (io instanceof HadoopFileIO) {
-      SerializableConfiguration serializableConf = new SerializableConfiguration(((HadoopFileIO) io).conf());
-      ioData = SerializationUtil.serializeToBytes(new HadoopFileIO(serializableConf::get));
-    } else {
-      ioData = SerializationUtil.serializeToBytes(io);
-    }
+    byte[] ioData = SerializationUtil.serializeToBytesWithHadoopConfig(io);
     out.writeInt(ioData.length);
     out.write(ioData);
 
-    byte[] encryptionManagerData = SerializationUtil.serializeToBytes(encryptionManager);
+    byte[] encryptionManagerData = SerializationUtil.serializeToBytesWithHadoopConfig(encryptionManager);
     out.writeInt(encryptionManagerData.length);
     out.write(encryptionManagerData);
   }

--- a/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergSplit.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergSplit.java
@@ -90,11 +90,11 @@ public class IcebergSplit extends InputSplit implements org.apache.hadoop.mapred
     out.writeInt(data.length);
     out.write(data);
 
-    byte[] ioData = SerializationUtil.serializeToBytesWithHadoopConfig(io);
+    byte[] ioData = SerializationUtil.serializeToBytes(io);
     out.writeInt(ioData.length);
     out.write(ioData);
 
-    byte[] encryptionManagerData = SerializationUtil.serializeToBytesWithHadoopConfig(encryptionManager);
+    byte[] encryptionManagerData = SerializationUtil.serializeToBytes(encryptionManager);
     out.writeInt(encryptionManagerData.length);
     out.write(encryptionManagerData);
   }

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.hadoop.HadoopFileIO;
+import org.apache.iceberg.hadoop.HadoopConfigurable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.transforms.Transform;
@@ -39,13 +39,14 @@ public class SparkUtil {
   }
 
   public static FileIO serializableFileIO(Table table) {
-    if (table.io() instanceof HadoopFileIO) {
+    if (table.io() instanceof HadoopConfigurable) {
+      HadoopConfigurable hadoopConfigurableIO = (HadoopConfigurable) table.io();
       // we need to use Spark's SerializableConfiguration to avoid issues with Kryo serialization
-      SerializableConfiguration conf = new SerializableConfiguration(((HadoopFileIO) table.io()).conf());
-      return new HadoopFileIO(conf::value);
-    } else {
-      return table.io();
+      SerializableConfiguration conf = new SerializableConfiguration(hadoopConfigurableIO.getConf());
+      hadoopConfigurableIO.setConfSupplier(conf::value);
     }
+
+    return table.io();
   }
 
   /**

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
@@ -40,10 +40,8 @@ public class SparkUtil {
 
   public static FileIO serializableFileIO(Table table) {
     if (table.io() instanceof HadoopConfigurable) {
-      HadoopConfigurable hadoopConfigurableIO = (HadoopConfigurable) table.io();
       // we need to use Spark's SerializableConfiguration to avoid issues with Kryo serialization
-      SerializableConfiguration conf = new SerializableConfiguration(hadoopConfigurableIO.getConf());
-      hadoopConfigurableIO.setConfSupplier(conf::value);
+      ((HadoopConfigurable) table.io()).serializeConfWith(conf -> new SerializableConfiguration(conf)::value);
     }
 
     return table.io();

--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
@@ -41,7 +41,7 @@ import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
-import org.apache.iceberg.hadoop.HadoopConfigurable;
+import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -132,7 +132,7 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
     this.splitLookback = options.get(SparkReadOptions.LOOKBACK).map(Integer::parseInt).orElse(null);
     this.splitOpenFileCost = options.get(SparkReadOptions.FILE_OPEN_COST).map(Long::parseLong).orElse(null);
 
-    if (table.io() instanceof HadoopConfigurable) {
+    if (table.io() instanceof HadoopFileIO) {
       String fsscheme = "no_exist";
       try {
         Configuration conf = SparkSession.active().sessionState().newHadoopConf();

--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
@@ -41,6 +41,7 @@ import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.hadoop.HadoopConfigurable;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.io.CloseableIterable;
@@ -132,7 +133,7 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
     this.splitLookback = options.get(SparkReadOptions.LOOKBACK).map(Integer::parseInt).orElse(null);
     this.splitOpenFileCost = options.get(SparkReadOptions.FILE_OPEN_COST).map(Long::parseLong).orElse(null);
 
-    if (table.io() instanceof HadoopFileIO) {
+    if (table.io() instanceof HadoopConfigurable) {
       String fsscheme = "no_exist";
       try {
         Configuration conf = SparkSession.active().sessionState().newHadoopConf();

--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
@@ -42,7 +42,6 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.hadoop.HadoopConfigurable;
-import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;


### PR DESCRIPTION
Currently we have special handling for `HadoopFileIO` in different code paths to make sure Hadoop configuration can be serialized and deserialized properly. This PR introduces `HadoopConfigurable` interface to make it more generic for other custom Hadoop configurable `FileIO` implementations to leverage the same code path.