### PR TITLE
Core: Add TypeUtil.project() for Explicit Projection

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/PruneColumns.java
+++ b/api/src/main/java/org/apache/iceberg/types/PruneColumns.java
@@ -118,7 +118,7 @@ class PruneColumns extends TypeUtil.SchemaVisitor<Type> {
         return projectList(list, projectedStruct);
       } else {
         Preconditions.checkArgument(list.elementType().isPrimitiveType(),
-            "Cannot explicitly project List or Map types, Field %s of type %s was selected",
+            "Cannot explicitly project List or Map types, List element %s of type %s was selected",
             list.elementId(), list.elementType());
         return list;
       }
@@ -138,7 +138,7 @@ class PruneColumns extends TypeUtil.SchemaVisitor<Type> {
         return projectMap(map, projectedStruct);
       } else {
         Preconditions.checkArgument(map.valueType().isPrimitiveType(),
-            "Cannot explicitly project List or Map types, Field %s of type %s was selected",
+            "Cannot explicitly project List or Map types, Map value %s of type %s was selected",
             map.valueId(), map.valueType());
         return map;
       }

--- a/api/src/main/java/org/apache/iceberg/types/PruneColumns.java
+++ b/api/src/main/java/org/apache/iceberg/types/PruneColumns.java
@@ -24,26 +24,27 @@ import java.util.Set;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types.ListType;
+import org.apache.iceberg.types.Types.MapType;
+import org.apache.iceberg.types.Types.StructType;
 
 class PruneColumns extends TypeUtil.SchemaVisitor<Type> {
   private final Set<Integer> selected;
-  private final boolean onlySelected;
+  private final boolean selectFullTypes;
 
   /**
    * Visits a schema and returns only those element's whose id's have been passed as selected
    * @param selected ids of elements to return
-   * @param onlySelected whether to return only elements which have been selected, no sub elements
+   * @param selectFullTypes whether explicitly selected fields should automatically include all subfields
    */
-  PruneColumns(Set<Integer> selected, boolean onlySelected) {
+  PruneColumns(Set<Integer> selected, boolean selectFullTypes) {
     Preconditions.checkNotNull(selected, "Selected field ids cannot be null");
     this.selected = selected;
-    this.onlySelected = onlySelected;
+    this.selectFullTypes = selectFullTypes;
   }
 
   PruneColumns(Set<Integer> selected) {
-    Preconditions.checkNotNull(selected, "Selected field ids cannot be null");
-    this.selected = selected;
-    this.onlySelected = false;
+    this(selected, true);
   }
 
   @Override
@@ -60,21 +61,18 @@ class PruneColumns extends TypeUtil.SchemaVisitor<Type> {
     for (int i = 0; i < fieldResults.size(); i += 1) {
       Types.NestedField field = fields.get(i);
       Type projectedType = fieldResults.get(i);
-      boolean includeField = !onlySelected || selected.contains(field.fieldId());
-      if (includeField) {
-        if (field.type() == projectedType) {
-          // uses identity because there is no need to check structure. if identity doesn't match
-          // then structure should not either.
-          selectedFields.add(field);
-        } else if (projectedType != null) {
-          sameTypes = false; // signal that some types were altered
-          if (field.isOptional()) {
-            selectedFields.add(
-                Types.NestedField.optional(field.fieldId(), field.name(), projectedType, field.doc()));
-          } else {
-            selectedFields.add(
-                Types.NestedField.required(field.fieldId(), field.name(), projectedType, field.doc()));
-          }
+      if (field.type() == projectedType) {
+        // uses identity because there is no need to check structure. if identity doesn't match
+        // then structure should not either.
+        selectedFields.add(field);
+      } else if (projectedType != null) {
+        sameTypes = false; // signal that some types were altered
+        if (field.isOptional()) {
+          selectedFields.add(
+              Types.NestedField.optional(field.fieldId(), field.name(), projectedType, field.doc()));
+        } else {
+          selectedFields.add(
+              Types.NestedField.required(field.fieldId(), field.name(), projectedType, field.doc()));
         }
       }
     }
@@ -85,8 +83,6 @@ class PruneColumns extends TypeUtil.SchemaVisitor<Type> {
       } else {
         return Types.StructType.of(selectedFields);
       }
-    } else if (onlySelected) {
-      return Types.StructType.of();
     }
 
     return null;
@@ -95,16 +91,17 @@ class PruneColumns extends TypeUtil.SchemaVisitor<Type> {
   @Override
   public Type field(Types.NestedField field, Type fieldResult) {
     if (selected.contains(field.fieldId())) {
-      if (onlySelected) {
-        // This may be an empty struct, if it is use the fieldResult which will be an emptyStruct
-        return fieldResult == null ? field.type() : fieldResult;
+      if (field.type().isStructType() && !selectFullTypes) {
+        return projectSelectedStruct(fieldResult);
       } else {
+        Preconditions.checkArgument(selectFullTypes || !field.type().isNestedType(),
+            "Cannot select partial List or Map types explicitly");
+        // Selected non-struct field
         return field.type();
       }
     } else if (fieldResult != null) {
-      // this isn't necessarily the same as field.type() because a struct may not have all
-      // fields selected.
-      return fieldResult;
+      // This field wasn't selected but a subfield was so include that
+      return  fieldResult;
     }
     return null;
   }
@@ -112,15 +109,14 @@ class PruneColumns extends TypeUtil.SchemaVisitor<Type> {
   @Override
   public Type list(Types.ListType list, Type elementResult) {
     if (selected.contains(list.elementId())) {
-      return list;
-    } else if (elementResult != null) {
-      if (list.elementType() == elementResult) {
-        return list;
-      } else if (list.isElementOptional()) {
-        return Types.ListType.ofOptional(list.elementId(), elementResult);
+      if (list.elementType().isStructType() && !selectFullTypes) {
+        StructType projectedStruct = projectSelectedStruct(elementResult);
+        return projectList(list, projectedStruct);
       } else {
-        return Types.ListType.ofRequired(list.elementId(), elementResult);
+        return list;
       }
+    } else if (elementResult != null) {
+      return projectList(list, elementResult);
     }
     return null;
   }
@@ -128,15 +124,14 @@ class PruneColumns extends TypeUtil.SchemaVisitor<Type> {
   @Override
   public Type map(Types.MapType map, Type ignored, Type valueResult) {
     if (selected.contains(map.valueId())) {
-      return map;
-    } else if (valueResult != null) {
-      if (map.valueType() == valueResult) {
-        return map;
-      } else if (map.isValueOptional()) {
-        return Types.MapType.ofOptional(map.keyId(), map.valueId(), map.keyType(), valueResult);
+      if (map.valueType().isStructType() && !selectFullTypes) {
+        Type projectedStruct = projectSelectedStruct(valueResult);
+        return projectMap(map, projectedStruct);
       } else {
-        return Types.MapType.ofRequired(map.keyId(), map.valueId(), map.keyType(), valueResult);
+        return map;
       }
+    } else if (valueResult != null) {
+      return projectMap(map, valueResult);
     } else if (selected.contains(map.keyId())) {
       // right now, maps can't be selected without values
       return map;
@@ -147,5 +142,45 @@ class PruneColumns extends TypeUtil.SchemaVisitor<Type> {
   @Override
   public Type primitive(Type.PrimitiveType primitive) {
     return null;
+  }
+
+  private ListType projectList(ListType list, Type elementResult) {
+    Preconditions.checkArgument(elementResult != null);
+    if (list.elementType() == elementResult) {
+      return list;
+    } else if (list.isElementOptional()) {
+      return Types.ListType.ofOptional(list.elementId(), elementResult);
+    } else {
+      return Types.ListType.ofRequired(list.elementId(), elementResult);
+    }
+  }
+
+  private MapType projectMap(MapType map, Type valueResult) {
+    Preconditions.checkArgument(valueResult != null);
+    if (map.valueType() == valueResult) {
+      return map;
+    } else if (map.isValueOptional()) {
+      return Types.MapType.ofOptional(map.keyId(), map.valueId(), map.keyType(), valueResult);
+    } else {
+      return Types.MapType.ofRequired(map.keyId(), map.valueId(), map.keyType(), valueResult);
+    }
+  }
+
+  /**
+   * If select full types is disabled we need to recreate the struct with only the selected
+   * subfields. If no subfields are selected we return an empty struct.
+   * @param projectedField subfields already selected in this projection
+   * @return projected struct
+   */
+  private StructType projectSelectedStruct(Type projectedField) {
+    Preconditions.checkArgument(projectedField == null || projectedField.isStructType());
+    // the struct was selected, ensure at least an empty struct is returned
+    if (projectedField == null) {
+      // no sub-fields were selected but the struct was, return an empty struct
+      return Types.StructType.of();
+    } else {
+      // sub-fields were selected so return the projected struct
+      return projectedField.asStructType();
+    }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -42,6 +42,45 @@ public class TypeUtil {
   private TypeUtil() {
   }
 
+  /**
+   * Project extracts particular fields from a schema. Unlike
+   * {@link TypeUtil#select(Schema, Set)}, project will pick out only
+   * the fields enumerated, this means no sub fields will be selected
+   * unless they are explicitly requested.
+   * @param schema to project fields from
+   * @param fieldIds list of explicit fields to extract
+   * @return the schema with all fields fields not selected removed
+   */
+  public static Schema project(Schema schema, Set<Integer> fieldIds) {
+    Preconditions.checkNotNull(schema, "Schema cannot be null");
+
+    Types.StructType result = project(schema.asStruct(), fieldIds);
+    if (Objects.equals(schema.asStruct(), result)) {
+      return schema;
+    } else if (result != null) {
+      if (schema.getAliases() != null) {
+        return new Schema(result.fields(), schema.getAliases());
+      } else {
+        return new Schema(result.fields());
+      }
+    }
+    return new Schema();
+  }
+
+  public static Types.StructType project(Types.StructType struct, Set<Integer> fieldIds) {
+    Preconditions.checkNotNull(struct, "Struct cannot be null");
+    Preconditions.checkNotNull(fieldIds, "Field ids cannot be null");
+
+    Type result = visit(struct, new PruneColumns(fieldIds, true));
+    if (struct == result) {
+      return struct;
+    } else if (result != null) {
+      return result.asStructType();
+    }
+
+    return Types.StructType.of();
+  }
+
   public static Schema select(Schema schema, Set<Integer> fieldIds) {
     Preconditions.checkNotNull(schema, "Schema cannot be null");
 

--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -71,7 +71,7 @@ public class TypeUtil {
     Preconditions.checkNotNull(struct, "Struct cannot be null");
     Preconditions.checkNotNull(fieldIds, "Field ids cannot be null");
 
-    Type result = visit(struct, new PruneColumns(fieldIds, true));
+    Type result = visit(struct, new PruneColumns(fieldIds, false));
     if (struct == result) {
       return struct;
     } else if (result != null) {

--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -74,7 +74,7 @@ public class TypeUtil {
     Preconditions.checkNotNull(fieldIds, "Field ids cannot be null");
 
     Type result = visit(struct, new PruneColumns(fieldIds, false));
-    if (struct == result) {
+    if (struct.equals(result)) {
       return struct;
     } else if (result != null) {
       return result.asStructType();

--- a/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
@@ -144,7 +144,9 @@ public class TestTypeUtil {
                 )))));
 
     Schema actualDepthTwo = TypeUtil.project(schema, Sets.newHashSet(11, 12, 15, 17));
+    Schema actualDepthTwoChildren = TypeUtil.project(schema, Sets.newHashSet(11, 17));
     Assert.assertEquals(expectedDepthTwo.asStruct(), actualDepthTwo.asStruct());
+    Assert.assertEquals(expectedDepthTwo.asStruct(), actualDepthTwoChildren.asStruct());
   }
 
   @Test
@@ -179,7 +181,9 @@ public class TestTypeUtil {
                 ))))));
 
     Schema actualDepthThree = TypeUtil.project(schema, Sets.newHashSet(12, 15, 20));
+    Schema actualDepthThreeChildren = TypeUtil.project(schema, Sets.newHashSet(20));
     Assert.assertEquals(expectedDepthThree.asStruct(), actualDepthThree.asStruct());
+    Assert.assertEquals(expectedDepthThree.asStruct(), actualDepthThreeChildren.asStruct());
   }
 
   @Test
@@ -260,7 +264,7 @@ public class TestTypeUtil {
 
   @Test
   public void testProjectMap() {
-    // We can't partially project keys
+    // We can't partially project keys because it changes key equality
     Schema schema = new Schema(
         Lists.newArrayList(
             required(10, "a", Types.IntegerType.get()),
@@ -297,7 +301,9 @@ public class TestTypeUtil {
                     optional(101, "y", Types.IntegerType.get())),
                 Types.StructType.of()))));
     Schema actualDepthOne = TypeUtil.project(schema, Sets.newHashSet(10, 13, 14, 100, 101));
+    Schema actualDepthOneNoKeys = TypeUtil.project(schema, Sets.newHashSet(10, 13, 14));
     Assert.assertEquals(expectedDepthOne.asStruct(), actualDepthOne.asStruct());
+    Assert.assertEquals(expectedDepthOne.asStruct(), actualDepthOneNoKeys.asStruct());
 
     Schema expectedDepthTwo = new Schema(
             Lists.newArrayList(

--- a/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
@@ -20,12 +20,14 @@
 
 package org.apache.iceberg.types;
 
+import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 
@@ -146,6 +148,41 @@ public class TestTypeUtil {
   }
 
   @Test
+  public void testProjectNaturallyEmpty() {
+    Schema schema = new Schema(
+        Lists.newArrayList(
+            required(12, "someStruct", Types.StructType.of(
+                required(15, "anotherStruct", Types.StructType.of(
+                    required(20, "empty", Types.StructType.of())
+                ))))));
+
+    Schema expectedDepthOne = new Schema(
+        Lists.newArrayList(
+            required(12, "someStruct", Types.StructType.of())));
+
+    Schema actualDepthOne = TypeUtil.project(schema, Sets.newHashSet(12));
+    Assert.assertEquals(expectedDepthOne.asStruct(), actualDepthOne.asStruct());
+
+    Schema expectedDepthTwo = new Schema(
+        Lists.newArrayList(
+            required(12, "someStruct", Types.StructType.of(
+                required(15, "anotherStruct", Types.StructType.of())))));
+
+    Schema actualDepthTwo = TypeUtil.project(schema, Sets.newHashSet(12, 15));
+    Assert.assertEquals(expectedDepthTwo.asStruct(), actualDepthTwo.asStruct());
+
+    Schema expectedDepthThree =  new Schema(
+        Lists.newArrayList(
+            required(12, "someStruct", Types.StructType.of(
+                required(15, "anotherStruct", Types.StructType.of(
+                    required(20, "empty", Types.StructType.of())
+                ))))));
+
+    Schema actualDepthThree = TypeUtil.project(schema, Sets.newHashSet(12, 15, 20));
+    Assert.assertEquals(expectedDepthThree.asStruct(), actualDepthThree.asStruct());
+  }
+
+  @Test
   public void testProjectEmpty() {
     Schema schema = new Schema(
         Lists.newArrayList(
@@ -172,6 +209,154 @@ public class TestTypeUtil {
                 required(15, "anotherStruct", Types.StructType.of())))));
 
     Schema actualDepthTwo = TypeUtil.project(schema, Sets.newHashSet(12, 15));
+    Assert.assertEquals(expectedDepthTwo.asStruct(), actualDepthTwo.asStruct());
+  }
+
+  @Test
+  public void testSelect() {
+    Schema schema = new Schema(
+        Lists.newArrayList(
+            required(10, "a", Types.IntegerType.get()),
+            required(11, "A", Types.IntegerType.get()),
+            required(12, "someStruct", Types.StructType.of(
+                required(13, "b", Types.IntegerType.get()),
+                required(14, "B", Types.IntegerType.get()),
+                required(15, "anotherStruct", Types.StructType.of(
+                    required(16, "c", Types.IntegerType.get()),
+                    required(17, "C", Types.IntegerType.get()))
+                )))));
+
+    Schema expectedTop = new Schema(
+        Lists.newArrayList(
+            required(11, "A", Types.IntegerType.get())));
+
+    Schema actualTop = TypeUtil.select(schema, Sets.newHashSet(11));
+    Assert.assertEquals(expectedTop.asStruct(), actualTop.asStruct());
+
+    Schema expectedDepthOne = new Schema(
+        Lists.newArrayList(
+            required(10, "a", Types.IntegerType.get()),
+            required(12, "someStruct", Types.StructType.of(
+                required(13, "b", Types.IntegerType.get()),
+                required(14, "B", Types.IntegerType.get()),
+                required(15, "anotherStruct", Types.StructType.of(
+                    required(16, "c", Types.IntegerType.get()),
+                    required(17, "C", Types.IntegerType.get())))))));
+
+    Schema actualDepthOne = TypeUtil.select(schema, Sets.newHashSet(10, 12));
+    Assert.assertEquals(expectedDepthOne.asStruct(), actualDepthOne.asStruct());
+
+    Schema expectedDepthTwo = new Schema(
+        Lists.newArrayList(
+            required(11, "A", Types.IntegerType.get()),
+            required(12, "someStruct", Types.StructType.of(
+                required(15, "anotherStruct", Types.StructType.of(
+                    required(17, "C", Types.IntegerType.get()))
+                )))));
+
+    Schema actualDepthTwo = TypeUtil.select(schema, Sets.newHashSet(11, 17));
+    Assert.assertEquals(expectedDepthTwo.asStruct(), actualDepthTwo.asStruct());
+  }
+
+  @Test
+  public void testProjectMap() {
+    // We can't partially project keys
+    Schema schema = new Schema(
+        Lists.newArrayList(
+            required(10, "a", Types.IntegerType.get()),
+            required(11, "A", Types.IntegerType.get()),
+            required(12, "map", Types.MapType.ofRequired(13, 14,
+                Types.StructType.of(
+                    optional(100, "x", Types.IntegerType.get()),
+                    optional(101, "y", Types.IntegerType.get())),
+                Types.StructType.of(
+                    required(200, "z", Types.IntegerType.get()),
+                    optional(201, "innerMap", Types.MapType.ofOptional(202, 203,
+                        Types.IntegerType.get(),
+                        Types.StructType.of(
+                            required(300, "foo", Types.IntegerType.get()),
+                            required(301, "bar", Types.IntegerType.get())))))))));
+
+    Assert.assertThrows("Cannot project maps explicitly", IllegalArgumentException.class,
+        () -> TypeUtil.project(schema, Sets.newHashSet(12)));
+
+    Assert.assertThrows("Cannot project maps explicitly", IllegalArgumentException.class,
+        () -> TypeUtil.project(schema, Sets.newHashSet(201)));
+
+    Schema expectedTopLevel = new Schema(
+        Lists.newArrayList(required(10, "a", Types.IntegerType.get())));
+    Schema actualTopLevel = TypeUtil.project(schema, Sets.newHashSet(10));
+    Assert.assertEquals(expectedTopLevel.asStruct(), actualTopLevel.asStruct());
+
+    Schema expectedDepthOne = new Schema(
+        Lists.newArrayList(
+            required(10, "a", Types.IntegerType.get()),
+            required(12, "map", Types.MapType.ofRequired(13, 14,
+                Types.StructType.of(
+                    optional(100, "x", Types.IntegerType.get()),
+                    optional(101, "y", Types.IntegerType.get())),
+                Types.StructType.of()))));
+    Schema actualDepthOne = TypeUtil.project(schema, Sets.newHashSet(10, 13, 14, 100, 101));
+    Assert.assertEquals(expectedDepthOne.asStruct(), actualDepthOne.asStruct());
+
+    Schema expectedDepthTwo = new Schema(
+            Lists.newArrayList(
+                required(10, "a", Types.IntegerType.get()),
+                required(12, "map", Types.MapType.ofRequired(13, 14,
+                    Types.StructType.of(
+                        optional(100, "x", Types.IntegerType.get()),
+                        optional(101, "y", Types.IntegerType.get())),
+                    Types.StructType.of(
+                        required(200, "z", Types.IntegerType.get()),
+                        optional(201, "innerMap", Types.MapType.ofOptional(202, 203,
+                            Types.IntegerType.get(),
+                            Types.StructType.of())))))));
+    Schema actualDepthTwo = TypeUtil.project(schema, Sets.newHashSet(10, 13, 14, 100, 101, 200, 202, 203));
+    Assert.assertEquals(expectedDepthTwo.asStruct(), actualDepthTwo.asStruct());
+  }
+
+  @Test
+  public void testProjectList() {
+    Schema schema = new Schema(
+        Lists.newArrayList(
+            required(10, "a", Types.IntegerType.get()),
+            required(11, "A", Types.IntegerType.get()),
+            required(12, "list", Types.ListType.ofRequired(13,
+                Types.StructType.of(
+                    optional(20, "foo", Types.IntegerType.get()),
+                    required(21, "subList", Types.ListType.ofRequired(14,
+                        Types.StructType.of(
+                            required(15, "x", Types.IntegerType.get()),
+                            required(16, "y", Types.IntegerType.get()),
+                            required(17, "z", Types.IntegerType.get())))))))));
+
+
+    AssertHelpers.assertThrows("Cannot explicitly project List",
+        IllegalArgumentException.class,
+        () -> TypeUtil.project(schema, Sets.newHashSet(12))
+    );
+
+    AssertHelpers.assertThrows("Cannot explicitly project List",
+        IllegalArgumentException.class,
+        () -> TypeUtil.project(schema, Sets.newHashSet(21))
+    );
+
+    Schema expectedDepthOne = new Schema(
+        Lists.newArrayList(
+            required(12, "list", Types.ListType.ofRequired(13,
+                Types.StructType.of()))));
+    Schema actualDepthOne = TypeUtil.project(schema, Sets.newHashSet(13));
+    Assert.assertEquals(expectedDepthOne.asStruct(), actualDepthOne.asStruct());
+
+    Schema expectedDepthTwo = new Schema(
+        Lists.newArrayList(
+            required(10, "a", Types.IntegerType.get()),
+            required(12, "list", Types.ListType.ofRequired(13,
+                Types.StructType.of(
+                    optional(20, "foo", Types.IntegerType.get()),
+                    required(21, "subList", Types.ListType.ofRequired(14,
+                        Types.StructType.of())))))));
+    Schema actualDepthTwo = TypeUtil.project(schema, Sets.newHashSet(10, 13, 20, 14));
     Assert.assertEquals(expectedDepthTwo.asStruct(), actualDepthTwo.asStruct());
   }
 


### PR DESCRIPTION
Previously we only had TypeUtil.select which would select all nested
elements of selected structs. This made it difficult to project empty
structs since they would have no selected leaf elements. The new
TypeUtil.project instead takes only the elements which are specifically
requested with no automatic selection of nested elements.