### PR TITLE
Spark: Fix random test failures in TestDeleteReachableFilesAction

### DIFF
--- a/spark/src/test/java/org/apache/iceberg/actions/TestDeleteReachableFilesAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestDeleteReachableFilesAction.java
@@ -131,7 +131,7 @@ public abstract class TestDeleteReachableFilesAction extends SparkTestBase {
         .rewriteFiles(ImmutableSet.of(FILE_A), ImmutableSet.of(FILE_C))
         .commit();
 
-    Set<String> deletedFiles = Sets.newHashSet();
+    Set<String> deletedFiles = ConcurrentHashMap.newKeySet();
     Set<String> deleteThreads = ConcurrentHashMap.newKeySet();
     AtomicInteger deleteThreadsIndex = new AtomicInteger(0);
 


### PR DESCRIPTION
-- Sometimes fails with exception (reported also on Slack)
```
org.apache.iceberg.actions.TestRemoveFilesAction3 > dataFilesCleanupWithParallelTasks FAILED
    java.lang.AssertionError: FILE_A should be deleted
```
-- Fixed by making Set used for the assertion and update by async thread, a concurrent set
-- Validated by running 50 times (some exceptions seen before, did not see after)