### PR TITLE
Doc: add link to PrestoDB support

### DIFF
--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -20,7 +20,7 @@
 # ![Iceberg](img/Iceberg-logo.png)
 
 
-**Apache Iceberg is an open table format for huge analytic datasets.** Iceberg adds tables to Trino and Spark that use a high-performance format that works just like a SQL table.
+**Apache Iceberg is an open table format for huge analytic datasets.** Iceberg adds tables to compute engines including Spark, Trino, PrestoDB, Flink and Hive using a high-performance format that works just like a SQL table.
 
 
 ### User experience

--- a/site/docs/presto.md
+++ b/site/docs/presto.md
@@ -15,6 +15,13 @@
  - limitations under the License.
  -->
 
-# Trino (formerly Presto SQL)
+# Presto
+
+## Trino (PrestoSQL)
 
 The Iceberg connector is available with Trino. It is feature complete and usage details can be found in the [documentation](https://trino.io/docs/current/connector/iceberg.html)
+
+## PrestoDB
+
+The Iceberg connector is available with PrestoDB. It is feature complete and usage details can be found in the [documentation](https://prestodb.io/docs/current/connector/iceberg.html)
+

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -36,7 +36,7 @@ plugins:
   - redirects:
       redirect_maps:
         'time-travel.md': 'spark-queries/#time-travel'
-        'presto.md': 'trino.md'
+        'trino.md': 'presto.md'
   - markdownextradata  
 markdown_extensions:
   - toc:
@@ -72,7 +72,9 @@ nav:
     - Maintenance Procedures: spark-procedures.md
     - Structured Streaming: spark-structured-streaming.md
     - Time Travel: spark-queries/#time-travel
-  - Trino: https://trino.io/docs/current/connector/iceberg.html
+  - Presto:
+    - Trino (PrestoSQL): https://trino.io/docs/current/connector/iceberg.html
+    - PrestoDB: https://prestodb.io/docs/current/connector/iceberg.html
   - Flink: flink.md
   - Hive: hive.md
   - Integrations:


### PR DESCRIPTION
GIven the fact that now PrestoDB also supports Iceberg, updating the tabs and links to reflect this. @yyanyy 