### PR TITLE
Spark: Add a method to load an Iceberg table by its name in Spark3.

### DIFF
--- a/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -770,10 +770,9 @@ public class Spark3Util {
     Preconditions.checkArgument(catalog instanceof BaseCatalog, "Catalog %s(%s) is not an Iceberg Catalog",
         catalog.name(), catalog.getClass().toString());
     BaseCatalog baseCatalog = (BaseCatalog) catalogAndIdentifier.catalog;
-    Table sparkTable = baseCatalog.loadTable(catalogAndIdentifier.identifier);
 
-    Preconditions.checkArgument(sparkTable instanceof SparkTable, "%s isn't a valid Iceberg table", name);
-    return ((SparkTable) sparkTable).table();
+    Table sparkTable = baseCatalog.loadTable(catalogAndIdentifier.identifier);
+    return toIcebergTable(sparkTable);
   }
 
   public static CatalogAndIdentifier catalogAndIdentifier(SparkSession spark, String name) throws ParseException {

--- a/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -755,6 +755,27 @@ public class Spark3Util {
     return null;
   }
 
+  /**
+   * Returns an Iceberg Table by its name from a Spark V2 Catalog
+   *
+   * @param spark SparkSession used for looking up catalog references and tables
+   * @param name  The multipart identifier of the Iceberg table
+   * @return an Iceberg table
+   */
+  public static org.apache.iceberg.Table loadIcebergTable(SparkSession spark, String name)
+      throws ParseException, NoSuchTableException {
+    CatalogAndIdentifier catalogAndIdentifier = catalogAndIdentifier(spark, name);
+
+    CatalogPlugin catalog = catalogAndIdentifier.catalog;
+    Preconditions.checkArgument(catalog instanceof BaseCatalog, "Catalog %s(%s) cannot be used " +
+        "to load Iceberg tables", catalog.name(), catalog.getClass().toString());
+    BaseCatalog baseCatalog = (BaseCatalog) catalogAndIdentifier.catalog;
+    Table table = baseCatalog.loadTable(catalogAndIdentifier.identifier);
+
+    Preconditions.checkArgument(table instanceof SparkTable, "%s isn't a valid Iceberg table", name);
+    return ((SparkTable) table).table();
+  }
+
   public static CatalogAndIdentifier catalogAndIdentifier(SparkSession spark, String name) throws ParseException {
     return catalogAndIdentifier(spark, name, spark.sessionState().catalogManager().currentCatalog());
   }

--- a/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -767,13 +767,13 @@ public class Spark3Util {
     CatalogAndIdentifier catalogAndIdentifier = catalogAndIdentifier(spark, name);
 
     CatalogPlugin catalog = catalogAndIdentifier.catalog;
-    Preconditions.checkArgument(catalog instanceof BaseCatalog, "Catalog %s(%s) cannot be used " +
-        "to load Iceberg tables", catalog.name(), catalog.getClass().toString());
+    Preconditions.checkArgument(catalog instanceof BaseCatalog, "Catalog %s(%s) is not an Iceberg Catalog",
+        catalog.name(), catalog.getClass().toString());
     BaseCatalog baseCatalog = (BaseCatalog) catalogAndIdentifier.catalog;
-    Table table = baseCatalog.loadTable(catalogAndIdentifier.identifier);
+    Table sparkTable = baseCatalog.loadTable(catalogAndIdentifier.identifier);
 
-    Preconditions.checkArgument(table instanceof SparkTable, "%s isn't a valid Iceberg table", name);
-    return ((SparkTable) table).table();
+    Preconditions.checkArgument(sparkTable instanceof SparkTable, "%s isn't a valid Iceberg table", name);
+    return ((SparkTable) sparkTable).table();
   }
 
   public static CatalogAndIdentifier catalogAndIdentifier(SparkSession spark, String name) throws ParseException {

--- a/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -757,8 +757,8 @@ public class Spark3Util {
   }
 
   /**
-   * Returns an Iceberg Table by its name from a Spark V2 Catalog. The {@link TableOperations} of the table may be
-   * stale, please refresh the table to get the latest one.
+   * Returns an Iceberg Table by its name from a Spark V2 Catalog. If cache is enabled in {@link SparkCatalog},
+   * the {@link TableOperations} of the table may be stale, please refresh the table to get the latest one.
    *
    * @param spark SparkSession used for looking up catalog references and tables
    * @param name  The multipart identifier of the Iceberg table

--- a/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.NullOrder;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.UpdateProperties;
 import org.apache.iceberg.UpdateSchema;
@@ -756,7 +757,8 @@ public class Spark3Util {
   }
 
   /**
-   * Returns an Iceberg Table by its name from a Spark V2 Catalog
+   * Returns an Iceberg Table by its name from a Spark V2 Catalog. The {@link TableOperations} of the table may be
+   * stale, please refresh the table to get the latest one.
    *
    * @param spark SparkSession used for looking up catalog references and tables
    * @param name  The multipart identifier of the Iceberg table


### PR DESCRIPTION
This is useful for any user or developer who want to get an Iceberg table by its name.