### PR TITLE
fix wrong position to get field from record

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergRecordObjectInspector.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergRecordObjectInspector.java
@@ -72,7 +72,7 @@ public final class IcebergRecordObjectInspector extends StructObjectInspector {
 
   @Override
   public Object getStructFieldData(Object o, StructField structField) {
-    return ((Record) o).get(((IcebergRecordStructField) structField).position());
+    return ((Record) o).getField(((IcebergRecordStructField) structField).getFieldName());
   }
 
   @Override


### PR DESCRIPTION
This bug is met when read iceberg format V2 table with hive on spark or hive on tez. As shown bellow, the position of filed `env_key` in table schema is 22. But in internal processing, the record has three fields: <'id', 'env_key', 'xxx'>. `id` and `env_key` is the `deleteSchema`, and `xxx` is the `requestSchema`. So we should not use pos 21 to get field data from record, but should use `getFieldName`.

![image](https://user-images.githubusercontent.com/7402327/122536915-9c6c2f80-d057-11eb-959d-3ff319c0d933.png)
