### PR TITLE
API: Change GetProjectedIds to Return all Ids

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/GetProjectedIds.java
+++ b/api/src/main/java/org/apache/iceberg/types/GetProjectedIds.java
@@ -25,7 +25,16 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 
 class GetProjectedIds extends TypeUtil.SchemaVisitor<Set<Integer>> {
+  private final boolean includeStructIds;
   private final Set<Integer> fieldIds = Sets.newHashSet();
+
+  GetProjectedIds() {
+    this(false);
+  }
+
+  GetProjectedIds(boolean includeStructIds) {
+    this.includeStructIds = includeStructIds;
+  }
 
   @Override
   public Set<Integer> schema(Schema schema, Set<Integer> structResult) {
@@ -39,7 +48,7 @@ class GetProjectedIds extends TypeUtil.SchemaVisitor<Set<Integer>> {
 
   @Override
   public Set<Integer> field(Types.NestedField field, Set<Integer> fieldResult) {
-    if (field.type().isStructType() || field.type().isPrimitiveType()) {
+    if ((includeStructIds && field.type().isStructType()) || field.type().isPrimitiveType()) {
       fieldIds.add(field.fieldId());
     }
     return fieldIds;

--- a/api/src/main/java/org/apache/iceberg/types/GetProjectedIds.java
+++ b/api/src/main/java/org/apache/iceberg/types/GetProjectedIds.java
@@ -39,9 +39,7 @@ class GetProjectedIds extends TypeUtil.SchemaVisitor<Set<Integer>> {
 
   @Override
   public Set<Integer> field(Types.NestedField field, Set<Integer> fieldResult) {
-    if (fieldResult == null) {
-      fieldIds.add(field.fieldId());
-    }
+    fieldIds.add(field.fieldId());
     return fieldIds;
   }
 

--- a/api/src/main/java/org/apache/iceberg/types/GetProjectedIds.java
+++ b/api/src/main/java/org/apache/iceberg/types/GetProjectedIds.java
@@ -39,7 +39,9 @@ class GetProjectedIds extends TypeUtil.SchemaVisitor<Set<Integer>> {
 
   @Override
   public Set<Integer> field(Types.NestedField field, Set<Integer> fieldResult) {
-    fieldIds.add(field.fieldId());
+    if (field.type().isStructType() || field.type().isPrimitiveType()) {
+      fieldIds.add(field.fieldId());
+    }
     return fieldIds;
   }
 

--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -125,18 +125,22 @@ public class TypeUtil {
     return ImmutableSet.copyOf(getIdsInternal(type));
   }
 
+  private static Set<Integer> getIdsInternal(Type type, boolean includeStructIds) {
+    return visit(type, new GetProjectedIds(includeStructIds));
+  }
+
   private static Set<Integer> getIdsInternal(Type type) {
-    return visit(type, new GetProjectedIds());
+    return getIdsInternal(type, true);
   }
 
   public static Types.StructType selectNot(Types.StructType struct, Set<Integer> fieldIds) {
-    Set<Integer> projectedIds = getIdsInternal(struct);
+    Set<Integer> projectedIds = getIdsInternal(struct, false);
     projectedIds.removeAll(fieldIds);
     return project(struct, projectedIds);
   }
 
   public static Schema selectNot(Schema schema, Set<Integer> fieldIds) {
-    Set<Integer> projectedIds = getIdsInternal(schema.asStruct());
+    Set<Integer> projectedIds = getIdsInternal(schema.asStruct(), false);
     projectedIds.removeAll(fieldIds);
     return project(schema, projectedIds);
   }

--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -115,22 +115,18 @@ public class TypeUtil {
   }
 
   public static Set<Integer> getProjectedIds(Schema schema) {
-    return ImmutableSet.copyOf(getIdsInternal(schema.asStruct()));
+    return ImmutableSet.copyOf(getIdsInternal(schema.asStruct(), true));
   }
 
   public static Set<Integer> getProjectedIds(Type type) {
     if (type.isPrimitiveType()) {
       return ImmutableSet.of();
     }
-    return ImmutableSet.copyOf(getIdsInternal(type));
+    return ImmutableSet.copyOf(getIdsInternal(type, true));
   }
 
   private static Set<Integer> getIdsInternal(Type type, boolean includeStructIds) {
     return visit(type, new GetProjectedIds(includeStructIds));
-  }
-
-  private static Set<Integer> getIdsInternal(Type type) {
-    return getIdsInternal(type, true);
   }
 
   public static Types.StructType selectNot(Types.StructType struct, Set<Integer> fieldIds) {

--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -132,13 +132,13 @@ public class TypeUtil {
   public static Types.StructType selectNot(Types.StructType struct, Set<Integer> fieldIds) {
     Set<Integer> projectedIds = getIdsInternal(struct);
     projectedIds.removeAll(fieldIds);
-    return select(struct, projectedIds);
+    return project(struct, projectedIds);
   }
 
   public static Schema selectNot(Schema schema, Set<Integer> fieldIds) {
     Set<Integer> projectedIds = getIdsInternal(schema.asStruct());
     projectedIds.removeAll(fieldIds);
-    return select(schema, projectedIds);
+    return project(schema, projectedIds);
   }
 
   public static Schema join(Schema left, Schema right) {

--- a/api/src/main/java/org/apache/iceberg/util/StructProjection.java
+++ b/api/src/main/java/org/apache/iceberg/util/StructProjection.java
@@ -42,7 +42,7 @@ public class StructProjection implements StructLike {
    */
   public static StructProjection create(Schema schema, Set<Integer> ids) {
     StructType structType = schema.asStruct();
-    return new StructProjection(structType, TypeUtil.select(structType, ids));
+    return new StructProjection(structType, TypeUtil.project(structType, ids));
   }
 
   /**

--- a/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
@@ -338,8 +338,7 @@ public class TestTypeUtil {
                     required(17, "C", Types.IntegerType.get()))
                 )))));
 
-    // Should select everything except 12 and 15 since they are structs with selected elements
-    Set<Integer> expectedIds = Sets.newHashSet(10, 11, 35, 13, 14, 16, 17);
+    Set<Integer> expectedIds = Sets.newHashSet(10, 11, 35, 12, 13, 14, 15, 16, 17);
     Set<Integer> actualIds = TypeUtil.getProjectedIds(schema);
 
     Assert.assertEquals(expectedIds, actualIds);

--- a/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
@@ -20,8 +20,8 @@
 
 package org.apache.iceberg.types;
 
-import org.apache.iceberg.AssertHelpers;
 import java.util.Set;
+import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;

--- a/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
@@ -21,6 +21,7 @@
 package org.apache.iceberg.types;
 
 import org.apache.iceberg.AssertHelpers;
+import java.util.Set;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -323,48 +324,25 @@ public class TestTypeUtil {
   }
 
   @Test
-  public void testProjectList() {
+  public void testGetProjectedIds() {
     Schema schema = new Schema(
         Lists.newArrayList(
             required(10, "a", Types.IntegerType.get()),
             required(11, "A", Types.IntegerType.get()),
-            required(12, "list", Types.ListType.ofRequired(13,
-                Types.StructType.of(
-                    optional(20, "foo", Types.IntegerType.get()),
-                    required(21, "subList", Types.ListType.ofRequired(14,
-                        Types.StructType.of(
-                            required(15, "x", Types.IntegerType.get()),
-                            required(16, "y", Types.IntegerType.get()),
-                            required(17, "z", Types.IntegerType.get())))))))));
+            required(35, "emptyStruct", Types.StructType.of()),
+            required(12, "someStruct", Types.StructType.of(
+                required(13, "b", Types.IntegerType.get()),
+                required(14, "B", Types.IntegerType.get()),
+                required(15, "anotherStruct", Types.StructType.of(
+                    required(16, "c", Types.IntegerType.get()),
+                    required(17, "C", Types.IntegerType.get()))
+                )))));
 
+    // Should select everything except 12 and 15 since they are structs with selected elements
+    Set<Integer> expectedIds = Sets.newHashSet(10, 11, 35, 13, 14, 16, 17);
+    Set<Integer> actualIds = TypeUtil.getProjectedIds(schema);
 
-    AssertHelpers.assertThrows("Cannot explicitly project List",
-        IllegalArgumentException.class,
-        () -> TypeUtil.project(schema, Sets.newHashSet(12))
-    );
-
-    AssertHelpers.assertThrows("Cannot explicitly project List",
-        IllegalArgumentException.class,
-        () -> TypeUtil.project(schema, Sets.newHashSet(21))
-    );
-
-    Schema expectedDepthOne = new Schema(
-        Lists.newArrayList(
-            required(12, "list", Types.ListType.ofRequired(13,
-                Types.StructType.of()))));
-    Schema actualDepthOne = TypeUtil.project(schema, Sets.newHashSet(13));
-    Assert.assertEquals(expectedDepthOne.asStruct(), actualDepthOne.asStruct());
-
-    Schema expectedDepthTwo = new Schema(
-        Lists.newArrayList(
-            required(10, "a", Types.IntegerType.get()),
-            required(12, "list", Types.ListType.ofRequired(13,
-                Types.StructType.of(
-                    optional(20, "foo", Types.IntegerType.get()),
-                    required(21, "subList", Types.ListType.ofRequired(14,
-                        Types.StructType.of())))))));
-    Schema actualDepthTwo = TypeUtil.project(schema, Sets.newHashSet(10, 13, 20, 14));
-    Assert.assertEquals(expectedDepthTwo.asStruct(), actualDepthTwo.asStruct());
+    Assert.assertEquals(expectedIds, actualIds);
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
@@ -452,4 +452,34 @@ public class TestTypeUtil {
 
     TypeUtil.indexByName(Types.StructType.of(nestedType));
   }
+
+  @Test
+  public void testSelectNot() {
+    Schema schema = new Schema(
+        Lists.newArrayList(
+            required(1, "id", Types.LongType.get()),
+            required(2, "location", Types.StructType.of(
+                required(3, "lat", Types.DoubleType.get()),
+                required(4, "long", Types.DoubleType.get())
+            ))));
+
+    Schema expectedNoPrimitive = new Schema(
+        Lists.newArrayList(
+            required(2, "location", Types.StructType.of(
+                required(3, "lat", Types.DoubleType.get()),
+                required(4, "long", Types.DoubleType.get())
+            ))));
+
+    Schema actualNoPrimitve = TypeUtil.selectNot(schema, Sets.newHashSet(1));
+    Assert.assertEquals(expectedNoPrimitive.asStruct(), actualNoPrimitve.asStruct());
+
+    // Expected legacy behavior is to completely remove structs if their elements are removed
+    Schema expectedNoStructElements = new Schema(required(1, "id", Types.LongType.get()));
+    Schema actualNoStructElements = TypeUtil.selectNot(schema, Sets.newHashSet(3, 4));
+    Assert.assertEquals(expectedNoStructElements.asStruct(), actualNoStructElements.asStruct());
+
+    // Expected legacy behavior is to ignore selectNot on struct elements.
+    Schema actualNoStruct = TypeUtil.selectNot(schema, Sets.newHashSet(2));
+    Assert.assertEquals(schema.asStruct(), actualNoStruct.asStruct());
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -296,7 +296,7 @@ abstract class BaseTableScan implements TableScan {
       }
       requiredFieldIds.addAll(selectedIds);
 
-      return TypeUtil.select(schema, requiredFieldIds);
+      return TypeUtil.project(schema, requiredFieldIds);
 
     } else if (context.projectedSchema() != null) {
       return context.projectedSchema();

--- a/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
+++ b/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
@@ -91,16 +91,18 @@ class PruneColumns extends AvroSchemaVisitor<Schema> {
       // selected by lower IDs.
       if (selectedIds.contains(fieldId)) {
         if (fieldSchema != null) {
+          hasChange = true; // Sub-fields may be different
           filteredFields.add(copyField(field, fieldSchema, fieldId));
         } else {
           if (isRecord(field.schema())) {
+            hasChange = true; // Sub-fields are now empty
             filteredFields.add(copyField(field, makeEmptyCopy(field.schema()), fieldId));
           } else {
             filteredFields.add(copyField(field, field.schema(), fieldId));
           }
         }
       } else if (fieldSchema != null) {
-        hasChange = true;
+        hasChange = true; // Sub-fields may be different
         filteredFields.add(copyField(field, fieldSchema, fieldId));
       }
     }

--- a/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
+++ b/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import java.util.Set;
 import org.apache.avro.JsonProperties;
 import org.apache.avro.Schema;
+import org.apache.avro.Schema.Type;
 import org.apache.avro.SchemaNormalization;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -81,13 +82,21 @@ class PruneColumns extends AvroSchemaVisitor<Schema> {
 
       Schema fieldSchema = fields.get(field.pos());
       // All primitives are selected by selecting the field, but map and list
-      // types can be selected by projecting the keys, values, or elements.
+      // types can be selected by projecting the keys, values, or elements. Empty
+      // Structs can be selected by selecting the record itself instead of it's children.
       // This creates two conditions where the field should be selected: if the
       // id is selected or if the result of the field is non-null. The only
       // case where the converted field is non-null is when a map or list is
       // selected by lower IDs.
       if (selectedIds.contains(fieldId)) {
-        filteredFields.add(copyField(field, field.schema(), fieldId));
+        if (isNestedRecord(field) &&
+            (fieldSchema == null || isEmptySchema(field.schema()) || isEmptySchema(fieldSchema))) {
+          filteredFields.add(copyEmptyField(field, record.getNamespace(), fieldId));
+        } else if (fieldSchema != null) {
+          filteredFields.add(copyField(field, fieldSchema, fieldId));
+        } else {
+          filteredFields.add(copyField(field, field.schema(), fieldId));
+        }
       } else if (fieldSchema != null) {
         hasChange = true;
         filteredFields.add(copyField(field, fieldSchema, fieldId));
@@ -103,6 +112,40 @@ class PruneColumns extends AvroSchemaVisitor<Schema> {
     }
 
     return null;
+  }
+
+  private boolean isNestedRecord(Schema.Field field) {
+    if (AvroSchemaUtil.isOptionSchema(field.schema())) {
+      Schema optionSchema = AvroSchemaUtil.fromOption(field.schema());
+      return optionSchema.getType() == Type.RECORD;
+    } else {
+      return field.schema().getType() == Type.RECORD;
+    }
+  }
+
+  private boolean isEmptySchema(Schema schema) {
+    if (AvroSchemaUtil.isOptionSchema(schema)) {
+      Schema optionSchema = AvroSchemaUtil.fromOption(schema);
+      if (optionSchema.getType() == Type.RECORD) {
+        return optionSchema.getFields().isEmpty();
+      }
+    } else if (schema.getType() == Type.RECORD) {
+      return schema.getFields().isEmpty();
+    }
+    return false;
+  }
+
+  private Schema.Field copyEmptyField(Schema.Field field, String namespace, Integer fieldId) {
+    Schema emptyRecordSchema =
+        Schema.createRecord("r" + fieldId, null, null, false, ImmutableList.of());
+
+    if (field.schema().isUnion()) {
+      return copyField(field, AvroSchemaUtil.toOption(emptyRecordSchema), fieldId);
+    } else if (field.schema().getType() == Type.RECORD) {
+      return copyField(field, emptyRecordSchema, fieldId);
+    } else {
+      throw new IllegalArgumentException(String.format("Cannot make an empty copy of a non Struct type, %s", field));
+    }
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
+++ b/core/src/main/java/org/apache/iceberg/avro/PruneColumns.java
@@ -19,12 +19,14 @@
 
 package org.apache.iceberg.avro;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import org.apache.avro.JsonProperties;
 import org.apache.avro.Schema;
+import org.apache.avro.Schema.Type;
 import org.apache.avro.SchemaNormalization;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -82,7 +84,7 @@ class PruneColumns extends AvroSchemaVisitor<Schema> {
       Schema fieldSchema = fields.get(field.pos());
       // All primitives are selected by selecting the field, but map and list
       // types can be selected by projecting the keys, values, or elements. Empty
-      // Structs can be selected by selecting the record itself instead of it's children.
+      // Structs can be selected by selecting the record itself instead of its children.
       // This creates two conditions where the field should be selected: if the
       // id is selected or if the result of the field is non-null. The only
       // case where the converted field is non-null is when a map or list is
@@ -91,7 +93,11 @@ class PruneColumns extends AvroSchemaVisitor<Schema> {
         if (fieldSchema != null) {
           filteredFields.add(copyField(field, fieldSchema, fieldId));
         } else {
-          filteredFields.add(copyField(field, field.schema(), fieldId));
+          if (isRecord(field.schema())) {
+            filteredFields.add(copyField(field, makeEmptyCopy(field.schema()), fieldId));
+          } else {
+            filteredFields.add(copyField(field, field.schema(), fieldId));
+          }
         }
       } else if (fieldSchema != null) {
         hasChange = true;
@@ -262,6 +268,26 @@ class PruneColumns extends AvroSchemaVisitor<Schema> {
     }
 
     return copy;
+  }
+
+  private boolean isRecord(Schema field) {
+    if (AvroSchemaUtil.isOptionSchema(field)) {
+      return AvroSchemaUtil.fromOption(field).getType().equals(Type.RECORD);
+    } else {
+      return field.getType().equals(Type.RECORD);
+    }
+  }
+
+  private static Schema makeEmptyCopy(Schema field) {
+    if (AvroSchemaUtil.isOptionSchema(field)) {
+      Schema innerSchema = AvroSchemaUtil.fromOption(field);
+      Schema emptyRecord = Schema.createRecord(innerSchema.getName(), innerSchema.getDoc(), innerSchema.getNamespace(),
+          innerSchema.isError(), Collections.emptyList());
+      return AvroSchemaUtil.toOption(emptyRecord);
+    } else {
+      return Schema.createRecord(field.getName(), field.getDoc(), field.getNamespace(), field.isError(),
+          Collections.emptyList());
+    }
   }
 
   private static Schema.Field copyField(Schema.Field field, Schema newSchema, Integer fieldId) {

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -93,7 +93,7 @@ public class TestSchemaUpdate {
       Schema del = new SchemaUpdate(SCHEMA, 19).deleteColumn(name).apply();
 
       Assert.assertEquals("Should match projection with '" + name + "' removed",
-          TypeUtil.select(SCHEMA, selected).asStruct(), del.asStruct());
+          TypeUtil.project(SCHEMA, selected).asStruct(), del.asStruct());
     }
   }
 

--- a/core/src/test/java/org/apache/iceberg/avro/TestReadProjection.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestReadProjection.java
@@ -37,11 +37,10 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 public abstract class TestReadProjection {
-
   protected abstract Record writeAndRead(String desc,
-      Schema writeSchema,
-      Schema readSchema,
-      Record record) throws IOException;
+                                         Schema writeSchema,
+                                         Schema readSchema,
+                                         Record record) throws IOException;
 
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();

--- a/core/src/test/java/org/apache/iceberg/avro/TestReadProjection.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestReadProjection.java
@@ -37,10 +37,11 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 public abstract class TestReadProjection {
+
   protected abstract Record writeAndRead(String desc,
-                                         Schema writeSchema,
-                                         Schema readSchema,
-                                         Record record) throws IOException;
+      Schema writeSchema,
+      Schema readSchema,
+      Record record) throws IOException;
 
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
@@ -525,5 +526,184 @@ public abstract class TestReadProjection {
     AssertHelpers.assertEmptyAvroField(projectedP2, "x");
     AssertHelpers.assertEmptyAvroField(projectedP2, "y");
     Assert.assertNull("Should project null z", projectedP2.get("z"));
+  }
+
+  @Test
+  public void testEmptyStructProjection() throws Exception {
+    Schema writeSchema = new Schema(
+        Types.NestedField.required(0, "id", Types.LongType.get()),
+        Types.NestedField.optional(3, "location", Types.StructType.of(
+            Types.NestedField.required(1, "lat", Types.FloatType.get()),
+            Types.NestedField.required(2, "long", Types.FloatType.get())
+        ))
+    );
+
+    Record record = new Record(AvroSchemaUtil.convert(writeSchema, "table"));
+    record.put("id", 34L);
+    Record location = new Record(
+        AvroSchemaUtil.fromOption(record.getSchema().getField("location").schema()));
+    location.put("lat", 52.995143f);
+    location.put("long", -1.539054f);
+    record.put("location", location);
+
+    Schema emptyStruct = new Schema(
+        Types.NestedField.required(3, "location", Types.StructType.of())
+    );
+
+    Record projected = writeAndRead("empty_proj", writeSchema, emptyStruct, record);
+    AssertHelpers.assertEmptyAvroField(projected, "id");
+    Record result = (Record) projected.get("location");
+
+    Assert.assertEquals("location should be in the 0th position", result, projected.get(0));
+    Assert.assertNotNull("Should contain an empty record", result);
+    AssertHelpers.assertEmptyAvroField(result, "lat");
+    AssertHelpers.assertEmptyAvroField(result, "long");
+  }
+
+  @Test
+  public void testEmptyStructRequiredProjection() throws Exception {
+    Schema writeSchema = new Schema(
+        Types.NestedField.required(0, "id", Types.LongType.get()),
+        Types.NestedField.required(3, "location", Types.StructType.of(
+            Types.NestedField.required(1, "lat", Types.FloatType.get()),
+            Types.NestedField.required(2, "long", Types.FloatType.get())
+        ))
+    );
+
+    Record record = new Record(AvroSchemaUtil.convert(writeSchema, "table"));
+    record.put("id", 34L);
+    Record location = new Record(record.getSchema().getField("location").schema());
+    location.put("lat", 52.995143f);
+    location.put("long", -1.539054f);
+    record.put("location", location);
+
+    Schema emptyStruct = new Schema(
+        Types.NestedField.required(3, "location", Types.StructType.of())
+    );
+
+    Record projected = writeAndRead("empty_req_proj", writeSchema, emptyStruct, record);
+    AssertHelpers.assertEmptyAvroField(projected, "id");
+    Record result = (Record) projected.get("location");
+    Assert.assertEquals("location should be in the 0th position", result, projected.get(0));
+    Assert.assertNotNull("Should contain an empty record", result);
+    AssertHelpers.assertEmptyAvroField(result, "lat");
+    AssertHelpers.assertEmptyAvroField(result, "long");
+  }
+
+  @Test
+  public void testRequiredEmptyStructInRequiredStruct() throws Exception {
+    Schema writeSchema = new Schema(
+        Types.NestedField.required(0, "id", Types.LongType.get()),
+        Types.NestedField.required(3, "location", Types.StructType.of(
+            Types.NestedField.required(1, "lat", Types.FloatType.get()),
+            Types.NestedField.required(2, "long", Types.FloatType.get()),
+            Types.NestedField.required(4, "empty", Types.StructType.of())
+        ))
+    );
+
+    Record record = new Record(AvroSchemaUtil.convert(writeSchema, "table"));
+    record.put("id", 34L);
+    Record location = new Record(record.getSchema().getField("location").schema());
+    location.put("lat", 52.995143f);
+    location.put("long", -1.539054f);
+    record.put("location", location);
+
+    Schema emptyStruct = new Schema(
+        Types.NestedField.required(0, "id", Types.LongType.get()),
+        Types.NestedField.required(3, "location", Types.StructType.of(
+            Types.NestedField.required(4, "empty", Types.StructType.of())
+        ))
+    );
+
+    Record projected = writeAndRead("req_empty_req_proj", writeSchema, emptyStruct, record);
+    Assert.assertEquals("Should project id", 34L, projected.get("id"));
+    Record result = (Record) projected.get("location");
+    Assert.assertEquals("location should be in the 1st position", result, projected.get(1));
+    Assert.assertNotNull("Should contain an empty record", result);
+    AssertHelpers.assertEmptyAvroField(result, "lat");
+    AssertHelpers.assertEmptyAvroField(result, "long");
+    Assert.assertNotNull("Should project empty", result.getSchema().getField("empty"));
+    Assert.assertNotNull("Empty should not be null", result.get("empty"));
+    Assert.assertEquals("Empty should be empty", 0,
+        ((Record) result.get("empty")).getSchema().getFields().size());
+  }
+
+  @Test
+  public void testEmptyNestedStructProjection() throws Exception {
+    Schema writeSchema = new Schema(
+        Types.NestedField.required(0, "id", Types.LongType.get()),
+        Types.NestedField.optional(3, "outer", Types.StructType.of(
+            Types.NestedField.required(1, "lat", Types.FloatType.get()),
+            Types.NestedField.optional(2, "inner", Types.StructType.of(
+                Types.NestedField.required(5, "lon", Types.FloatType.get())
+                )
+            )
+        ))
+    );
+
+    Record record = new Record(AvroSchemaUtil.convert(writeSchema, "table"));
+    record.put("id", 34L);
+    Record outer = new Record(
+        AvroSchemaUtil.fromOption(record.getSchema().getField("outer").schema()));
+    Record inner = new Record(AvroSchemaUtil.fromOption(outer.getSchema().getField("inner").schema()));
+    inner.put("lon", 32.14f);
+    outer.put("lat", 52.995143f);
+    outer.put("inner", inner);
+    record.put("outer", outer);
+
+    Schema emptyStruct = new Schema(
+        Types.NestedField.required(3, "outer", Types.StructType.of(
+            Types.NestedField.required(2, "inner", Types.StructType.of())
+        )));
+
+    Record projected = writeAndRead("nested_empty_proj", writeSchema, emptyStruct, record);
+    AssertHelpers.assertEmptyAvroField(projected, "id");
+    Record outerResult = (Record) projected.get("outer");
+    Assert.assertEquals("Outer should be in the 0th position", outerResult, projected.get(0));
+    Assert.assertNotNull("Should contain the outer record", outerResult);
+    AssertHelpers.assertEmptyAvroField(outerResult, "lat");
+    Record innerResult = (Record) outerResult.get("inner");
+    Assert.assertEquals("Inner should be in the 0th position", innerResult, outerResult.get(0));
+    Assert.assertNotNull("Should contain the inner record", innerResult);
+    AssertHelpers.assertEmptyAvroField(innerResult, "lon");
+  }
+
+  @Test
+  public void testEmptyNestedStructRequiredProjection() throws Exception {
+    Schema writeSchema = new Schema(
+        Types.NestedField.required(0, "id", Types.LongType.get()),
+        Types.NestedField.required(3, "outer", Types.StructType.of(
+            Types.NestedField.required(1, "lat", Types.FloatType.get()),
+            Types.NestedField.required(2, "inner", Types.StructType.of(
+                Types.NestedField.required(5, "lon", Types.FloatType.get())
+                )
+            )
+        ))
+    );
+
+    Record record = new Record(AvroSchemaUtil.convert(writeSchema, "table"));
+    record.put("id", 34L);
+    Record outer = new Record(record.getSchema().getField("outer").schema());
+    Record inner = new Record(outer.getSchema().getField("inner").schema());
+    inner.put("lon", 32.14f);
+    outer.put("lat", 52.995143f);
+    outer.put("inner", inner);
+    record.put("outer", outer);
+
+    Schema emptyStruct = new Schema(
+        Types.NestedField.required(3, "outer", Types.StructType.of(
+            Types.NestedField.required(2, "inner", Types.StructType.of())
+        )));
+
+    Record projected = writeAndRead("nested_empty_req_proj", writeSchema, emptyStruct, record);
+    AssertHelpers.assertEmptyAvroField(projected, "id");
+    Record outerResult = (Record) projected.get("outer");
+    Assert.assertEquals("Outer should be in the 0th position", outerResult, projected.get(0));
+    Assert.assertNotNull("Should contain the outer record", outerResult);
+    AssertHelpers.assertEmptyAvroField(outerResult, "lat");
+    Record innerResult = (Record) outerResult.get("inner");
+    Assert.assertEquals("Inner should be in the 0th position", innerResult, outerResult.get(0));
+    Assert.assertNotNull("Should contain the inner record", innerResult);
+    AssertHelpers.assertEmptyAvroField(innerResult, "lon");
   }
 }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
@@ -56,6 +56,7 @@ class PruneColumns extends ParquetTypeVisitor<Type> {
           builder.addField(field);
         } else {
           if (isStruct(originalField)) {
+            hasChange = true;
             builder.addField(originalField.asGroupType().withNewFields(Collections.emptyList()));
           } else {
             builder.addField(originalField);
@@ -63,9 +64,9 @@ class PruneColumns extends ParquetTypeVisitor<Type> {
         }
         fieldCount += 1;
       } else if (field != null) {
+        hasChange = true;
         builder.addField(field);
         fieldCount += 1;
-        hasChange = true;
       }
     }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
@@ -19,12 +19,14 @@
 
 package org.apache.iceberg.parquet;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
@@ -53,7 +55,11 @@ class PruneColumns extends ParquetTypeVisitor<Type> {
           hasChange = true;
           builder.addField(field);
         } else {
-          builder.addField(originalField);
+          if (isStruct(originalField)) {
+            builder.addField(originalField.asGroupType().withNewFields(Collections.emptyList()));
+          } else {
+            builder.addField(originalField);
+          }
         }
         fieldCount += 1;
       } else if (field != null) {
@@ -156,5 +162,16 @@ class PruneColumns extends ParquetTypeVisitor<Type> {
 
   private Integer getId(Type type) {
     return type.getId() == null ? null : type.getId().intValue();
+  }
+
+  private boolean isStruct(Type field) {
+    if (field.isPrimitive()) {
+      return false;
+    } else {
+      GroupType groupType = field.asGroupType();
+      LogicalTypeAnnotation logicalTypeAnnotation = groupType.getLogicalTypeAnnotation();
+      return !logicalTypeAnnotation.equals(LogicalTypeAnnotation.mapType()) &&
+          !logicalTypeAnnotation.equals(LogicalTypeAnnotation.listType());
+    }
   }
 }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
@@ -49,7 +49,12 @@ class PruneColumns extends ParquetTypeVisitor<Type> {
       Type field = fields.get(i);
       Integer fieldId = getId(originalField);
       if (fieldId != null && selectedIds.contains(fieldId)) {
-        builder.addField(originalField);
+        if (field != null) {
+          hasChange = true;
+          builder.addField(field);
+        } else {
+          builder.addField(originalField);
+        }
         fieldCount += 1;
       } else if (field != null) {
         builder.addField(field);


### PR DESCRIPTION
Previously getProjectedIds would only return leaf nodes and primitives that
were selected. This made it impossible to return empty structs. To fix this
we change the behavior to return all id's of required fields including structs.
This in turn requires fixing the alternate PruneColumn methods for Avro
and Parquet to respect that they will now have selected field ID's for non
primitive nodes. Previous use cases of TypeUtil.select are converted to
TypeUtil.project, which inverses this new getProjecetedIds code.