### PR TITLE
[WIP][BUILD] Remove the `/site` folder from the Intellij project to declutter search and reduce indexing time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,12 +30,14 @@ buildscript {
     classpath 'com.diffplug.spotless:spotless-plugin-gradle:3.14.0'
     classpath 'gradle.plugin.org.inferred:gradle-processors:2.1.0'
     classpath 'me.champeau.gradle:jmh-gradle-plugin:0.4.8'
+    classpath 'org.jetbrains.gradle.plugin.idea-ext:1.0'
   }
 }
 
 plugins {
   id 'nebula.dependency-recommender' version '9.0.2'
   id 'org.projectnessie' version '0.5.1'
+  id 'org.jetbrains.gradle.plugin.idea-ext' version '1.0'
 }
 
 try {
@@ -1237,4 +1239,5 @@ String getJavadocVersion() {
 apply from: 'baseline.gradle'
 apply from: 'deploy.gradle'
 apply from: 'tasks.gradle'
+apply from: 'idea.gradle'
 

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,6 @@ buildscript {
     classpath 'com.diffplug.spotless:spotless-plugin-gradle:3.14.0'
     classpath 'gradle.plugin.org.inferred:gradle-processors:2.1.0'
     classpath 'me.champeau.gradle:jmh-gradle-plugin:0.4.8'
-    classpath 'org.jetbrains.gradle.plugin.idea-ext:1.0'
   }
 }
 

--- a/idea.gradle
+++ b/idea.gradle
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: 'org.jetbrains.gradle.plugin.idea-ext'
+
+idea {
+    module {
+        // Explicitly exclude site from users intellij project, as they
+        // pollute search and greatly increase indexing times.
+        excludeDirs += project.projectDir.listFiles().findAll {
+            it.path.contains("/site/")
+        }
+       // Remove excluded directories from sources, it's not done automatically
+       sourceDirs -= excludeDirs
+       testSourceDirs -= excludeDirs // Not sure if this is needed
+    }
+}


### PR DESCRIPTION
* Add intellij gradle plugin
* Add /site docs to the excluded directories to declutter search and reduce indexing time

Marking this as WIP as I was doing some other gradle stuff in the same branch and need to verify this.

This closes: https://github.com/apache/iceberg/issues/2718