### PR TITLE
[python] Adding utility functions for converting iceberg to arrow

### DIFF
--- a/python/iceberg/parquet/iceberg_to_arrow.py
+++ b/python/iceberg/parquet/iceberg_to_arrow.py
@@ -1,0 +1,107 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+import json
+from typing import Callable, Dict
+
+from iceberg.api import Schema
+from iceberg.api.types import NestedField, TypeID
+from iceberg.core import SchemaParser
+import pyarrow as pa
+
+
+ICEBERG_TO_ARROW_MAP: Dict[TypeID, Callable] = {
+    TypeID.BOOLEAN: lambda type_var: pa.lib.bool_(),
+    TypeID.BINARY: lambda type_var: pa.lib.binary(),
+    TypeID.DATE: lambda type_var: pa.lib.date32(),
+    TypeID.DECIMAL: lambda type_var: pa.lib.decimal128(type_var.precision, type_var.scale),
+    TypeID.DOUBLE: lambda type_var: pa.lib.float64(),
+    TypeID.FIXED: lambda type_var: pa.lib.binary(length=type_var.length),
+    TypeID.FLOAT: lambda type_var: pa.lib.float32(),
+    TypeID.INTEGER: lambda type_var: pa.lib.int32(),
+    TypeID.LIST: lambda type_var: convert_field(type_var),
+    TypeID.LONG: lambda type_var: pa.lib.int64(),
+    TypeID.MAP: lambda type_var: convert_field(type_var),
+    TypeID.STRING: lambda type_var: pa.lib.string(),
+    TypeID.STRUCT: lambda type_var: convert_field(type_var),
+    TypeID.TIME: lambda type_var: pa.lib.time64("us"),
+    TypeID.TIMESTAMP: lambda type_var: pa.timestamp("us", tz="UTC" if type_var.adjust_to_utc else None),
+}
+
+
+def iceberg_to_arrow(iceberg_schema: Schema) -> pa.Schema:
+    """
+    Use an iceberg schema, to create an equivalent arrow schema with intact field_id metadata
+
+    Parameters
+    ----------
+    iceberg_schema : Schema
+        An iceberg schema to map
+
+    Returns
+    -------
+    pyarrow.Schema
+        returns an equivalent pyarrow Schema based on the iceberg schema provided. Performs
+    """
+    arrow_fields = []
+    for field in iceberg_schema.as_struct().fields:
+        arrow_fields.append(convert_field(field))
+
+    return pa.schema(arrow_fields,
+                     metadata={b'iceberg.schema': json.dumps(SchemaParser.to_dict(iceberg_schema)).encode("utf-8")})
+
+
+def convert_field(iceberg_field: NestedField) -> pa.Field:
+    """
+        Map an iceberg field to a pyarrow field. Recursively calls itself for nested fields
+        there is currently a limitation in the ability to convert map types since the pyarrow python bindings
+        don't expose a way to set fields for the key and value fields in a map
+
+        Parameters
+        ----------
+        iceberg_field: NestedField
+            An iceberg schema to map
+
+        Returns
+        -------
+        pa.Field
+            returns an equivalent pyarow Field based on the Nested Field.
+        """
+    if iceberg_field.type.is_primitive_type():
+        try:
+            arrow_field = ICEBERG_TO_ARROW_MAP[iceberg_field.type.type_id](iceberg_field.type)
+        except KeyError:
+            raise ValueError(f"Unable to convert {iceberg_field}")
+
+    elif iceberg_field.type.type_id == TypeID.STRUCT:
+        arrow_field = pa.struct([convert_field(field) for field in iceberg_field.type.fields])
+    elif iceberg_field.type.type_id == TypeID.LIST:
+        try:
+            arrow_field = pa.list_(ICEBERG_TO_ARROW_MAP[iceberg_field.type.type_id](iceberg_field.type.element_field))
+        except KeyError:
+            raise ValueError(f"Unable to convert {iceberg_field.type}")
+    elif iceberg_field.type.type_id == TypeID.MAP:
+        raise NotImplementedError("Unable to serialize Map types; python arrow bindings can't pass key/val metadata")
+
+    else:
+        raise ValueError(f"Unable to convert {iceberg_field}")
+
+    return pa.field(iceberg_field.name,
+                    arrow_field,
+                    iceberg_field.is_optional,
+                    {b'PARQUET:field_id': str(iceberg_field.id).encode("utf-8")})

