### PR TITLE
Add TableLocationSupplier for more flexible table placement

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/TableLocationSupplier.java
+++ b/api/src/main/java/org/apache/iceberg/io/TableLocationSupplier.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.io;
+
+import java.util.Map;
+import java.util.function.Supplier;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.catalog.TableIdentifier;
+
+/**
+ * Supplier interface to allow for customizing table locations based on
+ * contextual information from the table.
+ */
+public interface TableLocationSupplier extends Supplier<String> {
+  default TableLocationSupplier uuid(String uuid) { return this; }
+  default TableLocationSupplier identifier(TableIdentifier identifier) { return this; }
+  default TableLocationSupplier schema(Schema schema) { return this; }
+  default TableLocationSupplier partitionSpec(PartitionSpec partitionSpec) { return this; }
+  default TableLocationSupplier location(String currentLocation) { return this; }
+  default TableLocationSupplier sortOrder(SortOrder sortOrder) { return this; }
+  default TableLocationSupplier properties(Map<String, String> properties) { return this; }
+}

--- a/api/src/main/java/org/apache/iceberg/io/TableLocationSupplier.java
+++ b/api/src/main/java/org/apache/iceberg/io/TableLocationSupplier.java
@@ -1,16 +1,22 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
+
 
 package org.apache.iceberg.io;
 
@@ -26,11 +32,31 @@ import org.apache.iceberg.catalog.TableIdentifier;
  * contextual information from the table.
  */
 public interface TableLocationSupplier extends Supplier<String> {
-  default TableLocationSupplier uuid(String uuid) { return this; }
-  default TableLocationSupplier identifier(TableIdentifier identifier) { return this; }
-  default TableLocationSupplier schema(Schema schema) { return this; }
-  default TableLocationSupplier partitionSpec(PartitionSpec partitionSpec) { return this; }
-  default TableLocationSupplier location(String currentLocation) { return this; }
-  default TableLocationSupplier sortOrder(SortOrder sortOrder) { return this; }
-  default TableLocationSupplier properties(Map<String, String> properties) { return this; }
+  default TableLocationSupplier uuid(String uuid) {
+    return this;
+  }
+
+  default TableLocationSupplier identifier(TableIdentifier identifier) {
+    return this;
+  }
+
+  default TableLocationSupplier schema(Schema schema) {
+    return this;
+  }
+
+  default TableLocationSupplier partitionSpec(PartitionSpec partitionSpec) {
+    return this;
+  }
+
+  default TableLocationSupplier location(String currentLocation) {
+    return this;
+  }
+
+  default TableLocationSupplier sortOrder(SortOrder sortOrder) {
+    return this;
+  }
+
+  default TableLocationSupplier properties(Map<String, String> properties) {
+    return this;
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -159,7 +159,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
     // Return a supplier that mimics the current default warehouse location behavior
     // and preserves the current location for existing replace behavior
     return new TableLocationSupplier() {
-      String currentLocation;
+      private String currentLocation;
 
       @Override
       public TableLocationSupplier location(String currentLocation) {

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -621,7 +621,7 @@ public class TestTableMetadata {
     SortOrder order = SortOrder.builderFor(schema).asc("x").build();
 
     TableMetadata sortedByX = TableMetadata.newTableMetadata(
-        schema, PartitionSpec.unpartitioned(), order, null, ImmutableMap.of());
+        schema, PartitionSpec.unpartitioned(), order, () -> null, ImmutableMap.of());
     Assert.assertEquals("Should have 1 sort order", 1, sortedByX.sortOrders().size());
     Assert.assertEquals("Should use orderId 1", 1, sortedByX.sortOrder().orderId());
     Assert.assertEquals("Should be sorted by one field", 1, sortedByX.sortOrder().fields().size());

--- a/core/src/test/java/org/apache/iceberg/TestTables.java
+++ b/core/src/test/java/org/apache/iceberg/TestTables.java
@@ -58,7 +58,8 @@ public class TestTables {
       throw new AlreadyExistsException("Table %s already exists at location: %s", name, temp);
     }
 
-    ops.commit(null, newTableMetadata(schema, spec, sortOrder, temp.toString(), ImmutableMap.of(), formatVersion));
+    ops.commit(null, newTableMetadata(schema, spec, sortOrder, () -> temp.toString(), ImmutableMap.of(),
+        formatVersion));
 
     return new TestTable(ops, name);
   }
@@ -74,7 +75,7 @@ public class TestTables {
       throw new AlreadyExistsException("Table %s already exists at location: %s", name, temp);
     }
 
-    TableMetadata metadata = newTableMetadata(schema, spec, sortOrder, temp.toString(), ImmutableMap.of(), 1);
+    TableMetadata metadata = newTableMetadata(schema, spec, sortOrder, () -> temp.toString(), ImmutableMap.of(), 1);
 
     return Transactions.createTableTransaction(name, ops, metadata);
   }


### PR DESCRIPTION
Currently table location placement is somewhat restrictive because the base location is defined by the catalog, but doesn't have all relevant information to construct paths for certain scenarios.  The only information available to the catalog is `TableIdentifier`.

Adding a TableLocationSupplier interface allows for more information to be used in defining the location of the table and allow for more flexible layouts and take advantage of other fields that are only populated later in the table creation lifecycle (like uuid, partition spec, sort order, or table properties).

Due to the way the table/metadata creation is performed, this is a little difficult to integrate both cleanly and in a backwards compatible way.

Posting this as a possible approach to allow for more flexible table layouts.