### PR TITLE
Spark: Added ability to add uuid suffix to the table location in Hive catalog

### DIFF
--- a/spark3/src/test/java/org/apache/iceberg/spark/SparkCatalogTestBase.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/SparkCatalogTestBase.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -71,6 +72,12 @@ public abstract class SparkCatalogTestBase extends SparkTestBase {
             "default-namespace", "default",
             "parquet-enabled", "true",
             "cache-enabled", "false" // Spark will delete tables using v1, leaving the cache out of sync
+        ) },
+        { "spark_catalog_with_unique_location", SparkCatalog.class.getName(),
+           ImmutableMap.of(
+            "type", "hive",
+            "default-namespace", "default",
+            HiveCatalog.APPEND_UUID_SUFFIX_TO_TABLE_LOCATION, "true"
         ) }
     };
   }

--- a/spark3/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.spark.SparkCatalogTestBase;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
@@ -40,8 +41,14 @@ import org.junit.Assume;
 import org.junit.Test;
 
 public class TestCreateTable extends SparkCatalogTestBase {
+  private boolean shouldHaveUniqueTableLocation;
+
   public TestCreateTable(String catalogName, String implementation, Map<String, String> config) {
     super(catalogName, implementation, config);
+
+    if ("true".equals(config.get(HiveCatalog.APPEND_UUID_SUFFIX_TO_TABLE_LOCATION))) {
+      this.shouldHaveUniqueTableLocation = true;
+    }
   }
 
   @After
@@ -278,5 +285,25 @@ public class TestCreateTable extends SparkCatalogTestBase {
         IllegalArgumentException.class,
         "Cannot downgrade v2 table to v1",
         () -> sql("ALTER TABLE %s SET TBLPROPERTIES ('format-version'='1')", tableName));
+  }
+
+  @Test
+  public void testCreateTableWithUniqueLocation() {
+    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+    sql("CREATE TABLE %s (id BIGINT NOT NULL, data STRING) USING iceberg", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    Assert.assertNotNull("Should load the new table", table);
+
+    String location = table.location();
+    if (shouldHaveUniqueTableLocation) {
+      String tableNameWithUuidSuffix = ".*[0-9a-f]{8}\\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\\b[0-9a-f]{12}";
+      Assert.assertTrue(
+              "Should have uuid suffix in table name",
+              location.matches(tableNameWithUuidSuffix));
+    } else {
+      Assert.assertTrue("Should end with table name ",
+              location.endsWith(tableIdent.name()));
+    }
   }
 }


### PR DESCRIPTION
Hi, I would like to add ability to have unique table location for each new table in hive catalog.

Let me provide some details why I need it.
We have 2 main engines which works with iceberg tables: trino and spark. For storing metadata we are using Hive metastore. Data and metadata stored on s3. We also have a requirement don't drop table data and metadata when dropping table from hive metastore. It will allow us to restore any dropped table. 

In this PR I added new Catalog property `APPEND_UUID_SUFFIX_TO_TABLE_LOCATION`. If this property is set to `true`, on table create action we will add UUID suffix (like s3://bucket/tableName-UUID) which will be used for building table location.

@RussellSpitzer could you please take a look?  
