### PR TITLE
Arrow: Convert dict encoded vectors to their expected Arrow vector types

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/DictEncodedArrowConverter.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/DictEncodedArrowConverter.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.arrow;
+
+import java.math.BigDecimal;
+import org.apache.arrow.vector.DecimalVector;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.iceberg.arrow.vectorized.ArrowVectorAccessor;
+import org.apache.iceberg.arrow.vectorized.VectorHolder;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+
+/** This converts dictionary encoded arrow vectors to a correctly typed arrow vector. */
+public class DictEncodedArrowConverter {
+
+  private DictEncodedArrowConverter() {}
+
+  public static FieldVector toArrowVector(
+      VectorHolder vectorHolder, ArrowVectorAccessor<?, String, ?, ?> accessor) {
+    Preconditions.checkArgument(null != vectorHolder, "VectorHolder cannot be null");
+    Preconditions.checkArgument(null != accessor, "ArrowVectorAccessor cannot be null");
+    // TODO: add conversions for other types (https://github.com/apache/iceberg/issues/2484)
+    if (vectorHolder.isDictionaryEncoded()) {
+      if (Type.TypeID.DECIMAL.equals(vectorHolder.icebergType().typeId())) {
+        int precision = ((Types.DecimalType) vectorHolder.icebergType()).precision();
+        int scale = ((Types.DecimalType) vectorHolder.icebergType()).scale();
+
+        DecimalVector decimalVector =
+            new DecimalVector(
+                vectorHolder.vector().getName(),
+                ArrowSchemaUtil.convert(vectorHolder.icebergField()).getFieldType(),
+                vectorHolder.vector().getAllocator());
+
+        for (int i = 0; i < vectorHolder.vector().getValueCount(); i++) {
+          BigDecimal decimal = (BigDecimal) accessor.getDecimal(i, precision, scale);
+          decimalVector.setSafe(i, decimal);
+        }
+        decimalVector.setValueCount(vectorHolder.vector().getValueCount());
+        return decimalVector;
+      }
+    }
+
+    return vectorHolder.vector();
+  }
+}

--- a/arrow/src/main/java/org/apache/iceberg/arrow/DictEncodedArrowConverter.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/DictEncodedArrowConverter.java
@@ -19,8 +19,21 @@
 package org.apache.iceberg.arrow;
 
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.function.IntConsumer;
+import org.apache.arrow.vector.BaseFixedWidthVector;
+import org.apache.arrow.vector.BaseVariableWidthVector;
+import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.DecimalVector;
 import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.Float8Vector;
