### PR TITLE
Flink: Switch to using SerializableTable

### DIFF
--- a/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -42,6 +42,7 @@ import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.TableLoader;
@@ -356,9 +357,10 @@ public class FlinkSink {
     long targetFileSize = getTargetFileSizeBytes(props);
     FileFormat fileFormat = getFileFormat(props);
 
-    TaskWriterFactory<RowData> taskWriterFactory = new RowDataTaskWriterFactory(table.schema(), flinkRowType,
-        table.spec(), table.locationProvider(), table.io(), table.encryption(), targetFileSize, fileFormat, props,
-        equalityFieldIds);
+    Table serializableTable = SerializableTable.copyOf(table);
+    TaskWriterFactory<RowData> taskWriterFactory = new RowDataTaskWriterFactory(
+        serializableTable, flinkRowType, targetFileSize,
+        fileFormat, equalityFieldIds);
 
     return new IcebergStreamWriter<>(table.name(), taskWriterFactory);
   }

--- a/flink/src/main/java/org/apache/iceberg/flink/source/RowDataRewriter.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/source/RowDataRewriter.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.encryption.EncryptionManager;
@@ -52,7 +53,6 @@ public class RowDataRewriter {
   private static final Logger LOG = LoggerFactory.getLogger(RowDataRewriter.class);
 
   private final Schema schema;
-  private final FileFormat format;
   private final String nameMapping;
   private final FileIO io;
   private final boolean caseSensitive;
@@ -70,18 +70,13 @@ public class RowDataRewriter {
 
     String formatString = PropertyUtil.propertyAsString(table.properties(), TableProperties.DEFAULT_FILE_FORMAT,
         TableProperties.DEFAULT_FILE_FORMAT_DEFAULT);
-    this.format = FileFormat.valueOf(formatString.toUpperCase(Locale.ENGLISH));
+    FileFormat format = FileFormat.valueOf(formatString.toUpperCase(Locale.ENGLISH));
     RowType flinkSchema = FlinkSchemaUtil.convert(table.schema());
     this.taskWriterFactory = new RowDataTaskWriterFactory(
-        table.schema(),
+        SerializableTable.copyOf(table),
         flinkSchema,
-        table.spec(),
-        table.locationProvider(),
-        io,
-        encryptionManager,
         Long.MAX_VALUE,
         format,
-        table.properties(),
         null);
   }
 

--- a/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RowDelta;
+import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.TableTestBase;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
@@ -331,8 +332,8 @@ public class TestDeltaTaskWriter extends TableTestBase {
   }
 
   private TaskWriterFactory<RowData> createTaskWriterFactory(List<Integer> equalityFieldIds) {
-    return new RowDataTaskWriterFactory(table.schema(), FlinkSchemaUtil.convert(table.schema()),
-        table.spec(), table.locationProvider(), table.io(), table.encryption(), 128 * 1024 * 1024,
-        format, table.properties(), equalityFieldIds);
+    return new RowDataTaskWriterFactory(
+        SerializableTable.copyOf(table), FlinkSchemaUtil.convert(table.schema()),
+        128 * 1024 * 1024, format, equalityFieldIds);
   }
 }

--- a/flink/src/test/java/org/apache/iceberg/flink/sink/TestTaskWriters.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/sink/TestTaskWriters.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.data.Record;
@@ -236,10 +237,9 @@ public class TestTaskWriters {
   }
 
   private TaskWriter<RowData> createTaskWriter(long targetFileSize) {
-    TaskWriterFactory<RowData> taskWriterFactory = new RowDataTaskWriterFactory(table.schema(),
-        (RowType) SimpleDataUtil.FLINK_SCHEMA.toRowDataType().getLogicalType(), table.spec(),
-        table.locationProvider(), table.io(), table.encryption(),
-        targetFileSize, format, table.properties(), null);
+    TaskWriterFactory<RowData> taskWriterFactory = new RowDataTaskWriterFactory(
+        SerializableTable.copyOf(table), (RowType) SimpleDataUtil.FLINK_SCHEMA.toRowDataType().getLogicalType(),
+        targetFileSize, format, null);
     taskWriterFactory.initialize(1, 1);
     return taskWriterFactory.create();
   }


### PR DESCRIPTION
This PR switches Flink sink to use `SerializableTable` to avoid using deprecated methods in `OutputFileFactory`.