### PR TITLE
Arrow: Support DecimalType

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/DictEncodedArrowConverter.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/DictEncodedArrowConverter.java
@@ -1,0 +1,316 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.arrow;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.function.IntConsumer;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.BaseFixedWidthVector;
+import org.apache.arrow.vector.BaseVariableWidthVector;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.DecimalVector;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.Float8Vector;
+import org.apache.arrow.vector.TimeMicroVector;
+import org.apache.arrow.vector.TimeStampMicroTZVector;
+import org.apache.arrow.vector.TimeStampMicroVector;
+import org.apache.arrow.vector.TimeStampVector;
+import org.apache.arrow.vector.VarBinaryVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.iceberg.arrow.vectorized.ArrowVectorAccessor;
+import org.apache.iceberg.arrow.vectorized.NullabilityHolder;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+
+/**
+ * This converts dictionary encoded arrow vectors to a correctly typed arrow vector.
+ */
+public final class DictEncodedArrowConverter {
+
+  private DictEncodedArrowConverter() {
+  }
+
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
+  public static FieldVector allocateNonDictEncodedArrowVector(
+      Types.NestedField icebergField, int size, BufferAllocator allocator) {
+    Preconditions.checkArgument(null != icebergField, "icebergField cannot be null");
+    Preconditions.checkArgument(null != allocator, "BufferAllocator cannot be null");
+    if (Type.TypeID.DECIMAL.equals(icebergField.type().typeId())) {
+      return allocateDecimalVector(icebergField, size, allocator);
+    } else if (Type.TypeID.TIMESTAMP.equals(icebergField.type().typeId())) {
+      return allocateTimestampVector(icebergField, size, allocator);
+    } else if (Type.TypeID.LONG.equals(icebergField.type().typeId())) {
+      return allocateBigIntVector(icebergField, size, allocator);
+    } else if (Type.TypeID.FLOAT.equals(icebergField.type().typeId())) {
+      return allocateFloat4Vector(icebergField, size, allocator);
+    } else if (Type.TypeID.DOUBLE.equals(icebergField.type().typeId())) {
+      return allocateFloat8Vector(icebergField, size, allocator);
+    } else if (Type.TypeID.STRING.equals(icebergField.type().typeId())) {
+      return allocateVarCharVector(icebergField, size, allocator);
+    } else if (Type.TypeID.BINARY.equals(icebergField.type().typeId())) {
+      return allocateVarBinaryVector(icebergField, size, allocator);
+    } else if (Type.TypeID.TIME.equals(icebergField.type().typeId())) {
+      return allocateTimeMicroVector(icebergField, size, allocator);
+    }
+
+    throw new IllegalArgumentException(String.format(
+        "Cannot convert dict encoded field '%s' of type '%s' to Arrow vector as it is currently not supported",
+        icebergField.name(), icebergField.type().typeId()));
+  }
+
+  private static DecimalVector allocateDecimalVector(
+      Types.NestedField icebergField, int size, BufferAllocator allocator) {
+    DecimalVector vector = new DecimalVector(
+        icebergField.name(),
+        ArrowSchemaUtil.convert(icebergField).getFieldType(),
+        allocator);
+    vector.allocateNew(size);
+    return vector;
+  }
+
+  private static TimeStampVector allocateTimestampVector(
+      Types.NestedField icebergField, int size, BufferAllocator allocator) {
+    TimeStampVector vector;
+    if (((Types.TimestampType) icebergField.type()).shouldAdjustToUTC()) {
+      vector = new TimeStampMicroTZVector(
+          icebergField.name(),
+          ArrowSchemaUtil.convert(icebergField).getFieldType(),
+          allocator);
+    } else {
+      vector = new TimeStampMicroVector(
+          icebergField.name(),
+          ArrowSchemaUtil.convert(icebergField).getFieldType(),
+          allocator);
+    }
+    vector.allocateNew(size);
+    return vector;
+  }
+
+  private static BigIntVector allocateBigIntVector(
+      Types.NestedField icebergField, int size, BufferAllocator allocator) {
+    BigIntVector vector =
+        new BigIntVector(icebergField.name(), ArrowSchemaUtil.convert(icebergField).getFieldType(), allocator);
+    vector.allocateNew(size);
+    return vector;
+  }
+
+  private static Float4Vector allocateFloat4Vector(
+      Types.NestedField icebergField, int size, BufferAllocator allocator) {
+    Float4Vector vector = new Float4Vector(
+        icebergField.name(),
+        ArrowSchemaUtil.convert(icebergField).getFieldType(),
+        allocator);
+    vector.allocateNew(size);
+    return vector;
+  }
+
+  private static Float8Vector allocateFloat8Vector(
+      Types.NestedField icebergField, int size, BufferAllocator allocator) {
+    Float8Vector vector = new Float8Vector(
+        icebergField.name(),
+        ArrowSchemaUtil.convert(icebergField).getFieldType(),
+        allocator);
+    vector.allocateNew(size);
+    return vector;
+  }
+
+  private static VarCharVector allocateVarCharVector(
+      Types.NestedField icebergField, int size, BufferAllocator allocator) {
+    VarCharVector vector = new VarCharVector(
+        icebergField.name(),
+        ArrowSchemaUtil.convert(icebergField).getFieldType(),
+        allocator);
+    vector.allocateNew(size);
+    return vector;
+  }
+
+  private static VarBinaryVector allocateVarBinaryVector(
+      Types.NestedField icebergField, int size, BufferAllocator allocator) {
+    VarBinaryVector vector = new VarBinaryVector(
+        icebergField.name(),
+        ArrowSchemaUtil.convert(icebergField).getFieldType(),
+        allocator);
+    vector.allocateNew(size);
+    return vector;
+  }
+
+  private static TimeMicroVector allocateTimeMicroVector(
+      Types.NestedField icebergField, int size, BufferAllocator allocator) {
+    TimeMicroVector vector = new TimeMicroVector(
+        icebergField.name(),
+        ArrowSchemaUtil.convert(icebergField).getFieldType(),
+        allocator);
+    vector.allocateNew(size);
+    return vector;
+  }
+
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
+  public static FieldVector copyToNonDictEncodedVector(
+      FieldVector source, FieldVector target, Types.NestedField icebergField, NullabilityHolder nullabilityHolder,
+      ArrowVectorAccessor<?, String, ?, ?> accessor) {
+    Preconditions.checkArgument(null != source, "Source FieldVector cannot be null");
+    Preconditions.checkArgument(null != target, "Target FieldVector cannot be null");
+    Preconditions.checkArgument(null != nullabilityHolder, "NullabilityHolder cannot be null");
+    Preconditions.checkArgument(null != accessor, "ArrowVectorAccessor cannot be null");
+
+    if (Type.TypeID.DECIMAL.equals(icebergField.type().typeId())) {
+      return copyToDecimalVector(source, target, icebergField, nullabilityHolder, accessor);
+    } else if (Type.TypeID.TIMESTAMP.equals(icebergField.type().typeId())) {
+      return copyToTimestampVector(source, target, nullabilityHolder, accessor);
+    } else if (Type.TypeID.LONG.equals(icebergField.type().typeId())) {
+      return copyToBigIntVector(source, target, nullabilityHolder, accessor);
+    } else if (Type.TypeID.FLOAT.equals(icebergField.type().typeId())) {
+      return copyToFloat4Vector(source, target, nullabilityHolder, accessor);
+    } else if (Type.TypeID.DOUBLE.equals(icebergField.type().typeId())) {
+      return copyToFloat8Vector(source, target, nullabilityHolder, accessor);
+    } else if (Type.TypeID.STRING.equals(icebergField.type().typeId())) {
+      return copyToVarCharVector(source, target, nullabilityHolder, accessor);
+    } else if (Type.TypeID.BINARY.equals(icebergField.type().typeId())) {
+      return copyToVarBinaryVector(source, target, nullabilityHolder, accessor);
+    } else if (Type.TypeID.TIME.equals(icebergField.type().typeId())) {
+      return copyToTimeMicroVector(source, target, nullabilityHolder, accessor);
+    }
+
+    throw new IllegalArgumentException(String.format("Cannot convert dict encoded field '%s' of type '%s' to Arrow " +
+            "vector as it is currently not supported",
+        icebergField.name(), icebergField.type().typeId()));
+  }
+
+  private static boolean isNullAt(NullabilityHolder nullabilityHolder, int idx) {
+    return nullabilityHolder.isNullAt(idx) == 1;
+  }
+
+  private static DecimalVector copyToDecimalVector(
+      FieldVector source, FieldVector target, Types.NestedField icebergField, NullabilityHolder nullabilityHolder,
+      ArrowVectorAccessor<?, String, ?, ?> accessor) {
+    Preconditions.checkArgument(target instanceof DecimalVector, "ValueVector must be of type " +
+        DecimalVector.class + " but is " + target);
+    DecimalVector vector = (DecimalVector) target;
+    int precision = ((Types.DecimalType) icebergField.type()).precision();
+    int scale = ((Types.DecimalType) icebergField.type()).scale();
+
+    initVector(source, vector, nullabilityHolder, idx -> vector.setSafe(idx, (BigDecimal) accessor.getDecimal(idx,
+        precision, scale)));
+    return vector;
+  }
+
+  private static TimeStampVector copyToTimestampVector(
+      FieldVector source, FieldVector target, NullabilityHolder nullabilityHolder,
+      ArrowVectorAccessor<?, String, ?, ?> accessor) {
+    Preconditions.checkArgument(target instanceof TimeStampVector, "ValueVector must be of type " +
+        TimeStampVector.class + " but is " + target);
+    TimeStampVector vector = (TimeStampVector) target;
+    initVector(source, vector, nullabilityHolder, idx -> vector.set(idx, accessor.getLong(idx)));
+    return vector;
+  }
+
+  private static BigIntVector copyToBigIntVector(
+      FieldVector source, FieldVector target, NullabilityHolder nullabilityHolder,
+      ArrowVectorAccessor<?, String, ?, ?> accessor) {
+    Preconditions.checkArgument(target instanceof BigIntVector, "ValueVector must be of type " +
+        BigIntVector.class + " but is " + target);
+    BigIntVector vector = (BigIntVector) target;
+    initVector(source, vector, nullabilityHolder, idx -> vector.set(idx, accessor.getLong(idx)));
+    return vector;
+  }
+
+  private static Float4Vector copyToFloat4Vector(
+      FieldVector source, FieldVector target, NullabilityHolder nullabilityHolder,
+      ArrowVectorAccessor<?, String, ?, ?> accessor) {
+    Preconditions.checkArgument(target instanceof Float4Vector, "ValueVector must be of type " +
+        Float4Vector.class + " but is " + target);
+    Float4Vector vector = (Float4Vector) target;
+    initVector(source, vector, nullabilityHolder, idx -> vector.set(idx, accessor.getFloat(idx)));
+    return vector;
+  }
+
+  private static Float8Vector copyToFloat8Vector(
+      FieldVector source, FieldVector target, NullabilityHolder nullabilityHolder,
+      ArrowVectorAccessor<?, String, ?, ?> accessor) {
+    Preconditions.checkArgument(target instanceof Float8Vector, "ValueVector must be of type " +
+        Float8Vector.class + " but is " + target);
+    Float8Vector vector = (Float8Vector) target;
+    initVector(source, vector, nullabilityHolder, idx -> vector.set(idx, accessor.getDouble(idx)));
+    return vector;
+  }
+
+  private static VarCharVector copyToVarCharVector(
+      FieldVector source, FieldVector target, NullabilityHolder nullabilityHolder,
+      ArrowVectorAccessor<?, String, ?, ?> accessor) {
+    Preconditions.checkArgument(target instanceof VarCharVector, "ValueVector must be of type " +
+        VarCharVector.class + " but is " + target);
+    VarCharVector vector = (VarCharVector) target;
+
+    initVector(
+        source, vector, nullabilityHolder,
+        idx -> vector.set(idx, accessor.getUTF8String(idx).getBytes(StandardCharsets.UTF_8)));
+    return vector;
+  }
+
+  private static VarBinaryVector copyToVarBinaryVector(
+      FieldVector source, FieldVector target, NullabilityHolder nullabilityHolder,
+      ArrowVectorAccessor<?, String, ?, ?> accessor) {
+    Preconditions.checkArgument(target instanceof VarBinaryVector, "ValueVector must be of type " +
+        VarBinaryVector.class + " but is " + target);
+    VarBinaryVector vector = (VarBinaryVector) target;
+
+    initVector(source, vector, nullabilityHolder, idx -> vector.set(idx, accessor.getBinary(idx)));
+    return vector;
+  }
+
+  private static TimeMicroVector copyToTimeMicroVector(
+      FieldVector source, FieldVector target, NullabilityHolder nullabilityHolder,
+      ArrowVectorAccessor<?, String, ?, ?> accessor) {
+    Preconditions.checkArgument(target instanceof TimeMicroVector, "ValueVector must be of type " +
+        TimeMicroVector.class + " but is " + target);
+    TimeMicroVector vector = (TimeMicroVector) target;
+    initVector(source, vector, nullabilityHolder, idx -> vector.set(idx, accessor.getLong(idx)));
+    return vector;
+  }
+
+  private static void initVector(
+      FieldVector source, BaseFixedWidthVector target, NullabilityHolder nullabilityHolder,
+      IntConsumer consumer) {
+    for (int i = 0; i < source.getValueCount(); i++) {
+      if (isNullAt(nullabilityHolder, i)) {
+        target.setNull(i);
+      } else {
+        consumer.accept(i);
+      }
+    }
+    target.setValueCount(source.getValueCount());
+  }
+
+  private static void initVector(
+      FieldVector source, BaseVariableWidthVector target,
+      NullabilityHolder nullabilityHolder, IntConsumer consumer) {
+    for (int i = 0; i < source.getValueCount(); i++) {
+      if (isNullAt(nullabilityHolder, i)) {
+        target.setNull(i);
+      } else {
+        consumer.accept(i);
+      }
+    }
+    target.setValueCount(source.getValueCount());
+  }
+}

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowReader.java
@@ -113,7 +113,8 @@ public class ArrowReader extends CloseableGroup {
       TypeID.BINARY,
       TypeID.DATE,
       TypeID.UUID,
-      TypeID.TIME
+      TypeID.TIME,
+      TypeID.DECIMAL
   );
 
   private final Schema schema;

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowVectorAccessors.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowVectorAccessors.java
@@ -19,9 +19,11 @@
 
 package org.apache.iceberg.arrow.vectorized;
 
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.function.Supplier;
 import org.apache.arrow.vector.VarCharVector;
