### PR TITLE
[INFRA] Reduce permissions for Github tokens generated for labeler action

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -20,6 +20,10 @@
 name: "Pull Request Labeler"
 on: pull_request_target
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   triage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
According to [the docs on Permissions for the GITHUB_TOKEN](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token), the GITHUB_TOKEN that's generated for each run of a workflow has a specific set of permissions associated to it.

These permissions can be defined more granularly, to reduce the scope of the things the workflow can touch.

The full docs on `permissions` is located [here](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions).

To test this out, I'm using the permissions given in the example provided on the same page.

This partially closes the following issue issue https://github.com/apache/iceberg/issues/3006, though we should consider adding this to all workflows that use GITHUB_TOKEN.

For reference, I've tested this by merging it into my fork and ensuring that a new PR can still label (and update labels) as expected: https://github.com/kbendick/iceberg/pull/55