### PR TITLE
Flink: Auto compact file

### DIFF
--- a/core/src/main/java/org/apache/iceberg/GenericDataFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericDataFile.java
@@ -26,7 +26,7 @@ import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
 
-class GenericDataFile extends BaseFile<DataFile> implements DataFile {
+public class GenericDataFile extends BaseFile<DataFile> implements DataFile {
   /**
    * Used by Avro reflection to instantiate this class when reading manifest files.
    */

--- a/core/src/main/java/org/apache/iceberg/PartitionData.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionData.java
@@ -36,7 +36,7 @@ import org.apache.iceberg.relocated.com.google.common.hash.Hashing;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 
-class PartitionData
+public class PartitionData
     implements IndexedRecord, StructLike, SpecificData.SchemaConstructable, Serializable {
 
   static Schema partitionDataSchema(Types.StructType partitionType) {

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -188,4 +188,7 @@ public class TableProperties {
 
   public static final String MERGE_CARDINALITY_CHECK_ENABLED = "write.merge.cardinality-check.enabled";
   public static final boolean MERGE_CARDINALITY_CHECK_ENABLED_DEFAULT = true;
+
+  public static final String WRITE_AUTO_COMPACT_FILES = "write.auto-compact-files";
+  public static final boolean WRITE_AUTO_COMPACT_FILES_DEFAULT = false;
 }

--- a/flink/src/main/java/org/apache/iceberg/flink/actions/SyncRewriteDataFilesAction.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/actions/SyncRewriteDataFilesAction.java
@@ -102,9 +102,9 @@ public class SyncRewriteDataFilesAction extends BaseRewriteDataFilesAction<SyncR
       List<DataFile> dataFiles = new ArrayList<>();
       // Initialize the task writer.
       this.writer = taskWriterFactory.create();
-      for (CombinedScanTask task:combinedScanTask) {
+      for (CombinedScanTask task : combinedScanTask) {
         try (RowDataIterator iterator =
-                     new RowDataIterator(task, io, encryptionManager, schema, schema, nameMapping, caseSensitive)) {
+            new RowDataIterator(task, io, encryptionManager, schema, schema, nameMapping, caseSensitive)) {
           while (iterator.hasNext()) {
             RowData rowData = iterator.next();
             writer.write(rowData);
@@ -131,7 +131,6 @@ public class SyncRewriteDataFilesAction extends BaseRewriteDataFilesAction<SyncR
       }
       return dataFiles;
     }
-
   }
 
   @Override

--- a/flink/src/main/java/org/apache/iceberg/flink/actions/SyncRewriteDataFilesAction.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/actions/SyncRewriteDataFilesAction.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.flink.actions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.actions.BaseRewriteDataFilesAction;
+import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.sink.RowDataTaskWriterFactory;
+import org.apache.iceberg.flink.sink.TaskWriterFactory;
+import org.apache.iceberg.flink.source.RowDataIterator;
+import org.apache.iceberg.flink.source.RowDataRewriter;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.TaskWriter;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.PropertyUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.iceberg.TableProperties.DEFAULT_NAME_MAPPING;
+
+public class SyncRewriteDataFilesAction extends BaseRewriteDataFilesAction<SyncRewriteDataFilesAction> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RowDataRewriter.class);
+
+    private final Schema schema;
+    private final FileFormat format;
+    private final String nameMapping;
+    private final FileIO io;
+    private final boolean caseSensitive;
+    private final EncryptionManager encryptionManager;
+    private final TaskWriterFactory<RowData> taskWriterFactory;
+    private TaskWriter<RowData> writer;
+    private int subTaskId;
+    private int attemptId;
+    private Exception exception;
+
+    public SyncRewriteDataFilesAction(Table table, int subTaskId, int attemptId) {
+        super(table);
+        this.schema = table.schema();
+        this.caseSensitive = caseSensitive();
+        this.io = fileIO();
+        this.encryptionManager = encryptionManager();
+        this.nameMapping = PropertyUtil.propertyAsString(table.properties(), DEFAULT_NAME_MAPPING, null);
+
+        String formatString = PropertyUtil.propertyAsString(table.properties(), TableProperties.DEFAULT_FILE_FORMAT,
+                TableProperties.DEFAULT_FILE_FORMAT_DEFAULT);
+        this.format = FileFormat.valueOf(formatString.toUpperCase(Locale.ENGLISH));
+        RowType flinkSchema = FlinkSchemaUtil.convert(table.schema());
+        this.taskWriterFactory = new RowDataTaskWriterFactory(
+                table.schema(),
+                flinkSchema,
+                table.spec(),
+                table.locationProvider(),
+                io,
+                encryptionManager,
+                Long.MAX_VALUE,
+                format,
+                table.properties(),
+                null);
+
+        // Initialize the task writer factory.
+        this.taskWriterFactory.initialize(subTaskId, attemptId);
+        this.subTaskId = subTaskId;
+        this.attemptId = attemptId;
+    }
+
+    @Override
+    protected FileIO fileIO() {
+        return table().io();
+    }
+
+    @Override
+    protected List<DataFile> rewriteDataForTasks(List<CombinedScanTask> combinedScanTask) {
+        List<DataFile> dataFiles = new ArrayList<>();
+        // Initialize the task writer.
+        this.writer = taskWriterFactory.create();
+        for (CombinedScanTask task:combinedScanTask) {
+            try (RowDataIterator iterator =
+                         new RowDataIterator(task, io, encryptionManager, schema, schema, nameMapping, caseSensitive)) {
+                while (iterator.hasNext()) {
+                    RowData rowData = iterator.next();
+                    writer.write(rowData);
+                }
+                dataFiles.addAll(Lists.newArrayList(writer.dataFiles()));
+            } catch (Throwable originalThrowable) {
+                try {
+                    LOG.error("Aborting commit for  (subTaskId {}, attemptId {})", subTaskId, attemptId);
+                    writer.abort();
+                    LOG.error("Aborted commit for  (subTaskId {}, attemptId {})", subTaskId, attemptId);
+                } catch (Throwable inner) {
+                    if (originalThrowable != inner) {
+                        originalThrowable.addSuppressed(inner);
+                        LOG.warn("Suppressing exception in catch: {}", inner.getMessage(), inner);
+                    }
+                }
+
+                if (originalThrowable instanceof Exception) {
+                    this.exception = (Exception) originalThrowable;
+                } else {
+                    this.exception = new RuntimeException(originalThrowable);
+                }
+            }
+        }
+        return dataFiles;
+    }
+
+    @Override
+    protected SyncRewriteDataFilesAction self() {
+        return this;
+    }
+
+    public Exception getException() {
+        return this.exception;
+    }
+}

--- a/flink/src/main/java/org/apache/iceberg/flink/actions/SyncRewriteDataFilesAction.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/actions/SyncRewriteDataFilesAction.java
@@ -1,15 +1,20 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.iceberg.flink.actions;
@@ -31,7 +36,6 @@ import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.sink.RowDataTaskWriterFactory;
 import org.apache.iceberg.flink.sink.TaskWriterFactory;
 import org.apache.iceberg.flink.source.RowDataIterator;
-import org.apache.iceberg.flink.source.RowDataRewriter;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.TaskWriter;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -241,7 +241,9 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
 
       if (rewriteDataFilesAction != null) {
         rewriteDataFilesAction.execute();
-        if (action.getException() != null) throw action.getException();
+        if (action.getException() != null) {
+          throw action.getException();
+        }
       }
     }
   }

--- a/flink/src/main/java/org/apache/iceberg/flink/source/RowDataIterator.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/source/RowDataIterator.java
@@ -47,14 +47,14 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.PartitionUtil;
 
-class RowDataIterator extends DataIterator<RowData> {
+public class RowDataIterator extends DataIterator<RowData> {
 
   private final Schema tableSchema;
   private final Schema projectedSchema;
   private final String nameMapping;
   private final boolean caseSensitive;
 
-  RowDataIterator(CombinedScanTask task, FileIO io, EncryptionManager encryption, Schema tableSchema,
+  public RowDataIterator(CombinedScanTask task, FileIO io, EncryptionManager encryption, Schema tableSchema,
                   Schema projectedSchema, String nameMapping, boolean caseSensitive) {
     super(task, io, encryption);
     this.tableSchema = tableSchema;


### PR DESCRIPTION
This add one feature that flink write iceberg auto compact small files. And add config "write.auto-compact-files".
When we insert data into iceberg will generate much small files, so i try to auto compact small files when we use flink insert into iceberg. 
In this PR, in the flink function IcebergFilesCommitter.snapshotState(the first step of flink checkpoint) will generate one rewriteaction. And we get all partitions this transcation related to generate partition filter, then set partition filter to this rewriteaction so that we will compact files group by partition. 
The last step will add the rewriteaction in flink function IcebergFilesCommitter.notifyCheckpointComplete(the last step of flink checkpoint). In IcebergFilesCommitter.notifyCheckpointComplete will commit transcation first, then this function will execute rewriteaction.