--- a/python/tests/parquet/conftest.py
+++ b/python/tests/parquet/conftest.py
@@ -21,14 +21,21 @@ from decimal import Decimal
 from tempfile import NamedTemporaryFile
 
 from iceberg.api import Schema
-from iceberg.api.types import (DateType,
+from iceberg.api.types import (BinaryType,
+                               DateType,
                                DecimalType,
+                               DoubleType,
+                               FixedType,
                                FloatType,
                                IntegerType,
+                               ListType,
                                LongType,
+                               MapType,
                                NestedField,
                                StringType,
-                               TimestampType)
+                               StructType,
+                               TimestampType,
+                               TimeType)
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
@@ -224,3 +231,55 @@ def parquet_schema(type_test_parquet_file):
 @pytest.fixture(scope="session")
 def arrow_schema(type_test_parquet_file):
     return type_test_parquet_file.schema_arrow
+
+
+@pytest.fixture(scope="session")
+def iceberg_primitive_schema():
+    return Schema([NestedField.required(1, "int_col", IntegerType.get()),
+                   NestedField.required(2, "long_col", LongType.get()),
+                   NestedField.required(3, "float_col", FloatType.get()),
+                   NestedField.required(4, "double_col", DoubleType.get()),
+                   NestedField.required(5, "decimal_col", DecimalType.of(38, 5)),
+                   NestedField.required(6, "date_col", DateType.get()),
+                   NestedField.required(7, "string_col", StringType.get()),
+                   NestedField.required(8, "time_col", TimeType.get()),
+                   NestedField.required(9, "ts_col", TimestampType.without_timezone()),
+                   NestedField.required(10, "ts_w_tz_col", TimestampType.with_timezone()),
+                   NestedField.required(11, "bin_col", BinaryType.get()),
+                   NestedField.required(12, "fixed_bin_col", FixedType.of_length(10))
+                   ])
+
+
+@pytest.fixture(scope="session")
+def iceberg_struct_schema():
+    struct_type = StructType.of([NestedField.required(2, "a", IntegerType.get()),
+                                 NestedField.required(3, "b", IntegerType.get())])
+    return Schema([NestedField.required(1, "struct_col", struct_type)])
+
+
+@pytest.fixture(scope="session")
+def iceberg_map_schema():
+    map_type = MapType.of_required(2, 3, IntegerType.get(), StringType.get())
+    return Schema([NestedField.required(1, "map_col", map_type)])
+
+
+@pytest.fixture(scope="session")
+def iceberg_simple_nullability_schema():
+    return Schema([NestedField.required(1, "int_col", IntegerType.get()),
+                   NestedField.optional(2, "long_col", LongType.get())])
+
+
+@pytest.fixture(scope="session")
+def iceberg_nested_nullability_schema():
+    struct_type = StructType.of([NestedField.required(3, "a", IntegerType.get()),
+                                 NestedField.optional(4, "b", IntegerType.get())])
+    list_type = ListType.of_optional(5, IntegerType.get())
+    return Schema([NestedField.optional(1, "struct_col", struct_type),
+                   NestedField.required(2, "list_col", list_type)])
+
+
+@pytest.fixture(scope="session")
+def iceberg_list_schema():
+    return Schema([NestedField.required(1,
+                                        "list_col",
+                                        ListType.of_required("2", IntegerType.get()))])

