### PR TITLE
Flink - Ignore test that leads to infinite checkpoint loop and CI timeouts

### DIFF
--- a/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
@@ -49,6 +49,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
@@ -264,6 +265,7 @@ public class TestFlinkIcebergSink {
   }
 
   @Test
+  @Ignore  // Ignored as one DAG completing first can cause an infinite checkpoint loop in the other and CI timeouts
   public void testTwoSinksInDisjointedDAG() throws Exception {
     Map<String, String> props = ImmutableMap.of(TableProperties.DEFAULT_FILE_FORMAT, format.name());
 


### PR DESCRIPTION
This test has a race condition, where one of the two disjointed DAGs can finish and close its tasks before the other has finished.

When the task(s) belonging to the disjoint DAG which terminated aren't present to participate in checkpointing, it leads to an infinite loop of attempting to re-checkpoint.

Here are some of the logs (visible when passing `-i` for info level logs to gradle.

```
2021-09-13T08:19:47.7896411Z > Task :iceberg-flink:test
2021-09-13T08:19:47.7899950Z     [Checkpoint Timer] INFO org.apache.flink.runtime.checkpoint.CheckpointCoordinator - Checkpoint triggering task Source: rightCustomSource -> rightIcebergSink-rightIcebergSink -> rightIcebergSink-IcebergStreamWriter (1/1) of job 437e46445e777ca2231677f60f87496a is not in state RUNNING but FINISHED instead. Aborting checkpoint.
2021-09-13T08:19:47.7905489Z     [Checkpoint Timer] INFO org.apache.flink.runtime.checkpoint.CheckpointCoordinator - Checkpoint triggering task Source: rightCustomSource -> rightIcebergSink-rightIcebergSink -> rightIcebergSink-IcebergStreamWriter (1/1) of job 437e46445e777ca2231677f60f87496a is not in state RUNNING but FINISHED instead. Aborting checkpoint.
2021-09-13T08:19:47.7914766Z     [Checkpoint Timer] INFO org.apache.flink.runtime.checkpoint.CheckpointCoordinator - Checkpoint triggering task Source: rightCustomSource -> rightIcebergSink-rightIcebergSink -> rightIcebergSink-IcebergStreamWriter (1/1) of job 437e46445e777ca2231677f60f87496a is not in state RUNNING but FINISHED instead. Aborting checkpoint.
2021-09-13T08:19:47.7920502Z     [Checkpoint Timer] INFO org.apache.flink.runtime.checkpoint.CheckpointCoordinator - Checkpoint triggering task Source: rightCustomSource -> rightIcebergSink-rightIcebergSink -> rightIcebergSink-IcebergStreamWriter (1/1) of job 437e46445e777ca2231677f60f87496a is not in state RUNNING but FINISHED instead. Aborting checkpoint.
```

Link to another PR where I attempted to debug this with some relevant discussion - https://github.com/apache/iceberg/pull/3106

This (temporarily) closes this issue: https://github.com/apache/iceberg/issues/3091, though we should fix the `BoundedTestSource` (though this edge case might be fixed come Flink 1.14).

More details and discussion in the issue (particularly the linked FLIP).