### PR TITLE
Docs: fix alignment of new spec diagram on page

### DIFF
--- a/site/docs/css/extra.css
+++ b/site/docs/css/extra.css
@@ -92,3 +92,10 @@ pre {
   padding: 0.5em;
   padding-left: 1em;
 }
+
+.spec-img {
+  float: right;
+  max-width: 50%; 
+  min-width: 265px; 
+  margin: 1em 0 1em 2em;
+}

--- a/site/docs/spec.md
+++ b/site/docs/spec.md
@@ -42,7 +42,7 @@ The primary goal of version 2 is to provide a way to encode row-level deletes. T
 
 ## Overview
 
-![Iceberg snapshot structure](img/iceberg-metadata.png){.floating}
+![Iceberg snapshot structure](img/iceberg-metadata.png){.spec-img}
 
 This table format tracks individual data files in a table instead of directories. This allows writers to create data files in-place and only adds files to the table in an explicit commit.
 


### PR DESCRIPTION
@rdblue looks like the new spec diagram from #2622 was a larger image than the old one so when I only replaced the image, it took up a lot of the space on the page. this is to fix the alignment and size and alignment of it on the spec page

I tested it via mkdocs locally and it now looks good on both desktop and mobile