### PR TITLE
Core: Add WriterFactory and delete table properties

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -58,24 +58,31 @@ public class TableProperties {
   public static final boolean MANIFEST_MERGE_ENABLED_DEFAULT = true;
 
   public static final String DEFAULT_FILE_FORMAT = "write.format.default";
+  public static final String DELETE_DEFAULT_FILE_FORMAT = "write.delete.format.default";
   public static final String DEFAULT_FILE_FORMAT_DEFAULT = "parquet";
 
   public static final String PARQUET_ROW_GROUP_SIZE_BYTES = "write.parquet.row-group-size-bytes";
+  public static final String DELETE_PARQUET_ROW_GROUP_SIZE_BYTES = "write.delete.parquet.row-group-size-bytes";
   public static final String PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT = "134217728"; // 128 MB
 
   public static final String PARQUET_PAGE_SIZE_BYTES = "write.parquet.page-size-bytes";
+  public static final String DELETE_PARQUET_PAGE_SIZE_BYTES = "write.delete.parquet.page-size-bytes";
   public static final String PARQUET_PAGE_SIZE_BYTES_DEFAULT = "1048576"; // 1 MB
 
   public static final String PARQUET_DICT_SIZE_BYTES = "write.parquet.dict-size-bytes";
+  public static final String DELETE_PARQUET_DICT_SIZE_BYTES = "write.delete.parquet.dict-size-bytes";
   public static final String PARQUET_DICT_SIZE_BYTES_DEFAULT = "2097152"; // 2 MB
 
   public static final String PARQUET_COMPRESSION = "write.parquet.compression-codec";
+  public static final String DELETE_PARQUET_COMPRESSION = "write.delete.parquet.compression-codec";
   public static final String PARQUET_COMPRESSION_DEFAULT = "gzip";
 
   public static final String PARQUET_COMPRESSION_LEVEL = "write.parquet.compression-level";
+  public static final String DELETE_PARQUET_COMPRESSION_LEVEL = "write.delete.parquet.compression-level";
   public static final String PARQUET_COMPRESSION_LEVEL_DEFAULT = null;
 
   public static final String AVRO_COMPRESSION = "write.avro.compression-codec";
+  public static final String DELETE_AVRO_COMPRESSION = "write.delete.avro.compression-codec";
   public static final String AVRO_COMPRESSION_DEFAULT = "gzip";
 
   public static final String SPLIT_SIZE = "read.split.target-size";
@@ -142,6 +149,7 @@ public class TableProperties {
   public static final String WRITE_AUDIT_PUBLISH_ENABLED_DEFAULT = "false";
 
   public static final String WRITE_TARGET_FILE_SIZE_BYTES = "write.target-file-size-bytes";
+  public static final String DELETE_TARGET_FILE_SIZE_BYTES = "write.delete.target-file-size-bytes";
   public static final long WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT = 536870912; // 512 MB
 
   public static final String SPARK_WRITE_PARTITIONED_FANOUT_ENABLED = "write.spark.fanout.enabled";

--- a/core/src/main/java/org/apache/iceberg/io/WriterFactory.java
+++ b/core/src/main/java/org/apache/iceberg/io/WriterFactory.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io;
+
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.deletes.EqualityDeleteWriter;
+import org.apache.iceberg.deletes.PositionDeleteWriter;
+import org.apache.iceberg.encryption.EncryptedOutputFile;
+
+/**
+ * A factory for creating data and delete writers.
+ */
+public interface WriterFactory<T> {
+
+  /**
+   * Creates a new {@link DataWriter}.
+   *
+   * @param file the output file
+   * @param format the file format to use
+   * @param spec the partition spec the written data belongs to
+   * @param partition the partition the written data belongs to
+   * @return the constructed data writer
+   */
+  DataWriter<T> newDataWriter(EncryptedOutputFile file, FileFormat format,
+                              PartitionSpec spec, StructLike partition);
+
+  /**
+   * Creates a new {@link EqualityDeleteWriter}.
+   *
+   * @param file the output file
+   * @param format the file format to use
+   * @param spec the partition spec the written deletes belong to
+   * @param partition the partition the written deletes belong to
+   * @return the constructed equality delete writer
+   */
+  EqualityDeleteWriter<T> newEqualityDeleteWriter(EncryptedOutputFile file, FileFormat format,
+                                                  PartitionSpec spec, StructLike partition);
+
+  /**
+   * Creates a new {@link PositionDeleteWriter}.
+   *
+   * @param file the output file
+   * @param format the file format to use
+   * @param spec the partition spec the written deletes belong to
+   * @param partition the partition the written deletes belong to
+   * @return the constructed position delete writer
+   */
+  PositionDeleteWriter<T> newPositionDeleteWriter(EncryptedOutputFile file, FileFormat format,
+                                                  PartitionSpec spec, StructLike partition);
+}

--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroDeleteWriters.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroDeleteWriters.java
@@ -80,7 +80,7 @@ public class TestAvroDeleteWriters {
         .createWriterFunc(DataWriter::create)
         .overwrite()
         .rowSchema(SCHEMA)
-        .withSpec(PartitionSpec.unpartitioned())
+        .spec(PartitionSpec.unpartitioned())
         .equalityFieldIds(1)
         .buildEqualityWriter();
 
@@ -124,7 +124,7 @@ public class TestAvroDeleteWriters {
         .createWriterFunc(DataWriter::create)
         .overwrite()
         .rowSchema(SCHEMA)
-        .withSpec(PartitionSpec.unpartitioned())
+        .spec(PartitionSpec.unpartitioned())
         .buildPositionWriter();
 
     try (PositionDeleteWriter<Record> writer = deleteWriter) {
@@ -172,7 +172,7 @@ public class TestAvroDeleteWriters {
     PositionDeleteWriter<Void> deleteWriter = Avro.writeDeletes(out)
         .createWriterFunc(DataWriter::create)
         .overwrite()
-        .withSpec(PartitionSpec.unpartitioned())
+        .spec(PartitionSpec.unpartitioned())
         .buildPositionWriter();
 
     try (PositionDeleteWriter<Void> writer = deleteWriter) {

--- a/data/src/main/java/org/apache/iceberg/data/BaseWriterFactory.java
+++ b/data/src/main/java/org/apache/iceberg/data/BaseWriterFactory.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.data;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Map;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.MetricsConfig;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.avro.Avro;
+import org.apache.iceberg.deletes.EqualityDeleteWriter;
+import org.apache.iceberg.deletes.PositionDeleteWriter;
+import org.apache.iceberg.encryption.EncryptedOutputFile;
+import org.apache.iceberg.encryption.EncryptionKeyMetadata;
+import org.apache.iceberg.io.DataWriter;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.WriterFactory;
+import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+public abstract class BaseWriterFactory<T> implements WriterFactory<T> {
+  private final Map<String, String> properties;
+  private final Schema dataSchema;
+  private final int[] equalityFieldIds;
+  private final Schema equalityDeleteRowSchema;
+  private final Schema positionDeleteRowSchema;
+
+  protected BaseWriterFactory(Map<String, String> properties, Schema dataSchema,
+                              int[] equalityFieldIds, Schema equalityDeleteRowSchema,
+                              Schema positionDeleteRowSchema) {
+    this.properties = properties;
+    this.dataSchema = dataSchema;
+    this.equalityFieldIds = equalityFieldIds;
+    this.equalityDeleteRowSchema = equalityDeleteRowSchema;
+    this.positionDeleteRowSchema = positionDeleteRowSchema;
+  }
+
+  protected abstract void configureDataWrite(Avro.DataWriteBuilder builder);
+  protected abstract void configureEqualityDelete(Avro.DeleteWriteBuilder builder);
+  protected abstract void configurePositionDelete(Avro.DeleteWriteBuilder builder);
+
+  protected abstract void configureDataWrite(Parquet.DataWriteBuilder builder);
+  protected abstract void configureEqualityDelete(Parquet.DeleteWriteBuilder builder);
+  protected abstract void configurePositionDelete(Parquet.DeleteWriteBuilder builder);
+
+  protected Schema equalityDeleteRowSchema() {
+    return equalityDeleteRowSchema;
+  }
+
+  protected Schema positionDeleteRowSchema() {
+    return positionDeleteRowSchema;
+  }
+
+  @Override
+  public DataWriter<T> newDataWriter(EncryptedOutputFile file, FileFormat format,
+                                     PartitionSpec spec, StructLike partition) {
+    Preconditions.checkArgument(spec != null,
+        "Spec must not be null when creating a data writer");
+    Preconditions.checkArgument(spec.isUnpartitioned() || partition != null,
+        "Partition must not be null for partitioned writes");
+
+    OutputFile outputFile = file.encryptingOutputFile();
+    EncryptionKeyMetadata keyMetadata = file.keyMetadata();
+    MetricsConfig metricsConfig = MetricsConfig.fromProperties(properties);
+
+    try {
+      switch (format) {
+        case AVRO:
+          Avro.DataWriteBuilder avroBuilder = Avro.writeData(outputFile)
+              .setAll(properties)
+              .metricsConfig(metricsConfig)
+              .schema(dataSchema)
+              .spec(spec)
+              .partition(partition)
+              .keyMetadata(keyMetadata)
+              .overwrite();
+
+          configureDataWrite(avroBuilder);
+
+          return avroBuilder.buildDataWriter();
+
+        case PARQUET:
+          Parquet.DataWriteBuilder parquetBuilder = Parquet.writeData(outputFile)
+              .setAll(properties)
+              .metricsConfig(metricsConfig)
+              .schema(dataSchema)
+              .spec(spec)
+              .partition(partition)
+              .keyMetadata(keyMetadata)
+              .overwrite();
+
+          configureDataWrite(parquetBuilder);
+
+          return parquetBuilder.buildDataWriter();
+
+        default:
+          throw new UnsupportedOperationException("Cannot write data for unsupported file format: " + format);
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  @Override
+  public EqualityDeleteWriter<T> newEqualityDeleteWriter(EncryptedOutputFile file, FileFormat format,
+                                                         PartitionSpec spec, StructLike partition) {
+    Preconditions.checkArgument(spec != null,
+        "Spec must not be null when creating an equality delete writer");
+    Preconditions.checkArgument(spec.isUnpartitioned() || partition != null,
+        "Partition must not be null for partitioned writes");
+    Preconditions.checkArgument(equalityFieldIds != null && equalityFieldIds.length > 0,
+        "Equality field IDs must not be null or empty when creating an equality delete writer");
+    Preconditions.checkArgument(equalityDeleteRowSchema != null,
+        "Equality delete row schema must not be null when creating an equality delete writer");
+
+    OutputFile outputFile = file.encryptingOutputFile();
+    EncryptionKeyMetadata keyMetadata = file.keyMetadata();
+
+    try {
+      switch (format) {
+        case AVRO:
+          Avro.DeleteWriteBuilder avroBuilder = Avro.writeDeletes(outputFile)
+              .overwrite()
+              .rowSchema(equalityDeleteRowSchema)
+              .spec(spec)
+              .partition(partition)
+              .equalityFieldIds(equalityFieldIds)
+              .keyMetadata(keyMetadata);
+
+          configureEqualityDelete(avroBuilder);
+
+          return avroBuilder.buildEqualityWriter();
+
+        case PARQUET:
+          Parquet.DeleteWriteBuilder parquetBuilder = Parquet.writeDeletes(outputFile)
+              .overwrite()
+              .rowSchema(equalityDeleteRowSchema)
+              .spec(spec)
+              .partition(partition)
+              .equalityFieldIds(equalityFieldIds)
+              .keyMetadata(keyMetadata);
+
+          configureEqualityDelete(parquetBuilder);
+
+          return parquetBuilder.buildEqualityWriter();
+
+        default:
+          throw new UnsupportedOperationException("Cannot write equality deletes for unsupported format: " + format);
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to create new equality delete writer", e);
+    }
+  }
+
+  @Override
+  public PositionDeleteWriter<T> newPositionDeleteWriter(EncryptedOutputFile file, FileFormat format,
+                                                         PartitionSpec spec, StructLike partition) {
+    Preconditions.checkArgument(spec != null,
+        "Spec must not be null when creating a position delete writer");
+    Preconditions.checkArgument(spec.isUnpartitioned() || partition != null,
+        "Partition must not be null for partitioned writes");
+
+    OutputFile outputFile = file.encryptingOutputFile();
+    EncryptionKeyMetadata keyMetadata = file.keyMetadata();
+
+    try {
+      switch (format) {
+        case AVRO:
+          Avro.DeleteWriteBuilder avroBuilder = Avro.writeDeletes(outputFile)
+              .overwrite()
+              .rowSchema(positionDeleteRowSchema)
+              .spec(spec)
+              .partition(partition)
+              .keyMetadata(keyMetadata);
+
+          configurePositionDelete(avroBuilder);
+
+          return avroBuilder.buildPositionWriter();
+
+        case PARQUET:
+          Parquet.DeleteWriteBuilder parquetBuilder = Parquet.writeDeletes(outputFile)
+              .overwrite()
+              .rowSchema(positionDeleteRowSchema)
+              .spec(spec)
+              .partition(partition)
+              .keyMetadata(keyMetadata);
+
+          configurePositionDelete(parquetBuilder);
+
+          return parquetBuilder.buildPositionWriter();
+
+        default:
+          throw new UnsupportedOperationException("Cannot write position deletes for unsupported format: " + format);
+      }
+
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to create new position delete writer", e);
+    }
+  }
+}

--- a/data/src/main/java/org/apache/iceberg/data/GenericAppenderFactory.java
+++ b/data/src/main/java/org/apache/iceberg/data/GenericAppenderFactory.java
@@ -145,25 +145,25 @@ public class GenericAppenderFactory implements FileAppenderFactory<Record> {
         case AVRO:
           return Avro.writeDeletes(file.encryptingOutputFile())
               .createWriterFunc(DataWriter::create)
-              .withPartition(partition)
+              .partition(partition)
               .overwrite()
               .setAll(config)
               .rowSchema(eqDeleteRowSchema)
-              .withSpec(spec)
-              .withKeyMetadata(file.keyMetadata())
+              .spec(spec)
+              .keyMetadata(file.keyMetadata())
               .equalityFieldIds(equalityFieldIds)
               .buildEqualityWriter();
 
         case PARQUET:
           return Parquet.writeDeletes(file.encryptingOutputFile())
               .createWriterFunc(GenericParquetWriter::buildWriter)
-              .withPartition(partition)
+              .partition(partition)
               .overwrite()
               .setAll(config)
               .metricsConfig(metricsConfig)
               .rowSchema(eqDeleteRowSchema)
-              .withSpec(spec)
-              .withKeyMetadata(file.keyMetadata())
+              .spec(spec)
+              .keyMetadata(file.keyMetadata())
               .equalityFieldIds(equalityFieldIds)
               .buildEqualityWriter();
 
@@ -185,24 +185,24 @@ public class GenericAppenderFactory implements FileAppenderFactory<Record> {
         case AVRO:
           return Avro.writeDeletes(file.encryptingOutputFile())
               .createWriterFunc(DataWriter::create)
-              .withPartition(partition)
+              .partition(partition)
               .overwrite()
               .setAll(config)
               .rowSchema(posDeleteRowSchema)
-              .withSpec(spec)
-              .withKeyMetadata(file.keyMetadata())
+              .spec(spec)
+              .keyMetadata(file.keyMetadata())
               .buildPositionWriter();
 
         case PARQUET:
           return Parquet.writeDeletes(file.encryptingOutputFile())
               .createWriterFunc(GenericParquetWriter::buildWriter)
-              .withPartition(partition)
+              .partition(partition)
               .overwrite()
               .setAll(config)
               .metricsConfig(metricsConfig)
               .rowSchema(posDeleteRowSchema)
-              .withSpec(spec)
-              .withKeyMetadata(file.keyMetadata())
+              .spec(spec)
+              .keyMetadata(file.keyMetadata())
               .buildPositionWriter();
 
         default:

--- a/data/src/test/java/org/apache/iceberg/data/FileHelpers.java
+++ b/data/src/test/java/org/apache/iceberg/data/FileHelpers.java
@@ -54,7 +54,7 @@ public class FileHelpers {
       throws IOException {
     PositionDeleteWriter<?> writer = Parquet.writeDeletes(out)
         .forTable(table)
-        .withPartition(partition)
+        .partition(partition)
         .overwrite()
         .buildPositionWriter();
 
@@ -76,7 +76,7 @@ public class FileHelpers {
                                            List<Record> deletes, Schema deleteRowSchema) throws IOException {
     EqualityDeleteWriter<Record> writer = Parquet.writeDeletes(out)
         .forTable(table)
-        .withPartition(partition)
+        .partition(partition)
         .rowSchema(deleteRowSchema)
         .createWriterFunc(GenericParquetWriter::buildWriter)
         .overwrite()

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkAppenderFactory.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkAppenderFactory.java
@@ -153,25 +153,25 @@ public class FlinkAppenderFactory implements FileAppenderFactory<RowData>, Seria
         case AVRO:
           return Avro.writeDeletes(outputFile.encryptingOutputFile())
               .createWriterFunc(ignore -> new FlinkAvroWriter(lazyEqDeleteFlinkSchema()))
-              .withPartition(partition)
+              .partition(partition)
               .overwrite()
               .setAll(props)
               .rowSchema(eqDeleteRowSchema)
-              .withSpec(spec)
-              .withKeyMetadata(outputFile.keyMetadata())
+              .spec(spec)
+              .keyMetadata(outputFile.keyMetadata())
               .equalityFieldIds(equalityFieldIds)
               .buildEqualityWriter();
 
         case PARQUET:
           return Parquet.writeDeletes(outputFile.encryptingOutputFile())
               .createWriterFunc(msgType -> FlinkParquetWriters.buildWriter(lazyEqDeleteFlinkSchema(), msgType))
-              .withPartition(partition)
+              .partition(partition)
               .overwrite()
               .setAll(props)
               .metricsConfig(metricsConfig)
               .rowSchema(eqDeleteRowSchema)
-              .withSpec(spec)
-              .withKeyMetadata(outputFile.keyMetadata())
+              .spec(spec)
+              .keyMetadata(outputFile.keyMetadata())
               .equalityFieldIds(equalityFieldIds)
               .buildEqualityWriter();
 
@@ -193,25 +193,25 @@ public class FlinkAppenderFactory implements FileAppenderFactory<RowData>, Seria
         case AVRO:
           return Avro.writeDeletes(outputFile.encryptingOutputFile())
               .createWriterFunc(ignore -> new FlinkAvroWriter(lazyPosDeleteFlinkSchema()))
-              .withPartition(partition)
+              .partition(partition)
               .overwrite()
               .setAll(props)
               .rowSchema(posDeleteRowSchema)
-              .withSpec(spec)
-              .withKeyMetadata(outputFile.keyMetadata())
+              .spec(spec)
+              .keyMetadata(outputFile.keyMetadata())
               .buildPositionWriter();
 
         case PARQUET:
           RowType flinkPosDeleteSchema = FlinkSchemaUtil.convert(DeleteSchemaUtil.posDeleteSchema(posDeleteRowSchema));
           return Parquet.writeDeletes(outputFile.encryptingOutputFile())
               .createWriterFunc(msgType -> FlinkParquetWriters.buildWriter(flinkPosDeleteSchema, msgType))
-              .withPartition(partition)
+              .partition(partition)
               .overwrite()
               .setAll(props)
               .metricsConfig(metricsConfig)
               .rowSchema(posDeleteRowSchema)
-              .withSpec(spec)
-              .withKeyMetadata(outputFile.keyMetadata())
+              .spec(spec)
+              .keyMetadata(outputFile.keyMetadata())
               .transformPaths(path -> StringData.fromString(path.toString()))
               .buildPositionWriter();
 

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetDeleteWriters.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetDeleteWriters.java
@@ -81,7 +81,7 @@ public class TestParquetDeleteWriters {
         .createWriterFunc(GenericParquetWriter::buildWriter)
         .overwrite()
         .rowSchema(SCHEMA)
-        .withSpec(PartitionSpec.unpartitioned())
+        .spec(PartitionSpec.unpartitioned())
         .equalityFieldIds(1)
         .buildEqualityWriter();
 
@@ -125,7 +125,7 @@ public class TestParquetDeleteWriters {
         .createWriterFunc(GenericParquetWriter::buildWriter)
         .overwrite()
         .rowSchema(SCHEMA)
-        .withSpec(PartitionSpec.unpartitioned())
+        .spec(PartitionSpec.unpartitioned())
         .buildPositionWriter();
 
     try (PositionDeleteWriter<Record> writer = deleteWriter) {
@@ -173,7 +173,7 @@ public class TestParquetDeleteWriters {
     PositionDeleteWriter<Void> deleteWriter = Parquet.writeDeletes(out)
         .createWriterFunc(GenericParquetWriter::buildWriter)
         .overwrite()
-        .withSpec(PartitionSpec.unpartitioned())
+        .spec(PartitionSpec.unpartitioned())
         .buildPositionWriter();
 
     try (PositionDeleteWriter<Void> writer = deleteWriter) {

--- a/spark/src/main/java/org/apache/iceberg/spark/source/SparkAppenderFactory.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/SparkAppenderFactory.java
@@ -207,10 +207,10 @@ class SparkAppenderFactory implements FileAppenderFactory<InternalRow> {
               .createWriterFunc(msgType -> SparkParquetWriters.buildWriter(lazyEqDeleteSparkType(), msgType))
               .overwrite()
               .rowSchema(eqDeleteRowSchema)
-              .withSpec(spec)
-              .withPartition(partition)
+              .spec(spec)
+              .partition(partition)
               .equalityFieldIds(equalityFieldIds)
-              .withKeyMetadata(file.keyMetadata())
+              .keyMetadata(file.keyMetadata())
               .buildEqualityWriter();
 
         case AVRO:
@@ -218,10 +218,10 @@ class SparkAppenderFactory implements FileAppenderFactory<InternalRow> {
               .createWriterFunc(ignored -> new SparkAvroWriter(lazyEqDeleteSparkType()))
               .overwrite()
               .rowSchema(eqDeleteRowSchema)
-              .withSpec(spec)
-              .withPartition(partition)
+              .spec(spec)
+              .partition(partition)
               .equalityFieldIds(equalityFieldIds)
-              .withKeyMetadata(file.keyMetadata())
+              .keyMetadata(file.keyMetadata())
               .buildEqualityWriter();
 
         default:
@@ -245,9 +245,9 @@ class SparkAppenderFactory implements FileAppenderFactory<InternalRow> {
               .createWriterFunc(msgType -> SparkParquetWriters.buildWriter(sparkPosDeleteSchema, msgType))
               .overwrite()
               .rowSchema(posDeleteRowSchema)
-              .withSpec(spec)
-              .withPartition(partition)
-              .withKeyMetadata(file.keyMetadata())
+              .spec(spec)
+              .partition(partition)
+              .keyMetadata(file.keyMetadata())
               .transformPaths(path -> UTF8String.fromString(path.toString()))
               .buildPositionWriter();
 
@@ -256,9 +256,9 @@ class SparkAppenderFactory implements FileAppenderFactory<InternalRow> {
               .createWriterFunc(ignored -> new SparkAvroWriter(lazyPosDeleteSparkType()))
               .overwrite()
               .rowSchema(posDeleteRowSchema)
-              .withSpec(spec)
-              .withPartition(partition)
-              .withKeyMetadata(file.keyMetadata())
+              .spec(spec)
+              .partition(partition)
+              .keyMetadata(file.keyMetadata())
               .buildPositionWriter();
 
         default:

--- a/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriterFactory.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriterFactory.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+import java.util.Map;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.avro.Avro;
+import org.apache.iceberg.data.BaseWriterFactory;
+import org.apache.iceberg.io.DeleteSchemaUtil;
+import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.spark.data.SparkAvroWriter;
+import org.apache.iceberg.spark.data.SparkParquetWriters;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.StructType;
+
+class SparkWriterFactory extends BaseWriterFactory<InternalRow> {
+  private final StructType dataSparkType;
+  private StructType lazyEqualityDeleteSparkType = null;
+  private StructType lazyPositionDeleteSparkType = null;
+
+  SparkWriterFactory(Map<String, String> properties, Schema dataSchema, StructType dataSparkType,
+                     int[] equalityFieldIds, Schema equalityDeleteRowSchema, Schema positionDeleteRowSchema) {
+    super(properties, dataSchema, equalityFieldIds, equalityDeleteRowSchema, positionDeleteRowSchema);
+    this.dataSparkType = dataSparkType;
+  }
+
+  static Builder builderFor(Table table) {
+    return new Builder(table);
+  }
+
+  @Override
+  protected void configureDataWrite(Avro.DataWriteBuilder builder) {
+    builder.createWriterFunc(ignored -> new SparkAvroWriter(dataSparkType));
+  }
+
+  @Override
+  protected void configureEqualityDelete(Avro.DeleteWriteBuilder builder) {
+    builder.createWriterFunc(ignored -> new SparkAvroWriter(equalityDeleteSparkType()));
+  }
+
+  @Override
+  protected void configurePositionDelete(Avro.DeleteWriteBuilder builder) {
+    builder.createWriterFunc(ignored -> new SparkAvroWriter(positionDeleteSparkType()));
+  }
+
+  @Override
+  protected void configureDataWrite(Parquet.DataWriteBuilder builder) {
+    builder.createWriterFunc(msgType -> SparkParquetWriters.buildWriter(dataSparkType, msgType));
+  }
+
+  @Override
+  protected void configureEqualityDelete(Parquet.DeleteWriteBuilder builder) {
+    builder.createWriterFunc(msgType -> SparkParquetWriters.buildWriter(equalityDeleteSparkType(), msgType));
+  }
+
+  @Override
+  protected void configurePositionDelete(Parquet.DeleteWriteBuilder builder) {
+    builder.createWriterFunc(msgType -> SparkParquetWriters.buildWriter(positionDeleteSparkType(), msgType));
+  }
+
+  private StructType equalityDeleteSparkType() {
+    if (lazyEqualityDeleteSparkType == null) {
+      Preconditions.checkNotNull(equalityDeleteRowSchema(), "Equality delete row schema shouldn't be null");
+      this.lazyEqualityDeleteSparkType = SparkSchemaUtil.convert(equalityDeleteRowSchema());
+    }
+    return lazyEqualityDeleteSparkType;
+  }
+
+  private StructType positionDeleteSparkType() {
+    if (lazyPositionDeleteSparkType == null) {
+      // wrap the row schema into a position delete schema
+      Schema positionDeleteSchema = DeleteSchemaUtil.posDeleteSchema(positionDeleteRowSchema());
+      this.lazyPositionDeleteSparkType = SparkSchemaUtil.convert(positionDeleteSchema);
+    }
+    return lazyPositionDeleteSparkType;
+  }
+
+  static class Builder {
+    private final Table table;
+    private Schema dataSchema;
+    private StructType dataSparkType;
+    private int[] equalityFieldIds;
+    private Schema equalityDeleteRowSchema;
+    private Schema positionDeleteRowSchema;
+
+    Builder(Table table) {
+      this.table = table;
+    }
+
+    Builder dataSchema(Schema newDataSchema) {
+      this.dataSchema = newDataSchema;
+      return this;
+    }
+
+    Builder dataSparkType(StructType newDataSparkType) {
+      this.dataSparkType = newDataSparkType;
+      return this;
+    }
+
+    Builder equalityFieldIds(int[] newEqualityFieldIds) {
+      this.equalityFieldIds = newEqualityFieldIds;
+      return this;
+    }
+
+    Builder equalityDeleteRowSchema(Schema newEqualityDeleteRowSchema) {
+      this.equalityDeleteRowSchema = newEqualityDeleteRowSchema;
+      return this;
+    }
+
+    Builder positionDeleteRowSchema(Schema newPositionDeleteRowSchema) {
+      this.positionDeleteRowSchema = newPositionDeleteRowSchema;
+      return this;
+    }
+
+    SparkWriterFactory build() {
+      boolean noEqualityDeleteConf = equalityFieldIds == null && equalityDeleteRowSchema == null;
+      boolean fullEqualityDeleteConf = equalityFieldIds != null && equalityDeleteRowSchema != null;
+      Preconditions.checkArgument(noEqualityDeleteConf || fullEqualityDeleteConf,
+          "Equality field IDs and equality delete row schema must be set together");
+
+      return new SparkWriterFactory(
+          table.properties(), dataSchema, dataSparkType,
+          equalityFieldIds, equalityDeleteRowSchema,
+          positionDeleteRowSchema);
+    }
+  }
+}


### PR DESCRIPTION
This WIP PR has the following contributions (may be split into separate changes):
- Introduce table properties for configuring delete file formats. For example, users may want to use a smaller target file size for deletes, another compression codec/level (i.e. we should prefer faster reads with slightly worse compression as delete files are expected to be queried and rewritten often), row group config, etc.
- Changes in `Parquet` and `Avro` classes to pick up either data or delete table properties through a context.
- Builders in `Parquet` and `Avro` for creating `DataWriter`. Right now, the code is inconsistent as we can build delete file writers and an appender (not a data writer). 
- A factory for writers that is supposed to replace `FileAppenderFactory`. Originally, `FileAppenderFactory` was used to construct appenders but we then added methods for constructing writers too. I think we better move that logic into a separate factory.