### PR TITLE
Fix the problem that the metastore-client is not closed

### DIFF
--- a/baseline.gradle
+++ b/baseline.gradle
@@ -79,6 +79,7 @@ subprojects {
           '-Xep:StrictUnusedVariable:OFF',
           '-Xep:TypeParameterShadowing:OFF',
           '-Xep:TypeParameterUnusedInFormals:OFF',
+          '-Xep:ShutdownHook:OFF',
       )
     }
   }

--- a/core/src/main/java/org/apache/iceberg/ClientPoolImpl.java
+++ b/core/src/main/java/org/apache/iceberg/ClientPoolImpl.java
@@ -140,4 +140,8 @@ public abstract class ClientPoolImpl<C, E extends Exception> implements Closeabl
   public int poolSize() {
     return poolSize;
   }
+
+  public int getCurrentSize() {
+    return currentSize;
+  }
 }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/CachedClientPool.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/CachedClientPool.java
@@ -68,7 +68,6 @@ public class CachedClientPool implements ClientPool<HiveMetaStoreClient, TExcept
               .removalListener((key, value, cause) -> ((HiveClientPool) value).close())
               .build();
     }
-    
     Runtime.getRuntime().addShutdownHook(new Thread() {
       @Override
       public void run() {

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/CachedClientPool.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/CachedClientPool.java
@@ -31,9 +31,12 @@ import org.apache.iceberg.ClientPool;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.thrift.TException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CachedClientPool implements ClientPool<HiveMetaStoreClient, TException> {
 
+  private static final Logger LOG = LoggerFactory.getLogger(CachedClientPool.class);
   private static Cache<String, HiveClientPool> clientPoolCache;
 
   private final Configuration conf;
@@ -65,6 +68,17 @@ public class CachedClientPool implements ClientPool<HiveMetaStoreClient, TExcept
               .removalListener((key, value, cause) -> ((HiveClientPool) value).close())
               .build();
     }
+    
+    Runtime.getRuntime().addShutdownHook(new Thread() {
+      @Override
+      public void run() {
+        LOG.trace("Before being closed, the size of connections from current metastore uri {} in clientPoolCache is {}",
+            metastoreUri,  clientPool().getCurrentSize());
+        clientPool().close();
+        LOG.trace("After being closed, the size of connections from current metastore uri {} in clientPoolCache is {}",
+            metastoreUri,  clientPool().getCurrentSize());
+      }
+    });
   }
 
   @VisibleForTesting


### PR DESCRIPTION
The hiveClienPool is not closed in unit test, Here we can add close() function to fix memory leak in all unit test as follow :
https://github.com/apache/iceberg/pull/2785/commits/5d8de6f79270665b6fb068717d80155a22e6ed0f#diff-f6a9c582e0cbe50c837dc3c5bd6b7e6db17527977180242bc3c5dd8df668cf28R70. 

Another solution is that we need to add this close() into shutdownhook since  it can solve all situation especially user's program.
