### PR TITLE
Add an implemention of STARTS_WITH for Python API.

### DIFF
--- a/python/iceberg/api/expressions/evaluator.py
+++ b/python/iceberg/api/expressions/evaluator.py
@@ -85,6 +85,9 @@ class Evaluator(object):
         def not_eq(self, ref, lit):
             return ref.get(self.struct) != lit.value
 
+        def starts_with(self, ref, lit):
+            return ref.get(self.struct).startswith(lit.value)
+
         def in_(self, ref, lit):
             raise NotImplementedError()
 

--- a/python/iceberg/api/expressions/expression.py
+++ b/python/iceberg/api/expressions/expression.py
@@ -56,6 +56,7 @@ class Operation(Enum):
     NOT = "NOT"
     AND = "AND"
     OR = "OR"
+    STARTS_WITH = "STARTS_WITH"
 
     def negate(self): # noqa
         if self == Operation.IS_NULL:

--- a/python/iceberg/api/expressions/expression_parser.py
+++ b/python/iceberg/api/expressions/expression_parser.py
@@ -44,7 +44,7 @@ NOT_NULL = NOT + NULL
 ident = Word(alphas, alphanums + "_$").setName("identifier")
 columnName = delimitedList(ident, ".", combine=True).setName("column name")
 
-binop = oneOf("= == != < > >= <= eq ne lt le gt ge <>", caseless=False)
+binop = oneOf("= == != < > >= <= eq ne lt le gt ge <> startsWith", caseless=False)
 realNum = ppc.real()
 intNum = ppc.signed_integer()
 
@@ -90,7 +90,8 @@ op_map = {"=": "eq",
           "and": "and",
           "in": "in",
           "between": "between",
-          "is": "is"}
+          "is": "is",
+          "startsWith": "startsWith"}
 
 
 def get_expr_tree(tokens):

--- a/python/iceberg/api/expressions/expression_parser.py
+++ b/python/iceberg/api/expressions/expression_parser.py
@@ -44,7 +44,7 @@ NOT_NULL = NOT + NULL
 ident = Word(alphas, alphanums + "_$").setName("identifier")
 columnName = delimitedList(ident, ".", combine=True).setName("column name")
 
-binop = oneOf("= == != < > >= <= eq ne lt le gt ge <> startsWith", caseless=False)
+binop = oneOf("= == != < > >= <= eq ne lt le gt ge <> startsWith starts_with", caseless=False)
 realNum = ppc.real()
 intNum = ppc.signed_integer()
 
@@ -91,7 +91,8 @@ op_map = {"=": "eq",
           "in": "in",
           "between": "between",
           "is": "is",
-          "startsWith": "startsWith"}
+          "startsWith": "startsWith",
+          "starts_with": "startsWith"}
 
 
 def get_expr_tree(tokens):

--- a/python/iceberg/api/expressions/expressions.py
+++ b/python/iceberg/api/expressions/expressions.py
@@ -106,11 +106,12 @@ class Expressions(object):
     def not_equal(name, value):
         return UnboundPredicate(Operation.NOT_EQ, Expressions.ref(name), value)
 
-    # In Python we use "startswith", to match the direct conversion & the pythonic impl do both.
+    # startswith matches the Python API folks are used to using on strings.
     @staticmethod
     def startswith(name, value):
         return UnboundPredicate(Operation.STARTS_WITH, Expressions.ref(name), value)
 
+    # starts_with matches the camelCase to snake_case conversion used elsewhere.
     @staticmethod
     def starts_with(name, value):
         return UnboundPredicate(Operation.STARTS_WITH, Expressions.ref(name), value)

--- a/python/iceberg/api/expressions/expressions.py
+++ b/python/iceberg/api/expressions/expressions.py
@@ -106,6 +106,15 @@ class Expressions(object):
     def not_equal(name, value):
         return UnboundPredicate(Operation.NOT_EQ, Expressions.ref(name), value)
 
+    # In Python we use "startswith", to match the direct conversion & the pythonic impl do both.
+    @staticmethod
+    def startswith(name, value):
+        return UnboundPredicate(Operation.STARTS_WITH, Expressions.ref(name), value)
+
+    @staticmethod
+    def starts_with(name, value):
+        return UnboundPredicate(Operation.STARTS_WITH, Expressions.ref(name), value)
+
     @staticmethod
     def predicate(op, name, value=None, lit=None):
         if value is not None and op not in (Operation.IS_NULL, Operation.NOT_NULL):
@@ -147,7 +156,8 @@ class Expressions(object):
                     "missing": (Expressions.is_null,),
                     "neq": (Expressions.not_equal,),
                     "not": (Expressions.not_,),
-                    "or": (Expressions.or_,)}
+                    "or": (Expressions.or_,),
+                    "startsWith": (Expressions.starts_with,)}
 
         return parse_expr_string(predicate_string, expr_map)
 
@@ -229,6 +239,9 @@ class ExpressionVisitors(object):
         def not_eq(self, ref, lit):
             return None
 
