### PR TITLE
Spark: remove object storage data path in destination table for snapshot table action

### DIFF
--- a/spark3/src/main/java/org/apache/iceberg/spark/actions/BaseSnapshotTableSparkAction.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/actions/BaseSnapshotTableSparkAction.java
@@ -168,6 +168,7 @@ public class BaseSnapshotTableSparkAction
     properties.remove(LOCATION);
     properties.remove(TableProperties.WRITE_METADATA_LOCATION);
     properties.remove(TableProperties.WRITE_NEW_DATA_LOCATION);
+    properties.remove(TableProperties.OBJECT_STORE_PATH);
 
     // set default and user-provided props
     properties.put(TableCatalog.PROP_PROVIDER, "iceberg");


### PR DESCRIPTION
follow up for #2845 , because now we allow a fallback mechanism for object storage data path, it is safe to remove this property when doing a table snapshot. The destination table will use its default location as data path, and users can configure later for a new path if necessary.

@kbendick @aokolnychyi 