### PR TITLE
Spark: Better statistics estimation for spark2 Reader.

### DIFF
--- a/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
+++ b/spark2/src/main/java/org/apache/iceberg/spark/source/Reader.java
@@ -306,16 +306,15 @@ class Reader implements DataSourceReader, SupportsScanColumnarBatch, SupportsPus
       return new Stats(SparkSchemaUtil.estimateSize(lazyType(), totalRecords), totalRecords);
     }
 
-    long sizeInBytes = 0L;
     long numRows = 0L;
 
     for (CombinedScanTask task : tasks()) {
       for (FileScanTask file : task.files()) {
-        sizeInBytes += file.length();
         numRows += file.file().recordCount();
       }
     }
 
+    long sizeInBytes = SparkSchemaUtil.estimateSize(lazyType(), numRows);
     return new Stats(sizeInBytes, numRows);
   }
 


### PR DESCRIPTION
Follow-up to #3038.

Use (estimated) row size * number of rows to estimate the size instead of adding up file sizes.
The row size is estimated from the pruned schema if we prune columns.