### PR TITLE
Core: Add validation for row-level deletes with rewrites

### DIFF
--- a/api/src/main/java/org/apache/iceberg/RewriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteFiles.java
@@ -66,8 +66,8 @@ public interface RewriteFiles extends SnapshotUpdate<RewriteFiles> {
   /**
    * Set the snapshot ID used in any reads for this operation.
    * <p>
-   * Validations will check changes after this snapshot ID. If the from snapshot is not set, all ancestor snapshots
-   * through the table's initial snapshot are validated.
+   * Validations will check changes after this snapshot ID. If this is not called, all ancestor snapshots through the
+   * table's initial snapshot are validated.
    *
    * @param snapshotId a snapshot ID
    * @return this for method chaining

--- a/api/src/main/java/org/apache/iceberg/RewriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteFiles.java
@@ -54,12 +54,23 @@ public interface RewriteFiles extends SnapshotUpdate<RewriteFiles> {
   /**
    * Add a rewrite that replaces one set of files with another set that contains the same data.
    *
-   * @param dataFilesToDelete   data files that will be replaced (deleted).
-   * @param deleteFilesToDelete delete files that will be replaced (deleted).
+   * @param dataFilesToReplace   data files that will be replaced (deleted).
+   * @param deleteFilesToReplace delete files that will be replaced (deleted).
    * @param dataFilesToAdd      data files that will be added.
    * @param deleteFilesToAdd    delete files that will be added.
    * @return this for method chaining.
    */
-  RewriteFiles rewriteFiles(Set<DataFile> dataFilesToDelete, Set<DeleteFile> deleteFilesToDelete,
+  RewriteFiles rewriteFiles(Set<DataFile> dataFilesToReplace, Set<DeleteFile> deleteFilesToReplace,
                             Set<DataFile> dataFilesToAdd, Set<DeleteFile> deleteFilesToAdd);
+
+  /**
+   * Set the snapshot ID used in any reads for this operation.
+   * <p>
+   * Validations will check changes after this snapshot ID. If the from snapshot is not set, all ancestor snapshots
+   * through the table's initial snapshot are validated.
+   *
+   * @param snapshotId a snapshot ID
+   * @return this for method chaining
+   */
+  RewriteFiles validateFromSnapshot(long snapshotId);
 }

--- a/core/src/main/java/org/apache/iceberg/BaseRowDelta.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRowDelta.java
@@ -94,6 +94,7 @@ class BaseRowDelta extends MergingSnapshotProducer<RowDelta> implements RowDelta
         validateDataFilesExist(base, startingSnapshotId, referencedDataFiles, !validateDeletes);
       }
 
+      // TODO: does this need to check new delete files?
       if (conflictDetectionFilter != null) {
         validateAddedDataFiles(base, startingSnapshotId, conflictDetectionFilter, caseSensitive);
       }

--- a/core/src/main/java/org/apache/iceberg/BaseRowDelta.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRowDelta.java
@@ -94,7 +94,6 @@ class BaseRowDelta extends MergingSnapshotProducer<RowDelta> implements RowDelta
         validateDataFilesExist(base, startingSnapshotId, referencedDataFiles, !validateDeletes);
       }
 
-      // TODO: does this need to check new delete files?
       if (conflictDetectionFilter != null) {
         validateAddedDataFiles(base, startingSnapshotId, conflictDetectionFilter, caseSensitive);
       }

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -41,6 +41,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.CharSequenceSet;
+import org.apache.iceberg.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,6 +63,9 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
       ImmutableSet.of(DataOperations.OVERWRITE, DataOperations.REPLACE, DataOperations.DELETE);
   private static final Set<String> VALIDATE_DATA_FILES_EXIST_SKIP_DELETE_OPERATIONS =
       ImmutableSet.of(DataOperations.OVERWRITE, DataOperations.REPLACE);
+  // delete files are only added in "overwrite" operations
+  private static final Set<String> VALIDATE_REPLACED_DATA_FILES_OPERATIONS =
+      ImmutableSet.of(DataOperations.OVERWRITE);
 
   private final String tableName;
   private final TableOperations ops;
@@ -253,28 +257,10 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
       return;
     }
 
