### PR TITLE
Core: Predicate pushdown for files metadata table

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -35,7 +35,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
  * deserialization.
  */
 abstract class BaseMetadataTable implements Table, HasTableOperations, Serializable {
-  private static final String PARTITION_FIELD_PREFIX = "partition.";
+  protected static final String PARTITION_FIELD_PREFIX = "partition.";
   private final PartitionSpec spec = PartitionSpec.unpartitioned();
   private final SortOrder sortOrder = SortOrder.unsorted();
   private final TableOperations ops;
@@ -48,22 +48,22 @@ abstract class BaseMetadataTable implements Table, HasTableOperations, Serializa
     this.name = name;
   }
 
-
   /**
    * This method transforms the table's partition spec to a spec that is used to rewrite the user-provided filter
-   * expression against the partitions table.
+   * expression against the given metadata table.
    * <p>
-   * The resulting partition spec maps partition.X fields to partition X using an identity partition transform. When
-   * this spec is used to project an expression for the partitions table, the projection will remove predicates for
-   * non-partition fields (not in the spec) and will remove the "partition." prefix from fields.
+   * The resulting partition spec maps $partitionPrefix.X fields to partition X using an identity partition transform.
+   * When this spec is used to project an expression for the given metadata table, the projection will remove
+   * predicates for non-partition fields (not in the spec) and will remove the "$partitionPrefix." prefix from fields.
    *
-   * @param partitionTableSchema schema of the partition table
-   * @param spec spec on which the partition table schema is based
-   * @return a spec used to rewrite partition table filters to partition filters using an inclusive projection
+   * @param metadataTableSchena schema of the metadata table
+   * @param spec spec on which the metadata table schema is based
+   * @param partitionPrefix prefix to remove from each field in the partition spec
+   * @return a spec used to rewrite the metadata table filters to partition filters using an inclusive projection
    */
-  static PartitionSpec transformSpec(Schema partitionTableSchema, PartitionSpec spec) {
-    PartitionSpec.Builder identitySpecBuilder = PartitionSpec.builderFor(partitionTableSchema);
-    spec.fields().forEach(pf -> identitySpecBuilder.identity(PARTITION_FIELD_PREFIX + pf.name(), pf.name()));
+  static PartitionSpec transformSpec(Schema metadataTableSchena, PartitionSpec spec, String partitionPrefix) {
+    PartitionSpec.Builder identitySpecBuilder = PartitionSpec.builderFor(metadataTableSchena);
+    spec.fields().forEach(pf -> identitySpecBuilder.identity(partitionPrefix + pf.name(), pf.name()));
     return identitySpecBuilder.build();
   }
 

--- a/core/src/main/java/org/apache/iceberg/DataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DataFilesTable.java
@@ -128,7 +128,7 @@ public class DataFilesTable extends BaseMetadataTable {
       // empty struct in the schema for unpartitioned tables. Some engines, like Spark, can't handle empty structs in
       // all cases.
       return CloseableIterable.transform(filtered, manifest ->
-          new ManifestReadTask(ops.io(), manifest, fileSchema, schemaString, specString, residuals));
+          new ManifestReadTask(ops.io(), manifest, schema(), schemaString, specString, residuals));
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/DataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DataFilesTable.java
@@ -21,9 +21,12 @@ package org.apache.iceberg;
 
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.ManifestEvaluator;
+import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
@@ -109,8 +112,21 @@ public class DataFilesTable extends BaseMetadataTable {
       Expression filter = ignoreResiduals ? Expressions.alwaysTrue() : rowFilter;
       ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(filter);
 
-      return CloseableIterable.transform(manifests, manifest ->
-          new ManifestReadTask(ops.io(), manifest, schema(), schemaString, specString, residuals));
+      // use an inclusive projection to remove the partition name prefix and filter out any non-partition expressions
+      Expression partitionFilter = Projections
+          .inclusive(transformSpec(fileSchema, table().spec()), caseSensitive)
+          .project(rowFilter);
+
+      ManifestEvaluator manifestEval = ManifestEvaluator.forPartitionFilter(partitionFilter, table().spec(),
+          caseSensitive);
+      CloseableIterable<ManifestFile> filtered = CloseableIterable.filter(manifests, manifestEval::eval);
+
+      // Data tasks produce the table schema, not the projection schema and projection is done by processing engines.
+      // This data task needs to use the table schema, which may not include a partition schema to avoid having an
+      // empty struct in the schema for unpartitioned tables. Some engines, like Spark, can't handle empty structs in
+      // all cases.
+      return CloseableIterable.transform(filtered, manifest ->
+          new ManifestReadTask(ops.io(), manifest, fileSchema, schemaString, specString, residuals));
     }
   }
 
