### PR TITLE
Docs: Update Slack invite link

### DIFF
--- a/site/docs/community.md
+++ b/site/docs/community.md
@@ -21,7 +21,7 @@
 
 Apache Iceberg tracks issues in GitHub and prefers to receive contributions as pull requests.
 
-Community discussions happen primarily on the dev mailing list, on the #iceberg channel on the ASF's Slack workspace, and on specific Github issues.
+Community discussions happen primarily on the dev mailing list, on apache-iceberg Slack workspace, and on specific GitHub issues.
 
 
 ## Contributing

--- a/site/docs/community.md
+++ b/site/docs/community.md
@@ -49,8 +49,9 @@ Issues are tracked in GitHub:
 
 ## Slack
 
-You can join the community via the [apache-iceberg](https://apache-iceberg.slack.com/) Slack workspace.
-If you encounter problems using it, please let us know by sending an email to <dev@iceberg.apache.org>.
+We use the [Apache Iceberg workspace](https://apache-iceberg.slack.com/) on Slack. To be invited, follow [this invite link](https://join.slack.com/t/apache-iceberg/shared_invite/zt-tlv0zjz6-jGJEkHfb1~heMCJA3Uycrg).
+
+Please note that this link may occasionally break when Slack does an upgrade. If you encounter problems using it, please let us know by sending an email to <dev@iceberg.apache.org>.
 
 ## Mailing Lists
 


### PR DESCRIPTION
Update the Slack link to one for apache-iceberg.slack.com that will not expire.