### PR TITLE
Add list of Github collaborators to asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -17,6 +17,9 @@
 # under the License.
 #
 
+# The format of this file is documented at
+# https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features
+
 github:
   description: "Apache Iceberg"
   homepage: https://iceberg.apache.org/
@@ -27,6 +30,17 @@ github:
     wiki: true
     issues: true
     projects: true
+  collaborators:  # Note: the number of collaborators is limited to 10
+    - chenjunjiedada
+    - kbendick
+    - jun-he
+    - marton-bod
+    - nastra
+    - samarthjain
+    - mccheah
+    - szehon-ho
+    - findepi
+    - SreeramGarlapati
 
 notifications:
     commits:      commits@iceberg.apache.org


### PR DESCRIPTION
This patch adds a subset of non-committer project contributors to the list of collaborators defined in asf.yaml. Please note the following:

1. The documentation for asf.yaml states that the maximum number of collaborators is 20. However, the actual limit is 10.
2. The list of people to add was previously approved on a privtate@iceberg thread.
3. Since I was able to add only a subset of the people who were approved in the aforementioned private@iceberg thread, I based my selection on the total number of commits and the tempo of recent contributions.