@@ -137,6 +153,11 @@ public class DataFilesTable extends BaseMetadataTable {
     @Override
     public Iterable<FileScanTask> split(long splitSize) {
       return ImmutableList.of(this); // don't split
+    }
+
+    @VisibleForTesting
+    ManifestFile getManifest() {
+      return manifest;
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/DataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DataFilesTable.java
@@ -114,11 +114,13 @@ public class DataFilesTable extends BaseMetadataTable {
 
       // use an inclusive projection to remove the partition name prefix and filter out any non-partition expressions
       Expression partitionFilter = Projections
-          .inclusive(transformSpec(fileSchema, table().spec()), caseSensitive)
+          .inclusive(
+              transformSpec(fileSchema, table().spec(), PARTITION_FIELD_PREFIX),
+              caseSensitive)
           .project(rowFilter);
 
-      ManifestEvaluator manifestEval = ManifestEvaluator.forPartitionFilter(partitionFilter, table().spec(),
-          caseSensitive);
+      ManifestEvaluator manifestEval = ManifestEvaluator.forPartitionFilter(
+          partitionFilter, table().spec(), caseSensitive);
       CloseableIterable<ManifestFile> filtered = CloseableIterable.filter(manifests, manifestEval::eval);
 
       // Data tasks produce the table schema, not the projection schema and projection is done by processing engines.
@@ -156,7 +158,7 @@ public class DataFilesTable extends BaseMetadataTable {
     }
 
     @VisibleForTesting
-    ManifestFile getManifest() {
+    ManifestFile manifest() {
       return manifest;
     }
   }

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -111,7 +111,7 @@ public class PartitionsTable extends BaseMetadataTable {
 
     // use an inclusive projection to remove the partition name prefix and filter out any non-partition expressions
     Expression partitionFilter = Projections
-        .inclusive(transformSpec(scan.schema(), table.spec()), caseSensitive)
+        .inclusive(transformSpec(scan.schema(), table.spec(), PARTITION_FIELD_PREFIX), caseSensitive)
         .project(scan.filter());
 
     ManifestGroup manifestGroup = new ManifestGroup(table.io(), snapshot.dataManifests(), snapshot.deleteManifests())

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -37,7 +37,6 @@ public class PartitionsTable extends BaseMetadataTable {
   private final Schema schema;
   static final boolean PLAN_SCANS_WITH_WORKER_POOL =
       SystemProperties.getBoolean(SystemProperties.SCAN_THREAD_POOL_ENABLED, true);
-  private static final String PARTITION_FIELD_PREFIX = "partition.";
 
   PartitionsTable(TableOperations ops, Table table) {
     this(ops, table, table.name() + ".partitions");
@@ -130,24 +129,6 @@ public class PartitionsTable extends BaseMetadataTable {
     }
 
     return manifestGroup.planFiles();
-  }
-
-  /**
-   * This method transforms the table's partition spec to a spec that is used to rewrite the user-provided filter
-   * expression against the partitions table.
-   * <p>
-   * The resulting partition spec maps partition.X fields to partition X using an identity partition transform. When
-   * this spec is used to project an expression for the partitions table, the projection will remove predicates for
-   * non-partition fields (not in the spec) and will remove the "partition." prefix from fields.
-   *
-   * @param partitionTableSchema schema of the partition table
-   * @param spec spec on which the partition table schema is based
-   * @return a spec used to rewrite partition table filters to partition filters using an inclusive projection
-   */
-  private static PartitionSpec transformSpec(Schema partitionTableSchema, PartitionSpec spec) {
-    PartitionSpec.Builder identitySpecBuilder = PartitionSpec.builderFor(partitionTableSchema);
-    spec.fields().forEach(pf -> identitySpecBuilder.identity(PARTITION_FIELD_PREFIX + pf.name(), pf.name()));
-    return identitySpecBuilder.build();
   }
 
   private class PartitionsScan extends StaticTableScan {

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -20,8 +20,6 @@
 package org.apache.iceberg;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
@@ -48,6 +46,21 @@ public class TestMetadataTableScans extends TableTestBase {
 
   public TestMetadataTableScans(int formatVersion) {
     super(formatVersion);
+  }
+
+  private void preparePartitionedTable() {
+    table.newFastAppend()
+        .appendFile(FILE_PARTITION_0)
+        .commit();
+    table.newFastAppend()
+        .appendFile(FILE_PARTITION_1)
+        .commit();
+    table.newFastAppend()
+        .appendFile(FILE_PARTITION_2)
+        .commit();
+    table.newFastAppend()
+        .appendFile(FILE_PARTITION_3)
+        .commit();
   }
 
   @Test
@@ -167,18 +180,7 @@ public class TestMetadataTableScans extends TableTestBase {
 
   @Test
   public void testPartitionsTableScanNoFilter() {
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_0)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_1)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_2)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_3)
-        .commit();
+    preparePartitionedTable();
 
     Table partitionsTable = new PartitionsTable(table.ops(), table);
     Types.StructType expected = new Schema(
@@ -197,18 +199,7 @@ public class TestMetadataTableScans extends TableTestBase {
 
   @Test
   public void testPartitionsTableScanAndFilter() {
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_0)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_1)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_2)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_3)
-        .commit();
+    preparePartitionedTable();
 
     Table partitionsTable = new PartitionsTable(table.ops(), table);
 
@@ -223,18 +214,7 @@ public class TestMetadataTableScans extends TableTestBase {
 
   @Test
   public void testPartitionsTableScanLtFilter() {
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_0)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_1)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_2)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_3)
-        .commit();
+    preparePartitionedTable();
 
     Table partitionsTable = new PartitionsTable(table.ops(), table);
 
@@ -250,18 +230,7 @@ public class TestMetadataTableScans extends TableTestBase {
 
   @Test
   public void testPartitionsTableScanOrFilter() {
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_0)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_1)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_2)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_3)
-        .commit();
+    preparePartitionedTable();
 
     Table partitionsTable = new PartitionsTable(table.ops(), table);
 