+import org.apache.arrow.vector.TimeMicroVector;
+import org.apache.arrow.vector.TimeStampMicroTZVector;
+import org.apache.arrow.vector.TimeStampMicroVector;
+import org.apache.arrow.vector.TimeStampVector;
+import org.apache.arrow.vector.VarBinaryVector;
+import org.apache.arrow.vector.VarCharVector;
 import org.apache.iceberg.arrow.vectorized.ArrowVectorAccessor;
 import org.apache.iceberg.arrow.vectorized.VectorHolder;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -32,31 +45,181 @@ public class DictEncodedArrowConverter {
 
   private DictEncodedArrowConverter() {}
 
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
   public static FieldVector toArrowVector(
       VectorHolder vectorHolder, ArrowVectorAccessor<?, String, ?, ?> accessor) {
-    Preconditions.checkArgument(null != vectorHolder, "VectorHolder cannot be null");
-    Preconditions.checkArgument(null != accessor, "ArrowVectorAccessor cannot be null");
-    // TODO: add conversions for other types (https://github.com/apache/iceberg/issues/2484)
+    Preconditions.checkArgument(null != vectorHolder, "Invalid vector holder: null");
+    Preconditions.checkArgument(null != accessor, "Invalid arrow vector accessor: null");
+
     if (vectorHolder.isDictionaryEncoded()) {
       if (Type.TypeID.DECIMAL.equals(vectorHolder.icebergType().typeId())) {
-        int precision = ((Types.DecimalType) vectorHolder.icebergType()).precision();
-        int scale = ((Types.DecimalType) vectorHolder.icebergType()).scale();
-
-        DecimalVector decimalVector =
-            new DecimalVector(
-                vectorHolder.vector().getName(),
-                ArrowSchemaUtil.convert(vectorHolder.icebergField()).getFieldType(),
-                vectorHolder.vector().getAllocator());
-
-        for (int i = 0; i < vectorHolder.vector().getValueCount(); i++) {
-          BigDecimal decimal = (BigDecimal) accessor.getDecimal(i, precision, scale);
-          decimalVector.setSafe(i, decimal);
-        }
-        decimalVector.setValueCount(vectorHolder.vector().getValueCount());
-        return decimalVector;
+        return toDecimalVector(vectorHolder, accessor);
+      } else if (Type.TypeID.TIMESTAMP.equals(vectorHolder.icebergType().typeId())) {
+        return toTimestampVector(vectorHolder, accessor);
+      } else if (Type.TypeID.LONG.equals(vectorHolder.icebergType().typeId())) {
+        return toBigIntVector(vectorHolder, accessor);
+      } else if (Type.TypeID.FLOAT.equals(vectorHolder.icebergType().typeId())) {
+        return toFloat4Vector(vectorHolder, accessor);
+      } else if (Type.TypeID.DOUBLE.equals(vectorHolder.icebergType().typeId())) {
+        return toFloat8Vector(vectorHolder, accessor);
+      } else if (Type.TypeID.STRING.equals(vectorHolder.icebergType().typeId())) {
+        return toVarCharVector(vectorHolder, accessor);
+      } else if (Type.TypeID.BINARY.equals(vectorHolder.icebergType().typeId())) {
+        return toVarBinaryVector(vectorHolder, accessor);
+      } else if (Type.TypeID.TIME.equals(vectorHolder.icebergType().typeId())) {
+        return toTimeMicroVector(vectorHolder, accessor);
       }
+
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot convert dict encoded field '%s' of type '%s' to Arrow "
+                  + "vector as it is currently not supported",
+              vectorHolder.icebergField().name(), vectorHolder.icebergType().typeId()));
     }
 
     return vectorHolder.vector();
