### PR TITLE
Core: Add FileWriter interface

### DIFF
--- a/core/src/main/java/org/apache/iceberg/deletes/EqualityDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/EqualityDeleteWriter.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.deletes;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import org.apache.iceberg.DeleteFile;
@@ -29,10 +28,12 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.encryption.EncryptionKeyMetadata;
+import org.apache.iceberg.io.DeleteWriteResult;
 import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.io.FileWriter;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
-public class EqualityDeleteWriter<T> implements Closeable {
+public class EqualityDeleteWriter<T> implements FileWriter<T, DeleteWriteResult> {
   private final FileAppender<T> appender;
   private final FileFormat format;
   private final String location;
@@ -56,14 +57,32 @@ public class EqualityDeleteWriter<T> implements Closeable {
     this.equalityFieldIds = equalityFieldIds;
   }
 
+  @Override
+  public void write(T row) throws IOException {
+    appender.add(row);
+  }
+
+  /**
+   * Writes equality deletes.
+   *
+   * @deprecated since 0.13.0, will be removed in 0.14.0; use {@link #write(Iterable)} instead.
+   */
+  @Deprecated
   public void deleteAll(Iterable<T> rows) {
     appender.addAll(rows);
   }
 
+  /**
+   * Writes an equality delete.
+   *
+   * @deprecated since 0.13.0, will be removed in 0.14.0; use {@link #write(Object)} instead.
+   */
+  @Deprecated
   public void delete(T row) {
     appender.add(row);
   }
 
+  @Override
   public long length() {
     return appender.length();
   }
@@ -88,5 +107,10 @@ public class EqualityDeleteWriter<T> implements Closeable {
   public DeleteFile toDeleteFile() {
     Preconditions.checkState(deleteFile != null, "Cannot create delete file from unclosed writer");
     return deleteFile;
+  }
+
+  @Override
+  public DeleteWriteResult result() {
+    return new DeleteWriteResult(toDeleteFile());
   }
 }

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteWriter.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.deletes;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import org.apache.iceberg.DeleteFile;
@@ -28,11 +27,13 @@ import org.apache.iceberg.FileMetadata;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.encryption.EncryptionKeyMetadata;
+import org.apache.iceberg.io.DeleteWriteResult;
 import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.io.FileWriter;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.CharSequenceSet;
 
-public class PositionDeleteWriter<T> implements Closeable {
+public class PositionDeleteWriter<T> implements FileWriter<PositionDelete<T>, DeleteWriteResult> {
   private final FileAppender<StructLike> appender;
   private final FileFormat format;
   private final String location;
@@ -40,7 +41,7 @@ public class PositionDeleteWriter<T> implements Closeable {
   private final StructLike partition;
   private final ByteBuffer keyMetadata;
   private final PositionDelete<T> delete;
-  private final CharSequenceSet pathSet;
+  private final CharSequenceSet referencedDataFiles;
   private DeleteFile deleteFile = null;
 
   public PositionDeleteWriter(FileAppender<StructLike> appender, FileFormat format, String location,
@@ -52,16 +53,39 @@ public class PositionDeleteWriter<T> implements Closeable {
     this.partition = partition;
     this.keyMetadata = keyMetadata != null ? keyMetadata.buffer() : null;
     this.delete = PositionDelete.create();
-    this.pathSet = CharSequenceSet.empty();
+    this.referencedDataFiles = CharSequenceSet.empty();
   }
 
+  @Override
+  public void write(PositionDelete<T> positionDelete) throws IOException {
+    referencedDataFiles.add(positionDelete.path());
+    appender.add(positionDelete);
+  }
+
+  /**
+   * Writes a position delete.
+   *
+   * @deprecated since 0.13.0, will be removed in 0.14.0; use {@link #write(PositionDelete)} instead.
+   */
+  @Deprecated
   public void delete(CharSequence path, long pos) {
     delete(path, pos, null);
   }
 
+  /**
+   * Writes a position delete and persists the deleted row.
+   *
+   * @deprecated since 0.13.0, will be removed in 0.14.0; use {@link #write(PositionDelete)} instead.
+   */
+  @Deprecated
   public void delete(CharSequence path, long pos, T row) {
-    pathSet.add(path);
+    referencedDataFiles.add(path);
     appender.add(delete.set(path, pos, row));
+  }
+
+  @Override
+  public long length() {
+    return appender.length();
   }
 
   @Override
@@ -81,11 +105,16 @@ public class PositionDeleteWriter<T> implements Closeable {
   }
 
   public CharSequenceSet referencedDataFiles() {
-    return pathSet;
+    return referencedDataFiles;
   }
 
   public DeleteFile toDeleteFile() {
     Preconditions.checkState(deleteFile != null, "Cannot create delete file from unclosed writer");
     return deleteFile;
+  }
+
+  @Override
+  public DeleteWriteResult result() {
+    return new DeleteWriteResult(toDeleteFile(), referencedDataFiles());
   }
 }

--- a/core/src/main/java/org/apache/iceberg/io/DataWriteResult.java
+++ b/core/src/main/java/org/apache/iceberg/io/DataWriteResult.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io;
+
+import java.util.Collections;
+import java.util.List;
+import org.apache.iceberg.DataFile;
+
+/**
+ * A result of writing data files.
+ * <p>
+ * Note that objects of this class are NOT meant to be serialized. Task or delta writers will wrap
+ * these results into their own serializable results that can be sent back to query engines.
+ */
+public class DataWriteResult {
+  private final List<DataFile> dataFiles;
+
+  public DataWriteResult(DataFile dataFile) {
+    this.dataFiles = Collections.singletonList(dataFile);
+  }
+
+  public DataWriteResult(List<DataFile> dataFiles) {
+    this.dataFiles = dataFiles;
+  }
+
+  public List<DataFile> dataFiles() {
+    return dataFiles;
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/io/DeleteWriteResult.java
+++ b/core/src/main/java/org/apache/iceberg/io/DeleteWriteResult.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io;
+
+import java.util.Collections;
+import java.util.List;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.util.CharSequenceSet;
+
+/**
+ * A result of writing delete files.
+ * <p>
+ * Note that objects of this class are NOT meant to be serialized. Task or delta writers will wrap
+ * these results into their own serializable results that can be sent back to query engines.
+ */
+public class DeleteWriteResult {
+  private final List<DeleteFile> deleteFiles;
+  private final CharSequenceSet referencedDataFiles;
+
+  public DeleteWriteResult(DeleteFile deleteFile) {
+    this.deleteFiles = Collections.singletonList(deleteFile);
+    this.referencedDataFiles = CharSequenceSet.empty();
+  }
+
+  public DeleteWriteResult(DeleteFile deleteFile, CharSequenceSet referencedDataFiles) {
+    this.deleteFiles = Collections.singletonList(deleteFile);
+    this.referencedDataFiles = referencedDataFiles;
+  }
+
+  public DeleteWriteResult(List<DeleteFile> deleteFiles) {
+    this.deleteFiles = deleteFiles;
+    this.referencedDataFiles = CharSequenceSet.empty();
+  }
+
+  public DeleteWriteResult(List<DeleteFile> deleteFiles, CharSequenceSet referencedDataFiles) {
+    this.deleteFiles = deleteFiles;
+    this.referencedDataFiles = referencedDataFiles;
+  }
+
+  public List<DeleteFile> deleteFiles() {
+    return deleteFiles;
+  }
+
+  public CharSequenceSet referencedDataFiles() {
+    return referencedDataFiles;
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/io/FileWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/FileWriter.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io;
+
+import java.io.Closeable;
+import java.io.IOException;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+
+/**
+ * A writer capable of writing files of a single type (i.e. data/delete) to one spec/partition.
+ * <p>
+ * As opposed to {@link FileAppender}, this interface should be implemented by classes that not only
+ * append records to files but actually produce {@link DataFile}s or {@link DeleteFile}s objects
+ * with Iceberg metadata. Implementations may wrap {@link FileAppender}s with extra information
+ * such as spec, partition, sort order ID needed to construct {@link DataFile}s or {@link DeleteFile}s.
+ *
+ * @param <T> the row type
+ * @param <R> the result type
+ */
+public interface FileWriter<T, R> extends Closeable {
+
+  /**
+   * Writes rows to a predefined spec/partition.
+   *
+   * @param rows data or delete records
+   * @throws IOException in case of an error during the write process
+   */
+  default void write(Iterable<T> rows) throws IOException {
+    for (T row : rows) {
+      write(row);
+    }
+  }
+
+  /**
+   * Writes a row to a predefined spec/partition.
+   *
+   * @param row a data or delete record
+   * @throws IOException in case of an error during the write process
+   */
+  void write(T row) throws IOException;
+
+  /**
+   * Returns the number of bytes that were currently written by this writer.
+   *
+   * @return the number of written bytes
+   */
+  long length();
+
+  /**
+   * Returns a result that contains information about written {@link DataFile}s or {@link DeleteFile}s.
+   * The result is valid only after the writer is closed.
+   *
+   * @return the file writer result
+   */
+  R result();
+}

--- a/core/src/main/java/org/apache/iceberg/io/FileWriterFactory.java
+++ b/core/src/main/java/org/apache/iceberg/io/FileWriterFactory.java
@@ -28,7 +28,7 @@ import org.apache.iceberg.encryption.EncryptedOutputFile;
 /**
  * A factory for creating data and delete writers.
  */
-public interface WriterFactory<T> {
+public interface FileWriterFactory<T> {
 
   /**
    * Creates a new {@link DataWriter}.

--- a/core/src/main/java/org/apache/iceberg/io/SortedPosDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/SortedPosDeleteWriter.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.io;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Comparator;
@@ -28,15 +27,17 @@ import java.util.Map;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.StructLike;
+import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.util.CharSequenceSet;
 import org.apache.iceberg.util.CharSequenceWrapper;
 
-class SortedPosDeleteWriter<T> implements Closeable {
+class SortedPosDeleteWriter<T> implements FileWriter<PositionDelete<T>, DeleteWriteResult> {
   private static final long DEFAULT_RECORDS_NUM_THRESHOLD = 100_000L;
 
   private final Map<CharSequenceWrapper, List<PosRow<T>>> posDeletes = Maps.newHashMap();
@@ -51,6 +52,7 @@ class SortedPosDeleteWriter<T> implements Closeable {
   private final long recordsNumThreshold;
 
   private int records = 0;
+  private boolean closed = false;
 
   SortedPosDeleteWriter(FileAppenderFactory<T> appenderFactory,
                         OutputFileFactory fileFactory,
@@ -69,6 +71,16 @@ class SortedPosDeleteWriter<T> implements Closeable {
                         FileFormat format,
                         StructLike partition) {
     this(appenderFactory, fileFactory, format, partition, DEFAULT_RECORDS_NUM_THRESHOLD);
+  }
+
+  @Override
+  public long length() {
+    throw new UnsupportedOperationException(this.getClass().getName() + " does not implement length");
+  }
+
+  @Override
+  public void write(PositionDelete<T> payload) throws IOException {
+    delete(payload.path(), payload.pos(), payload.row());
   }
 
   public void delete(CharSequence path, long pos) {
@@ -103,7 +115,16 @@ class SortedPosDeleteWriter<T> implements Closeable {
 
   @Override
   public void close() throws IOException {
-    flushDeletes();
+    if (!closed) {
+      flushDeletes();
+      this.closed = true;
+    }
+  }
+
+  @Override
+  public DeleteWriteResult result() {
+    Preconditions.checkState(closed, "Cannot get result from unclosed writer");
+    return new DeleteWriteResult(completedFiles, referencedDataFiles);
   }
 
   private void flushDeletes() {

--- a/data/src/main/java/org/apache/iceberg/data/BaseFileWriterFactory.java
+++ b/data/src/main/java/org/apache/iceberg/data/BaseFileWriterFactory.java
@@ -35,15 +35,15 @@ import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.encryption.EncryptionKeyMetadata;
 import org.apache.iceberg.io.DataWriter;
+import org.apache.iceberg.io.FileWriterFactory;
 import org.apache.iceberg.io.OutputFile;
-import org.apache.iceberg.io.WriterFactory;
 import org.apache.iceberg.orc.ORC;
 import org.apache.iceberg.parquet.Parquet;
 
 /**
  * A base writer factory to be extended by query engine integrations.
  */
-public abstract class BaseWriterFactory<T> implements WriterFactory<T> {
+public abstract class BaseFileWriterFactory<T> implements FileWriterFactory<T> {
   private final Table table;
   private final FileFormat dataFileFormat;
   private final Schema dataSchema;
@@ -54,10 +54,10 @@ public abstract class BaseWriterFactory<T> implements WriterFactory<T> {
   private final SortOrder equalityDeleteSortOrder;
   private final Schema positionDeleteRowSchema;
 
-  protected BaseWriterFactory(Table table, FileFormat dataFileFormat, Schema dataSchema,
-                              SortOrder dataSortOrder, FileFormat deleteFileFormat,
-                              int[] equalityFieldIds, Schema equalityDeleteRowSchema,
-                              SortOrder equalityDeleteSortOrder, Schema positionDeleteRowSchema) {
+  protected BaseFileWriterFactory(Table table, FileFormat dataFileFormat, Schema dataSchema,
+                                  SortOrder dataSortOrder, FileFormat deleteFileFormat,
+                                  int[] equalityFieldIds, Schema equalityDeleteRowSchema,
+                                  SortOrder equalityDeleteSortOrder, Schema positionDeleteRowSchema) {
     this.table = table;
     this.dataFileFormat = dataFileFormat;
     this.dataSchema = dataSchema;

--- a/data/src/test/java/org/apache/iceberg/io/TestWriterMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestWriterMetrics.java
@@ -91,7 +91,7 @@ public abstract class TestWriterMetrics<T> {
     this.fileFormat = fileFormat;
   }
 
-  protected abstract WriterFactory<T> newWriterFactory(Schema dataSchema);
+  protected abstract FileWriterFactory<T> newWriterFactory(Schema dataSchema);
 
   protected abstract T toRow(Integer id, String data, boolean boolValue, Long longValue);
 

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkFileWriterFactory.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkFileWriterFactory.java
@@ -17,51 +17,51 @@
  * under the License.
  */
 
-package org.apache.iceberg.spark.source;
+package org.apache.iceberg.flink.sink;
 
+import java.io.Serializable;
 import java.util.Locale;
 import java.util.Map;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.avro.Avro;
-import org.apache.iceberg.data.BaseWriterFactory;
+import org.apache.iceberg.data.BaseFileWriterFactory;
+import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.data.FlinkAvroWriter;
+import org.apache.iceberg.flink.data.FlinkOrcWriter;
+import org.apache.iceberg.flink.data.FlinkParquetWriters;
 import org.apache.iceberg.io.DeleteSchemaUtil;
 import org.apache.iceberg.orc.ORC;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.spark.SparkSchemaUtil;
-import org.apache.iceberg.spark.data.SparkAvroWriter;
-import org.apache.iceberg.spark.data.SparkOrcWriter;
-import org.apache.iceberg.spark.data.SparkParquetWriters;
-import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.types.StructField;
-import org.apache.spark.sql.types.StructType;
-import org.apache.spark.unsafe.types.UTF8String;
 
 import static org.apache.iceberg.MetadataColumns.DELETE_FILE_ROW_FIELD_NAME;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
 import static org.apache.iceberg.TableProperties.DELETE_DEFAULT_FILE_FORMAT;
 
-class SparkWriterFactory extends BaseWriterFactory<InternalRow> {
-  private StructType dataSparkType;
-  private StructType equalityDeleteSparkType;
-  private StructType positionDeleteSparkType;
+class FlinkFileWriterFactory extends BaseFileWriterFactory<RowData> implements Serializable {
+  private RowType dataFlinkType;
+  private RowType equalityDeleteFlinkType;
+  private RowType positionDeleteFlinkType;
 
-  SparkWriterFactory(Table table, FileFormat dataFileFormat, Schema dataSchema, StructType dataSparkType,
-                     SortOrder dataSortOrder, FileFormat deleteFileFormat,
-                     int[] equalityFieldIds, Schema equalityDeleteRowSchema, StructType equalityDeleteSparkType,
-                     SortOrder equalityDeleteSortOrder, Schema positionDeleteRowSchema,
-                     StructType positionDeleteSparkType) {
+  FlinkFileWriterFactory(Table table, FileFormat dataFileFormat, Schema dataSchema, RowType dataFlinkType,
+                         SortOrder dataSortOrder, FileFormat deleteFileFormat,
+                         int[] equalityFieldIds, Schema equalityDeleteRowSchema, RowType equalityDeleteFlinkType,
+                         SortOrder equalityDeleteSortOrder, Schema positionDeleteRowSchema,
+                         RowType positionDeleteFlinkType) {
 
     super(table, dataFileFormat, dataSchema, dataSortOrder, deleteFileFormat, equalityFieldIds,
         equalityDeleteRowSchema, equalityDeleteSortOrder, positionDeleteRowSchema);
 
-    this.dataSparkType = dataSparkType;
-    this.equalityDeleteSparkType = equalityDeleteSparkType;
-    this.positionDeleteSparkType = positionDeleteSparkType;
+    this.dataFlinkType = dataFlinkType;
+    this.equalityDeleteFlinkType = equalityDeleteFlinkType;
+    this.positionDeleteFlinkType = positionDeleteFlinkType;
   }
 
   static Builder builderFor(Table table) {
@@ -70,87 +70,86 @@ class SparkWriterFactory extends BaseWriterFactory<InternalRow> {
 
   @Override
   protected void configureDataWrite(Avro.DataWriteBuilder builder) {
-    builder.createWriterFunc(ignored -> new SparkAvroWriter(dataSparkType()));
+    builder.createWriterFunc(ignore -> new FlinkAvroWriter(dataFlinkType()));
   }
 
   @Override
   protected void configureEqualityDelete(Avro.DeleteWriteBuilder builder) {
-    builder.createWriterFunc(ignored -> new SparkAvroWriter(equalityDeleteSparkType()));
+    builder.createWriterFunc(ignored -> new FlinkAvroWriter(equalityDeleteFlinkType()));
   }
 
   @Override
   protected void configurePositionDelete(Avro.DeleteWriteBuilder builder) {
-    boolean withRow = positionDeleteSparkType().getFieldIndex(DELETE_FILE_ROW_FIELD_NAME).isDefined();
-    if (withRow) {
-      // SparkAvroWriter accepts just the Spark type of the row ignoring the path and pos
-      StructField rowField = positionDeleteSparkType().apply(DELETE_FILE_ROW_FIELD_NAME);
-      StructType positionDeleteRowSparkType = (StructType) rowField.dataType();
-      builder.createWriterFunc(ignored -> new SparkAvroWriter(positionDeleteRowSparkType));
+    int rowFieldIndex = positionDeleteFlinkType().getFieldIndex(DELETE_FILE_ROW_FIELD_NAME);
+    if (rowFieldIndex >= 0) {
+      // FlinkAvroWriter accepts just the Flink type of the row ignoring the path and pos
+      RowType positionDeleteRowFlinkType = (RowType) positionDeleteFlinkType().getTypeAt(rowFieldIndex);
+      builder.createWriterFunc(ignored -> new FlinkAvroWriter(positionDeleteRowFlinkType));
     }
   }
 
   @Override
   protected void configureDataWrite(Parquet.DataWriteBuilder builder) {
-    builder.createWriterFunc(msgType -> SparkParquetWriters.buildWriter(dataSparkType(), msgType));
+    builder.createWriterFunc(msgType -> FlinkParquetWriters.buildWriter(dataFlinkType(), msgType));
   }
 
   @Override
   protected void configureEqualityDelete(Parquet.DeleteWriteBuilder builder) {
-    builder.createWriterFunc(msgType -> SparkParquetWriters.buildWriter(equalityDeleteSparkType(), msgType));
+    builder.createWriterFunc(msgType -> FlinkParquetWriters.buildWriter(equalityDeleteFlinkType(), msgType));
   }
 
   @Override
   protected void configurePositionDelete(Parquet.DeleteWriteBuilder builder) {
-    builder.createWriterFunc(msgType -> SparkParquetWriters.buildWriter(positionDeleteSparkType(), msgType));
-    builder.transformPaths(path -> UTF8String.fromString(path.toString()));
+    builder.createWriterFunc(msgType -> FlinkParquetWriters.buildWriter(positionDeleteFlinkType(), msgType));
+    builder.transformPaths(path -> StringData.fromString(path.toString()));
   }
 
   @Override
   protected void configureDataWrite(ORC.DataWriteBuilder builder) {
-    builder.createWriterFunc(SparkOrcWriter::new);
+    builder.createWriterFunc((iSchema, typDesc) -> FlinkOrcWriter.buildWriter(dataFlinkType(), iSchema));
   }
 
-  private StructType dataSparkType() {
-    if (dataSparkType == null) {
+  private RowType dataFlinkType() {
+    if (dataFlinkType == null) {
       Preconditions.checkNotNull(dataSchema(), "Data schema must not be null");
-      this.dataSparkType = SparkSchemaUtil.convert(dataSchema());
+      this.dataFlinkType = FlinkSchemaUtil.convert(dataSchema());
     }
 
-    return dataSparkType;
+    return dataFlinkType;
   }
 
-  private StructType equalityDeleteSparkType() {
-    if (equalityDeleteSparkType == null) {
+  private RowType equalityDeleteFlinkType() {
+    if (equalityDeleteFlinkType == null) {
       Preconditions.checkNotNull(equalityDeleteRowSchema(), "Equality delete schema must not be null");
-      this.equalityDeleteSparkType = SparkSchemaUtil.convert(equalityDeleteRowSchema());
+      this.equalityDeleteFlinkType = FlinkSchemaUtil.convert(equalityDeleteRowSchema());
     }
 
-    return equalityDeleteSparkType;
+    return equalityDeleteFlinkType;
   }
 
-  private StructType positionDeleteSparkType() {
-    if (positionDeleteSparkType == null) {
+  private RowType positionDeleteFlinkType() {
+    if (positionDeleteFlinkType == null) {
       // wrap the optional row schema into the position delete schema that contains path and position
       Schema positionDeleteSchema = DeleteSchemaUtil.posDeleteSchema(positionDeleteRowSchema());
-      this.positionDeleteSparkType = SparkSchemaUtil.convert(positionDeleteSchema);
+      this.positionDeleteFlinkType = FlinkSchemaUtil.convert(positionDeleteSchema);
     }
 
-    return positionDeleteSparkType;
+    return positionDeleteFlinkType;
   }
 
   static class Builder {
     private final Table table;
     private FileFormat dataFileFormat;
     private Schema dataSchema;
-    private StructType dataSparkType;
+    private RowType dataFlinkType;
     private SortOrder dataSortOrder;
     private FileFormat deleteFileFormat;
     private int[] equalityFieldIds;
     private Schema equalityDeleteRowSchema;
-    private StructType equalityDeleteSparkType;
+    private RowType equalityDeleteFlinkType;
     private SortOrder equalityDeleteSortOrder;
     private Schema positionDeleteRowSchema;
-    private StructType positionDeleteSparkType;
+    private RowType positionDeleteFlinkType;
 
     Builder(Table table) {
       this.table = table;
@@ -174,8 +173,13 @@ class SparkWriterFactory extends BaseWriterFactory<InternalRow> {
       return this;
     }
 
-    Builder dataSparkType(StructType newDataSparkType) {
-      this.dataSparkType = newDataSparkType;
+    /**
+     * Sets a Flink type for data.
+     * <p>
+     * If not set, the value is derived from the provided Iceberg schema.
+     */
+    Builder dataFlinkType(RowType newDataFlinkType) {
+      this.dataFlinkType = newDataFlinkType;
       return this;
     }
 
@@ -199,8 +203,13 @@ class SparkWriterFactory extends BaseWriterFactory<InternalRow> {
       return this;
     }
 
-    Builder equalityDeleteSparkType(StructType newEqualityDeleteSparkType) {
-      this.equalityDeleteSparkType = newEqualityDeleteSparkType;
+    /**
+     * Sets a Flink type for equality deletes.
+     * <p>
+     * If not set, the value is derived from the provided Iceberg schema.
+     */
+    Builder equalityDeleteFlinkType(RowType newEqualityDeleteFlinkType) {
+      this.equalityDeleteFlinkType = newEqualityDeleteFlinkType;
       return this;
     }
 
@@ -214,21 +223,26 @@ class SparkWriterFactory extends BaseWriterFactory<InternalRow> {
       return this;
     }
 
-    Builder positionDeleteSparkType(StructType newPositionDeleteSparkType) {
-      this.positionDeleteSparkType = newPositionDeleteSparkType;
+    /**
+     * Sets a Flink type for position deletes.
+     * <p>
+     * If not set, the value is derived from the provided Iceberg schema.
+     */
+    Builder positionDeleteFlinkType(RowType newPositionDeleteFlinkType) {
+      this.positionDeleteFlinkType = newPositionDeleteFlinkType;
       return this;
     }
 
-    SparkWriterFactory build() {
+    FlinkFileWriterFactory build() {
       boolean noEqualityDeleteConf = equalityFieldIds == null && equalityDeleteRowSchema == null;
       boolean fullEqualityDeleteConf = equalityFieldIds != null && equalityDeleteRowSchema != null;
       Preconditions.checkArgument(noEqualityDeleteConf || fullEqualityDeleteConf,
           "Equality field IDs and equality delete row schema must be set together");
 
-      return new SparkWriterFactory(
-          table, dataFileFormat, dataSchema, dataSparkType, dataSortOrder, deleteFileFormat,
-          equalityFieldIds, equalityDeleteRowSchema, equalityDeleteSparkType, equalityDeleteSortOrder,
-          positionDeleteRowSchema, positionDeleteSparkType);
+      return new FlinkFileWriterFactory(
+          table, dataFileFormat, dataSchema, dataFlinkType, dataSortOrder, deleteFileFormat,
+          equalityFieldIds, equalityDeleteRowSchema, equalityDeleteFlinkType, equalityDeleteSortOrder,
+          positionDeleteRowSchema, positionDeleteFlinkType);
     }
   }
 }

--- a/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkFileWriterFactory.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkFileWriterFactory.java
@@ -27,21 +27,22 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.RowDataWrapper;
 import org.apache.iceberg.flink.SimpleDataUtil;
-import org.apache.iceberg.io.TestWriterFactory;
-import org.apache.iceberg.io.WriterFactory;
+import org.apache.iceberg.io.FileWriterFactory;
+import org.apache.iceberg.io.TestFileWriterFactory;
 import org.apache.iceberg.util.ArrayUtil;
 import org.apache.iceberg.util.StructLikeSet;
 
-public class TestFlinkWriterFactory extends TestWriterFactory<RowData> {
+public class TestFlinkFileWriterFactory extends TestFileWriterFactory<RowData> {
 
-  public TestFlinkWriterFactory(FileFormat fileFormat, boolean partitioned) {
+  public TestFlinkFileWriterFactory(FileFormat fileFormat, boolean partitioned) {
     super(fileFormat, partitioned);
   }
 
   @Override
-  protected WriterFactory<RowData> newWriterFactory(Schema dataSchema, List<Integer> equalityFieldIds,
-                                                    Schema equalityDeleteRowSchema, Schema positionDeleteRowSchema) {
-    return FlinkWriterFactory.builderFor(table)
+  protected FileWriterFactory<RowData> newWriterFactory(Schema dataSchema, List<Integer> equalityFieldIds,
+                                                        Schema equalityDeleteRowSchema,
+                                                        Schema positionDeleteRowSchema) {
+    return FlinkFileWriterFactory.builderFor(table)
         .dataSchema(table.schema())
         .dataFileFormat(format())
         .deleteFileFormat(format())

--- a/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkWriterMetrics.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkWriterMetrics.java
@@ -24,8 +24,8 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.io.FileWriterFactory;
 import org.apache.iceberg.io.TestWriterMetrics;
-import org.apache.iceberg.io.WriterFactory;
 
 public class TestFlinkWriterMetrics extends TestWriterMetrics<RowData> {
 
@@ -34,8 +34,8 @@ public class TestFlinkWriterMetrics extends TestWriterMetrics<RowData> {
   }
 
   @Override
-  protected WriterFactory<RowData> newWriterFactory(Schema dataSchema) {
-    return FlinkWriterFactory.builderFor(table)
+  protected FileWriterFactory<RowData> newWriterFactory(Schema dataSchema) {
+    return FlinkFileWriterFactory.builderFor(table)
         .dataSchema(table.schema())
         .dataFileFormat(fileFormat)
         .deleteFileFormat(fileFormat)

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkFileWriterFactory.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkFileWriterFactory.java
@@ -22,8 +22,8 @@ package org.apache.iceberg.spark.source;
 import java.util.List;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Schema;
-import org.apache.iceberg.io.TestWriterFactory;
-import org.apache.iceberg.io.WriterFactory;
+import org.apache.iceberg.io.FileWriterFactory;
+import org.apache.iceberg.io.TestFileWriterFactory;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.util.ArrayUtil;
 import org.apache.iceberg.util.StructLikeSet;
@@ -32,17 +32,17 @@ import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.unsafe.types.UTF8String;
 
-public class TestSparkWriterFactory extends TestWriterFactory<InternalRow> {
+public class TestSparkFileWriterFactory extends TestFileWriterFactory<InternalRow> {
 
-  public TestSparkWriterFactory(FileFormat fileFormat, boolean partitioned) {
+  public TestSparkFileWriterFactory(FileFormat fileFormat, boolean partitioned) {
     super(fileFormat, partitioned);
   }
 
   @Override
-  protected WriterFactory<InternalRow> newWriterFactory(Schema dataSchema, List<Integer> equalityFieldIds,
-                                                        Schema equalityDeleteRowSchema,
-                                                        Schema positionDeleteRowSchema) {
-    return SparkWriterFactory.builderFor(table)
+  protected FileWriterFactory<InternalRow> newWriterFactory(Schema dataSchema, List<Integer> equalityFieldIds,
+                                                            Schema equalityDeleteRowSchema,
+                                                            Schema positionDeleteRowSchema) {
+    return SparkFileWriterFactory.builderFor(table)
         .dataSchema(table.schema())
         .dataFileFormat(format())
         .deleteFileFormat(format())

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkWriterMetrics.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkWriterMetrics.java
@@ -21,8 +21,8 @@ package org.apache.iceberg.spark.source;
 
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.io.FileWriterFactory;
 import org.apache.iceberg.io.TestWriterMetrics;
-import org.apache.iceberg.io.WriterFactory;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.unsafe.types.UTF8String;
@@ -34,8 +34,8 @@ public class TestSparkWriterMetrics extends TestWriterMetrics<InternalRow> {
   }
 
   @Override
-  protected WriterFactory<InternalRow> newWriterFactory(Schema dataSchema) {
-    return SparkWriterFactory.builderFor(table)
+  protected FileWriterFactory<InternalRow> newWriterFactory(Schema dataSchema) {
+    return SparkFileWriterFactory.builderFor(table)
         .dataSchema(table.schema())
         .dataFileFormat(fileFormat)
         .deleteFileFormat(fileFormat)


### PR DESCRIPTION
This PR adds the `FileWriter` interface that defines a contract for writing a number of files of a single type within one spec/partition.