### PR TITLE
Spark: Add Spark extension for table encryption key

### DIFF
--- a/spark3-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
+++ b/spark3-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
@@ -73,7 +73,7 @@ statement
     | ALTER TABLE multipartIdentifier WRITE writeSpec                                       #setWriteDistributionAndOrdering
     | ALTER TABLE multipartIdentifier SET IDENTIFIER_KW FIELDS fieldList                    #setIdentifierFields
     | ALTER TABLE multipartIdentifier DROP IDENTIFIER_KW FIELDS fieldList                   #dropIdentifierFields
-    | ALTER TABLE multipartIdentifier ENCRYPTED WITH (KEK | MEK) BY TABLE KEY keyId         #createTableEncKey
+    | ALTER TABLE multipartIdentifier ENCRYPTED WITH (KEK | MEK) KEY keyId                  #createTableEncKey
     ;
 
 writeSpec

--- a/spark3-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
+++ b/spark3-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
@@ -73,6 +73,7 @@ statement
     | ALTER TABLE multipartIdentifier WRITE writeSpec                                       #setWriteDistributionAndOrdering
     | ALTER TABLE multipartIdentifier SET IDENTIFIER_KW FIELDS fieldList                    #setIdentifierFields
     | ALTER TABLE multipartIdentifier DROP IDENTIFIER_KW FIELDS fieldList                   #dropIdentifierFields
+    | ALTER TABLE multipartIdentifier ENCRYPTED WITH (KEK | MEK) BY TABLE KEY keyId         #createTableEncKey
     ;
 
 writeSpec
@@ -163,9 +164,14 @@ fieldList
     : fields+=multipartIdentifier (',' fields+=multipartIdentifier)*
     ;
 
+keyId
+    : STRING
+    ;
+
 nonReserved
     : ADD | ALTER | AS | ASC | BY | CALL | DESC | DROP | FIELD | FIRST | LAST | NULLS | ORDERED | PARTITION | TABLE | WRITE
     | DISTRIBUTED | LOCALLY | UNORDERED | REPLACE | WITH | IDENTIFIER_KW | FIELDS | SET
+    | ENCRYPTED | KEY | KEK | MEK
     | TRUE | FALSE
     | MAP
     ;
@@ -194,6 +200,10 @@ TABLE: 'TABLE';
 UNORDERED: 'UNORDERED';
 WITH: 'WITH';
 WRITE: 'WRITE';
+ENCRYPTED: 'ENCRYPTED';
+KEK: 'KEK';
+MEK: 'MEK';
+KEY: 'KEY';
 
 TRUE: 'TRUE';
 FALSE: 'FALSE';

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
@@ -120,7 +120,8 @@ class IcebergSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserI
             normalized.contains("write distributed by") ||
             normalized.contains("write unordered") ||
             normalized.contains("set identifier fields") ||
