### PR TITLE
Handle OVERWRITE snapshot on spark streaming for table v1

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Table.java
+++ b/api/src/main/java/org/apache/iceberg/Table.java
@@ -40,6 +40,13 @@ public interface Table {
   }
 
   /**
+   * Return the version for this table.
+   *
+   * @return this table's version
+   */
+  int formatVersion();
+
+  /**
    * Refresh the current table metadata.
    */
   void refresh();

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -64,6 +64,11 @@ abstract class BaseMetadataTable implements Table, HasTableOperations, Serializa
   }
 
   @Override
+  public int formatVersion() {
+    return ops.current().formatVersion();
+  }
+
+  @Override
   public FileIO io() {
     return table().io();
   }

--- a/core/src/main/java/org/apache/iceberg/BaseTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTable.java
@@ -55,6 +55,11 @@ public class BaseTable implements Table, HasTableOperations, Serializable {
   }
 
   @Override
+  public int formatVersion() {
+    return ops.current().formatVersion();
+  }
+
+  @Override
   public void refresh() {
     ops.refresh();
   }

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -513,6 +513,11 @@ class BaseTransaction implements Transaction {
     }
 
     @Override
+    public int formatVersion() {
+      return current.formatVersion();
+    }
+
+    @Override
     public void refresh() {
     }
 

--- a/core/src/main/java/org/apache/iceberg/SerializableTable.java
+++ b/core/src/main/java/org/apache/iceberg/SerializableTable.java
@@ -50,6 +50,7 @@ import org.apache.iceberg.util.SerializableMap;
 public class SerializableTable implements Table, Serializable {
 
   private final String name;
+  private final Integer formatVersion;
   private final String location;
   private final String metadataFileLocation;
   private final Map<String, String> properties;
@@ -67,6 +68,7 @@ public class SerializableTable implements Table, Serializable {
 
   private SerializableTable(Table table) {
     this.name = table.name();
+    this.formatVersion = table.formatVersion();
     this.location = table.location();
     this.metadataFileLocation = metadataFileLocation(table);
     this.properties = SerializableMap.copyOf(table.properties());
@@ -133,6 +135,11 @@ public class SerializableTable implements Table, Serializable {
   @Override
   public String name() {
     return name;
+  }
+
+  @Override
+  public int formatVersion() {
+    return formatVersion;
   }
 
   @Override

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java
@@ -53,4 +53,7 @@ public class SparkReadOptions {
 
   // skip snapshots of type delete while reading stream out of iceberg table
   public static final String STREAMING_SKIP_DELETE_SNAPSHOTS = "streaming-skip-delete-snapshots";
+
+  // resend snapshots of type overwrite while reading stream out of iceberg table
+  public static final String STREAMING_RESEND_OVERWRITE_SNAPSHOTS = "streaming-resend-overwrite-snapshots";
 }


### PR DESCRIPTION
Base on the proposal of @SreeramGarlapati,
As we can not to better for table v1, user can add the option
streaming-resend-overwrite-snapshots if he allow spark to resent
all the data for overwrite snapshots

Fix table v1 part of https://github.com/apache/iceberg/issues/2788