-    List<ManifestFile> manifests = Lists.newArrayList();
-    Set<Long> newSnapshots = Sets.newHashSet();
-
-    Long currentSnapshotId = base.currentSnapshot().snapshotId();
-    while (currentSnapshotId != null && !currentSnapshotId.equals(startingSnapshotId)) {
-      Snapshot currentSnapshot = ops.current().snapshot(currentSnapshotId);
-
-      ValidationException.check(currentSnapshot != null,
-          "Cannot determine history between starting snapshot %s and current %s",
-          startingSnapshotId, currentSnapshotId);
-
-      if (VALIDATE_ADDED_FILES_OPERATIONS.contains(currentSnapshot.operation())) {
-        newSnapshots.add(currentSnapshotId);
-        for (ManifestFile manifest : currentSnapshot.dataManifests()) {
-          if (manifest.snapshotId() == (long) currentSnapshotId) {
-            manifests.add(manifest);
-          }
-        }
-      }
-
-      currentSnapshotId = currentSnapshot.parentId();
-    }
+    Pair<List<ManifestFile>, Set<Long>> history =
+        validationHistory(base, startingSnapshotId, VALIDATE_ADDED_FILES_OPERATIONS, ManifestContent.DATA);
+    List<ManifestFile> manifests = history.first();
+    Set<Long> newSnapshots = history.second();
 
     ManifestGroup conflictGroup = new ManifestGroup(ops.io(), manifests, ImmutableList.of())
         .caseSensitive(caseSensitive)
@@ -297,6 +283,38 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
     }
   }
 
