### PR TITLE
Spark3: Add validation for merge into/update/delete  on different distribution-mode

### DIFF
--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteDelete.java
@@ -26,8 +26,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 public class TestCopyOnWriteDelete extends TestDelete {
 
   public TestCopyOnWriteDelete(String catalogName, String implementation, Map<String, String> config,
-                               String fileFormat, Boolean vectorized) {
-    super(catalogName, implementation, config, fileFormat, vectorized);
+                               String fileFormat, Boolean vectorized, String distributionMode) {
+    super(catalogName, implementation, config, fileFormat, vectorized, distributionMode);
   }
 
   @Override

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteMerge.java
@@ -26,8 +26,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 public class TestCopyOnWriteMerge extends TestMerge {
 
   public TestCopyOnWriteMerge(String catalogName, String implementation, Map<String, String> config,
-                              String fileFormat, boolean vectorized) {
-    super(catalogName, implementation, config, fileFormat, vectorized);
+                              String fileFormat, boolean vectorized, String distributionMode) {
+    super(catalogName, implementation, config, fileFormat, vectorized, distributionMode);
   }
 
   @Override

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteUpdate.java
@@ -26,8 +26,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 public class TestCopyOnWriteUpdate extends TestUpdate {
 
   public TestCopyOnWriteUpdate(String catalogName, String implementation, Map<String, String> config,
-                               String fileFormat, boolean vectorized) {
-    super(catalogName, implementation, config, fileFormat, vectorized);
+                               String fileFormat, boolean vectorized, String distributionMode) {
+    super(catalogName, implementation, config, fileFormat, vectorized, distributionMode);
   }
 
   @Override

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -59,8 +59,8 @@ import static org.apache.spark.sql.functions.lit;
 public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
 
   public TestDelete(String catalogName, String implementation, Map<String, String> config,
-                    String fileFormat, Boolean vectorized) {
-    super(catalogName, implementation, config, fileFormat, vectorized);
+                    String fileFormat, Boolean vectorized, String distributionMode) {
+    super(catalogName, implementation, config, fileFormat, vectorized, distributionMode);
   }
 
   @BeforeClass

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -60,8 +60,8 @@ import static org.apache.spark.sql.functions.lit;
 public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
 
   public TestMerge(String catalogName, String implementation, Map<String, String> config,
-                   String fileFormat, boolean vectorized) {
-    super(catalogName, implementation, config, fileFormat, vectorized);
+                   String fileFormat, boolean vectorized, String distributionMode) {
+    super(catalogName, implementation, config, fileFormat, vectorized, distributionMode);
   }
 
   @BeforeClass

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -60,8 +60,8 @@ import static org.apache.spark.sql.functions.lit;
 public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
 
   public TestUpdate(String catalogName, String implementation, Map<String, String> config,
-                    String fileFormat, boolean vectorized) {
-    super(catalogName, implementation, config, fileFormat, vectorized);
+                    String fileFormat, boolean vectorized, String distributionMode) {
+    super(catalogName, implementation, config, fileFormat, vectorized, distributionMode);
   }
 
   @BeforeClass


### PR DESCRIPTION
When `MERGE INTO` works in `distribution-mode=hash` and `distribution-mode=range`,  we should check there are no duplicate commits. https://github.com/apache/iceberg/blob/master/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/utils/RewriteRowLevelOperationHelper.scala#L217