+import org.apache.iceberg.arrow.vectorized.GenericArrowVectorAccessorFactory.DecimalFactory;
 import org.apache.iceberg.arrow.vectorized.GenericArrowVectorAccessorFactory.StringFactory;
 
 final class ArrowVectorAccessors {
@@ -30,7 +32,7 @@ final class ArrowVectorAccessors {
 
   static {
     factory = new GenericArrowVectorAccessorFactory<>(
-        throwingSupplier("Decimal type is not supported"),
+        JavaDecimalFactory::new,
         JavaStringFactory::new,
         throwingSupplier("Struct type is not supported"),
         throwingSupplier("List type is not supported")
@@ -65,6 +67,24 @@ final class ArrowVectorAccessors {
     @Override
     public String ofBytes(byte[] bytes) {
       return new String(bytes, StandardCharsets.UTF_8);
+    }
+  }
+
+  private static final class JavaDecimalFactory implements DecimalFactory<BigDecimal> {
+
+    @Override
+    public Class<BigDecimal> getGenericClass() {
+      return BigDecimal.class;
+    }
+
+    @Override
+    public BigDecimal ofLong(long value, int precision, int scale) {
+      return BigDecimal.valueOf(value, scale);
+    }
+
+    @Override
+    public BigDecimal ofBigDecimal(BigDecimal value, int precision, int scale) {
+      return BigDecimal.valueOf(value.unscaledValue().longValue(), scale);
     }
   }
 }

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ColumnarBatch.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ColumnarBatch.java
@@ -50,7 +50,7 @@ public class ColumnarBatch implements AutoCloseable {
    */
   public VectorSchemaRoot createVectorSchemaRootFromVectors() {
     return VectorSchemaRoot.of(Arrays.stream(columns)
-        .map(ColumnVector::getFieldVector)
+        .map(ColumnVector::getArrowVector)
         .toArray(FieldVector[]::new));
   }
 

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorHolder.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorHolder.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.arrow.vectorized;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Dictionary;
 
@@ -32,44 +33,48 @@ import org.apache.parquet.column.Dictionary;
 public class VectorHolder {
   private final ColumnDescriptor columnDescriptor;
   private final FieldVector vector;
+  private final FieldVector nonDictEncodedVector;
   private final boolean isDictionaryEncoded;
   private final Dictionary dictionary;
   private final NullabilityHolder nullabilityHolder;
-  private final Type icebergType;
+  private final Types.NestedField icebergField;
 
   public VectorHolder(
-      ColumnDescriptor columnDescriptor, FieldVector vector, boolean isDictionaryEncoded,
-      Dictionary dictionary, NullabilityHolder holder, Type type) {
+      ColumnDescriptor columnDescriptor, FieldVector vector, FieldVector nonDictEncodedVector,
+      boolean isDictionaryEncoded, Dictionary dictionary, NullabilityHolder holder, Types.NestedField icebergField) {
     // All the fields except dictionary are not nullable unless it is a dummy holder
     Preconditions.checkNotNull(columnDescriptor, "ColumnDescriptor cannot be null");
     Preconditions.checkNotNull(vector, "Vector cannot be null");
     Preconditions.checkNotNull(holder, "NullabilityHolder cannot be null");
-    Preconditions.checkNotNull(type, "IcebergType cannot be null");
+    Preconditions.checkNotNull(icebergField, "IcebergField cannot be null");
     this.columnDescriptor = columnDescriptor;
     this.vector = vector;
+    this.nonDictEncodedVector = nonDictEncodedVector;
     this.isDictionaryEncoded = isDictionaryEncoded;
     this.dictionary = dictionary;
     this.nullabilityHolder = holder;
-    this.icebergType = type;
+    this.icebergField = icebergField;
   }
 
   // Only used for returning dummy holder
   private VectorHolder() {
     columnDescriptor = null;
     vector = null;
+    nonDictEncodedVector = null;
     isDictionaryEncoded = false;
     dictionary = null;
     nullabilityHolder = null;
-    icebergType = null;
+    icebergField = null;
   }
 
-  private VectorHolder(FieldVector vec, Type type, NullabilityHolder nulls) {
+  private VectorHolder(FieldVector vec, Types.NestedField field, NullabilityHolder nulls) {
     columnDescriptor = null;
     vector = vec;
+    nonDictEncodedVector = null;
     isDictionaryEncoded = false;
     dictionary = null;
     nullabilityHolder = nulls;
-    icebergType = type;
+    icebergField = field;
   }
 
   public ColumnDescriptor descriptor() {
@@ -78,6 +83,10 @@ public class VectorHolder {
 
   public FieldVector vector() {
     return vector;
+  }
+
+  public FieldVector nonDictEncodedVector() {
+    return nonDictEncodedVector;
   }
 
   public boolean isDictionaryEncoded() {
@@ -93,7 +102,11 @@ public class VectorHolder {
   }
 
   public Type icebergType() {
-    return icebergType;
+    return icebergField.type();
+  }
+
+  public Types.NestedField icebergField() {
+    return icebergField;
   }
 
   public int numValues() {
@@ -141,8 +154,8 @@ public class VectorHolder {
   }
 
   public static class PositionVectorHolder extends VectorHolder {
-    public PositionVectorHolder(FieldVector vector, Type type, NullabilityHolder nulls) {
-      super(vector, type, nulls);
+    public PositionVectorHolder(FieldVector vector, Types.NestedField icebergField, NullabilityHolder nulls) {
+      super(vector, icebergField, nulls);
     }
   }
 

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/ArrowReaderTest.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/ArrowReaderTest.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.arrow.vectorized;
 
 import java.io.File;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -42,6 +43,7 @@ import java.util.stream.Collectors;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.DateDayVector;
+import org.apache.arrow.vector.DecimalVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.FixedSizeBinaryVector;
 import org.apache.arrow.vector.Float4Vector;
@@ -81,7 +83,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.UUIDUtil;
 import org.assertj.core.api.Assertions;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -123,7 +124,9 @@ public class ArrowReaderTest {
           "time",
           "time_nullable",
           "uuid",
-          "uuid_nullable"
+          "uuid_nullable",
+          "decimal",
+          "decimal_nullable"
       );
 
   @Rule
@@ -147,66 +150,11 @@ public class ArrowReaderTest {
   }
 
   /**
-   * This test writes each partition with constant value rows. The Arrow vectors returned are mostly of type int32
-   * which is unexpected. This is happening because of dictionary encoding at the storage level.
-   * <p>
-   * Following are the expected and actual Arrow schema:
-   * <pre>
-   * Expected Arrow Schema:
-   * timestamp: Timestamp(MICROSECOND, null) not null,
-   * timestamp_nullable: Timestamp(MICROSECOND, null),
-   * boolean: Bool not null,
-   * boolean_nullable: Bool,
-   * int: Int(32, true) not null,
-   * int_nullable: Int(32, true),
-   * long: Int(64, true) not null,
-   * long_nullable: Int(64, true),
-   * float: FloatingPoint(SINGLE) not null,
-   * float_nullable: FloatingPoint(SINGLE),
-   * double: FloatingPoint(DOUBLE) not null,
-   * double_nullable: FloatingPoint(DOUBLE),
-   * timestamp_tz: Timestamp(MICROSECOND, UTC) not null,
-   * timestamp_tz_nullable: Timestamp(MICROSECOND, UTC),
-   * string: Utf8 not null,
-   * string_nullable: Utf8,
-   * bytes: Binary not null,
-   * bytes_nullable: Binary,
-   * date: Date(DAY) not null,
-   * date_nullable: Date(DAY),
-   * int_promotion: Int(32, true) not null
-   *
-   * Actual Arrow Schema:
-   * timestamp: Int(32, true) not null,
-   * timestamp_nullable: Int(32, true),
-   * boolean: Bool not null,
-   * boolean_nullable: Bool,
-   * int: Int(32, true) not null,
-   * int_nullable: Int(32, true),
-   * long: Int(32, true) not null,
-   * long_nullable: Int(32, true),
-   * float: Int(32, true) not null,
-   * float_nullable: Int(32, true),
-   * double: Int(32, true) not null,
-   * double_nullable: Int(32, true),
-   * timestamp_tz: Int(32, true) not null,
-   * timestamp_tz_nullable: Int(32, true),
-   * string: Int(32, true) not null,
-   * string_nullable: Int(32, true),
-   * bytes: Int(32, true) not null,
-   * bytes_nullable: Int(32, true),
-   * date: Date(DAY) not null,
-   * date_nullable: Date(DAY),
-   * int_promotion: Int(32, true) not null
-   * </pre>
-   * <p>
-   * TODO: fix the returned Arrow vectors to have vector types consistent with Iceberg types.
-   * <p>
    * Read all rows and columns from the table without any filter. The test asserts that the Arrow {@link
    * VectorSchemaRoot} contains the expected schema and expected vector types. Then the test asserts that the vectors
    * contains expected values. The test also asserts the total number of rows match the expected value.
    */
   @Test
-  @Ignore
   public void testReadAllWithConstantRecords() throws Exception {
     writeTableWithConstantRecords();
     Table table = tables.load(tableLocation);
@@ -572,6 +520,20 @@ public class ArrowReaderTest {
         (records, i) -> records.get(i).getField("time_nullable"),
         (array, i) -> LocalTime.ofNanoOfDay(array.getLong(i) * 1000)
     );
+
+    checkColumnarArrayValues(
+        expectedNumRows, expectedRows, batch, columnNameToIndex.get("decimal"),
+        columnSet, "decimal",
+        (records, i) -> records.get(i).getField("decimal"),
+        (array, i) -> array.getDecimal(i, 9, 2)
+    );
+
+    checkColumnarArrayValues(
+        expectedNumRows, expectedRows, batch, columnNameToIndex.get("decimal_nullable"),
+        columnSet, "decimal_nullable",
+        (records, i) -> records.get(i).getField("decimal_nullable"),
+        (array, i) -> array.getDecimal(i, 9, 2)
+    );
   }
 
   private static void checkColumnarArrayValues(
@@ -633,7 +595,9 @@ public class ArrowReaderTest {
         Types.NestedField.required(22, "time", Types.TimeType.get()),
         Types.NestedField.optional(23, "time_nullable", Types.TimeType.get()),
         Types.NestedField.required(24, "uuid", Types.UUIDType.get()),
-        Types.NestedField.optional(25, "uuid_nullable", Types.UUIDType.get())
+        Types.NestedField.optional(25, "uuid_nullable", Types.UUIDType.get()),
+        Types.NestedField.required(26, "decimal", Types.DecimalType.of(9, 2)),
+        Types.NestedField.optional(27, "decimal_nullable", Types.DecimalType.of(9, 2))
     );
 
     PartitionSpec spec = PartitionSpec.builderFor(schema)
@@ -719,7 +683,11 @@ public class ArrowReaderTest {
         new Field(
             "uuid", new FieldType(false, new ArrowType.FixedSizeBinary(16), null), null),
         new Field(
-            "uuid_nullable", new FieldType(true, new ArrowType.FixedSizeBinary(16), null), null)
+            "uuid_nullable", new FieldType(true, new ArrowType.FixedSizeBinary(16), null), null),
+        new Field(
+            "decimal", new FieldType(false, new ArrowType.Decimal(9, 2), null), null),
+        new Field(
+            "decimal_nullable", new FieldType(true, new ArrowType.Decimal(9, 2), null), null)
     );
     List<Field> filteredFields = allFields.stream()
         .filter(f -> columnSet.contains(f.getName()))
@@ -758,6 +726,8 @@ public class ArrowReaderTest {
       byte[] uuid = bb.array();
       rec.setField("uuid", uuid);
       rec.setField("uuid_nullable", uuid);
+      rec.setField("decimal", new BigDecimal("14.0" + i % 10));
+      rec.setField("decimal_nullable", new BigDecimal("14.0" + i % 10));
       records.add(rec);
     }
     return records;
@@ -794,6 +764,8 @@ public class ArrowReaderTest {
       byte[] uuid = bb.array();
       rec.setField("uuid", uuid);
       rec.setField("uuid_nullable", uuid);
+      rec.setField("decimal", new BigDecimal("14.20"));
+      rec.setField("decimal_nullable", new BigDecimal("14.20"));
       records.add(rec);
     }
     return records;
@@ -872,6 +844,8 @@ public class ArrowReaderTest {
     assertEqualsForField(root, columnSet, "uuid", FixedSizeBinaryVector.class);
     assertEqualsForField(root, columnSet, "uuid_nullable", FixedSizeBinaryVector.class);
     assertEqualsForField(root, columnSet, "int_promotion", IntVector.class);
+    assertEqualsForField(root, columnSet, "decimal", DecimalVector.class);
+    assertEqualsForField(root, columnSet, "decimal_nullable", DecimalVector.class);
   }
 
   private void assertEqualsForField(
@@ -1015,6 +989,18 @@ public class ArrowReaderTest {
         expectedNumRows, expectedRows, root, columnSet, "time_nullable",
         (records, i) -> records.get(i).getField("time_nullable"),
         (vector, i) -> LocalTime.ofNanoOfDay(((TimeMicroVector) vector).get(i) * 1000)
+    );
+
+    checkVectorValues(
+        expectedNumRows, expectedRows, root, columnSet, "decimal",
+        (records, i) -> records.get(i).getField("decimal"),
+        (vector, i) -> ((DecimalVector) vector).getObject(i)
+    );
+
+    checkVectorValues(
+        expectedNumRows, expectedRows, root, columnSet, "decimal_nullable",
+        (records, i) -> records.get(i).getField("decimal_nullable"),
+        (vector, i) -> ((DecimalVector) vector).getObject(i)
     );
   }
 


### PR DESCRIPTION
This is partly fixing https://github.com/apache/iceberg/issues/2486 and adding `DecimalType` support.
Additional functionality to `DictEncodedArrowConverter` will be added as part of https://github.com/apache/iceberg/issues/2484. 


# VectorizedReadFlatParquetDataBenchmark
## Results on this branch

```
Benchmark                                                                 Mode  Cnt  Score   Error  Units
VectorizedReadFlatParquetDataBenchmark.readDatesIcebergVectorized5k         ss    5  1.609 ± 0.114   s/op
VectorizedReadFlatParquetDataBenchmark.readDatesSparkVectorized5k           ss    5  1.522 ± 0.092   s/op
VectorizedReadFlatParquetDataBenchmark.readDecimalsIcebergVectorized5k      ss    5  8.706 ± 0.063   s/op
VectorizedReadFlatParquetDataBenchmark.readDecimalsSparkVectorized5k        ss    5  7.947 ± 0.079   s/op
VectorizedReadFlatParquetDataBenchmark.readDoublesIcebergVectorized5k       ss    5  2.826 ± 0.044   s/op
VectorizedReadFlatParquetDataBenchmark.readDoublesSparkVectorized5k         ss    5  3.082 ± 0.158   s/op
VectorizedReadFlatParquetDataBenchmark.readFloatsIcebergVectorized5k        ss    5  2.392 ± 0.094   s/op
VectorizedReadFlatParquetDataBenchmark.readFloatsSparkVectorized5k          ss    5  2.231 ± 0.105   s/op
VectorizedReadFlatParquetDataBenchmark.readIntegersIcebergVectorized5k      ss    5  2.700 ± 0.152   s/op
VectorizedReadFlatParquetDataBenchmark.readIntegersSparkVectorized5k        ss    5  2.559 ± 0.135   s/op
VectorizedReadFlatParquetDataBenchmark.readLongsIcebergVectorized5k         ss    5  2.773 ± 0.234   s/op
VectorizedReadFlatParquetDataBenchmark.readLongsSparkVectorized5k           ss    5  2.593 ± 0.066   s/op
VectorizedReadFlatParquetDataBenchmark.readStringsIcebergVectorized5k       ss    5  4.289 ± 0.157   s/op
VectorizedReadFlatParquetDataBenchmark.readStringsSparkVectorized5k         ss    5  4.222 ± 0.176   s/op
VectorizedReadFlatParquetDataBenchmark.readTimestampsIcebergVectorized5k    ss    5  1.593 ± 0.030   s/op
VectorizedReadFlatParquetDataBenchmark.readTimestampsSparkVectorized5k      ss    5  1.554 ± 0.063   s/op
```


## Results on `master`

```
Benchmark                                                                 Mode  Cnt  Score   Error  Units
VectorizedReadFlatParquetDataBenchmark.readDatesIcebergVectorized5k         ss    5  1.587 ± 0.106   s/op
VectorizedReadFlatParquetDataBenchmark.readDatesSparkVectorized5k           ss    5  1.515 ± 0.061   s/op
VectorizedReadFlatParquetDataBenchmark.readDecimalsIcebergVectorized5k      ss    5  9.324 ± 0.511   s/op
VectorizedReadFlatParquetDataBenchmark.readDecimalsSparkVectorized5k        ss    5  7.987 ± 0.164   s/op
VectorizedReadFlatParquetDataBenchmark.readDoublesIcebergVectorized5k       ss    5  2.829 ± 0.239   s/op
VectorizedReadFlatParquetDataBenchmark.readDoublesSparkVectorized5k         ss    5  2.381 ± 0.142   s/op
VectorizedReadFlatParquetDataBenchmark.readFloatsIcebergVectorized5k        ss    5  2.399 ± 0.088   s/op
VectorizedReadFlatParquetDataBenchmark.readFloatsSparkVectorized5k          ss    5  2.584 ± 0.230   s/op
VectorizedReadFlatParquetDataBenchmark.readIntegersIcebergVectorized5k      ss    5  2.664 ± 0.083   s/op
VectorizedReadFlatParquetDataBenchmark.readIntegersSparkVectorized5k        ss    5  2.535 ± 0.090   s/op
VectorizedReadFlatParquetDataBenchmark.readLongsIcebergVectorized5k         ss    5  2.740 ± 0.171   s/op
VectorizedReadFlatParquetDataBenchmark.readLongsSparkVectorized5k           ss    5  2.255 ± 0.128   s/op
VectorizedReadFlatParquetDataBenchmark.readStringsIcebergVectorized5k       ss    5  4.803 ± 0.142   s/op
VectorizedReadFlatParquetDataBenchmark.readStringsSparkVectorized5k         ss    5  4.326 ± 0.286   s/op
VectorizedReadFlatParquetDataBenchmark.readTimestampsIcebergVectorized5k    ss    5  1.946 ± 0.152   s/op
VectorizedReadFlatParquetDataBenchmark.readTimestampsSparkVectorized5k      ss    5  1.551 ± 0.042   s/op
```
[vectorized-read-flat-parquet-data-result-branch.txt](https://github.com/apache/iceberg/files/7189398/vectorized-read-flat-parquet-data-result-branch.txt)
[vectorized-read-flat-parquet-data-result-master.txt](https://github.com/apache/iceberg/files/7189399/vectorized-read-flat-parquet-data-result-master.txt)

