### PR TITLE
Update the comment content of 'commit.retry.total-timeout-ms'

### DIFF
--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -91,7 +91,7 @@ Iceberg tables support table properties to configure table behavior, like the de
 | commit.retry.num-retries           | 4                | Number of times to retry a commit before failing              |
 | commit.retry.min-wait-ms           | 100              | Minimum time in milliseconds to wait before retrying a commit |
 | commit.retry.max-wait-ms           | 60000 (1 min)    | Maximum time in milliseconds to wait before retrying a commit |
-| commit.retry.total-timeout-ms      | 1800000 (30 min) | Total timeout in milliseconds between retrying a commit.                              |
+| commit.retry.total-timeout-ms      | 1800000 (30 min) | Total timeout in milliseconds when retrying a commit.                              |
 | commit.manifest.target-size-bytes  | 8388608 (8 MB)   | Target size when merging manifest files                       |
 | commit.manifest.min-count-to-merge | 100              | Minimum number of manifests to accumulate before merging      |
 | commit.manifest-merge.enabled      | true             | Controls whether to automatically merge manifests on writes   |

--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -91,7 +91,7 @@ Iceberg tables support table properties to configure table behavior, like the de
 | commit.retry.num-retries           | 4                | Number of times to retry a commit before failing              |
 | commit.retry.min-wait-ms           | 100              | Minimum time in milliseconds to wait before retrying a commit |
 | commit.retry.max-wait-ms           | 60000 (1 min)    | Maximum time in milliseconds to wait before retrying a commit |
-| commit.retry.total-timeout-ms      | 1800000 (30 min) | Maximum time in milliseconds to wait before retrying a commit |
+| commit.retry.total-timeout-ms      | 1800000 (30 min) | Total timeout in milliseconds between retrying a commit.                              |
 | commit.manifest.target-size-bytes  | 8388608 (8 MB)   | Target size when merging manifest files                       |
 | commit.manifest.min-count-to-merge | 100              | Minimum number of manifests to accumulate before merging      |
 | commit.manifest-merge.enabled      | true             | Controls whether to automatically merge manifests on writes   |


### PR DESCRIPTION
The comment content of the current parameter commit.retry.total-timeout-ms and commit.retry.max-wait-ms is the same.