### PR TITLE
Core: do not allow optional, double and float identifier fields

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Schema.java
+++ b/api/src/main/java/org/apache/iceberg/Schema.java
@@ -193,11 +193,11 @@ public class Schema implements Serializable {
    * It consists of a unique set of primitive fields in the schema.
    * An identifier field must be at root, or nested in a chain of structs (no maps or lists).
    * A row should be unique in a table based on the values of the identifier fields.
+   * Optional, float and double columns cannot be used as identifier fields.
    * However, Iceberg identifier differs from primary key in the following ways:
    * <ul>
    * <li>Iceberg does not enforce the uniqueness of a row based on this identifier information.
    * It is used for operations like upsert to define the default upsert key.</li>
-   * <li>NULL can be used as value of an identifier field. Iceberg ensures null-safe equality check.</li>
    * <li>A nested field in a struct can be used as an identifier. For example, if there is a "last_name" field
    * inside a "user" struct in a schema, field "user.last_name" can be set as a part of the identifier field.</li>
    * </ul>
@@ -215,7 +215,7 @@ public class Schema implements Serializable {
   public Set<String> identifierFieldNames() {
     return identifierFieldIds()
             .stream()
-            .map(id -> findField(id).name())
+            .map(id -> lazyIdToName().get(id))
             .collect(Collectors.toSet());
   }
 

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -474,6 +474,11 @@ class SchemaUpdate implements UpdateSchema {
     Types.NestedField field = idToField.get(fieldId);
     Preconditions.checkArgument(field.type().isPrimitiveType(),
         "Cannot add field %s as an identifier field: not a primitive type field", field.name());
+    Preconditions.checkArgument(field.isRequired(),
+        "Cannot add field %s as an identifier field: not a required field", field.name());
+    Preconditions.checkArgument(!Types.DoubleType.get().equals(field.type()) &&
+        !Types.FloatType.get().equals(field.type()),
+        "Cannot add field %s as an identifier field: must not be float or double field", field.name());
 
     // check whether the nested field is in a chain of struct fields
     Integer parentId = idToParent.get(field.fieldId());

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -458,7 +458,7 @@ class SchemaUpdate implements UpdateSchema {
     Set<Integer> freshIdentifierFieldIds = Sets.newHashSet();
     for (String name : identifierFieldNames) {
       Preconditions.checkArgument(nameToId.containsKey(name),
-          "Cannot add field %s as an identifier field: not found in current schema or added columns");
+          "Cannot add field %s as an identifier field: not found in current schema or added columns", name);
       freshIdentifierFieldIds.add(nameToId.get(name));
     }
 

--- a/core/src/test/java/org/apache/iceberg/TestCreateTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestCreateTransaction.java
@@ -86,7 +86,8 @@ public class TestCreateTransaction extends TableTestBase {
         TestTables.metadataVersion("test_create"));
 
     txn.updateSchema()
-        .addColumn("col", Types.StringType.get())
+        .allowIncompatibleChanges()
+        .addRequiredColumn("col", Types.StringType.get())
         .setIdentifierFields("id", "col")
         .commit();
 
@@ -103,7 +104,7 @@ public class TestCreateTransaction extends TableTestBase {
         Lists.newArrayList(
             required(1, "id", Types.IntegerType.get()),
             required(2, "data", Types.StringType.get()),
-            optional(3, "col", Types.StringType.get())),
+            required(3, "col", Types.StringType.get())),
         Sets.newHashSet(1, 3)
     );
 

--- a/core/src/test/java/org/apache/iceberg/TestCreateTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestCreateTransaction.java
@@ -32,7 +32,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import static org.apache.iceberg.PartitionSpec.unpartitioned;
-import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 @RunWith(Parameterized.class)


### PR DESCRIPTION
@rdblue follow up for #2654 