### PR TITLE
Hive: Push filtering for Iceberg table type to Hive MetaStore when listing tables

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -115,12 +115,15 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
         "Missing database in namespace: %s", namespace);
     String database = namespace.level(0);
 
+    String filter = String.format("%s%s = \"%s\"",
+        hive_metastoreConstants.HIVE_FILTER_FIELD_PARAMS,
+        BaseMetastoreTableOperations.TABLE_TYPE_PROP,
+        BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE.toUpperCase(Locale.ENGLISH));
+
     try {
-      List<String> tableNames = clients.run(client -> client.getAllTables(database));
+      List<String> tableNames = clients.run(client -> client.listTableNamesByFilter(database, filter, -1));
       List<Table> tableObjects = clients.run(client -> client.getTableObjectsByName(database, tableNames));
       List<TableIdentifier> tableIdentifiers = tableObjects.stream()
-          .filter(table -> table.getParameters() != null && BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE
-                  .equalsIgnoreCase(table.getParameters().get(BaseMetastoreTableOperations.TABLE_TYPE_PROP)))
           .map(table -> TableIdentifier.of(namespace, table.getTableName()))
           .collect(Collectors.toList());
 

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -123,7 +123,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
         BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE.toUpperCase(Locale.ENGLISH));
 
     try {
-      List<String> tableNames = clients.run(client -> client.listTableNamesByFilter(database, filter, -1));
+      List<String> tableNames = clients.run(client -> client.listTableNamesByFilter(database, filter, (short) -1));
       List<Table> tableObjects = clients.run(client -> client.getTableObjectsByName(database, tableNames));
       List<TableIdentifier> tableIdentifiers = tableObjects.stream()
           .map(table -> TableIdentifier.of(namespace, table.getTableName()))

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.hive;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -34,6 +35,7 @@ import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.UnknownDBException;
+import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.iceberg.BaseMetastoreCatalog;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.CatalogProperties;


### PR DESCRIPTION
# Summary

The `HiveCatalog#listTables` method could be optimized, by filtering for Hive tables of the `"ICEBERG"` type directly in the Hive MetaStore instead of from client-side.

# Changes

1. Replace the use of `HiveMetaStoreClient#getAllTables` with [`HiveMetaStoreClient#listTableNamesByFilter`](https://hive.apache.org/javadocs/r2.2.0/api/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.html#listTableNamesByFilter-java.lang.String-java.lang.String-short-), passing the filter statement `hive_filter_field_params__table_type = "ICEBERG"`.

2. Remove the now redundant client-side filtering of Hive `Table`s.

# Assumption

I believe that we should be able to safely assume that the `table_type` parameter of any Hive table in Iceberg format is always set to `"ICEBERG"` in uppercase, given the following:

https://github.com/apache/iceberg/blob/1460743422af341be997176ca5c0bf9dcff0946f/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java#L359

# Hive Version Compatibility

The `HiveMetaStoreClient#listTableNamesByFilter` method, having the support for filtering by table parameters (via `hive_filter_field_params__`), was introduced in Hive v0.8.0.

See apache/hive@8d143c6c5b43e4cc3afa5985bd31903f31252d7f ([HIVE-2226](https://issues.apache.org/jira/browse/HIVE-2226)).