### PR TITLE
[python] Updating pyarrow dependencies

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -36,7 +36,7 @@ setup(
                       'requests',
                       'retrying',
                       'pandas',
-                      'pyarrow>=3.0.0<4.0.0'
+                      'pyarrow>=3.0.0,<=4.0.1'
                       ],
     extras_require={
         "dev": [


### PR DESCRIPTION
The dependencies were pulling in pyarrow 5.0.0, which just released today, and it was breaking the current python build.