### PR TITLE
Doc: refactor engines pages and add link to PrestoDB

### DIFF
--- a/site/docs/getting-started.md
+++ b/site/docs/getting-started.md
@@ -17,9 +17,13 @@
 
 # Getting Started
 
-## Using Iceberg in Spark 3
-
 The latest version of Iceberg is [{{ versions.iceberg }}](./releases.md).
+
+Spark is currently the most feature-rich compute engine for Iceberg operations. 
+We recommend you to get started with Spark to understand Iceberg concepts and features with examples.
+You can also view documentations of using Iceberg with other compute engine under the **Engines** tab.
+
+## Using Iceberg in Spark 3
 
 To use Iceberg in a Spark shell, use the `--packages` option:
 

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -20,8 +20,7 @@
 # ![Iceberg](img/Iceberg-logo.png)
 
 
-**Apache Iceberg is an open table format for huge analytic datasets.** Iceberg adds tables to Trino and Spark that use a high-performance format that works just like a SQL table.
-
+**Apache Iceberg is an open table format for huge analytic datasets.** Iceberg adds tables to compute engines including Spark, Trino, PrestoDB, Flink and Hive using a high-performance format that works just like a SQL table.
 
 ### User experience
 

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -20,7 +20,7 @@
 # ![Iceberg](img/Iceberg-logo.png)
 
 
-**Apache Iceberg is an open table format for huge analytic datasets.** Iceberg adds tables to compute engines including Spark, Trino, PrestoDB, Flink and Hive using a high-performance format that works just like a SQL table.
+**Apache Iceberg is an open table format for huge analytic datasets.** Iceberg adds tables to compute engines including Spark, Trino, PrestoDB, Flink and Hive using a high-performance table format that works just like a SQL table.
 
 ### User experience
 

--- a/site/docs/trino-prestodb.md
+++ b/site/docs/trino-prestodb.md
@@ -19,9 +19,9 @@
 
 The Iceberg connector is available with PrestoSQL, which is rebranded as Trino since January 2021.
 This page is kept for backwards compatibility only.
-The Trino Iceberg connector usage details can be found in its [documentation](https://trino.io/docs/current/connector/iceberg.html).
+The documentation for Iceberg's Trino connector has moved to the Trino website. Please consult the [Iceberg section](https://trino.io/docs/current/connector/iceberg.html) of the Trino docs for more information.
 
 # PrestoDB
 
 The Presto trademark is now exclusively reserved for PrestoDB.
-The PrestoDB Iceberg connector usage details can be found in its [documentation](https://prestodb.io/docs/current/connector/iceberg.html).
+The documentation for Iceberg's PrestoDB connector is in the PrestoDB website. Please consult the [Iceberg section](https://prestodb.io/docs/current/connector/iceberg.html) of the PrestoDB docs for more information.

--- a/site/docs/trino-prestodb.md
+++ b/site/docs/trino-prestodb.md
@@ -17,4 +17,11 @@
 
 # Trino (formerly Presto SQL)
 
-The Iceberg connector is available with Trino. It is feature complete and usage details can be found in the [documentation](https://trino.io/docs/current/connector/iceberg.html)
+The Iceberg connector is available with PrestoSQL, which is rebranded as Trino since January 2021.
+This page is kept for backwards compatibility only.
+The Trino Iceberg connector usage details can be found in its [documentation](https://trino.io/docs/current/connector/iceberg.html).
+
+# PrestoDB
+
+The Presto trademark is now exclusively reserved for PrestoDB.
+The PrestoDB Iceberg connector usage details can be found in its [documentation](https://prestodb.io/docs/current/connector/iceberg.html).

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -36,7 +36,7 @@ plugins:
   - redirects:
       redirect_maps:
         'time-travel.md': 'spark-queries/#time-travel'
-        'presto.md': 'trino.md'
+        'presto.md': 'trino-prestodb.md'
   - markdownextradata  
 markdown_extensions:
   - toc:
@@ -56,6 +56,7 @@ nav:
     - Trademarks: trademarks.md
     - How to Release: how-to-release.md
     - Security: security.md
+  - Getting Started: getting-started.md
   - Tables:
     - Configuration: configuration.md
     - Schemas: schemas.md
@@ -64,18 +65,20 @@ nav:
     - Maintenance: maintenance.md
     - Performance: performance.md
     - Reliability: reliability.md
-  - Spark:
-    - Getting Started: getting-started.md
-    - Configuration: spark-configuration.md
-    - DDL: spark-ddl.md
-    - Queries: spark-queries.md
-    - Writes: spark-writes.md
-    - Maintenance Procedures: spark-procedures.md
-    - Structured Streaming: spark-structured-streaming.md
-    - Time Travel: spark-queries/#time-travel
-  - Trino: https://trino.io/docs/current/connector/iceberg.html
-  - Flink: flink.md
-  - Hive: hive.md
+  - Engines:
+    - Spark:
+      - Getting Started: getting-started.md
+      - Configuration: spark-configuration.md
+      - DDL: spark-ddl.md
+      - Queries: spark-queries.md
+      - Writes: spark-writes.md
+      - Maintenance Procedures: spark-procedures.md
+      - Structured Streaming: spark-structured-streaming.md
+      - Time Travel: spark-queries/#time-travel
+    - Flink: flink.md
+    - Hive: hive.md
+    - Trino: https://trino.io/docs/current/connector/iceberg.html
+    - PrestoDB: https://prestodb.io/docs/current/connector/iceberg.html
   - Integrations:
     - AWS: aws.md
     - Nessie: nessie.md


### PR DESCRIPTION
continuation of #2832 

Based on the discussion, proposing a way to refactor engines pages to accommodate more Iceberg support in the future.

@rdblue @electrum please see if this version is better.