### PR TITLE
Flink: merge the configurations of hive-conf-dir to CatalogLoader

### DIFF
--- a/flink/src/main/java/org/apache/iceberg/flink/CatalogLoader.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/CatalogLoader.java
@@ -51,7 +51,9 @@ public interface CatalogLoader extends Serializable {
   }
 
   static CatalogLoader hive(String name, Configuration hadoopConf, Map<String, String> properties) {
-    return new HiveCatalogLoader(name, hadoopConf, properties);
+    String hiveConfDir = properties.get(FlinkCatalogFactory.HIVE_CONF_DIR);
+    Configuration newHadoopConf = FlinkCatalogFactory.mergeHiveConf(hadoopConf, hiveConfDir);
+    return new HiveCatalogLoader(name, newHadoopConf, properties);
   }
 
   static CatalogLoader custom(String name, Map<String, String> properties, Configuration hadoopConf, String impl) {

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -131,7 +131,7 @@ public class FlinkCatalogFactory implements CatalogFactory {
     return new FlinkCatalog(name, defaultDatabase, baseNamespace, catalogLoader, cacheEnabled);
   }
 
-  private static Configuration mergeHiveConf(Configuration hadoopConf, String hiveConfDir) {
+  static Configuration mergeHiveConf(Configuration hadoopConf, String hiveConfDir) {
     Configuration newConf = new Configuration(hadoopConf);
     if (!Strings.isNullOrEmpty(hiveConfDir)) {
       Preconditions.checkState(Files.exists(Paths.get(hiveConfDir, "hive-site.xml")),


### PR DESCRIPTION
Merge the configurations from hive-conf-dir to the current Hadoop configuration. And users can use HiveCatalog to load iceberg tables.
```
CatalogLoader loader =  CatalogLoader.hive("iceberg_catalog", new Configuration(), properties);
TableLoader tableLoader = TableLoader.fromCatalog(loader, TableIdentifier.of("db", "table"));
```