### PR TITLE
Core: added includeColumnStats option in FindFiles API

### DIFF
--- a/core/src/main/java/org/apache/iceberg/FindFiles.java
+++ b/core/src/main/java/org/apache/iceberg/FindFiles.java
@@ -44,6 +44,7 @@ public class FindFiles {
     private final Table table;
     private final TableOperations ops;
     private boolean caseSensitive = true;
+    private boolean includeColumnStats = false;
     private Long snapshotId = null;
     private Expression rowFilter = Expressions.alwaysTrue();
     private Expression fileFilter = Expressions.alwaysTrue();
@@ -61,6 +62,11 @@ public class FindFiles {
 
     public Builder caseSensitive(boolean findCaseSensitive) {
       this.caseSensitive = findCaseSensitive;
+      return this;
+    }
+
+    public Builder includeColumnStats() {
+      this.includeColumnStats = true;
       return this;
     }
 
@@ -206,7 +212,8 @@ public class FindFiles {
           .caseSensitive(caseSensitive)
           .entries();
 
-      return CloseableIterable.transform(entries, entry -> entry.file().copyWithoutStats());
+      return CloseableIterable.transform(entries,
+          entry -> includeColumnStats ? entry.file().copy() : entry.file().copyWithoutStats());
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TableTestBase.java
@@ -28,11 +28,13 @@ import java.util.stream.LongStream;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.io.Files;
+import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Types;
 import org.junit.After;
 import org.junit.Assert;
@@ -129,6 +131,20 @@ public class TableTestBase {
       .withFileSizeInBytes(10)
       .withPartition(TestHelpers.Row.of(3))
       .withRecordCount(1)
+      .build();
+  static final DataFile FILE_WITH_STATS = DataFiles.builder(SPEC)
+      .withPath("/path/to/data-with-stats.parquet")
+      .withMetrics(new Metrics(10L,
+          ImmutableMap.of(3, 100L, 4, 200L), // column sizes
+          ImmutableMap.of(3, 90L, 4, 180L), // value counts
+          ImmutableMap.of(3, 10L, 4, 20L), // null value counts
+          ImmutableMap.of(3, 0L, 4, 0L), // nan value counts
+          ImmutableMap.of(3, Conversions.toByteBuffer(Types.IntegerType.get(), 1),
+             4, Conversions.toByteBuffer(Types.IntegerType.get(), 2)),  // lower bounds
+          ImmutableMap.of(3, Conversions.toByteBuffer(Types.IntegerType.get(), 5),
+             4, Conversions.toByteBuffer(Types.IntegerType.get(), 10))  // upperbounds
+          ))
+      .withFileSizeInBytes(350)
       .build();
 
   static final FileIO FILE_IO = new TestTables.LocalFileIO();

--- a/core/src/test/java/org/apache/iceberg/TestFindFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestFindFiles.java
@@ -191,6 +191,25 @@ public class TestFindFiles extends TableTestBase {
   }
 
   @Test
+  public void testIncludeColumnStats() {
+    table.newAppend()
+        .appendFile(FILE_WITH_STATS)
+        .commit();
+
+    Iterable<DataFile> files = FindFiles.in(table)
+        .includeColumnStats()
+        .collect();
+    final DataFile file = files.iterator().next();
+
+    Assert.assertEquals(FILE_WITH_STATS.columnSizes(), file.columnSizes());
+    Assert.assertEquals(FILE_WITH_STATS.valueCounts(), file.valueCounts());
+    Assert.assertEquals(FILE_WITH_STATS.nullValueCounts(), file.nullValueCounts());
+    Assert.assertEquals(FILE_WITH_STATS.nanValueCounts(), file.nanValueCounts());
+    Assert.assertEquals(FILE_WITH_STATS.lowerBounds(), file.lowerBounds());
+    Assert.assertEquals(FILE_WITH_STATS.upperBounds(), file.upperBounds());
+  }
+
+  @Test
   public void testNoSnapshot() {
     // a table has no snapshot when it just gets created and no data is loaded yet
 


### PR DESCRIPTION
This PR  added includeColumnStats option in FindFiles API so that we can choose to remain column stat when select data files and commit them to other iceberg table.
Reference #2870  
@openinx 