### PR TITLE
Spark: Rewrite adjust check group count before to group stream

### DIFF
--- a/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
@@ -125,12 +125,13 @@ abstract class BaseRewriteDataFilesSparkAction
 
     Map<StructLike, List<List<FileScanTask>>> fileGroupsByPartition = planFileGroups(startingSnapshotId);
     RewriteExecutionContext ctx = new RewriteExecutionContext(fileGroupsByPartition);
-    Stream<RewriteFileGroup> groupStream = toGroupStream(ctx, fileGroupsByPartition);
 
     if (ctx.totalGroupCount() == 0) {
       LOG.info("Nothing found to rewrite in {}", table.name());
       return new BaseRewriteDataFilesResult(Collections.emptyList());
     }
+
+    Stream<RewriteFileGroup> groupStream = toGroupStream(ctx, fileGroupsByPartition);
 
     RewriteDataFilesCommitManager commitManager = commitManager(startingSnapshotId);
     if (partialProgressEnabled) {


### PR DESCRIPTION
It should be checked whether there is no need to rewrite before calling the `toGroupStream()` method, so as to reduce the code logic that does not need to be rewritten.

cc @RussellSpitzer @rdblue @aokolnychyi 