### PR TITLE
Spark: Add missing deprecation annotations for old actions

### DIFF
--- a/spark/src/main/java/org/apache/iceberg/actions/Actions.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/Actions.java
@@ -27,6 +27,12 @@ import org.apache.iceberg.spark.actions.BaseExpireSnapshotsSparkAction;
 import org.apache.iceberg.spark.actions.BaseRewriteManifestsSparkAction;
 import org.apache.spark.sql.SparkSession;
 
+/**
+ * An API for interacting with actions in Spark.
+ *
+ * @deprecated since 0.12.0, will be removed in 0.13.0; use an implementation of {@link ActionsProvider} instead.
+ */
+@Deprecated
 public class Actions {
 
   /*
@@ -61,28 +67,52 @@ public class Actions {
     this.table = table;
   }
 
+  /**
+   * @deprecated since 0.12.0, will be removed in 0.13.0; use an implementation of {@link ActionsProvider} instead.
+   */
+  @Deprecated
   public static Actions forTable(SparkSession spark, Table table) {
     return actionConstructor().newInstance(spark, table);
   }
 
+  /**
+   * @deprecated since 0.12.0, will be removed in 0.13.0; use an implementation of {@link ActionsProvider} instead.
+   */
+  @Deprecated
   public static Actions forTable(Table table) {
     return forTable(SparkSession.active(), table);
   }
 
+  /**
+   * @deprecated since 0.12.0, will be removed in 0.13.0; use {@link DeleteOrphanFiles} instead.
+   */
+  @Deprecated
   public RemoveOrphanFilesAction removeOrphanFiles() {
     BaseDeleteOrphanFilesSparkAction delegate = new BaseDeleteOrphanFilesSparkAction(spark, table);
     return new RemoveOrphanFilesAction(delegate);
   }
 
+  /**
+   * @deprecated since 0.12.0, will be removed in 0.13.0; use {@link RewriteManifests} instead.
+   */
+  @Deprecated
   public RewriteManifestsAction rewriteManifests() {
     BaseRewriteManifestsSparkAction delegate = new BaseRewriteManifestsSparkAction(spark, table);
     return new RewriteManifestsAction(delegate);
   }
 
+  /**
+   * @deprecated since 0.12.0, will be removed in 0.13.0; use {@link RewriteDataFiles} instead.
+   */
+  @Deprecated
   public RewriteDataFilesAction rewriteDataFiles() {
     return new RewriteDataFilesAction(spark, table);
   }
 
+  /**
+   * @deprecated since 0.12.0, will be removed in 0.13.0; use {@link ExpireSnapshots} instead.
+   */
+  @Deprecated
   public ExpireSnapshotsAction expireSnapshots() {
     BaseExpireSnapshotsSparkAction delegate = new BaseExpireSnapshotsSparkAction(spark, table);
     return new ExpireSnapshotsAction(delegate);
@@ -94,7 +124,9 @@ public class Actions {
    *
    * @param tableName Table to be converted
    * @return {@link CreateAction} to perform migration
+   * @deprecated since 0.12.0, will be removed in 0.13.0; use {@link MigrateTable} instead.
    */
+  @Deprecated
   public static CreateAction migrate(String tableName) {
     try {
       return DynMethods.builder("migrate")
@@ -112,7 +144,9 @@ public class Actions {
    * @param tableName Table to be converted
    * @param spark     Spark session to use for looking up table
    * @return {@link CreateAction} to perform migration
+   * @deprecated since 0.12.0, will be removed in 0.13.0; use {@link MigrateTable} instead.
    */
+  @Deprecated
   public static CreateAction migrate(SparkSession spark, String tableName) {
     try {
       return DynMethods.builder("migrate")
@@ -131,7 +165,9 @@ public class Actions {
    * @param sourceTable Original table which is the basis for the new Iceberg table
    * @param destTable   New Iceberg table being created
    * @return {@link SnapshotAction} to perform snapshot
+   * @deprecated since 0.12.0, will be removed in 0.13.0; use {@link SnapshotTable} instead.
    */
+  @Deprecated
   public static SnapshotAction snapshot(SparkSession spark, String sourceTable, String destTable) {
     try {
       return DynMethods.builder("snapshot")
@@ -150,7 +186,9 @@ public class Actions {
    * @param sourceTable Original table which is the basis for the new Iceberg table
    * @param destTable   New Iceberg table being created
    * @return {@link SnapshotAction} to perform snapshot
+   * @deprecated since 0.12.0, will be removed in 0.13.0; use {@link SnapshotTable} instead.
    */
+  @Deprecated
   public static SnapshotAction snapshot(String sourceTable, String destTable) {
     try {
       return DynMethods.builder("snapshot")

--- a/spark/src/main/java/org/apache/iceberg/actions/CreateAction.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/CreateAction.java
@@ -21,6 +21,9 @@ package org.apache.iceberg.actions;
 
 import java.util.Map;
 
+/**
+ * @deprecated since 0.12.0, will be removed in 0.13.0; use {@link SnapshotTable} or {@link MigrateTable} instead.
+ */
 @Deprecated
 public interface CreateAction extends Action<CreateAction, Long> {
 

--- a/spark/src/main/java/org/apache/iceberg/actions/RewriteDataFilesAction.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/RewriteDataFilesAction.java
@@ -32,6 +32,10 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.sql.SparkSession;
 
+/**
+ * @deprecated since 0.12.0, will be removed in 0.13.0; use {@link RewriteDataFilesAction} instead.
+ */
+@Deprecated
 public class RewriteDataFilesAction
     extends BaseRewriteDataFilesAction<RewriteDataFilesAction> {
 

--- a/spark/src/main/java/org/apache/iceberg/actions/SnapshotAction.java
+++ b/spark/src/main/java/org/apache/iceberg/actions/SnapshotAction.java
@@ -19,6 +19,9 @@
 
 package org.apache.iceberg.actions;
 
+/**
+ * @deprecated since 0.12.0, will be removed in 0.13.0; use {@link SnapshotTable} instead.
+ */
 @Deprecated
 public interface SnapshotAction extends CreateAction {
   SnapshotAction withLocation(String location);

--- a/spark2/src/main/java/org/apache/iceberg/actions/SparkActions.java
+++ b/spark2/src/main/java/org/apache/iceberg/actions/SparkActions.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.actions;
 import org.apache.iceberg.Table;
 import org.apache.spark.sql.SparkSession;
 
+@Deprecated
 class SparkActions extends Actions {
   protected SparkActions(SparkSession spark, Table table) {
     super(spark, table);

--- a/spark3/src/main/java/org/apache/iceberg/actions/SparkActions.java
+++ b/spark3/src/main/java/org/apache/iceberg/actions/SparkActions.java
@@ -26,15 +26,18 @@ import org.apache.iceberg.spark.Spark3Util.CatalogAndIdentifier;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.catalog.CatalogPlugin;
 
+@Deprecated
 public class SparkActions extends Actions {
   protected SparkActions(SparkSession spark, Table table) {
     super(spark, table);
   }
 
+  @Deprecated
   public static CreateAction migrate(String tableName) {
     return migrate(SparkSession.active(), tableName);
   }
 
+  @Deprecated
   public static CreateAction migrate(SparkSession spark, String tableName) {
     CatalogPlugin defaultCatalog = spark.sessionState().catalogManager().currentCatalog();
     CatalogAndIdentifier catalogAndIdentifier;
@@ -42,10 +45,12 @@ public class SparkActions extends Actions {
     return new Spark3MigrateAction(spark, catalogAndIdentifier.catalog(), catalogAndIdentifier.identifier());
   }
 
+  @Deprecated
   public static SnapshotAction snapshot(String sourceId, String destId) {
     return snapshot(SparkSession.active(), sourceId, destId);
   }
 
+  @Deprecated
   public static SnapshotAction snapshot(SparkSession spark, String sourceId, String destId) {
     CatalogPlugin defaultCatalog = spark.sessionState().catalogManager().currentCatalog();
     CatalogAndIdentifier sourceIdent = Spark3Util.catalogAndIdentifier("snapshot source", spark, sourceId,


### PR DESCRIPTION
This PR adds missing deprecation annotations for old Spark actions.