### PR TITLE
Core: Fix partition field ID generation in v1 tables

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
@@ -69,7 +69,7 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
     this.schema = spec.schema();
     this.nameToField = indexSpecByName(spec);
     this.transformToField = indexSpecByTransform(spec);
-    this.lastAssignedPartitionId = base.lastAssignedPartitionId();
+    this.lastAssignedPartitionId = formatVersion == 1 ? spec.lastAssignedFieldId() : base.lastAssignedPartitionId();
 
     spec.fields().stream()
         .filter(field -> field.transform() instanceof UnknownTransform)


### PR DESCRIPTION
This PR fixes the generation of partition field IDs for v1 tables. Right now, we always use `base.lastAssignedPartitionId()` as the starting field ID for new partition fields. This value is present only in v2 tables. In v1 tables, we need to use the max assigned field ID in the current spec. In v1, spec field IDs must be sequential.

Originally, this use case was brought to my attention by @karuppayya.