### PR TITLE
Use HTTPS for getting dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ import groovy.transform.Memoized
 buildscript {
   repositories {
     gradlePluginPortal()
-    maven { url "http://palantir.bintray.com/releases" }
+    maven { url "https://palantir.bintray.com/releases" }
     maven { url "https://plugins.gradle.org/m2/" }
   }
   dependencies {
@@ -63,7 +63,7 @@ allprojects {
   group = "org.apache.iceberg"
   version = getProjectVersion()
   repositories {
-    maven { url  "http://palantir.bintray.com/releases" }
+    maven { url  "https://palantir.bintray.com/releases" }
     mavenCentral()
     mavenLocal()
   }


### PR DESCRIPTION
This increases safety of the build.