### PR TITLE
Core: Use correct metrics config for delete files

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/Avro.java
+++ b/core/src/main/java/org/apache/iceberg/avro/Avro.java
@@ -354,6 +354,7 @@ public class Avro {
       rowSchema(table.schema());
       withSpec(table.spec());
       setAll(table.properties());
+      metricsConfig(MetricsConfig.forTable(table));
       return this;
     }
 
@@ -383,6 +384,11 @@ public class Avro {
 
     public DeleteWriteBuilder overwrite(boolean enabled) {
       appenderBuilder.overwrite(enabled);
+      return this;
+    }
+
+    public DeleteWriteBuilder metricsConfig(MetricsConfig newMetricsConfig) {
+      appenderBuilder.metricsConfig(newMetricsConfig);
       return this;
     }
 

--- a/data/src/main/java/org/apache/iceberg/data/BaseFileWriterFactory.java
+++ b/data/src/main/java/org/apache/iceberg/data/BaseFileWriterFactory.java
@@ -153,10 +153,9 @@ public abstract class BaseFileWriterFactory<T> implements FileWriterFactory<T> {
     try {
       switch (deleteFileFormat) {
         case AVRO:
-          // TODO: support metrics configs in Avro equality delete writer
-
           Avro.DeleteWriteBuilder avroBuilder = Avro.writeDeletes(outputFile)
               .setAll(properties)
+              .metricsConfig(metricsConfig)
               .rowSchema(equalityDeleteRowSchema)
               .equalityFieldIds(equalityFieldIds)
               .withSpec(spec)
@@ -199,14 +198,14 @@ public abstract class BaseFileWriterFactory<T> implements FileWriterFactory<T> {
     OutputFile outputFile = file.encryptingOutputFile();
     EncryptionKeyMetadata keyMetadata = file.keyMetadata();
     Map<String, String> properties = table.properties();
-
-    // TODO: build and pass a correct metrics config for position deletes
+    MetricsConfig metricsConfig = MetricsConfig.forPositionDelete(table);
 
     try {
       switch (deleteFileFormat) {
         case AVRO:
           Avro.DeleteWriteBuilder avroBuilder = Avro.writeDeletes(outputFile)
               .setAll(properties)
+              .metricsConfig(metricsConfig)
               .rowSchema(positionDeleteRowSchema)
               .withSpec(spec)
               .withPartition(partition)
@@ -220,6 +219,7 @@ public abstract class BaseFileWriterFactory<T> implements FileWriterFactory<T> {
         case PARQUET:
           Parquet.DeleteWriteBuilder parquetBuilder = Parquet.writeDeletes(outputFile)
               .setAll(properties)
+              .metricsConfig(metricsConfig)
               .rowSchema(positionDeleteRowSchema)
               .withSpec(spec)
               .withPartition(partition)

--- a/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkWriterMetrics.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkWriterMetrics.java
@@ -39,6 +39,7 @@ public class TestFlinkWriterMetrics extends TestWriterMetrics<RowData> {
         .dataSchema(table.schema())
         .dataFileFormat(fileFormat)
         .deleteFileFormat(fileFormat)
+        .positionDeleteRowSchema(table.schema())
         .build();
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -518,7 +518,6 @@ public class Parquet {
     }
 
     public DeleteWriteBuilder metricsConfig(MetricsConfig newMetricsConfig) {
-      // TODO: keep full metrics for position delete file columns
       appenderBuilder.metricsConfig(newMetricsConfig);
       return this;
     }

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkWriterMetrics.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkWriterMetrics.java
@@ -39,6 +39,7 @@ public class TestSparkWriterMetrics extends TestWriterMetrics<InternalRow> {
         .dataSchema(table.schema())
         .dataFileFormat(fileFormat)
         .deleteFileFormat(fileFormat)
+        .positionDeleteRowSchema(table.schema())
         .build();
   }
 


### PR DESCRIPTION
This PR propagates a correct metrics config for Avro equality deletes and position deletes in Parquet and Avro.