### PR TITLE
Add security page to site docs

### DIFF
--- a/site/docs/security.md
+++ b/site/docs/security.md
@@ -1,0 +1,26 @@
+<!--
+ - Licensed to the Apache Software Foundation (ASF) under one or more
+ - contributor license agreements.  See the NOTICE file distributed with
+ - this work for additional information regarding copyright ownership.
+ - The ASF licenses this file to You under the Apache License, Version 2.0
+ - (the "License"); you may not use this file except in compliance with
+ - the License.  You may obtain a copy of the License at
+ -
+ -   http://www.apache.org/licenses/LICENSE-2.0
+ -
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -->
+
+# Reporting Security Issues
+
+The Apache Iceberg Project uses the standard process outlined by the [Apache
+Security Team](https://www.apache.org/security/) for reporting vulnerabilities.
+Note that vulnerabilities should not be publicly disclosed until the project has
+responded.
+
+To report a possible security vulnerability, please email <a
+href="mailto:security@iceberg.apache.org">security@iceberg.apache.org</a>.

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
     - Blogs: blogs.md
     - Trademarks: trademarks.md
     - How to Release: how-to-release.md
+    - Security: security.md
   - Tables:
     - Configuration: configuration.md
     - Schemas: schemas.md


### PR DESCRIPTION
This patch adds a page to the site docs which describes the process for
reporting security vulnerabilites found in Apache Iceberg.
