### PR TITLE
[Spark] Support building against both Spark 3.0 and Spark 3.1: follow-up

### DIFF
--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDelete.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDelete.scala
@@ -38,7 +38,8 @@ import org.apache.spark.sql.catalyst.plans.logical.ReplaceData
 import org.apache.spark.sql.catalyst.plans.logical.Sort
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.utils.DistributionAndOrderingUtils
-import org.apache.spark.sql.catalyst.utils.PlanUtils._
+import org.apache.spark.sql.catalyst.utils.PlanUtils.createRepartitionByExpression
+import org.apache.spark.sql.catalyst.utils.PlanUtils.isIcebergRelation
 import org.apache.spark.sql.catalyst.utils.RewriteRowLevelOperationHelper
 import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.iceberg.catalog.ExtendedSupportsDelete

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDelete.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDelete.scala
@@ -34,12 +34,11 @@ import org.apache.spark.sql.catalyst.plans.logical.DeleteFromTable
 import org.apache.spark.sql.catalyst.plans.logical.Filter
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.plans.logical.Project
-import org.apache.spark.sql.catalyst.plans.logical.RepartitionByExpression
 import org.apache.spark.sql.catalyst.plans.logical.ReplaceData
 import org.apache.spark.sql.catalyst.plans.logical.Sort
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.utils.DistributionAndOrderingUtils
-import org.apache.spark.sql.catalyst.utils.PlanUtils.isIcebergRelation
+import org.apache.spark.sql.catalyst.utils.PlanUtils._
 import org.apache.spark.sql.catalyst.utils.RewriteRowLevelOperationHelper
 import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.connector.iceberg.catalog.ExtendedSupportsDelete
@@ -96,12 +95,7 @@ case class RewriteDelete(spark: SparkSession) extends Rule[LogicalPlan] with Rew
       case _ =>
         // apply hash partitioning by file if the distribution mode is hash or range
         val numShufflePartitions = conf.numShufflePartitions
-        val rbeCtor = DistributionAndOrderingUtils.repartitionByExpressionCtor
-        if (Spark3VersionUtil.isSpark30) {
-          rbeCtor.newInstance(Seq(fileNameCol), remainingRowsPlan, Integer.valueOf(numShufflePartitions))
-        } else {
-          rbeCtor.newInstance(Seq(fileNameCol), remainingRowsPlan, Some(numShufflePartitions))
-        }
+        createRepartitionByExpression(Seq(fileNameCol), remainingRowsPlan, numShufflePartitions)
     }
 
     val order = Seq(createSortOrder(fileNameCol, Ascending), createSortOrder(rowPosCol, Ascending))

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDelete.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/RewriteDelete.scala
@@ -21,7 +21,6 @@ package org.apache.spark.sql.catalyst.optimizer
 
 import org.apache.iceberg.DistributionMode
 import org.apache.iceberg.spark.Spark3Util
-import org.apache.iceberg.spark.Spark3VersionUtil
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.Ascending
 import org.apache.spark.sql.catalyst.expressions.AttributeReference

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/utils/DistributionAndOrderingUtils.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/utils/DistributionAndOrderingUtils.scala
@@ -60,7 +60,7 @@ import org.apache.spark.sql.types.IntegerType
 
 object DistributionAndOrderingUtils {
 
-  private val repartitionByExpressionCtor: DynConstructors.Ctor[RepartitionByExpression] =
+  private[catalyst] val repartitionByExpressionCtor: DynConstructors.Ctor[RepartitionByExpression] =
     DynConstructors.builder()
       .impl(classOf[RepartitionByExpression],
         classOf[Seq[catalyst.expressions.Expression]],

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/utils/DistributionAndOrderingUtils.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/utils/DistributionAndOrderingUtils.scala
@@ -32,7 +32,6 @@ import org.apache.spark.sql.catalyst.expressions.IcebergTruncateTransform
 import org.apache.spark.sql.catalyst.expressions.IcebergYearTransform
 import org.apache.spark.sql.catalyst.expressions.NamedExpression
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.catalyst.plans.logical.RepartitionByExpression
 import org.apache.spark.sql.catalyst.plans.logical.Sort
 import org.apache.spark.sql.connector.catalog.CatalogV2Implicits
 import org.apache.spark.sql.connector.expressions.ApplyTransform
@@ -60,18 +59,6 @@ import org.apache.spark.sql.types.IntegerType
 
 object DistributionAndOrderingUtils {
 
-  private[catalyst] val repartitionByExpressionCtor: DynConstructors.Ctor[RepartitionByExpression] =
-    DynConstructors.builder()
-      .impl(classOf[RepartitionByExpression],
-        classOf[Seq[catalyst.expressions.Expression]],
-        classOf[LogicalPlan],
-        classOf[Option[Int]])
-      .impl(classOf[RepartitionByExpression],
-        classOf[Seq[catalyst.expressions.Expression]],
-        classOf[LogicalPlan],
-        Integer.TYPE)
-      .build()
-
   def prepareQuery(
       requiredDistribution: Distribution,
       requiredOrdering: Seq[SortOrder],
@@ -94,11 +81,7 @@ object DistributionAndOrderingUtils {
       // the conversion to catalyst expressions above produces SortOrder expressions
       // for OrderedDistribution and generic expressions for ClusteredDistribution
       // this allows RepartitionByExpression to pick either range or hash partitioning
-      if (Spark3VersionUtil.isSpark30) {
-        repartitionByExpressionCtor.newInstance(distribution.toSeq, query, Integer.valueOf(numShufflePartitions))
-      } else {
-        repartitionByExpressionCtor.newInstance(distribution.toSeq, query, Some(numShufflePartitions))
-      }
+      PlanUtils.createRepartitionByExpression(distribution.toSeq, query, numShufflePartitions)
     } else {
       query
     }

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/utils/PlanUtils.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/utils/PlanUtils.scala
@@ -19,8 +19,12 @@
 
 package org.apache.spark.sql.catalyst.utils
 
+import org.apache.iceberg.common.DynConstructors
+import org.apache.iceberg.spark.Spark3VersionUtil
 import org.apache.iceberg.spark.source.SparkTable
+import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.RepartitionByExpression
 import org.apache.spark.sql.catalyst.plans.logical.SubqueryAlias
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 
@@ -35,6 +39,29 @@ object PlanUtils {
       case s: SubqueryAlias => isIcebergRelation(s.child)
       case r: DataSourceV2Relation => isIcebergTable(r)
       case _ => false
+    }
+  }
+
+  private val repartitionByExpressionCtor: DynConstructors.Ctor[RepartitionByExpression] =
+    DynConstructors.builder()
+      .impl(classOf[RepartitionByExpression],
+        classOf[Seq[Expression]],
+        classOf[LogicalPlan],
+        classOf[Option[Int]])
+      .impl(classOf[RepartitionByExpression],
+        classOf[Seq[Expression]],
+        classOf[LogicalPlan],
+        Integer.TYPE)
+      .build()
+
+  def createRepartitionByExpression(
+      partitionExpressions: Seq[Expression],
+      child: LogicalPlan,
+      numPartitions: Int): RepartitionByExpression = {
+    if (Spark3VersionUtil.isSpark30) {
+      repartitionByExpressionCtor.newInstance(partitionExpressions, child, Integer.valueOf(numPartitions))
+    } else {
+      repartitionByExpressionCtor.newInstance(partitionExpressions, child, Some(numPartitions))
     }
   }
 }


### PR DESCRIPTION
The constructor of RepartitionByExpression changed between Spark 3.0 and 3.1.
There was an instance of constructing RepartitionByExpression that was missed in the original commit (#2512).