### PR TITLE
Spark: Don't create empty partition replace operations

### DIFF
--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Writer.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Writer.java
@@ -184,10 +184,17 @@ class Writer implements DataSourceWriter {
   }
 
   private void replacePartitions(WriterCommitMessage[] messages) {
+    Iterable<DataFile> files = files(messages);
+
+    if (!files.iterator().hasNext()) {
+      LOG.info("Dyanmic overwrite is empty, skipping commit");
+      return;
+    }
+
     ReplacePartitions dynamicOverwrite = table.newReplacePartitions();
 
     int numFiles = 0;
-    for (DataFile file : files(messages)) {
+    for (DataFile file : files) {
       numFiles += 1;
       dynamicOverwrite.addFile(file);
     }

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -263,7 +263,8 @@ class SparkWrite {
     @Override
     public void commit(WriterCommitMessage[] messages) {
       Iterable<DataFile> files = files(messages);
-      if (Iterables.size(files) == 0) {
+
+      if (!files.iterator().hasNext()) {
         LOG.info("Dynamic overwrite is empty, skipping commit");
         return;
       }

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -262,10 +262,16 @@ class SparkWrite {
   private class DynamicOverwrite extends BaseBatchWrite {
     @Override
     public void commit(WriterCommitMessage[] messages) {
+      Iterable<DataFile> files = files(messages);
+      if (Iterables.size(files) == 0) {
+        LOG.info("Dynamic overwrite is empty, skipping commit");
+        return;
+      }
+
       ReplacePartitions dynamicOverwrite = table.newReplacePartitions();
 
       int numFiles = 0;
-      for (DataFile file : files(messages)) {
+      for (DataFile file : files) {
         numFiles += 1;
         dynamicOverwrite.addFile(file);
       }


### PR DESCRIPTION
When attempting to insert overwrite with an empty dataset
we would previously throw an error. This patch causes spark
to skip any no-op partition replacement operations.