### PR TITLE
API: Use delete instead of remove in actions for clarity

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
@@ -41,10 +41,10 @@ public interface ActionsProvider {
   }
 
   /**
-   * Instantiates an action to remove orphan files.
+   * Instantiates an action to delete orphan files.
    */
-  default RemoveOrphanFiles removeOrphanFiles(Table table) {
-    throw new UnsupportedOperationException(this.getClass().getName() + " does not implement removeOrphanFiles");
+  default DeleteOrphanFiles deleteOrphanFiles(Table table) {
+    throw new UnsupportedOperationException(this.getClass().getName() + " does not implement deleteOrphanFiles");
   }
 
   /**
@@ -69,9 +69,9 @@ public interface ActionsProvider {
   }
 
   /**
-   * Instantiates an action to remove all the files reachable from given metadata location.
+   * Instantiates an action to delete all the files reachable from given metadata location.
    */
-  default RemoveReachableFiles removeReachableFiles(String metadataLocation) {
-    throw new UnsupportedOperationException(this.getClass().getName() + " does not implement removeReachableFiles");
+  default DeleteReachableFiles deleteReachableFiles(String metadataLocation) {
+    throw new UnsupportedOperationException(this.getClass().getName() + " does not implement deleteReachableFiles");
   }
 }

--- a/api/src/main/java/org/apache/iceberg/actions/DeleteOrphanFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/DeleteOrphanFiles.java
@@ -22,13 +22,13 @@ package org.apache.iceberg.actions;
 import java.util.function.Consumer;
 
 /**
- * An action that removes orphan files in a table.
+ * An action that deletes orphan files in a table.
  * <p>
  * A metadata or data file is considered orphan if it is not reachable by any valid snapshot.
  * The set of actual files is built by listing the underlying storage which makes this operation
  * expensive.
  */
-public interface RemoveOrphanFiles extends Action<RemoveOrphanFiles, RemoveOrphanFiles.Result> {
+public interface DeleteOrphanFiles extends Action<DeleteOrphanFiles, DeleteOrphanFiles.Result> {
   /**
    * Passes a location which should be scanned for orphan files.
    * <p>
@@ -38,7 +38,7 @@ public interface RemoveOrphanFiles extends Action<RemoveOrphanFiles, RemoveOrpha
    * @param location the location where to look for orphan files
    * @return this for method chaining
    */
-  RemoveOrphanFiles location(String location);
+  DeleteOrphanFiles location(String location);
 
   /**
    * Removes orphan files only if they are older than the given timestamp.
@@ -52,7 +52,7 @@ public interface RemoveOrphanFiles extends Action<RemoveOrphanFiles, RemoveOrpha
    * @param olderThanTimestamp a long timestamp, as returned by {@link System#currentTimeMillis()}
    * @return this for method chaining
    */
-  RemoveOrphanFiles olderThan(long olderThanTimestamp);
+  DeleteOrphanFiles olderThan(long olderThanTimestamp);
 
   /**
    * Passes an alternative delete implementation that will be used for orphan files.
@@ -65,7 +65,7 @@ public interface RemoveOrphanFiles extends Action<RemoveOrphanFiles, RemoveOrpha
    * @param deleteFunc a function that will be called to delete files
    * @return this for method chaining
    */
-  RemoveOrphanFiles deleteWith(Consumer<String> deleteFunc);
+  DeleteOrphanFiles deleteWith(Consumer<String> deleteFunc);
 
   /**
    * The action result that contains a summary of the execution.

--- a/api/src/main/java/org/apache/iceberg/actions/DeleteReachableFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/DeleteReachableFiles.java
@@ -24,7 +24,7 @@ import java.util.function.Consumer;
 import org.apache.iceberg.io.FileIO;
 
 /**
- * An action that removes all files referenced by a table metadata file.
+ * An action that deletes all files referenced by a table metadata file.
  * <p>
  * This action will irreversibly delete all reachable files such as data files, manifests,
  * manifest lists and should be used to clean up the underlying storage once a table is dropped
@@ -32,16 +32,16 @@ import org.apache.iceberg.io.FileIO;
  * <p>
  * Implementations may use a query engine to distribute parts of work.
  */
-public interface RemoveReachableFiles extends Action<RemoveReachableFiles, RemoveReachableFiles.Result> {
+public interface DeleteReachableFiles extends Action<DeleteReachableFiles, DeleteReachableFiles.Result> {
 
   /**
    * Passes an alternative delete implementation that will be used for files.
    *
-   * @param removeFunc a function that will be called to delete files.
+   * @param deleteFunc a function that will be called to delete files.
    *                   The function accepts path to file as an argument.
    * @return this for method chaining
    */
-  RemoveReachableFiles deleteWith(Consumer<String> removeFunc);
+  DeleteReachableFiles deleteWith(Consumer<String> deleteFunc);
 
   /**
    * Passes an alternative executor service that will be used for files removal.
@@ -51,7 +51,7 @@ public interface RemoveReachableFiles extends Action<RemoveReachableFiles, Remov
    *  @param executorService the service to use
    * @return this for method chaining
    */
-  RemoveReachableFiles executeDeleteWith(ExecutorService executorService);
+  DeleteReachableFiles executeDeleteWith(ExecutorService executorService);
 
   /**
    * Set the {@link FileIO} to be used for files removal
@@ -59,7 +59,7 @@ public interface RemoveReachableFiles extends Action<RemoveReachableFiles, Remov
    * @param io FileIO to use for files removal
    * @return this for method chaining
    */
-  RemoveReachableFiles io(FileIO io);
+  DeleteReachableFiles io(FileIO io);
 
   /**
    * The action result that contains a summary of the execution.
@@ -67,23 +67,23 @@ public interface RemoveReachableFiles extends Action<RemoveReachableFiles, Remov
   interface Result {
 
     /**
-     * Returns the number of data files removed.
+     * Returns the number of deleted data files.
      */
-    long removedDataFilesCount();
+    long deletedDataFilesCount();
 
     /**
-     * Returns the number of manifests removed.
+     * Returns the number of deleted manifests.
      */
-    long removedManifestsCount();
+    long deletedManifestsCount();
 
     /**
-     * Returns the number of manifest lists removed.
+     * Returns the number of deleted manifest lists.
      */
-    long removedManifestListsCount();
+    long deletedManifestListsCount();
 
     /**
-     * Returns the number of metadata json, version hint files removed.
+     * Returns the number of deleted metadata json, version hint files.
      */
-    long otherRemovedFilesCount();
+    long deletedOtherFilesCount();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/actions/BaseDeleteOrphanFilesActionResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseDeleteOrphanFilesActionResult.java
@@ -19,11 +19,11 @@
 
 package org.apache.iceberg.actions;
 
-public class BaseRemoveOrphanFilesActionResult implements RemoveOrphanFiles.Result {
+public class BaseDeleteOrphanFilesActionResult implements DeleteOrphanFiles.Result {
 
   private final Iterable<String> orphanFileLocations;
 
-  public BaseRemoveOrphanFilesActionResult(Iterable<String> orphanFileLocations) {
+  public BaseDeleteOrphanFilesActionResult(Iterable<String> orphanFileLocations) {
     this.orphanFileLocations = orphanFileLocations;
   }
 

--- a/core/src/main/java/org/apache/iceberg/actions/BaseDeleteReachableFilesActionResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseDeleteReachableFilesActionResult.java
@@ -19,17 +19,17 @@
 
 package org.apache.iceberg.actions;
 
-public class BaseRemoveFilesActionResult implements RemoveReachableFiles.Result {
+public class BaseDeleteReachableFilesActionResult implements DeleteReachableFiles.Result {
 
   private final long deletedDataFilesCount;
   private final long deletedManifestsCount;
   private final long deletedManifestListsCount;
   private final long deletedOtherFilesCount;
 
-  public BaseRemoveFilesActionResult(long deletedDataFilesCount,
-                                     long deletedManifestsCount,
-                                     long deletedManifestListsCount,
-                                     long otherDeletedFilesCount) {
+  public BaseDeleteReachableFilesActionResult(long deletedDataFilesCount,
+                                              long deletedManifestsCount,
+                                              long deletedManifestListsCount,
+                                              long otherDeletedFilesCount) {
     this.deletedDataFilesCount = deletedDataFilesCount;
     this.deletedManifestsCount = deletedManifestsCount;
     this.deletedManifestListsCount = deletedManifestListsCount;
@@ -37,22 +37,22 @@ public class BaseRemoveFilesActionResult implements RemoveReachableFiles.Result 
   }
 
   @Override
-  public long removedDataFilesCount() {
+  public long deletedDataFilesCount() {
     return deletedDataFilesCount;
   }
 
   @Override
-  public long removedManifestsCount() {
+  public long deletedManifestsCount() {
     return deletedManifestsCount;
   }
 
   @Override
-  public long removedManifestListsCount() {
+  public long deletedManifestListsCount() {
     return deletedManifestListsCount;
   }
 
   @Override
-  public long otherRemovedFilesCount() {
+  public long deletedOtherFilesCount() {
     return deletedOtherFilesCount;
   }
 }

--- a/spark/src/main/java/org/apache/iceberg/actions/Actions.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/Actions.java
@@ -22,8 +22,8 @@ package org.apache.iceberg.actions;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.common.DynMethods;
+import org.apache.iceberg.spark.actions.BaseDeleteOrphanFilesSparkAction;
 import org.apache.iceberg.spark.actions.BaseExpireSnapshotsSparkAction;
-import org.apache.iceberg.spark.actions.BaseRemoveOrphanFilesSparkAction;
 import org.apache.iceberg.spark.actions.BaseRewriteManifestsSparkAction;
 import org.apache.spark.sql.SparkSession;
 
@@ -70,7 +70,7 @@ public class Actions {
   }
 
   public RemoveOrphanFilesAction removeOrphanFiles() {
-    BaseRemoveOrphanFilesSparkAction delegate = new BaseRemoveOrphanFilesSparkAction(spark, table);
+    BaseDeleteOrphanFilesSparkAction delegate = new BaseDeleteOrphanFilesSparkAction(spark, table);
     return new RemoveOrphanFilesAction(delegate);
   }
 

--- a/spark/src/main/java/org/apache/iceberg/actions/RemoveOrphanFilesAction.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/RemoveOrphanFilesAction.java
@@ -39,13 +39,13 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
  * <em>Note:</em> It is dangerous to call this action with a short retention interval as it might corrupt
  * the state of the table if another operation is writing at the same time.
  *
- * @deprecated since 0.12.0, will be removed in 0.13.0; use {@link RemoveOrphanFiles} instead.
+ * @deprecated since 0.12.0, will be removed in 0.13.0; use {@link DeleteOrphanFiles} instead.
  */
 @Deprecated
 public class RemoveOrphanFilesAction implements Action<RemoveOrphanFilesAction, List<String>> {
-  private final RemoveOrphanFiles delegate;
+  private final DeleteOrphanFiles delegate;
 
-  RemoveOrphanFilesAction(RemoveOrphanFiles delegate) {
+  RemoveOrphanFilesAction(DeleteOrphanFiles delegate) {
     this.delegate = delegate;
   }
 
@@ -84,7 +84,7 @@ public class RemoveOrphanFilesAction implements Action<RemoveOrphanFilesAction, 
 
   @Override
   public List<String> execute() {
-    RemoveOrphanFiles.Result result = delegate.execute();
+    DeleteOrphanFiles.Result result = delegate.execute();
     return ImmutableList.copyOf(result.orphanFileLocations());
   }
 }

--- a/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkActions.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkActions.java
@@ -21,9 +21,9 @@ package org.apache.iceberg.spark.actions;
 
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.ActionsProvider;
+import org.apache.iceberg.actions.DeleteOrphanFiles;
+import org.apache.iceberg.actions.DeleteReachableFiles;
 import org.apache.iceberg.actions.ExpireSnapshots;
-import org.apache.iceberg.actions.RemoveOrphanFiles;
-import org.apache.iceberg.actions.RemoveReachableFiles;
 import org.apache.iceberg.actions.RewriteManifests;
 import org.apache.spark.sql.SparkSession;
 
@@ -40,8 +40,8 @@ abstract class BaseSparkActions implements ActionsProvider {
   }
 
   @Override
-  public RemoveOrphanFiles removeOrphanFiles(Table table) {
-    return new BaseRemoveOrphanFilesSparkAction(spark, table);
+  public DeleteOrphanFiles deleteOrphanFiles(Table table) {
+    return new BaseDeleteOrphanFilesSparkAction(spark, table);
   }
 
   @Override
@@ -55,7 +55,7 @@ abstract class BaseSparkActions implements ActionsProvider {
   }
 
   @Override
-  public RemoveReachableFiles removeReachableFiles(String metadataLocation) {
-    return new BaseRemoveReachableFilesSparkAction(spark, metadataLocation);
+  public DeleteReachableFiles deleteReachableFiles(String metadataLocation) {
+    return new BaseDeleteReachableFilesSparkAction(spark, metadataLocation);
   }
 }

--- a/spark/src/test/java/org/apache/iceberg/spark/actions/TestNewRewriteDataFilesAction.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/actions/TestNewRewriteDataFilesAction.java
@@ -644,7 +644,7 @@ public abstract class TestNewRewriteDataFilesAction extends SparkTestBase {
 
   protected void shouldHaveNoOrphans(Table table) {
     Assert.assertEquals("Should not have found any orphan files", ImmutableList.of(),
-        actions().removeOrphanFiles(table)
+        actions().deleteOrphanFiles(table)
             .olderThan(System.currentTimeMillis())
             .execute()
             .orphanFileLocations());

--- a/spark2/src/test/java/org/apache/iceberg/actions/TestDeleteReachableFilesAction24.java
+++ b/spark2/src/test/java/org/apache/iceberg/actions/TestDeleteReachableFilesAction24.java
@@ -21,7 +21,7 @@ package org.apache.iceberg.actions;
 
 import org.apache.iceberg.spark.actions.SparkActions;
 
-public class TestRemoveReachableFilesAction24 extends TestRemoveReachableFilesAction {
+public class TestDeleteReachableFilesAction24 extends TestDeleteReachableFilesAction {
 
   @Override
   ActionsProvider sparkActions() {

--- a/spark3/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -21,7 +21,7 @@ package org.apache.iceberg.spark.procedures;
 
 import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.actions.Actions;
-import org.apache.iceberg.actions.RemoveOrphanFiles;
+import org.apache.iceberg.actions.DeleteOrphanFiles;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.iceberg.util.DateTimeUtil;
@@ -84,7 +84,7 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
     boolean dryRun = args.isNullAt(3) ? false : args.getBoolean(3);
 
     return withIcebergTable(tableIdent, table -> {
-      RemoveOrphanFiles action = actions().removeOrphanFiles(table);
+      DeleteOrphanFiles action = actions().deleteOrphanFiles(table);
 
       if (olderThanMillis != null) {
         boolean isTesting = Boolean.parseBoolean(spark().conf().get("spark.testing", "false"));
@@ -102,13 +102,13 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
         action.deleteWith(file -> { });
       }
 
-      RemoveOrphanFiles.Result result = action.execute();
+      DeleteOrphanFiles.Result result = action.execute();
 
       return toOutputRows(result);
     });
   }
 
-  private InternalRow[] toOutputRows(RemoveOrphanFiles.Result result) {
+  private InternalRow[] toOutputRows(DeleteOrphanFiles.Result result) {
     Iterable<String> orphanFileLocations = result.orphanFileLocations();
 
     int orphanFileLocationsCount = Iterables.size(orphanFileLocations);

--- a/spark3/src/test/java/org/apache/iceberg/actions/TestRemoveFilesAction3.java
+++ b/spark3/src/test/java/org/apache/iceberg/actions/TestRemoveFilesAction3.java
@@ -21,7 +21,7 @@ package org.apache.iceberg.actions;
 
 import org.apache.iceberg.spark.actions.SparkActions;
 
-public class TestRemoveFilesAction3 extends TestRemoveReachableFilesAction {
+public class TestRemoveFilesAction3 extends TestDeleteReachableFilesAction {
   @Override
   ActionsProvider sparkActions() {
     return SparkActions.get();


### PR DESCRIPTION
 This PR switches our new actions to use `delete` instead of `remove` as I think `delete` makes more sense given the naming of methods in these actions.

This is NOT a breaking change as we modify only the unreleased Actions API.