### PR TITLE
Upgrade to JUnit 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,8 @@ subprojects {
     compile 'org.slf4j:slf4j-api'
     compile 'com.github.stephenc.findbugs:findbugs-annotations'
 
-    testCompile 'junit:junit'
+    testCompile 'org.junit.vintage:junit-vintage-engine'
+    testCompile 'org.junit.jupiter:junit-jupiter'
     testCompile 'org.slf4j:slf4j-simple'
     testCompile 'org.mockito:mockito-core'
     testCompile 'org.assertj:assertj-core'
@@ -285,6 +286,7 @@ project(':iceberg-aws') {
     testCompile("com.adobe.testing:s3mock-junit4") {
       exclude module: "spring-boot-starter-logging"
       exclude module: "logback-classic"
+      exclude group: 'junit'
     }
   }
 
@@ -332,9 +334,12 @@ project(':iceberg-flink') {
     testCompile "org.apache.flink:flink-core"
     testCompile "org.apache.flink:flink-runtime_2.12"
     testCompile "org.apache.flink:flink-table-planner-blink_2.12"
-    testCompile "org.apache.flink:flink-test-utils-junit"
+    testCompile ("org.apache.flink:flink-test-utils-junit") {
+      exclude group: 'junit'
+    }
     testCompile("org.apache.flink:flink-test-utils_2.12") {
       exclude group: "org.apache.curator", module: 'curator-test'
+      exclude group: 'junit'
     }
 
     testCompile project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
@@ -1026,6 +1031,7 @@ project(':iceberg-spark3') {
     spark31Implementation("org.apache.spark:spark-hive_2.12:${project.ext.Spark31Version}") {
       exclude group: 'org.apache.avro', module: 'avro'
       exclude group: 'org.apache.arrow'
+      exclude group: 'junit'
     }
   }
 
@@ -1165,7 +1171,7 @@ project(':iceberg-spark3-runtime') {
     }
 
     integrationImplementation "org.apache.spark:spark-hive_2.12:${project.ext.Spark30Version}"
-    integrationImplementation 'junit:junit'
+    integrationImplementation 'org.junit.vintage:junit-vintage-engine'
     integrationImplementation 'org.slf4j:slf4j-simple'
     integrationImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
     integrationImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')

--- a/versions.props
+++ b/versions.props
@@ -23,7 +23,8 @@ javax.ws.rs:javax.ws.rs-api = 2.1.1
 io.quarkus:* = 1.13.1.Final
 
 # test deps
-junit:junit = 4.12
+org.junit.vintage:junit-vintage-engine = 5.7.2
+org.junit.jupiter:junit-jupiter = 5.7.2
 org.mockito:mockito-core = 3.7.7
 org.apache.hive:hive-exec = 2.3.8
 org.apache.hive:hive-service = 2.3.8


### PR DESCRIPTION
Upgrading to JUnit 5 using `junit-vintage-engine` is fairly straightforward as `junit-vintage-engine` makes sure that JUnit 4 tests work as usual.

`junit-vintage-engine` brings junit **4.13** as can be seen below:
```
+--- org.junit.vintage:junit-vintage-engine -> 5.7.2
|    +--- org.junit.platform:junit-platform-engine:1.7.2
|    |    \--- org.junit.platform:junit-platform-commons:1.7.2
|    \--- junit:junit:4.13

```

I also analyzed the dependencies of all projects and made sure that those projects don't pull in older junit versions.

The reason for upgrading to JUnit5 is that we'd like to make use of the new [Extension model](https://junit.org/junit5/docs/current/user-guide/#extensions) that comes with it.

/cc @snazy @rymurr 