### PR TITLE
API: Add validation that delete file referenced files are not rewritten

### DIFF
--- a/api/src/main/java/org/apache/iceberg/RewriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteFiles.java
@@ -73,4 +73,16 @@ public interface RewriteFiles extends SnapshotUpdate<RewriteFiles> {
    * @return this for method chaining
    */
   RewriteFiles validateFromSnapshot(long snapshotId);
+
+  /**
+   * Add data file paths that must not be rewritten by conflicting commits for this operation to succeed.
+   * <p>
+   * If any path has been rewritten in a replace by a conflicting commit in the table since the snapshot passed to
+   * {@link #validateFromSnapshot(long)}, the operation will fail with a
+   * {@link org.apache.iceberg.exceptions.ValidationException}.
+   *
+   * @param referencedFiles file paths that are referenced by a position delete file
+   * @return this for method chaining
+   */
+  RewriteFiles validateDataFilesNotRewritten(Iterable<? extends CharSequence> referencedFiles);
 }


### PR DESCRIPTION
This is a follow-up to [OpenInx's comment](https://github.com/apache/iceberg/pull/2865#discussion_r677072072) on #2865 that adds a validation to check that referenced data files are not concurrently rewritten when rewriting delete files.