### PR TITLE
INFRA - Remove additional logs added to Java CI for debugging timeouts

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -49,7 +49,7 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: ${{ runner.os }}-gradle
     - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-    - run: ./gradlew check -Pquick=true -x javadoc -i
+    - run: ./gradlew check -Pquick=true -x javadoc
     - uses: actions/upload-artifact@v2
       if: failure()
       with:
@@ -64,7 +64,7 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 8
-    - run: ./gradlew build -x test -x javadoc -x integrationTest -i
+    - run: ./gradlew build -x test -x javadoc -x integrationTest
 
   build-javadoc:
     runs-on: ubuntu-latest
@@ -73,4 +73,4 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 8
-    - run: ./gradlew -Pquick=true javadoc -i
+    - run: ./gradlew -Pquick=true javadoc


### PR DESCRIPTION
As part of investigating timeouts in CI (https://github.com/apache/iceberg/issues/3091), we added additional logging.

This reverts that logging as we've located the source of the timeouts and are ignoring the one test for now in this PR: https://github.com/apache/iceberg/pull/3110