--- a/python/tests/parquet/test_iceberg_to_arrow.py
+++ b/python/tests/parquet/test_iceberg_to_arrow.py
@@ -1,0 +1,83 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from iceberg.parquet.iceberg_to_arrow import iceberg_to_arrow
+import pyarrow as pa
+
+
+def schema_equals(base: pa.Schema, other: pa.Schema):
+    for i in range(len(base.names)):
+        assert base.field(i) == other.field(i)
+
+    return True
+
+
+def test_convert_primitives(iceberg_primitive_schema):
+    expected_arrow_schema = pa.schema([pa.field("int_col", pa.int32(), False, {b"PARQUET:field_id": b"1"}),
+                                       pa.field("long_col", pa.int64(), False, {b"PARQUET:field_id": b"2"}),
+                                       pa.field("float_col", pa.float32(), False, {b"PARQUET:field_id": b"3"}),
+                                       pa.field("double_col", pa.float64(), False, {b"PARQUET:field_id": b"4"}),
+                                       pa.field("decimal_col", pa.decimal128(38, 5), False, {b"PARQUET:field_id": b"5"}),
+                                       pa.field("date_col", pa.date32(), False, {b"PARQUET:field_id": b"6"}),
+                                       pa.field("string_col", pa.string(), False, {b"PARQUET:field_id": b"7"}),
+                                       pa.field("time_col", pa.time64("us"), False, {b"PARQUET:field_id": b"8"}),
+                                       pa.field("ts_col", pa.timestamp("us"), False, {b"PARQUET:field_id": b"9"}),
+                                       pa.field("ts_w_tz_col", pa.timestamp("us", "UTC"), False,
+                                                {b"PARQUET:field_id": b"10"}),
+                                       pa.field("bin_col", pa.binary(), False, {b"PARQUET:field_id": b"11"}),
+                                       pa.field("fixed_bin_col", pa.binary(10), False, {b"PARQUET:field_id": b"12"})
+                                       ])
+    converted = iceberg_to_arrow(iceberg_primitive_schema)
+    assert schema_equals(expected_arrow_schema, converted)
+
+
+def test_convert_struct_type(iceberg_struct_schema):
+
+    arrow_struct = pa.struct([pa.field("a", pa.int32(), False, {b"PARQUET:field_id": b"2"}),
+                              pa.field("b", pa.int32(), False, {b"PARQUET:field_id": b"3"})])
+    arrow_schema = pa.schema([pa.field("struct_col", arrow_struct, False, {b"PARQUET:field_id": b"1"})])
+
+    converted = iceberg_to_arrow(iceberg_struct_schema)
+    assert schema_equals(arrow_schema, converted)
+
+
+def test_convert_list(iceberg_list_schema):
+    element_field = pa.field("element", pa.int32(), False, {b"PARQUET:field_id": b"2"})
+    arrow_schema = pa.schema([pa.field("list_col", pa.list_(element_field), False, {b"PARQUET:field_id": b"1"})])
+    converted = iceberg_to_arrow(iceberg_list_schema)
+
+    assert schema_equals(arrow_schema, converted)
+
+
+def test_primitive_nullabilty(iceberg_simple_nullability_schema):
+    arrow_schema = pa.schema([pa.field("int_col", pa.int32(), False, {b"PARQUET:field_id": b"1"}),
+                              pa.field("long_col", pa.int64(), True, {b"PARQUET:field_id": b"2"})])
+
+    converted = iceberg_to_arrow(iceberg_simple_nullability_schema)
+    assert schema_equals(arrow_schema, converted)
+
+
+def test_nested_nullabilty(iceberg_nested_nullability_schema):
+
+    element_field = pa.field("element", pa.int32(), True, {b"PARQUET:field_id": b"5"})
+    arrow_struct = pa.struct([pa.field("a", pa.int32(), False, {b"PARQUET:field_id": b"3"}),
+                              pa.field("b", pa.int32(), True, {b"PARQUET:field_id": b"4"}), ])
+    arrow_schema = pa.schema([pa.field("struct_col", arrow_struct, True, {b"PARQUET:field_id": b"1"}),
+                              pa.field("list_col", pa.list_(element_field), False, {b"PARQUET:field_id": b"2"})])
+
+    converted = iceberg_to_arrow(iceberg_nested_nullability_schema)
+    assert schema_equals(arrow_schema, converted)


### PR DESCRIPTION
Utility functions for creating an arrow schema from an iceberg schema.  This will be necessary for an eventual write path.