### PR TITLE
Core: Add table property for ORC batch size

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -132,6 +132,9 @@ public class TableProperties {
   public static final String ORC_VECTORIZATION_ENABLED = "read.orc.vectorization.enabled";
   public static final boolean ORC_VECTORIZATION_ENABLED_DEFAULT = false;
 
+  public static final String ORC_BATCH_SIZE = "read.orc.vectorization.batch-size";
+  public static final int ORC_BATCH_SIZE_DEFAULT = 5000;
+
   public static final String OBJECT_STORE_ENABLED = "write.object-storage.enabled";
   public static final boolean OBJECT_STORE_ENABLED_DEFAULT = false;
 

--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
@@ -98,7 +98,6 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
   private List<Expression> filterExpressions = null;
   private Filter[] pushedFilters = NO_FILTERS;
   private final boolean localityPreferred;
-  private final int batchSize;
   private final boolean readTimestampWithoutZone;
 
   // lazy variables
@@ -106,6 +105,7 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
   private StructType type = null; // cached because Spark accesses it multiple times
   private List<CombinedScanTask> tasks = null; // lazy cache of tasks
   private Boolean readUsingBatch = null;
+  private int batchSize = 0;
 
   Reader(SparkSession spark, Table table, boolean caseSensitive, DataSourceOptions options) {
     this.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
@@ -346,6 +346,10 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
 
       this.readUsingBatch = batchReadsEnabled && hasNoDeleteFiles && (allOrcFileScanTasks ||
           (allParquetFileScanTasks && atLeastOneColumn && onlyPrimitives));
+
+      if (readUsingBatch) {
+        this.batchSize = batchSize(allParquetFileScanTasks, allOrcFileScanTasks);
+      }
     }
     return readUsingBatch;
   }
@@ -385,6 +389,40 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
             TableProperties.ORC_VECTORIZATION_ENABLED_DEFAULT);
       default:
         return false;
+    }
+  }
+
+  private int batchSize(boolean isParquetOnly, boolean isOrcOnly) {
+    if (isParquetOnly) {
+      return batchSize(FileFormat.PARQUET);
+    } else if (isOrcOnly) {
+      return batchSize(FileFormat.ORC);
+    } else {
+      return 0;
+    }
+  }
+
+  private int batchSize(FileFormat fileFormat) {
+    String readOptionValue = options.asMap().get(SparkReadOptions.VECTORIZATION_BATCH_SIZE);
+    if (readOptionValue != null) {
+      return Integer.parseInt(readOptionValue);
+    }
+
+    switch (fileFormat) {
+      case PARQUET:
+        return PropertyUtil.propertyAsInt(
+            table.properties(),
+            TableProperties.PARQUET_BATCH_SIZE,
+            TableProperties.PARQUET_BATCH_SIZE_DEFAULT);
+
+      case ORC:
+        return PropertyUtil.propertyAsInt(
+            table.properties(),
+            TableProperties.ORC_BATCH_SIZE,
+            TableProperties.ORC_BATCH_SIZE_DEFAULT);
+
+      default:
+        throw new IllegalArgumentException("File format does not support batch reads: " + fileFormat);
     }
   }
 

--- a/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -531,10 +531,29 @@ public class Spark3Util {
     }
   }
 
-  public static int batchSize(Map<String, String> properties, CaseInsensitiveStringMap readOptions) {
-    return readOptions.getInt(SparkReadOptions.VECTORIZATION_BATCH_SIZE,
-        PropertyUtil.propertyAsInt(properties,
-            TableProperties.PARQUET_BATCH_SIZE, TableProperties.PARQUET_BATCH_SIZE_DEFAULT));
+  public static int batchSize(FileFormat fileFormat, Map<String, String> properties,
+                              CaseInsensitiveStringMap readOptions) {
+    String readOptionValue = readOptions.get(SparkReadOptions.VECTORIZATION_BATCH_SIZE);
+    if (readOptionValue != null) {
+      return Integer.parseInt(readOptionValue);
+    }
+
+    switch (fileFormat) {
+      case PARQUET:
+        return PropertyUtil.propertyAsInt(
+            properties,
+            TableProperties.PARQUET_BATCH_SIZE,
+            TableProperties.PARQUET_BATCH_SIZE_DEFAULT);
+
+      case ORC:
+        return PropertyUtil.propertyAsInt(
+            properties,
+            TableProperties.ORC_BATCH_SIZE,
+            TableProperties.ORC_BATCH_SIZE_DEFAULT);
+
+      default:
+        throw new IllegalArgumentException("File format does not support batch reads: " + fileFormat);
+    }
   }
 
   public static Long propertyAsLong(CaseInsensitiveStringMap options, String property, Long defaultValue) {

--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
@@ -72,7 +72,6 @@ abstract class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
   private final boolean localityPreferred;
   private final Schema expectedSchema;
   private final List<Expression> filterExpressions;
-  private final int batchSize;
   private final boolean readTimestampWithoutZone;
   private final CaseInsensitiveStringMap options;
 
@@ -87,7 +86,6 @@ abstract class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
     this.expectedSchema = expectedSchema;
     this.filterExpressions = filters != null ? filters : Collections.emptyList();
     this.localityPreferred = Spark3Util.isLocalityEnabled(table.io(), table.location(), options);
-    this.batchSize = Spark3Util.batchSize(table.properties(), options);
     this.options = options;
 
     RuntimeConfig sessionConf = SparkSession.active().conf();
@@ -180,7 +178,9 @@ abstract class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
     boolean readUsingBatch = batchReadsEnabled && hasNoDeleteFiles && (allOrcFileScanTasks ||
         (allParquetFileScanTasks && atLeastOneColumn && onlyPrimitives));
 
-    return new ReaderFactory(readUsingBatch ? batchSize : 0);
+    int batchSize = readUsingBatch ? batchSize(allParquetFileScanTasks, allOrcFileScanTasks) : 0;
+
+    return new ReaderFactory(batchSize);
   }
 
   private boolean batchReadsEnabled(boolean isParquetOnly, boolean isOrcOnly) {
@@ -192,6 +192,17 @@ abstract class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
       return Spark3Util.isVectorizationEnabled(FileFormat.ORC, properties, sessionConf, options);
     } else {
       return false;
+    }
+  }
+
+  private int batchSize(boolean isParquetOnly, boolean isOrcOnly) {
+    Map<String, String> properties = table.properties();
+    if (isParquetOnly) {
+      return Spark3Util.batchSize(FileFormat.PARQUET, properties, options);
+    } else if (isOrcOnly) {
+      return Spark3Util.batchSize(FileFormat.ORC, properties, options);
+    } else {
+      return 0;
     }
   }
 


### PR DESCRIPTION
This PR adds a new table property to control the ORC batch size. Previously, we used the Parquet batch size for ORC reads.