### PR TITLE
AWS: update DynamoDbCatalog.dropNamespace attr check

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalogTest.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalogTest.java
@@ -283,6 +283,18 @@ public class DynamoDbCatalogTest {
     Assert.assertEquals(2, table.schema().columns().size());
   }
 
+  @Test
+  public void testDropNamespace() {
+    Namespace namespace = Namespace.of(genRandomName());
+    catalog.createNamespace(namespace);
+    catalog.dropNamespace(namespace);
+    GetItemResponse response = dynamo.getItem(GetItemRequest.builder()
+            .tableName(catalogTableName)
+            .key(DynamoDbCatalog.namespacePrimaryKey(namespace))
+            .build());
+    Assert.assertFalse("namespace must not exist", response.hasItem());
+  }
+
   private static String genRandomName() {
     return UUID.randomUUID().toString().replace("-", "");
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
@@ -248,7 +248,7 @@ public class DynamoDbCatalog extends BaseMetastoreCatalog implements Closeable, 
       dynamo.deleteItem(DeleteItemRequest.builder()
           .tableName(awsProperties.dynamoDbTableName())
           .key(namespacePrimaryKey(namespace))
-          .conditionExpression("attribute_exists(" + DynamoDbCatalog.COL_NAMESPACE + ")")
+          .conditionExpression("attribute_exists(" + COL_NAMESPACE + ")")
           .build());
       return true;
     } catch (ConditionalCheckFailedException e) {

--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
@@ -248,7 +248,7 @@ public class DynamoDbCatalog extends BaseMetastoreCatalog implements Closeable, 
       dynamo.deleteItem(DeleteItemRequest.builder()
           .tableName(awsProperties.dynamoDbTableName())
           .key(namespacePrimaryKey(namespace))
-          .conditionExpression("attribute_exists(" + namespace + ")")
+          .conditionExpression("attribute_exists(" + DynamoDbCatalog.COL_NAMESPACE + ")")
           .build());
       return true;
     } catch (ConditionalCheckFailedException e) {


### PR DESCRIPTION
This PR is intended to resolve an issue with `DynamoDbCatalog.dropNamespace()` --  the dynamoDB delete fails as the conditionExpression evaluates to e.g. `attribute_exists(my_db)`, rather than `attribute_exists(namespace)`.  

Example namespace record in dynamo:
```json
{
 "identifier": "NAMESPACE",
 "namespace": "my_db",
 "updated_at": 1628190933466,
 "created_at": 1628190933466,
 "v": "0203ec48-317b-4197-9712-4a7c91b5c91a",
 "p.owner": "bijan"
}
```

@jackye1995 - can you confirm this change makes sense  / is what was intended?
@danielcweeks 