@@ -280,18 +249,7 @@ public class TestMetadataTableScans extends TableTestBase {
 
   @Test
   public void testPartitionsScanNotFilter() {
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_0)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_1)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_2)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_3)
-        .commit();
+    preparePartitionedTable();
     Table partitionsTable = new PartitionsTable(table.ops(), table);
 
     Expression not = Expressions.not(Expressions.lessThan("partition.data_bucket", 2));
@@ -304,18 +262,7 @@ public class TestMetadataTableScans extends TableTestBase {
 
   @Test
   public void testPartitionsTableScanInFilter() {
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_0)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_1)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_2)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_3)
-        .commit();
+    preparePartitionedTable();
 
     Table partitionsTable = new PartitionsTable(table.ops(), table);
 
@@ -329,18 +276,7 @@ public class TestMetadataTableScans extends TableTestBase {
 
   @Test
   public void testPartitionsTableScanNotNullFilter() {
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_0)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_1)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_2)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_3)
-        .commit();
+    preparePartitionedTable();
 
     Table partitionsTable = new PartitionsTable(table.ops(), table);
 
@@ -356,18 +292,7 @@ public class TestMetadataTableScans extends TableTestBase {
 
   @Test
   public void testFilesTableScanNoFilter() {
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_0)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_1)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_2)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_3)
-        .commit();
+    preparePartitionedTable();
 
     Table dataFilesTable = new DataFilesTable(table.ops(), table);
     Types.StructType expected = new Schema(
@@ -377,32 +302,33 @@ public class TestMetadataTableScans extends TableTestBase {
 
     TableScan scanNoFilter = dataFilesTable.newScan().select("partition.data_bucket");
     Assert.assertEquals(expected, scanNoFilter.schema().asStruct());
-    CloseableIterable<CombinedScanTask> tasksNoFilter = scanNoFilter.planTasks();
-    List<ManifestFile> manifests = StreamSupport.stream(tasksNoFilter.spliterator(), false)
-        .flatMap(c -> c.files().stream().map(t -> ((DataFilesTable.ManifestReadTask) t).getManifest()))
-        .collect(Collectors.toList());
+    CloseableIterable<FileScanTask> tasksAndEq = scanNoFilter.planFiles();
 
-    Assert.assertEquals(4, manifests.size());
-    validateIncludesManifestFile(manifests, 0);
-    validateIncludesManifestFile(manifests, 1);
-    validateIncludesManifestFile(manifests, 2);
-    validateIncludesManifestFile(manifests, 3);
+    Assert.assertEquals(4, Iterables.size(tasksAndEq));
+    validateFileScanTasks(tasksAndEq, 0);
+    validateFileScanTasks(tasksAndEq, 1);
+    validateFileScanTasks(tasksAndEq, 2);
+    validateFileScanTasks(tasksAndEq, 3);
   }
 
   @Test
   public void testFilesTableScanAndFilter() {
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_0)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_1)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_2)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_3)
-        .commit();
+    preparePartitionedTable();
+
+    Table dataFilesTable = new DataFilesTable(table.ops(), table);
+
+    Expression andEquals = Expressions.and(
+        Expressions.equal("partition.data_bucket", 0),
+        Expressions.greaterThan("record_count", 0));
+    TableScan scanAndEq = dataFilesTable.newScan().filter(andEquals);
+    CloseableIterable<FileScanTask> tasksAndEq = scanAndEq.planFiles();
+    Assert.assertEquals(1, Iterables.size(tasksAndEq));
+    validateFileScanTasks(tasksAndEq, 0);
+  }
+
+  @Test
+  public void testFilesTableScanAndFilterWithPlanTasks() {
+    preparePartitionedTable();
 
     Table dataFilesTable = new DataFilesTable(table.ops(), table);
 
@@ -411,58 +337,27 @@ public class TestMetadataTableScans extends TableTestBase {
         Expressions.greaterThan("record_count", 0));
     TableScan scanAndEq = dataFilesTable.newScan().filter(andEquals);
     CloseableIterable<CombinedScanTask> tasksAndEq = scanAndEq.planTasks();
-    List<ManifestFile> manifests = StreamSupport.stream(tasksAndEq.spliterator(), false)
-        .flatMap(c -> c.files().stream().map(t -> ((DataFilesTable.ManifestReadTask) t).getManifest()))
-        .collect(Collectors.toList());
-    Assert.assertEquals(1, manifests.size());
-    validateIncludesManifestFile(manifests, 0);
+    Assert.assertEquals(1, Iterables.size(tasksAndEq));
+    validateCombinedScanTasks(tasksAndEq, 0);
   }
 
   @Test
   public void testFilesTableScanLtFilter() {
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_0)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_1)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_2)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_3)
-        .commit();
+    preparePartitionedTable();
 
     Table dataFilesTable = new DataFilesTable(table.ops(), table);
 
