### PR TITLE
Build: Exclude zstd-jni from iceberg-spark3-runtime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1157,6 +1157,7 @@ project(':iceberg-spark3-runtime') {
       exclude group: 'org.xerial.snappy'
       exclude group: 'javax.xml.bind'
       exclude group: 'javax.annotation'
+      exclude group: 'com.github.luben'
     }
     spark31Implementation.extendsFrom integrationImplementation
     spark31CompileOnly.extendsFrom integrationCompileOnly


### PR DESCRIPTION
`spark-core` already has the dependency `zstd-jni`, it should be exclude from `iceberg-spark3-runtime`.