### PR TITLE
Core : Fixing allowed null values for iceberg table properties

### DIFF
--- a/core/src/main/java/org/apache/iceberg/PropertiesUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/PropertiesUpdate.java
@@ -50,7 +50,7 @@ class PropertiesUpdate implements UpdateProperties {
   @Override
   public UpdateProperties set(String key, String value) {
     Preconditions.checkNotNull(key, "Key cannot be null");
-    Preconditions.checkNotNull(key, "Value cannot be null");
+    Preconditions.checkNotNull(value, "Value cannot be null");
     Preconditions.checkArgument(!removals.contains(key),
         "Cannot remove and update the same key: %s", key);
 


### PR DESCRIPTION
The current iceberg table properties by design do not support any other value than non-null string values. However, due to a typo in the code, it allows a null value for a table property. Due to this we can store the value as null but breaks the read/load of iceberg table back due to non-null property values checks as part of metadata parsers.
This PR just updates the typo to ensure we cannot populate non-null values.

@rdblue @jackye1995 @aokolnychyi @RussellSpitzer 