-    Expression ltAnd = Expressions.and(
-        Expressions.lessThan("partition.data_bucket", 2),
-        Expressions.greaterThan("record_count", 0));
-    TableScan scan = dataFilesTable.newScan()
-        .filter(ltAnd);
-    CloseableIterable<CombinedScanTask> tasksLt = scan.planTasks();
-    List<ManifestFile> manifests = StreamSupport.stream(tasksLt.spliterator(), false)
-        .flatMap(c -> c.files().stream().map(t -> ((DataFilesTable.ManifestReadTask) t).getManifest()))
-        .collect(Collectors.toList());
-    Assert.assertEquals(2, manifests.size());
-    validateIncludesManifestFile(manifests, 0);
-    validateIncludesManifestFile(manifests, 1);
+    Expression lt = Expressions.lessThan("partition.data_bucket", 2);
+    TableScan scan = dataFilesTable.newScan().filter(lt);
+    CloseableIterable<FileScanTask> tasksLt = scan.planFiles();
+    Assert.assertEquals(2, Iterables.size(tasksLt));
+    validateFileScanTasks(tasksLt, 0);
+    validateFileScanTasks(tasksLt, 1);
   }
 
   @Test
   public void testFilesTableScanOrFilter() {
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_0)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_1)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_2)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_3)
-        .commit();
+    preparePartitionedTable();
 
     Table dataFilesTable = new DataFilesTable(table.ops(), table);
 
