### PR TITLE
fix: JdbcCatalog jdbc.user is overwrite by user property

### DIFF
--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcClientPool.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcClientPool.java
@@ -47,8 +47,7 @@ class JdbcClientPool extends ClientPoolImpl<Connection, SQLException> {
   @Override
   protected Connection newClient() {
     try {
-      Properties dbProps = new Properties();
-      properties.forEach((key, value) -> dbProps.put(key.replace(JdbcCatalog.PROPERTY_PREFIX, ""), value));
+      Properties dbProps = JdbcUtil.filterAndRemovePrefix(properties, JdbcCatalog.PROPERTY_PREFIX);
       return DriverManager.getConnection(dbUrl, dbProps);
     } catch (SQLException e) {
       throw new UncheckedSQLException(e, "Failed to connect: %s", dbUrl);

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcUtil.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcUtil.java
@@ -19,6 +19,8 @@
 
 package org.apache.iceberg.jdbc;
 
+import java.util.Map;
+import java.util.Properties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
@@ -86,4 +88,15 @@ final class JdbcUtil {
     return TableIdentifier.of(JdbcUtil.stringToNamespace(tableNamespace), tableName);
   }
 
+  public static Properties filterAndRemovePrefix(Map<String, String> properties,
+                                                 String prefix) {
+    Properties result = new Properties();
+    properties.forEach((key, value) -> {
+      if (key.startsWith(prefix)) {
+        result.put(key.substring(prefix.length()), value);
+      }
+    });
+
+    return result;
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcUtil.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcUtil.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.jdbc;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class TestJdbcUtil {
+
+  @Test
+  public void testFilterAndRemovePrefix() {
+    Map<String, String> input = new HashMap<>();
+    input.put("warehouse", "/tmp/warehouse");
+    input.put("user", "foo");
+    input.put("jdbc.user", "bar");
+    input.put("jdbc.pass", "secret");
+    input.put("jdbc.jdbc.abcxyz", "abcxyz");
+
+    Properties expected = new Properties();
+    expected.put("user", "bar");
+    expected.put("pass", "secret");
+    expected.put("jdbc.abcxyz", "abcxyz");
+
+    Properties actual = JdbcUtil.filterAndRemovePrefix(input, "jdbc.");
+
+    Assertions.assertThat(expected).isEqualTo(actual);
+  }
+}


### PR DESCRIPTION
I just try JDBC Catalog in my local machine following [this guide](https://iceberg.apache.org/jdbc/), but I got the following exception:
```bash
$ spark-sql --packages org.apache.iceberg:iceberg-spark3-runtime:0.12.0,org.postgresql:postgresql:42.2.23 \
    --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
    --conf spark.sql.catalog.iceberg=org.apache.iceberg.spark.SparkCatalog \
    --conf spark.sql.catalog.iceberg.warehouse=/tmp/warehouse \
    --conf spark.sql.catalog.iceberg.catalog-impl=org.apache.iceberg.jdbc.JdbcCatalog \
    --conf spark.sql.catalog.iceberg.uri=jdbc:postgresql://postgres:5432/iceberg \
    --conf spark.sql.catalog.iceberg.jdbc.user=postgres \
    --conf spark.sql.catalog.iceberg.jdbc.password=SuperSecr3t
spark-sql> CREATE TABLE iceberg.default.student (id bigint, name string) USING iceberg;
21/09/05 08:46:37 ERROR SparkSQLDriver: Failed in [CREATE TABLE iceberg.default.student (id bigint, name string) USING iceberg]
org.apache.iceberg.jdbc.UncheckedSQLException: Failed to connect: jdbc:postgresql://postgres:5432/iceberg
	at org.apache.iceberg.jdbc.JdbcClientPool.newClient(JdbcClientPool.java:54)
	at org.apache.iceberg.jdbc.JdbcClientPool.newClient(JdbcClientPool.java:31)
	...
Caused by: org.postgresql.util.PSQLException: FATAL: password authentication failed for user "dungdm93"
	at org.postgresql.core.v3.ConnectionFactoryImpl.doAuthentication(ConnectionFactoryImpl.java:613)
	at org.postgresql.core.v3.ConnectionFactoryImpl.tryConnect(ConnectionFactoryImpl.java:161)
	at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:213)
	at org.postgresql.core.ConnectionFactory.openConnection(ConnectionFactory.java:51)
	at org.postgresql.jdbc.PgConnection.<init>(PgConnection.java:223)
	at org.postgresql.Driver.makeConnection(Driver.java:465)
	at org.postgresql.Driver.connect(Driver.java:264)
	at java.sql.DriverManager.getConnection(DriverManager.java:664)
	at java.sql.DriverManager.getConnection(DriverManager.java:208)
	at org.apache.iceberg.jdbc.JdbcClientPool.newClient(JdbcClientPool.java:52)
```

After some investigation, I found the reason is because `jdbc.user` property is overwrite by `user` property
![Screenshot from 2021-09-05 13-28-00](https://user-images.githubusercontent.com/6848311/132121062-e542d43f-beab-4791-90cf-8d1922d64b5e.png)
