### PR TITLE
Add one configuration  to config the records num threshold when write pos-delete files

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -199,4 +199,7 @@ public class TableProperties {
 
   public static final String WRITE_RECORDS_NUM_THRESHOLD = "write.records-num-threshold";
   public static final long WRITE_RECORDS_NUM_THRESHOLD_DEFAULT = 100_000L;
+
+  public static final String WRITE_POSITION_DELETE_FLUSH_THRESHOLD = "write.position.delete.flush.threshold";
+  public static final long WRITE_POSITION_DELETE_FLUSH_THRESHOLD_DEFAULT = 100_000L;
 }

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -197,9 +197,6 @@ public class TableProperties {
   public static final String MERGE_CARDINALITY_CHECK_ENABLED = "write.merge.cardinality-check.enabled";
   public static final boolean MERGE_CARDINALITY_CHECK_ENABLED_DEFAULT = true;
 
-  public static final String WRITE_RECORDS_NUM_THRESHOLD = "write.records-num-threshold";
-  public static final long WRITE_RECORDS_NUM_THRESHOLD_DEFAULT = 100_000L;
-
   public static final String WRITE_POSITION_DELETE_FLUSH_THRESHOLD = "write.position.delete.flush.threshold";
   public static final long WRITE_POSITION_DELETE_FLUSH_THRESHOLD_DEFAULT = 100_000L;
 }

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -196,4 +196,7 @@ public class TableProperties {
 
   public static final String MERGE_CARDINALITY_CHECK_ENABLED = "write.merge.cardinality-check.enabled";
   public static final boolean MERGE_CARDINALITY_CHECK_ENABLED_DEFAULT = true;
+
+  public static final String WRITE_RECORDS_NUM_THRESHOLD = "write.records-num-threshold";
+  public static final long WRITE_RECORDS_NUM_THRESHOLD_DEFAULT = 100_000L;
 }

--- a/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java
@@ -57,8 +57,9 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
   private final long targetFileSize;
   private final Map<String, String> properties;
 
