### PR TITLE
Core: allow default data location for ObjectStorageLocationProvider

### DIFF
--- a/core/src/main/java/org/apache/iceberg/LocationProviders.java
+++ b/core/src/main/java/org/apache/iceberg/LocationProviders.java
@@ -68,13 +68,15 @@ public class LocationProviders {
     }
   }
 
+  private static String defaultDataLocation(String tableLocation, Map<String, String> properties) {
+    return properties.getOrDefault(TableProperties.WRITE_NEW_DATA_LOCATION, String.format("%s/data", tableLocation));
+  }
+
   static class DefaultLocationProvider implements LocationProvider {
     private final String dataLocation;
 
     DefaultLocationProvider(String tableLocation, Map<String, String> properties) {
-      this.dataLocation = stripTrailingSlash(properties.getOrDefault(
-          TableProperties.WRITE_NEW_DATA_LOCATION,
-          String.format("%s/data", tableLocation)));
+      this.dataLocation = stripTrailingSlash(defaultDataLocation(tableLocation, properties));
     }
 
     @Override
@@ -96,7 +98,8 @@ public class LocationProviders {
     private final String context;
 
     ObjectStoreLocationProvider(String tableLocation, Map<String, String> properties) {
-      this.storageLocation = stripTrailingSlash(properties.get(OBJECT_STORE_PATH));
+      this.storageLocation = stripTrailingSlash(properties.getOrDefault(OBJECT_STORE_PATH,
+          defaultDataLocation(tableLocation, properties)));
       this.context = pathContext(tableLocation);
     }
 

--- a/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
+++ b/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
@@ -212,4 +212,23 @@ public class TestLocationProvider extends TableTestBase {
         () -> table.locationProvider()
     );
   }
+
+  @Test
+  public void testObjectStorageLocationProvider() {
+    table.updateProperties()
+        .set(TableProperties.OBJECT_STORE_ENABLED, "true")
+        .commit();
+
+    Assert.assertTrue("default data location should be used when object storage path not set",
+        table.locationProvider().newDataLocation("file").contains(table.location() + "/data"));
+
+    String storagePath = "s3://random/location";
+    table.updateProperties()
+        .set(TableProperties.OBJECT_STORE_ENABLED, "true")
+        .set(TableProperties.OBJECT_STORE_PATH, storagePath)
+        .commit();
+
+    Assert.assertTrue("storage path should be used when set",
+        table.locationProvider().newDataLocation("file").contains(storagePath));
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
+++ b/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
@@ -222,13 +222,20 @@ public class TestLocationProvider extends TableTestBase {
     Assert.assertTrue("default data location should be used when object storage path not set",
         table.locationProvider().newDataLocation("file").contains(table.location() + "/data"));
 
-    String storagePath = "s3://random/location";
+    String folderPath = "s3://random/folder/location";
     table.updateProperties()
-        .set(TableProperties.OBJECT_STORE_ENABLED, "true")
+        .set(TableProperties.WRITE_NEW_DATA_LOCATION, folderPath)
+        .commit();
+
+    Assert.assertTrue("folder storage path should be used when set",
+        table.locationProvider().newDataLocation("file").contains(folderPath));
+
+    String storagePath = "s3://random/object/location";
+    table.updateProperties()
         .set(TableProperties.OBJECT_STORE_PATH, storagePath)
         .commit();
 
-    Assert.assertTrue("storage path should be used when set",
+    Assert.assertTrue("object storage path should be used when set",
         table.locationProvider().newDataLocation("file").contains(storagePath));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
+++ b/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
@@ -214,7 +214,7 @@ public class TestLocationProvider extends TableTestBase {
   }
 
   @Test
-  public void testObjectStorageLocationProvider() {
+  public void testObjectStorageLocationProviderPathResolution() {
     table.updateProperties()
         .set(TableProperties.OBJECT_STORE_ENABLED, "true")
         .commit();
@@ -230,12 +230,12 @@ public class TestLocationProvider extends TableTestBase {
     Assert.assertTrue("folder storage path should be used when set",
         table.locationProvider().newDataLocation("file").contains(folderPath));
 
-    String storagePath = "s3://random/object/location";
+    String objectPath = "s3://random/object/location";
     table.updateProperties()
-        .set(TableProperties.OBJECT_STORE_PATH, storagePath)
+        .set(TableProperties.OBJECT_STORE_PATH, objectPath)
         .commit();
 
     Assert.assertTrue("object storage path should be used when set",
-        table.locationProvider().newDataLocation("file").contains(storagePath));
+        table.locationProvider().newDataLocation("file").contains(objectPath));
   }
 }


### PR DESCRIPTION
when table property `write.object-storage.path` is not set, use the default table data path which is `tableLocation/data`

@yyanyy 