### PR TITLE
Support all operations in incremental scan

### DIFF
--- a/api/src/main/java/org/apache/iceberg/TableScan.java
+++ b/api/src/main/java/org/apache/iceberg/TableScan.java
@@ -144,20 +144,20 @@ public interface TableScan {
    *
    * @param fromSnapshotId the last snapshot id read by the user, exclusive
    * @param toSnapshotId read append data up to this snapshot id
-   * @return a table scan which can read append data from {@code fromSnapshotId}
+   * @return a table scan which can read data from {@code fromSnapshotId}
    * exclusive and up to {@code toSnapshotId} inclusive
    */
-  TableScan appendsBetween(long fromSnapshotId, long toSnapshotId);
+  TableScan dataBetween(long fromSnapshotId, long toSnapshotId);
 
   /**
    * Create a new {@link TableScan} to read appended data from {@code fromSnapshotId} exclusive to the current snapshot
    * inclusive.
    *
    * @param fromSnapshotId - the last snapshot id read by the user, exclusive
-   * @return a table scan which can read append data from {@code fromSnapshotId}
+   * @return a table scan which can read data from {@code fromSnapshotId}
    * exclusive and up to current snapshot inclusive
    */
-  TableScan appendsAfter(long fromSnapshotId);
+  TableScan dataAfter(long fromSnapshotId);
 
   /**
    * Plan the {@link FileScanTask files} that will be read by this scan.

--- a/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
@@ -45,13 +45,13 @@ abstract class BaseAllMetadataTableScan extends BaseTableScan {
   protected abstract String tableType();
 
   @Override
-  public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
+  public TableScan dataBetween(long fromSnapshotId, long toSnapshotId) {
     throw new UnsupportedOperationException(
         String.format("Cannot incrementally scan table of type %s", tableType()));
   }
 
   @Override
-  public TableScan appendsAfter(long fromSnapshotId) {
+  public TableScan dataAfter(long fromSnapshotId) {
     throw new UnsupportedOperationException(
         String.format("Cannot incrementally scan table of type %s", tableType()));
   }

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -108,12 +108,12 @@ abstract class BaseTableScan implements TableScan {
   }
 
   @Override
-  public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
+  public TableScan dataBetween(long fromSnapshotId, long toSnapshotId) {
     throw new UnsupportedOperationException("Incremental scan is not supported");
   }
 
   @Override
-  public TableScan appendsAfter(long fromSnapshotId) {
+  public TableScan dataAfter(long fromSnapshotId) {
     throw new UnsupportedOperationException("Incremental scan is not supported");
   }
 

--- a/core/src/main/java/org/apache/iceberg/DataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DataFilesTable.java
@@ -77,13 +77,13 @@ public class DataFilesTable extends BaseMetadataTable {
     }
 
     @Override
-    public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
+    public TableScan dataBetween(long fromSnapshotId, long toSnapshotId) {
       throw new UnsupportedOperationException(
           String.format("Cannot incrementally scan table of type %s", MetadataTableType.FILES.name()));
     }
 
     @Override
-    public TableScan appendsAfter(long fromSnapshotId) {
+    public TableScan dataAfter(long fromSnapshotId) {
       throw new UnsupportedOperationException(
           String.format("Cannot incrementally scan table of type %s", MetadataTableType.FILES.name()));
     }

--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -46,7 +46,7 @@ public class DataTableScan extends BaseTableScan {
   }
 
   @Override
-  public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
+  public TableScan dataBetween(long fromSnapshotId, long toSnapshotId) {
     Long scanSnapshotId = snapshotId();
     Preconditions.checkState(scanSnapshotId == null,
         "Cannot enable incremental scan, scan-snapshot set to id=%s", scanSnapshotId);
@@ -55,11 +55,11 @@ public class DataTableScan extends BaseTableScan {
   }
 
   @Override
-  public TableScan appendsAfter(long fromSnapshotId) {
+  public TableScan dataAfter(long fromSnapshotId) {
     Snapshot currentSnapshot = table().currentSnapshot();
     Preconditions.checkState(currentSnapshot != null, "Cannot scan appends after %s, there is no current snapshot",
         fromSnapshotId);
-    return appendsBetween(fromSnapshotId, currentSnapshot.snapshotId());
+    return dataBetween(fromSnapshotId, currentSnapshot.snapshotId());
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
@@ -78,13 +78,13 @@ public class ManifestEntriesTable extends BaseMetadataTable {
     }
 
     @Override
-    public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
+    public TableScan dataBetween(long fromSnapshotId, long toSnapshotId) {
       throw new UnsupportedOperationException(
           String.format("Cannot incrementally scan table of type %s", MetadataTableType.ENTRIES.name()));
     }
 
     @Override
-    public TableScan appendsAfter(long fromSnapshotId) {
+    public TableScan dataAfter(long fromSnapshotId) {
       throw new UnsupportedOperationException(
           String.format("Cannot incrementally scan table of type %s", MetadataTableType.ENTRIES.name()));
     }

--- a/core/src/main/java/org/apache/iceberg/StaticTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/StaticTableScan.java
@@ -42,13 +42,13 @@ class StaticTableScan extends BaseTableScan {
   }
 
   @Override
-  public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
+  public TableScan dataBetween(long fromSnapshotId, long toSnapshotId) {
     throw new UnsupportedOperationException(
         String.format("Cannot incrementally scan table of type %s", tableType));
   }
 
   @Override
-  public TableScan appendsAfter(long fromSnapshotId) {
+  public TableScan dataAfter(long fromSnapshotId) {
     throw new UnsupportedOperationException(
         String.format("Cannot incrementally scan table of type %s", tableType));
   }

--- a/core/src/test/java/org/apache/iceberg/TestIncrementalDataTableScan.java
+++ b/core/src/test/java/org/apache/iceberg/TestIncrementalDataTableScan.java
@@ -67,11 +67,11 @@ public class TestIncrementalDataTableScan extends TableTestBase {
     AssertHelpers.assertThrows(
         "Check refinement api",
         IllegalArgumentException.class, "from snapshot id 1 not in existing snapshot ids range (2, 4]",
-        () -> table.newScan().appendsBetween(2, 5).appendsBetween(1, 4));
+        () -> table.newScan().dataBetween(2, 5).dataBetween(1, 4));
     AssertHelpers.assertThrows(
         "Check refinement api",
         IllegalArgumentException.class, "to snapshot id 3 not in existing snapshot ids range (1, 2]",
-        () -> table.newScan().appendsBetween(1, 2).appendsBetween(1, 3));
+        () -> table.newScan().dataBetween(1, 2).dataBetween(1, 3));
   }
 
   @Test
@@ -208,7 +208,7 @@ public class TestIncrementalDataTableScan extends TableTestBase {
 
     TableScan scan1 = table.newScan()
         .filter(Expressions.equal("id", 5))
-        .appendsBetween(1, 3);
+        .dataBetween(1, 3);
 
     try (CloseableIterable<CombinedScanTask> tasks = scan1.planTasks()) {
       Assert.assertTrue("Tasks should not be empty", com.google.common.collect.Iterables.size(tasks) > 0);
@@ -221,7 +221,7 @@ public class TestIncrementalDataTableScan extends TableTestBase {
 
     TableScan scan2 = table.newScan()
         .filter(Expressions.equal("id", 5))
-        .appendsBetween(1, 3)
+        .dataBetween(1, 3)
         .ignoreResiduals();
 
     try (CloseableIterable<CombinedScanTask> tasks = scan2.planTasks()) {
@@ -277,14 +277,14 @@ public class TestIncrementalDataTableScan extends TableTestBase {
   }
 
   private List<String> appendsAfterScan(long fromSnapshotId) {
-    final TableScan appendsAfter = table.newScan().appendsAfter(fromSnapshotId);
+    final TableScan appendsAfter = table.newScan().dataAfter(fromSnapshotId);
     return filesToScan(appendsAfter);
   }
 
   private List<String> appendsBetweenScan(long fromSnapshotId, long toSnapshotId) {
     Snapshot s1 = table.snapshot(fromSnapshotId);
     Snapshot s2 = table.snapshot(toSnapshotId);
-    TableScan appendsBetween = table.newScan().appendsBetween(s1.snapshotId(), s2.snapshotId());
+    TableScan appendsBetween = table.newScan().dataBetween(s1.snapshotId(), s2.snapshotId());
     return filesToScan(appendsBetween);
   }
 

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestStaticTable.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestStaticTable.java
@@ -69,7 +69,7 @@ public class TestStaticTable extends HadoopTableTestBase {
       AssertHelpers.assertThrows("Static tables do not support incremental scans",
           UnsupportedOperationException.class,
           String.format("Cannot incrementally scan table of type %s", type),
-          () -> staticTable.newScan().appendsAfter(1));
+          () -> staticTable.newScan().dataAfter(1));
     }
   }
 

--- a/data/src/main/java/org/apache/iceberg/data/IcebergGenerics.java
+++ b/data/src/main/java/org/apache/iceberg/data/IcebergGenerics.java
@@ -78,12 +78,12 @@ public class IcebergGenerics {
     }
 
     public ScanBuilder appendsBetween(long fromSnapshotId, long toSnapshotId) {
-      this.tableScan = tableScan.appendsBetween(fromSnapshotId, toSnapshotId);
+      this.tableScan = tableScan.dataBetween(fromSnapshotId, toSnapshotId);
       return this;
     }
 
     public ScanBuilder appendsAfter(long fromSnapshotId) {
-      this.tableScan = tableScan.appendsAfter(fromSnapshotId);
+      this.tableScan = tableScan.dataAfter(fromSnapshotId);
       return this;
     }
 

--- a/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitGenerator.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitGenerator.java
@@ -59,9 +59,9 @@ class FlinkSplitGenerator {
 
     if (context.startSnapshotId() != null) {
       if (context.endSnapshotId() != null) {
-        scan = scan.appendsBetween(context.startSnapshotId(), context.endSnapshotId());
+        scan = scan.dataBetween(context.startSnapshotId(), context.endSnapshotId());
       } else {
-        scan = scan.appendsAfter(context.startSnapshotId());
+        scan = scan.dataAfter(context.startSnapshotId());
       }
     }
 

--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
@@ -397,9 +397,9 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
 
       if (startSnapshotId != null) {
         if (endSnapshotId != null) {
-          scan = scan.appendsBetween(startSnapshotId, endSnapshotId);
+          scan = scan.dataBetween(startSnapshotId, endSnapshotId);
         } else {
-          scan = scan.appendsAfter(startSnapshotId);
+          scan = scan.dataAfter(startSnapshotId);
         }
       }
 

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
@@ -97,9 +97,9 @@ class SparkBatchQueryScan extends SparkBatchScan {
 
       if (startSnapshotId != null) {
         if (endSnapshotId != null) {
-          scan = scan.appendsBetween(startSnapshotId, endSnapshotId);
+          scan = scan.dataBetween(startSnapshotId, endSnapshotId);
         } else {
-          scan = scan.appendsAfter(startSnapshotId);
+          scan = scan.dataAfter(startSnapshotId);
         }
       }
 

--- a/spark3/src/test/java/org/apache/iceberg/spark/TestFileRewriteCoordinator.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/TestFileRewriteCoordinator.java
@@ -188,7 +188,7 @@ public class TestFileRewriteCoordinator extends SparkCatalogTestBase {
 
     String secondFileSetID = UUID.randomUUID().toString();
 
-    try (CloseableIterable<FileScanTask> tasks = table.newScan().appendsAfter(firstFileSetSnapshotId).planFiles()) {
+    try (CloseableIterable<FileScanTask> tasks = table.newScan().dataAfter(firstFileSetSnapshotId).planFiles()) {
       // stage 2 more files for compaction
       taskSetManager.stageTasks(table, secondFileSetID, Lists.newArrayList(tasks));
     }


### PR DESCRIPTION
Currently, incremental scan supports only appends operation(https://github.com/apache/iceberg/issues/2690). This PR is to support other data operations too.

It's WIP, I will be updating the test cases too.

