### PR TITLE
Spark: Set properties for deletewriter

### DIFF
--- a/spark/src/main/java/org/apache/iceberg/spark/source/SparkAppenderFactory.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/SparkAppenderFactory.java
@@ -205,6 +205,7 @@ class SparkAppenderFactory implements FileAppenderFactory<InternalRow> {
         case PARQUET:
           return Parquet.writeDeletes(file.encryptingOutputFile())
               .createWriterFunc(msgType -> SparkParquetWriters.buildWriter(lazyEqDeleteSparkType(), msgType))
+              .setAll(properties)
               .overwrite()
               .rowSchema(eqDeleteRowSchema)
               .withSpec(spec)
@@ -216,6 +217,7 @@ class SparkAppenderFactory implements FileAppenderFactory<InternalRow> {
         case AVRO:
           return Avro.writeDeletes(file.encryptingOutputFile())
               .createWriterFunc(ignored -> new SparkAvroWriter(lazyEqDeleteSparkType()))
+              .setAll(properties)
               .overwrite()
               .rowSchema(eqDeleteRowSchema)
               .withSpec(spec)
@@ -243,6 +245,7 @@ class SparkAppenderFactory implements FileAppenderFactory<InternalRow> {
               SparkSchemaUtil.convert(DeleteSchemaUtil.posDeleteSchema(posDeleteRowSchema));
           return Parquet.writeDeletes(file.encryptingOutputFile())
               .createWriterFunc(msgType -> SparkParquetWriters.buildWriter(sparkPosDeleteSchema, msgType))
+              .setAll(properties)
               .overwrite()
               .rowSchema(posDeleteRowSchema)
               .withSpec(spec)
@@ -254,6 +257,7 @@ class SparkAppenderFactory implements FileAppenderFactory<InternalRow> {
         case AVRO:
           return Avro.writeDeletes(file.encryptingOutputFile())
               .createWriterFunc(ignored -> new SparkAvroWriter(lazyPosDeleteSparkType()))
+              .setAll(properties)
               .overwrite()
               .rowSchema(posDeleteRowSchema)
               .withSpec(spec)


### PR DESCRIPTION
DeleteWrite should call `setAll(properties)` to set properties for Parquet and Avro.