### PR TITLE
Move Assert.assertTrue(..) instance checks to AssertJ assertions

### DIFF
--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionBinding.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionBinding.java
@@ -23,6 +23,7 @@ import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.StructType;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -182,7 +183,7 @@ public class TestExpressionBinding {
     Expression bound = Binder.bind(STRUCT, equal(bucket("x", 16), 10));
     TestHelpers.assertAllReferencesBound("BoundTransform", bound);
     BoundPredicate<?> pred = TestHelpers.assertAndUnwrap(bound);
-    Assert.assertTrue("Should use a BoundTransform child", pred.term() instanceof BoundTransform);
+    Assertions.assertThat(pred.term()).as("Should use a BoundTransform child").isInstanceOf(BoundTransform.class);
     BoundTransform<?, ?> transformExpr = (BoundTransform<?, ?>) pred.term();
     Assert.assertEquals("Should use a bucket[16] transform", "bucket[16]", transformExpr.transform().toString());
   }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestProjection.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -259,12 +260,12 @@ public class TestProjection {
 
     Expression projection = Projections.inclusive(spec).project(filter);
 
-    Assert.assertTrue(projection instanceof Or);
+    Assertions.assertThat(projection).isInstanceOf(Or.class);
     Or or1 = (Or) projection;
     UnboundPredicate<?> dateint1 = assertAndUnwrapUnbound(or1.left());
     Assert.assertEquals("Should be a dateint predicate", "dateint", dateint1.ref().name());
     Assert.assertEquals("Should be dateint=20180416", 20180416, dateint1.literal().value());
-    Assert.assertTrue(or1.right() instanceof Or);
+    Assertions.assertThat(or1.right()).isInstanceOf(Or.class);
     Or or2 = (Or) or1.right();
     UnboundPredicate<?> dateint2 = assertAndUnwrapUnbound(or2.left());
     Assert.assertEquals("Should be a dateint predicate", "dateint", dateint2.ref().name());

--- a/api/src/test/java/org/apache/iceberg/transforms/TestStartsWith.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestStartsWith.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -55,7 +56,7 @@ public class TestStartsWith {
     assertProjectionStrict(spec, startsWith(COLUMN, "abab"), "abab", Expression.Operation.EQ);
 
     Expression projection = Projections.strict(spec).project(startsWith(COLUMN, "ababab"));
-    Assert.assertTrue(projection instanceof False);
+    Assertions.assertThat(projection).isInstanceOf(False.class);
   }
 
   @Test

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/LockManagersTest.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/LockManagersTest.java
@@ -22,21 +22,21 @@ package org.apache.iceberg.aws.glue;
 import java.util.Map;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.junit.Assert;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 public class LockManagersTest {
 
   @Test
   public void testLoadDefaultLockManager() {
-    Assert.assertTrue(LockManagers.defaultLockManager() instanceof LockManagers.InMemoryLockManager);
+    Assertions.assertThat(LockManagers.defaultLockManager()).isInstanceOf(LockManagers.InMemoryLockManager.class);
   }
 
   @Test
   public void testLoadCustomLockManager() {
     Map<String, String> properties = Maps.newHashMap();
     properties.put(CatalogProperties.LOCK_IMPL, CustomLockManager.class.getName());
-    Assert.assertTrue(LockManagers.from(properties) instanceof CustomLockManager);
+    Assertions.assertThat(LockManagers.from(properties)).isInstanceOf(CustomLockManager.class);
   }
 
   static class CustomLockManager implements LockManager {

--- a/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -44,7 +45,7 @@ public class TestCatalogUtil {
     Configuration hadoopConf = new Configuration();
     String name = "custom";
     Catalog catalog = CatalogUtil.loadCatalog(TestCatalog.class.getName(), name, options, hadoopConf);
-    Assert.assertTrue(catalog instanceof TestCatalog);
+    Assertions.assertThat(catalog).isInstanceOf(TestCatalog.class);
     Assert.assertEquals(name, ((TestCatalog) catalog).catalogName);
     Assert.assertEquals(options, ((TestCatalog) catalog).flinkOptions);
   }
@@ -57,7 +58,7 @@ public class TestCatalogUtil {
     hadoopConf.set("key", "val");
     String name = "custom";
     Catalog catalog = CatalogUtil.loadCatalog(TestCatalogConfigurable.class.getName(), name, options, hadoopConf);
-    Assert.assertTrue(catalog instanceof TestCatalogConfigurable);
+    Assertions.assertThat(catalog).isInstanceOf(TestCatalogConfigurable.class);
     Assert.assertEquals(name, ((TestCatalogConfigurable) catalog).catalogName);
     Assert.assertEquals(options, ((TestCatalogConfigurable) catalog).flinkOptions);
     Assert.assertEquals(hadoopConf, ((TestCatalogConfigurable) catalog).configuration);
@@ -120,7 +121,7 @@ public class TestCatalogUtil {
     Map<String, String> properties = Maps.newHashMap();
     properties.put("key", "val");
     FileIO fileIO = CatalogUtil.loadFileIO(TestFileIONoArg.class.getName(), properties, null);
-    Assert.assertTrue(fileIO instanceof TestFileIONoArg);
+    Assertions.assertThat(fileIO).isInstanceOf(TestFileIONoArg.class);
     Assert.assertEquals(properties, ((TestFileIONoArg) fileIO).map);
   }
 
@@ -129,7 +130,7 @@ public class TestCatalogUtil {
     Configuration configuration = new Configuration();
     configuration.set("key", "val");
     FileIO fileIO = CatalogUtil.loadFileIO(HadoopFileIO.class.getName(), Maps.newHashMap(), configuration);
-    Assert.assertTrue(fileIO instanceof HadoopFileIO);
+    Assertions.assertThat(fileIO).isInstanceOf(HadoopFileIO.class);
     Assert.assertEquals("val", ((HadoopFileIO) fileIO).conf().get("key"));
   }
 
@@ -138,7 +139,7 @@ public class TestCatalogUtil {
     Configuration configuration = new Configuration();
     configuration.set("key", "val");
     FileIO fileIO = CatalogUtil.loadFileIO(TestFileIOConfigurable.class.getName(), Maps.newHashMap(), configuration);
-    Assert.assertTrue(fileIO instanceof TestFileIOConfigurable);
+    Assertions.assertThat(fileIO).isInstanceOf(TestFileIOConfigurable.class);
     Assert.assertEquals(configuration, ((TestFileIOConfigurable) fileIO).configuration);
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestSortOrderParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestSortOrderParser.java
@@ -47,7 +47,7 @@ public class TestSortOrderParser extends TableTestBase {
 
     Assert.assertEquals(10, order.orderId());
     Assert.assertEquals(1, order.fields().size());
-    Assert.assertTrue(order.fields().get(0).transform() instanceof UnknownTransform);
+    org.assertj.core.api.Assertions.assertThat(order.fields().get(0).transform()).isInstanceOf(UnknownTransform.class);
     Assert.assertEquals("custom_transform", order.fields().get(0).transform().toString());
     Assert.assertEquals(2, order.fields().get(0).sourceId());
     Assert.assertEquals(DESC, order.fields().get(0).direction());

--- a/core/src/test/java/org/apache/iceberg/avro/AvroTestHelpers.java
+++ b/core/src/test/java/org/apache/iceberg/avro/AvroTestHelpers.java
@@ -27,6 +27,7 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 
 import static org.apache.iceberg.avro.AvroSchemaUtil.toOption;
@@ -129,18 +130,18 @@ class AvroTestHelpers {
         Assert.assertEquals("Primitive value should be equal to expected", expected, actual);
         break;
       case STRUCT:
-        Assert.assertTrue("Expected should be a Record", expected instanceof Record);
-        Assert.assertTrue("Actual should be a Record", actual instanceof Record);
+        Assertions.assertThat(expected).as("Expected should be a Record").isInstanceOf(Record.class);
+        Assertions.assertThat(actual).as("Actual should be a Record").isInstanceOf(Record.class);
         assertEquals(type.asStructType(), (Record) expected, (Record) actual);
         break;
       case LIST:
-        Assert.assertTrue("Expected should be a List", expected instanceof List);
-        Assert.assertTrue("Actual should be a List", actual instanceof List);
+        Assertions.assertThat(expected).as("Expected should be a List").isInstanceOf(List.class);
+        Assertions.assertThat(actual).as("Actual should be a List").isInstanceOf(List.class);
         assertEquals(type.asListType(), (List) expected, (List) actual);
         break;
       case MAP:
-        Assert.assertTrue("Expected should be a Map", expected instanceof Map);
-        Assert.assertTrue("Actual should be a Map", actual instanceof Map);
+        Assertions.assertThat(expected).as("Expected should be a Map").isInstanceOf(Map.class);
+        Assertions.assertThat(actual).as("Actual should be a Map").isInstanceOf(Map.class);
         assertEquals(type.asMapType(), (Map<?, ?>) expected, (Map<?, ?>) actual);
         break;
       default:

--- a/core/src/test/java/org/apache/iceberg/util/TestExceptionUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestExceptionUtil.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.util;
 
 import java.io.IOException;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -56,11 +57,11 @@ public class TestExceptionUtil {
       Assert.assertEquals("Should have 2 suppressed exceptions", 2, e.getSuppressed().length);
 
       Throwable throwSuppressed = e.getSuppressed()[0];
-      Assert.assertTrue("Should be an Exception", throwSuppressed instanceof Exception);
+      Assertions.assertThat(throwSuppressed).as("Should be an Exception").isInstanceOf(Exception.class);
       Assert.assertEquals("Should have correct message", "test catch suppression", throwSuppressed.getMessage());
 
       Throwable finallySuppressed = e.getSuppressed()[1];
-      Assert.assertTrue("Should be a RuntimeException", finallySuppressed instanceof RuntimeException);
+      Assertions.assertThat(finallySuppressed).as("Should be a RuntimeException").isInstanceOf(RuntimeException.class);
       Assert.assertEquals("Should have correct message", "test finally suppression", finallySuppressed.getMessage());
     }
   }
@@ -90,11 +91,11 @@ public class TestExceptionUtil {
       Assert.assertEquals("Should have 2 suppressed exceptions", 2, e.getSuppressed().length);
 
       Throwable throwSuppressed = e.getSuppressed()[0];
-      Assert.assertTrue("Should be an Exception", throwSuppressed instanceof Exception);
+      Assertions.assertThat(throwSuppressed).as("Should be an Exception").isInstanceOf(Exception.class);
       Assert.assertEquals("Should have correct message", "test catch suppression", throwSuppressed.getMessage());
 
       Throwable finallySuppressed = e.getSuppressed()[1];
-      Assert.assertTrue("Should be a RuntimeException", finallySuppressed instanceof RuntimeException);
+      Assertions.assertThat(finallySuppressed).as("Should be a RuntimeException").isInstanceOf(RuntimeException.class);
       Assert.assertEquals("Should have correct message", "test finally suppression", finallySuppressed.getMessage());
     }
   }
@@ -125,11 +126,11 @@ public class TestExceptionUtil {
       Assert.assertEquals("Should have 2 suppressed exceptions", 2, e.getSuppressed().length);
 
       Throwable throwSuppressed = e.getSuppressed()[0];
-      Assert.assertTrue("Should be an Exception", throwSuppressed instanceof Exception);
+      Assertions.assertThat(throwSuppressed).as("Should be an Exception").isInstanceOf(Exception.class);
       Assert.assertEquals("Should have correct message", "test catch suppression", throwSuppressed.getMessage());
 
       Throwable finallySuppressed = e.getSuppressed()[1];
-      Assert.assertTrue("Should be a RuntimeException", finallySuppressed instanceof RuntimeException);
+      Assertions.assertThat(finallySuppressed).as("Should be a RuntimeException").isInstanceOf(RuntimeException.class);
       Assert.assertEquals("Should have correct message", "test finally suppression", finallySuppressed.getMessage());
     }
   }
@@ -156,11 +157,12 @@ public class TestExceptionUtil {
       Assert.assertEquals("Should have 2 suppressed exceptions", 2, e.getSuppressed().length);
 
       Throwable throwSuppressed = e.getSuppressed()[0];
-      Assert.assertTrue("Should be an Exception", throwSuppressed instanceof Exception);
+      Assertions.assertThat(throwSuppressed).as("Should be an Exception").isInstanceOf(Exception.class);
       Assert.assertEquals("Should have correct message", "test catch suppression", throwSuppressed.getMessage());
 
       Throwable finallySuppressed = e.getSuppressed()[1];
-      Assert.assertTrue("Should be a CustomCheckedException", finallySuppressed instanceof CustomCheckedException);
+      Assertions.assertThat(finallySuppressed).as("Should be a CustomCheckedException")
+          .isInstanceOf(CustomCheckedException.class);
       Assert.assertEquals("Should have correct message", "test finally suppression", finallySuppressed.getMessage());
     }
   }

--- a/data/src/test/java/org/apache/iceberg/data/DataTestHelpers.java
+++ b/data/src/test/java/org/apache/iceberg/data/DataTestHelpers.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 
 public class DataTestHelpers {
@@ -88,24 +89,24 @@ public class DataTestHelpers {
         Assert.assertEquals("Primitive value should be equal to expected for type " + type, expected, actual);
         break;
       case FIXED:
-        Assert.assertTrue("Expected should be a byte[]", expected instanceof byte[]);
-        Assert.assertTrue("Actual should be a byte[]", actual instanceof byte[]);
+        Assertions.assertThat(expected).as("Expected should be a byte[]").isInstanceOf(byte[].class);
+        Assertions.assertThat(expected).as("Actual should be a byte[]").isInstanceOf(byte[].class);
         Assert.assertArrayEquals("Array contents should be equal",
             (byte[]) expected, (byte[]) actual);
         break;
       case STRUCT:
-        Assert.assertTrue("Expected should be a Record", expected instanceof Record);
-        Assert.assertTrue("Actual should be a Record", actual instanceof Record);
+        Assertions.assertThat(expected).as("Expected should be a Record").isInstanceOf(Record.class);
+        Assertions.assertThat(actual).as("Actual should be a Record").isInstanceOf(Record.class);
         assertEquals(type.asStructType(), (Record) expected, (Record) actual);
         break;
       case LIST:
-        Assert.assertTrue("Expected should be a List", expected instanceof List);
-        Assert.assertTrue("Actual should be a List", actual instanceof List);
+        Assertions.assertThat(expected).as("Expected should be a List").isInstanceOf(List.class);
+        Assertions.assertThat(actual).as("Actual should be a List").isInstanceOf(List.class);
         assertEquals(type.asListType(), (List) expected, (List) actual);
         break;
       case MAP:
-        Assert.assertTrue("Expected should be a Map", expected instanceof Map);
-        Assert.assertTrue("Actual should be a Map", actual instanceof Map);
+        Assertions.assertThat(expected).as("Expected should be a Map").isInstanceOf(Map.class);
+        Assertions.assertThat(actual).as("Actual should be a Map").isInstanceOf(Map.class);
         assertEquals(type.asMapType(), (Map<?, ?>) expected, (Map<?, ?>) actual);
         break;
       default:

--- a/flink/src/test/java/org/apache/iceberg/flink/TestCatalogTableLoader.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestCatalogTableLoader.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -107,7 +108,7 @@ public class TestCatalogTableLoader extends FlinkTestBase {
 
   private static void validateHadoopConf(Table table) {
     FileIO io = table.io();
-    Assert.assertTrue("FileIO should be a HadoopFileIO", io instanceof HadoopFileIO);
+    Assertions.assertThat(io).as("FileIO should be a HadoopFileIO").isInstanceOf(HadoopFileIO.class);
     HadoopFileIO hadoopIO = (HadoopFileIO) io;
     Assert.assertEquals("my_value", hadoopIO.conf().get("my_key"));
   }

--- a/flink/src/test/java/org/apache/iceberg/flink/TestDataFileSerialization.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestDataFileSerialization.java
@@ -42,7 +42,7 @@ import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
-import org.junit.Assert;
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
@@ -133,19 +133,19 @@ public class TestDataFileSerialization {
     try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
       for (int i = 0; i < 2; i += 1) {
         Object obj = in.readObject();
-        Assert.assertTrue("Should be a DataFile", obj instanceof DataFile);
+        Assertions.assertThat(obj).as("Should be a DataFile").isInstanceOf(DataFile.class);
         TestHelpers.assertEquals(DATA_FILE, (DataFile) obj);
       }
 
       for (int i = 0; i < 2; i += 1) {
         Object obj = in.readObject();
-        Assert.assertTrue("Should be a position DeleteFile", obj instanceof DeleteFile);
+        Assertions.assertThat(obj).as("Should be a position DeleteFile").isInstanceOf(DeleteFile.class);
         TestHelpers.assertEquals(POS_DELETE_FILE, (DeleteFile) obj);
       }
 
       for (int i = 0; i < 2; i += 1) {
         Object obj = in.readObject();
-        Assert.assertTrue("Should be a equality DeleteFile", obj instanceof DeleteFile);
+        Assertions.assertThat(obj).as("Should be a equality DeleteFile").isInstanceOf(DeleteFile.class);
         TestHelpers.assertEquals(EQ_DELETE_FILE, (DeleteFile) obj);
       }
     }

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkFilters.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkFilters.java
@@ -50,6 +50,7 @@ import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.iceberg.util.Pair;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -342,12 +343,14 @@ public class TestFlinkFilters {
     Optional<org.apache.iceberg.expressions.Expression> actual = FlinkFilters.convert(expr);
     Assert.assertTrue("Conversion should succeed", actual.isPresent());
     org.apache.iceberg.expressions.Expression expression = actual.get();
-    Assert.assertTrue("The expression should be a UnboundPredicate", expression instanceof UnboundPredicate);
+    Assertions.assertThat(expression).as("The expression should be a UnboundPredicate")
+        .isInstanceOf(UnboundPredicate.class);
     UnboundPredicate<T> unboundPredicate = (UnboundPredicate<T>) expression;
 
     org.apache.iceberg.expressions.Expression expression1 =
         unboundPredicate.bind(FlinkSchemaUtil.convert(TABLE_SCHEMA).asStruct(), false);
-    Assert.assertTrue("The expression should be a BoundLiteralPredicate", expression1 instanceof BoundLiteralPredicate);
+    Assertions.assertThat(expression1).as("The expression should be a BoundLiteralPredicate")
+        .isInstanceOf(BoundLiteralPredicate.class);
 
     BoundLiteralPredicate<T> predicate = (BoundLiteralPredicate<T>) expression1;
     Assert.assertTrue("Should match the  literal", predicate.test(icebergLiteral));
@@ -389,8 +392,10 @@ public class TestFlinkFilters {
 
   private void assertPredicatesMatch(org.apache.iceberg.expressions.Expression expected,
                                      org.apache.iceberg.expressions.Expression actual) {
-    Assert.assertTrue("The expected expression should be a UnboundPredicate", expected instanceof UnboundPredicate<?>);
-    Assert.assertTrue("The actual expression should be a UnboundPredicate", actual instanceof UnboundPredicate<?>);
+    Assertions.assertThat(expected).as("The expected expression should be a UnboundPredicate")
+        .isInstanceOf(UnboundPredicate.class);
+    Assertions.assertThat(actual).as("The actual expression should be a UnboundPredicate")
+        .isInstanceOf(UnboundPredicate.class);
     UnboundPredicate<?> predicateExpected = (UnboundPredicate<?>) expected;
     UnboundPredicate<?> predicateActual = (UnboundPredicate<?>) actual;
     Assert.assertEquals("Predicate operation should match", predicateExpected.op(), predicateActual.op());

--- a/flink/src/test/java/org/apache/iceberg/flink/TestHelpers.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestHelpers.java
@@ -58,6 +58,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.DateTimeUtil;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 
 public class TestHelpers {
@@ -163,44 +164,44 @@ public class TestHelpers {
         Assert.assertEquals("double value should be equal", expected, actual);
         break;
       case STRING:
-        Assert.assertTrue("Should expect a CharSequence", expected instanceof CharSequence);
+        Assertions.assertThat(expected).as("Should expect a CharSequence").isInstanceOf(CharSequence.class);
         Assert.assertEquals("string should be equal", String.valueOf(expected), actual.toString());
         break;
       case DATE:
-        Assert.assertTrue("Should expect a Date", expected instanceof LocalDate);
+        Assertions.assertThat(expected).as("Should expect a Date").isInstanceOf(LocalDate.class);
         LocalDate date = DateTimeUtil.dateFromDays((int) actual);
         Assert.assertEquals("date should be equal", expected, date);
         break;
       case TIME:
-        Assert.assertTrue("Should expect a LocalTime", expected instanceof LocalTime);
+        Assertions.assertThat(expected).as("Should expect a LocalTime").isInstanceOf(LocalTime.class);
         int milliseconds = (int) (((LocalTime) expected).toNanoOfDay() / 1000_000);
         Assert.assertEquals("time millis should be equal", milliseconds, actual);
         break;
       case TIMESTAMP:
         if (((Types.TimestampType) type).shouldAdjustToUTC()) {
-          Assert.assertTrue("Should expect a OffsetDataTime", expected instanceof OffsetDateTime);
+          Assertions.assertThat(expected).as("Should expect a OffsetDataTime").isInstanceOf(OffsetDateTime.class);
           OffsetDateTime ts = (OffsetDateTime) expected;
           Assert.assertEquals("OffsetDataTime should be equal", ts.toLocalDateTime(),
               ((TimestampData) actual).toLocalDateTime());
         } else {
-          Assert.assertTrue("Should expect a LocalDataTime", expected instanceof LocalDateTime);
+          Assertions.assertThat(expected).as("Should expect a LocalDataTime").isInstanceOf(LocalDateTime.class);
           LocalDateTime ts = (LocalDateTime) expected;
           Assert.assertEquals("LocalDataTime should be equal", ts,
               ((TimestampData) actual).toLocalDateTime());
         }
         break;
       case BINARY:
-        Assert.assertTrue("Should expect a ByteBuffer", expected instanceof ByteBuffer);
+        Assertions.assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
         Assert.assertEquals("binary should be equal", expected, ByteBuffer.wrap((byte[]) actual));
         break;
       case DECIMAL:
-        Assert.assertTrue("Should expect a BigDecimal", expected instanceof BigDecimal);
+        Assertions.assertThat(expected).as("Should expect a BigDecimal").isInstanceOf(BigDecimal.class);
         BigDecimal bd = (BigDecimal) expected;
         Assert.assertEquals("decimal value should be equal", bd,
             ((DecimalData) actual).toBigDecimal());
         break;
       case LIST:
-        Assert.assertTrue("Should expect a Collection", expected instanceof Collection);
+        Assertions.assertThat(expected).as("Should expect a Collection").isInstanceOf(Collection.class);
         Collection<?> expectedArrayData = (Collection<?>) expected;
         ArrayData actualArrayData = (ArrayData) actual;
         LogicalType elementType = ((ArrayType) logicalType).getElementType();
@@ -208,20 +209,20 @@ public class TestHelpers {
         assertArrayValues(type.asListType().elementType(), elementType, expectedArrayData, actualArrayData);
         break;
       case MAP:
-        Assert.assertTrue("Should expect a Map", expected instanceof Map);
+        Assertions.assertThat(expected).as("Should expect a Map").isInstanceOf(Map.class);
         assertMapValues(type.asMapType(), logicalType, (Map<?, ?>) expected, (MapData) actual);
         break;
       case STRUCT:
-        Assert.assertTrue("Should expect a Record", expected instanceof Record);
+        Assertions.assertThat(expected).as("Should expect a Record").isInstanceOf(Record.class);
         assertRowData(type.asStructType(), logicalType, (Record) expected, (RowData) actual);
         break;
       case UUID:
-        Assert.assertTrue("Should expect a UUID", expected instanceof UUID);
+        Assertions.assertThat(expected).as("Should expect a UUID").isInstanceOf(UUID.class);
         Assert.assertEquals("UUID should be equal", expected.toString(),
             UUID.nameUUIDFromBytes((byte[]) actual).toString());
         break;
       case FIXED:
-        Assert.assertTrue("Should expect byte[]", expected instanceof byte[]);
+        Assertions.assertThat(expected).as("Should expect byte[]").isInstanceOf(byte[].class);
         Assert.assertArrayEquals("binary should be equal", (byte[]) expected, (byte[]) actual);
         break;
       default:

--- a/flink/src/test/java/org/apache/iceberg/flink/TestManifestFileSerialization.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestManifestFileSerialization.java
@@ -46,6 +46,7 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -140,7 +141,7 @@ public class TestManifestFileSerialization {
     try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
       for (int i = 0; i < 3; i += 1) {
         Object obj = in.readObject();
-        Assert.assertTrue("Should be a ManifestFile", obj instanceof ManifestFile);
+        Assertions.assertThat(obj).as("Should be a ManifestFile").isInstanceOf(ManifestFile.class);
         TestHelpers.assertEquals(manifest, (ManifestFile) obj);
       }
     }

--- a/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergStreamWriter.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergStreamWriter.java
@@ -55,6 +55,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -213,7 +214,7 @@ public class TestIcebergStreamWriter {
       testHarness.processElement(SimpleDataUtil.createRowData(1, "hello"), 1);
       testHarness.processElement(SimpleDataUtil.createRowData(2, "world"), 2);
 
-      Assert.assertTrue(testHarness.getOneInputOperator() instanceof BoundedOneInput);
+      Assertions.assertThat(testHarness.getOneInputOperator()).isInstanceOf(BoundedOneInput.class);
       ((BoundedOneInput) testHarness.getOneInputOperator()).endInput();
 
       long expectedDataFiles = partitioned ? 2 : 1;

--- a/mr/src/test/java/org/apache/iceberg/mr/TestCatalogs.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestCatalogs.java
@@ -39,6 +39,7 @@ import org.apache.iceberg.hadoop.HadoopCatalog;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.types.Types;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -195,7 +196,7 @@ public class TestCatalogs {
   public void testLegacyLoadCatalogDefault() {
     Optional<Catalog> defaultCatalog = Catalogs.loadCatalog(conf, null);
     Assert.assertTrue(defaultCatalog.isPresent());
-    Assert.assertTrue(defaultCatalog.get() instanceof HiveCatalog);
+    Assertions.assertThat(defaultCatalog.get()).isInstanceOf(HiveCatalog.class);
   }
 
   @Test
@@ -203,7 +204,7 @@ public class TestCatalogs {
     conf.set(InputFormatConfig.CATALOG, CatalogUtil.ICEBERG_CATALOG_TYPE_HIVE);
     Optional<Catalog> hiveCatalog = Catalogs.loadCatalog(conf, null);
     Assert.assertTrue(hiveCatalog.isPresent());
-    Assert.assertTrue(hiveCatalog.get() instanceof HiveCatalog);
+    Assertions.assertThat(hiveCatalog.get()).isInstanceOf(HiveCatalog.class);
   }
 
   @Test
@@ -212,7 +213,7 @@ public class TestCatalogs {
     conf.set(InputFormatConfig.HADOOP_CATALOG_WAREHOUSE_LOCATION, "/tmp/mylocation");
     Optional<Catalog> hadoopCatalog = Catalogs.loadCatalog(conf, null);
     Assert.assertTrue(hadoopCatalog.isPresent());
-    Assert.assertTrue(hadoopCatalog.get() instanceof HadoopCatalog);
+    Assertions.assertThat(hadoopCatalog.get()).isInstanceOf(HadoopCatalog.class);
   }
 
   @Test
@@ -221,7 +222,7 @@ public class TestCatalogs {
     conf.set(InputFormatConfig.HADOOP_CATALOG_WAREHOUSE_LOCATION, "/tmp/mylocation");
     Optional<Catalog> customHadoopCatalog = Catalogs.loadCatalog(conf, null);
     Assert.assertTrue(customHadoopCatalog.isPresent());
-    Assert.assertTrue(customHadoopCatalog.get() instanceof CustomHadoopCatalog);
+    Assertions.assertThat(customHadoopCatalog.get()).isInstanceOf(CustomHadoopCatalog.class);
   }
 
   @Test
@@ -242,7 +243,7 @@ public class TestCatalogs {
   public void testLoadCatalogDefault() {
     Optional<Catalog> defaultCatalog = Catalogs.loadCatalog(conf, "barCatalog");
     Assert.assertTrue(defaultCatalog.isPresent());
-    Assert.assertTrue(defaultCatalog.get() instanceof HiveCatalog);
+    Assertions.assertThat(defaultCatalog.get()).isInstanceOf(HiveCatalog.class);
   }
 
   @Test
@@ -252,7 +253,7 @@ public class TestCatalogs {
         CatalogUtil.ICEBERG_CATALOG_TYPE_HIVE);
     Optional<Catalog> hiveCatalog = Catalogs.loadCatalog(conf, catalogName);
     Assert.assertTrue(hiveCatalog.isPresent());
-    Assert.assertTrue(hiveCatalog.get() instanceof HiveCatalog);
+    Assertions.assertThat(hiveCatalog.get()).isInstanceOf(HiveCatalog.class);
   }
 
   @Test
@@ -264,7 +265,7 @@ public class TestCatalogs {
         "/tmp/mylocation");
     Optional<Catalog> hadoopCatalog = Catalogs.loadCatalog(conf, catalogName);
     Assert.assertTrue(hadoopCatalog.isPresent());
-    Assert.assertTrue(hadoopCatalog.get() instanceof HadoopCatalog);
+    Assertions.assertThat(hadoopCatalog.get()).isInstanceOf(HadoopCatalog.class);
     Assert.assertEquals("HadoopCatalog{name=barCatalog, location=/tmp/mylocation}", hadoopCatalog.get().toString());
   }
 
@@ -276,7 +277,7 @@ public class TestCatalogs {
     conf.set(InputFormatConfig.HADOOP_CATALOG_WAREHOUSE_LOCATION, "/tmp/mylocation");
     Optional<Catalog> hadoopCatalog = Catalogs.loadCatalog(conf, catalogName);
     Assert.assertTrue(hadoopCatalog.isPresent());
-    Assert.assertTrue(hadoopCatalog.get() instanceof HadoopCatalog);
+    Assertions.assertThat(hadoopCatalog.get()).isInstanceOf(HadoopCatalog.class);
     Assert.assertEquals("HadoopCatalog{name=barCatalog, location=/tmp/mylocation}", hadoopCatalog.get().toString());
   }
 
@@ -289,7 +290,7 @@ public class TestCatalogs {
         "/tmp/mylocation");
     Optional<Catalog> customHadoopCatalog = Catalogs.loadCatalog(conf, catalogName);
     Assert.assertTrue(customHadoopCatalog.isPresent());
-    Assert.assertTrue(customHadoopCatalog.get() instanceof CustomHadoopCatalog);
+    Assertions.assertThat(customHadoopCatalog.get()).isInstanceOf(CustomHadoopCatalog.class);
   }
 
   @Test

--- a/parquet/src/test/java/org/apache/iceberg/TestHelpers.java
+++ b/parquet/src/test/java/org/apache/iceberg/TestHelpers.java
@@ -22,7 +22,8 @@ package org.apache.iceberg;
 import java.util.concurrent.Callable;
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.generic.GenericRecord;
-import org.junit.Assert;
+import org.assertj.core.api.AbstractThrowableAssert;
+import org.assertj.core.api.Assertions;
 
 public class TestHelpers {
 
@@ -41,12 +42,11 @@ public class TestHelpers {
                                   Class<? extends Exception> expected,
                                   String containedInMessage,
                                   Callable callable) {
-    try {
-      callable.call();
-      Assert.fail("No exception was thrown (" + message + "), expected: " +
-          expected.getName());
-    } catch (Exception actual) {
-      handleException(message, expected, containedInMessage, actual);
+    AbstractThrowableAssert<?, ? extends Throwable> check = Assertions.assertThatThrownBy(callable::call)
+        .as(message)
+        .isInstanceOf(expected);
+    if (null != containedInMessage) {
+      check.hasMessageContaining(containedInMessage);
     }
   }
 
@@ -62,29 +62,11 @@ public class TestHelpers {
                                   Class<? extends Exception> expected,
                                   String containedInMessage,
                                   Runnable runnable) {
-    try {
-      runnable.run();
-      Assert.fail("No exception was thrown (" + message + "), expected: " +
-          expected.getName());
-    } catch (Exception actual) {
-      handleException(message, expected, containedInMessage, actual);
-    }
-  }
-
-  private static void handleException(String message,
-                                      Class<? extends Exception> expected,
-                                      String containedInMessage,
-                                      Exception actual) {
-    try {
-      Assert.assertEquals(message, expected, actual.getClass());
-      Assert.assertTrue(
-          "Expected exception message (" + containedInMessage + ") missing: " +
-              actual.getMessage(),
-          actual.getMessage().contains(containedInMessage)
-      );
-    } catch (AssertionError e) {
-      e.addSuppressed(actual);
-      throw e;
+    AbstractThrowableAssert<?, ? extends Throwable> check = Assertions.assertThatThrownBy(runnable::run)
+        .as(message)
+        .isInstanceOf(expected);
+    if (null != containedInMessage) {
+      check.hasMessageContaining(containedInMessage);
     }
   }
 

--- a/spark/src/test/java/org/apache/iceberg/TestDataFileSerialization.java
+++ b/spark/src/test/java/org/apache/iceberg/TestDataFileSerialization.java
@@ -45,6 +45,7 @@ import org.apache.iceberg.types.Types;
 import org.apache.spark.SparkConf;
 import org.apache.spark.serializer.KryoSerializer;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -113,7 +114,7 @@ public class TestDataFileSerialization {
     try (Input in = new Input(new FileInputStream(data))) {
       for (int i = 0; i < 2; i += 1) {
         Object obj = kryo.readClassAndObject(in);
-        Assert.assertTrue("Should be a DataFile", obj instanceof DataFile);
+        Assertions.assertThat(obj).as("Should be a DataFile").isInstanceOf(DataFile.class);
         assertEquals(DATA_FILE, (DataFile) obj);
       }
     }
@@ -130,7 +131,7 @@ public class TestDataFileSerialization {
     try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
       for (int i = 0; i < 2; i += 1) {
         Object obj = in.readObject();
-        Assert.assertTrue("Should be a DataFile", obj instanceof DataFile);
+        Assertions.assertThat(obj).as("Should be a DataFile").isInstanceOf(DataFile.class);
         assertEquals(DATA_FILE, (DataFile) obj);
       }
     }

--- a/spark/src/test/java/org/apache/iceberg/TestManifestFileSerialization.java
+++ b/spark/src/test/java/org/apache/iceberg/TestManifestFileSerialization.java
@@ -41,6 +41,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.SparkConf;
 import org.apache.spark.serializer.KryoSerializer;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -115,7 +116,7 @@ public class TestManifestFileSerialization {
     try (Input in = new Input(new FileInputStream(data))) {
       for (int i = 0; i < 3; i += 1) {
         Object obj = kryo.readClassAndObject(in);
-        Assert.assertTrue("Should be a ManifestFile", obj instanceof ManifestFile);
+        Assertions.assertThat(obj).as("Should be a ManifestFile").isInstanceOf(ManifestFile.class);
         checkManifestFile(manifest, (ManifestFile) obj);
       }
     }
@@ -136,7 +137,7 @@ public class TestManifestFileSerialization {
     try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
       for (int i = 0; i < 3; i += 1) {
         Object obj = in.readObject();
-        Assert.assertTrue("Should be a ManifestFile", obj instanceof ManifestFile);
+        Assertions.assertThat(obj).as("Should be a ManifestFile").isInstanceOf(ManifestFile.class);
         checkManifestFile(manifest, (ManifestFile) obj);
       }
     }

--- a/spark/src/test/java/org/apache/iceberg/TestScanTaskSerialization.java
+++ b/spark/src/test/java/org/apache/iceberg/TestScanTaskSerialization.java
@@ -43,6 +43,7 @@ import org.apache.spark.SparkConf;
 import org.apache.spark.serializer.KryoSerializer;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -85,7 +86,7 @@ public abstract class TestScanTaskSerialization extends SparkTestBase {
 
     try (Input in = new Input(new FileInputStream(data))) {
       Object obj = kryo.readClassAndObject(in);
-      Assert.assertTrue("Should be a BaseCombinedScanTask", obj instanceof BaseCombinedScanTask);
+      Assertions.assertThat(obj).as("Should be a BaseCombinedScanTask").isInstanceOf(BaseCombinedScanTask.class);
       TaskCheckHelper.assertEquals(scanTask, (BaseCombinedScanTask) obj);
     }
   }
@@ -101,7 +102,7 @@ public abstract class TestScanTaskSerialization extends SparkTestBase {
 
     try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
       Object obj = in.readObject();
-      Assert.assertTrue("Should be a BaseCombinedScanTask", obj instanceof BaseCombinedScanTask);
+      Assertions.assertThat(obj).as("Should be a BaseCombinedScanTask").isInstanceOf(BaseCombinedScanTask.class);
       TaskCheckHelper.assertEquals(scanTask, (BaseCombinedScanTask) obj);
     }
   }

--- a/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
@@ -44,6 +44,7 @@ import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.MapData;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.unsafe.types.UTF8String;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import scala.collection.Seq;
 
@@ -119,66 +120,66 @@ public class GenericsHelpers {
         Assert.assertEquals("Primitive value should be equal to expected", expected, actual);
         break;
       case DATE:
-        Assert.assertTrue("Should expect a LocalDate", expected instanceof LocalDate);
-        Assert.assertTrue("Should be a Date", actual instanceof Date);
+        Assertions.assertThat(expected).as("Should expect a LocalDate").isInstanceOf(LocalDate.class);
+        Assertions.assertThat(actual).as("Should be a Date").isInstanceOf(Date.class);
         Assert.assertEquals("ISO-8601 date should be equal", expected.toString(), actual.toString());
         break;
       case TIMESTAMP:
-        Assert.assertTrue("Should be a Timestamp", actual instanceof Timestamp);
+        Assertions.assertThat(actual).as("Should be a Timestamp").isInstanceOf(Timestamp.class);
         Timestamp ts = (Timestamp) actual;
         // milliseconds from nanos has already been added by getTime
         OffsetDateTime actualTs = EPOCH.plusNanos(
             (ts.getTime() * 1_000_000) + (ts.getNanos() % 1_000_000));
         Types.TimestampType timestampType = (Types.TimestampType) type;
         if (timestampType.shouldAdjustToUTC()) {
-          Assert.assertTrue("Should expect an OffsetDateTime", expected instanceof OffsetDateTime);
+          Assertions.assertThat(expected).as("Should expect an OffsetDateTime").isInstanceOf(OffsetDateTime.class);
           Assert.assertEquals("Timestamp should be equal", expected, actualTs);
         } else {
-          Assert.assertTrue("Should expect an LocalDateTime", expected instanceof LocalDateTime);
+          Assertions.assertThat(expected).as("Should expect an LocalDateTime").isInstanceOf(LocalDateTime.class);
           Assert.assertEquals("Timestamp should be equal", expected, actualTs.toLocalDateTime());
         }
         break;
       case STRING:
-        Assert.assertTrue("Should be a String", actual instanceof String);
+        Assertions.assertThat(actual).as("Should be a String").isInstanceOf(String.class);
         Assert.assertEquals("Strings should be equal", String.valueOf(expected), actual);
         break;
       case UUID:
-        Assert.assertTrue("Should expect a UUID", expected instanceof UUID);
-        Assert.assertTrue("Should be a String", actual instanceof String);
+        Assertions.assertThat(expected).as("Should expect a UUID").isInstanceOf(UUID.class);
+        Assertions.assertThat(actual).as("Should be a String").isInstanceOf(String.class);
         Assert.assertEquals("UUID string representation should match",
             expected.toString(), actual);
         break;
       case FIXED:
-        Assert.assertTrue("Should expect a byte[]", expected instanceof byte[]);
-        Assert.assertTrue("Should be a byte[]", actual instanceof byte[]);
+        Assertions.assertThat(expected).as("Should expect a byte[]").isInstanceOf(byte[].class);
+        Assertions.assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
         Assert.assertArrayEquals("Bytes should match",
             (byte[]) expected, (byte[]) actual);
         break;
       case BINARY:
-        Assert.assertTrue("Should expect a ByteBuffer", expected instanceof ByteBuffer);
-        Assert.assertTrue("Should be a byte[]", actual instanceof byte[]);
+        Assertions.assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
+        Assertions.assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
         Assert.assertArrayEquals("Bytes should match",
             ((ByteBuffer) expected).array(), (byte[]) actual);
         break;
       case DECIMAL:
-        Assert.assertTrue("Should expect a BigDecimal", expected instanceof BigDecimal);
-        Assert.assertTrue("Should be a BigDecimal", actual instanceof BigDecimal);
+        Assertions.assertThat(expected).as("Should expect a BigDecimal").isInstanceOf(BigDecimal.class);
+        Assertions.assertThat(actual).as("Should be a BigDecimal").isInstanceOf(BigDecimal.class);
         Assert.assertEquals("BigDecimals should be equal", expected, actual);
         break;
       case STRUCT:
-        Assert.assertTrue("Should expect a Record", expected instanceof Record);
-        Assert.assertTrue("Should be a Row", actual instanceof Row);
+        Assertions.assertThat(expected).as("Should expect a Record").isInstanceOf(Record.class);
+        Assertions.assertThat(actual).as("Should be a Row").isInstanceOf(Row.class);
         assertEqualsSafe(type.asNestedType().asStructType(), (Record) expected, (Row) actual);
         break;
       case LIST:
-        Assert.assertTrue("Should expect a Collection", expected instanceof Collection);
-        Assert.assertTrue("Should be a Seq", actual instanceof Seq);
+        Assertions.assertThat(expected).as("Should expect a Collection").isInstanceOf(Collection.class);
+        Assertions.assertThat(actual).as("Should be a Seq").isInstanceOf(Seq.class);
         List<?> asList = seqAsJavaListConverter((Seq<?>) actual).asJava();
         assertEqualsSafe(type.asNestedType().asListType(), (Collection<?>) expected, asList);
         break;
       case MAP:
-        Assert.assertTrue("Should expect a Collection", expected instanceof Map);
-        Assert.assertTrue("Should be a Map", actual instanceof scala.collection.Map);
+        Assertions.assertThat(expected).as("Should expect a Collection").isInstanceOf(Map.class);
+        Assertions.assertThat(actual).as("Should be a Map").isInstanceOf(scala.collection.Map.class);
         Map<String, ?> asMap = mapAsJavaMapConverter(
             (scala.collection.Map<String, ?>) actual).asJava();
         assertEqualsSafe(type.asNestedType().asMapType(), (Map<?, ?>) expected, asMap);
@@ -244,62 +245,62 @@ public class GenericsHelpers {
         Assert.assertEquals("Primitive value should be equal to expected", expected, actual);
         break;
       case DATE:
-        Assert.assertTrue("Should expect a LocalDate", expected instanceof LocalDate);
+        Assertions.assertThat(expected).as("Should expect a LocalDate").isInstanceOf(LocalDate.class);
         int expectedDays = (int) ChronoUnit.DAYS.between(EPOCH_DAY, (LocalDate) expected);
         Assert.assertEquals("Primitive value should be equal to expected", expectedDays, actual);
         break;
       case TIMESTAMP:
         Types.TimestampType timestampType = (Types.TimestampType) type;
         if (timestampType.shouldAdjustToUTC()) {
-          Assert.assertTrue("Should expect an OffsetDateTime", expected instanceof OffsetDateTime);
+          Assertions.assertThat(expected).as("Should expect an OffsetDateTime").isInstanceOf(OffsetDateTime.class);
           long expectedMicros = ChronoUnit.MICROS.between(EPOCH, (OffsetDateTime) expected);
           Assert.assertEquals("Primitive value should be equal to expected", expectedMicros, actual);
         } else {
-          Assert.assertTrue("Should expect an LocalDateTime", expected instanceof LocalDateTime);
+          Assertions.assertThat(expected).as("Should expect an LocalDateTime").isInstanceOf(LocalDateTime.class);
           long expectedMicros = ChronoUnit.MICROS.between(EPOCH, ((LocalDateTime) expected).atZone(ZoneId.of("UTC")));
           Assert.assertEquals("Primitive value should be equal to expected", expectedMicros, actual);
         }
         break;
       case STRING:
-        Assert.assertTrue("Should be a UTF8String", actual instanceof UTF8String);
+        Assertions.assertThat(actual).as("Should be a UTF8String").isInstanceOf(UTF8String.class);
         Assert.assertEquals("Strings should be equal", expected, actual.toString());
         break;
       case UUID:
-        Assert.assertTrue("Should expect a UUID", expected instanceof UUID);
-        Assert.assertTrue("Should be a UTF8String", actual instanceof UTF8String);
+        Assertions.assertThat(expected).as("Should expect a UUID").isInstanceOf(UUID.class);
+        Assertions.assertThat(actual).as("Should be a UTF8String").isInstanceOf(UTF8String.class);
         Assert.assertEquals("UUID string representation should match",
             expected.toString(), actual.toString());
         break;
       case FIXED:
-        Assert.assertTrue("Should expect a byte[]", expected instanceof byte[]);
-        Assert.assertTrue("Should be a byte[]", actual instanceof byte[]);
+        Assertions.assertThat(expected).as("Should expect a byte[]").isInstanceOf(byte[].class);
+        Assertions.assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
         Assert.assertArrayEquals("Bytes should match", (byte[]) expected, (byte[]) actual);
         break;
       case BINARY:
-        Assert.assertTrue("Should expect a ByteBuffer", expected instanceof ByteBuffer);
-        Assert.assertTrue("Should be a byte[]", actual instanceof byte[]);
+        Assertions.assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
+        Assertions.assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
         Assert.assertArrayEquals("Bytes should match",
             ((ByteBuffer) expected).array(), (byte[]) actual);
         break;
       case DECIMAL:
-        Assert.assertTrue("Should expect a BigDecimal", expected instanceof BigDecimal);
-        Assert.assertTrue("Should be a Decimal", actual instanceof Decimal);
+        Assertions.assertThat(expected).as("Should expect a BigDecimal").isInstanceOf(BigDecimal.class);
+        Assertions.assertThat(actual).as("Should be a Decimal").isInstanceOf(Decimal.class);
         Assert.assertEquals("BigDecimals should be equal",
             expected, ((Decimal) actual).toJavaBigDecimal());
         break;
       case STRUCT:
-        Assert.assertTrue("Should expect a Record", expected instanceof Record);
-        Assert.assertTrue("Should be an InternalRow", actual instanceof InternalRow);
+        Assertions.assertThat(expected).as("Should expect a Record").isInstanceOf(Record.class);
+        Assertions.assertThat(actual).as("Should be an InternalRow").isInstanceOf(InternalRow.class);
         assertEqualsUnsafe(type.asNestedType().asStructType(), (Record) expected, (InternalRow) actual);
         break;
       case LIST:
-        Assert.assertTrue("Should expect a Collection", expected instanceof Collection);
-        Assert.assertTrue("Should be an ArrayData", actual instanceof ArrayData);
+        Assertions.assertThat(expected).as("Should expect a Collection").isInstanceOf(Collection.class);
+        Assertions.assertThat(actual).as("Should be an ArrayData").isInstanceOf(ArrayData.class);
         assertEqualsUnsafe(type.asNestedType().asListType(), (Collection<?>) expected, (ArrayData) actual);
         break;
       case MAP:
-        Assert.assertTrue("Should expect a Map", expected instanceof Map);
-        Assert.assertTrue("Should be an ArrayBasedMapData", actual instanceof MapData);
+        Assertions.assertThat(expected).as("Should expect a Map").isInstanceOf(Map.class);
+        Assertions.assertThat(actual).as("Should be an ArrayBasedMapData").isInstanceOf(MapData.class);
         assertEqualsUnsafe(type.asNestedType().asMapType(), (Map<?, ?>) expected, (MapData) actual);
         break;
       case TIME:

--- a/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -59,6 +59,7 @@ import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.apache.spark.unsafe.types.UTF8String;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import scala.collection.Seq;
 
@@ -156,61 +157,61 @@ public class TestHelpers {
         Assert.assertEquals("Primitive value should be equal to expected", expected, actual);
         break;
       case DATE:
-        Assert.assertTrue("Should be an int", expected instanceof Integer);
-        Assert.assertTrue("Should be a Date", actual instanceof Date);
+        Assertions.assertThat(expected).as("Should be an int").isInstanceOf(Integer.class);
+        Assertions.assertThat(actual).as("Should be a Date").isInstanceOf(Date.class);
         int daysFromEpoch = (Integer) expected;
         LocalDate date = ChronoUnit.DAYS.addTo(EPOCH_DAY, daysFromEpoch);
         Assert.assertEquals("ISO-8601 date should be equal", date.toString(), actual.toString());
         break;
       case TIMESTAMP:
-        Assert.assertTrue("Should be a long", expected instanceof Long);
-        Assert.assertTrue("Should be a Timestamp", actual instanceof Timestamp);
+        Assertions.assertThat(expected).as("Should be a long").isInstanceOf(Long.class);
+        Assertions.assertThat(actual).as("Should be a Timestamp").isInstanceOf(Timestamp.class);
         Timestamp ts = (Timestamp) actual;
         // milliseconds from nanos has already been added by getTime
         long tsMicros = (ts.getTime() * 1000) + ((ts.getNanos() / 1000) % 1000);
         Assert.assertEquals("Timestamp micros should be equal", expected, tsMicros);
         break;
       case STRING:
-        Assert.assertTrue("Should be a String", actual instanceof String);
+        Assertions.assertThat(actual).as("Should be a String").isInstanceOf(String.class);
         Assert.assertEquals("Strings should be equal", String.valueOf(expected), actual);
         break;
       case UUID:
-        Assert.assertTrue("Should expect a UUID", expected instanceof UUID);
-        Assert.assertTrue("Should be a String", actual instanceof String);
+        Assertions.assertThat(expected).as("Should expect a UUID").isInstanceOf(UUID.class);
+        Assertions.assertThat(actual).as("Should be a String").isInstanceOf(String.class);
         Assert.assertEquals("UUID string representation should match",
             expected.toString(), actual);
         break;
       case FIXED:
-        Assert.assertTrue("Should expect a Fixed", expected instanceof GenericData.Fixed);
-        Assert.assertTrue("Should be a byte[]", actual instanceof byte[]);
+        Assertions.assertThat(expected).as("Should expect a Fixed").isInstanceOf(GenericData.Fixed.class);
+        Assertions.assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
         Assert.assertArrayEquals("Bytes should match",
             ((GenericData.Fixed) expected).bytes(), (byte[]) actual);
         break;
       case BINARY:
-        Assert.assertTrue("Should expect a ByteBuffer", expected instanceof ByteBuffer);
-        Assert.assertTrue("Should be a byte[]", actual instanceof byte[]);
+        Assertions.assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
+        Assertions.assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
         Assert.assertArrayEquals("Bytes should match",
             ((ByteBuffer) expected).array(), (byte[]) actual);
         break;
       case DECIMAL:
-        Assert.assertTrue("Should expect a BigDecimal", expected instanceof BigDecimal);
-        Assert.assertTrue("Should be a BigDecimal", actual instanceof BigDecimal);
+        Assertions.assertThat(expected).as("Should expect a BigDecimal").isInstanceOf(BigDecimal.class);
+        Assertions.assertThat(actual).as("Should be a BigDecimal").isInstanceOf(BigDecimal.class);
         Assert.assertEquals("BigDecimals should be equal", expected, actual);
         break;
       case STRUCT:
-        Assert.assertTrue("Should expect a Record", expected instanceof Record);
-        Assert.assertTrue("Should be a Row", actual instanceof Row);
+        Assertions.assertThat(expected).as("Should expect a Record").isInstanceOf(Record.class);
+        Assertions.assertThat(actual).as("Should be a Row").isInstanceOf(Row.class);
         assertEqualsSafe(type.asNestedType().asStructType(), (Record) expected, (Row) actual);
         break;
       case LIST:
-        Assert.assertTrue("Should expect a Collection", expected instanceof Collection);
-        Assert.assertTrue("Should be a Seq", actual instanceof Seq);
+        Assertions.assertThat(expected).as("Should expect a Collection").isInstanceOf(Collection.class);
+        Assertions.assertThat(actual).as("Should be a Seq").isInstanceOf(Seq.class);
         List<?> asList = seqAsJavaListConverter((Seq<?>) actual).asJava();
         assertEqualsSafe(type.asNestedType().asListType(), (Collection) expected, asList);
         break;
       case MAP:
-        Assert.assertTrue("Should expect a Collection", expected instanceof Map);
-        Assert.assertTrue("Should be a Map", actual instanceof scala.collection.Map);
+        Assertions.assertThat(expected).as("Should expect a Collection").isInstanceOf(Map.class);
+        Assertions.assertThat(actual).as("Should be a Map").isInstanceOf(scala.collection.Map.class);
         Map<String, ?> asMap = mapAsJavaMapConverter(
             (scala.collection.Map<String, ?>) actual).asJava();
         assertEqualsSafe(type.asNestedType().asMapType(), (Map<String, ?>) expected, asMap);
@@ -269,7 +270,7 @@ public class TestHelpers {
 
     switch (type.typeId()) {
       case LONG:
-        Assert.assertTrue("Should be a long", actual instanceof Long);
+        Assertions.assertThat(actual).as("Should be a long").isInstanceOf(Long.class);
         if (expected instanceof Integer) {
           Assert.assertEquals("Values didn't match", ((Number) expected).longValue(), actual);
         } else {
@@ -277,7 +278,7 @@ public class TestHelpers {
         }
         break;
       case DOUBLE:
-        Assert.assertTrue("Should be a double", actual instanceof Double);
+        Assertions.assertThat(actual).as("Should be a double").isInstanceOf(Double.class);
         if (expected instanceof Float) {
           Assert.assertEquals("Values didn't match", Double.doubleToLongBits(((Number) expected).doubleValue()),
                   Double.doubleToLongBits((double) actual));
@@ -293,46 +294,46 @@ public class TestHelpers {
         Assert.assertEquals("Primitive value should be equal to expected", expected, actual);
         break;
       case STRING:
-        Assert.assertTrue("Should be a UTF8String", actual instanceof UTF8String);
+        Assertions.assertThat(actual).as("Should be a UTF8String").isInstanceOf(UTF8String.class);
         Assert.assertEquals("Strings should be equal", expected, actual.toString());
         break;
       case UUID:
-        Assert.assertTrue("Should expect a UUID", expected instanceof UUID);
-        Assert.assertTrue("Should be a UTF8String", actual instanceof UTF8String);
+        Assertions.assertThat(expected).as("Should expect a UUID").isInstanceOf(UUID.class);
+        Assertions.assertThat(actual).as("Should be a UTF8String").isInstanceOf(UTF8String.class);
         Assert.assertEquals("UUID string representation should match",
             expected.toString(), actual.toString());
         break;
       case FIXED:
-        Assert.assertTrue("Should expect a Fixed", expected instanceof GenericData.Fixed);
-        Assert.assertTrue("Should be a byte[]", actual instanceof byte[]);
+        Assertions.assertThat(expected).as("Should expect a Fixed").isInstanceOf(GenericData.Fixed.class);
+        Assertions.assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
         Assert.assertArrayEquals("Bytes should match",
             ((GenericData.Fixed) expected).bytes(), (byte[]) actual);
         break;
       case BINARY:
-        Assert.assertTrue("Should expect a ByteBuffer", expected instanceof ByteBuffer);
-        Assert.assertTrue("Should be a byte[]", actual instanceof byte[]);
+        Assertions.assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
+        Assertions.assertThat(actual).as("Should be a byte[]").isInstanceOf(byte[].class);
         Assert.assertArrayEquals("Bytes should match",
             ((ByteBuffer) expected).array(), (byte[]) actual);
         break;
       case DECIMAL:
-        Assert.assertTrue("Should expect a BigDecimal", expected instanceof BigDecimal);
-        Assert.assertTrue("Should be a Decimal", actual instanceof Decimal);
+        Assertions.assertThat(expected).as("Should expect a BigDecimal").isInstanceOf(BigDecimal.class);
+        Assertions.assertThat(actual).as("Should be a Decimal").isInstanceOf(Decimal.class);
         Assert.assertEquals("BigDecimals should be equal",
             expected, ((Decimal) actual).toJavaBigDecimal());
         break;
       case STRUCT:
-        Assert.assertTrue("Should expect a Record", expected instanceof Record);
-        Assert.assertTrue("Should be an InternalRow", actual instanceof InternalRow);
+        Assertions.assertThat(expected).as("Should expect a Record").isInstanceOf(Record.class);
+        Assertions.assertThat(actual).as("Should be an InternalRow").isInstanceOf(InternalRow.class);
         assertEqualsUnsafe(type.asNestedType().asStructType(), (Record) expected, (InternalRow) actual);
         break;
       case LIST:
-        Assert.assertTrue("Should expect a Collection", expected instanceof Collection);
-        Assert.assertTrue("Should be an ArrayData", actual instanceof ArrayData);
+        Assertions.assertThat(expected).as("Should expect a Collection").isInstanceOf(Collection.class);
+        Assertions.assertThat(actual).as("Should be an ArrayData").isInstanceOf(ArrayData.class);
         assertEqualsUnsafe(type.asNestedType().asListType(), (Collection) expected, (ArrayData) actual);
         break;
       case MAP:
-        Assert.assertTrue("Should expect a Map", expected instanceof Map);
-        Assert.assertTrue("Should be an ArrayBasedMapData", actual instanceof MapData);
+        Assertions.assertThat(expected).as("Should expect a Map").isInstanceOf(Map.class);
+        Assertions.assertThat(actual).as("Should be an ArrayBasedMapData").isInstanceOf(MapData.class);
         assertEqualsUnsafe(type.asNestedType().asMapType(), (Map) expected, (MapData) actual);
         break;
       case TIME:
@@ -621,24 +622,24 @@ public class TestHelpers {
     }
 
     if (type instanceof StructType) {
-      Assert.assertTrue("Expected should be an InternalRow: " + context,
-          expected instanceof InternalRow);
-      Assert.assertTrue("Actual should be an InternalRow: " + context,
-          actual instanceof InternalRow);
+      Assertions.assertThat(expected).as("Expected should be an InternalRow: " + context)
+          .isInstanceOf(InternalRow.class);
+      Assertions.assertThat(actual).as("Actual should be an InternalRow: " + context)
+          .isInstanceOf(InternalRow.class);
       assertEquals(context, (StructType) type, (InternalRow) expected, (InternalRow) actual);
 
     } else if (type instanceof ArrayType) {
-      Assert.assertTrue("Expected should be an ArrayData: " + context,
-          expected instanceof ArrayData);
-      Assert.assertTrue("Actual should be an ArrayData: " + context,
-          actual instanceof ArrayData);
+      Assertions.assertThat(expected).as("Expected should be an ArrayData: " + context)
+          .isInstanceOf(ArrayData.class);
+      Assertions.assertThat(actual).as("Actual should be an ArrayData: " + context)
+          .isInstanceOf(ArrayData.class);
       assertEquals(context, (ArrayType) type, (ArrayData) expected, (ArrayData) actual);
 
     } else if (type instanceof MapType) {
-      Assert.assertTrue("Expected should be a MapData: " + context,
-          expected instanceof MapData);
-      Assert.assertTrue("Actual should be a MapData: " + context,
-          actual instanceof MapData);
+      Assertions.assertThat(expected).as("Expected should be a MapData: " + context)
+          .isInstanceOf(MapData.class);
+      Assertions.assertThat(actual).as("Actual should be a MapData: " + context)
+          .isInstanceOf(MapData.class);
       assertEquals(context, (MapType) type, (MapData) expected, (MapData) actual);
 
     } else if (type instanceof BinaryType) {

--- a/spark2/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
+++ b/spark2/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
@@ -67,6 +67,7 @@ import org.apache.spark.sql.sources.v2.reader.SupportsPushDownFilters;
 import org.apache.spark.sql.types.IntegerType$;
 import org.apache.spark.sql.types.LongType$;
 import org.apache.spark.sql.types.StringType$;
+import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -539,7 +540,7 @@ public class TestFilteredScan {
   }
 
   private void pushFilters(DataSourceReader reader, Filter... filters) {
-    Assert.assertTrue(reader instanceof SupportsPushDownFilters);
+    Assertions.assertThat(reader).isInstanceOf(SupportsPushDownFilters.class);
     SupportsPushDownFilters filterable = (SupportsPushDownFilters) reader;
     filterable.pushFilters(filters);
   }

--- a/spark3/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
@@ -65,6 +65,7 @@ import org.apache.spark.sql.types.IntegerType$;
 import org.apache.spark.sql.types.LongType$;
 import org.apache.spark.sql.types.StringType$;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
@@ -491,7 +492,7 @@ public class TestFilteredScan {
   }
 
   private void pushFilters(ScanBuilder scan, Filter... filters) {
-    Assert.assertTrue(scan instanceof SupportsPushDownFilters);
+    Assertions.assertThat(scan).isInstanceOf(SupportsPushDownFilters.class);
     SupportsPushDownFilters filterable = (SupportsPushDownFilters) scan;
     filterable.pushFilters(filters);
   }

--- a/spark3/src/test/java/org/apache/iceberg/spark/source/TestPathIdentifier.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/source/TestPathIdentifier.java
@@ -34,6 +34,7 @@ import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
 import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -77,8 +78,8 @@ public class TestPathIdentifier extends SparkTestBase {
         ImmutableMap.of());
 
     Assert.assertEquals(table.table().location(), tableLocation.getAbsolutePath());
-    Assert.assertTrue(table.table() instanceof BaseTable);
-    Assert.assertTrue(((BaseTable) table.table()).operations() instanceof HadoopTableOperations);
+    Assertions.assertThat(table.table()).isInstanceOf(BaseTable.class);
+    Assertions.assertThat(((BaseTable) table.table()).operations()).isInstanceOf(HadoopTableOperations.class);
 
     Assert.assertEquals(sparkCatalog.loadTable(identifier), table);
     Assert.assertTrue(sparkCatalog.dropTable(identifier));


### PR DESCRIPTION
While working on some other code where I was debugging an issue that resulted in failing checks in `TestHelpers`. Those failing checks were essentially of the form `Should be XYZ` without actually knowing what the actual value was, thus requiring to add some additional context to the failure message.

For example, the check `Assert.assertTrue("Should be a long", actual instanceof Long)` could fail either if `actual` is `null` or of a different type. Yet one doesn't know and has to add some additional context to understand what `actual`'s value is.

Therefore it seems better to move to AssertJ checks, where the actual value will be reported.

Note that I didn't touch all the other `Assert.assertEquals` checks in order to keep the change set to an absolute minimum but still improve the debugging experience when a test fails.