### PR TITLE
Spark: Create metadata tables directly to preserve custom FileIO

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
@@ -30,11 +30,25 @@ public class MetadataTableUtils {
     return MetadataTableType.from(identifier.name()) != null;
   }
 
+  public static Table createMetadataTableInstance(Table table, MetadataTableType type) {
+    if (table instanceof BaseTable) {
+      TableOperations ops = ((BaseTable) table).operations();
+      return createMetadataTableInstance(ops, table, metadataTableName(table.name(), type), type);
+    } else {
+      throw new IllegalArgumentException(String.format("Cannot create metadata table for table: %s", table));
+    }
+  }
+
   public static Table createMetadataTableInstance(TableOperations ops,
                                                   String baseTableName,
                                                   String metadataTableName,
                                                   MetadataTableType type) {
     Table baseTable = new BaseTable(ops, baseTableName);
+    return createMetadataTableInstance(ops, baseTable, metadataTableName, type);
+  }
+
+  private static Table createMetadataTableInstance(TableOperations ops, Table baseTable, String metadataTableName,
+                                                   MetadataTableType type) {
     switch (type) {
       case ENTRIES:
         return new ManifestEntriesTable(ops, baseTable, metadataTableName);
@@ -67,5 +81,9 @@ public class MetadataTableUtils {
     String baseTableName = BaseMetastoreCatalog.fullTableName(catalogName, baseTableIdentifier);
     String metadataTableName = BaseMetastoreCatalog.fullTableName(catalogName, metadataTableIdentifier);
     return createMetadataTableInstance(ops, baseTableName, metadataTableName, type);
+  }
+
+  private static String metadataTableName(String tableName, MetadataTableType type) {
+    return tableName + (tableName.contains("/") ? "#" : ".") + type;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
@@ -35,7 +35,8 @@ public class MetadataTableUtils {
       TableOperations ops = ((BaseTable) table).operations();
       return createMetadataTableInstance(ops, table, metadataTableName(table.name(), type), type);
     } else {
-      throw new IllegalArgumentException(String.format("Cannot create metadata table for table: %s", table));
+      throw new IllegalArgumentException(String.format(
+          "Cannot create metadata table for table %s: not a base table", table));
     }
   }
 

--- a/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -595,17 +595,25 @@ public class SparkTableUtil {
   }
 
   // Attempt to use Spark3 Catalog resolution if available on the path
-  private static final DynMethods.UnboundMethod LOAD_CATALOG = DynMethods.builder("loadCatalogMetadataTable")
-      .hiddenImpl("org.apache.iceberg.spark.Spark3Util", SparkSession.class, String.class, MetadataTableType.class)
+  private static final DynMethods.UnboundMethod LOAD_METADATA_TABLE = DynMethods.builder("loadMetadataTable")
+      .hiddenImpl("org.apache.iceberg.spark.Spark3Util", SparkSession.class, Table.class, MetadataTableType.class)
       .orNoop()
       .build();
 
-  public static Dataset<Row> loadCatalogMetadataTable(SparkSession spark, String tableName, MetadataTableType type) {
-    Preconditions.checkArgument(!LOAD_CATALOG.isNoop(), "Cannot find Spark3Util class but Spark3 is in use");
-    return LOAD_CATALOG.asStatic().invoke(spark, tableName, type);
+  public static Dataset<Row> loadCatalogMetadataTable(SparkSession spark, Table table, MetadataTableType type) {
+    Preconditions.checkArgument(!LOAD_METADATA_TABLE.isNoop(), "Cannot find Spark3Util class but Spark3 is in use");
+    return LOAD_METADATA_TABLE.asStatic().invoke(spark, table, type);
   }
 
   public static Dataset<Row> loadMetadataTable(SparkSession spark, Table table, MetadataTableType type) {
+    if (spark.version().startsWith("3")) {
+      // construct the metadata table instance directly
+      Dataset<Row> catalogMetadataTable = loadCatalogMetadataTable(spark, table, type);
+      if (catalogMetadataTable != null) {
+        return catalogMetadataTable;
+      }
+    }
+
     String tableName = table.name();
     String tableLocation = table.location();
 
@@ -613,14 +621,6 @@ public class SparkTableUtil {
     if (tableName.contains("/")) {
       // Hadoop Table or Metadata location passed, load without a catalog
       return dataFrameReader.load(tableName + "#" + type);
-    }
-
-    // Try DSV2 catalog based name based resolution
-    if (spark.version().startsWith("3")) {
-      Dataset<Row> catalogMetadataTable = loadCatalogMetadataTable(spark, tableName, type);
-      if (catalogMetadataTable != null) {
-        return catalogMetadataTable;
-      }
     }
 
     // Catalog based resolution failed, our catalog may be a non-DatasourceV2 Catalog


### PR DESCRIPTION
This updates Spark 3 to create metadata tables directly inside of actions, instead of loading them through a SparkCatalog.

This avoids a problem where metadata tables used by the expire snapshots action were using `HadoopFileIO` instead of a custom `FileIO` implementation. The problem happened in the expire snapshots action, where metadata tables are used for file reachability datasets, but are based on a `StaticTableOperations` that points directly to a metadata file path. `SparkTableUtil` would create the metadata table by translating the table back to an identifier and loading it. For static tables, the identifier is the location of the metadata file. This causes Spark to load the metadata table using HadoopTables instead of a catalog, which then uses `HadoopFileIO`.

The solution is to construct a metadata table directly from the `Table` instance passed into `SparkTableUtil` for Spark 3.