### PR TITLE
Core: Support nulls in StructLike collections

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/JavaHashes.java
+++ b/api/src/main/java/org/apache/iceberg/types/JavaHashes.java
@@ -81,6 +81,10 @@ public class JavaHashes {
 
     @Override
     public int hash(StructLike struct) {
+      if (struct == null) {
+        return 0;
+      }
+
       int result = 97;
       int len = hashes.length;
       result = 41 * result + len;
@@ -100,6 +104,10 @@ public class JavaHashes {
 
     @Override
     public int hash(List<?> list) {
+      if (list == null) {
+        return 0;
+      }
+
       int result = 17;
       int len = list.size();
       result = 37 * result + len;

--- a/core/src/main/java/org/apache/iceberg/util/StructLikeMap.java
+++ b/core/src/main/java/org/apache/iceberg/util/StructLikeMap.java
@@ -57,7 +57,7 @@ public class StructLikeMap<T> extends AbstractMap<StructLike, T> implements Map<
 
   @Override
   public boolean containsKey(Object key) {
-    if (key instanceof StructLike) {
+    if (key instanceof StructLike || key == null) {
       StructLikeWrapper wrapper = wrappers.get();
       boolean result = wrapperMap.containsKey(wrapper.set((StructLike) key));
       wrapper.set(null); // don't hold a reference to the key.
@@ -73,7 +73,7 @@ public class StructLikeMap<T> extends AbstractMap<StructLike, T> implements Map<
 
   @Override
   public T get(Object key) {
-    if (key instanceof StructLike) {
+    if (key instanceof StructLike || key == null) {
       StructLikeWrapper wrapper = wrappers.get();
       T value = wrapperMap.get(wrapper.set((StructLike) key));
       wrapper.set(null); // don't hold a reference to the key.
@@ -89,7 +89,7 @@ public class StructLikeMap<T> extends AbstractMap<StructLike, T> implements Map<
 
   @Override
   public T remove(Object key) {
-    if (key instanceof StructLike) {
+    if (key instanceof StructLike || key == null) {
       StructLikeWrapper wrapper = wrappers.get();
       T value = wrapperMap.remove(wrapper.set((StructLike) key));
       wrapper.set(null); // don't hold a reference to the key.

--- a/core/src/main/java/org/apache/iceberg/util/StructLikeSet.java
+++ b/core/src/main/java/org/apache/iceberg/util/StructLikeSet.java
@@ -57,7 +57,7 @@ public class StructLikeSet extends AbstractSet<StructLike> implements Set<Struct
 
   @Override
   public boolean contains(Object obj) {
-    if (obj instanceof StructLike) {
+    if (obj instanceof StructLike || obj == null) {
       StructLikeWrapper wrapper = wrappers.get();
       boolean result = wrapperSet.contains(wrapper.set((StructLike) obj));
       wrapper.set(null); // don't hold a reference to the value
@@ -105,7 +105,7 @@ public class StructLikeSet extends AbstractSet<StructLike> implements Set<Struct
 
   @Override
   public boolean remove(Object obj) {
-    if (obj instanceof StructLike) {
+    if (obj instanceof StructLike || obj == null) {
       StructLikeWrapper wrapper = wrappers.get();
       boolean result = wrapperSet.remove(wrapper.set((StructLike) obj));
       wrapper.set(null); // don't hold a reference to the value

--- a/core/src/test/java/org/apache/iceberg/util/TestStructLikeMap.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestStructLikeMap.java
@@ -129,4 +129,40 @@ public class TestStructLikeMap {
     map.put(record, "1-aaa");
     Assert.assertEquals("1-aaa", map.get(record));
   }
+
+  @Test
+  public void testNullKeys() {
+    Map<StructLike, String> map = StructLikeMap.create(STRUCT_TYPE);
+    Assert.assertFalse(map.containsKey(null));
+
+    map.put(null, "aaa");
+    Assert.assertTrue(map.containsKey(null));
+    Assert.assertEquals("aaa", map.get(null));
+
+    String replacedValue = map.put(null, "bbb");
+    Assert.assertEquals("aaa", replacedValue);
+
+    String removedValue = map.remove(null);
+    Assert.assertEquals("bbb", removedValue);
+  }
+
+  @Test
+  public void testKeysWithNulls() {
+    Record recordTemplate = GenericRecord.create(STRUCT_TYPE);
+    Record record1 = recordTemplate.copy("id", 1, "data", null);
+    Record record2 = recordTemplate.copy("id", 2, "data", null);
+
+    Map<StructLike, String> map = StructLikeMap.create(STRUCT_TYPE);
+    map.put(record1, "aaa");
+    map.put(record2, "bbb");
+
+    Assert.assertEquals("aaa", map.get(record1));
+    Assert.assertEquals("bbb", map.get(record2));
+
+    Record record3 = record1.copy();
+    Assert.assertTrue(map.containsKey(record3));
+    Assert.assertEquals("aaa", map.get(record3));
+
+    Assert.assertEquals("aaa", map.remove(record3));
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/util/TestStructLikeSet.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestStructLikeSet.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import java.util.Set;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.types.Types;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestStructLikeSet {
+  private static final Types.StructType STRUCT_TYPE = Types.StructType.of(
+      Types.NestedField.required(1, "id", Types.IntegerType.get()),
+      Types.NestedField.optional(2, "data", Types.LongType.get())
+  );
+
+  @Test
+  public void testNullElements() {
+    Set<StructLike> set = StructLikeSet.create(STRUCT_TYPE);
+    Assert.assertFalse(set.contains(null));
+
+    set.add(null);
+    Assert.assertTrue(set.contains(null));
+
+    boolean added = set.add(null);
+    Assert.assertFalse(added);
+
+    boolean removed = set.remove(null);
+    Assert.assertTrue(removed);
+    Assert.assertTrue(set.isEmpty());
+  }
+
+  @Test
+  public void testElementsWithNulls() {
+    Record recordTemplate = GenericRecord.create(STRUCT_TYPE);
+    Record record1 = recordTemplate.copy("id", 1, "data", null);
+    Record record2 = recordTemplate.copy("id", 2, "data", null);
+
+    Set<StructLike> set = StructLikeSet.create(STRUCT_TYPE);
+    set.add(record1);
+    set.add(record2);
+
+    Assert.assertTrue(set.contains(record1));
+    Assert.assertTrue(set.contains(record2));
+
+    Record record3 = record1.copy();
+    Assert.assertTrue(set.contains(record3));
+
+    boolean removed = set.remove(record3);
+    Assert.assertTrue(removed);
+  }
+}


### PR DESCRIPTION
Our `JavaHashes` are inconsistent in handling nulls. Specifically, only `CharSequenceHash` currently handles nulls correctly and all others fail with a NPE. In addition, our `StructLike` collections don't handle nulls too. It is possible to add a null object but never retrieve it.