### PR TITLE
Build: Add test-retry-gradle-plugin to retry flaky tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ buildscript {
     classpath 'com.diffplug.spotless:spotless-plugin-gradle:5.14.0'
     classpath 'gradle.plugin.org.inferred:gradle-processors:2.1.0'
     classpath 'me.champeau.gradle:jmh-gradle-plugin:0.4.8'
+    classpath "org.gradle:test-retry-gradle-plugin:1.3.1"
   }
 }
 
@@ -72,6 +73,7 @@ allprojects {
 subprojects {
   apply plugin: 'nebula.dependency-recommender'
   apply plugin: 'java'
+  apply plugin: 'org.gradle.test-retry'
 
   configurations {
     testCompile.extendsFrom compileOnly
@@ -154,6 +156,15 @@ subprojects {
     testLogging {
       events "failed"
       exceptionFormat "full"
+    }
+
+    retry {
+      // Whether tests that initially fail and then pass on retry should fail the task.
+      failOnPassedAfterRetry = false
+      // The maximum number of test failures that are allowed before retrying is disabled
+      maxFailures = 3
+      // The maximum number of times to retry an individual test
+      maxRetries = 3
     }
   }
 }


### PR DESCRIPTION
I was curious whether this would bring any value to the project as it seems we occasionally run into flaky tests. The latest flaky failure that happened in one of my PRs is reported in https://github.com/apache/iceberg/issues/3033 (which passes locally).

The [test-retry-gradle-plugin](https://github.com/gradle/test-retry-gradle-plugin) causes failed tests to be retried within the same task. After executing all tests, any failed tests are retried. The process repeats with tests that continue to fail until the maximum specified number of retries has been attempted, or there are no more failing tests.

By default, all failed tests passing on retry prevents the test task from failing. This mode prevents flaky tests from causing build failure. This setting can be changed so that flaky tests cause build failure, which can be used to identify flaky tests.

When something goes badly wrong and all tests start failing, it can be preferable to not keep retrying tests. The plugin can be configured to stop retrying after a certain number of total test failures.

In case we don't want to retry everything in general, there's also the option to only retry a given set of tests, which can be specified via `includeClasses` / `includeAnnotationClasses`.