### PR TITLE
Flink: support write watermark in snapshot

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -228,4 +228,10 @@ public class TableProperties {
 
   public static final String MERGE_CARDINALITY_CHECK_ENABLED = "write.merge.cardinality-check.enabled";
   public static final boolean MERGE_CARDINALITY_CHECK_ENABLED_DEFAULT = true;
+
+  public static final String WATERMARK_FIELD_NAME = "write.watermark.field";
+  public static final String WATERMARK_FIELD_NAME_DEFAULT = "";
+
+  public static final String WATERMARK_VALUE = "write.watermark";
+  public static final long WATERMARK_VALUE_DEFAULT = -1;
 }

--- a/core/src/main/java/org/apache/iceberg/io/WriteResult.java
+++ b/core/src/main/java/org/apache/iceberg/io/WriteResult.java
@@ -28,14 +28,19 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.CharSequenceSet;
 
+import static org.apache.iceberg.TableProperties.WATERMARK_VALUE_DEFAULT;
+
 public class WriteResult implements Serializable {
   private DataFile[] dataFiles;
   private DeleteFile[] deleteFiles;
   private CharSequence[] referencedDataFiles;
 
-  private WriteResult(List<DataFile> dataFiles,
-                      List<DeleteFile> deleteFiles,
-                      CharSequenceSet referencedDataFiles) {
+  private Long watermark = WATERMARK_VALUE_DEFAULT;
+
+  private WriteResult(
+      List<DataFile> dataFiles,
+      List<DeleteFile> deleteFiles,
+      CharSequenceSet referencedDataFiles) {
     this.dataFiles = dataFiles.toArray(new DataFile[0]);
     this.deleteFiles = deleteFiles.toArray(new DeleteFile[0]);
     this.referencedDataFiles = referencedDataFiles.toArray(new CharSequence[0]);
@@ -51,6 +56,15 @@ public class WriteResult implements Serializable {
 
   public CharSequence[] referencedDataFiles() {
     return referencedDataFiles;
+  }
+
+  public Long getWatermark() {
+    return watermark;
+  }
+
+  public WriteResult setWatermark(Long watermark) {
+    this.watermark = watermark;
+    return this;
   }
 
   public static Builder builder() {

--- a/core/src/main/java/org/apache/iceberg/io/WriteResult.java
+++ b/core/src/main/java/org/apache/iceberg/io/WriteResult.java
@@ -37,10 +37,9 @@ public class WriteResult implements Serializable {
 
   private Long watermark = WATERMARK_VALUE_DEFAULT;
 
-  private WriteResult(
-      List<DataFile> dataFiles,
-      List<DeleteFile> deleteFiles,
-      CharSequenceSet referencedDataFiles) {
+  private WriteResult(List<DataFile> dataFiles,
+                      List<DeleteFile> deleteFiles,
+                      CharSequenceSet referencedDataFiles) {
     this.dataFiles = dataFiles.toArray(new DataFile[0]);
     this.deleteFiles = deleteFiles.toArray(new DeleteFile[0]);
     this.referencedDataFiles = referencedDataFiles.toArray(new CharSequence[0]);

--- a/flink/src/main/java/org/apache/iceberg/flink/IcebergWatermark.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/IcebergWatermark.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink;
+
+import java.io.Serializable;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+public class IcebergWatermark implements Serializable {
+  private final String watermarkFieldName;
+  private final RowType flinkRowType;
+  private final int watermarkFieldPos;
+
+  public IcebergWatermark(String watermarkFieldName, RowType flinkRowType) {
+    Preconditions.checkArgument(
+        watermarkFieldName != null && !"".equals(watermarkFieldName),
+        "watermarkFieldName must not empty.");
+    Preconditions.checkArgument(flinkRowType != null, "flinkRowType must not null.");
+    Preconditions.checkArgument(
+        flinkRowType.getFieldIndex(watermarkFieldName) > -1,
+        "flink schema must have watermarkFieldName.");
+
+    this.watermarkFieldName = watermarkFieldName;
+    this.flinkRowType = flinkRowType;
+    this.watermarkFieldPos = flinkRowType.getFieldIndex(watermarkFieldName);
+  }
+
+  public Long getWatermark(RowData rowData) {
+    return rowData.getLong(watermarkFieldPos);
+  }
+
+  public String getWatermarkFieldName() {
+    return watermarkFieldName;
+  }
+
+  public RowType getFlinkRowType() {
+    return flinkRowType;
+  }
+
+  public int getWatermarkFieldPos() {
+    return watermarkFieldPos;
+  }
+}

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -86,10 +86,9 @@ public class FlinkSink {
    * @param <T>        the data type of records.
    * @return {@link Builder} to connect the iceberg table.
    */
-  public static <T> Builder builderFor(
-      DataStream<T> input,
-      MapFunction<T, RowData> mapper,
-      TypeInformation<RowData> outputType) {
+  public static <T> Builder builderFor(DataStream<T> input,
+                                       MapFunction<T, RowData> mapper,
+                                       TypeInformation<RowData> outputType) {
     return new Builder().forMapperOutputType(input, mapper, outputType);
   }
 
@@ -140,10 +139,9 @@ public class FlinkSink {
       return this;
     }
 
-    private <T> Builder forMapperOutputType(
-        DataStream<T> input,
-        MapFunction<T, RowData> mapper,
-        TypeInformation<RowData> outputType) {
+    private <T> Builder forMapperOutputType(DataStream<T> input,
+                                            MapFunction<T, RowData> mapper,
+                                            TypeInformation<RowData> outputType) {
       this.inputCreator = newUidPrefix -> {
         if (newUidPrefix != null) {
           return input.map(mapper, outputType)
@@ -200,8 +198,7 @@ public class FlinkSink {
      * @return {@link Builder} to connect the iceberg table.
      */
     public Builder distributionMode(DistributionMode mode) {
-      Preconditions.checkArgument(
-          !DistributionMode.RANGE.equals(mode),
+      Preconditions.checkArgument(!DistributionMode.RANGE.equals(mode),
           "Flink does not support 'range' write distribution mode now.");
       this.distributionMode = mode;
       return this;
@@ -256,8 +253,7 @@ public class FlinkSink {
     }
 
     private <T> DataStreamSink<T> chainIcebergOperators() {
-      Preconditions.checkArgument(
-          inputCreator != null,
+      Preconditions.checkArgument(inputCreator != null,
           "Please use forRowData() or forMapperOutputType() to initialize the input DataStream.");
       Preconditions.checkNotNull(tableLoader, "Table loader shouldn't be null");
 
@@ -362,17 +358,15 @@ public class FlinkSink {
       return writerStream;
     }
 
-    private DataStream<RowData> distributeDataStream(
-        DataStream<RowData> input,
-        Map<String, String> properties,
-        PartitionSpec partitionSpec,
-        Schema iSchema,
-        RowType flinkRowType) {
+    private DataStream<RowData> distributeDataStream(DataStream<RowData> input,
+                                                     Map<String, String> properties,
+                                                     PartitionSpec partitionSpec,
+                                                     Schema iSchema,
+                                                     RowType flinkRowType) {
       DistributionMode writeMode;
       if (distributionMode == null) {
         // Fallback to use distribution mode parsed from table properties if don't specify in job level.
-        String modeName = PropertyUtil.propertyAsString(
-            properties,
+        String modeName = PropertyUtil.propertyAsString(properties,
             WRITE_DISTRIBUTION_MODE,
             WRITE_DISTRIBUTION_MODE_DEFAULT);
 
@@ -419,10 +413,9 @@ public class FlinkSink {
     }
   }
 
-  static IcebergStreamWriter<RowData> createStreamWriter(
-      Table table,
-      RowType flinkRowType,
-      List<Integer> equalityFieldIds) {
+  static IcebergStreamWriter<RowData> createStreamWriter(Table table,
+                                                         RowType flinkRowType,
+                                                         List<Integer> equalityFieldIds) {
     Map<String, String> props = table.properties();
     long targetFileSize = getTargetFileSizeBytes(props);
     FileFormat fileFormat = getFileFormat(props);
@@ -447,15 +440,13 @@ public class FlinkSink {
   }
 
   private static long getTargetFileSizeBytes(Map<String, String> properties) {
-    return PropertyUtil.propertyAsLong(
-        properties,
+    return PropertyUtil.propertyAsLong(properties,
         WRITE_TARGET_FILE_SIZE_BYTES,
         WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT);
   }
 
   private static String getWatermarkFieldName(Map<String, String> properties) {
-    return PropertyUtil.propertyAsString(
-        properties,
+    return PropertyUtil.propertyAsString(properties,
         WATERMARK_FIELD_NAME,
         WATERMARK_FIELD_NAME_DEFAULT);
   }

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -145,8 +145,9 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     this.manifestOutputFileFactory = FlinkManifestUtil.createOutputFileFactory(table, flinkJobId, subTaskId, attemptId);
     this.maxCommittedCheckpointId = INITIAL_CHECKPOINT_ID;
 
-    Map<String, String> currentSummary = this.table.currentSnapshot().summary();
-    this.currentWatermark = PropertyUtil.propertyAsLong(currentSummary, WATERMARK_VALUE, WATERMARK_VALUE_DEFAULT);
+    Snapshot currentSnapshot = this.table.currentSnapshot();
+    this.currentWatermark = currentSnapshot == null ? WATERMARK_VALUE_DEFAULT :
+            PropertyUtil.propertyAsLong(currentSnapshot.summary(), WATERMARK_VALUE, WATERMARK_VALUE_DEFAULT);
     this.watermarkState = context.getOperatorStateStore().getListState(WATERMARK_DESCRIPTOR);
 
     this.checkpointsState = context.getOperatorStateStore().getListState(STATE_DESCRIPTOR);

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -136,8 +136,7 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     this.table = tableLoader.loadTable();
 
     maxContinuousEmptyCommits = PropertyUtil.propertyAsInt(table.properties(), MAX_CONTINUOUS_EMPTY_COMMITS, 10);
-    Preconditions.checkArgument(
-        maxContinuousEmptyCommits > 0,
+    Preconditions.checkArgument(maxContinuousEmptyCommits > 0,
         MAX_CONTINUOUS_EMPTY_COMMITS + " must be positive");
 
     int subTaskId = getRuntimeContext().getIndexOfThisSubtask();
@@ -159,8 +158,7 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
       }
 
       String restoredFlinkJobId = jobIdState.get().iterator().next();
-      Preconditions.checkState(
-          !Strings.isNullOrEmpty(restoredFlinkJobId),
+      Preconditions.checkState(!Strings.isNullOrEmpty(restoredFlinkJobId),
           "Flink job id parsed from checkpoint snapshot shouldn't be null or empty");
 
       // Since flink's checkpoint id will start from the max-committed-checkpoint-id + 1 in the new flink job even if
@@ -223,10 +221,9 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     }
   }
 
-  private void commitUpToCheckpoint(
-      NavigableMap<Long, byte[]> deltaManifestsMap,
-      String newFlinkJobId,
-      long checkpointId) throws IOException {
+  private void commitUpToCheckpoint(NavigableMap<Long, byte[]> deltaManifestsMap,
+                                    String newFlinkJobId,
+                                    long checkpointId) throws IOException {
     NavigableMap<Long, byte[]> pendingMap = deltaManifestsMap.headMap(checkpointId, true);
     List<ManifestFile> manifests = Lists.newArrayList();
     NavigableMap<Long, WriteResult> pendingResults = Maps.newTreeMap();
@@ -272,9 +269,8 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     }
   }
 
-  private void replacePartitions(
-      NavigableMap<Long, WriteResult> pendingResults, String newFlinkJobId,
-      long checkpointId) {
+  private void replacePartitions(NavigableMap<Long, WriteResult> pendingResults, String newFlinkJobId,
+                                 long checkpointId) {
     // Partition overwrite does not support delete files.
     int deleteFilesNum = pendingResults.values().stream().mapToInt(r -> r.deleteFiles().length).sum();
     Preconditions.checkState(deleteFilesNum == 0, "Cannot overwrite partitions with delete files.");
@@ -331,9 +327,8 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     }
   }
 
-  private void commitOperation(
-      SnapshotUpdate<?> operation, int numDataFiles, int numDeleteFiles, String description,
-      String newFlinkJobId, long checkpointId) {
+  private void commitOperation(SnapshotUpdate<?> operation, int numDataFiles, int numDeleteFiles, String description,
+                               String newFlinkJobId, long checkpointId) {
     LOG.info("Committing {} with {} data files and {} delete files to table {}", description, numDataFiles,
         numDeleteFiles, table);
     operation.set(MAX_COMMITTED_CHECKPOINT_ID, Long.toString(checkpointId));

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -30,6 +30,7 @@ import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
+import org.apache.flink.api.java.typeutils.MapTypeInfo;
 import org.apache.flink.core.io.SimpleVersionedSerialization;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
@@ -59,6 +60,9 @@ import org.apache.iceberg.util.PropertyUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.iceberg.TableProperties.WATERMARK_VALUE;
+import static org.apache.iceberg.TableProperties.WATERMARK_VALUE_DEFAULT;
+
 class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     implements OneInputStreamOperator<WriteResult, Void>, BoundedOneInput {
 
@@ -87,6 +91,13 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
   // any data loss in iceberg table. So we keep the finished files <1, <file0, file1>> in memory and retry to commit
   // iceberg table when the next checkpoint happen.
   private final NavigableMap<Long, byte[]> dataFilesPerCheckpoint = Maps.newTreeMap();
+
+  // watermark
+  private transient long currentWatermark;
+  private final NavigableMap<Long, Long> watermarkPerCheckpoint = Maps.newTreeMap();
+  private static final ListStateDescriptor<Map<Long, Long>> WATERMARK_DESCRIPTOR = new ListStateDescriptor<>(
+      "iceberg-flink-watermark", new MapTypeInfo<>(BasicTypeInfo.LONG_TYPE_INFO, BasicTypeInfo.LONG_TYPE_INFO));
+  private transient ListState<Map<Long, Long>> watermarkState;
 
   // The completed files cache for current checkpoint. Once the snapshot barrier received, it will be flushed to the
   // 'dataFilesPerCheckpoint'.
@@ -125,7 +136,8 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     this.table = tableLoader.loadTable();
 
     maxContinuousEmptyCommits = PropertyUtil.propertyAsInt(table.properties(), MAX_CONTINUOUS_EMPTY_COMMITS, 10);
-    Preconditions.checkArgument(maxContinuousEmptyCommits > 0,
+    Preconditions.checkArgument(
+        maxContinuousEmptyCommits > 0,
         MAX_CONTINUOUS_EMPTY_COMMITS + " must be positive");
 
     int subTaskId = getRuntimeContext().getIndexOfThisSubtask();
@@ -133,11 +145,21 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     this.manifestOutputFileFactory = FlinkManifestUtil.createOutputFileFactory(table, flinkJobId, subTaskId, attemptId);
     this.maxCommittedCheckpointId = INITIAL_CHECKPOINT_ID;
 
+    Map<String, String> currentSummary = this.table.currentSnapshot().summary();
+    this.currentWatermark = PropertyUtil.propertyAsLong(currentSummary, WATERMARK_VALUE, WATERMARK_VALUE_DEFAULT);
+    this.watermarkState = context.getOperatorStateStore().getListState(WATERMARK_DESCRIPTOR);
+
     this.checkpointsState = context.getOperatorStateStore().getListState(STATE_DESCRIPTOR);
     this.jobIdState = context.getOperatorStateStore().getListState(JOB_ID_DESCRIPTOR);
     if (context.isRestored()) {
+      Map<Long, Long> restoredWatermarkPerCheckpoint = watermarkState.get().iterator().next();
+      if (restoredWatermarkPerCheckpoint != null) {
+        watermarkPerCheckpoint.putAll(restoredWatermarkPerCheckpoint);
+      }
+
       String restoredFlinkJobId = jobIdState.get().iterator().next();
-      Preconditions.checkState(!Strings.isNullOrEmpty(restoredFlinkJobId),
+      Preconditions.checkState(
+          !Strings.isNullOrEmpty(restoredFlinkJobId),
           "Flink job id parsed from checkpoint snapshot shouldn't be null or empty");
 
       // Since flink's checkpoint id will start from the max-committed-checkpoint-id + 1 in the new flink job even if
@@ -168,6 +190,15 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     checkpointsState.clear();
     checkpointsState.add(dataFilesPerCheckpoint);
 
+    // min(watermarkPerWriter).
+    Long minWatermarkPerWriter = writeResultsOfCurrentCkpt.stream().map(r -> r.getWatermark()).min((w1, w2) -> w1 > w2 ?
+        1 : -1).get();
+    // watermark must move forward, Can't go back.
+    currentWatermark = minWatermarkPerWriter > currentWatermark ? minWatermarkPerWriter : currentWatermark;
+    watermarkPerCheckpoint.put(checkpointId, currentWatermark);
+    watermarkState.clear();
+    watermarkState.add(watermarkPerCheckpoint);
+
     jobIdState.clear();
     jobIdState.add(flinkJobId);
 
@@ -191,9 +222,10 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     }
   }
 
-  private void commitUpToCheckpoint(NavigableMap<Long, byte[]> deltaManifestsMap,
-                                    String newFlinkJobId,
-                                    long checkpointId) throws IOException {
+  private void commitUpToCheckpoint(
+      NavigableMap<Long, byte[]> deltaManifestsMap,
+      String newFlinkJobId,
+      long checkpointId) throws IOException {
     NavigableMap<Long, byte[]> pendingMap = deltaManifestsMap.headMap(checkpointId, true);
     List<ManifestFile> manifests = Lists.newArrayList();
     NavigableMap<Long, WriteResult> pendingResults = Maps.newTreeMap();
@@ -239,8 +271,9 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     }
   }
 
-  private void replacePartitions(NavigableMap<Long, WriteResult> pendingResults, String newFlinkJobId,
-                                 long checkpointId) {
+  private void replacePartitions(
+      NavigableMap<Long, WriteResult> pendingResults, String newFlinkJobId,
+      long checkpointId) {
     // Partition overwrite does not support delete files.
     int deleteFilesNum = pendingResults.values().stream().mapToInt(r -> r.deleteFiles().length).sum();
     Preconditions.checkState(deleteFilesNum == 0, "Cannot overwrite partitions with delete files.");
@@ -297,15 +330,26 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     }
   }
 
-  private void commitOperation(SnapshotUpdate<?> operation, int numDataFiles, int numDeleteFiles, String description,
-                               String newFlinkJobId, long checkpointId) {
+  private void commitOperation(
+      SnapshotUpdate<?> operation, int numDataFiles, int numDeleteFiles, String description,
+      String newFlinkJobId, long checkpointId) {
     LOG.info("Committing {} with {} data files and {} delete files to table {}", description, numDataFiles,
         numDeleteFiles, table);
     operation.set(MAX_COMMITTED_CHECKPOINT_ID, Long.toString(checkpointId));
     operation.set(FLINK_JOB_ID, newFlinkJobId);
 
+    NavigableMap<Long, Long> watermarkMap = watermarkPerCheckpoint.headMap(checkpointId, true);
+    Long watermarkNow = watermarkMap.get(checkpointId);
+    if (watermarkNow != null && watermarkNow > 0) {
+      operation.set(WATERMARK_VALUE, String.valueOf(watermarkNow));
+      LOG.info("Committing {} to {}", WATERMARK_VALUE, watermarkNow);
+    }
+
     long start = System.currentTimeMillis();
     operation.commit(); // abort is automatically called if this fails.
+
+    watermarkMap.clear();
+
     long duration = System.currentTimeMillis() - start;
     LOG.info("Committed in {} ms", duration);
   }


### PR DESCRIPTION
thanks @stevenzwu  @rdblue 

This PR is from Flink: support write watermark in snapshot #3093, based on the master and revert unrelated formatting change.

The current point of discussion is how to implement watermark, my idea is https://github.com/apache/iceberg/pull/3093#issuecomment-916904105,  @stevenzwu @openinx  How do you think?