+        def starts_with(self, ref, lit):
+            return None
+
         def in_(self, ref, lit):
             return None
 
@@ -262,6 +275,8 @@ class ExpressionVisitors(object):
                 return self.in_(pred.ref, pred.lit)
             elif pred.op == Operation.NOT_IN:
                 return self.not_in(pred.ref, pred.lit)
+            elif pred.op == Operation.STARTS_WITH:
+                return self.starts_with(pred.ref, pred.lit)
             else:
                 raise RuntimeError("Unknown operation for Predicate: {}".format(pred.op))
 

--- a/python/iceberg/api/expressions/inclusive_manifest_evaluator.py
+++ b/python/iceberg/api/expressions/inclusive_manifest_evaluator.py
@@ -159,3 +159,7 @@ class ManifestEvalVisitor(ExpressionVisitors.BoundExpressionVisitor):
 
     def not_in(self, ref, lit):
         return ROWS_MIGHT_MATCH
+
+    def starts_with(self, ref, lit):
+        # if it's all null then we can't match :)
+        return self.not_null(ref)

--- a/python/iceberg/api/expressions/inclusive_metrics_evaluator.py
+++ b/python/iceberg/api/expressions/inclusive_metrics_evaluator.py
@@ -186,3 +186,7 @@ class MetricsEvalVisitor(ExpressionVisitors.BoundExpressionVisitor):
 
     def not_in(self, ref, lit):
         return MetricsEvalVisitor.ROWS_MIGHT_MATCH
+
+    def starts_with(self, ref, lit):
+        # If it's all null we can't match :)
+        return self.not_null(ref)

--- a/python/iceberg/api/expressions/residual_evaluator.py
+++ b/python/iceberg/api/expressions/residual_evaluator.py
@@ -74,6 +74,9 @@ class ResidualVisitor(ExpressionVisitors.BoundExpressionVisitor):
     def not_eq(self, ref, lit):
         return self.always_true() if ref.get(self.struct) != lit.value else self.always_false()
 
+    def starts_with(self, ref, lit):
+        return self.always_true() if ref.get(self.struct).startsWith(lit.value) else self.always_false()
+
     def not_(self, result):
         return Expressions.not_(result)
 

--- a/python/iceberg/api/expressions/strict_metrics_evaluator.py
+++ b/python/iceberg/api/expressions/strict_metrics_evaluator.py
@@ -219,3 +219,6 @@ class StrictMetricsEvaluator(object):
 
         def not_in(self, ref, lit):
             return StrictMetricsEvaluator.MetricsEvalVisitor.ROWS_MIGHT_NOT_MATCH
+
+        def starts_with(self, ref, lit):
+            return StrictMetricsEvaluator.MetricsEvalVisitor.ROWS_MIGHT_NOT_MATCH

--- a/python/iceberg/parquet/dataset_utils.py
+++ b/python/iceberg/parquet/dataset_utils.py
@@ -104,6 +104,8 @@ def predicate(pred: Predicate, field_map: dict) -> ds.Expression:  # noqa: ignor
         return ds.field(col_name).isin(pred.lit.value)
     elif pred.op == Operation.NOT_IN:
         return ds.field(col_name).isin(pred.lit.value)
+    elif pred.op == Operation.STARTS_WITH:
+        return ds.field(col_name).startswith(pred.lit.value)
 
 
 def and_(left: ds.Expression, right: ds.Expression) -> ds.Expression:

--- a/python/tests/api/expressions/test_evaluator.py
+++ b/python/tests/api/expressions/test_evaluator.py
@@ -29,6 +29,10 @@ STRUCT = StructType.of([NestedField.required(13, "x", IntegerType.get()),
                        NestedField.required(14, "y", IntegerType.get()),
                        NestedField.optional(15, "z", IntegerType.get())])
 
+STRINGS_STRUCT = StructType.of([NestedField.required(13, "x", StringType.get()),
+                                NestedField.required(14, "y", StringType.get()),
+                                NestedField.optional(15, "z", StringType.get())])
+
 
 def test_less_than(row_of):
     evaluator = exp.evaluator.Evaluator(STRUCT,
@@ -72,6 +76,22 @@ def test_not_equal(row_of):
                                         exp.expressions.Expressions.not_equal("x", 7))
     assert not evaluator.eval(row_of((7, 8, None)))
     assert evaluator.eval(row_of((6, 8, None)))
+
+
+def test_starts_with(row_of):
+    evaluator = exp.evaluator.Evaluator(STRINGS_STRUCT,
+                                        exp.expressions.Expressions.starts_with("x", "cheeseburger"))
+    assert not evaluator.eval(row_of(("frenchfries", "cheese", None)))
+    assert not evaluator.eval(row_of(("you should buy your friends cheeseburgers", "buttons", None)))
+    assert evaluator.eval(row_of(("cheeseburgers are delicious with frenchfries.", "buttons", None)))
+
+
+def test_startswith(row_of):
+    evaluator = exp.evaluator.Evaluator(STRINGS_STRUCT,
+                                        exp.expressions.Expressions.startswith("x", "cheeseburger"))
+    assert not evaluator.eval(row_of(("frenchfries", "cheese", None)))
+    assert not evaluator.eval(row_of(("you should buy your friends cheeseburgers", "buttons", None)))
+    assert evaluator.eval(row_of(("cheeseburgers are delicious with frenchfries.", "buttons", None)))
 
 
 def test_always_true(row_of):

