### PR TITLE
[DOCS] Document how to add per-catalog hadoop conf values with Spark

### DIFF
--- a/site/docs/spark-configuration.md
+++ b/site/docs/spark-configuration.md
@@ -94,6 +94,14 @@ Spark's built-in catalog supports existing v1 and v2 tables tracked in a Hive Me
 
 This configuration can use same Hive Metastore for both Iceberg and non-Iceberg tables.
 
+### Using catalog specific Hadoop configuration values
+
+Similar to configuring Hadoop properties by using `spark.hadoop.*`, it is possible to set per-catalog Hadoop configuration values by adding the priperty for the catalog with the prefix `spark.sql.catalog.(catalog-name).hadoop.*`. These properties will take precedence over values configured globally using `spark.hadoop.*` and will only affect Iceberg tables.
+
+```plain
+spark.sql.catalog.hadoop_prod.hadoop.fs.s3a.endpoint = http://aws-local:9000
+```
+
 ### Loading a custom catalog
 
 Spark supports loading a custom Iceberg `Catalog` implementation by specifying the `catalog-impl` property.

--- a/site/docs/spark-configuration.md
+++ b/site/docs/spark-configuration.md
@@ -96,7 +96,7 @@ This configuration can use same Hive Metastore for both Iceberg and non-Iceberg 
 
 ### Using catalog specific Hadoop configuration values
 
-Similar to configuring Hadoop properties by using `spark.hadoop.*`, it is possible to set per-catalog Hadoop configuration values by adding the priperty for the catalog with the prefix `spark.sql.catalog.(catalog-name).hadoop.*`. These properties will take precedence over values configured globally using `spark.hadoop.*` and will only affect Iceberg tables.
+Similar to configuring Hadoop properties by using `spark.hadoop.*`, it's possible to set per-catalog Hadoop configuration values when using Spark by adding the property for the catalog with the prefix `spark.sql.catalog.(catalog-name).hadoop.*`. These properties will take precedence over values configured globally using `spark.hadoop.*` and will only affect Iceberg tables.
 
 ```plain
 spark.sql.catalog.hadoop_prod.hadoop.fs.s3a.endpoint = http://aws-local:9000


### PR DESCRIPTION
Adds a section to the Spark documentation on the website about how to override hadoop configuration values per catalog.

This is a very simple explanation and I'm open to discussion on what should be added.

This closes issue https://github.com/apache/iceberg/issues/2907

cc @rdblue 