### PR TITLE
Build: Upgrade Gradle to 5.6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Community discussions happen primarily on the [dev mailing list][dev-list] or on
 
 ### Building
 
-Iceberg is built using Gradle 5.4.1 with Java 1.8 or Java 11.
+Iceberg is built using Gradle 5.6.4 with Java 1.8 or Java 11.
 
 * To invoke a build and run tests: `./gradlew build`
 * To skip tests: `./gradlew build -x test`

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -21,4 +21,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip

--- a/gradlew
+++ b/gradlew
@@ -65,7 +65,7 @@ case "`uname`" in
 esac
 
 if [ ! -e $APP_HOME/gradle/wrapper/gradle-wrapper.jar ]; then
-    curl -o $APP_HOME/gradle/wrapper/gradle-wrapper.jar https://raw.githubusercontent.com/gradle/gradle/v5.4.1/gradle/wrapper/gradle-wrapper.jar
+    curl -o $APP_HOME/gradle/wrapper/gradle-wrapper.jar https://raw.githubusercontent.com/gradle/gradle/v5.6.4/gradle/wrapper/gradle-wrapper.jar
 fi
 
 CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar


### PR DESCRIPTION
This PR upgrades our Gradle version to 5.6.4.

The primary motivation is to have the ability to upgrade the JMH plugin so that we can support async-profiler and flamegraphs.