### PR TITLE
Core: Serialize all specs in SerializableTable

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SerializableTable.java
+++ b/core/src/main/java/org/apache/iceberg/SerializableTable.java
@@ -54,7 +54,8 @@ public class SerializableTable implements Table, Serializable {
   private final String metadataFileLocation;
   private final Map<String, String> properties;
   private final String schemaAsJson;
-  private final String specAsJson;
+  private final int defaultSpecId;
+  private final Map<Integer, String> specAsJsonMap;
   private final String sortOrderAsJson;
   private final FileIO io;
   private final EncryptionManager encryption;
@@ -62,7 +63,7 @@ public class SerializableTable implements Table, Serializable {
 
   private transient volatile Table lazyTable = null;
   private transient volatile Schema lazySchema = null;
-  private transient volatile PartitionSpec lazySpec = null;
+  private transient volatile Map<Integer, PartitionSpec> lazySpecs = null;
   private transient volatile SortOrder lazySortOrder = null;
 
   private SerializableTable(Table table) {
@@ -71,7 +72,10 @@ public class SerializableTable implements Table, Serializable {
     this.metadataFileLocation = metadataFileLocation(table);
     this.properties = SerializableMap.copyOf(table.properties());
     this.schemaAsJson = SchemaParser.toJson(table.schema());
-    this.specAsJson = PartitionSpecParser.toJson(table.spec());
+    this.defaultSpecId = table.spec().specId();
+    this.specAsJsonMap = Maps.newHashMap();
+    Map<Integer, PartitionSpec> specs = table.specs();
+    specs.forEach((specId, spec) -> specAsJsonMap.put(specId, PartitionSpecParser.toJson(spec)));
     this.sortOrderAsJson = SortOrderParser.toJson(table.sortOrder());
     this.io = fileIO(table);
     this.encryption = table.encryption();
@@ -168,23 +172,27 @@ public class SerializableTable implements Table, Serializable {
 
   @Override
   public PartitionSpec spec() {
-    if (lazySpec == null) {
-      synchronized (this) {
-        if (lazySpec == null && lazyTable == null) {
-          // prefer parsing JSON as opposed to loading the metadata
-          this.lazySpec = PartitionSpecParser.fromJson(schema(), specAsJson);
-        } else if (lazySpec == null) {
-          this.lazySpec = lazyTable.spec();
-        }
-      }
-    }
-
-    return lazySpec;
+    return specs().get(defaultSpecId);
   }
 
   @Override
   public Map<Integer, PartitionSpec> specs() {
-    return lazyTable().specs();
+    if (lazySpecs == null) {
+      synchronized (this) {
+        if (lazySpecs == null && lazyTable == null) {
+          // prefer parsing JSON as opposed to loading the metadata
+          Map<Integer, PartitionSpec> parsedSpecs = Maps.newHashMap();
+          specAsJsonMap.forEach((specId, specAsJson) -> {
+            parsedSpecs.put(specId, PartitionSpecParser.fromJson(schema(), specAsJson));
+          });
+          this.lazySpecs = parsedSpecs;
+        } else if (lazySpecs == null) {
+          this.lazySpecs = lazyTable.specs();
+        }
+      }
+    }
+
+    return lazySpecs;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/SerializableTable.java
+++ b/core/src/main/java/org/apache/iceberg/SerializableTable.java
@@ -181,11 +181,11 @@ public class SerializableTable implements Table, Serializable {
       synchronized (this) {
         if (lazySpecs == null && lazyTable == null) {
           // prefer parsing JSON as opposed to loading the metadata
-          Map<Integer, PartitionSpec> parsedSpecs = Maps.newHashMap();
+          Map<Integer, PartitionSpec> specs = Maps.newHashMapWithExpectedSize(specAsJsonMap.size());
           specAsJsonMap.forEach((specId, specAsJson) -> {
-            parsedSpecs.put(specId, PartitionSpecParser.fromJson(schema(), specAsJson));
+            specs.put(specId, PartitionSpecParser.fromJson(schema(), specAsJson));
           });
-          this.lazySpecs = parsedSpecs;
+          this.lazySpecs = specs;
         } else if (lazySpecs == null) {
           this.lazySpecs = lazyTable.specs();
         }


### PR DESCRIPTION
This PR makes our `SerializableTable` to capture all specs. This is needed to avoid reading the JSON file while writing deltas as deletes may be written to historical specs.

The downside of the new approach is that we always capture all specs even if we actually need only the current spec. I considered offering a builder that would let us customize what to include but I did some quick benchmarks and capturing 4 specs adds less than 2% overhead in terms of size. We are still heavily dominated by the size of the serialized `FileIO`. That's why I went with the simple option and captured all specs.