### PR TITLE
[2806]Dell EMC ECS features required by a new ECS Catalog impl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,9 @@ allprojects {
   group = "org.apache.iceberg"
   version = getProjectVersion()
   repositories {
+    maven {
+      url = "https://maven.aliyun.com/repository/central"
+    }
     mavenCentral()
     mavenLocal()
   }
@@ -406,6 +409,7 @@ project(':iceberg-flink-runtime') {
     compile(project(':iceberg-nessie')) {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }
+    compile(project(':iceberg-dell'))
   }
 
   shadowJar {
@@ -945,6 +949,7 @@ if (jdkVersion == '8') {
       compile(project(':iceberg-nessie')) {
         exclude group: 'com.google.code.findbugs', module: 'jsr305'
       }
+      compile(project(':iceberg-dell'))
     }
 
     shadowJar {
@@ -1169,6 +1174,7 @@ project(':iceberg-spark3-runtime') {
     compile(project(':iceberg-nessie')) {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }
+    compile(project(':iceberg-dell'))
 
     integrationImplementation "org.apache.spark:spark-hive_2.12:${project.ext.Spark30Version}"
     integrationImplementation 'org.junit.vintage:junit-vintage-engine'
@@ -1283,6 +1289,14 @@ project(':iceberg-nessie') {
     compileOnly "org.apache.hadoop:hadoop-common"
 
     testCompile project(path: ':iceberg-api', configuration: 'testArtifacts')
+  }
+}
+
+project(':iceberg-dell') {
+
+  dependencies {
+    compile project(':iceberg-core')
+    compileOnly 'com.amazonaws:aws-java-sdk-s3'
   }
 }
 

--- a/dell/src/main/java/org/apache/iceberg/dell/EcsClient.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/EcsClient.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.dell;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.NoSuchNamespaceException;
+
+/**
+ * ECS client and its util-methods.
+ */
+public interface EcsClient extends AutoCloseable {
+
+  /**
+   * utils of object key that provide methods to convert {@link ObjectKey} to other objects declared in Iceberg.
+   *
+   * @return utils class
+   */
+  ObjectKeys getKeys();
+
+  /**
+   * utils of properties that provide methods to convert object to properties.
+   *
+   * @return utils class
+   */
+  default PropertiesSerDes getPropertiesSerDes() {
+    return PropertiesSerDes.useJdk();
+  }
+
+  /**
+   * get original properties.
+   * <p>
+   * when try to implement this interface, make this properties same as input of {@link EcsClient#create(Map)}
+   *
+   * @return properties of client
+   */
+  Map<String, String> getProperties();
+
+  /**
+   * get object info of specific key. If object is absent, return {@link Optional#empty()}
+   *
+   * @param key object key
+   * @return head info if present
+   */
+  Optional<ObjectHeadInfo> head(ObjectKey key);
+
+  /**
+   * get object input stream of specific key.
+   *
+   * @param key object key
+   * @return input stream
+   */
+  InputStream inputStream(ObjectKey key, long pos);
+
+  /**
+   * get object output stream of specific key.
+   *
+   * @param key object key
+   * @return output stream
+   */
+  OutputStream outputStream(ObjectKey key);
+
+  /**
+   * return tuple of {@link #readAll(ObjectKey)}
+   */
+  interface ContentAndETag {
+    ObjectHeadInfo getHeadInfo();
+
+    byte[] getContent();
+  }
+
+  /**
+   * read all bytes of object
+   *
+   * @return bytes and e-tag
+   */
+  ContentAndETag readAll(ObjectKey key);
+
+  /**
+   * a util method of {@link #readAll(ObjectKey)}
+   */
+  default Map<String, String> readProperties(ObjectKey key) {
+    ContentAndETag contentAndETag = readAll(key);
+    return getPropertiesSerDes().readProperties(
+        contentAndETag.getContent(),
+        contentAndETag.getHeadInfo().getETag(),
+        contentAndETag.getHeadInfo().getUserMetadata().getOrDefault(
+            PROPERTY_VERSION_KEY,
+            PropertiesSerDes.CURRENT_VERSION));
+  }
+
+  /**
+   * CAS operation
+   * <p>
+   * we assume that E-Tag can distinct content of the objects.
+   * <p>
+   * if current object's eTag is not matched, the method will return false, and the object won't be changed
+   */
+  boolean replace(ObjectKey key, String eTag, byte[] bytes, Map<String, String> userMetadata);
+
+  /**
+   * a util method of {@link #replace(ObjectKey, String, byte[], Map)}
+   */
+  default boolean replaceProperties(ObjectKey key, String eTag, Map<String, String> properties) {
+    return replace(key, eTag, getPropertiesSerDes().toBytes(properties),
+        Collections.singletonMap(PROPERTY_VERSION_KEY, PropertiesSerDes.CURRENT_VERSION));
+  }
+
+  /**
+   * compare-and-swap operation
+   * <p>
+   * if current key is not existed, the method will return false, and the key is still absent.
+   */
+  boolean writeIfAbsent(ObjectKey key, byte[] bytes, Map<String, String> userMetadata);
+
+  /**
+   * a util method of {@link #writeIfAbsent(ObjectKey, byte[], Map)}
+   */
+  default boolean writePropertiesIfAbsent(ObjectKey key, Map<String, String> properties) {
+    return writeIfAbsent(key, getPropertiesSerDes().toBytes(properties),
+        Collections.singletonMap(PROPERTY_VERSION_KEY, PropertiesSerDes.CURRENT_VERSION));
+  }
+
+  /**
+   * compare-and-swap operation
+   * <p>
+   * we assume that E-Tag can distinct content of the objects.
+   */
+  boolean copyObjectIfAbsent(ObjectKey fromKey, String eTag, ObjectKey toKey);
+
+  /**
+   * delete object
+   *
+   * @param key is object key
+   */
+  void deleteObject(ObjectKey key);
+
+  /**
+   * list all objects with delimiter.
+   * <p>
+   * for example: there are objects like:
+   * <ul>
+   * <li>namespace1/namespace2.namespace</li>
+   * <li>namespace1/namespace2/table1.table</li>
+   * <li>namespace1/table1.table</li>
+   * <li>namespace1/table2.table</li>
+   * </ul>
+   * if prefix is namespace1 and delimiter is /, then return value will be
+   * <ul>
+   * <li>namespace1/table1.table</li>
+   * <li>namespace1/table2.table</li>
+   * </ul>
+   * <p>
+   * The function will can filter and convert to the object that user want to use
+   * <p>
+   * note: the common prefixes, such as namespace1/namespace2/, won't return by this method.
+   *
+   * @param prefix          prefix key
+   * @param filterAndMapper map object key to specify item
+   * @param <T>             search item type
+   * @return all items with given prefix
+   */
+  <T> List<T> listDelimiterAll(ObjectKey prefix, Function<ObjectKey, Optional<T>> filterAndMapper);
+
+  /**
+   * list all tables under this namespace.
+   *
+   * @param namespace a namespace
+   * @return a list of identifiers for tables
+   */
+  default List<TableIdentifier> listTables(Namespace namespace) throws NoSuchNamespaceException {
+    assertNamespaceExist(namespace);
+    return listDelimiterAll(getKeys().getPrefix(namespace), key -> getKeys().extractTableIdentifier(key, namespace));
+  }
+
+  /**
+   * list all namespaces under this namespace.
+   *
+   * @param namespace a namespace
+   * @return a list of namespace
+   */
+  default List<Namespace> listNamespaces(Namespace namespace) throws NoSuchNamespaceException {
+    assertNamespaceExist(namespace);
+    return listDelimiterAll(getKeys().getPrefix(namespace), key -> getKeys().extractNamespace(key, namespace));
+  }
+
+  /**
+   * check namespace object existence. If not exist, throw exception.
+   *
+   * @param namespace is a non-null namespace
+   * @throws NoSuchNamespaceException if namespace object is absent
+   */
+  default void assertNamespaceExist(Namespace namespace) throws NoSuchNamespaceException {
+    if (namespace.isEmpty()) {
+      return;
+    }
+    ObjectKey key = getKeys().getMetadataKey(namespace);
+    if (!head(key).isPresent()) {
+      throw new NoSuchNamespaceException("namespace %s(%s) is not found", namespace, key);
+    }
+  }
+
+  /**
+   * ETag property name in results
+   *
+   * @see #readProperties(ObjectKey)
+   */
+  String E_TAG_KEY = "ecs-object-e-tag";
+
+  /**
+   * version property name in results
+   *
+   * @see #readProperties(ObjectKey)
+   */
+  String PROPERTY_VERSION_KEY = "ecs-object-property-version";
+}

--- a/dell/src/main/java/org/apache/iceberg/dell/ObjectBaseKey.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ObjectBaseKey.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.dell;
+
+import java.util.Objects;
+
+/**
+ * a immutable record class of object base key which allow not null bucket and key.
+ */
+public class ObjectBaseKey {
+
+  private final String bucket;
+  public final String key;
+
+  public ObjectBaseKey(String bucket, String key) {
+    this.bucket = bucket;
+    this.key = key;
+  }
+
+  public ObjectKey asKey() {
+    if (bucket == null) {
+      throw new IllegalArgumentException(String.format(
+          "fail to cast base key %s as object key, bucket is unknown",
+          this));
+    }
+    return new ObjectKey(bucket, key == null ? "" : key);
+  }
+
+  public String getBucket() {
+    return bucket;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  @Override
+  public String toString() {
+    return "ObjectBaseKey{" +
+        "bucket='" + bucket + '\'' +
+        ", key='" + key + '\'' +
+        '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ObjectBaseKey that = (ObjectBaseKey) o;
+    return Objects.equals(bucket, that.bucket) && Objects.equals(key, that.key);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(bucket, key);
+  }
+}

--- a/dell/src/main/java/org/apache/iceberg/dell/ObjectHeadInfo.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ObjectHeadInfo.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.dell;
+
+import java.util.Map;
+
+/**
+ * object head info
+ * <p>
+ * it's the basic info of an object in the object storage.
+ */
+public interface ObjectHeadInfo {
+
+  /**
+   * content length of object
+   *
+   * @return length in bytes
+   */
+  long getContentLength();
+
+  /**
+   * eTag of object
+   *
+   * @return eTag
+   */
+  String getETag();
+
+  /**
+   * user metadata of object
+   *
+   * @return user metadata
+   */
+  Map<String, String> getUserMetadata();
+}

--- a/dell/src/main/java/org/apache/iceberg/dell/ObjectKey.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ObjectKey.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.dell;
+
+import java.util.Objects;
+
+/**
+ * a immutable record class of object key
+ */
+public class ObjectKey {
+  /**
+   * bucket
+   */
+  private final String bucket;
+
+  /**
+   * key
+   */
+  private final String key;
+
+  public ObjectKey(String bucket, String key) {
+    if (bucket == null || key == null) {
+      throw new IllegalArgumentException(String.format("bucket %s and key %s must be not null", bucket, key));
+    }
+    this.bucket = bucket;
+    this.key = key;
+  }
+
+  public String getBucket() {
+    return bucket;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  @Override
+  public String toString() {
+    return "ObjectKey{" +
+        "bucket='" + bucket + '\'' +
+        ", key='" + key + '\'' +
+        '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ObjectKey objectKey = (ObjectKey) o;
+    return Objects.equals(bucket, objectKey.bucket) && Objects.equals(key, objectKey.key);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(bucket, key);
+  }
+}

--- a/dell/src/main/java/org/apache/iceberg/dell/ObjectKeys.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ObjectKeys.java
@@ -1,0 +1,297 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.dell;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.base.Splitter;
+
+/**
+ * operations of {@link ObjectKey}
+ */
+public interface ObjectKeys {
+
+  /**
+   * default delimiter
+   */
+  String DELIMITER = "/";
+  /**
+   * default suffix of table metadata object
+   */
+  String TABLE_METADATA_SUFFIX = ".table";
+  /**
+   * default suffix of namespace metadata object
+   */
+  String NAMESPACE_METADATA_SUFFIX = ".namespace";
+
+  /**
+   * base key of catalog
+   *
+   * @return the base key
+   */
+  ObjectBaseKey getBaseKey();
+
+  /**
+   * base key parts for calculate sub key
+   *
+   * @return the parts of the base key
+   */
+  default List<String> getBaseKeyParts() {
+    ObjectBaseKey baseKey = getBaseKey();
+    if (baseKey.getBucket() == null) {
+      return Collections.emptyList();
+    } else if (baseKey.getKey() == null) {
+      return Collections.singletonList(baseKey.getBucket());
+    } else {
+      List<String> parts = new ArrayList<>();
+      parts.add(baseKey.getBucket());
+      for (String result : Splitter.on(getDelimiter()).split(baseKey.getKey())) {
+        parts.add(result);
+      }
+      if (!checkParts(parts)) {
+        throw new IllegalArgumentException(String.format("invalid base key %s with delimiter %s",
+            baseKey, getDelimiter()));
+      }
+      return Collections.unmodifiableList(parts);
+    }
+  }
+
+  default String getDelimiter() {
+    return DELIMITER;
+  }
+
+  default String getNamespaceMetadataSuffix() {
+    return NAMESPACE_METADATA_SUFFIX;
+  }
+
+  default String getTableMetadataSuffix() {
+    return TABLE_METADATA_SUFFIX;
+  }
+
+  /**
+   * convert relative parts to object key
+   *
+   * @param parts that relative to base key
+   * @return object key
+   */
+  default ObjectKey getObjectKey(List<String> parts) {
+    ObjectBaseKey baseKey = getBaseKey();
+    if (parts.isEmpty()) {
+      return baseKey.asKey();
+    }
+    String delimiter = getDelimiter();
+    if (parts.stream().anyMatch(it -> it.contains(delimiter))) {
+      throw new IllegalArgumentException(String.format("delimiter %s in key parts: %s", delimiter, parts));
+    }
+    if (baseKey.getBucket() == null) {
+      return new ObjectKey(parts.get(0), String.join(delimiter, parts.subList(1, parts.size())));
+    } else {
+      String prefix = baseKey.getKey() == null ? "" : (baseKey.getKey() + delimiter);
+      return new ObjectKey(baseKey.getBucket(), prefix + String.join(delimiter, parts));
+    }
+  }
+
+  /**
+   * get metadata key of namespace
+   *
+   * @param namespace is a namespace
+   * @return object key
+   */
+  default ObjectKey getMetadataKey(Namespace namespace) {
+    if (namespace.isEmpty()) {
+      return getObjectKey(Collections.singletonList(getNamespaceMetadataSuffix()));
+    }
+    // copy namespace levels
+    List<String> keyParts = new ArrayList<>(Arrays.asList(namespace.levels()));
+    int lastIndex = keyParts.size() - 1;
+    keyParts.set(lastIndex, keyParts.get(lastIndex) + getNamespaceMetadataSuffix());
+    return getObjectKey(keyParts);
+  }
+
+  /**
+   * get prefix key of namespace.
+   * <p>
+   * The prefix key lack namespace metadata suffix.
+   *
+   * @param namespace is a namespace
+   * @return object prefix
+   */
+  default ObjectKey getPrefix(Namespace namespace) {
+    return getObjectKey(Arrays.asList(namespace.levels()));
+  }
+
+  /**
+   * try to extract namespace from specific key
+   *
+   * @param key    key
+   * @param parent is parent namespace
+   * @return namespace if present
+   */
+  default Optional<Namespace> extractNamespace(ObjectKey key, Namespace parent) {
+    if (!key.getKey().endsWith(getNamespaceMetadataSuffix())) {
+      return Optional.empty();
+    }
+    Optional<String> lastPartOpt = extractLastPart(key, parent);
+    if (!lastPartOpt.isPresent()) {
+      return Optional.empty();
+    }
+    String lastPart = lastPartOpt.get();
+    String namespaceName = lastPart.substring(0, lastPart.length() - getNamespaceMetadataSuffix().length());
+    String[] levels = Arrays.copyOf(parent.levels(), parent.levels().length + 1);
+    levels[levels.length - 1] = namespaceName;
+    return Optional.of(Namespace.of(levels));
+  }
+
+  /**
+   * get metadata key of namespace
+   *
+   * @param tableIdentifier is a table id
+   * @return object key
+   */
+  default ObjectKey getMetadataKey(TableIdentifier tableIdentifier) {
+    if (tableIdentifier.hasNamespace()) {
+      List<String> parts = new ArrayList<>(tableIdentifier.namespace().levels().length + 1);
+      parts.addAll(Arrays.asList(tableIdentifier.namespace().levels()));
+      parts.add(tableIdentifier.name() + getTableMetadataSuffix());
+      return getObjectKey(parts);
+    } else {
+      return getObjectKey(Collections.singletonList(tableIdentifier.name() + getTableMetadataSuffix()));
+    }
+  }
+
+  /**
+   * try to extract table id from specific key
+   *
+   * @param key       key
+   * @param namespace is parent namespace
+   * @return table id if present
+   */
+  default Optional<TableIdentifier> extractTableIdentifier(ObjectKey key, Namespace namespace) {
+    if (!key.getKey().endsWith(getTableMetadataSuffix())) {
+      return Optional.empty();
+    }
+    Optional<String> lastPartOpt = extractLastPart(key, namespace);
+    if (!lastPartOpt.isPresent()) {
+      return Optional.empty();
+    }
+    String lastPart = lastPartOpt.get();
+    String tableName = lastPart.substring(0, lastPart.length() - getTableMetadataSuffix().length());
+    return Optional.of(TableIdentifier.of(namespace, tableName));
+  }
+
+  /**
+   * check namespace is expected and extract last part
+   *
+   * @param key             is object key
+   * @param expectNamespace is parent namespace
+   * @return the last part if namespace is matched
+   */
+  default Optional<String> extractLastPart(ObjectKey key, Namespace expectNamespace) {
+    Optional<List<String>> partsOpt = subParts(key);
+    if (!partsOpt.isPresent()) {
+      return Optional.empty();
+    }
+    List<String> parts = partsOpt.get();
+    if (parts.isEmpty()) {
+      return Optional.empty();
+    }
+    int lastIndex = parts.size() - 1;
+    Namespace namespace = Namespace.of(parts.subList(0, lastIndex).toArray(new String[] {}));
+    if (expectNamespace != null && !Objects.equals(expectNamespace, namespace)) {
+      throw new IllegalArgumentException(String.format("namespace not match: %s != %s", namespace, expectNamespace));
+    }
+    return Optional.of(parts.get(lastIndex));
+  }
+
+  /**
+   * get the relative parts of {@link #getBaseKey()}
+   *
+   * @param key is object key
+   * @return relative parts if this key start with base key
+   */
+  default Optional<List<String>> subParts(ObjectKey key) {
+    List<String> parts = new ArrayList<>();
+    parts.add(key.getBucket());
+    for (String result : Splitter.on(getDelimiter()).split(key.getKey())) {
+      parts.add(result);
+    }
+    if (!checkParts(parts)) {
+      return Optional.empty();
+    }
+    List<String> baseParts = getBaseKeyParts();
+    if (parts.size() < baseParts.size() || !Objects.equals(parts.subList(0, baseParts.size()), baseParts)) {
+      return Optional.empty();
+    } else {
+      return Optional.of(parts.subList(baseParts.size(), parts.size()));
+    }
+  }
+
+  /**
+   * check all parts are valid.
+   *
+   * @param parts is key parts
+   * @return true if all parts are valid
+   */
+  default boolean checkParts(List<String> parts) {
+    return parts.stream().noneMatch(String::isEmpty);
+  }
+
+  /**
+   * get default warehouse location of table id
+   *
+   * @param tableIdentifier is table id
+   * @return default warehouse location prefix key
+   */
+  default ObjectKey warehouseLocation(TableIdentifier tableIdentifier) {
+    if (!tableIdentifier.hasNamespace()) {
+      return getObjectKey(Collections.singletonList(tableIdentifier.name()));
+    } else {
+      List<String> parts = new ArrayList<>(tableIdentifier.namespace().levels().length + 1);
+      parts.addAll(Arrays.asList(tableIdentifier.namespace().levels()));
+      parts.add(tableIdentifier.name());
+      return getObjectKey(parts);
+    }
+  }
+
+  /**
+   * convert key to string
+   *
+   * @param key is object key
+   * @return string key
+   */
+  default String toString(ObjectKey key) {
+    return key.getBucket() + getDelimiter() + key.getKey();
+  }
+
+  /**
+   * convert string to key
+   *
+   * @param key is string key
+   * @return object key
+   */
+  default ObjectKey parse(String key) {
+    String[] r = key.split(getDelimiter(), 2);
+    if (r.length < 2) {
+      throw new IllegalArgumentException("failed to parse key " + key);
+    }
+    return new ObjectKey(r[0], r[1]);
+  }
+}

--- a/dell/src/main/java/org/apache/iceberg/dell/PropertiesSerDes.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/PropertiesSerDes.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.dell;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * convert Map properties to bytes.
+ */
+public interface PropertiesSerDes {
+
+  /**
+   * version of properties.
+   * <p>
+   * this properties is only a placeholder and may use in future.
+   */
+  String CURRENT_VERSION = "0";
+
+  Logger log = LoggerFactory.getLogger(PropertiesSerDes.class);
+
+  /**
+   * read properties from stream
+   *
+   * @param input is stream
+   * @return properties
+   */
+  Map<String, String> read(InputStream input);
+
+  /**
+   * a utils to read properties from object content.
+   *
+   * @param content is content of object
+   * @param eTag    is eTag of object
+   * @param version is property version (current field is a placeholder for future changes)
+   * @return properties which loaded by content
+   */
+  default Map<String, String> readProperties(byte[] content, String eTag, String version) {
+    Map<String, String> propertiesInObject = read(new ByteArrayInputStream(content));
+    Map<String, String> properties = new HashMap<>(propertiesInObject);
+    properties.put(EcsClient.E_TAG_KEY, eTag);
+    properties.put(EcsClient.PROPERTY_VERSION_KEY, version);
+    return properties;
+  }
+
+  /**
+   * write properties to bytes.
+   *
+   * @param value is properties
+   * @return bytes content
+   */
+  byte[] toBytes(Map<String, String> value);
+
+  /**
+   * use {@link Properties} to serialize and deserialize properties.
+   *
+   * @return interface
+   */
+  static PropertiesSerDes useJdk() {
+    return new PropertiesSerDes() {
+      @Override
+      public Map<String, String> read(InputStream input) {
+        Properties jdkProperties = new Properties();
+        try {
+          jdkProperties.load(new InputStreamReader(input, StandardCharsets.UTF_8));
+        } catch (IOException e) {
+          log.error("fail to read properties", e);
+          throw new UncheckedIOException(e);
+        }
+        Set<String> propertyNames = jdkProperties.stringPropertyNames();
+        Map<String, String> properties = new HashMap<>();
+        for (String name : propertyNames) {
+          properties.put(name, jdkProperties.getProperty(name));
+        }
+        return Collections.unmodifiableMap(properties);
+      }
+
+      @Override
+      public byte[] toBytes(Map<String, String> value) {
+        Properties jdkProperties = new Properties();
+        for (Map.Entry<String, String> entry : value.entrySet()) {
+          jdkProperties.setProperty(entry.getKey(), entry.getValue());
+        }
+        try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+          jdkProperties.store(new OutputStreamWriter(output, StandardCharsets.UTF_8), null);
+          return output.toByteArray();
+        } catch (IOException e) {
+          log.error("fail to store properties {} to file", value, e);
+          throw new UncheckedIOException(e);
+        }
+      }
+    };
+  }
+}

--- a/dell/src/main/java/org/apache/iceberg/dell/impl/ContentAndETagImpl.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/impl/ContentAndETagImpl.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.dell.impl;
+
+import org.apache.iceberg.dell.EcsClient;
+import org.apache.iceberg.dell.ObjectHeadInfo;
+
+/**
+ * a record class of {@link EcsClient.ContentAndETag}
+ */
+public class ContentAndETagImpl implements EcsClient.ContentAndETag {
+
+  private final ObjectHeadInfo headInfo;
+  private final byte[] content;
+
+  public ContentAndETagImpl(ObjectHeadInfo headInfo, byte[] content) {
+    this.headInfo = headInfo;
+    this.content = content;
+  }
+
+  @Override
+  public ObjectHeadInfo getHeadInfo() {
+    return headInfo;
+  }
+
+  @Override
+  public byte[] getContent() {
+    return content;
+  }
+}

--- a/dell/src/main/java/org/apache/iceberg/dell/impl/EcsAppendOutputStream.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/impl/EcsAppendOutputStream.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.dell.impl;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.Headers;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import java.io.ByteArrayInputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import org.apache.iceberg.dell.ObjectKey;
+
+/**
+ * use ECS append api to write data
+ */
+public class EcsAppendOutputStream extends OutputStream {
+
+  private final AmazonS3 s3;
+
+  private final ObjectKey key;
+
+  /**
+   * local bytes cache that avoid too many requests
+   * <p>
+   * use {@link ByteBuffer} to maintain offset
+   */
+  private final ByteBuffer localCache;
+
+  private boolean firstPart = true;
+
+  public EcsAppendOutputStream(AmazonS3 s3, ObjectKey key, byte[] localCache) {
+    this.s3 = s3;
+    this.key = key;
+    this.localCache = ByteBuffer.wrap(localCache);
+  }
+
+  @Override
+  public void write(int b) {
+    if (!checkBuffer(1)) {
+      flush();
+    }
+    localCache.put((byte) b);
+  }
+
+  @Override
+  public void write(byte[] b, int off, int len) {
+    if (!checkBuffer(len)) {
+      flush();
+    }
+    if (checkBuffer(len)) {
+      localCache.put(b, off, len);
+    } else {
+      // if content > cache, directly flush itself.
+      flushBuffer(b, off, len);
+    }
+  }
+
+  private boolean checkBuffer(int nextWrite) {
+    return localCache.remaining() >= nextWrite;
+  }
+
+  private void flushBuffer(byte[] buffer, int offset, int length) {
+    ObjectMetadata metadata = new ObjectMetadata();
+    if (firstPart) {
+      firstPart = false;
+    } else {
+      // only following parts need append api
+      metadata.setHeader(Headers.RANGE, "bytes=-1-");
+    }
+    metadata.setContentLength(length);
+    s3.putObject(key.getBucket(), key.getKey(), new ByteArrayInputStream(buffer, offset, length), metadata);
+  }
+
+  /**
+   * flush all cached bytes
+   */
+  @Override
+  public void flush() {
+    if (localCache.remaining() < localCache.capacity()) {
+      localCache.flip();
+      flushBuffer(localCache.array(), localCache.arrayOffset(), localCache.remaining());
+      localCache.clear();
+    }
+  }
+
+  @Override
+  public void close() {
+    // call flush to guarantee all bytes are submitted
+    flush();
+  }
+}

--- a/dell/src/main/java/org/apache/iceberg/dell/impl/EcsClientImpl.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/impl/EcsClientImpl.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.dell.impl;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.CopyObjectRequest;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import org.apache.iceberg.dell.EcsClient;
+import org.apache.iceberg.dell.ObjectHeadInfo;
+import org.apache.iceberg.dell.ObjectKey;
+import org.apache.iceberg.dell.ObjectKeys;
+import org.apache.iceberg.dell.PropertiesSerDes;
+
+/**
+ * the implementation of {@link EcsClient}
+ * <p>
+ * ECS use aws sdk v1 to support private function.
+ */
+public class EcsClientImpl implements EcsClient {
+
+  private final AmazonS3 s3;
+  private final Map<String, String> properties;
+  private final ObjectKeys keys;
+  private final PropertiesSerDes propertiesSerDes;
+
+  public EcsClientImpl(
+      AmazonS3 s3,
+      Map<String, String> properties,
+      ObjectKeys keys,
+      PropertiesSerDes propertiesSerDes) {
+    this.s3 = s3;
+    this.properties = Collections.unmodifiableMap(new LinkedHashMap<>(properties));
+    this.keys = keys;
+    this.propertiesSerDes = propertiesSerDes;
+  }
+
+  @Override
+  public ObjectKeys getKeys() {
+    return keys;
+  }
+
+  @Override
+  public PropertiesSerDes getPropertiesSerDes() {
+    return propertiesSerDes;
+  }
+
+  @Override
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  @Override
+  public Optional<ObjectHeadInfo> head(ObjectKey key) {
+    try {
+      ObjectMetadata metadata = s3.getObjectMetadata(key.getBucket(), key.getKey());
+      return Optional.of(new ObjectHeadInfoImpl(
+          metadata.getContentLength(),
+          metadata.getETag(),
+          metadata.getUserMetadata()));
+    } catch (AmazonS3Exception e) {
+      if (e.getStatusCode() == 404) {
+        return Optional.empty();
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  @Override
+  public InputStream inputStream(ObjectKey key, long pos) {
+    S3Object object = s3.getObject(new GetObjectRequest(key.getBucket(), key.getKey())
+        .withRange(pos));
+    return object.getObjectContent();
+  }
+
+  @Override
+  public OutputStream outputStream(ObjectKey key) {
+    return new EcsAppendOutputStream(s3, key, new byte[1_000]);
+  }
+
+  @Override
+  public ContentAndETag readAll(ObjectKey key) {
+    S3Object object = s3.getObject(new GetObjectRequest(key.getBucket(), key.getKey()));
+    ObjectMetadata metadata = object.getObjectMetadata();
+    int size = (int) metadata.getContentLength();
+    byte[] content = new byte[size];
+    try (S3ObjectInputStream input = object.getObjectContent()) {
+      int offset = 0;
+      while (offset < size) {
+        offset += input.read(content, offset, size - offset);
+      }
+      if (offset != size) {
+        throw new IllegalStateException(String.format(
+            "size of %s is unmatched, current size %d != %d",
+            key, offset, size));
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException("rethrow unchecked exception during read all bytes", e);
+    }
+    ObjectHeadInfoImpl headInfo = new ObjectHeadInfoImpl(
+        metadata.getContentLength(),
+        metadata.getETag(),
+        metadata.getUserMetadata());
+    return new ContentAndETagImpl(headInfo, content);
+  }
+
+  /**
+   * using If-Match to replace object with eTag
+   *
+   * @param key          is object key
+   * @param eTag         is e-tag
+   * @param bytes        is content
+   * @param userMetadata is user metadata stored in object metadata
+   * @return true if replace success
+   */
+  @Override
+  public boolean replace(ObjectKey key, String eTag, byte[] bytes, Map<String, String> userMetadata) {
+    return cas(() -> {
+      ObjectMetadata metadata = new ObjectMetadata();
+      metadata.setHeader("If-Match", eTag);
+      metadata.setContentLength(bytes.length);
+      metadata.setUserMetadata(userMetadata);
+      s3.putObject(key.getBucket(), key.getKey(), new ByteArrayInputStream(bytes), metadata);
+    });
+  }
+
+  /**
+   * using If-None-Match to write object
+   *
+   * @param key          is object key
+   * @param bytes        is content
+   * @param userMetadata is user metadata stored in object metadata
+   * @return true if object is absent when write object
+   */
+  @Override
+  public boolean writeIfAbsent(ObjectKey key, byte[] bytes, Map<String, String> userMetadata) {
+    return cas(() -> {
+      ObjectMetadata metadata = new ObjectMetadata();
+      metadata.setHeader("If-None-Match", "*");
+      metadata.setContentLength(bytes.length);
+      metadata.setUserMetadata(userMetadata);
+      s3.putObject(key.getBucket(), key.getKey(), new ByteArrayInputStream(bytes), metadata);
+    });
+  }
+
+  /**
+   * using x-amz-copy-source-if-match and If-None-Match to copy object
+   *
+   * @param fromKey is source key
+   * @param eTag    is E-Tag of source key
+   * @param toKey   is destination key
+   * @return true if object is copied to destination
+   */
+  @Override
+  public boolean copyObjectIfAbsent(ObjectKey fromKey, String eTag, ObjectKey toKey) {
+    return cas(() -> {
+      CopyObjectRequest request = new CopyObjectRequest(
+          fromKey.getBucket(),
+          fromKey.getKey(),
+          toKey.getBucket(),
+          toKey.getKey());
+      request.setMatchingETagConstraints(Collections.singletonList(eTag));
+      request.putCustomRequestHeader("If-None-Match", "*");
+      s3.copyObject(request);
+    });
+  }
+
+  /**
+   * cas error code
+   *
+   * @param fn is function that sending request
+   * @return true if cas operation succeed
+   */
+  private boolean cas(Runnable fn) {
+    try {
+      fn.run();
+      return true;
+    } catch (AmazonS3Exception e) {
+      if ("PreconditionFailed".equals(e.getErrorCode())) {
+        return false;
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  @Override
+  public void deleteObject(ObjectKey key) {
+    s3.deleteObject(key.getBucket(), key.getKey());
+  }
+
+  @Override
+  public <T> List<T> listDelimiterAll(ObjectKey prefix, Function<ObjectKey, Optional<T>> filterAndMapper) {
+    String delimiter = getKeys().getDelimiter();
+    List<T> result = new ArrayList<>();
+    String prefixKey;
+    if (prefix.getKey().isEmpty()) {
+      prefixKey = "";
+    } else if (prefix.getKey().endsWith(delimiter)) {
+      prefixKey = prefix.getKey();
+    } else {
+      prefixKey = prefix.getKey() + delimiter;
+    }
+    String continuationToken = null;
+    do {
+      ListObjectsV2Result response = s3.listObjectsV2(
+          new ListObjectsV2Request()
+              .withDelimiter(delimiter)
+              .withPrefix(prefixKey)
+              .withContinuationToken(continuationToken));
+      continuationToken = response.getNextContinuationToken();
+      for (S3ObjectSummary objectSummary : response.getObjectSummaries()) {
+        Optional<T> itemOpt = filterAndMapper.apply(new ObjectKey(
+            objectSummary.getBucketName(),
+            objectSummary.getKey()));
+        if (!itemOpt.isPresent()) {
+          continue;
+        }
+        result.add(itemOpt.get());
+      }
+    } while (continuationToken != null);
+    return result;
+  }
+
+  @Override
+  public void close() {
+  }
+}

--- a/dell/src/main/java/org/apache/iceberg/dell/impl/ObjectHeadInfoImpl.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/impl/ObjectHeadInfoImpl.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.dell.impl;
+
+import java.util.Collections;
+import java.util.Map;
+import org.apache.iceberg.dell.ObjectHeadInfo;
+
+/**
+ * a record class of {@link ObjectHeadInfo}
+ */
+public class ObjectHeadInfoImpl implements ObjectHeadInfo {
+  private final long contentLength;
+  private final String eTag;
+  private final Map<String, String> userMetadata;
+
+  public ObjectHeadInfoImpl(long contentLength, String eTag, Map<String, String> userMetadata) {
+    this.contentLength = contentLength;
+    this.eTag = eTag;
+    this.userMetadata = Collections.unmodifiableMap(userMetadata);
+  }
+
+  @Override
+  public long getContentLength() {
+    return contentLength;
+  }
+
+  @Override
+  public String getETag() {
+    return eTag;
+  }
+
+  @Override
+  public Map<String, String> getUserMetadata() {
+    return userMetadata;
+  }
+
+  @Override
+  public String toString() {
+    return "ObjectHeadInfoImpl{" +
+        "contentLength=" + contentLength +
+        ", eTag='" + eTag + '\'' +
+        ", userMetadata=" + userMetadata +
+        '}';
+  }
+}

--- a/dell/src/main/java/org/apache/iceberg/dell/impl/ObjectKeysImpl.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/impl/ObjectKeysImpl.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.dell.impl;
+
+import java.util.List;
+import org.apache.iceberg.dell.ObjectBaseKey;
+import org.apache.iceberg.dell.ObjectKeys;
+
+/**
+ * impl of {@link ObjectKeys}
+ */
+public class ObjectKeysImpl implements ObjectKeys {
+
+  private final ObjectBaseKey baseKey;
+
+  /**
+   * lazy results of {@link #getBaseKeyParts()}
+   */
+  private volatile List<String> lazyBaseKeyParts;
+
+  public ObjectKeysImpl(ObjectBaseKey baseKey) {
+    this.baseKey = baseKey;
+  }
+
+  @Override
+  public ObjectBaseKey getBaseKey() {
+    return baseKey;
+  }
+
+  /**
+   * use field to cache result parts.
+   *
+   * @return cached base key parts
+   */
+  @Override
+  public List<String> getBaseKeyParts() {
+    // code isn't full thread safe. but creating instances in multiple times is fine
+    if (lazyBaseKeyParts == null) {
+      lazyBaseKeyParts = ObjectKeys.super.getBaseKeyParts();
+    }
+    return lazyBaseKeyParts;
+  }
+}

--- a/dell/src/test/java/org/apache/iceberg/dell/MemoryEcsClient.java
+++ b/dell/src/test/java/org/apache/iceberg/dell/MemoryEcsClient.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.dell;
+
+import com.amazonaws.util.Md5Utils;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.iceberg.dell.impl.ContentAndETagImpl;
+import org.apache.iceberg.dell.impl.ObjectHeadInfoImpl;
+import org.apache.iceberg.dell.impl.ObjectKeysImpl;
+
+public class MemoryEcsClient implements EcsClient {
+
+  private final ObjectBaseKey baseKey;
+
+  private final ConcurrentMap<ObjectKey, EcsObject> data = new ConcurrentHashMap<>();
+
+  public MemoryEcsClient(ObjectBaseKey baseKey) {
+    this.baseKey = baseKey;
+  }
+
+  @Override
+  public ObjectKeys getKeys() {
+    return new ObjectKeysImpl(baseKey);
+  }
+
+  @Override
+  public Map<String, String> getProperties() {
+    return null;
+  }
+
+  @Override
+  public Optional<ObjectHeadInfo> head(ObjectKey key) {
+    return Optional.ofNullable(data.get(key)).map(EcsObject::getHeadInfo);
+  }
+
+  @Override
+  public InputStream inputStream(ObjectKey key, long pos) {
+    EcsObject object = data.get(key);
+    byte[] content = object.getContent();
+    return new ByteArrayInputStream(content, (int) pos, content.length);
+  }
+
+  @Override
+  public OutputStream outputStream(ObjectKey key) {
+    return new WrappedOutputStream(key);
+  }
+
+  @Override
+  public ContentAndETag readAll(ObjectKey key) {
+    return data.get(key).getContentAndETag();
+  }
+
+  @Override
+  public boolean replace(ObjectKey key, String eTag, byte[] bytes, Map<String, String> userMetadata) {
+    EcsObject original = data.get(key);
+    if (original == null) {
+      return false;
+    }
+    if (!original.getHeadInfo().getETag().equals(eTag)) {
+      return false;
+    }
+    return data.replace(key, original, EcsObject.create(bytes, userMetadata));
+  }
+
+  @Override
+  public boolean writeIfAbsent(ObjectKey key, byte[] bytes, Map<String, String> userMetadata) {
+    return data.putIfAbsent(key, EcsObject.create(bytes, userMetadata)) == null;
+  }
+
+  @Override
+  public boolean copyObjectIfAbsent(ObjectKey fromKey, String eTag, ObjectKey toKey) {
+    EcsObject original = data.get(fromKey);
+    if (original == null) {
+      return false;
+    }
+    if (!original.getHeadInfo().getETag().equals(eTag)) {
+      return false;
+    }
+    return data.putIfAbsent(toKey, original) == null;
+  }
+
+  @Override
+  public void deleteObject(ObjectKey key) {
+    data.remove(key);
+  }
+
+  @Override
+  public <T> List<T> listDelimiterAll(ObjectKey prefix, Function<ObjectKey, Optional<T>> filterAndMapper) {
+    String delimiter = getKeys().getDelimiter();
+    String prefixKey;
+    if (prefix.getKey().isEmpty()) {
+      prefixKey = "";
+    } else if (prefix.getKey().endsWith(delimiter)) {
+      prefixKey = prefix.getKey();
+    } else {
+      prefixKey = prefix.getKey() + delimiter;
+    }
+    int prefixLength = prefixKey.length();
+    return data.keySet().stream()
+        .filter(key -> {
+          if (!Objects.equals(key.getBucket(), prefix.getBucket())) {
+            return false;
+          }
+          if (!key.getKey().startsWith(prefixKey)) {
+            return false;
+          }
+          return key.getKey().indexOf(delimiter, prefixLength) < 0;
+        })
+        .sorted(Comparator.comparing(ObjectKey::getBucket).thenComparing(ObjectKey::getKey))
+        .flatMap(key -> filterAndMapper.apply(key).map(Stream::of).orElse(Stream.empty()))
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public void close() {
+  }
+
+  public static class EcsObject {
+
+    private final ObjectHeadInfo headInfo;
+    private final byte[] content;
+
+    public EcsObject(ObjectHeadInfo headInfo, byte[] content) {
+      this.headInfo = headInfo;
+      this.content = content;
+    }
+
+    public ObjectHeadInfo getHeadInfo() {
+      return headInfo;
+    }
+
+    public byte[] getContent() {
+      return Arrays.copyOf(content, content.length);
+    }
+
+    public ContentAndETag getContentAndETag() {
+      return new ContentAndETagImpl(getHeadInfo(), getContent());
+    }
+
+    public static EcsObject create(byte[] content, Map<String, String> userMetadata) {
+      return new EcsObject(
+          new ObjectHeadInfoImpl(content.length, Md5Utils.md5AsBase64(content), userMetadata),
+          content);
+    }
+  }
+
+  public class WrappedOutputStream extends OutputStream {
+
+    private final ObjectKey key;
+    private final ByteArrayOutputStream byteArrayOutput = new ByteArrayOutputStream();
+
+    public WrappedOutputStream(ObjectKey key) {
+      this.key = key;
+    }
+
+    @Override
+    public void write(int b) {
+      byteArrayOutput.write(b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) {
+      byteArrayOutput.write(b, off, len);
+    }
+
+    @Override
+    public void close() {
+      data.put(key, EcsObject.create(byteArrayOutput.toByteArray(), Collections.emptyMap()));
+    }
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -38,6 +38,7 @@ include 'spark3-runtime'
 include 'pig'
 include 'hive-metastore'
 include 'nessie'
+include 'dell'
 
 project(':api').name = 'iceberg-api'
 project(':common').name = 'iceberg-common'
@@ -59,6 +60,7 @@ project(':spark3-runtime').name = 'iceberg-spark3-runtime'
 project(':pig').name = 'iceberg-pig'
 project(':hive-metastore').name = 'iceberg-hive-metastore'
 project(':nessie').name = 'iceberg-nessie'
+project(':dell').name = 'iceberg-dell'
 
 if (JavaVersion.current() == JavaVersion.VERSION_1_8) {
   include 'spark2'

--- a/versions.props
+++ b/versions.props
@@ -17,6 +17,7 @@ org.apache.arrow:arrow-vector = 2.0.0
 org.apache.arrow:arrow-memory-netty = 2.0.0
 com.github.stephenc.findbugs:findbugs-annotations = 1.3.9-1
 software.amazon.awssdk:* = 2.15.7
+com.amazonaws:* = 1.11.974
 org.scala-lang:scala-library = 2.12.10
 org.projectnessie:* = 0.5.1
 javax.ws.rs:javax.ws.rs-api = 2.1.1


### PR DESCRIPTION
It's the first part of https://github.com/apache/iceberg/pull/2807 .

Dell EMC ECS is an Object Storage which delivers rich S3-compatibility.

This PR is to add new interfaces that provide several features from the Dell EMC ECS.

The main interface is `EcsClient`, it provides methods like:

1. To get object info.
2. To read and write object with Java InputStream/OutputStream that for data files.
3. To read, replace, write and copy object that for metadata files.
4. To list objects that for fetch concepts such as namespaces and databases.

And there are 2 additional interfaces which provide helper method of client:

1. `PropertiesSerDes` is used to convert `Map<String, String>` to file content. I add a default version value to avoid compatible problems in future.
2. `ObjectKeys` is used to convert name of Iceberg resources to object key.

The `EcsClientImpl` provide the impl that use Amazon AWS S3 Java SDK (V1) to connect with the ECS.
The Amazon AWS S3 Java SDK (V2), used in the `:iceberg-aws` module, doesn't provide extension.

The `MemoryEcsClient` provide the impl that mock all operations of `EcsClient` in memory. I will use in future tests.

