### PR TITLE
Add partition files to SparkBatchScan description

### DIFF
--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
@@ -75,8 +75,6 @@ abstract class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
   // lazy variables
   private StructType readSchema = null;
 
-  private InputPartition[] readTasks = null;
-
   SparkBatchScan(SparkSession spark, Table table, boolean caseSensitive, Schema expectedSchema,
                  List<Expression> filters, CaseInsensitiveStringMap options) {
     this.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
@@ -128,17 +126,13 @@ abstract class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
 
   @Override
   public InputPartition[] planInputPartitions() {
-    if (readTasks != null) {
-      return readTasks;
-    }
-
     String expectedSchemaString = SchemaParser.toJson(expectedSchema);
 
     // broadcast the table metadata as input partitions will be sent to executors
     Broadcast<Table> tableBroadcast = sparkContext.broadcast(SerializableTable.copyOf(table));
 
     List<CombinedScanTask> scanTasks = tasks();
-    readTasks = new InputPartition[scanTasks.size()];
+    InputPartition[] readTasks = new InputPartition[scanTasks.size()];
     for (int i = 0; i < scanTasks.size(); i++) {
       readTasks[i] = new ReadTask(
           scanTasks.get(i), tableBroadcast, expectedSchemaString,
@@ -225,11 +219,9 @@ abstract class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
   public String description() {
     String filters = filterExpressions.stream().map(Spark3Util::describe).collect(Collectors.joining(", "));
 
-    planInputPartitions();
     List<String> filePaths = new ArrayList<>();
-    for (InputPartition partition : readTasks) {
-      SparkBatchScan.ReadTask readTask = (SparkBatchScan.ReadTask) partition;
-      for (FileScanTask partitionFile : readTask.files()) {
+    for (CombinedScanTask scanTask : tasks()) {
+      for (FileScanTask partitionFile : scanTask.files()) {
         filePaths.add(partitionFile.file().path().toString());
       }
     }


### PR DESCRIPTION
I've created this draft to discuss about a potential solution to https://github.com/apache/iceberg/issues/2517. 

A few items to discuss:
- Is it too expensive to call `planInputPartitions` before it is actually needed?
- Is the name of each partition file the only relevant piece of information to show in the description?
- The list of partition files is potentially very long. Can it be too expensive to create and keep? Should it be limited to _n_ elements? Should its string representation be shortened?