### PR TITLE
[BUILD] Add gradle info level logs to JVM CI suite to debug irregular timeouts during CI

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -49,7 +49,7 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: ${{ runner.os }}-gradle
     - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-    - run: ./gradlew check -Pquick=true -x javadoc
+    - run: ./gradlew check -Pquick=true -x javadoc -i
     - uses: actions/upload-artifact@v2
       if: failure()
       with:
@@ -64,7 +64,7 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 8
-    - run: ./gradlew build -x test -x javadoc -x integrationTest
+    - run: ./gradlew build -x test -x javadoc -x integrationTest -i
 
   build-javadoc:
     runs-on: ubuntu-latest
@@ -73,4 +73,4 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 8
-    - run: ./gradlew -Pquick=true javadoc
+    - run: ./gradlew -Pquick=true javadoc -i


### PR DESCRIPTION
Adding info level logs to the JVM CI suite to help debug occasional timeouts that occur when the CI suite is trying to run the Spark 3 tests (happens occasionally for both Java 8 and Java 11).

We can revert this after we have the chance to review logs with timeouts.

From there, we'll either be able to fix our situation or need to run with `-d` (debug logs). Then there are additional GitHub Actions logs we can get too after that.

Related to this issue https://github.com/apache/iceberg/issues/3091