### PR TITLE
Orc: Correct Metrics Modes for nested fields

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestMetrics.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetrics.java
@@ -277,6 +277,22 @@ public abstract class TestMetrics {
     assertBounds(7, DoubleType.get(), null, null, metrics);
   }
 
+  @Test
+  public void testMetricsModeForNestedStructFields() throws IOException {
+    Map<String, String> properties = ImmutableMap.of(
+        TableProperties.DEFAULT_WRITE_METRICS_MODE,
+        MetricsModes.None.get().toString(),
+        TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "nestedStructCol.longCol",
+        MetricsModes.Full.get().toString());
+    MetricsConfig config = MetricsConfig.fromProperties(properties);
+
+    Metrics metrics = getMetrics(NESTED_SCHEMA, config, buildNestedTestRecord());
+    Assert.assertEquals(1L, (long) metrics.recordCount());
+    Assert.assertEquals(1, metrics.lowerBounds().size());
+    Assert.assertEquals(1, metrics.upperBounds().size());
+    assertBounds(3, LongType.get(), 100L, 100L, metrics);
+  }
+
   private Record buildNestedTestRecord() {
     Record leafStruct = GenericRecord.create(LEAF_STRUCT_TYPE);
     leafStruct.setField("leafLongCol", 20L);

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
@@ -146,7 +146,8 @@ public class OrcMetrics {
       if (icebergColOpt.isPresent()) {
         final Types.NestedField icebergCol = icebergColOpt.get();
         final int fieldId = icebergCol.fieldId();
-        final MetricsMode metricsMode = effectiveMetricsConfig.columnMode(icebergCol.name());
+        final String colName = schema.findColumnName(icebergCol.fieldId());
+        final MetricsMode metricsMode = effectiveMetricsConfig.columnMode(colName);
 
         columnSizes.put(fieldId, colStat.getBytesOnDisk());
 

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
@@ -146,9 +146,8 @@ public class OrcMetrics {
       if (icebergColOpt.isPresent()) {
         final Types.NestedField icebergCol = icebergColOpt.get();
         final int fieldId = icebergCol.fieldId();
-        final String colName = schema.findColumnName(icebergCol.fieldId());
-        final MetricsMode metricsMode = effectiveMetricsConfig.columnMode(colName);
 
+        final MetricsMode metricsMode = MetricsUtil.metricsMode(schema, effectiveMetricsConfig, icebergCol.fieldId());
         columnSizes.put(fieldId, colStat.getBytesOnDisk());
 
         if (metricsMode == MetricsModes.None.get()) {


### PR DESCRIPTION
This is not a new PR, but one I was trying to fix along with https://github.com/apache/iceberg/pull/2240, found at the time when writing unit tests for configured metrics modes for nested structs.

To be clearer, breaking this fix out to separate PR and adding a specific unit test to reproduce problem.