+  }
+
+  private static DecimalVector toDecimalVector(
+      VectorHolder vectorHolder, ArrowVectorAccessor<?, String, ?, ?> accessor) {
+    int precision = ((Types.DecimalType) vectorHolder.icebergType()).precision();
+    int scale = ((Types.DecimalType) vectorHolder.icebergType()).scale();
+
+    DecimalVector vector =
+        new DecimalVector(
+            vectorHolder.vector().getName(),
+            ArrowSchemaUtil.convert(vectorHolder.icebergField()).getFieldType(),
+            vectorHolder.vector().getAllocator());
+
+    initVector(
+        vector,
+        vectorHolder,
+        idx -> vector.set(idx, (BigDecimal) accessor.getDecimal(idx, precision, scale)));
+    return vector;
+  }
+
+  private static TimeStampVector toTimestampVector(
+      VectorHolder vectorHolder, ArrowVectorAccessor<?, String, ?, ?> accessor) {
+    TimeStampVector vector;
+    if (((Types.TimestampType) vectorHolder.icebergType()).shouldAdjustToUTC()) {
+      vector =
+          new TimeStampMicroTZVector(
+              vectorHolder.vector().getName(),
+              ArrowSchemaUtil.convert(vectorHolder.icebergField()).getFieldType(),
+              vectorHolder.vector().getAllocator());
+    } else {
+      vector =
+          new TimeStampMicroVector(
+              vectorHolder.vector().getName(),
+              ArrowSchemaUtil.convert(vectorHolder.icebergField()).getFieldType(),
+              vectorHolder.vector().getAllocator());
+    }
+
+    initVector(vector, vectorHolder, idx -> vector.set(idx, accessor.getLong(idx)));
+    return vector;
+  }
+
+  private static BigIntVector toBigIntVector(
+      VectorHolder vectorHolder, ArrowVectorAccessor<?, String, ?, ?> accessor) {
+    BigIntVector vector =
+        new BigIntVector(
+            vectorHolder.vector().getName(),
+            ArrowSchemaUtil.convert(vectorHolder.icebergField()).getFieldType(),
+            vectorHolder.vector().getAllocator());
+
+    initVector(vector, vectorHolder, idx -> vector.set(idx, accessor.getLong(idx)));
+    return vector;
+  }
+
+  private static Float4Vector toFloat4Vector(
+      VectorHolder vectorHolder, ArrowVectorAccessor<?, String, ?, ?> accessor) {
+    Float4Vector vector =
+        new Float4Vector(
+            vectorHolder.vector().getName(),
+            ArrowSchemaUtil.convert(vectorHolder.icebergField()).getFieldType(),
+            vectorHolder.vector().getAllocator());
+
+    initVector(vector, vectorHolder, idx -> vector.set(idx, accessor.getFloat(idx)));
+    return vector;
+  }
+
+  private static Float8Vector toFloat8Vector(
+      VectorHolder vectorHolder, ArrowVectorAccessor<?, String, ?, ?> accessor) {
+    Float8Vector vector =
+        new Float8Vector(
+            vectorHolder.vector().getName(),
+            ArrowSchemaUtil.convert(vectorHolder.icebergField()).getFieldType(),
+            vectorHolder.vector().getAllocator());
+
+    initVector(vector, vectorHolder, idx -> vector.set(idx, accessor.getDouble(idx)));
+    return vector;
+  }
+
+  private static VarCharVector toVarCharVector(
+      VectorHolder vectorHolder, ArrowVectorAccessor<?, String, ?, ?> accessor) {
+    VarCharVector vector =
+        new VarCharVector(
+            vectorHolder.vector().getName(),
+            ArrowSchemaUtil.convert(vectorHolder.icebergField()).getFieldType(),
+            vectorHolder.vector().getAllocator());
+
+    initVector(
+        vector,
+        vectorHolder,
+        idx -> vector.setSafe(idx, accessor.getUTF8String(idx).getBytes(StandardCharsets.UTF_8)));
+    return vector;
+  }
+
+  private static VarBinaryVector toVarBinaryVector(
+      VectorHolder vectorHolder, ArrowVectorAccessor<?, String, ?, ?> accessor) {
+    VarBinaryVector vector =
+        new VarBinaryVector(
+            vectorHolder.vector().getName(),
+            ArrowSchemaUtil.convert(vectorHolder.icebergField()).getFieldType(),
+            vectorHolder.vector().getAllocator());
+
+    initVector(vector, vectorHolder, idx -> vector.setSafe(idx, accessor.getBinary(idx)));
+    return vector;
+  }
+
+  private static TimeMicroVector toTimeMicroVector(
+      VectorHolder vectorHolder, ArrowVectorAccessor<?, String, ?, ?> accessor) {
+    TimeMicroVector vector =
+        new TimeMicroVector(
+            vectorHolder.vector().getName(),
+            ArrowSchemaUtil.convert(vectorHolder.icebergField()).getFieldType(),
+            vectorHolder.vector().getAllocator());
+
+    initVector(vector, vectorHolder, idx -> vector.set(idx, accessor.getLong(idx)));
+    return vector;
+  }
+
+  private static void initVector(
+      BaseFixedWidthVector vector, VectorHolder vectorHolder, IntConsumer consumer) {
+    vector.allocateNew(vectorHolder.vector().getValueCount());
+    init(vector, vectorHolder, consumer, vectorHolder.vector().getValueCount());
+  }
+
+  private static void initVector(
+      BaseVariableWidthVector vector, VectorHolder vectorHolder, IntConsumer consumer) {
+    vector.allocateNew(vectorHolder.vector().getValueCount());
+    init(vector, vectorHolder, consumer, vectorHolder.vector().getValueCount());
+  }
+
+  private static void init(
+      FieldVector vector, VectorHolder vectorHolder, IntConsumer consumer, int valueCount) {
+    for (int i = 0; i < valueCount; i++) {
+      if (isNullAt(vectorHolder, i)) {
+        vector.setNull(i);
+      } else {
+        consumer.accept(i);
+      }
+    }
+
+    vector.setValueCount(valueCount);
+  }
+
+  private static boolean isNullAt(VectorHolder vectorHolder, int idx) {
+    return vectorHolder.nullabilityHolder().isNullAt(idx) == 1;
   }
 }

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowReader.java
@@ -113,7 +113,8 @@ public class ArrowReader extends CloseableGroup {
           TypeID.BINARY,
           TypeID.DATE,
           TypeID.UUID,
-          TypeID.TIME);
+          TypeID.TIME,
+          TypeID.DECIMAL);
 
   private final Schema schema;
   private final FileIO io;

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ColumnVector.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ColumnVector.java
@@ -18,7 +18,9 @@
  */
 package org.apache.iceberg.arrow.vectorized;
 