@@ -471,105 +366,59 @@ public class TestMetadataTableScans extends TableTestBase {
         Expressions.greaterThan("record_count", 0));
     TableScan scan = dataFilesTable.newScan()
         .filter(or);
-    CloseableIterable<CombinedScanTask> tasksOr = scan.planTasks();
-    List<ManifestFile> manifests = StreamSupport.stream(tasksOr.spliterator(), false)
-        .flatMap(c -> c.files().stream().map(t -> ((DataFilesTable.ManifestReadTask) t).getManifest()))
-        .collect(Collectors.toList());
-    Assert.assertEquals(4, manifests.size());
-    validateIncludesManifestFile(manifests, 0);
-    validateIncludesManifestFile(manifests, 1);
-    validateIncludesManifestFile(manifests, 2);
-    validateIncludesManifestFile(manifests, 3);
+    CloseableIterable<FileScanTask> tasksOr = scan.planFiles();
+    Assert.assertEquals(4, Iterables.size(tasksOr));
+    validateFileScanTasks(tasksOr, 0);
+    validateFileScanTasks(tasksOr, 1);
+    validateFileScanTasks(tasksOr, 2);
+    validateFileScanTasks(tasksOr, 3);
   }
 
   @Test
   public void testFilesScanNotFilter() {
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_0)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_1)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_2)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_3)
-        .commit();
+    preparePartitionedTable();
     Table dataFilesTable = new DataFilesTable(table.ops(), table);
 
     Expression not = Expressions.not(Expressions.lessThan("partition.data_bucket", 2));
     TableScan scan = dataFilesTable.newScan()
         .filter(not);
-    CloseableIterable<CombinedScanTask> tasksNot = scan.planTasks();
-    List<ManifestFile> manifests = StreamSupport.stream(tasksNot.spliterator(), false)
-        .flatMap(c -> c.files().stream().map(t -> ((DataFilesTable.ManifestReadTask) t).getManifest()))
-        .collect(Collectors.toList());
-    Assert.assertEquals(2, manifests.size());
-    validateIncludesManifestFile(manifests, 2);
-    validateIncludesManifestFile(manifests, 3);
+    CloseableIterable<FileScanTask> tasksNot = scan.planFiles();
+    Assert.assertEquals(2, Iterables.size(tasksNot));
+    validateFileScanTasks(tasksNot, 2);
+    validateFileScanTasks(tasksNot, 3);
   }
-
 
   @Test
   public void testFilesTableScanInFilter() {
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_0)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_1)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_2)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_3)
-        .commit();
+    preparePartitionedTable();
 
     Table dataFilesTable = new DataFilesTable(table.ops(), table);
 
     Expression set = Expressions.in("partition.data_bucket", 2, 3);
     TableScan scan = dataFilesTable.newScan()
           .filter(set);
-    CloseableIterable<CombinedScanTask> tasksSet = scan.planTasks();
-    List<ManifestFile> manifests = StreamSupport.stream(tasksSet.spliterator(), false)
-        .flatMap(c -> c.files().stream().map(t -> ((DataFilesTable.ManifestReadTask) t).getManifest()))
-        .collect(Collectors.toList());
-    Assert.assertEquals(2, manifests.size());
+    CloseableIterable<FileScanTask> tasksNot = scan.planFiles();
+    Assert.assertEquals(2, Iterables.size(tasksNot));
 
