### PR TITLE
Core: allow creating v2 tables through table property

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -63,7 +63,7 @@ public class TableMetadata implements Serializable {
                                                SortOrder sortOrder,
                                                String location,
                                                Map<String, String> properties) {
-    int formatVersion = PropertyUtil.propertyAsInt(properties, TableProperties.RESERVED_PROPERTY_FORMAT_VERSION,
+    int formatVersion = PropertyUtil.propertyAsInt(properties, TableProperties.FORMAT_VERSION,
         DEFAULT_TABLE_FORMAT_VERSION);
     return newTableMetadata(schema, spec, sortOrder, location, unreservedProperties(properties), formatVersion);
   }
@@ -73,7 +73,7 @@ public class TableMetadata implements Serializable {
                                                String location,
                                                Map<String, String> properties) {
     SortOrder sortOrder = SortOrder.unsorted();
-    int formatVersion = PropertyUtil.propertyAsInt(properties, TableProperties.RESERVED_PROPERTY_FORMAT_VERSION,
+    int formatVersion = PropertyUtil.propertyAsInt(properties, TableProperties.FORMAT_VERSION,
         DEFAULT_TABLE_FORMAT_VERSION);
     return newTableMetadata(schema, spec, sortOrder, location, unreservedProperties(properties), formatVersion);
   }
@@ -688,8 +688,7 @@ public class TableMetadata implements Serializable {
         lastAssignedPartitionId, defaultSortOrderId, sortOrders, newProperties, currentSnapshotId, snapshots,
         snapshotLog, addPreviousFile(file, lastUpdatedMillis, newProperties));
 
-    int newFormatVersion = PropertyUtil.propertyAsInt(rawProperties,
-        TableProperties.RESERVED_PROPERTY_FORMAT_VERSION, formatVersion);
+    int newFormatVersion = PropertyUtil.propertyAsInt(rawProperties, TableProperties.FORMAT_VERSION, formatVersion);
     if (formatVersion != newFormatVersion) {
       metadata = metadata.upgradeToFormatVersion(newFormatVersion);
     }
@@ -769,8 +768,7 @@ public class TableMetadata implements Serializable {
     newProperties.putAll(unreservedProperties(updatedProperties));
 
     // check if there is format version override
-    int newFormatVersion = PropertyUtil.propertyAsInt(updatedProperties,
-        TableProperties.RESERVED_PROPERTY_FORMAT_VERSION, formatVersion);
+    int newFormatVersion = PropertyUtil.propertyAsInt(updatedProperties, TableProperties.FORMAT_VERSION, formatVersion);
 
     // determine the next schema id
     int freshSchemaId = reuseOrCreateNewSchemaId(freshSchema);

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -48,7 +48,6 @@ import org.apache.iceberg.util.PropertyUtil;
  * Metadata for a table.
  */
 public class TableMetadata implements Serializable {
-
   static final long INITIAL_SEQUENCE_NUMBER = 0;
   static final long INVALID_SEQUENCE_NUMBER = -1;
   static final int DEFAULT_TABLE_FORMAT_VERSION = 1;

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -63,18 +63,19 @@ public class TableMetadata implements Serializable {
                                                SortOrder sortOrder,
                                                String location,
                                                Map<String, String> properties) {
-    return newTableMetadata(schema, spec, sortOrder, location, unreservedProperties(properties),
-        PropertyUtil.propertyAsInt(properties, TableProperties.RESERVED_PROPERTY_FORMAT_VERSION,
-            DEFAULT_TABLE_FORMAT_VERSION));
+    int formatVersion = PropertyUtil.propertyAsInt(properties, TableProperties.RESERVED_PROPERTY_FORMAT_VERSION,
+        DEFAULT_TABLE_FORMAT_VERSION);
+    return newTableMetadata(schema, spec, sortOrder, location, unreservedProperties(properties), formatVersion);
   }
 
   public static TableMetadata newTableMetadata(Schema schema,
                                                PartitionSpec spec,
                                                String location,
                                                Map<String, String> properties) {
-    return newTableMetadata(schema, spec, SortOrder.unsorted(), location, unreservedProperties(properties),
-        PropertyUtil.propertyAsInt(properties, TableProperties.RESERVED_PROPERTY_FORMAT_VERSION,
-            DEFAULT_TABLE_FORMAT_VERSION));
+    SortOrder sortOrder = SortOrder.unsorted();
+    int formatVersion = PropertyUtil.propertyAsInt(properties, TableProperties.RESERVED_PROPERTY_FORMAT_VERSION,
+        DEFAULT_TABLE_FORMAT_VERSION);
+    return newTableMetadata(schema, spec, sortOrder, location, unreservedProperties(properties), formatVersion);
   }
 
   private static Map<String, String> unreservedProperties(Map<String, String> rawProperties) {

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -49,8 +49,6 @@ import org.apache.iceberg.util.PropertyUtil;
  */
 public class TableMetadata implements Serializable {
 
-
-
   static final long INITIAL_SEQUENCE_NUMBER = 0;
   static final long INVALID_SEQUENCE_NUMBER = -1;
   static final int DEFAULT_TABLE_FORMAT_VERSION = 1;
@@ -687,7 +685,8 @@ public class TableMetadata implements Serializable {
         lastAssignedPartitionId, defaultSortOrderId, sortOrders, newProperties, currentSnapshotId, snapshots,
         snapshotLog, addPreviousFile(file, lastUpdatedMillis, newProperties));
 
-    int newFormatVersion = PropertyUtil.propertyAsInt(rawProperties, TableProperties.RESERVED_PROPERTY_FORMAT_VERSION, formatVersion);
+    int newFormatVersion = PropertyUtil.propertyAsInt(rawProperties,
+        TableProperties.RESERVED_PROPERTY_FORMAT_VERSION, formatVersion);
     if (formatVersion != newFormatVersion) {
       metadata = metadata.upgradeToFormatVersion(newFormatVersion);
     }
@@ -769,7 +768,8 @@ public class TableMetadata implements Serializable {
     Map<String, String> newProperties = unreservedProperties(newRawProperties);
 
     // check if there is format version override
-    int newFormatVersion = PropertyUtil.propertyAsInt(newRawProperties, TableProperties.RESERVED_PROPERTY_FORMAT_VERSION, formatVersion);
+    int newFormatVersion = PropertyUtil.propertyAsInt(newRawProperties,
+        TableProperties.RESERVED_PROPERTY_FORMAT_VERSION, formatVersion);
 
     // determine the next schema id
     int freshSchemaId = reuseOrCreateNewSchemaId(freshSchema);

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -19,8 +19,8 @@
 
 package org.apache.iceberg;
 
-import java.util.List;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import java.util.Set;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 
 public class TableProperties {
 
@@ -47,7 +47,7 @@ public class TableProperties {
    * Reserved table properties are only used to control behaviors during the construction of table metadata.
    * The value of these properties are not persisted as a part of the table metadata.
    */
-  public static final List<String> RESERVED_PROPERTIES = ImmutableList.of(
+  public static final Set<String> RESERVED_PROPERTIES = ImmutableSet.of(
       RESERVED_PROPERTY_FORMAT_VERSION
   );
 

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -39,7 +39,7 @@ public class TableProperties {
    * <p>
    * Note: incomplete or unstable versions cannot be selected using this property.
    */
-  public static final String RESERVED_PROPERTY_FORMAT_VERSION = "format-version";
+  public static final String FORMAT_VERSION = "format-version";
 
   /**
    * Reserved Iceberg table properties list.
@@ -48,7 +48,7 @@ public class TableProperties {
    * The value of these properties are not persisted as a part of the table metadata.
    */
   public static final Set<String> RESERVED_PROPERTIES = ImmutableSet.of(
-      RESERVED_PROPERTY_FORMAT_VERSION
+      FORMAT_VERSION
   );
 
   public static final String COMMIT_NUM_RETRIES = "commit.retry.num-retries";

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -35,7 +35,6 @@ public class TableProperties {
    * <p>
    * If this table property exists when creating a table, the table will use the specified format version.
    * If a table updates this property, it will try to upgrade to the specified format version.
-   * This helps developers to try out new features in an unreleased version or migrate existing tables to a new version.
    * <p>
    * Note: incomplete or unstable versions cannot be selected using this property.
    */
@@ -44,7 +43,7 @@ public class TableProperties {
   /**
    * Reserved Iceberg table properties list.
    * <p>
-   * Reserved table properties are only used to control behaviors during the construction of table metadata.
+   * Reserved table properties are only used to control behaviors when creating or updating a table.
    * The value of these properties are not persisted as a part of the table metadata.
    */
   public static final Set<String> RESERVED_PROPERTIES = ImmutableSet.of(

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -19,10 +19,37 @@
 
 package org.apache.iceberg;
 
+import java.util.List;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+
 public class TableProperties {
 
   private TableProperties() {
   }
+
+  /**
+   * Reserved table property for table format version.
+   * <p>
+   * Iceberg will default a new table's format version to the latest stable and recommended version.
+   * This reserved property keyword allows users to override the Iceberg format version of the table metadata.
+   * <p>
+   * If this table property exists when creating a table, the table will use the specified format version.
+   * If a table updates this property, it will try to upgrade to the specified format version.
+   * This helps developers to try out new features in an unreleased version or migrate existing tables to a new version.
+   * <p>
+   * Note: incomplete or unstable versions cannot be selected using this property.
+   */
+  public static final String RESERVED_PROPERTY_FORMAT_VERSION = "format-version";
+
+  /**
+   * Reserved Iceberg table properties list.
+   * <p>
+   * Reserved table properties are only used to control behaviors during the construction of table metadata.
+   * The value of these properties are not persisted as a part of the table metadata.
+   */
+  public static final List<String> RESERVED_PROPERTIES = ImmutableList.of(
+      RESERVED_PROPERTY_FORMAT_VERSION
+  );
 
   public static final String COMMIT_NUM_RETRIES = "commit.retry.num-retries";
   public static final int COMMIT_NUM_RETRIES_DEFAULT = 4;

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -807,4 +807,17 @@ public class TestTableMetadata {
     Assert.assertEquals("should not contain format-version but should contain new properties",
         ImmutableMap.of("key2", "val2"), meta.properties());
   }
+
+  @Test
+  public void testNoReservedPropertyForTableMetadataCreation() {
+    Schema schema = new Schema(
+        Types.NestedField.required(10, "x", Types.StringType.get())
+    );
+
+    AssertHelpers.assertThrows("should not allow reserved table property when creating table metadata",
+        IllegalArgumentException.class,
+        "Table properties should not contain reserved properties, but got {format-version=1}",
+        () -> TableMetadata.newTableMetadata(schema, PartitionSpec.unpartitioned(), null, "/tmp",
+            ImmutableMap.of(TableProperties.RESERVED_PROPERTY_FORMAT_VERSION, "1"), 1));
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -764,7 +764,7 @@ public class TestTableMetadata {
     );
 
     TableMetadata meta = TableMetadata.newTableMetadata(schema, PartitionSpec.unpartitioned(), null,
-        ImmutableMap.of(TableProperties.RESERVED_PROPERTY_FORMAT_VERSION, "2", "key", "val"));
+        ImmutableMap.of(TableProperties.FORMAT_VERSION, "2", "key", "val"));
 
     Assert.assertEquals("format version should be configured based on the format-version key",
         2, meta.formatVersion());
@@ -779,10 +779,10 @@ public class TestTableMetadata {
     );
 
     TableMetadata meta = TableMetadata.newTableMetadata(schema, PartitionSpec.unpartitioned(), null,
-        ImmutableMap.of(TableProperties.RESERVED_PROPERTY_FORMAT_VERSION, "1", "key", "val"));
+        ImmutableMap.of(TableProperties.FORMAT_VERSION, "1", "key", "val"));
 
     meta = meta.buildReplacement(meta.schema(), meta.spec(), meta.sortOrder(), meta.location(),
-        ImmutableMap.of(TableProperties.RESERVED_PROPERTY_FORMAT_VERSION, "2", "key2", "val2"));
+        ImmutableMap.of(TableProperties.FORMAT_VERSION, "2", "key2", "val2"));
 
     Assert.assertEquals("format version should be configured based on the format-version key",
         2, meta.formatVersion());
@@ -797,9 +797,9 @@ public class TestTableMetadata {
     );
 
     TableMetadata meta = TableMetadata.newTableMetadata(schema, PartitionSpec.unpartitioned(), null,
-        ImmutableMap.of(TableProperties.RESERVED_PROPERTY_FORMAT_VERSION, "1", "key", "val"));
+        ImmutableMap.of(TableProperties.FORMAT_VERSION, "1", "key", "val"));
 
-    meta = meta.replaceProperties(ImmutableMap.of(TableProperties.RESERVED_PROPERTY_FORMAT_VERSION,
+    meta = meta.replaceProperties(ImmutableMap.of(TableProperties.FORMAT_VERSION,
         "2", "key2", "val2"));
 
     Assert.assertEquals("format version should be configured based on the format-version key",
@@ -818,6 +818,6 @@ public class TestTableMetadata {
         IllegalArgumentException.class,
         "Table properties should not contain reserved properties, but got {format-version=1}",
         () -> TableMetadata.newTableMetadata(schema, PartitionSpec.unpartitioned(), null, "/tmp",
-            ImmutableMap.of(TableProperties.RESERVED_PROPERTY_FORMAT_VERSION, "1"), 1));
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, "1"), 1));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -799,7 +799,8 @@ public class TestTableMetadata {
     TableMetadata meta = TableMetadata.newTableMetadata(schema, PartitionSpec.unpartitioned(), null,
         ImmutableMap.of(TableProperties.RESERVED_PROPERTY_FORMAT_VERSION, "1", "key", "val"));
 
-    meta = meta.replaceProperties(ImmutableMap.of(TableProperties.RESERVED_PROPERTY_FORMAT_VERSION, "2", "key2", "val2"));
+    meta = meta.replaceProperties(ImmutableMap.of(TableProperties.RESERVED_PROPERTY_FORMAT_VERSION,
+        "2", "key2", "val2"));
 
     Assert.assertEquals("format version should be configured based on the format-version key",
         2, meta.formatVersion());

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -35,6 +35,7 @@ import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
@@ -44,6 +45,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchTableException;
@@ -237,6 +239,29 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
         catalogTable.getSchema());
     Assert.assertEquals(Maps.newHashMap(), catalogTable.getOptions());
     Assert.assertEquals(Collections.singletonList("dt"), catalogTable.getPartitionKeys());
+  }
+
+  @Test
+  public void testCreateTableWithFormatV2ThroughTableProperty() throws Exception {
+    sql("CREATE TABLE tl(id BIGINT) WITH ('format-version'='2')");
+
+    Table table = table("tl");
+    Assert.assertEquals("should create table using format v2",
+        2, ((BaseTable) table).operations().current().formatVersion());
+  }
+
+  @Test
+  public void testUpgradeTableWithFormatV2ThroughTableProperty() throws Exception {
+    sql("CREATE TABLE tl(id BIGINT) WITH ('format-version'='1')");
+
+    Table table = table("tl");
+    TableOperations ops = ((BaseTable) table).operations();
+    Assert.assertEquals("should create table using format v1",
+        1, ops.refresh().formatVersion());
+
+    sql("ALTER TABLE tl SET('format-version'='2')");
+    Assert.assertEquals("should update table to use format v2",
+        2, ops.refresh().formatVersion());
   }
 
   @Test

--- a/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -28,7 +28,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.constraints.UniqueConstraint;

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -285,7 +285,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
         "'" + InputFormatConfig.PARTITION_SPEC + "'='" +
         PartitionSpecParser.toJson(PartitionSpec.unpartitioned()) + "', " +
         "'" + InputFormatConfig.CATALOG_NAME + "'='" + testTables.catalogName() + "', " +
-        "'" + TableProperties.RESERVED_PROPERTY_FORMAT_VERSION + "'='" + 2 + "')");
+        "'" + TableProperties.FORMAT_VERSION + "'='" + 2 + "')");
 
     // Check the Iceberg table partition data
     org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -274,6 +274,26 @@ public class TestHiveIcebergStorageHandlerNoScan {
   }
 
   @Test
+  public void testCreateTableWithFormatV2ThroughTableProperty() {
+    TableIdentifier identifier = TableIdentifier.of("default", "customers");
+    // We need the location for HadoopTable based tests only
+    shell.executeStatement("CREATE EXTERNAL TABLE customers " +
+        "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
+        testTables.locationForCreateTableSQL(identifier) +
+        "TBLPROPERTIES ('" + InputFormatConfig.TABLE_SCHEMA + "'='" +
+        SchemaParser.toJson(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA) + "', " +
+        "'" + InputFormatConfig.PARTITION_SPEC + "'='" +
+        PartitionSpecParser.toJson(PartitionSpec.unpartitioned()) + "', " +
+        "'" + InputFormatConfig.CATALOG_NAME + "'='" + testTables.catalogName() + "', " +
+        "'" + TableProperties.RESERVED_PROPERTY_FORMAT_VERSION + "'='" + 2 + "')");
+
+    // Check the Iceberg table partition data
+    org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);
+    Assert.assertEquals("should create table using format v2",
+        2, ((BaseTable) icebergTable).operations().current().formatVersion());
+  }
+
+  @Test
   public void testDeleteBackingTable() throws TException, IOException, InterruptedException {
     TableIdentifier identifier = TableIdentifier.of("default", "customers");
 

--- a/spark3/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
+++ b/spark3/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
@@ -22,9 +22,11 @@ package org.apache.iceberg.spark.sql;
 import java.io.File;
 import java.util.Map;
 import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.hadoop.HadoopCatalog;
 import org.apache.iceberg.spark.SparkCatalogTestBase;
@@ -220,5 +222,40 @@ public class TestCreateTable extends SparkCatalogTestBase {
     Assert.assertEquals("Should not be partitioned", 0, table.spec().fields().size());
     Assert.assertEquals("Should have property p1", "2", table.properties().get("p1"));
     Assert.assertEquals("Should have property p2", "x", table.properties().get("p2"));
+  }
+
+  @Test
+  public void testCreateTableWithFormatV2ThroughTableProperty() {
+    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+
+    sql("CREATE TABLE %s " +
+            "(id BIGINT NOT NULL, data STRING) " +
+            "USING iceberg " +
+            "TBLPROPERTIES ('format-version'='2')",
+        tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    Assert.assertEquals("should create table using format v2",
+        2, ((BaseTable) table).operations().current().formatVersion());
+  }
+
+  @Test
+  public void testUpgradeTableWithFormatV2ThroughTableProperty() {
+    Assert.assertFalse("Table should not already exist", validationCatalog.tableExists(tableIdent));
+
+    sql("CREATE TABLE %s " +
+            "(id BIGINT NOT NULL, data STRING) " +
+            "USING iceberg " +
+            "TBLPROPERTIES ('format-version'='1')",
+        tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    TableOperations ops = ((BaseTable) table).operations();
+    Assert.assertEquals("should create table using format v1",
+        1, ops.refresh().formatVersion());
+
+    sql("ALTER TABLE %s SET TBLPROPERTIES ('format-version'='2')", tableName);
+    Assert.assertEquals("should update table to use format v2",
+        2, ops.refresh().formatVersion());
   }
 }


### PR DESCRIPTION
Based on the discussion on dev list, it would be good to have a way to directly create experimental v2 tables. This is my current proposal:

When `format-version` is specified in the table properties section of a CREATE TABLE DDL, we use the specific format version, otherwise use default version

Some considerations I had:
1. `format-version` is not a part of `TableProperties`, but just a property used at table creation time. The value is never stored as actual table property, and updating this property has no effect on table version.
2. Because of 1, we do not use a traditional property syntax like `format.version` but instead use `table-format` to distinguish it from other actual table properties.
3. I am trying to make this a long-term solution for future format versions, so I made the property a public variable that can be imported.
4. The table properties section of a CREATE TABLE DDL is used because it exists in all SQL dialects, which means that all engines can have this functionality to test experimental feature through this change.

It is a bit hard to test this in unit test because format version is not publicly accessible. I have tested with Spark on EMR and manually verified that the metadata file shows the correct version.

Example:

```sql
CREATE TABLE sample (
    id bigint,
    data string,
    category string)
USING iceberg
OPTIONS ('format-version'='2')
PARTITIONED BY (category);
```

@rdblue @openinx 