+  /**
+   * Validates that no new delete files have been added to the table since a starting snapshot.
+   *
+   * @param base table metadata to validate
+   * @param startingSnapshotId id of the snapshot current at the start of the operation
+   * @param dataFiles data files to validate have no new row deletes
+   */
+  protected void validateNoNewDeletesForDataFiles(TableMetadata base, Long startingSnapshotId,
+                                                  Iterable<DataFile> dataFiles) {
+    // if there is no current table state, no files have been added
+    if (base.currentSnapshot() == null) {
+      return;
+    }
+
+    Pair<List<ManifestFile>, Set<Long>> history =
+        validationHistory(base, startingSnapshotId, VALIDATE_REPLACED_DATA_FILES_OPERATIONS, ManifestContent.DELETES);
+    List<ManifestFile> deleteManifests = history.first();
+
+    long startingSequenceNumber = startingSnapshotId == null ? 0 : base.snapshot(startingSnapshotId).sequenceNumber();
+    DeleteFileIndex deletes = DeleteFileIndex.builderFor(ops.io(), deleteManifests)
+        .afterSequenceNumber(startingSequenceNumber)
+        .specsById(ops.current().specsById())
+        .build();
+
+    for (DataFile dataFile : dataFiles) {
+      // if any delete is found that applies to files written in or before the starting snapshot, fail
+      if (deletes.forDataFile(startingSequenceNumber, dataFile).length > 0) {
+        throw new ValidationException("Cannot commit, found new delete for replaced data file: %s", dataFile);
+      }
+    }
+  }
+
   @SuppressWarnings("CollectionUndefinedEquality")
   protected void validateDataFilesExist(TableMetadata base, Long startingSnapshotId,
                                         CharSequenceSet requiredDataFiles, boolean skipDeletes) {
@@ -309,28 +327,10 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
         VALIDATE_DATA_FILES_EXIST_SKIP_DELETE_OPERATIONS :
         VALIDATE_DATA_FILES_EXIST_OPERATIONS;
 
-    List<ManifestFile> manifests = Lists.newArrayList();
-    Set<Long> newSnapshots = Sets.newHashSet();
-
-    Long currentSnapshotId = base.currentSnapshot().snapshotId();
-    while (currentSnapshotId != null && !currentSnapshotId.equals(startingSnapshotId)) {
-      Snapshot currentSnapshot = ops.current().snapshot(currentSnapshotId);
-
-      ValidationException.check(currentSnapshot != null,
-          "Cannot determine history between starting snapshot %s and current %s",
-          startingSnapshotId, currentSnapshotId);
-
-      if (matchingOperations.contains(currentSnapshot.operation())) {
-        newSnapshots.add(currentSnapshotId);
-        for (ManifestFile manifest : currentSnapshot.dataManifests()) {
-          if (manifest.snapshotId() == (long) currentSnapshotId) {
-            manifests.add(manifest);
-          }
-        }
-      }
-
-      currentSnapshotId = currentSnapshot.parentId();
-    }
+    Pair<List<ManifestFile>, Set<Long>> history =
+        validationHistory(base, startingSnapshotId, matchingOperations, ManifestContent.DATA);
+    List<ManifestFile> manifests = history.first();
+    Set<Long> newSnapshots = history.second();
 
     ManifestGroup matchingDeletesGroup = new ManifestGroup(ops.io(), manifests, ImmutableList.of())
         .filterManifestEntries(entry -> entry.status() != ManifestEntry.Status.ADDED &&
@@ -347,6 +347,43 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to validate required files exist", e);
     }
+  }
+
+  private Pair<List<ManifestFile>, Set<Long>> validationHistory(TableMetadata base, Long startingSnapshotId,
+                                                                Set<String> matchingOperations,
+                                                                ManifestContent content) {
+    List<ManifestFile> manifests = Lists.newArrayList();
+    Set<Long> newSnapshots = Sets.newHashSet();
+
+    Long currentSnapshotId = base.currentSnapshot().snapshotId();
+    while (currentSnapshotId != null && !currentSnapshotId.equals(startingSnapshotId)) {
+      Snapshot currentSnapshot = ops.current().snapshot(currentSnapshotId);
+
+      ValidationException.check(currentSnapshot != null,
+          "Cannot determine history between starting snapshot %s and current %s",
+          startingSnapshotId, currentSnapshotId);
+
+      if (matchingOperations.contains(currentSnapshot.operation())) {
+        newSnapshots.add(currentSnapshotId);
+        if (content == ManifestContent.DATA) {
+          for (ManifestFile manifest : currentSnapshot.dataManifests()) {
+            if (manifest.snapshotId() == (long) currentSnapshotId) {
+              manifests.add(manifest);
+            }
+          }
+        } else {
+          for (ManifestFile manifest : currentSnapshot.deleteManifests()) {
+            if (manifest.snapshotId() == (long) currentSnapshotId) {
+              manifests.add(manifest);
+            }
+          }
+        }
+      }
+
+      currentSnapshotId = currentSnapshot.parentId();
+    }
+
+    return Pair.of(manifests, newSnapshots);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -284,7 +284,8 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
   }
 
   /**
-   * Validates that no new delete files have been added to the table since a starting snapshot.
+   * Validates that no new delete files that must be applied to the given data files have been added to the table since
+   * a starting snapshot.
    *
    * @param base table metadata to validate
    * @param startingSnapshotId id of the snapshot current at the start of the operation

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -63,9 +63,9 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
       ImmutableSet.of(DataOperations.OVERWRITE, DataOperations.REPLACE, DataOperations.DELETE);
   private static final Set<String> VALIDATE_DATA_FILES_EXIST_SKIP_DELETE_OPERATIONS =
       ImmutableSet.of(DataOperations.OVERWRITE, DataOperations.REPLACE);
-  // delete files are only added in "overwrite" operations
+  // delete files can be added in "overwrite" or "delete" operations
   private static final Set<String> VALIDATE_REPLACED_DATA_FILES_OPERATIONS =
-      ImmutableSet.of(DataOperations.OVERWRITE);
+      ImmutableSet.of(DataOperations.OVERWRITE, DataOperations.DELETE);
 
   private final String tableName;
   private final TableOperations ops;

--- a/spark/src/test/java/org/apache/iceberg/spark/actions/TestNewRewriteDataFilesAction.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/actions/TestNewRewriteDataFilesAction.java
@@ -395,7 +395,7 @@ public abstract class TestNewRewriteDataFilesAction extends SparkTestBase {
 
     doReturn(util)
         .when(spyRewrite)
-        .commitManager();
+        .commitManager(table.currentSnapshot().snapshotId());
 
     AssertHelpers.assertThrows("Should fail entire rewrite if commit fails", RuntimeException.class,
         () -> spyRewrite.execute());
@@ -548,7 +548,7 @@ public abstract class TestNewRewriteDataFilesAction extends SparkTestBase {
 
     doReturn(util)
         .when(spyRewrite)
-        .commitManager();
+        .commitManager(table.currentSnapshot().snapshotId());
 
     RewriteDataFiles.Result result = spyRewrite.execute();
 
@@ -608,7 +608,7 @@ public abstract class TestNewRewriteDataFilesAction extends SparkTestBase {
 
     doReturn(util)
         .when(spyAction)
-        .commitManager();
+        .commitManager(table.currentSnapshot().snapshotId());
 
     AssertHelpers.assertThrows("Should propagate CommitStateUnknown Exception",
         CommitStateUnknownException.class, () -> spyAction.execute());


### PR DESCRIPTION
This adds a new validation for `RewriteFiles` that checks whether delete files have been added for any of the files that are being rewritten. The check constructs a delete file index for all the delete files in snapshots written since a starting snapshot and filters the delete file entries using the sequence number of the starting snapshot to ensure that only delete files that were added after the starting snapshot are indexed. Next, if any data file being replaced matches a delete file in the index, a validation exception is thrown.

This also updates actions to correctly set the starting snapshot ID for validation.

This fixes #2308.