### PR TITLE
Replace LinkedList usage with ArrayDeque for better performance

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -677,7 +677,7 @@ class SchemaUpdate implements UpdateSchema {
     return newFields;
   }
 
-  @SuppressWarnings("checkstyle:IllegalType")
+  @SuppressWarnings({"checkstyle:IllegalType", "JdkObsolete"})
   private static List<Types.NestedField> moveFields(List<Types.NestedField> fields,
                                                     Collection<Move> moves) {
     LinkedList<Types.NestedField> reordered = Lists.newLinkedList(fields);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/TypeWithSchemaVisitor.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/TypeWithSchemaVisitor.java
@@ -19,7 +19,7 @@
 
 package org.apache.iceberg.parquet;
 
-import java.util.LinkedList;
+import java.util.ArrayDeque;
 import java.util.List;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -36,8 +36,8 @@ import org.apache.parquet.schema.Type;
  * @param <T> the Java class returned by the visitor
  */
 public class TypeWithSchemaVisitor<T> {
-  @SuppressWarnings({"checkstyle:VisibilityModifier", "checkstyle:IllegalType"})
-  protected LinkedList<String> fieldNames = Lists.newLinkedList();
+  @SuppressWarnings("checkstyle:VisibilityModifier")
+  protected ArrayDeque<String> fieldNames = new ArrayDeque<>();
 
   @SuppressWarnings("checkstyle:CyclomaticComplexity")
   public static <T> T visit(org.apache.iceberg.types.Type iType, Type type, TypeWithSchemaVisitor<T> visitor) {


### PR DESCRIPTION
See also https://errorprone.info/bugpattern/JdkObsolete

This also suppresses the same warning for `SchemaUpdate.moveField` as we can't move to an `ArrayDeque` there.