### PR TITLE
Spec: Make contains_nan partition summary field optional in v2

### DIFF
--- a/site/docs/spec.md
+++ b/site/docs/spec.md
@@ -490,7 +490,7 @@ Manifest list files store `manifest_file`, a struct with the following fields:
 | v1         | v2         | Field id, name          | Type          | Description |
 | ---------- | ---------- |-------------------------|---------------|-------------|
 | _required_ | _required_ | **`509 contains_null`** | `boolean`     | Whether the manifest contains at least one partition with a null value for the field |
-| _optional_ | _required_ | **`518 contains_nan`**  | `boolean`     | Whether the manifest contains at least one partition with a NaN value for the field |
+| _optional_ | _optional_ | **`518 contains_nan`**  | `boolean`     | Whether the manifest contains at least one partition with a NaN value for the field |
 | _optional_ | _optional_ | **`510 lower_bound`**   | `bytes`   [1] | Lower bound for the non-null, non-NaN values in the partition field, or null if all values are null or NaN [2] |
 | _optional_ | _optional_ | **`511 upper_bound`**   | `bytes`   [1] | Upper bound for the non-null, non-NaN values in the partition field, or null if all values are null or NaN [2] |
 
@@ -1054,8 +1054,6 @@ Writing v2 metadata:
     * `added_rows_count` is now required
     * `existing_rows_count` is now required
     * `deleted_rows_count` is now required
-* Manifest list `field_summary`:
-    * `contains_nan` is now required
 * Manifest key-value metadata:
     * `schema-id` is now required
     * `partition-spec-id` is now required


### PR DESCRIPTION
This was caught by the v2 discussion on the dev list. Because v1 manifests are valid in v2 and a manifest list is written for each snapshot, a writer may not know whether a v1 manifest contains a NaN value in one of its partitions. As a result, the `contains_nan` field of the manifest list's partition summary should not be required.