### PR TITLE
Core: rename WRITE_NEW_DATA_LOCATION to WRITE_FOLDER_STORAGE_LOCATION

### DIFF
--- a/core/src/main/java/org/apache/iceberg/LocationProviders.java
+++ b/core/src/main/java/org/apache/iceberg/LocationProviders.java
@@ -69,7 +69,7 @@ public class LocationProviders {
   }
 
   private static String defaultDataLocation(String tableLocation, Map<String, String> properties) {
-    return properties.getOrDefault(TableProperties.WRITE_LOCATION_PROVIDER_IMPL,
+    return properties.getOrDefault(TableProperties.WRITE_FOLDER_STORAGE_LOCATION,
         String.format("%s/data", tableLocation));
   }
 

--- a/core/src/main/java/org/apache/iceberg/LocationProviders.java
+++ b/core/src/main/java/org/apache/iceberg/LocationProviders.java
@@ -69,7 +69,8 @@ public class LocationProviders {
   }
 
   private static String defaultDataLocation(String tableLocation, Map<String, String> properties) {
-    return properties.getOrDefault(TableProperties.WRITE_NEW_DATA_LOCATION, String.format("%s/data", tableLocation));
+    return properties.getOrDefault(TableProperties.WRITE_LOCATION_PROVIDER_IMPL,
+        String.format("%s/data", tableLocation));
   }
 
   static class DefaultLocationProvider implements LocationProvider {

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -142,6 +142,12 @@ public class TableProperties {
   // This only applies to files written after this property is set. Files previously written aren't
   // relocated to reflect this parameter.
   // If not set, defaults to a "data" folder underneath the root path of the table.
+  public static final String WRITE_FOLDER_STORAGE_LOCATION = "write.folder-storage.path";
+
+  /**
+   * @deprecated will be removed in 0.14.0, use {@link #WRITE_FOLDER_STORAGE_LOCATION} instead
+   */
+  @Deprecated
   public static final String WRITE_NEW_DATA_LOCATION = "write.folder-storage.path";
 
   // This only applies to files written after this property is set. Files previously written aren't

--- a/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
+++ b/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
@@ -114,7 +114,7 @@ public class TestLocationProvider extends TableTestBase {
   @Test
   public void testDefaultLocationProviderWithCustomDataLocation() {
     this.table.updateProperties()
-        .set(TableProperties.WRITE_NEW_DATA_LOCATION, "new_location")
+        .set(TableProperties.WRITE_FOLDER_STORAGE_LOCATION, "new_location")
         .commit();
 
     this.table.locationProvider().newDataLocation("my_file");

--- a/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
+++ b/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
@@ -224,7 +224,7 @@ public class TestLocationProvider extends TableTestBase {
 
     String folderPath = "s3://random/folder/location";
     table.updateProperties()
-        .set(TableProperties.WRITE_NEW_DATA_LOCATION, folderPath)
+        .set(TableProperties.WRITE_FOLDER_STORAGE_LOCATION, folderPath)
         .commit();
 
     Assert.assertTrue("folder storage path should be used when set",

--- a/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
+++ b/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceBenchmark.java
@@ -44,8 +44,6 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
-import static org.apache.iceberg.TableProperties.WRITE_NEW_DATA_LOCATION;
-
 @Fork(1)
 @State(Scope.Benchmark)
 @Warmup(iterations = 3)
@@ -81,7 +79,8 @@ public abstract class IcebergSourceBenchmark {
 
   protected String dataLocation() {
     Map<String, String> properties = table.properties();
-    return properties.getOrDefault(WRITE_NEW_DATA_LOCATION, String.format("%s/data", table.location()));
+    return properties.getOrDefault(TableProperties.WRITE_FOLDER_STORAGE_LOCATION,
+        String.format("%s/data", table.location()));
   }
 
   protected void cleanupFiles() throws IOException {

--- a/spark/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction.java
@@ -285,7 +285,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
   public void testMetadataFolderIsIntact() throws InterruptedException {
     // write data directly to the table location
     Map<String, String> props = Maps.newHashMap();
-    props.put(TableProperties.WRITE_NEW_DATA_LOCATION, tableLocation);
+    props.put(TableProperties.WRITE_FOLDER_STORAGE_LOCATION, tableLocation);
     Table table = TABLES.create(SCHEMA, SPEC, props, tableLocation);
 
     List<ThreeColumnRecord> records = Lists.newArrayList(
@@ -357,7 +357,7 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
   @Test
   public void testRemoveUnreachableMetadataVersionFiles() throws InterruptedException {
     Map<String, String> props = Maps.newHashMap();
-    props.put(TableProperties.WRITE_NEW_DATA_LOCATION, tableLocation);
+    props.put(TableProperties.WRITE_FOLDER_STORAGE_LOCATION, tableLocation);
     props.put(TableProperties.METADATA_PREVIOUS_VERSIONS_MAX, "1");
     Table table = TABLES.create(SCHEMA, SPEC, props, tableLocation);
 

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWrites.java
@@ -145,7 +145,7 @@ public abstract class TestDataFrameWrites extends AvroDataTest {
     File tablePropertyDataLocation = temp.newFolder("test-table-property-data-dir");
     Table table = createTable(new Schema(SUPPORTED_PRIMITIVES.fields()), location);
     table.updateProperties().set(
-        TableProperties.WRITE_NEW_DATA_LOCATION, tablePropertyDataLocation.getAbsolutePath()).commit();
+        TableProperties.WRITE_FOLDER_STORAGE_LOCATION, tablePropertyDataLocation.getAbsolutePath()).commit();
     writeAndValidateWithLocations(table, location, tablePropertyDataLocation);
   }
 
@@ -271,7 +271,7 @@ public abstract class TestDataFrameWrites extends AvroDataTest {
     String sourcePath = String.format("%s/nullable_poc/sourceFolder/", location.toString());
     String targetPath = String.format("%s/nullable_poc/targetFolder/", location.toString());
 
-    tableProperties = ImmutableMap.of(TableProperties.WRITE_NEW_DATA_LOCATION, targetPath);
+    tableProperties = ImmutableMap.of(TableProperties.WRITE_FOLDER_STORAGE_LOCATION, targetPath);
 
     // read this and append to iceberg dataset
     spark
@@ -312,7 +312,7 @@ public abstract class TestDataFrameWrites extends AvroDataTest {
     String sourcePath = String.format("%s/nullable_poc/sourceFolder/", location.toString());
     String targetPath = String.format("%s/nullable_poc/targetFolder/", location.toString());
 
-    tableProperties = ImmutableMap.of(TableProperties.WRITE_NEW_DATA_LOCATION, targetPath);
+    tableProperties = ImmutableMap.of(TableProperties.WRITE_FOLDER_STORAGE_LOCATION, targetPath);
 
     // read this and append to iceberg dataset
     spark

--- a/spark3/src/main/java/org/apache/iceberg/spark/actions/BaseSnapshotTableSparkAction.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/actions/BaseSnapshotTableSparkAction.java
@@ -167,7 +167,7 @@ public class BaseSnapshotTableSparkAction
     // remove any possible location properties from origin properties
     properties.remove(LOCATION);
     properties.remove(TableProperties.WRITE_METADATA_LOCATION);
-    properties.remove(TableProperties.WRITE_NEW_DATA_LOCATION);
+    properties.remove(TableProperties.WRITE_FOLDER_STORAGE_LOCATION);
 
     // set default and user-provided props
     properties.put(TableCatalog.PROP_PROVIDER, "iceberg");


### PR DESCRIPTION
closes #2964 

@cobookman, @kbendick and @openinx brought up the issue during #2845 that the variable name `WRITE_NEW_DATA_LOCATION` is inconsistent with the actual value `write.folder-storage.path`.  This PR deprecates the old variable name to use a name that is consistent with the actual value.

I looked into the original PR that introduced this which is #6, I think @rdblue suggested using the value `write.folder-storage.path`, but the author @mccheah did not update the variable name.

Please let me know if there is any concern about this deprecation.