### PR TITLE
[Parquet] Throw Better Exception with Vectorized Parquet V2 Format

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/BaseVectorizedParquetValuesReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/BaseVectorizedParquetValuesReader.java
@@ -183,8 +183,14 @@ public class BaseVectorizedParquetValuesReader extends ValuesReader {
    * Reads the next group.
    */
   void readNextGroup() {
+    int header;
     try {
-      int header = readUnsignedVarInt();
+      try {
+        header = readUnsignedVarInt();
+      } catch (NullPointerException nullPointerException) {
+        throw new ParquetDecodingException("Cannot determine the encoding of parquet file. Vectorized reading of " +
+            "Parquet files is currently only compatible with Parquet V1 Encodings.", nullPointerException);
+      }
       this.mode = (header & 1) == 0 ? Mode.RLE : Mode.PACKED;
       switch (mode) {
         case RLE:


### PR DESCRIPTION
Previously when vectorizied reading was enabled and a ParquetV2 File
was being read our reader would throw a NullPointer exception because
the inputStream would not have the expected bytes. To temporarily give
a better error, we rethrow any npe errors in attempting to read the
encoding as a ParquetDecodingException with details on Vectorized
reading only being compatible with V1 Encodings.