### PR TITLE
AWS: fix integration test after assert library refactor

### DIFF
--- a/api/src/test/java/org/apache/iceberg/AssertHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/AssertHelpers.java
@@ -114,12 +114,14 @@ public class AssertHelpers {
   }
 
   /**
-   * A convenience method to assert the cause of thrown exception.
+   * A convenience method to assert both the thrown exception and the cause of thrown exception.
    * @param message A String message to describe this assertion
    * @param expected  An Exception class that the Runnable should throw
-   * @param expectedContainedInMessage A String that should be contained by the thrown exception's message
+   * @param expectedContainedInMessage A String that should be contained by the thrown exception's message,
+   *                                   will be skipped if null.
    * @param cause An Exception class that the cause of the Runnable should throw
-   * @param causeContainedInMessage A String that should be contained by the cause of the thrown exception's message
+   * @param causeContainedInMessage A String that should be contained by the cause of the thrown exception's message,
+   *                                will be skipped if null.
    * @param runnable A Runnable that is expected to throw the runtime exception
    */
   public static void assertThrowsWithCause(String message,

--- a/api/src/test/java/org/apache/iceberg/AssertHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/AssertHelpers.java
@@ -114,6 +114,35 @@ public class AssertHelpers {
   }
 
   /**
+   * A convenience method to assert the cause of thrown exception.
+   * @param message A String message to describe this assertion
+   * @param expected  An Exception class that the Runnable should throw
+   * @param expectedContainedInMessage A String that should be contained by the thrown exception's message
+   * @param cause An Exception class that the cause of the Runnable should throw
+   * @param causeContainedInMessage A String that should be contained by the cause of the thrown exception's message
+   * @param runnable A Runnable that is expected to throw the runtime exception
+   */
+  public static void assertThrowsWithCause(String message,
+                                           Class<? extends Exception> expected,
+                                           String expectedContainedInMessage,
+                                           Class<? extends Exception> cause,
+                                           String causeContainedInMessage,
+                                           Runnable runnable) {
+    AbstractThrowableAssert<?, ?> chain = Assertions.assertThatThrownBy(runnable::run)
+        .as(message)
+        .isInstanceOf(expected);
+
+    if (expectedContainedInMessage != null) {
+      chain = chain.hasMessageContaining(expectedContainedInMessage);
+    }
+
+    chain = chain.getCause().isInstanceOf(cause);
+    if (causeContainedInMessage != null) {
+      chain.hasMessageContaining(causeContainedInMessage);
+    }
+  }
+
+  /**
    * A convenience method to check if an Avro field is empty.
    * @param record The record to read from
    * @param field The name of the field

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueCatalogCommitFailureTest.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueCatalogCommitFailureTest.java
@@ -76,8 +76,11 @@ public class GlueCatalogCommitFailureTest extends GlueTestBase {
     GlueTableOperations spyOps = Mockito.spy(ops);
     failCommitAndThrowException(spyOps, ConcurrentModificationException.builder().build());
 
-    AssertHelpers.assertThrows("GlueCatalog should fail on concurrent modifications",
-        ConcurrentModificationException.class, "Glue detected concurrent update",
+    AssertHelpers.assertThrowsWithCause("GlueCatalog should fail on concurrent modifications",
+        CommitFailedException.class,
+        "Glue detected concurrent update",
+        ConcurrentModificationException.class,
+        null,
         () -> spyOps.commit(metadataV2, metadataV1));
     Mockito.verify(spyOps, Mockito.times(0)).refresh();
 


### PR DESCRIPTION
@kbendick @yyanyy 

Integration test fails when running 0.12.0 build verification, due to the change in #2721. We never merged this internally so did not get a chance to test it.