+import java.math.BigDecimal;
 import org.apache.arrow.vector.FieldVector;
+import org.apache.iceberg.arrow.DictEncodedArrowConverter;
 import org.apache.iceberg.types.Types;
 
 /**
@@ -40,6 +42,7 @@ import org.apache.iceberg.types.Types;
  *   <li>{@link Types.DateType}
  *   <li>{@link Types.TimeType}
  *   <li>{@link Types.UUIDType}
+ *   <li>{@link Types.DecimalType}
  * </ul>
  */
 public class ColumnVector implements AutoCloseable {
@@ -54,9 +57,7 @@ public class ColumnVector implements AutoCloseable {
   }
 
   public FieldVector getFieldVector() {
-    // TODO Convert dictionary encoded vectors to correctly typed arrow vector.
-    //   e.g. convert long dictionary encoded vector to a BigIntVector.
-    return vectorHolder.vector();
+    return DictEncodedArrowConverter.toArrowVector(vectorHolder, accessor);
   }
 
   public boolean hasNull() {
@@ -108,6 +109,13 @@ public class ColumnVector implements AutoCloseable {
       return null;
     }
     return accessor.getBinary(rowId);
+  }
+
+  public BigDecimal getDecimal(int rowId, int precision, int scale) {
+    if (isNullAt(rowId)) {
+      return null;
+    }
+    return (BigDecimal) accessor.getDecimal(rowId, precision, scale);
   }
 
   private static ArrowVectorAccessor<?, String, ?, ?> getVectorAccessor(VectorHolder holder) {

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ColumnVector.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ColumnVector.java
@@ -56,7 +56,13 @@ public class ColumnVector implements AutoCloseable {
     this.accessor = getVectorAccessor(vectorHolder);
   }
 
+  /** @return the potentially dict-encoded {@link FieldVector}. */
   public FieldVector getFieldVector() {
+    return vectorHolder.vector();
+  }
+
+  /** @return decodes a dict-encoded vector and returns the actual arrow vector. */
+  public FieldVector getArrowVector() {
     return DictEncodedArrowConverter.toArrowVector(vectorHolder, accessor);
   }
 

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ColumnarBatch.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ColumnarBatch.java
@@ -55,7 +55,7 @@ public class ColumnarBatch implements AutoCloseable {
    */
   public VectorSchemaRoot createVectorSchemaRootFromVectors() {
     return VectorSchemaRoot.of(
-        Arrays.stream(columns).map(ColumnVector::getFieldVector).toArray(FieldVector[]::new));
+        Arrays.stream(columns).map(ColumnVector::getArrowVector).toArray(FieldVector[]::new));
   }
 
   /**

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorHolder.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorHolder.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.arrow.vectorized;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Dictionary;
 
@@ -34,7 +35,7 @@ public class VectorHolder {
   private final boolean isDictionaryEncoded;
   private final Dictionary dictionary;
   private final NullabilityHolder nullabilityHolder;
-  private final Type icebergType;
+  private final Types.NestedField icebergField;
 
   public VectorHolder(
       ColumnDescriptor columnDescriptor,
@@ -42,18 +43,18 @@ public class VectorHolder {
       boolean isDictionaryEncoded,
       Dictionary dictionary,
       NullabilityHolder holder,
-      Type type) {
+      Types.NestedField icebergField) {
     // All the fields except dictionary are not nullable unless it is a dummy holder
     Preconditions.checkNotNull(columnDescriptor, "ColumnDescriptor cannot be null");
     Preconditions.checkNotNull(vector, "Vector cannot be null");
     Preconditions.checkNotNull(holder, "NullabilityHolder cannot be null");
-    Preconditions.checkNotNull(type, "IcebergType cannot be null");
+    Preconditions.checkNotNull(icebergField, "IcebergField cannot be null");
     this.columnDescriptor = columnDescriptor;
     this.vector = vector;
     this.isDictionaryEncoded = isDictionaryEncoded;
     this.dictionary = dictionary;
     this.nullabilityHolder = holder;
-    this.icebergType = type;
+    this.icebergField = icebergField;
   }
 
   // Only used for returning dummy holder
@@ -63,16 +64,16 @@ public class VectorHolder {
     isDictionaryEncoded = false;
     dictionary = null;
     nullabilityHolder = null;
-    icebergType = null;
+    icebergField = null;
   }
 
-  private VectorHolder(FieldVector vec, Type type, NullabilityHolder nulls) {
+  private VectorHolder(FieldVector vec, Types.NestedField field, NullabilityHolder nulls) {
     columnDescriptor = null;
     vector = vec;
     isDictionaryEncoded = false;
     dictionary = null;
     nullabilityHolder = nulls;
-    icebergType = type;
+    icebergField = field;
   }
 
   public ColumnDescriptor descriptor() {
@@ -96,7 +97,11 @@ public class VectorHolder {
   }
 
   public Type icebergType() {
-    return icebergType;
+    return icebergField.type();
+  }
+
+  public Types.NestedField icebergField() {
+    return icebergField;
   }
 
   public int numValues() {
@@ -148,8 +153,9 @@ public class VectorHolder {
   }
 
   public static class PositionVectorHolder extends VectorHolder {
-    public PositionVectorHolder(FieldVector vector, Type type, NullabilityHolder nulls) {
-      super(vector, type, nulls);
+    public PositionVectorHolder(
+        FieldVector vector, Types.NestedField icebergField, NullabilityHolder nulls) {
+      super(vector, icebergField, nulls);
     }
   }
 

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -197,7 +197,7 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
         vec.getValueCount(),
         numValsToRead);
     return new VectorHolder(
-        columnDescriptor, vec, dictEncoded, dictionary, nullabilityHolder, icebergField.type());
+        columnDescriptor, vec, dictEncoded, dictionary, nullabilityHolder, icebergField);
   }
 
   private void allocateFieldVector(boolean dictionaryEncodedVector) {
@@ -513,7 +513,7 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
       rowStart += numValsToRead;
       vec.setValueCount(numValsToRead);
 
-      return new VectorHolder.PositionVectorHolder(vec, MetadataColumns.ROW_POSITION.type(), nulls);
+      return new VectorHolder.PositionVectorHolder(vec, MetadataColumns.ROW_POSITION, nulls);
     }
 
     private static BigIntVector newVector(int valueCount) {

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/ArrowReaderTest.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/ArrowReaderTest.java
@@ -86,7 +86,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.UUIDUtil;
 import org.assertj.core.api.Assertions;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -153,67 +152,11 @@ public class ArrowReaderTest {
   /**
    * This test writes each partition with constant value rows. The Arrow vectors returned are mostly
    * of type int32 which is unexpected. This is happening because of dictionary encoding at the
-   * storage level.
-   *
-   * <p>Following are the expected and actual Arrow schema:
-   *
-   * <pre>
-   * Expected Arrow Schema:
-   * timestamp: Timestamp(MICROSECOND, null) not null,
-   * timestamp_nullable: Timestamp(MICROSECOND, null),
-   * boolean: Bool not null,
-   * boolean_nullable: Bool,
-   * int: Int(32, true) not null,
-   * int_nullable: Int(32, true),
-   * long: Int(64, true) not null,
-   * long_nullable: Int(64, true),
-   * float: FloatingPoint(SINGLE) not null,
-   * float_nullable: FloatingPoint(SINGLE),
-   * double: FloatingPoint(DOUBLE) not null,
-   * double_nullable: FloatingPoint(DOUBLE),
-   * timestamp_tz: Timestamp(MICROSECOND, UTC) not null,
-   * timestamp_tz_nullable: Timestamp(MICROSECOND, UTC),
-   * string: Utf8 not null,
-   * string_nullable: Utf8,
-   * bytes: Binary not null,
-   * bytes_nullable: Binary,
-   * date: Date(DAY) not null,
-   * date_nullable: Date(DAY),
-   * int_promotion: Int(32, true) not null
-   *
-   * Actual Arrow Schema:
-   * timestamp: Int(32, true) not null,
-   * timestamp_nullable: Int(32, true),
-   * boolean: Bool not null,
-   * boolean_nullable: Bool,
-   * int: Int(32, true) not null,
-   * int_nullable: Int(32, true),
-   * long: Int(32, true) not null,
-   * long_nullable: Int(32, true),
-   * float: Int(32, true) not null,
-   * float_nullable: Int(32, true),
-   * double: Int(32, true) not null,
-   * double_nullable: Int(32, true),
-   * timestamp_tz: Int(32, true) not null,
-   * timestamp_tz_nullable: Int(32, true),
-   * string: Int(32, true) not null,
-   * string_nullable: Int(32, true),
-   * bytes: Int(32, true) not null,
-   * bytes_nullable: Int(32, true),
-   * date: Date(DAY) not null,
-   * date_nullable: Date(DAY),
-   * int_promotion: Int(32, true) not null
-   * </pre>
-   *
-   * <p>TODO: fix the returned Arrow vectors to have vector types consistent with Iceberg types.
-   *
-   * <p>Read all rows and columns from the table without any filter. The test asserts that the Arrow
-   * {@link VectorSchemaRoot} contains the expected schema and expected vector types. Then the test
-   * asserts that the vectors contains expected values. The test also asserts the total number of
-   * rows match the expected value.
+   * storage level. The test asserts that the Arrow {@link VectorSchemaRoot} contains the expected
+   * schema and expected vector types. Then the test asserts that the vectors contains expected
+   * values. The test also asserts the total number of rows match the expected value.
    */
   @Test
-  @Ignore
   public void testReadAllWithConstantRecords() throws Exception {
     writeTableWithConstantRecords();
     Table table = tables.load(tableLocation);


### PR DESCRIPTION
# Problem and Goal
For testing we would like to check the Arrow Schema, but since dict-encoded Vectors all end up being of type `IntVector`, we essentially can't perform this check. That's why https://github.com/apache/iceberg/blob/master/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/ArrowReaderTest.java#L207-L213 is currently ignored on `master`.

The goal of this PR is to convert dict-encoded vector to their correct vector types, so that a Schema check is possible. Note that this PR only affects code relevant for testing and not for production.

Note that this currently contains the commit from https://github.com/apache/iceberg/pull/3023, but will be rebased once #3023 is merged.

fixes #2484 

# Benchmark results
## VectorizedReadFlatParquetDataBenchmark
### Results on this branch

```
Benchmark                                                                 Mode  Cnt  Score   Error  Units
VectorizedReadFlatParquetDataBenchmark.readDatesIcebergVectorized5k         ss    5  1.879 ± 0.041   s/op
VectorizedReadFlatParquetDataBenchmark.readDatesSparkVectorized5k           ss    5  2.121 ± 0.035   s/op
VectorizedReadFlatParquetDataBenchmark.readDecimalsIcebergVectorized5k      ss    5  8.685 ± 0.432   s/op
VectorizedReadFlatParquetDataBenchmark.readDecimalsSparkVectorized5k        ss    5  8.208 ± 0.264   s/op
VectorizedReadFlatParquetDataBenchmark.readDoublesIcebergVectorized5k       ss    5  3.152 ± 0.183   s/op
VectorizedReadFlatParquetDataBenchmark.readDoublesSparkVectorized5k         ss    5  2.739 ± 0.291   s/op
VectorizedReadFlatParquetDataBenchmark.readFloatsIcebergVectorized5k        ss    5  2.723 ± 0.145   s/op
VectorizedReadFlatParquetDataBenchmark.readFloatsSparkVectorized5k          ss    5  2.588 ± 0.094   s/op
VectorizedReadFlatParquetDataBenchmark.readIntegersIcebergVectorized5k      ss    5  2.362 ± 0.135   s/op
VectorizedReadFlatParquetDataBenchmark.readIntegersSparkVectorized5k        ss    5  2.602 ± 0.030   s/op
VectorizedReadFlatParquetDataBenchmark.readLongsIcebergVectorized5k         ss    5  2.783 ± 0.149   s/op
VectorizedReadFlatParquetDataBenchmark.readLongsSparkVectorized5k           ss    5  2.924 ± 0.134   s/op
VectorizedReadFlatParquetDataBenchmark.readStringsIcebergVectorized5k       ss    5  4.175 ± 0.120   s/op
VectorizedReadFlatParquetDataBenchmark.readStringsSparkVectorized5k         ss    5  4.569 ± 0.118   s/op
VectorizedReadFlatParquetDataBenchmark.readTimestampsIcebergVectorized5k    ss    5  1.654 ± 0.031   s/op
VectorizedReadFlatParquetDataBenchmark.readTimestampsSparkVectorized5k      ss    5  1.540 ± 0.054   s/op
```


### Results on `master` (copied from https://github.com/apache/iceberg/pull/3023)

```
Benchmark                                                                 Mode  Cnt  Score   Error  Units
VectorizedReadFlatParquetDataBenchmark.readDatesIcebergVectorized5k         ss    5  1.587 ± 0.106   s/op
VectorizedReadFlatParquetDataBenchmark.readDatesSparkVectorized5k           ss    5  1.515 ± 0.061   s/op
VectorizedReadFlatParquetDataBenchmark.readDecimalsIcebergVectorized5k      ss    5  9.324 ± 0.511   s/op
VectorizedReadFlatParquetDataBenchmark.readDecimalsSparkVectorized5k        ss    5  7.987 ± 0.164   s/op
VectorizedReadFlatParquetDataBenchmark.readDoublesIcebergVectorized5k       ss    5  2.829 ± 0.239   s/op
VectorizedReadFlatParquetDataBenchmark.readDoublesSparkVectorized5k         ss    5  2.381 ± 0.142   s/op
VectorizedReadFlatParquetDataBenchmark.readFloatsIcebergVectorized5k        ss    5  2.399 ± 0.088   s/op
VectorizedReadFlatParquetDataBenchmark.readFloatsSparkVectorized5k          ss    5  2.584 ± 0.230   s/op
VectorizedReadFlatParquetDataBenchmark.readIntegersIcebergVectorized5k      ss    5  2.664 ± 0.083   s/op
VectorizedReadFlatParquetDataBenchmark.readIntegersSparkVectorized5k        ss    5  2.535 ± 0.090   s/op
VectorizedReadFlatParquetDataBenchmark.readLongsIcebergVectorized5k         ss    5  2.740 ± 0.171   s/op
VectorizedReadFlatParquetDataBenchmark.readLongsSparkVectorized5k           ss    5  2.255 ± 0.128   s/op
VectorizedReadFlatParquetDataBenchmark.readStringsIcebergVectorized5k       ss    5  4.803 ± 0.142   s/op
VectorizedReadFlatParquetDataBenchmark.readStringsSparkVectorized5k         ss    5  4.326 ± 0.286   s/op
VectorizedReadFlatParquetDataBenchmark.readTimestampsIcebergVectorized5k    ss    5  1.946 ± 0.152   s/op
VectorizedReadFlatParquetDataBenchmark.readTimestampsSparkVectorized5k      ss    5  1.551 ± 0.042   s/op
```

[vectorized-read-flat-parquet-data-result-3024.txt](https://github.com/apache/iceberg/files/7189570/vectorized-read-flat-parquet-data-result-3024.txt)
[vectorized-read-flat-parquet-data-result-master.txt](https://github.com/apache/iceberg/files/7189571/vectorized-read-flat-parquet-data-result-master.txt)