### PR TITLE
Hive: Reconnect client if connection exception is wrapped in RuntimeE…

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveClientPool.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveClientPool.java
@@ -84,8 +84,16 @@ public class HiveClientPool extends ClientPoolImpl<HiveMetaStoreClient, TExcepti
 
   @Override
   protected boolean isConnectionException(Exception e) {
-    return super.isConnectionException(e) || (e != null && e instanceof MetaException &&
-        e.getMessage().contains("Got exception: org.apache.thrift.transport.TTransportException"));
+    Throwable tx = e;
+    while (tx instanceof Exception) {
+      Exception cause = (Exception) tx;
+      if (super.isConnectionException(cause) || (cause != null && cause instanceof MetaException &&
+          cause.getMessage().contains("Got exception: org.apache.thrift.transport.TTransportException"))) {
+        return true;
+      }
+      tx = tx.getCause();
+    }
+    return false;
   }
 
   @Override


### PR DESCRIPTION
…xception
https://github.com/apache/iceberg/blob/d5443e3a34a4288441a015ab616d965557d78202/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java#L303 wraps the internal exception into a RuntimeException and throws, the Hive client may fail to reconnect if if the internal exception is an exception that should reconnect. For example, 
```
java.lang.RuntimeException: org.apache.thrift.transport.TTransportException: java.net.SocketTimeoutException: Read timed out
        at org.apache.iceberg.relocated.com.google.common.base.Throwables.propagate(Throwables.java:241)
        at org.apache.iceberg.common.DynMethods$UnboundMethod.invoke(DynMethods.java:80)
```
Reusing the timeout client may result to `org.apache.thrift.TApplicationException: get_table failed: out of sequence response`.