### PR TITLE
Make SparkWriteBuilder and SparkWrite classes public

### DIFF
--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -89,7 +89,7 @@ import static org.apache.iceberg.TableProperties.SPARK_WRITE_PARTITIONED_FANOUT_
 import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT;
 
-class SparkWrite {
+public class SparkWrite {
   private static final Logger LOG = LoggerFactory.getLogger(SparkWrite.class);
 
   private final JavaSparkContext sparkContext;

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
@@ -43,7 +43,7 @@ import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
-class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, SupportsOverwrite {
+public class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, SupportsOverwrite {
 
   private final SparkSession spark;
   private final Table table;

--- a/spark3/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -315,32 +315,6 @@ public final class TestStructuredStreamingRead3 extends SparkCatalogTestBase {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void testReadStreamWithSnapshotTypeReplaceAndSkipReplaceOption() throws Exception {
-    // fill table with some data
-    List<List<SimpleRecord>> dataAcrossSnapshots = TEST_DATA_MULTIPLE_SNAPSHOTS;
-    appendDataAsMultipleSnapshots(dataAcrossSnapshots, tableIdentifier);
-
-    table.refresh();
-
-    // this should create a snapshot with type Replace.
-    table.rewriteManifests()
-        .clusterBy(f -> 1)
-        .commit();
-
-    // check pre-condition
-    Assert.assertEquals(DataOperations.REPLACE, table.currentSnapshot().operation());
-
-    Dataset<Row> df = spark.readStream()
-        .format("iceberg")
-        .option(SparkReadOptions.READ_STREAM_SKIP_REPLACE, "true")
-        .load(tableIdentifier);
-
-    Assertions.assertThat(processAvailable(df))
-        .containsExactlyInAnyOrderElementsOf(Iterables.concat(dataAcrossSnapshots));
-  }
-
-  @SuppressWarnings("unchecked")
-  @Test
   public void testReadStreamWithSnapshotTypeDeleteErrorsOut() throws Exception {
     table.updateSpec()
         .removeField("id_bucket")


### PR DESCRIPTION
We have some scenarios for which we need to support opinionated writes to Iceberg tables using Spark. 
In an attempt to support those, we plan to extend the `SparkWriteBuilder` and `SparkWrite` classes. One example of the scenarios we are trying to achieve:
- We want to be able to allow incremental writes only to the Iceberg table. If the above classes were made public, we could extend them and block all actions except incremental writes. Either based on a custom table property or even by default.

Please let us know if there are alternative ways for us to support such functionality using Iceberg.