-  protected BaseTaskWriter(PartitionSpec spec, FileFormat format, FileAppenderFactory<T> appenderFactory,
-                           OutputFileFactory fileFactory, FileIO io, long targetFileSize, Map<String, String> properties) {
+  protected BaseTaskWriter(
+      PartitionSpec spec, FileFormat format, FileAppenderFactory<T> appenderFactory,
+      OutputFileFactory fileFactory, FileIO io, long targetFileSize, Map<String, String> properties) {
     this.spec = spec;
     this.format = format;
     this.appenderFactory = appenderFactory;
@@ -66,7 +67,6 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
     this.io = io;
     this.targetFileSize = targetFileSize;
     this.properties = properties;
-
   }
 
   protected PartitionSpec spec() {
@@ -112,7 +112,11 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
 
       this.dataWriter = new RollingFileWriter(partition);
       this.eqDeleteWriter = new RollingEqDeleteWriter(partition);
-      this.posDeleteWriter = new SortedPosDeleteWriter<>(appenderFactory, fileFactory, format, partition, getRecordsNumThreshold(properties));
+      this.posDeleteWriter = new SortedPosDeleteWriter<>(appenderFactory,
+          fileFactory,
+          format,
+          partition,
+          getRecordsNumThreshold(properties));
       this.insertedRowMap = StructLikeMap.create(deleteSchema.asStruct());
     }
 
@@ -358,8 +362,9 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
   }
 
   private static long getRecordsNumThreshold(Map<String, String> properties) {
-    return PropertyUtil.propertyAsLong(properties,
-            WRITE_RECORDS_NUM_THRESHOLD,
-            WRITE_RECORDS_NUM_THRESHOLD_DEFAULT);
+    return PropertyUtil.propertyAsLong(
+        properties,
+        WRITE_RECORDS_NUM_THRESHOLD,
+        WRITE_RECORDS_NUM_THRESHOLD_DEFAULT);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java
@@ -41,8 +41,8 @@ import org.apache.iceberg.util.StructLikeMap;
 import org.apache.iceberg.util.StructProjection;
 import org.apache.iceberg.util.Tasks;
 
-import static org.apache.iceberg.TableProperties.WRITE_RECORDS_NUM_THRESHOLD;
-import static org.apache.iceberg.TableProperties.WRITE_RECORDS_NUM_THRESHOLD_DEFAULT;
+import static org.apache.iceberg.TableProperties.WRITE_POSITION_DELETE_FLUSH_THRESHOLD;
+import static org.apache.iceberg.TableProperties.WRITE_POSITION_DELETE_FLUSH_THRESHOLD_DEFAULT;
 
 public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
   private final List<DataFile> completedDataFiles = Lists.newArrayList();
@@ -364,7 +364,7 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
   private static long getRecordsNumThreshold(Map<String, String> properties) {
     return PropertyUtil.propertyAsLong(
         properties,
-        WRITE_RECORDS_NUM_THRESHOLD,
-        WRITE_RECORDS_NUM_THRESHOLD_DEFAULT);
+        WRITE_POSITION_DELETE_FLUSH_THRESHOLD,
+        WRITE_POSITION_DELETE_FLUSH_THRESHOLD_DEFAULT);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/io/PartitionedFanoutWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/PartitionedFanoutWriter.java
@@ -30,8 +30,9 @@ public abstract class PartitionedFanoutWriter<T> extends BaseTaskWriter<T> {
   private final Map<PartitionKey, RollingFileWriter> writers = Maps.newHashMap();
 
   protected PartitionedFanoutWriter(PartitionSpec spec, FileFormat format, FileAppenderFactory<T> appenderFactory,
-                          OutputFileFactory fileFactory, FileIO io, long targetFileSize) {
-    super(spec, format, appenderFactory, fileFactory, io, targetFileSize);
+                                    OutputFileFactory fileFactory, FileIO io, long targetFileSize,
+                                    Map<String, String> properties) {
+    super(spec, format, appenderFactory, fileFactory, io, targetFileSize, properties);
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/io/PartitionedWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/PartitionedWriter.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.io;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionKey;
@@ -38,8 +39,9 @@ public abstract class PartitionedWriter<T> extends BaseTaskWriter<T> {
   private RollingFileWriter currentWriter = null;
 
   protected PartitionedWriter(PartitionSpec spec, FileFormat format, FileAppenderFactory<T> appenderFactory,
-                           OutputFileFactory fileFactory, FileIO io, long targetFileSize) {
-    super(spec, format, appenderFactory, fileFactory, io, targetFileSize);
+                              OutputFileFactory fileFactory, FileIO io, long targetFileSize,
+                              Map<String, String> properties) {
+    super(spec, format, appenderFactory, fileFactory, io, targetFileSize, properties);
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/io/UnpartitionedWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/UnpartitionedWriter.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.io;
 
 import java.io.IOException;
+import java.util.Map;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 
@@ -28,8 +29,9 @@ public class UnpartitionedWriter<T> extends BaseTaskWriter<T> {
   private final RollingFileWriter currentWriter;
 
   public UnpartitionedWriter(PartitionSpec spec, FileFormat format, FileAppenderFactory<T> appenderFactory,
-                             OutputFileFactory fileFactory, FileIO io, long targetFileSize) {
-    super(spec, format, appenderFactory, fileFactory, io, targetFileSize);
+                             OutputFileFactory fileFactory, FileIO io, long targetFileSize,
+                             Map<String, String> properties) {
+    super(spec, format, appenderFactory, fileFactory, io, targetFileSize, properties);
     currentWriter = new RollingFileWriter(null);
   }
 

--- a/data/src/test/java/org/apache/iceberg/io/TestBaseTaskWriter.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestBaseTaskWriter.java
@@ -37,6 +37,7 @@ import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.IcebergGenerics;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.StructLikeSet;
 import org.junit.Assert;
 import org.junit.Before;
@@ -217,7 +218,7 @@ public class TestBaseTaskWriter extends TableTestBase {
                            FileAppenderFactory<Record> appenderFactory,
                            OutputFileFactory fileFactory, FileIO io,
                            long targetFileSize) {
-      super(spec, format, appenderFactory, fileFactory, io, targetFileSize);
+      super(spec, format, appenderFactory, fileFactory, io, targetFileSize, Maps.newHashMap());
       this.dataWriter = new RollingFileWriter(null);
       this.deleteWriter = new RollingEqDeleteWriter(null);
     }

--- a/data/src/test/java/org/apache/iceberg/io/TestTaskEqualityDeltaWriter.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestTaskEqualityDeltaWriter.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.function.Function;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
@@ -441,7 +442,7 @@ public class TestTaskEqualityDeltaWriter extends TableTestBase {
     Schema deleteSchema = table.schema().select(columns);
 
     return new GenericTaskDeltaWriter(table.schema(), deleteSchema, table.spec(), format, appenderFactory,
-        fileFactory, table.io(), TARGET_FILE_SIZE);
+        fileFactory, table.io(), TARGET_FILE_SIZE, table.properties());
   }
 
   private static class GenericTaskDeltaWriter extends BaseTaskWriter<Record> {
@@ -449,8 +450,9 @@ public class TestTaskEqualityDeltaWriter extends TableTestBase {
 
     private GenericTaskDeltaWriter(Schema schema, Schema deleteSchema, PartitionSpec spec, FileFormat format,
                                    FileAppenderFactory<Record> appenderFactory,
-                                   OutputFileFactory fileFactory, FileIO io, long targetFileSize) {
-      super(spec, format, appenderFactory, fileFactory, io, targetFileSize);
+                                   OutputFileFactory fileFactory, FileIO io, long targetFileSize,
+                                   Map<String, String> properties) {
+      super(spec, format, appenderFactory, fileFactory, io, targetFileSize, properties);
       this.deltaWriter = new GenericEqualityDeltaWriter(null, schema, deleteSchema);
     }
 

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/BaseDeltaTaskWriter.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/BaseDeltaTaskWriter.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.flink.sink;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.iceberg.FileFormat;
@@ -48,10 +49,11 @@ abstract class BaseDeltaTaskWriter extends BaseTaskWriter<RowData> {
                       OutputFileFactory fileFactory,
                       FileIO io,
                       long targetFileSize,
+                      Map<String, String> properties,
                       Schema schema,
                       RowType flinkSchema,
                       List<Integer> equalityFieldIds) {
-    super(spec, format, appenderFactory, fileFactory, io, targetFileSize);
+    super(spec, format, appenderFactory, fileFactory, io, targetFileSize, properties);
     this.schema = schema;
     this.deleteSchema = TypeUtil.select(schema, Sets.newHashSet(equalityFieldIds));
     this.wrapper = new RowDataWrapper(flinkSchema, schema.asStruct());

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/PartitionedDeltaWriter.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/PartitionedDeltaWriter.java
@@ -47,10 +47,12 @@ class PartitionedDeltaWriter extends BaseDeltaTaskWriter {
                          OutputFileFactory fileFactory,
                          FileIO io,
                          long targetFileSize,
+                         Map<String, String> properties,
                          Schema schema,
                          RowType flinkSchema,
                          List<Integer> equalityFieldIds) {
-    super(spec, format, appenderFactory, fileFactory, io, targetFileSize, schema, flinkSchema, equalityFieldIds);
+    super(spec, format, appenderFactory, fileFactory, io, targetFileSize, properties, schema, flinkSchema,
+            equalityFieldIds);
     this.partitionKey = new PartitionKey(spec, schema);
   }
 

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/RowDataTaskWriterFactory.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/RowDataTaskWriterFactory.java
@@ -48,6 +48,7 @@ public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
   private final EncryptionManager encryptionManager;
   private final long targetFileSizeBytes;
   private final FileFormat format;
+  private final Map<String, String> tableProperties;
   private final List<Integer> equalityFieldIds;
   private final FileAppenderFactory<RowData> appenderFactory;
 
@@ -71,6 +72,7 @@ public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
     this.encryptionManager = encryptionManager;
     this.targetFileSizeBytes = targetFileSizeBytes;
     this.format = format;
+    this.tableProperties = tableProperties;
     this.equalityFieldIds = equalityFieldIds;
 
     if (equalityFieldIds == null || equalityFieldIds.isEmpty()) {
@@ -95,19 +97,20 @@ public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
     if (equalityFieldIds == null || equalityFieldIds.isEmpty()) {
       // Initialize a task writer to write INSERT only.
       if (spec.isUnpartitioned()) {
-        return new UnpartitionedWriter<>(spec, format, appenderFactory, outputFileFactory, io, targetFileSizeBytes);
+        return new UnpartitionedWriter<>(spec, format, appenderFactory, outputFileFactory, io, targetFileSizeBytes,
+                tableProperties);
       } else {
         return new RowDataPartitionedFanoutWriter(spec, format, appenderFactory, outputFileFactory,
-            io, targetFileSizeBytes, schema, flinkSchema);
+                io, targetFileSizeBytes, tableProperties, schema, flinkSchema);
       }
     } else {
       // Initialize a task writer to write both INSERT and equality DELETE.
       if (spec.isUnpartitioned()) {
         return new UnpartitionedDeltaWriter(spec, format, appenderFactory, outputFileFactory, io,
-            targetFileSizeBytes, schema, flinkSchema, equalityFieldIds);
+                targetFileSizeBytes, tableProperties, schema, flinkSchema, equalityFieldIds);
       } else {
         return new PartitionedDeltaWriter(spec, format, appenderFactory, outputFileFactory, io,
-            targetFileSizeBytes, schema, flinkSchema, equalityFieldIds);
+                targetFileSizeBytes, tableProperties, schema, flinkSchema, equalityFieldIds);
       }
     }
   }
@@ -118,9 +121,10 @@ public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
     private final RowDataWrapper rowDataWrapper;
 
     RowDataPartitionedFanoutWriter(PartitionSpec spec, FileFormat format, FileAppenderFactory<RowData> appenderFactory,
-                                   OutputFileFactory fileFactory, FileIO io, long targetFileSize, Schema schema,
+                                   OutputFileFactory fileFactory, FileIO io, long targetFileSize,
+                                   Map<String, String> properties, Schema schema,
                                    RowType flinkSchema) {
-      super(spec, format, appenderFactory, fileFactory, io, targetFileSize);
+      super(spec, format, appenderFactory, fileFactory, io, targetFileSize, properties);
       this.partitionKey = new PartitionKey(spec, schema);
       this.rowDataWrapper = new RowDataWrapper(flinkSchema, schema.asStruct());
     }

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/UnpartitionedDeltaWriter.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/UnpartitionedDeltaWriter.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.flink.sink;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.iceberg.FileFormat;
@@ -39,10 +40,12 @@ class UnpartitionedDeltaWriter extends BaseDeltaTaskWriter {
                            OutputFileFactory fileFactory,
                            FileIO io,
                            long targetFileSize,
+                           Map<String, String> properties,
                            Schema schema,
                            RowType flinkSchema,
                            List<Integer> equalityFieldIds) {
-    super(spec, format, appenderFactory, fileFactory, io, targetFileSize, schema, flinkSchema, equalityFieldIds);
+    super(spec, format, appenderFactory, fileFactory, io, targetFileSize, properties, schema, flinkSchema,
+            equalityFieldIds);
     this.writer = new RowDataDeltaWriter(null);
   }
 

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputFormat.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputFormat.java
@@ -86,6 +86,7 @@ public class HiveIcebergOutputFormat<T> implements OutputFormat<NullWritable, Co
     String tableName = jc.get(Catalogs.NAME);
 
     return new HiveIcebergRecordWriter(schema, spec, fileFormat,
-        new GenericAppenderFactory(schema, spec), outputFileFactory, io, targetFileSize, taskAttemptID, tableName);
+            new GenericAppenderFactory(schema, spec), outputFileFactory, io, targetFileSize, table.properties(),
+            taskAttemptID, tableName);
   }
 }

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergRecordWriter.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergRecordWriter.java
@@ -64,8 +64,8 @@ class HiveIcebergRecordWriter extends PartitionedFanoutWriter<Record>
 
   HiveIcebergRecordWriter(Schema schema, PartitionSpec spec, FileFormat format,
       FileAppenderFactory<Record> appenderFactory, OutputFileFactory fileFactory, FileIO io, long targetFileSize,
-      TaskAttemptID taskAttemptID, String tableName) {
-    super(spec, format, appenderFactory, fileFactory, io, targetFileSize);
+                          Map<String, String> properties, TaskAttemptID taskAttemptID, String tableName) {
+    super(spec, format, appenderFactory, fileFactory, io, targetFileSize, properties);
     this.io = io;
     this.currentKey = new PartitionKey(spec, schema);
     writers.putIfAbsent(taskAttemptID, Maps.newConcurrentMap());

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergOutputCommitter.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergOutputCommitter.java
@@ -278,7 +278,7 @@ public class TestHiveIcebergOutputCommitter {
           .operationId(operationId)
           .build();
       HiveIcebergRecordWriter testWriter = new HiveIcebergRecordWriter(schema, spec, fileFormat,
-          new GenericAppenderFactory(schema), outputFileFactory, io, TARGET_FILE_SIZE,
+          new GenericAppenderFactory(schema), outputFileFactory, io, TARGET_FILE_SIZE, table.properties(),
           TezUtil.taskAttemptWrapper(taskId), conf.get(Catalogs.NAME));
 
       Container<Record> container = new Container<>();

--- a/spark/src/main/java/org/apache/iceberg/spark/source/SparkPartitionedFanoutWriter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/SparkPartitionedFanoutWriter.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.spark.source;
 
+import java.util.Map;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.PartitionSpec;
@@ -37,8 +38,8 @@ public class SparkPartitionedFanoutWriter extends PartitionedFanoutWriter<Intern
   public SparkPartitionedFanoutWriter(PartitionSpec spec, FileFormat format,
       FileAppenderFactory<InternalRow> appenderFactory,
       OutputFileFactory fileFactory, FileIO io, long targetFileSize,
-      Schema schema, StructType sparkSchema) {
-    super(spec, format, appenderFactory, fileFactory, io, targetFileSize);
+      Map<String, String> properties, Schema schema, StructType sparkSchema) {
+    super(spec, format, appenderFactory, fileFactory, io, targetFileSize, properties);
     this.partitionKey = new PartitionKey(spec, schema);
     this.internalRowWrapper = new InternalRowWrapper(sparkSchema);
   }

--- a/spark/src/main/java/org/apache/iceberg/spark/source/SparkPartitionedWriter.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/source/SparkPartitionedWriter.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.spark.source;
 
+import java.util.Map;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.PartitionSpec;
@@ -37,8 +38,8 @@ public class SparkPartitionedWriter extends PartitionedWriter<InternalRow> {
   public SparkPartitionedWriter(PartitionSpec spec, FileFormat format,
                                 FileAppenderFactory<InternalRow> appenderFactory,
                                 OutputFileFactory fileFactory, FileIO io, long targetFileSize,
-                                Schema schema, StructType sparkSchema) {
-    super(spec, format, appenderFactory, fileFactory, io, targetFileSize);
+                                Map<String, String> properties, Schema schema, StructType sparkSchema) {
+    super(spec, format, appenderFactory, fileFactory, io, targetFileSize, properties);
     this.partitionKey = new PartitionKey(spec, schema);
     this.internalRowWrapper = new InternalRowWrapper(sparkSchema);
   }

--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Writer.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Writer.java
@@ -268,15 +268,16 @@ class Writer implements DataSourceWriter {
 
       PartitionSpec spec = table.spec();
       FileIO io = table.io();
+      Map<String, String> properties = table.properties();
 
       if (spec.isUnpartitioned()) {
-        return new Unpartitioned24Writer(spec, format, appenderFactory, fileFactory, io, targetFileSize);
+        return new Unpartitioned24Writer(spec, format, appenderFactory, fileFactory, io, targetFileSize, properties);
       } else if (partitionedFanoutEnabled) {
         return new PartitionedFanout24Writer(spec, format, appenderFactory, fileFactory, io, targetFileSize,
-            writeSchema, dsSchema);
+            properties, writeSchema, dsSchema);
       } else {
         return new Partitioned24Writer(spec, format, appenderFactory, fileFactory, io, targetFileSize,
-            writeSchema, dsSchema);
+            properties, writeSchema, dsSchema);
       }
     }
   }
@@ -284,8 +285,9 @@ class Writer implements DataSourceWriter {
   private static class Unpartitioned24Writer extends UnpartitionedWriter<InternalRow>
       implements DataWriter<InternalRow> {
     Unpartitioned24Writer(PartitionSpec spec, FileFormat format, SparkAppenderFactory appenderFactory,
-                          OutputFileFactory fileFactory, FileIO fileIo, long targetFileSize) {
-      super(spec, format, appenderFactory, fileFactory, fileIo, targetFileSize);
+        OutputFileFactory fileFactory, FileIO fileIo, long targetFileSize,
+        Map<String, String> properties) {
+      super(spec, format, appenderFactory, fileFactory, fileIo, targetFileSize, properties);
     }
 
     @Override
@@ -299,9 +301,9 @@ class Writer implements DataSourceWriter {
   private static class Partitioned24Writer extends SparkPartitionedWriter implements DataWriter<InternalRow> {
 
     Partitioned24Writer(PartitionSpec spec, FileFormat format, SparkAppenderFactory appenderFactory,
-                        OutputFileFactory fileFactory, FileIO fileIo, long targetFileSize,
-                        Schema schema, StructType sparkSchema) {
-      super(spec, format, appenderFactory, fileFactory, fileIo, targetFileSize, schema, sparkSchema);
+        OutputFileFactory fileFactory, FileIO fileIo, long targetFileSize,
+        Map<String, String> properties, Schema schema, StructType sparkSchema) {
+      super(spec, format, appenderFactory, fileFactory, fileIo, targetFileSize, properties, schema, sparkSchema);
     }
 
     @Override
@@ -316,11 +318,10 @@ class Writer implements DataSourceWriter {
       implements DataWriter<InternalRow> {
 
     PartitionedFanout24Writer(PartitionSpec spec, FileFormat format,
-                              SparkAppenderFactory appenderFactory,
-                              OutputFileFactory fileFactory, FileIO fileIo, long targetFileSize,
-                              Schema schema, StructType sparkSchema) {
-      super(spec, format, appenderFactory, fileFactory, fileIo, targetFileSize, schema,
-          sparkSchema);
+        SparkAppenderFactory appenderFactory,
+        OutputFileFactory fileFactory, FileIO fileIo, long targetFileSize,
+        Map<String, String> properties, Schema schema, StructType sparkSchema) {
+      super(spec, format, appenderFactory, fileFactory, fileIo, targetFileSize, properties, schema, sparkSchema);
     }
 
     @Override

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -537,15 +537,16 @@ class SparkWrite {
 
       PartitionSpec spec = table.spec();
       FileIO io = table.io();
+      Map<String, String> properties = table.properties();
 
       if (spec.isUnpartitioned()) {
-        return new Unpartitioned3Writer(spec, format, appenderFactory, fileFactory, io, targetFileSize);
+        return new Unpartitioned3Writer(spec, format, appenderFactory, fileFactory, io, targetFileSize, properties);
       } else if (partitionedFanoutEnabled) {
         return new PartitionedFanout3Writer(
-            spec, format, appenderFactory, fileFactory, io, targetFileSize, writeSchema, dsSchema);
+            spec, format, appenderFactory, fileFactory, io, targetFileSize, properties, writeSchema, dsSchema);
       } else {
         return new Partitioned3Writer(
-            spec, format, appenderFactory, fileFactory, io, targetFileSize, writeSchema, dsSchema);
+            spec, format, appenderFactory, fileFactory, io, targetFileSize, properties, writeSchema, dsSchema);
       }
     }
   }
@@ -553,8 +554,9 @@ class SparkWrite {
   private static class Unpartitioned3Writer extends UnpartitionedWriter<InternalRow>
       implements DataWriter<InternalRow> {
     Unpartitioned3Writer(PartitionSpec spec, FileFormat format, SparkAppenderFactory appenderFactory,
-                         OutputFileFactory fileFactory, FileIO io, long targetFileSize) {
-      super(spec, format, appenderFactory, fileFactory, io, targetFileSize);
+                         OutputFileFactory fileFactory, FileIO io, long targetFileSize,
+                         Map<String, String> properties) {
+      super(spec, format, appenderFactory, fileFactory, io, targetFileSize, properties);
     }
 
     @Override
@@ -567,9 +569,9 @@ class SparkWrite {
 
   private static class Partitioned3Writer extends SparkPartitionedWriter implements DataWriter<InternalRow> {
     Partitioned3Writer(PartitionSpec spec, FileFormat format, SparkAppenderFactory appenderFactory,
-                       OutputFileFactory fileFactory, FileIO io, long targetFileSize,
-                       Schema schema, StructType sparkSchema) {
-      super(spec, format, appenderFactory, fileFactory, io, targetFileSize, schema, sparkSchema);
+        OutputFileFactory fileFactory, FileIO io, long targetFileSize,
+        Map<String, String> properties, Schema schema, StructType sparkSchema) {
+      super(spec, format, appenderFactory, fileFactory, io, targetFileSize, properties, schema, sparkSchema);
     }
 
     @Override
@@ -584,8 +586,8 @@ class SparkWrite {
       implements DataWriter<InternalRow> {
     PartitionedFanout3Writer(PartitionSpec spec, FileFormat format, SparkAppenderFactory appenderFactory,
                              OutputFileFactory fileFactory, FileIO io, long targetFileSize,
-                             Schema schema, StructType sparkSchema) {
-      super(spec, format, appenderFactory, fileFactory, io, targetFileSize, schema, sparkSchema);
+                             Map<String, String> properties, Schema schema, StructType sparkSchema) {
+      super(spec, format, appenderFactory, fileFactory, io, targetFileSize, properties, schema, sparkSchema);
     }
 
     @Override


### PR DESCRIPTION
Add configuration write.position.delete.flush.threshold to control how many rows data will open new pos-delete file. Then we can control pos-delete file numbers.
When iceberg write pos-delete file there is one default value 'DEFAULT_RECORDS_NUM_THRESHOLD = 100_000L'. When pos-delete records number attain 100_000 will open one new file, so when there is too much pos-delete records will create too much pos-delete. So in this PR add configuration write.records-num-threshold that users can control pos-delete file number.