### PR TITLE
Flink:Add Flink Scala Api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -311,6 +311,9 @@ project(':iceberg-aws') {
 }
 
 project(':iceberg-flink') {
+  apply plugin: 'java'
+  apply plugin: 'scala'
+
   dependencies {
     compile project(':iceberg-api')
     compile project(':iceberg-common')
@@ -320,6 +323,7 @@ project(':iceberg-flink') {
     compile project(':iceberg-parquet')
     compile project(':iceberg-hive-metastore')
 
+    compileOnly "org.scala-lang:scala-library"
     compileOnly "org.apache.flink:flink-streaming-java_2.12"
     compileOnly "org.apache.flink:flink-streaming-java_2.12::tests"
     compileOnly "org.apache.flink:flink-table-api-java-bridge_2.12"

--- a/flink/src/main/scala/org/apache/iceberg/flink/scala/sink/FlinkSink.scala
+++ b/flink/src/main/scala/org/apache/iceberg/flink/scala/sink/FlinkSink.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *   
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.scala.sink
+
+import org.apache.flink.api.common.functions.MapFunction
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.streaming.api.datastream.{DataStream => JavaStream}
+import org.apache.flink.streaming.api.scala.DataStream
+import org.apache.flink.table.api.TableSchema
+import org.apache.flink.table.data.RowData
+import org.apache.flink.types.Row
+import org.apache.iceberg.flink.sink.{FlinkSink => JavaFlinkSink}
+import scala.language.implicitConversions
+
+object FlinkSink {
+
+  /**
+   * Initialize a {@link Builder} to export the data from generic input data stream into iceberg table. We use
+   * {@link RowData} inside the sink connector, so users need to provide a mapper function and a
+   * {@link TypeInformation} to convert those generic records to a RowData DataStream.
+   *
+   * @param input      the generic source input data stream.
+   * @param mapper     function to convert the generic data to {@link RowData}
+   * @param outputType to define the {@link TypeInformation} for the input data.
+   * @param <          T>        the data type of records.
+   * @return {@link Builder} to connect the iceberg table.
+   */
+  def builderFor[T](input: DataStream[T],
+                    mapper: MapFunction[T, RowData],
+                    outputType: TypeInformation[RowData]): JavaFlinkSink.Builder =
+    JavaFlinkSink.builderFor(input, mapper, outputType)
+
+  /**
+   * Initialize a {@link Builder} to export the data from input data stream with {@link Row}s into iceberg table. We use
+   * {@link RowData} inside the sink connector, so users need to provide a {@link TableSchema} for builder to convert
+   * those {@link Row}s to a {@link RowData} DataStream.
+   *
+   * @param input       the source input data stream with {@link Row}s.
+   * @param tableSchema defines the {@link TypeInformation} for input data.
+   * @return {@link Builder} to connect the iceberg table.
+   */
+  def forRow(input: DataStream[Row], tableSchema: TableSchema): JavaFlinkSink.Builder =
+    JavaFlinkSink.forRow(input, tableSchema)
+
+  /**
+   * Initialize a {@link Builder} to export the data from input data stream with {@link RowData}s into iceberg table.
+   *
+   * @param input the source input data stream with {@link RowData}s.
+   * @return {@link Builder} to connect the iceberg table.
+   */
+  def forRowData(input: DataStream[RowData]): JavaFlinkSink.Builder = JavaFlinkSink.forRowData(input)
+
+  implicit def scalaStream2JavaStream[R](stream: DataStream[R]): JavaStream[R] = stream.javaStream
+}

--- a/flink/src/main/scala/org/apache/iceberg/flink/scala/source/FlinkSource.scala
+++ b/flink/src/main/scala/org/apache/iceberg/flink/scala/source/FlinkSource.scala
@@ -20,8 +20,9 @@
 package org.apache.iceberg.flink.scala.source
 
 import org.apache.flink.streaming.api.datastream.{DataStream => JavaStream}
-import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
-import org.apache.iceberg.flink.source.{FlinkInputFormat, FlinkSource => JavaFlinkSource}
+import org.apache.flink.streaming.api.scala.DataStream
+import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.iceberg.flink.source.{FlinkSource => JavaFlinkSource}
 import scala.collection.JavaConverters.mapAsJavaMapConverter
 import scala.language.implicitConversions
 

--- a/flink/src/main/scala/org/apache/iceberg/flink/scala/source/FlinkSource.scala
+++ b/flink/src/main/scala/org/apache/iceberg/flink/scala/source/FlinkSource.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *   
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.scala.source
+
+import org.apache.flink.streaming.api.datastream.{DataStream => JavaStream}
+import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
+import org.apache.iceberg.flink.source.{FlinkInputFormat, FlinkSource => JavaFlinkSource}
+import scala.collection.JavaConverters.mapAsJavaMapConverter
+import scala.language.implicitConversions
+
+object FlinkSource {
+
+  /**
+   * Initialize a {@link Builder} to read the data from iceberg table. Equivalent to {@link TableScan}. See more options
+   * in {@link ScanContext}.
+   * <p>
+   * The Source can be read static data in bounded mode. It can also continuously check the arrival of new data and read
+   * records incrementally.
+   * <ul>
+   * <li>Without startSnapshotId: Bounded</li>
+   * <li>With startSnapshotId and with endSnapshotId: Bounded</li>
+   * <li>With startSnapshotId (-1 means unbounded preceding) and Without endSnapshotId: Unbounded</li>
+   * </ul>
+   * <p>
+   *
+   * @return {@link Builder} to connect the iceberg table.
+   */
+  def forRowData: JavaFlinkSource.Builder = new JavaFlinkSource.Builder
+
+  def isBounded(properties: Map[String, String]): Boolean = JavaFlinkSource.isBounded(properties.asJava)
+
+  class ScalaBuilder(builder: JavaFlinkSource.Builder) {
+    def env(newEnv: StreamExecutionEnvironment): JavaFlinkSource.Builder = builder.env(newEnv.getJavaEnv)
+  }
+
+  implicit def javaBuild2ScalaBuild(builder: JavaFlinkSource.Builder): ScalaBuilder = new ScalaBuilder(builder)
+  implicit def javaStream2ScalaStream[R](stream: JavaStream[R]): DataStream[R] = new DataStream[R](stream)
+}


### PR DESCRIPTION
Add flink scala api, about #2861 

use case:

```
import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
import org.apache.flink.table.data.RowData
import org.apache.iceberg.flink.TableLoader
import org.apache.iceberg.flink.scala.sink.FlinkSink
import org.apache.iceberg.flink.scala.source.FlinkSource
import org.apache.iceberg.flink.scala.source.FlinkSource._

object TestIcebergScalaApi {

  def main(args: Array[String]): Unit = {
    val env = StreamExecutionEnvironment.getExecutionEnvironment
    val tableLoader1 = TableLoader.fromHadoopTable("hdfs:///iceberg/hadoop_catalog/iceberg_db/sample")

    val batch: DataStream[RowData] = FlinkSource
      .forRowData.env(env)
      .tableLoader(tableLoader1)
      .streaming(false).build()

    val tableLoader2 = TableLoader.fromHadoopTable("hdfs:///iceberg/hadoop_catalog/iceberg_db/sample2")
    
    FlinkSink.forRowData(batch)
      .tableLoader(tableLoader2)
      .overwrite(true)
      .build()

    env.execute("Test Iceberg Batch Read")
  }
}
```