### PR TITLE
#2468 fix the catalog interface cast exception.

### DIFF
--- a/common/src/main/java/org/apache/iceberg/common/DynConstructors.java
+++ b/common/src/main/java/org/apache/iceberg/common/DynConstructors.java
@@ -126,6 +126,7 @@ public class DynConstructors {
 
     public Builder(Class<?> baseClass) {
       this.baseClass = baseClass;
+      this.loader = this.baseClass.getClassLoader();
     }
 
     public Builder() {


### PR DESCRIPTION
#2468 

fix the catalog interface cast exception.
in DynConstructors.java, the dynamic class is loaded by current thread, and the base class/interface is not loaded by current thread. it will have the cast Exception.