### PR TITLE
[INFRA] Add Workflow to Cancel Duplicate Workflow Runs

### DIFF
--- a/.github/workflows/cancel-dupliate-workflow-runs.yml
+++ b/.github/workflows/cancel-dupliate-workflow-runs.yml
@@ -17,16 +17,16 @@
 # under the License.
 #
 
-name: "Canel Duplicates""
+name: "Cancel Duplicates"
 on:
   workflow_run:
     workflows: 
       - 'Java CI'
-    types: ['requested', 'completed']
+    types: ['requested']
 
 jobs:
   cancel-duplicate-workflow-runs:
-    name: "Cancel Duplicate Workflow Runs"
+    name: "Cancel duplicate workflow runs"
     runs-on: ubuntu-latest
     steps:
       - uses: potiuk/cancel-workflow-runs@4723494a065d162f8e9efd071b98e0126e00f866 # @master

--- a/.github/workflows/cancel-dupliate-workflow-runs.yml
+++ b/.github/workflows/cancel-dupliate-workflow-runs.yml
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: "Canel Duplicates""
+on:
+  workflow_run:
+    workflows: 
+      - 'Java CI'
+    types: ['requested', 'completed']
+
+jobs:
+  cancel-duplicate-workflow-runs:
+    name: "Cancel Duplicate Workflow Runs"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: potiuk/cancel-workflow-runs@4723494a065d162f8e9efd071b98e0126e00f866 # @master
+        name: "Cancel duplicate workflow runs"
+        with:
+          cancelMode: allDuplicates
+          token: ${{ secrets.GITHUB_TOKEN }}
+          sourceRunId: ${{ github.event.workflow_run.id }}
+          skipEventTypes: '["push", "schedule"]'  # TODO - May not to remove push from skipEventTypes


### PR DESCRIPTION
Presently, if somebody pushes to an open PR, the previous workflow run still goes to completion.

This PR adds a cancel duplicate workflow run actions that will cancel them. I have tested this in my fork and confirmed thet it works.

Because GitHub Actions work differently in forks than in the upstream repo, it's probably best we merge this and then work out any potential nuances in behavior. I have confirmed that it works in my fork though (of course if anybody catches anything in review, that's obviously better).

I have not seen any, but major things I'd watch out for after merging this are:
- Ensuring that we don't generate too many cancel workflow runs (that aren't needed) - this can be tuned by the events etc. This workflow is inexpensive compared to the actual CI so this isn't a large concern if it does happen for a bit.
- Double check we're cancelling duplicate workflows (e.g. after push) when a new workflow is pushed. I've checked this in my fork, but forks behave differently than the upstream repo for GH Actions

Things that I would grab in a v2:
- Cancel workflows for PRs that have been merged (if still running) - especially useful for forks where we don't control the behavior of people's merging.

Even if there are some minor kinks, the added availability of CI runners will greatly outweigh a small period of time with possibly extra workflow runs as Java CI takes >30 minutes and occupies ~4 task runners.

This workflow takes ~30 seconds or so.

I chose this action as it's used in Spark.

This closes issue https://github.com/apache/iceberg/issues/3002