### PR TITLE
Flink:Remove repeat set reuseContainers.

### DIFF
--- a/flink/src/main/java/org/apache/iceberg/flink/source/RowDataIterator.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/source/RowDataIterator.java
@@ -125,8 +125,7 @@ class RowDataIterator extends DataIterator<RowData> {
         .project(schema)
         .createReaderFunc(fileSchema -> FlinkParquetReaders.buildReader(schema, fileSchema, idToConstant))
         .filter(task.residual())
-        .caseSensitive(caseSensitive)
-        .reuseContainers();
+        .caseSensitive(caseSensitive);
 
     if (nameMapping != null) {
       builder.withNameMapping(NameMappingParser.fromJson(nameMapping));


### PR DESCRIPTION
Parquet.ReadBuilder set reuseContainers twice. Remove repeat set reuseContainers.
The origin code as follows:
```
Parquet.ReadBuilder builder = Parquet.read(getInputFile(task))
        .reuseContainers()
        .split(task.start(), task.length())
        .project(schema)
        .createReaderFunc(fileSchema -> FlinkParquetReaders.buildReader(schema, fileSchema, idToConstant))
        .filter(task.residual())
        .caseSensitive(caseSensitive)
        .reuseContainers();
```