--- a/python/tests/api/expressions/test_inclusive_manifest_evaluator.py
+++ b/python/tests/api/expressions/test_inclusive_manifest_evaluator.py
@@ -21,10 +21,18 @@ import pytest
 
 
 @pytest.mark.parametrize("expression,expected", [
+    (Expressions.starts_with("all_nulls", "a"), False),
+    (Expressions.starts_with("some_nulls", "a"), True),
+    (Expressions.starts_with("no_nulls", "a"), True)])
+def test_starts_with(inc_man_spec, inc_man_file, expression, expected):
+    assert InclusiveManifestEvaluator(inc_man_spec, expression).eval(inc_man_file) == expected
+
+
+@pytest.mark.parametrize("expression,expected", [
     (Expressions.not_null("all_nulls"), False),
     (Expressions.not_null("some_nulls"), True),
     (Expressions.not_null("no_nulls"), True)])
-def test_all_nulls(inc_man_spec, inc_man_file, expression, expected):
+def test_not_nulls(inc_man_spec, inc_man_file, expression, expected):
     assert InclusiveManifestEvaluator(inc_man_spec, expression).eval(inc_man_file) == expected
 
 
@@ -32,7 +40,7 @@ def test_all_nulls(inc_man_spec, inc_man_file, expression, expected):
     (Expressions.is_null("all_nulls"), True),
     (Expressions.is_null("some_nulls"), True),
     (Expressions.is_null("no_nulls"), False)])
-def test_no_nulls(inc_man_spec, inc_man_file, expression, expected):
+def test_is_nulls(inc_man_spec, inc_man_file, expression, expected):
     assert InclusiveManifestEvaluator(inc_man_spec, expression).eval(inc_man_file) == expected
 
 

--- a/python/tests/api/expressions/test_str_to_expr.py
+++ b/python/tests/api/expressions/test_str_to_expr.py
@@ -95,6 +95,12 @@ def test_not_equal():
     assert expected_expr == conv_expr
 
 
+def test_starts_with():
+    expected_expr = Expressions.starts_with("col_a", "cheeseburgers")
+    conv_expr = Expressions.convert_string_to_expr("col_a startsWith cheeseburgers")
+    assert expected_expr == conv_expr
+
+
 def test_not_equal_alt_syntax():
     expected_expr = Expressions.not_equal("col_a", 7)
     conv_expr = Expressions.convert_string_to_expr("col_a != 7")

--- a/python/tests/api/expressions/test_strict_metrics_evaluator.py
+++ b/python/tests/api/expressions/test_strict_metrics_evaluator.py
@@ -21,13 +21,19 @@ from iceberg.exceptions import ValidationException
 from pytest import raises
 
 
-def test_all_nulls(strict_schema, strict_file):
+def test_starts_with(strict_schema, strict_file):
+    assert not StrictMetricsEvaluator(strict_schema, Expressions.starts_with("all_nulls", "a")).eval(strict_file)
+    assert not StrictMetricsEvaluator(strict_schema, Expressions.starts_with("some_nulls", "a")).eval(strict_file)
+    assert not StrictMetricsEvaluator(strict_schema, Expressions.starts_with("no_nulls", "a")).eval(strict_file)
+
+
+def test_not_nulls(strict_schema, strict_file):
     assert not StrictMetricsEvaluator(strict_schema, Expressions.not_null("all_nulls")).eval(strict_file)
     assert not StrictMetricsEvaluator(strict_schema, Expressions.not_null("some_nulls")).eval(strict_file)
     assert StrictMetricsEvaluator(strict_schema, Expressions.not_null("no_nulls")).eval(strict_file)
 
 
-def test_no_nulls(strict_schema, strict_file):
+def test_is_nulls(strict_schema, strict_file):
     assert StrictMetricsEvaluator(strict_schema, Expressions.is_null("all_nulls")).eval(strict_file)
     assert not StrictMetricsEvaluator(strict_schema, Expressions.is_null("some_nulls")).eval(strict_file)
     assert not StrictMetricsEvaluator(strict_schema, Expressions.is_null("no_nulls")).eval(strict_file)


### PR DESCRIPTION
This is a follow up of  (follow up for https://github.com/apache/iceberg/pull/327 filed in https://github.com/apache/iceberg/issues/2019 ).

This is my first time working on the Python code in Iceberg. Implementation wise I based this on NOT_EQ.

For Python API compat this exposes both `starts_with` (which is the snake case version of the Java API startsWith) and `startswith` the name of the logical similar method in the Python string library.

