### PR TITLE
Annotate UUID fields in Parquet

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/TypeToMessageType.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/TypeToMessageType.java
@@ -179,7 +179,10 @@ public class TypeToMessageType {
         }
 
       case UUID:
-        return Types.primitive(FIXED_LEN_BYTE_ARRAY, repetition).length(16).id(id).named(name);
+        return Types.primitive(FIXED_LEN_BYTE_ARRAY, repetition).length(16)
+                .as(LogicalTypeAnnotation.uuidType())
+                .id(id)
+                .named(name);
 
       default:
         throw new UnsupportedOperationException("Unsupported type for Parquet: " + primitive);


### PR DESCRIPTION
The spec mandates that UUID fields in Parquet have logical type "UUID"
(https://iceberg.apache.org/spec/#parquet). This is possible to fulfill
after 236615497bdc2c6fbedbd3acc41a4ed85c4a8bfd, as
`LogicalTypeAnnotation.uuidType` was added in Parquet 1.12.0.