### PR TITLE
[python] Adding type ignores for dependencies without type support

### DIFF
--- a/python/tox.ini
+++ b/python/tox.ini
@@ -60,6 +60,8 @@ basepython = python3
 skip_install = true
 deps =
     mypy
+    types-pytz
+    types-python-dateutil
 commands =
     mypy --ignore-missing-imports iceberg/
 


### PR DESCRIPTION
Adds mypy ignores for `pytz` and `dateutil`