### PR TITLE
Use equals() instead of Ref. equality

### DIFF
--- a/api/src/main/java/org/apache/iceberg/SortField.java
+++ b/api/src/main/java/org/apache/iceberg/SortField.java
@@ -80,7 +80,7 @@ public class SortField implements Serializable {
    * @return true if this order satisfies the given order
    */
   public boolean satisfies(SortField other) {
-    if (this == other) {
+    if (Objects.equals(this, other)) {
       return true;
     } else if (sourceId != other.sourceId || direction != other.direction || nullOrder != other.nullOrder) {
       return false;

--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.types;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
@@ -45,7 +46,7 @@ public class TypeUtil {
     Preconditions.checkNotNull(schema, "Schema cannot be null");
 
     Types.StructType result = select(schema.asStruct(), fieldIds);
-    if (schema.asStruct() == result) {
+    if (Objects.equals(schema.asStruct(), result)) {
       return schema;
     } else if (result != null) {
       if (schema.getAliases() != null) {

--- a/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
+++ b/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.avro;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Supplier;
 import org.apache.avro.JsonProperties;
 import org.apache.avro.Schema;
@@ -133,7 +134,7 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
     try {
       Schema schema = fieldResult.get();
 
-      if (schema != field.schema() || !expectedName.equals(field.name())) {
+      if (!Objects.equals(schema, field.schema()) || !expectedName.equals(field.name())) {
         // add an alias for the field
         return AvroSchemaUtil.copyField(field, schema, AvroSchemaUtil.makeCompatibleName(expectedName));
       } else {
@@ -153,7 +154,7 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
     Schema nonNullOriginal = AvroSchemaUtil.fromOption(union);
     Schema nonNullResult = AvroSchemaUtil.fromOptions(Lists.newArrayList(options));
 
-    if (nonNullOriginal != nonNullResult) {
+    if (!Objects.equals(nonNullOriginal, nonNullResult)) {
       return AvroSchemaUtil.toOption(nonNullResult);
     }
 
@@ -174,7 +175,7 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
         Schema.Field valueProjection = element.get().getField("value");
 
         // element was changed, create a new array
-        if (valueProjection.schema() != valueField.schema()) {
+        if (!Objects.equals(valueProjection.schema(), valueField.schema())) {
           return AvroSchemaUtil.createProjectionMap(keyValueSchema.getFullName(),
               AvroSchemaUtil.getFieldId(keyField), keyField.name(), keyField.schema(),
               AvroSchemaUtil.getFieldId(valueField), valueField.name(), valueProjection.schema());
@@ -199,7 +200,7 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
         Schema elementSchema = element.get();
 
         // element was changed, create a new array
-        if (elementSchema != array.getElementType()) {
+        if (!Objects.equals(elementSchema, array.getElementType())) {
           return Schema.createArray(elementSchema);
         }
 
@@ -223,7 +224,7 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
       Schema valueSchema = value.get();
 
       // element was changed, create a new map
-      if (valueSchema != map.getValueType()) {
+      if (!Objects.equals(valueSchema, map.getValueType())) {
         return Schema.createMap(valueSchema);
       }
 

--- a/core/src/main/java/org/apache/iceberg/avro/RemoveIds.java
+++ b/core/src/main/java/org/apache/iceberg/avro/RemoveIds.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.avro;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.apache.avro.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
@@ -74,7 +75,7 @@ public class RemoveIds extends AvroSchemaVisitor<Schema> {
     Schema.Field copy = new Schema.Field(field.name(), newSchema, field.doc(), field.defaultVal(), field.order());
     for (Map.Entry<String, Object> prop : field.getObjectProps().entrySet()) {
       String key = prop.getKey();
-      if (key != AvroSchemaUtil.FIELD_ID_PROP) {
+      if (!Objects.equals(key, AvroSchemaUtil.FIELD_ID_PROP)) {
         copy.addProp(key, prop.getValue());
       }
     }

--- a/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
+++ b/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.avro;
 
 import java.util.List;
+import java.util.Objects;
 import org.apache.avro.LogicalType;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
@@ -83,7 +84,7 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
     List<Schema.Field> fields = record.getFields();
     List<Types.NestedField> newFields = Lists.newArrayListWithExpectedSize(fields.size());
 
-    if (root == record) {
+    if (Objects.equals(root, record)) {
       this.nextId = 0;
     }
 

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkTypeToType.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkTypeToType.java
@@ -171,6 +171,7 @@ class FlinkTypeToType extends FlinkTypeVisitor<Type> {
   }
 
   @Override
+  @SuppressWarnings("ReferenceEquality")
   public Type visit(RowType rowType) {
     List<Types.NestedField> newFields = Lists.newArrayListWithExpectedSize(rowType.getFieldCount());
     boolean isRoot = root == rowType;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
@@ -131,7 +131,7 @@ class PruneColumns extends ParquetTypeVisitor<Type> {
     } else if (value != null) {
       Integer mapId = getId(map);
       if (!Objects.equal(value, originalValue)) {
-        Type mapType =  Types.map(map.getRepetition())
+        Type mapType = Types.map(map.getRepetition())
             .key(originalKey)
             .value(value)
             .named(map.getName());

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -372,7 +372,7 @@ public class SparkTableUtil {
     try {
       PartitionSpec spec = SparkSchemaUtil.specForTable(spark, sourceTableIdentWithDB.unquotedString());
 
-      if (spec == PartitionSpec.unpartitioned()) {
+      if (Objects.equal(spec, PartitionSpec.unpartitioned())) {
         importUnpartitionedSparkTable(spark, sourceTableIdentWithDB, targetTable);
       } else {
         List<SparkPartition> sourceTablePartitions = getPartitions(spark, sourceTableIdent);

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkTypeToType.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkTypeToType.java
@@ -64,6 +64,7 @@ class SparkTypeToType extends SparkTypeVisitor<Type> {
   }
 
   @Override
+  @SuppressWarnings("ReferenceEquality")
   public Type struct(StructType struct, List<Type> types) {
     StructField[] fields = struct.fields();
     List<Types.NestedField> newFields = Lists.newArrayListWithExpectedSize(fields.length);


### PR DESCRIPTION
@rdblue looks like I missed a few places in https://github.com/apache/iceberg/pull/2714 because Gradle was caching some stuff and therefore didn't recompile & re-run ErrorProne. Turns out one has to delete `~/.gradle/caches/build-cache-1` before running `./gradlew build -x test -x javadoc -x integrationTest` locally in order to see **all** ErrorProne warnings, as otherwise you only get the results for the projects that were re-compiled.