### PR TITLE
[Spark] Support building against both Spark 3.0 and Spark 3.1: follow-up

### DIFF
--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/utils/DistributionAndOrderingUtils.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/utils/DistributionAndOrderingUtils.scala
@@ -60,7 +60,7 @@ import org.apache.spark.sql.types.IntegerType
 
 object DistributionAndOrderingUtils {
 
-  private val repartitionByExpressionCtor: DynConstructors.Ctor[RepartitionByExpression] =
+  private[catalyst] val repartitionByExpressionCtor: DynConstructors.Ctor[RepartitionByExpression] =
     DynConstructors.builder()
       .impl(classOf[RepartitionByExpression],
         classOf[Seq[catalyst.expressions.Expression]],


### PR DESCRIPTION
The constructor of RepartitionByExpression changed between Spark 3.0 and 3.1.
There was an instance of constructing RepartitionByExpression that was missed in the original commit (#2512).
