### PR TITLE
Build: Enable zip64 to allow > 65535 files for JMH

### DIFF
--- a/jmh.gradle
+++ b/jmh.gradle
@@ -36,6 +36,7 @@ configure(jmhProjects) {
     includeTests = true
     humanOutputFile = file(jmhOutputPath)
     include = [jmhIncludeRegex]
+    zip64 true
   }
 
   // Path is relative to either spark2 or spark3 folder, depending on project being tested


### PR DESCRIPTION
This started to happen after the Gradle 7 upgrade

```
> Task :iceberg-spark3:jmhJar FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':iceberg-spark3:jmhJar'.
> archive contains more than 65535 entries.

  To build this archive, please enable the zip64 extension.
  See: https://docs.gradle.org/7.2/dsl/org.gradle.api.tasks.bundling.Zip.html#org.gradle.api.tasks.bundling.Zip:zip64
```