### PR TITLE
Spark: Add Multi-thread to construct ReadTask

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -188,4 +188,7 @@ public class TableProperties {
 
   public static final String MERGE_CARDINALITY_CHECK_ENABLED = "write.merge.cardinality-check.enabled";
   public static final boolean MERGE_CARDINALITY_CHECK_ENABLED_DEFAULT = true;
+
+  public static final String SPARK_BATCH_SCAN_POOL_SIZE = "read.spark.scan.pool-size";
+  public static final int SPARK_BATCH_SCAN_POOL_SIZE_DEFAULT = 6;
 }

--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
@@ -202,6 +202,7 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
   /**
    * This is called in the Spark Driver when data is to be materialized into {@link ColumnarBatch}
    */
+  @SuppressWarnings({"checkstyle:LocalVariableName", "checkstyle:RegexpSinglelineJava"})
   @Override
   public List<InputPartition<ColumnarBatch>> planBatchInputPartitions() {
     Preconditions.checkState(enableBatchRead(), "Batched reads not enabled");
@@ -241,7 +242,7 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
   /**
    * This is called in the Spark Driver when data is to be materialized into {@link InternalRow}
    */
-  @SuppressWarnings("checkstyle:LocalVariableName")
+  @SuppressWarnings({"checkstyle:LocalVariableName", "checkstyle:RegexpSinglelineJava"})
   @Override
   public List<InputPartition<InternalRow>> planInputPartitions() {
     String expectedSchemaString = SchemaParser.toJson(lazySchema());

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
@@ -131,7 +131,7 @@ abstract class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
     return readSchema;
   }
 
-  @SuppressWarnings({"checkstyle:LocalVariableName", "checkstyle:RegexpSinglelineJava"})
+  @SuppressWarnings("checkstyle:LocalVariableName")
   @Override
   public InputPartition[] planInputPartitions() {
     String expectedSchemaString = SchemaParser.toJson(expectedSchema);
@@ -142,7 +142,7 @@ abstract class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
     List<CombinedScanTask> scanTasks = tasks();
     int taskSize = scanTasks.size();
     InputPartition[] readTasks = new InputPartition[taskSize];
-    long start_time = System.currentTimeMillis();
+    long startTime = System.currentTimeMillis();
 
     try {
       pool.submit(() -> IntStream.range(0, taskSize).parallel()
@@ -154,13 +154,14 @@ abstract class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
                 return true;
               }).collect(Collectors.toList())).get();
     } catch (Exception e) {
-      e.printStackTrace();
+      LOG.error("Fail to construct ReadTask with thread size = {}, and the size of scanTasks is {}",
+          poolSize, taskSize, e);
       System.exit(-1);
     }
 
-    long end_time = System.currentTimeMillis();
-    LOG.info("It took {} s to construct {} readTasks with localityPreferred = {}.", (end_time - start_time) / 1000,
-            taskSize, localityPreferred);
+    long endTime = System.currentTimeMillis();
+    LOG.info("It took {} s to construct {} readTasks with localityPreferred = {}.", (startTime - endTime) / 1000,
+        taskSize, localityPreferred);
     return readTasks;
   }
 

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
@@ -131,7 +131,7 @@ abstract class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
     return readSchema;
   }
 
-  @SuppressWarnings("checkstyle:LocalVariableName")
+  @SuppressWarnings({"checkstyle:LocalVariableName", "checkstyle:RegexpSinglelineJava"})
   @Override
   public InputPartition[] planInputPartitions() {
     String expectedSchemaString = SchemaParser.toJson(expectedSchema);

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
@@ -154,7 +154,8 @@ abstract class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
                 return true;
               }).collect(Collectors.toList())).get();
     } catch (Exception e) {
-      // Do nothing.
+      e.printStackTrace();
+      System.exit(-1);
     }
 
     long end_time = System.currentTimeMillis();


### PR DESCRIPTION
For Spark2/Spark3, It always takes about 30 minutes to enter the Job Submitted state for over 100000 files,  the more files, the longer waiting time for driver to scan. This piece of current  code takes into account the locality strategy of the data, and will call getBlockLocations sequentially in a single thread.
Here is the thread log :
 
![image](https://user-images.githubusercontent.com/20614350/125168157-8ffe7100-e1d6-11eb-8c1b-60eeebac4443.png)


We can use multithreading to solve this problem.

**Manual Test**

Before this：
```
It took about 30min

```
After this：

`21/07/09 18:41:12 INFO Reader: It took 164 s to construct 184082 readTasks with localityPreferred = true.
`


