### PR TITLE
[Spark] Add limited support for vectorized reads for Parquet V2

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/BaseVectorizedParquetValuesReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/BaseVectorizedParquetValuesReader.java
@@ -80,12 +80,18 @@ public class BaseVectorizedParquetValuesReader extends ValuesReader {
     this.setArrowValidityVector = setValidityVector;
   }
 
-  public BaseVectorizedParquetValuesReader(
-      int bitWidth,
-      int maxDefLevel,
-      boolean setValidityVector) {
+  public BaseVectorizedParquetValuesReader(int bitWidth, int maxDefLevel, boolean setValidityVector) {
     this.fixedWidth = true;
     this.readLength = bitWidth != 0;
+    this.maxDefLevel = maxDefLevel;
+    this.setArrowValidityVector = setValidityVector;
+    init(bitWidth);
+  }
+
+  public BaseVectorizedParquetValuesReader(int bitWidth, int maxDefLevel, boolean readLength,
+                                           boolean setValidityVector) {
+    this.fixedWidth = true;
+    this.readLength = readLength;
     this.maxDefLevel = maxDefLevel;
     this.setArrowValidityVector = setValidityVector;
     init(bitWidth);

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/BaseVectorizedParquetValuesReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/BaseVectorizedParquetValuesReader.java
@@ -81,11 +81,7 @@ public class BaseVectorizedParquetValuesReader extends ValuesReader {
   }
 
   public BaseVectorizedParquetValuesReader(int bitWidth, int maxDefLevel, boolean setValidityVector) {
-    this.fixedWidth = true;
-    this.readLength = bitWidth != 0;
-    this.maxDefLevel = maxDefLevel;
-    this.setArrowValidityVector = setValidityVector;
-    init(bitWidth);
+    this(bitWidth, maxDefLevel, bitWidth != 0, setValidityVector);
   }
 
   public BaseVectorizedParquetValuesReader(int bitWidth, int maxDefLevel, boolean readLength,

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedPageIterator.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedPageIterator.java
@@ -512,6 +512,9 @@ public class VectorizedPageIterator extends BasePageIterator {
         throw new ParquetDecodingException("could not read page in col " + desc, e);
       }
     } else {
+      if (dataEncoding != Encoding.PLAIN) {
+        throw new UnsupportedOperationException("Unsupported encoding: " + dataEncoding);
+      }
       plainValuesReader = new ValuesAsBytesReader();
       plainValuesReader.initFromPage(valueCount, in);
       dictionaryDecodeMode = DictionaryDecodeMode.NONE;
@@ -526,18 +529,20 @@ public class VectorizedPageIterator extends BasePageIterator {
   @Override
   protected void initDefinitionLevelsReader(DataPageV1 dataPageV1, ColumnDescriptor desc, ByteBufferInputStream in,
                                             int triplesCount) throws IOException {
-    this.vectorizedDefinitionLevelReader = newVectorizedDefinitionLevelReader(desc);
+    int bitWidth = BytesUtils.getWidthFromMaxInt(desc.getMaxDefinitionLevel());
+    this.vectorizedDefinitionLevelReader = new VectorizedParquetDefinitionLevelReader(bitWidth,
+            desc.getMaxDefinitionLevel(), setArrowValidityVector);
     this.vectorizedDefinitionLevelReader.initFromPage(triplesCount, in);
   }
 
   @Override
-  protected void initDefinitionLevelsReader(DataPageV2 dataPageV2, ColumnDescriptor desc) {
-    this.vectorizedDefinitionLevelReader = newVectorizedDefinitionLevelReader(desc);
-  }
-
-  private VectorizedParquetDefinitionLevelReader newVectorizedDefinitionLevelReader(ColumnDescriptor desc) {
-    int bitwidth = BytesUtils.getWidthFromMaxInt(desc.getMaxDefinitionLevel());
-    return new VectorizedParquetDefinitionLevelReader(bitwidth, desc.getMaxDefinitionLevel(), setArrowValidityVector);
+  protected void initDefinitionLevelsReader(DataPageV2 dataPageV2, ColumnDescriptor desc) throws IOException {
+    int bitWidth = BytesUtils.getWidthFromMaxInt(desc.getMaxDefinitionLevel());
+    // do not read the length from the stream. v2 pages handle dividing the page bytes.
+    this.vectorizedDefinitionLevelReader = new VectorizedParquetDefinitionLevelReader(bitWidth,
+            desc.getMaxDefinitionLevel(), false, setArrowValidityVector);
+    this.vectorizedDefinitionLevelReader.initFromPage(
+            dataPageV2.getValueCount(), dataPageV2.getDefinitionLevels().toInputStream());
   }
 
 }

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedPageIterator.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedPageIterator.java
@@ -513,8 +513,8 @@ public class VectorizedPageIterator extends BasePageIterator {
       }
     } else {
       if (dataEncoding != Encoding.PLAIN) {
-        throw new UnsupportedOperationException("Vectorized reads are not supported for column " + desc + " with " +
-            "encoding " + dataEncoding + ". Disable vectorized reads to read this table/file");
+        throw new UnsupportedOperationException("Cannot support vectorized reads for column " + desc + " with " +
+                "encoding " + dataEncoding + ". Disable vectorized reads to read this table/file");
       }
       plainValuesReader = new ValuesAsBytesReader();
       plainValuesReader.initFromPage(valueCount, in);

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedPageIterator.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedPageIterator.java
@@ -513,7 +513,8 @@ public class VectorizedPageIterator extends BasePageIterator {
       }
     } else {
       if (dataEncoding != Encoding.PLAIN) {
-        throw new UnsupportedOperationException("Unsupported encoding: " + dataEncoding);
+        throw new UnsupportedOperationException("Vectorized reads are not supported for column " + desc + " with " +
+            "encoding " + dataEncoding + ". Disable vectorized reads to read this table/file");
       }
       plainValuesReader = new ValuesAsBytesReader();
       plainValuesReader.initFromPage(valueCount, in);

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
@@ -39,6 +39,11 @@ public final class VectorizedParquetDefinitionLevelReader extends BaseVectorized
     super(bitWidth, maxDefLevel, setArrowValidityVector);
   }
 
+  public VectorizedParquetDefinitionLevelReader(int bitWidth, int maxDefLevel, boolean readLength,
+                                                boolean setArrowValidityVector) {
+    super(bitWidth, maxDefLevel, readLength, setArrowValidityVector);
+  }
+
   public void readBatchOfDictionaryIds(
       final IntVector vector,
       final int startOffset,

--- a/parquet/src/main/java/org/apache/iceberg/parquet/BasePageIterator.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/BasePageIterator.java
@@ -77,7 +77,8 @@ public abstract class BasePageIterator {
   protected abstract void initDefinitionLevelsReader(DataPageV1 dataPageV1, ColumnDescriptor descriptor,
                                                      ByteBufferInputStream in, int count) throws IOException;
 
-  protected abstract void initDefinitionLevelsReader(DataPageV2 dataPageV2, ColumnDescriptor descriptor);
+  protected abstract void initDefinitionLevelsReader(DataPageV2 dataPageV2, ColumnDescriptor descriptor)
+          throws IOException;
 
   public int currentPageCount() {
     return triplesCount;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -170,6 +170,11 @@ public class Parquet {
       return this;
     }
 
+    public WriteBuilder writerVersion(WriterVersion version) {
+      this.writerVersion = version;
+      return this;
+    }
+
     @SuppressWarnings("unchecked")
     private <T> WriteSupport<T> getWriteSupport(MessageType type) {
       if (writeSupport != null) {
@@ -216,6 +221,7 @@ public class Parquet {
           PARQUET_DICT_SIZE_BYTES, PARQUET_DICT_SIZE_BYTES_DEFAULT));
       String compressionLevel = config.getOrDefault(
           PARQUET_COMPRESSION_LEVEL, PARQUET_COMPRESSION_LEVEL_DEFAULT);
+
 
       if (compressionLevel != null) {
         switch (codec()) {

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -222,7 +222,6 @@ public class Parquet {
       String compressionLevel = config.getOrDefault(
           PARQUET_COMPRESSION_LEVEL, PARQUET_COMPRESSION_LEVEL_DEFAULT);
 
-
       if (compressionLevel != null) {
         switch (codec()) {
           case GZIP:

--- a/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
@@ -39,6 +39,7 @@ import org.apache.iceberg.spark.data.TestHelpers;
 import org.apache.iceberg.spark.data.vectorized.VectorizedSparkParquetReaders;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
+import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Type;
@@ -108,6 +109,14 @@ public class TestParquetVectorizedReads extends AvroDataTest {
         .schema(schema)
         .named("test")
         .build();
+  }
+
+  FileAppender<GenericData.Record> getParquetV2Writer(Schema schema, File testFile) throws IOException {
+    return Parquet.write(Files.localOutput(testFile))
+            .schema(schema)
+            .named("test")
+            .writerVersion(ParquetProperties.WriterVersion.PARQUET_2_0)
+            .build();
   }
 
   void assertRecordsMatch(
@@ -259,5 +268,42 @@ public class TestParquetVectorizedReads extends AvroDataTest {
 
     assertRecordsMatch(readSchema, 30000, data, dataFile, false,
         true, BATCH_SIZE);
+  }
+
+  @Test
+  public void testSupportedReadsForParquetV2() throws Exception {
+    // Only float and double column types are written using plain encoding with Parquet V2
+    Schema schema = new Schema(
+            optional(102, "float_data", Types.FloatType.get()),
+            optional(103, "double_data", Types.DoubleType.get()));
+
+    File dataFile = temp.newFile();
+    Assert.assertTrue("Delete should succeed", dataFile.delete());
+    Iterable<GenericData.Record> data = generateData(schema, 30000, 0L,
+            RandomData.DEFAULT_NULL_PERCENTAGE, IDENTITY);
+    try (FileAppender<GenericData.Record> writer = getParquetV2Writer(schema, dataFile)) {
+      writer.addAll(data);
+    }
+    assertRecordsMatch(schema, 30000, data, dataFile, false,
+            true, BATCH_SIZE);
+  }
+
+  @Test
+  public void testUnsupportedReadsForParquetV2() throws Exception {
+    // Longs, ints, string types etc use delta encoding and which are not supported for vectorized reads
+    Schema schema = new Schema(SUPPORTED_PRIMITIVES.fields());
+    File dataFile = temp.newFile();
+    Assert.assertTrue("Delete should succeed", dataFile.delete());
+    Iterable<GenericData.Record> data = generateData(schema, 30000, 0L,
+        RandomData.DEFAULT_NULL_PERCENTAGE, IDENTITY);
+    try (FileAppender<GenericData.Record> writer = getParquetV2Writer(schema, dataFile)) {
+      writer.addAll(data);
+    }
+    AssertHelpers.assertThrows("Vectorized reads not supported",
+        UnsupportedOperationException.class, "Unsupported encoding:", () -> {
+          assertRecordsMatch(schema, 30000, data, dataFile, false,
+              true, BATCH_SIZE);
+          return null;
+        });
   }
 }

--- a/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetVectorizedReads.java
@@ -300,7 +300,7 @@ public class TestParquetVectorizedReads extends AvroDataTest {
       writer.addAll(data);
     }
     AssertHelpers.assertThrows("Vectorized reads not supported",
-        UnsupportedOperationException.class, "Unsupported encoding:", () -> {
+        UnsupportedOperationException.class, "Cannot support vectorized reads for column", () -> {
           assertRecordsMatch(schema, 30000, data, dataFile, false,
               true, BATCH_SIZE);
           return null;


### PR DESCRIPTION
With this change, we have added support for Parquet data written in V2 format.
The only data encodings we support are dictionary and plain.
Vectorized reads against data written using Delta/RLE and other encodings are
not supported. As of this commit, note that the Spark Parquet vectorized reads also don't
support vectorized reads for such encodings.