### PR TITLE
[AWS] Fix MissingFail error prone warning by cleaning up GlueCatalogC…

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueCatalogCommitFailureTest.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueCatalogCommitFailureTest.java
@@ -76,14 +76,9 @@ public class GlueCatalogCommitFailureTest extends GlueTestBase {
     GlueTableOperations spyOps = Mockito.spy(ops);
     failCommitAndThrowException(spyOps, ConcurrentModificationException.builder().build());
 
-    try {
-      spyOps.commit(metadataV2, metadataV1);
-    } catch (CommitFailedException e) {
-      Assert.assertTrue("Exception message should mention concurrent exception",
-          e.getMessage().contains("Glue detected concurrent update"));
-      Assert.assertTrue("Cause should be concurrent modification exception",
-          e.getCause() instanceof ConcurrentModificationException);
-    }
+    AssertHelpers.assertThrows("GlueCatalog should fail on concurrent modifications",
+        ConcurrentModificationException.class, "Glue detected concurrent update",
+        () -> spyOps.commit(metadataV2, metadataV1));
     Mockito.verify(spyOps, Mockito.times(0)).refresh();
 
     ops.refresh();


### PR DESCRIPTION
…ommitFailureTest

There was an error prone warning in the output for `MissingFail`.

I could have suppressed it, but we already have this utility which seems cleaner.