### PR TITLE
Make SparkWriteBuilder and SparkWrite classes public

### DIFF
--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -89,7 +89,7 @@ import static org.apache.iceberg.TableProperties.SPARK_WRITE_PARTITIONED_FANOUT_
 import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT;
 
-class SparkWrite {
+public class SparkWrite {
   private static final Logger LOG = LoggerFactory.getLogger(SparkWrite.class);
 
   private final JavaSparkContext sparkContext;

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
@@ -43,7 +43,7 @@ import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
-class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, SupportsOverwrite {
+public class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, SupportsOverwrite {
 
   private final SparkSession spark;
   private final Table table;


### PR DESCRIPTION
We have some scenarios for which we need to support opinionated writes to Iceberg tables using Spark.
In an attempt to support those, we plan to extend the SparkWriteBuilder and SparkWrite classes. One example of the scenarios we are trying to achieve:

- We want to be able to allow **only** incremental writes to the Iceberg table. If the above classes were made public, we could extend them and block all actions except incremental writes. Either based on a custom table property or even by default.

Please let us know if there are alternative ways for us to support such functionality using Iceberg.

cc: @SreeramGarlapati 