### PR TITLE
Build: bump up DiffPlug Spotless version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
     classpath 'com.github.jengelman.gradle.plugins:shadow:5.0.0'
     classpath 'com.palantir.baseline:gradle-baseline-java:3.36.2'
     classpath 'com.palantir.gradle.gitversion:gradle-git-version:0.12.3'
-    classpath 'com.diffplug.spotless:spotless-plugin-gradle:3.20.0'
+    classpath 'com.diffplug.spotless:spotless-plugin-gradle:5.14.0'
     classpath 'gradle.plugin.org.inferred:gradle-processors:2.1.0'
     classpath 'me.champeau.gradle:jmh-gradle-plugin:0.4.8'
   }

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
     classpath 'com.github.jengelman.gradle.plugins:shadow:5.0.0'
     classpath 'com.palantir.baseline:gradle-baseline-java:3.36.2'
     classpath 'com.palantir.gradle.gitversion:gradle-git-version:0.12.3'
-    classpath 'com.diffplug.spotless:spotless-plugin-gradle:3.14.0'
+    classpath 'com.diffplug.spotless:spotless-plugin-gradle:3.20.0'
     classpath 'gradle.plugin.org.inferred:gradle-processors:2.1.0'
     classpath 'me.champeau.gradle:jmh-gradle-plugin:0.4.8'
   }


### PR DESCRIPTION
We are using a version of spotless plugin that is vulnerable to attack https://nvd.nist.gov/vuln/detail/CVE-2019-9843, thus bumping up the version to 3.20