### PR TITLE
Docs: Adobe Apache Iceberg Migration

### DIFF
--- a/site/docs/blogs.md
+++ b/site/docs/blogs.md
@@ -19,6 +19,11 @@
 
 Here is a list of company blogs that talk about Iceberg. The blogs are ordered from most recent to oldest.
 
+### [Migrating to Apache Iceberg at Adobe Experience Platform](https://medium.com/adobetech/migrating-to-apache-iceberg-at-adobe-experience-platform-40fa80f8b8de)
+**Date**: Jun 17th, 2021, **Company**: Adobe
+
+**Author**: [Romin Parekh](https://www.linkedin.com/in/rominparekh/), [Miao Wang](https://www.linkedin.com/in/miao-wang-0406a74/), [Shone Sadler](https://www.linkedin.com/in/shonesadler/)
+
 ### [A Short Introduction to Apache Iceberg](https://medium.com/expedia-group-tech/a-short-introduction-to-apache-iceberg-d34f628b6799)
 **Date**: Jan 26th, 2021, **Company**: Expedia
 


### PR DESCRIPTION
Adds link to Adobe's blog on migrating to Apache Iceberg