### PR TITLE
Core: Fix the NPE in DataFiles.Builder#copy

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DataFiles.java
+++ b/core/src/main/java/org/apache/iceberg/DataFiles.java
@@ -121,7 +121,7 @@ public class DataFiles {
     private FileFormat format = null;
     private long recordCount = -1L;
     private long fileSizeInBytes = -1L;
-    private int sortOrderId = SortOrder.unsorted().orderId();
+    private Integer sortOrderId = SortOrder.unsorted().orderId();
 
     // optional fields
     private Map<Integer, Long> columnSizes = null;

--- a/core/src/main/java/org/apache/iceberg/DataFiles.java
+++ b/core/src/main/java/org/apache/iceberg/DataFiles.java
@@ -176,7 +176,7 @@ public class DataFiles {
       this.keyMetadata = toCopy.keyMetadata() == null ? null
           : ByteBuffers.copy(toCopy.keyMetadata());
       this.splitOffsets = toCopy.splitOffsets() == null ? null : copyList(toCopy.splitOffsets());
-      this.sortOrderId = toCopy.sortOrderId() == null ? SortOrder.unsorted().orderId() : toCopy.sortOrderId();
+      this.sortOrderId = toCopy.sortOrderId();
       return this;
     }
 

--- a/core/src/main/java/org/apache/iceberg/DataFiles.java
+++ b/core/src/main/java/org/apache/iceberg/DataFiles.java
@@ -176,7 +176,7 @@ public class DataFiles {
       this.keyMetadata = toCopy.keyMetadata() == null ? null
           : ByteBuffers.copy(toCopy.keyMetadata());
       this.splitOffsets = toCopy.splitOffsets() == null ? null : copyList(toCopy.splitOffsets());
-      this.sortOrderId = toCopy.sortOrderId();
+      this.sortOrderId = toCopy.sortOrderId() == null ? SortOrder.unsorted().orderId() : toCopy.sortOrderId();
       return this;
     }
 

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataFile.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.ManifestReader;
@@ -160,7 +161,10 @@ public abstract class TestSparkDataFile {
 
     List<DataFile> dataFiles = Lists.newArrayList();
     try (ManifestReader<DataFile> reader = ManifestFiles.read(manifests.get(0), table.io())) {
-      reader.forEach(dataFile -> dataFiles.add(dataFile.copy()));
+      for (DataFile dataFile : reader) {
+        checkDataFile(dataFile.copy(), DataFiles.builder(table.spec()).copy(dataFile).build());
+        dataFiles.add(dataFile.copy());
+      }
     }
 
     Dataset<Row> dataFileDF = spark.read().format("iceberg").load(tableLocation + "#files");


### PR DESCRIPTION
There's a minor bug that was introduced from this [PR](https://github.com/apache/iceberg/pull/1975/files#diff-ac5b4d1edab36f13fd929683cad0f56951ac019353354ac886e84d099d5dd219R179). 

The DataFiles which were deserialized from manifests have a null sortOrderId, that means it will encounter an Exception when we convert the `null` Integer to a primitive int.