### PR TITLE
Suppress invalid ErrorProne warnings related to calling getNano metho…

### DIFF
--- a/data/src/main/java/org/apache/iceberg/data/orc/GenericOrcWriters.java
+++ b/data/src/main/java/org/apache/iceberg/data/orc/GenericOrcWriters.java
@@ -395,6 +395,7 @@ public class GenericOrcWriters {
     }
 
     @Override
+    @SuppressWarnings("JavaLocalDateTimeGetNano")
     public void nonNullWrite(int rowId, LocalDateTime data, ColumnVector output) {
       TimestampColumnVector cv = (TimestampColumnVector) output;
       cv.setIsUTC(true);

--- a/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcWriters.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/data/FlinkOrcWriters.java
@@ -167,6 +167,7 @@ class FlinkOrcWriters {
     }
 
     @Override
+    @SuppressWarnings("JavaInstantGetSecondsGetNano")
     public void nonNullWrite(int rowId, TimestampData data, ColumnVector output) {
       TimestampColumnVector cv = (TimestampColumnVector) output;
       // millis

--- a/hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampObjectInspectorHive3.java
+++ b/hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampObjectInspectorHive3.java
@@ -50,6 +50,7 @@ public class IcebergTimestampObjectInspectorHive3 extends AbstractPrimitiveJavaO
   }
 
   @Override
+  @SuppressWarnings("JavaLocalDateTimeGetNano")
   public Timestamp getPrimitiveJavaObject(Object o) {
     if (o == null) {
       return null;


### PR DESCRIPTION
…ds without nearby getSeconds calls

As we set `nanos` specifically in a field, these warning do not apply. Remove them from the logs.

Also removed one instance of it in `hive3/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergTimestampObjectInspectorHive3.#getPrimitiveJavaObject`. I checked manually in a scala shell with the hive classes in it (placing the Iceberg jar on the classpath) that the call to getNanos is correct.