### PR TITLE
make iceberg sql command recognition more whitespace tolerant

### DIFF
--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
@@ -107,7 +107,7 @@ class IcebergSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserI
   }
 
   private def isIcebergCommand(sqlText: String): Boolean = {
-    val normalized = sqlText.toLowerCase(Locale.ROOT).trim()
+    val normalized = sqlText.toLowerCase(Locale.ROOT).trim().replaceAll("\\s+", " ")
     normalized.startsWith("call") || (
         normalized.startsWith("alter table") && (
             normalized.contains("add partition field") ||

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAlterTablePartitionFields.java
@@ -265,7 +265,8 @@ public class TestAlterTablePartitionFields extends SparkExtensionsTestBase {
 
     Assert.assertEquals("Table should have 1 partition field", 1, table.spec().fields().size());
 
-    sql("ALTER TABLE %s DROP PARTITION FIELD shard", tableName);
+    // Should be recognized as iceberg command even with extra white spaces
+    sql("ALTER TABLE %s DROP  PARTITION \n FIELD shard", tableName);
 
     table.refresh();
 


### PR DESCRIPTION
Currently, iceberg sql command recognition is strict: extra white spaces between some of the keywords are not allowed. 
This fix looses this restriction and make it more user friendly as well as more aligned with general sql syntax.  
