### PR TITLE
Core: Validate user provided split planning configs

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -223,6 +223,8 @@ abstract class BaseTableScan implements TableScan {
     } else {
       splitSize = targetSplitSize();
     }
+    Preconditions.checkArgument(splitSize > 0, "Split size should be greater than zero. Found: %s", splitSize);
+
     int lookback;
     if (options.containsKey(TableProperties.SPLIT_LOOKBACK)) {
       lookback = Integer.parseInt(options.get(TableProperties.SPLIT_LOOKBACK));
@@ -230,6 +232,9 @@ abstract class BaseTableScan implements TableScan {
       lookback = ops.current().propertyAsInt(
           TableProperties.SPLIT_LOOKBACK, TableProperties.SPLIT_LOOKBACK_DEFAULT);
     }
+    Preconditions.checkArgument(lookback > 0,
+        "Split planning lookback should be greater than zero. Found: %s", lookback);
+
     long openFileCost;
     if (options.containsKey(TableProperties.SPLIT_OPEN_FILE_COST)) {
       openFileCost = Long.parseLong(options.get(TableProperties.SPLIT_OPEN_FILE_COST));
@@ -237,6 +242,8 @@ abstract class BaseTableScan implements TableScan {
       openFileCost = ops.current().propertyAsLong(
           TableProperties.SPLIT_OPEN_FILE_COST, TableProperties.SPLIT_OPEN_FILE_COST_DEFAULT);
     }
+    Preconditions.checkArgument(openFileCost >= 0,
+        "Split open file cost should not be negative. Found: %s", openFileCost);
 
     CloseableIterable<FileScanTask> fileScanTasks = planFiles();
     CloseableIterable<FileScanTask> splitFiles = TableScanUtil.splitFiles(fileScanTasks, splitSize);

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -241,7 +241,7 @@ abstract class BaseTableScan implements TableScan {
       openFileCost = ops.current().propertyAsLong(
           TableProperties.SPLIT_OPEN_FILE_COST, TableProperties.SPLIT_OPEN_FILE_COST_DEFAULT);
     }
-    Preconditions.checkArgument(openFileCost >= 0, "Invalid file open file cost (negative): %s", openFileCost);
+    Preconditions.checkArgument(openFileCost >= 0, "Invalid file open cost (negative): %s", openFileCost);
 
     CloseableIterable<FileScanTask> fileScanTasks = planFiles();
     CloseableIterable<FileScanTask> splitFiles = TableScanUtil.splitFiles(fileScanTasks, splitSize);

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -223,7 +223,7 @@ abstract class BaseTableScan implements TableScan {
     } else {
       splitSize = targetSplitSize();
     }
-    Preconditions.checkArgument(splitSize > 0, "Split size should be greater than zero. Found: %s", splitSize);
+    Preconditions.checkArgument(splitSize > 0, "Invalid split size (negative): %s", splitSize);
 
     int lookback;
     if (options.containsKey(TableProperties.SPLIT_LOOKBACK)) {
@@ -232,8 +232,7 @@ abstract class BaseTableScan implements TableScan {
       lookback = ops.current().propertyAsInt(
           TableProperties.SPLIT_LOOKBACK, TableProperties.SPLIT_LOOKBACK_DEFAULT);
     }
-    Preconditions.checkArgument(lookback > 0,
-        "Split planning lookback should be greater than zero. Found: %s", lookback);
+    Preconditions.checkArgument(lookback > 0, "Invalid split planning lookback (negative): %s", lookback);
 
     long openFileCost;
     if (options.containsKey(TableProperties.SPLIT_OPEN_FILE_COST)) {
@@ -242,8 +241,7 @@ abstract class BaseTableScan implements TableScan {
       openFileCost = ops.current().propertyAsLong(
           TableProperties.SPLIT_OPEN_FILE_COST, TableProperties.SPLIT_OPEN_FILE_COST_DEFAULT);
     }
-    Preconditions.checkArgument(openFileCost >= 0,
-        "Split open file cost should not be negative. Found: %s", openFileCost);
+    Preconditions.checkArgument(openFileCost >= 0, "Invalid file open file cost (negative): %s", openFileCost);
 
     CloseableIterable<FileScanTask> fileScanTasks = planFiles();
     CloseableIterable<FileScanTask> splitFiles = TableScanUtil.splitFiles(fileScanTasks, splitSize);

--- a/core/src/test/java/org/apache/iceberg/TestSplitPlanning.java
+++ b/core/src/test/java/org/apache/iceberg/TestSplitPlanning.java
@@ -178,7 +178,7 @@ public class TestSplitPlanning extends TableTestBase {
     AssertHelpers.assertThrows(
         "User provided split size should be validated",
         IllegalArgumentException.class,
-        "Split size should be greater than zero",
+        "Invalid split size (negative): -10",
         () -> {
           table.newScan()
               .option(TableProperties.SPLIT_SIZE, String.valueOf(-10))
@@ -188,7 +188,7 @@ public class TestSplitPlanning extends TableTestBase {
     AssertHelpers.assertThrows(
         "User provided split planning lookback should be validated",
         IllegalArgumentException.class,
-        "Split planning lookback should be greater than zero",
+        "Invalid split planning lookback (negative): -10",
         () -> {
           table.newScan()
               .option(TableProperties.SPLIT_LOOKBACK, String.valueOf(-10))
@@ -198,7 +198,7 @@ public class TestSplitPlanning extends TableTestBase {
     AssertHelpers.assertThrows(
         "User provided split open file cost should be validated",
         IllegalArgumentException.class,
-        "Split open file cost should not be negative",
+        "Invalid file open cost (negative): -10",
         () -> {
           table.newScan()
               .option(TableProperties.SPLIT_OPEN_FILE_COST, String.valueOf(-10))

--- a/core/src/test/java/org/apache/iceberg/TestSplitPlanning.java
+++ b/core/src/test/java/org/apache/iceberg/TestSplitPlanning.java
@@ -173,6 +173,39 @@ public class TestSplitPlanning extends TableTestBase {
     Assert.assertEquals(4, Iterables.size(scan.planTasks()));
   }
 
+  @Test
+  public void testSplitPlanningWithNegativeValues() {
+    AssertHelpers.assertThrows(
+        "User provided split size should be validated",
+        IllegalArgumentException.class,
+        "Split size should be greater than zero",
+        () -> {
+          table.newScan()
+              .option(TableProperties.SPLIT_SIZE, String.valueOf(-10))
+              .planTasks();
+        });
+
+    AssertHelpers.assertThrows(
+        "User provided split planning lookback should be validated",
+        IllegalArgumentException.class,
+        "Split planning lookback should be greater than zero",
+        () -> {
+          table.newScan()
+              .option(TableProperties.SPLIT_LOOKBACK, String.valueOf(-10))
+              .planTasks();
+        });
+
+    AssertHelpers.assertThrows(
+        "User provided split open file cost should be validated",
+        IllegalArgumentException.class,
+        "Split open file cost should not be negative",
+        () -> {
+          table.newScan()
+              .option(TableProperties.SPLIT_OPEN_FILE_COST, String.valueOf(-10))
+              .planTasks();
+        });
+  }
+
   private void appendFiles(Iterable<DataFile> files) {
     AppendFiles appendFiles = table.newAppend();
     files.forEach(appendFiles::appendFile);


### PR DESCRIPTION
One of our Spark apps using Iceberg started reporting huge GCs and eventually getting killed by YARN due to OOM. Looking at jmap we found that Iceberg was creating too many scan tasks
```
num     #instances         #bytes  class name
----------------------------------------------
   1:      29334684      938709888  org.apache.iceberg.BaseFileScanTask$SplitScanTask
   2:      29334673      704032152  [Lorg.apache.iceberg.FileScanTask;
   3:      29334673      469354768  org.apache.iceberg.BaseCombinedScanTask
   4:          8964      125336304  [Ljava.lang.Object;
   5:         47486        7061560  [C
   6:         15733        1723088  java.lang.Class
 ```
 Turns out this was because of an integer overflow when user passed in `split-size`. User provided value was `2048 * 1024 * 1024` which was converted to `-2147483648`. Since it really does not make sense for these split planning parameters to be negative, I added some checks. One thing I am not too sure on, should we allow split open file cost to be negative? Since it's a  cost, it can theoretically be negative but I don't see any practical use case for that.
 
Thanks @venkata91, who initially figured out the issue in our ecosystem.