### PR TITLE
Core: Avoid throwing IOException in new write methods

### DIFF
--- a/core/src/main/java/org/apache/iceberg/deletes/EqualityDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/EqualityDeleteWriter.java
@@ -58,7 +58,7 @@ public class EqualityDeleteWriter<T> implements FileWriter<T, DeleteWriteResult>
   }
 
   @Override
-  public void write(T row) throws IOException {
+  public void write(T row) {
     appender.add(row);
   }
 

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteWriter.java
@@ -57,7 +57,7 @@ public class PositionDeleteWriter<T> implements FileWriter<PositionDelete<T>, De
   }
 
   @Override
-  public void write(PositionDelete<T> positionDelete) throws IOException {
+  public void write(PositionDelete<T> positionDelete) {
     referencedDataFiles.add(positionDelete.path());
     appender.add(positionDelete);
   }

--- a/core/src/main/java/org/apache/iceberg/io/FanoutWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/FanoutWriter.java
@@ -49,7 +49,7 @@ abstract class FanoutWriter<T, R> implements PartitioningWriter<T, R> {
   protected abstract R aggregatedResult();
 
   @Override
-  public void write(T row, PartitionSpec spec, StructLike partition) throws IOException {
+  public void write(T row, PartitionSpec spec, StructLike partition) {
     FileWriter<T, R> writer = writer(spec, partition);
     writer.write(row);
   }

--- a/core/src/main/java/org/apache/iceberg/io/FileWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/FileWriter.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.io;
 
 import java.io.Closeable;
-import java.io.IOException;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 
@@ -41,9 +40,8 @@ public interface FileWriter<T, R> extends Closeable {
    * Writes rows to a predefined spec/partition.
    *
    * @param rows data or delete records
-   * @throws IOException in case of an error during the write process
    */
-  default void write(Iterable<T> rows) throws IOException {
+  default void write(Iterable<T> rows) {
     for (T row : rows) {
       write(row);
     }
@@ -53,9 +51,8 @@ public interface FileWriter<T, R> extends Closeable {
    * Writes a row to a predefined spec/partition.
    *
    * @param row a data or delete record
-   * @throws IOException in case of an error during the write process
    */
-  void write(T row) throws IOException;
+  void write(T row);
 
   /**
    * Returns the number of bytes that were currently written by this writer.

--- a/core/src/main/java/org/apache/iceberg/io/PartitioningWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/PartitioningWriter.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.io;
 
 import java.io.Closeable;
-import java.io.IOException;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.PartitionSpec;
@@ -46,9 +45,8 @@ public interface PartitioningWriter<T, R> extends Closeable {
    * @param row a data or delete record
    * @param spec a partition spec
    * @param partition a partition or null if the spec is unpartitioned
-   * @throws IOException in case of an error during the write process
    */
-  void write(T row, PartitionSpec spec, StructLike partition) throws IOException;
+  void write(T row, PartitionSpec spec, StructLike partition);
 
   /**
    * Returns a result that contains information about written {@link DataFile}s or {@link DeleteFile}s.

--- a/core/src/main/java/org/apache/iceberg/io/SortedPosDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/SortedPosDeleteWriter.java
@@ -79,7 +79,7 @@ class SortedPosDeleteWriter<T> implements FileWriter<PositionDelete<T>, DeleteWr
   }
 
   @Override
-  public void write(PositionDelete<T> payload) throws IOException {
+  public void write(PositionDelete<T> payload) {
     delete(payload.path(), payload.pos(), payload.row());
   }
 

--- a/data/src/test/java/org/apache/iceberg/io/TestPartitioningWriters.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestPartitioningWriters.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.io;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.List;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
@@ -152,13 +151,7 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
 
     AssertHelpers.assertThrows("Should fail to write out of order partitions",
         IllegalStateException.class, "Encountered records that belong to already closed files",
-        () -> {
-          try {
-            writer.write(toRow(6, "aaa"), spec, partitionKey(spec, "aaa"));
-          } catch (IOException e) {
-            throw new UncheckedIOException(e);
-          }
-        });
+        () -> writer.write(toRow(6, "aaa"), spec, partitionKey(spec, "aaa")));
 
     writer.close();
   }
@@ -303,23 +296,11 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
 
     AssertHelpers.assertThrows("Should fail to write out of order partitions",
         IllegalStateException.class, "Encountered records that belong to already closed files",
-        () -> {
-          try {
-            writer.write(toRow(7, "ccc"), identitySpec, partitionKey(identitySpec, "ccc"));
-          } catch (IOException e) {
-            throw new UncheckedIOException(e);
-          }
-        });
+        () -> writer.write(toRow(7, "ccc"), identitySpec, partitionKey(identitySpec, "ccc")));
 
     AssertHelpers.assertThrows("Should fail to write out of order specs",
         IllegalStateException.class, "Encountered records that belong to already closed files",
-        () -> {
-          try {
-            writer.write(toRow(7, "aaa"), unpartitionedSpec, null);
-          } catch (IOException e) {
-            throw new UncheckedIOException(e);
-          }
-        });
+        () -> writer.write(toRow(7, "aaa"), unpartitionedSpec, null));
 
     writer.close();
   }
@@ -459,23 +440,15 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
     AssertHelpers.assertThrows("Should fail to write out of order partitions",
         IllegalStateException.class, "Encountered records that belong to already closed files",
         () -> {
-          try {
-            PositionDelete<T> positionDelete = positionDelete("file-5.parquet", 1L, null);
-            writer.write(positionDelete, identitySpec, partitionKey(identitySpec, "ccc"));
-          } catch (IOException e) {
-            throw new UncheckedIOException(e);
-          }
+          PositionDelete<T> positionDelete = positionDelete("file-5.parquet", 1L, null);
+          writer.write(positionDelete, identitySpec, partitionKey(identitySpec, "ccc"));
         });
 
     AssertHelpers.assertThrows("Should fail to write out of order specs",
         IllegalStateException.class, "Encountered records that belong to already closed files",
         () -> {
-          try {
-            PositionDelete<T> positionDelete = positionDelete("file-1.parquet", 3L, null);
-            writer.write(positionDelete, unpartitionedSpec, null);
-          } catch (IOException e) {
-            throw new UncheckedIOException(e);
-          }
+          PositionDelete<T> positionDelete = positionDelete("file-1.parquet", 3L, null);
+          writer.write(positionDelete, unpartitionedSpec, null);
         });
 
     writer.close();


### PR DESCRIPTION
This method removes `IOException` from `write` methods in new writers.

This is a follow-up to address [this](https://github.com/apache/iceberg/pull/3164#discussion_r715166505) comment and make using the new APIs easier. This also aligns new classes with existing writers and appenders.