### PR TITLE
Flink: support insert options set equality fields columns

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -228,4 +228,7 @@ public class TableProperties {
 
   public static final String MERGE_CARDINALITY_CHECK_ENABLED = "write.merge.cardinality-check.enabled";
   public static final boolean MERGE_CARDINALITY_CHECK_ENABLED_DEFAULT = true;
+
+  public static final String WRITE_EQUALITY_FIELD_COLUMNS_ENABLE = "write.equality-field-columns.enabled";
+  public static final boolean WRITE_EQUALITY_FIELD_COLUMNS_ENABLE_DEFAULT = false;
 }

--- a/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -113,7 +113,7 @@ public class FlinkDynamicTableFactory implements DynamicTableSinkFactory, Dynami
           objectPath.getObjectName());
     }
 
-    return new IcebergTableSink(tableLoader, tableSchema);
+    return new IcebergTableSink(tableLoader, tableSchema, tableProps);
   }
 
   @Override

--- a/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSink.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSink.java
@@ -36,18 +36,20 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 public class IcebergTableSink implements DynamicTableSink, SupportsPartitioning, SupportsOverwrite {
   private final TableLoader tableLoader;
   private final TableSchema tableSchema;
-
+  private final  Map<String, String> tableProps;
   private boolean overwrite = false;
 
   private IcebergTableSink(IcebergTableSink toCopy) {
     this.tableLoader = toCopy.tableLoader;
     this.tableSchema = toCopy.tableSchema;
     this.overwrite = toCopy.overwrite;
+    this.tableProps = toCopy.tableProps;
   }
 
-  public IcebergTableSink(TableLoader tableLoader, TableSchema tableSchema) {
+  public IcebergTableSink(TableLoader tableLoader, TableSchema tableSchema,  Map<String, String> tableProps) {
     this.tableLoader = tableLoader;
     this.tableSchema = tableSchema;
+    this.tableProps = tableProps;
   }
 
   @Override
@@ -63,6 +65,7 @@ public class IcebergTableSink implements DynamicTableSink, SupportsPartitioning,
         .tableLoader(tableLoader)
         .tableSchema(tableSchema)
         .equalityFieldColumns(equalityColumns)
+        .properties(tableProps)
         .overwrite(overwrite)
         .build();
   }

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/SinkContext.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/SinkContext.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.flink.sink;
+
+import java.io.Serializable;
+import java.util.Map;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
+
+/**
+ * Context object with optional arguments for a Flink sink.
+ */
+class SinkContext implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private static final ConfigOption<String> EQUALITY_FIELD_COLUMNS =
+      ConfigOptions.key("equality-field-columns").stringType().defaultValue("");
+
+  private final String equalityFieldColumns;
+
+  private SinkContext(String equalityFieldColumns) {
+    this.equalityFieldColumns = equalityFieldColumns;
+  }
+
+  String equalityFieldColumns() {
+    return equalityFieldColumns;
+  }
+
+
+  static Builder builder() {
+    return new Builder();
+  }
+
+  static class Builder {
+    private String equalityFieldColumns = EQUALITY_FIELD_COLUMNS.defaultValue();
+
+    private Builder() {
+    }
+
+    Builder equalityFieldColumns(String newEqualityFieldColumns) {
+      this.equalityFieldColumns = newEqualityFieldColumns;
+      return this;
+    }
+
+    Builder fromProperties(Map<String, String> properties) {
+      if (properties == null) {
+        return this;
+      }
+      Configuration config = new Configuration();
+      properties.forEach(config::setString);
+
+      return this.equalityFieldColumns(config.get(EQUALITY_FIELD_COLUMNS));
+    }
+
+    public SinkContext build() {
+      return new SinkContext(equalityFieldColumns);
+    }
+  }
+}


### PR DESCRIPTION
This branch mainly provides support for setting options parameters for sink tables when performing streaming inserts. The sinkContext is designed in the scheme to facilitate the addition of parameters. Currently, the equality-field-columns parameter is mainly added to support uosert based on different field columns for the same table.

```
INSERT INTO sample /* OPTIONS('equality-field-columns'='id,data') */
```