### PR TITLE
Hive: Fix toString NPE with recommended constructor

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -507,7 +507,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("name", name)
-        .add("uri", this.conf.get(HiveConf.ConfVars.METASTOREURIS.varname))
+        .add("uri", this.conf == null ? "" : this.conf.get(HiveConf.ConfVars.METASTOREURIS.varname))
         .toString();
   }
 


### PR DESCRIPTION
Small fix.  

When running the Spark shell or other Scala REPL  , the new no-arg constructor, replacing the deprecated one, hits this NPE which prevents it from being constructed

```
scala> val catalog = new HiveCatalog()
java.lang.NullPointerException
  at org.apache.iceberg.hive.HiveCatalog.toString(HiveCatalog.java:523)
  at scala.runtime.ScalaRunTime$.inner$1(ScalaRunTime.scala:254)
```