### PR TITLE
AWS: Add check to create staging directory if not exists for S3OutputStream

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/OutputFile.java
+++ b/api/src/main/java/org/apache/iceberg/io/OutputFile.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.io;
 
 import java.io.IOException;
+import java.security.AccessControlException;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 
@@ -48,6 +49,7 @@ public interface OutputFile {
    *
    * @return an output stream that can report its position
    * @throws RuntimeIOException If the implementation throws an {@link IOException}
+   * @throws AccessControlException If the implementation throws an {@link SecurityException}
    */
   PositionOutputStream createOrOverwrite();
 

--- a/api/src/main/java/org/apache/iceberg/io/OutputFile.java
+++ b/api/src/main/java/org/apache/iceberg/io/OutputFile.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.io;
 
 import java.io.IOException;
-import java.security.AccessControlException;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 
@@ -49,7 +48,7 @@ public interface OutputFile {
    *
    * @return an output stream that can report its position
    * @throws RuntimeIOException If the implementation throws an {@link IOException}
-   * @throws AccessControlException If the implementation throws an {@link SecurityException}
+   * @throws SecurityException If staging directory creation fails due to missing JVM level permission
    */
   PositionOutputStream createOrOverwrite();
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.aws.s3;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.security.AccessControlException;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.io.InputFile;
@@ -63,9 +62,6 @@ public class S3OutputFile extends BaseS3File implements OutputFile {
       return new S3OutputStream(client(), uri(), awsProperties());
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to create output stream for location: " + uri(), e);
-    } catch (SecurityException e) {
-      throw new AccessControlException(
-          "Access denied while creating staging directory for output stream: " + uri());
     }
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.aws.s3;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.security.AccessControlException;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.io.InputFile;
@@ -62,6 +63,9 @@ public class S3OutputFile extends BaseS3File implements OutputFile {
       return new S3OutputStream(client(), uri(), awsProperties());
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to create output stream for location: " + uri(), e);
+    } catch (SecurityException e) {
+      throw new AccessControlException(
+          "Access denied while creating staging directory for output stream: " + uri());
     }
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -175,8 +175,15 @@ class S3OutputStream extends PositionOutputStream {
       stream.close();
     }
 
+    boolean createStagingDirectory = false;
+    if (!stagingDirectory.exists()) {
+      createStagingDirectory = stagingDirectory.mkdirs();
+    }
     currentStagingFile = File.createTempFile("s3fileio-", ".tmp", stagingDirectory);
     currentStagingFile.deleteOnExit();
+    if (createStagingDirectory) {
+      stagingDirectory.deleteOnExit();
+    }
     stagingFiles.add(currentStagingFile);
 
     stream = new CountingOutputStream(new BufferedOutputStream(new FileOutputStream(currentStagingFile)));

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -330,11 +330,22 @@ class S3OutputStream extends PositionOutputStream {
     }
   }
 
-  private void createStagingDirectoryIfNotExists() throws SecurityException {
+  private void createStagingDirectoryIfNotExists() throws IOException, SecurityException {
     if (!stagingDirectory.exists()) {
+      LOG.info("Staging directory: {} does not exist, trying to create one",
+          stagingDirectory.getAbsolutePath());
       boolean createdStagingDirectory = stagingDirectory.mkdirs();
       if (createdStagingDirectory) {
         LOG.info("Successfully created staging directory: {}", stagingDirectory.getAbsolutePath());
+      } else {
+        if (stagingDirectory.exists()) {
+          LOG.info("Staging directory: {} is created by another process",
+              stagingDirectory.getAbsolutePath());
+        } else {
+          throw new IOException(String
+              .format("Staging directory: %s creation failed due to some unknown reason",
+                  stagingDirectory.getAbsolutePath()));
+        }
       }
     }
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -331,7 +331,7 @@ class S3OutputStream extends PositionOutputStream {
 
   private void createStagingDirectoryIfNotExists() throws IOException, SecurityException {
     if (!stagingDirectory.exists()) {
-      LOG.info("Staging directory: {} does not exist, trying to create one",
+      LOG.info("Staging directory does not exist, trying to create one: {}",
           stagingDirectory.getAbsolutePath());
       boolean createdStagingDirectory = stagingDirectory.mkdirs();
       if (createdStagingDirectory) {

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -335,8 +335,6 @@ class S3OutputStream extends PositionOutputStream {
       boolean createdStagingDirectory = stagingDirectory.mkdirs();
       if (createdStagingDirectory) {
         LOG.info("Successfully created staging directory: {}", stagingDirectory.getAbsolutePath());
-      } else {
-        LOG.error("Staging directory: {} creation failed", stagingDirectory.getAbsolutePath());
       }
     }
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -86,8 +86,7 @@ class S3OutputStream extends PositionOutputStream {
   private boolean closed = false;
 
   @SuppressWarnings("StaticAssignmentInConstructor")
-  S3OutputStream(S3Client s3, S3URI location, AwsProperties awsProperties)
-      throws IOException, SecurityException {
+  S3OutputStream(S3Client s3, S3URI location, AwsProperties awsProperties) throws IOException {
     if (executorService == null) {
       synchronized (S3OutputStream.class) {
         if (executorService == null) {
@@ -171,7 +170,7 @@ class S3OutputStream extends PositionOutputStream {
     }
   }
 
-  private void newStream() throws IOException, SecurityException {
+  private void newStream() throws IOException {
     if (stream != null) {
       stream.close();
     }
@@ -339,12 +338,12 @@ class S3OutputStream extends PositionOutputStream {
         LOG.info("Successfully created staging directory: {}", stagingDirectory.getAbsolutePath());
       } else {
         if (stagingDirectory.exists()) {
-          LOG.info("Staging directory: {} is created by another process",
+          LOG.info("Successfully created staging directory by another process: {}",
               stagingDirectory.getAbsolutePath());
         } else {
-          throw new IOException(String
-              .format("Staging directory: %s creation failed due to some unknown reason",
-                  stagingDirectory.getAbsolutePath()));
+          throw new IOException(
+              "Failed to create staging directory due to some unknown reason: " + stagingDirectory
+                  .getAbsolutePath());
         }
       }
     }


### PR DESCRIPTION
Fix for #2991 

Seems like for EMR 6.x (Spark 3.x) Iceberg attempts to write the temp files ([S3FileIO Reference](https://iceberg.apache.org/aws/#progressive-multipart-upload)) before the `tmp` directory is created in some cases. This results in `java.io.IOException: No such file or directory` exception. 

The `tmp` files look something like this by default (here `System.getProperty("java.io.tmpdir")` is `/mnt1/yarn/usercache/hadoop/appcache/application_1632368478936_0042/container_1632368478936_0042_01_000001/tmp`):

```
/mnt1/yarn/usercache/hadoop/appcache/application_1632368478936_0042/container_1632368478936_0042_01_000001/tmp/s3fileio-2279038237918274355.tmp
/mnt1/yarn/usercache/hadoop/appcache/application_1632368478936_0042/container_1632368478936_0042_01_000001/tmp/s3fileio-2279038237918274355.tmp
/mnt1/yarn/usercache/hadoop/appcache/application_1632368478936_0042/container_1632368478936_0042_01_000001/tmp/s3fileio-2279038237918274355.tmp
```

(or) something like this if `s3fileIoStagingDirectory` is set via `s3.staging-dir` (`/mnt/tmp` for this case):
```
/mnt/tmp/s3fileio-6715538145691725671.tmp
/mnt/tmp/s3fileio-5266666342669697861.tmp
/mnt/tmp/s3fileio-4592572815837116260.tmp
```

Adding a defensive check to ensure we check the existence of the staging directory before writing the temp files. With this check I could see the executor tasks succeeding in `cluster` deploy mode consistently. 

Configurations for testing: 
- EMR 6.4.0, Iceberg 0.12.0, Master node: 1 instance, Core node: 10 instances, Spark 3.1.2
- EMR 6.2.0, Iceberg 0.11.1, Master node: 1 instance, Core node: 10 instances, Spark 3.0.1

Final Status of jobs deployed in cluster mode:

<img width="1208" alt="Screenshot 2021-09-27 at 4 54 27 PM" src="https://user-images.githubusercontent.com/4561678/134899328-d9305b88-0f63-438a-8c33-b19315fa296d.png">