### PR TITLE
[SPARK] Add in config value needed in tests once Spark 3.2 is supported

### DIFF
--- a/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkExtensionsTestBase.java
+++ b/spark3-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkExtensionsTestBase.java
@@ -51,6 +51,7 @@ public abstract class SparkExtensionsTestBase extends SparkCatalogTestBase {
         .config("spark.sql.extensions", IcebergSparkSessionExtensions.class.getName())
         .config("spark.hadoop." + METASTOREURIS.varname, hiveConf.get(METASTOREURIS.varname))
         .config("spark.sql.shuffle.partitions", "4")
+        .config("spark.sql.hive.metastorePartitionPruningFallbackOnException", "true")
         .enableHiveSupport()
         .getOrCreate();
 


### PR DESCRIPTION
The (non-Iceberg) tables generated during testing in `TestAddFiles` procedure are partitioned on date columns that are not casts to strings.

Most metastores will handle this just fine, but Derby and some others will throw an exception. MySQL and Postgres backed metastores will handle this fine and won't need to fall back or generate an exception.

Without setting this, many of the tests in `TestAddFiles` fail with `MetaException(message:Filtering is supported only on partition keys of type string)`

This is related to https://issues.apache.org/jira/browse/SPARK-36128. The consensus in the community was that `false` is the best value for this in production environments as this can in theory have impact on performance, to let users know and adjust their data accordingly.

For tests though, it should probably be set everywhere.

Setting it here now as this is the only place that I've encountered that will need it once https://issues.apache.org/jira/browse/SPARK-36128 is part of a supported version (should be Spark 3.2 which has release candidates though is not GA).