### PR TITLE
[AWS][Minor] Fix typo in S3OutputFile.createOrOverwrite exception message

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
@@ -61,7 +61,7 @@ public class S3OutputFile extends BaseS3File implements OutputFile {
     try {
       return new S3OutputStream(client(), uri(), awsProperties());
     } catch (IOException e) {
-      throw new UncheckedIOException("Filed to create output stream for location: " + uri(), e);
+      throw new UncheckedIOException("Failed to create output stream for location: " + uri(), e);
     }
   }
 


### PR DESCRIPTION
Small hot fix for a typo I noticed from a user's support request in Slack.