### PR TITLE
AWS: add HadoopConfigurableGlueCatalog

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -25,8 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.hadoop.conf.Configurable;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseMetastoreCatalog;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.CatalogProperties;
@@ -69,12 +67,11 @@ import software.amazon.awssdk.services.glue.model.Table;
 import software.amazon.awssdk.services.glue.model.TableInput;
 import software.amazon.awssdk.services.glue.model.UpdateDatabaseRequest;
 
-public class GlueCatalog extends BaseMetastoreCatalog implements Closeable, SupportsNamespaces, Configurable {
+public class GlueCatalog extends BaseMetastoreCatalog implements Closeable, SupportsNamespaces {
 
   private static final Logger LOG = LoggerFactory.getLogger(GlueCatalog.class);
 
   private GlueClient glue;
-  private Configuration hadoopConf;
   private String catalogName;
   private String warehousePath;
   private AwsProperties awsProperties;
@@ -100,14 +97,14 @@ public class GlueCatalog extends BaseMetastoreCatalog implements Closeable, Supp
         initializeFileIO(properties));
   }
 
-  private FileIO initializeFileIO(Map<String, String> properties) {
+  FileIO initializeFileIO(Map<String, String> properties) {
     String fileIOImpl = properties.get(CatalogProperties.FILE_IO_IMPL);
     if (fileIOImpl == null) {
       FileIO io = new S3FileIO();
       io.initialize(properties);
       return io;
     } else {
-      return CatalogUtil.loadFileIO(fileIOImpl, properties, hadoopConf);
+      return CatalogUtil.loadFileIO(fileIOImpl, properties, null);
     }
   }
 
@@ -416,15 +413,5 @@ public class GlueCatalog extends BaseMetastoreCatalog implements Closeable, Supp
   @Override
   public void close() throws IOException {
     glue.close();
-  }
-
-  @Override
-  public void setConf(Configuration conf) {
-    this.hadoopConf = conf;
-  }
-
-  @Override
-  public Configuration getConf() {
-    return hadoopConf;
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/HadoopConfigurableGlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/HadoopConfigurableGlueCatalog.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.aws.glue;
+
+import java.util.Map;
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.aws.s3.S3FileIO;
+import org.apache.iceberg.io.FileIO;
+
+/**
+ * Glue catalog that also accepts Hadoop configuration,
+ * for users that would like to use GlueCatalog with HadoopFileIO or
+ * other dynamic FileIO implementation that leverages Hadoop configuration.
+ */
+public class HadoopConfigurableGlueCatalog extends GlueCatalog implements Configurable {
+
+  private Configuration hadoopConf;
+
+  public HadoopConfigurableGlueCatalog() {
+  }
+
+  @Override
+  FileIO initializeFileIO(Map<String, String> properties) {
+    String fileIOImpl = properties.get(CatalogProperties.FILE_IO_IMPL);
+    if (fileIOImpl == null) {
+      FileIO io = new S3FileIO();
+      io.initialize(properties);
+      return io;
+    } else {
+      return CatalogUtil.loadFileIO(fileIOImpl, properties, hadoopConf);
+    }
+  }
+
+  @Override
+  public void setConf(Configuration conf) {
+    this.hadoopConf = conf;
+  }
+
+  @Override
+  public Configuration getConf() {
+    return hadoopConf;
+  }
+}


### PR DESCRIPTION
fixes #3044 

Try to have a different class for Hadoop-based FileIO use cases, so that user of the normal `GlueCatalog` do not need any Hadoop dependency bundled.

@kbendick @yyanyy 