### PR TITLE
Core: Add delete table properties for Avro and Parquet

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -58,24 +58,31 @@ public class TableProperties {
   public static final boolean MANIFEST_MERGE_ENABLED_DEFAULT = true;
 
   public static final String DEFAULT_FILE_FORMAT = "write.format.default";
+  public static final String DELETE_DEFAULT_FILE_FORMAT = "write.delete.format.default";
   public static final String DEFAULT_FILE_FORMAT_DEFAULT = "parquet";
 
   public static final String PARQUET_ROW_GROUP_SIZE_BYTES = "write.parquet.row-group-size-bytes";
+  public static final String DELETE_PARQUET_ROW_GROUP_SIZE_BYTES = "write.delete.parquet.row-group-size-bytes";
   public static final String PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT = "134217728"; // 128 MB
 
   public static final String PARQUET_PAGE_SIZE_BYTES = "write.parquet.page-size-bytes";
+  public static final String DELETE_PARQUET_PAGE_SIZE_BYTES = "write.delete.parquet.page-size-bytes";
   public static final String PARQUET_PAGE_SIZE_BYTES_DEFAULT = "1048576"; // 1 MB
 
   public static final String PARQUET_DICT_SIZE_BYTES = "write.parquet.dict-size-bytes";
+  public static final String DELETE_PARQUET_DICT_SIZE_BYTES = "write.delete.parquet.dict-size-bytes";
   public static final String PARQUET_DICT_SIZE_BYTES_DEFAULT = "2097152"; // 2 MB
 
   public static final String PARQUET_COMPRESSION = "write.parquet.compression-codec";
+  public static final String DELETE_PARQUET_COMPRESSION = "write.delete.parquet.compression-codec";
   public static final String PARQUET_COMPRESSION_DEFAULT = "gzip";
 
   public static final String PARQUET_COMPRESSION_LEVEL = "write.parquet.compression-level";
+  public static final String DELETE_PARQUET_COMPRESSION_LEVEL = "write.delete.parquet.compression-level";
   public static final String PARQUET_COMPRESSION_LEVEL_DEFAULT = null;
 
   public static final String AVRO_COMPRESSION = "write.avro.compression-codec";
+  public static final String DELETE_AVRO_COMPRESSION = "write.delete.avro.compression-codec";
   public static final String AVRO_COMPRESSION_DEFAULT = "gzip";
 
   public static final String SPLIT_SIZE = "read.split.target-size";
@@ -142,6 +149,7 @@ public class TableProperties {
   public static final String WRITE_AUDIT_PUBLISH_ENABLED_DEFAULT = "false";
 
   public static final String WRITE_TARGET_FILE_SIZE_BYTES = "write.target-file-size-bytes";
+  public static final String DELETE_TARGET_FILE_SIZE_BYTES = "write.delete.target-file-size-bytes";
   public static final long WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT = 536870912; // 512 MB
 
   public static final String SPARK_WRITE_PARTITIONED_FANOUT_ENABLED = "write.spark.fanout.enabled";

--- a/core/src/main/java/org/apache/iceberg/avro/Avro.java
+++ b/core/src/main/java/org/apache/iceberg/avro/Avro.java
@@ -203,14 +203,14 @@ public class Avro {
         this.codec = codec;
       }
 
-      public static Context dataContext(Map<String, String> config) {
+      static Context dataContext(Map<String, String> config) {
         String codecAsString = config.getOrDefault(AVRO_COMPRESSION, AVRO_COMPRESSION_DEFAULT);
         CodecFactory codec = toCodec(codecAsString);
 
         return new Context(codec);
       }
 
-      public static Context deleteContext(Map<String, String> config) {
+      static Context deleteContext(Map<String, String> config) {
         // default delete config using data config
         Context dataContext = dataContext(config);
 
@@ -228,7 +228,7 @@ public class Avro {
         }
       }
 
-      public CodecFactory codec() {
+      CodecFactory codec() {
         return codec;
       }
     }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -300,7 +300,7 @@ public class Parquet {
         this.compressionLevel = compressionLevel;
       }
 
-      public static Context dataContext(Map<String, String> config) {
+      static Context dataContext(Map<String, String> config) {
         int rowGroupSize = Integer.parseInt(config.getOrDefault(
             PARQUET_ROW_GROUP_SIZE_BYTES, PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT));
 
@@ -318,7 +318,7 @@ public class Parquet {
         return new Context(rowGroupSize, pageSize, dictionaryPageSize, codec, compressionLevel);
       }
 
-      public static Context deleteContext(Map<String, String> config) {
+      static Context deleteContext(Map<String, String> config) {
         // default delete config using data config
         Context dataContext = dataContext(config);
 
@@ -347,23 +347,23 @@ public class Parquet {
         }
       }
 
-      public int rowGroupSize() {
+      int rowGroupSize() {
         return rowGroupSize;
       }
 
-      public int pageSize() {
+      int pageSize() {
         return pageSize;
       }
 
-      public int dictionaryPageSize() {
+      int dictionaryPageSize() {
         return dictionaryPageSize;
       }
 
-      public CompressionCodecName codec() {
+      CompressionCodecName codec() {
         return codec;
       }
 
-      public String compressionLevel() {
+      String compressionLevel() {
         return compressionLevel;
       }
     }


### PR DESCRIPTION
 This PR adds table properties to configure delete Avro and Parquet writers independently of data writers.

It is a subset of the changes in #2827.