-            normalized.contains("drop identifier fields")))
+            normalized.contains("drop identifier fields") ||
+            normalized.contains("encrypted with")))
   }
 
   protected def parse[T](command: String)(toResult: IcebergSqlExtensionsParser => T): T = {

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
@@ -117,7 +117,7 @@ class IcebergSqlExtensionsAstBuilder(delegate: ParserInterface) extends IcebergS
   }
 
   /**
-   * Create a ENCRYPTED WITH (KEK | MEK) BY TABLE KEY command.
+   * Create a [[CreateTableEncKey]] for creating a KEK or MEK encryption key for the table.
    */
   override def visitCreateTableEncKey(ctx: CreateTableEncKeyContext): CreateTableEncKey = withOrigin(ctx) {
     val isKEK = if (ctx.KEK() != null) true else false

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.catalyst.parser.extensions.IcebergSqlExtensionsParse
 import org.apache.spark.sql.catalyst.plans.logical.AddPartitionField
 import org.apache.spark.sql.catalyst.plans.logical.CallArgument
 import org.apache.spark.sql.catalyst.plans.logical.CallStatement
+import org.apache.spark.sql.catalyst.plans.logical.CreateTableEncKey
 import org.apache.spark.sql.catalyst.plans.logical.DropIdentifierFields
 import org.apache.spark.sql.catalyst.plans.logical.DropPartitionField
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -113,6 +114,18 @@ class IcebergSqlExtensionsAstBuilder(delegate: ParserInterface) extends IcebergS
     DropIdentifierFields(
       typedVisit[Seq[String]](ctx.multipartIdentifier),
       ctx.fieldList.fields.asScala.map(_.getText))
+  }
+
+  /**
+   * Create a ENCRYPTED WITH (KEK | MEK) BY TABLE KEY command.
+   */
+  override def visitCreateTableEncKey(ctx: CreateTableEncKeyContext): CreateTableEncKey = withOrigin(ctx) {
+    val isKEK = if (ctx.KEK() != null) true else false
+    CreateTableEncKey(
+      typedVisit[Seq[String]](ctx.multipartIdentifier),
+      isKEK,
+      ctx.keyId().getText
+    )
   }
 
   /**

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/CreateTableEncKey.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/CreateTableEncKey.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+case class CreateTableEncKey(
+    table: Seq[String],
+    isKEK: Boolean,
+    keyId: String) extends Command {
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override def simpleString(maxFields: Int): String = {
+    s"CreateTableEncKey ${table.quoted} isKEK: $isKEK $keyId"
+  }
+}

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateTableEncKeyExec.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateTableEncKeyExec.scala
@@ -41,7 +41,7 @@ case class CreateTableEncKeyExec(
         throw new UnsupportedOperationException(s"create Table encryption key not supported yet: " +
           s"${catalog.name}.${ident.quoted} isKEK: $isKEK $keyId")
       case table =>
-        throw new UnsupportedOperationException(s"Cannot create Table encryption key  for a non-Iceberg table: $table")
+        throw new UnsupportedOperationException(s"Cannot create Table encryption key for a non-Iceberg table: $table")
     }
 
     Nil

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateTableEncKeyExec.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateTableEncKeyExec.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.execution.datasources.v2
+
+import org.apache.iceberg.spark.source.SparkTable
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.connector.catalog.Identifier
+import org.apache.spark.sql.connector.catalog.TableCatalog
+
+case class CreateTableEncKeyExec(
+    catalog: TableCatalog,
+    ident: Identifier,
+    isKEK: Boolean,
+    keyId: String) extends V2CommandExec {
+  import org.apache.spark.sql.connector.catalog.CatalogV2Implicits._
+
+  override lazy val output: Seq[Attribute] = Nil
+
+  override protected def run(): Seq[InternalRow] = {
+    catalog.loadTable(ident) match {
+      case iceberg: SparkTable =>
+        // Todo: This will be replaced by Table encryption key implementation in next PR
+        throw new UnsupportedOperationException(s"create Table encryption key not supported yet: " +
+          s"${catalog.name}.${ident.quoted} isKEK: $isKEK $keyId")
+      case table =>
+        throw new UnsupportedOperationException(s"Cannot create Table encryption key: $table")
+    }
+
+    Nil
+  }
+
+  override def simpleString(maxFields: Int): String = {
+    s"CreateTableEncKey ${catalog.name}.${ident.quoted} isKEK: $isKEK $keyId";
+  }
+}

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateTableEncKeyExec.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/CreateTableEncKeyExec.scala
@@ -41,7 +41,7 @@ case class CreateTableEncKeyExec(
         throw new UnsupportedOperationException(s"create Table encryption key not supported yet: " +
           s"${catalog.name}.${ident.quoted} isKEK: $isKEK $keyId")
       case table =>
-        throw new UnsupportedOperationException(s"Cannot create Table encryption key: $table")
+        throw new UnsupportedOperationException(s"Cannot create Table encryption key  for a non-Iceberg table: $table")
     }
 
     Nil

--- a/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Strategy.scala
+++ b/spark3-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Strategy.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.catalyst.expressions.NamedExpression
 import org.apache.spark.sql.catalyst.planning.PhysicalOperation
 import org.apache.spark.sql.catalyst.plans.logical.AddPartitionField
 import org.apache.spark.sql.catalyst.plans.logical.Call
+import org.apache.spark.sql.catalyst.plans.logical.CreateTableEncKey
 import org.apache.spark.sql.catalyst.plans.logical.DropIdentifierFields
 import org.apache.spark.sql.catalyst.plans.logical.DropPartitionField
 import org.apache.spark.sql.catalyst.plans.logical.DynamicFileFilter
@@ -100,6 +101,9 @@ case class ExtendedDataSourceV2Strategy(spark: SparkSession) extends Strategy {
 
     case MergeInto(mergeIntoParams, output, child) =>
       MergeIntoExec(mergeIntoParams, output, planLater(child)) :: Nil
+
+    case CreateTableEncKey(IcebergCatalogAndIdentifier(catalog, ident), isKEK, keyId) =>
+      CreateTableEncKeyExec(catalog, ident, isKEK, keyId) :: Nil
 
     case _ => Nil
   }

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTableEncryption.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTableEncryption.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.spark.extensions;
 
+import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.Table;
 import org.junit.After;
 import org.junit.Assert;
@@ -43,12 +44,10 @@ public class TestTableEncryption extends SparkExtensionsTestBase {
         "location struct<lon:bigint NOT NULL,lat:bigint NOT NULL> NOT NULL) USING iceberg", tableName);
     Table table = validationCatalog.loadTable(tableIdent);
     Assert.assertTrue("Table should start without identifier", table.schema().identifierFieldIds().isEmpty());
-    try {
-        sql("ALTER TABLE %s ENCRYPTED WITH KEK BY TABLE KEY '12345'", tableName);
-    } catch (UnsupportedOperationException e) {
-        String message = e.getMessage();
-        Assert.assertTrue(message.contains(tableName) &&
-        message.contains("isKEK: true") && message.contains("12345"));
-    }
+
+    AssertHelpers.assertThrows("Should throw an Unsupported Operation Exception for now",
+        UnsupportedOperationException.class,
+        tableName + " isKEK: true '12345'",
+        () -> sql("ALTER TABLE %s ENCRYPTED WITH KEK BY TABLE KEY '12345'", tableName));
   }
 }

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTableEncryption.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTableEncryption.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.extensions;
+
+import org.apache.iceberg.Table;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class TestTableEncryption extends SparkExtensionsTestBase {
+  public TestTableEncryption(String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
+  }
+
+  @After
+  public void removeTable() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @Test
+  public void testEncKey() {
+
+    sql("CREATE TABLE %s (id bigint NOT NULL, " +
+        "location struct<lon:bigint NOT NULL,lat:bigint NOT NULL> NOT NULL) USING iceberg", tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+    Assert.assertTrue("Table should start without identifier", table.schema().identifierFieldIds().isEmpty());
+    try {
+        sql("ALTER TABLE %s ENCRYPTED WITH KEK BY TABLE KEY '12345'", tableName);
+    } catch (UnsupportedOperationException e) {
+        String message = e.getMessage();
+        Assert.assertTrue(message.contains(tableName) &&
+        message.contains("isKEK: true") && message.contains("12345"));
+    }
+  }
+}

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTableEncryption.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTableEncryption.java
@@ -40,7 +40,7 @@ public class TestTableEncryption extends SparkExtensionsTestBase {
   public void testEncKey() {
 
     sql("CREATE TABLE %s (id bigint NOT NULL, " +
-        "location struct<lon:bigint NOT NULL,lat:bigint NOT NULL> NOT NULL) USING iceberg", tableName);
+        "coordinates struct<lon:bigint NOT NULL,lat:bigint NOT NULL> NOT NULL) USING iceberg", tableName);
     Table table = validationCatalog.loadTable(tableIdent);
     Assert.assertTrue("Table should start without identifier", table.schema().identifierFieldIds().isEmpty());
 

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTableEncryption.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTableEncryption.java
@@ -19,13 +19,12 @@
 
 package org.apache.iceberg.spark.extensions;
 
+import java.util.Map;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.Table;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.Map;
 
 public class TestTableEncryption extends SparkExtensionsTestBase {
   public TestTableEncryption(String catalogName, String implementation, Map<String, String> config) {

--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTableEncryption.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTableEncryption.java
@@ -21,9 +21,7 @@ package org.apache.iceberg.spark.extensions;
 
 import java.util.Map;
 import org.apache.iceberg.AssertHelpers;
-import org.apache.iceberg.Table;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class TestTableEncryption extends SparkExtensionsTestBase {
@@ -38,15 +36,11 @@ public class TestTableEncryption extends SparkExtensionsTestBase {
 
   @Test
   public void testEncKey() {
-
     sql("CREATE TABLE %s (id bigint NOT NULL, " +
         "coordinates struct<lon:bigint NOT NULL,lat:bigint NOT NULL> NOT NULL) USING iceberg", tableName);
-    Table table = validationCatalog.loadTable(tableIdent);
-    Assert.assertTrue("Table should start without identifier", table.schema().identifierFieldIds().isEmpty());
-
     AssertHelpers.assertThrows("Should throw an Unsupported Operation Exception for now",
         UnsupportedOperationException.class,
         tableName + " isKEK: true '12345'",
-        () -> sql("ALTER TABLE %s ENCRYPTED WITH KEK BY TABLE KEY '12345'", tableName));
+        () -> sql("ALTER TABLE %s ENCRYPTED WITH KEK KEY '12345'", tableName));
   }
 }


### PR DESCRIPTION
This is the first PR for supporting table encryption key syntax proposed in this https://docs.google.com/document/d/1kkcjr9KrlB9QagRX3ToulG_Rf-65NMSlVANheDNzJq4/edit#heading=h.5e5qu1qyfmhm

The new syntax we will support:
```
ALTER TABLE table ENCRYPTED WITH KEK|MEK BY TABLE KEY key-id
```
This PR added the new syntax and the new logical/physical operators. Currently the run method in the physical operator will throw `UnsupportedOperationException`. Next PR will implement the run method to generate the table encryption key  and change the table into an encrypted table.