-    validateIncludesManifestFile(manifests, 2);
-    validateIncludesManifestFile(manifests, 3);
+    validateFileScanTasks(tasksNot, 2);
+    validateFileScanTasks(tasksNot, 3);
   }
 
   @Test
   public void testFilesTableScanNotNullFilter() {
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_0)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_1)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_2)
-        .commit();
-    table.newFastAppend()
-        .appendFile(FILE_PARTITION_3)
-        .commit();
+    preparePartitionedTable();
 
     Table dataFilesTable = new DataFilesTable(table.ops(), table);
     Expression unary = Expressions.notNull("partition.data_bucket");
     TableScan scan = dataFilesTable.newScan()
         .filter(unary);
-    CloseableIterable<CombinedScanTask> tasksUnary = scan.planTasks();
-    List<ManifestFile> manifests = StreamSupport.stream(tasksUnary.spliterator(), false)
-        .flatMap(c -> c.files().stream().map(t -> ((DataFilesTable.ManifestReadTask) t).getManifest()))
-        .collect(Collectors.toList());
-    Assert.assertEquals(4, manifests.size());
+    CloseableIterable<FileScanTask> tasksUnary = scan.planFiles();
+    Assert.assertEquals(4, Iterables.size(tasksUnary));
 
-    validateIncludesManifestFile(manifests, 0);
-    validateIncludesManifestFile(manifests, 1);
-    validateIncludesManifestFile(manifests, 2);
-    validateIncludesManifestFile(manifests, 3);
+    validateFileScanTasks(tasksUnary, 0);
+    validateFileScanTasks(tasksUnary, 1);
+    validateFileScanTasks(tasksUnary, 2);
+    validateFileScanTasks(tasksUnary, 3);
   }
 
   @Test
@@ -614,13 +463,23 @@ public class TestMetadataTableScans extends TableTestBase {
             a -> a.file().partition().get(0, Object.class).equals(partValue)));
   }
 
-  private void validateIncludesManifestFile(List<ManifestFile> manifests, int partValue) {
+  private void validateFileScanTasks(CloseableIterable<FileScanTask> fileScanTasks, int partValue) {
     Assert.assertTrue("File scan tasks do not include correct file",
-        manifests.stream().anyMatch(m -> {
-          Assert.assertEquals("Table should be partitioned by one field", 1, m.partitions().size());
-          int lower = Conversions.fromByteBuffer(Types.IntegerType.get(), m.partitions().get(0).lowerBound());
-          int upper = Conversions.fromByteBuffer(Types.IntegerType.get(), m.partitions().get(0).upperBound());
-          return (lower <= partValue) && (upper >= partValue);
+        StreamSupport.stream(fileScanTasks.spliterator(), false).anyMatch(t -> {
+          ManifestFile mf = ((DataFilesTable.ManifestReadTask) t).manifest();
+          return manifestHasPartition(mf, partValue);
         }));
+  }
+
+  private void validateCombinedScanTasks(CloseableIterable<CombinedScanTask> tasks, int partValue) {
+    StreamSupport.stream(tasks.spliterator(), false)
+        .flatMap(c -> c.files().stream().map(t -> ((DataFilesTable.ManifestReadTask) t).manifest()))
+        .anyMatch(m -> manifestHasPartition(m, partValue));
+  }
+
+  private boolean manifestHasPartition(ManifestFile mf, int partValue) {
+    int lower = Conversions.fromByteBuffer(Types.IntegerType.get(), mf.partitions().get(0).lowerBound());
+    int upper = Conversions.fromByteBuffer(Types.IntegerType.get(), mf.partitions().get(0).upperBound());
+    return (lower <= partValue) && (upper >= partValue);
   }
 }


### PR DESCRIPTION
* This re-uses the logic of https://github.com/apache/iceberg/pull/2358 (partitions metadata table)