### PR TITLE
Parquet: make row group check (min and max record count) configurable.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -115,12 +115,16 @@ public class TableProperties {
   public static final String DELETE_PARQUET_COMPRESSION_LEVEL = "write.delete.parquet.compression-level";
   public static final String PARQUET_COMPRESSION_LEVEL_DEFAULT = null;
 
-  public static final String PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT = "write.parquet.row-group-check-min-record-count";
-  public static final String DELETE_PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT = "write.delete.parquet.row-group-check-min-record-count";
+  public static final String PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT =
+      "write.parquet.row-group-check-min-record-count";
+  public static final String DELETE_PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT =
+      "write.delete.parquet.row-group-check-min-record-count";
   public static final String PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT_DEFAULT = "100";
 
-  public static final String PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT = "write.parquet.row-group-check-max-record-count";
-  public static final String DELETE_PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT = "write.delete.parquet.row-group-check-max-record-count";
+  public static final String PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT =
+      "write.parquet.row-group-check-max-record-count";
+  public static final String DELETE_PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT =
+      "write.delete.parquet.row-group-check-max-record-count";
   public static final String PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT_DEFAULT = "10000";
 
   public static final String AVRO_COMPRESSION = "write.avro.compression-codec";

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -97,15 +97,15 @@ public class TableProperties {
 
   public static final String PARQUET_ROW_GROUP_SIZE_BYTES = "write.parquet.row-group-size-bytes";
   public static final String DELETE_PARQUET_ROW_GROUP_SIZE_BYTES = "write.delete.parquet.row-group-size-bytes";
-  public static final String PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT = "134217728"; // 128 MB
+  public static final int PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT = 134217728; // 128 MB
 
   public static final String PARQUET_PAGE_SIZE_BYTES = "write.parquet.page-size-bytes";
   public static final String DELETE_PARQUET_PAGE_SIZE_BYTES = "write.delete.parquet.page-size-bytes";
-  public static final String PARQUET_PAGE_SIZE_BYTES_DEFAULT = "1048576"; // 1 MB
+  public static final int PARQUET_PAGE_SIZE_BYTES_DEFAULT = 1048576; // 1 MB
 
   public static final String PARQUET_DICT_SIZE_BYTES = "write.parquet.dict-size-bytes";
   public static final String DELETE_PARQUET_DICT_SIZE_BYTES = "write.delete.parquet.dict-size-bytes";
-  public static final String PARQUET_DICT_SIZE_BYTES_DEFAULT = "2097152"; // 2 MB
+  public static final int PARQUET_DICT_SIZE_BYTES_DEFAULT = 2097152; // 2 MB
 
   public static final String PARQUET_COMPRESSION = "write.parquet.compression-codec";
   public static final String DELETE_PARQUET_COMPRESSION = "write.delete.parquet.compression-codec";
@@ -119,13 +119,13 @@ public class TableProperties {
       "write.parquet.row-group-check-min-record-count";
   public static final String DELETE_PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT =
       "write.delete.parquet.row-group-check-min-record-count";
-  public static final String PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT_DEFAULT = "100";
+  public static final int PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT_DEFAULT = 100;
 
   public static final String PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT =
       "write.parquet.row-group-check-max-record-count";
   public static final String DELETE_PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT =
       "write.delete.parquet.row-group-check-max-record-count";
-  public static final String PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT_DEFAULT = "10000";
+  public static final int PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT_DEFAULT = 10000;
 
   public static final String AVRO_COMPRESSION = "write.avro.compression-codec";
   public static final String DELETE_AVRO_COMPRESSION = "write.delete.avro.compression-codec";

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -115,6 +115,14 @@ public class TableProperties {
   public static final String DELETE_PARQUET_COMPRESSION_LEVEL = "write.delete.parquet.compression-level";
   public static final String PARQUET_COMPRESSION_LEVEL_DEFAULT = null;
 
+  public static final String PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT = "write.parquet.row-group-check-min-record-count";
+  public static final String DELETE_PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT = "write.delete.parquet.row-group-check-min-record-count";
+  public static final String PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT_DEFAULT = "100";
+
+  public static final String PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT = "write.parquet.row-group-check-max-record-count";
+  public static final String DELETE_PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT = "write.delete.parquet.row-group-check-max-record-count";
+  public static final String PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT_DEFAULT = "10000";
+
   public static final String AVRO_COMPRESSION = "write.avro.compression-codec";
   public static final String DELETE_AVRO_COMPRESSION = "write.delete.avro.compression-codec";
   public static final String AVRO_COMPRESSION_DEFAULT = "gzip";

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -317,24 +317,37 @@ public class Parquet {
       }
 
       static Context dataContext(Map<String, String> config) {
-        int rowGroupSize = Integer.parseInt(config.getOrDefault(
-            PARQUET_ROW_GROUP_SIZE_BYTES, PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT));
+        int rowGroupSize = PropertyUtil.propertyAsInt(config,
+            PARQUET_ROW_GROUP_SIZE_BYTES, PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT);
+        Preconditions.checkArgument(rowGroupSize > 0,
+            "Row group size must be > 0");
 
-        int pageSize = Integer.parseInt(config.getOrDefault(
-            PARQUET_PAGE_SIZE_BYTES, PARQUET_PAGE_SIZE_BYTES_DEFAULT));
+        int pageSize = PropertyUtil.propertyAsInt(config,
+            PARQUET_PAGE_SIZE_BYTES, PARQUET_PAGE_SIZE_BYTES_DEFAULT);
+        Preconditions.checkArgument(pageSize > 0,
+            "Page size must be > 0");
 
-        int dictionaryPageSize = Integer.parseInt(config.getOrDefault(
-            PARQUET_DICT_SIZE_BYTES, PARQUET_DICT_SIZE_BYTES_DEFAULT));
+        int dictionaryPageSize = PropertyUtil.propertyAsInt(config,
+            PARQUET_DICT_SIZE_BYTES, PARQUET_DICT_SIZE_BYTES_DEFAULT);
+        Preconditions.checkArgument(dictionaryPageSize > 0,
+            "Dictionary page size must be > 0");
 
         String codecAsString = config.getOrDefault(PARQUET_COMPRESSION, PARQUET_COMPRESSION_DEFAULT);
         CompressionCodecName codec = toCodec(codecAsString);
 
         String compressionLevel = config.getOrDefault(PARQUET_COMPRESSION_LEVEL, PARQUET_COMPRESSION_LEVEL_DEFAULT);
 
-        int rowGroupCheckMinRecordCount = Integer.parseInt(config.getOrDefault(
-            PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT, PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT_DEFAULT));
-        int rowGroupCheckMaxRecordCount = Integer.parseInt(config.getOrDefault(
-            PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT, PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT_DEFAULT));
+        int rowGroupCheckMinRecordCount = PropertyUtil.propertyAsInt(config,
+            PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT, PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT_DEFAULT);
+        Preconditions.checkArgument(rowGroupCheckMinRecordCount > 0,
+            "Row group check minimal record count must be > 0");
+
+        int rowGroupCheckMaxRecordCount = PropertyUtil.propertyAsInt(config,
+            PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT, PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT_DEFAULT);
+        Preconditions.checkArgument(rowGroupCheckMaxRecordCount > 0,
+            "Row group check maximum record count must be > 0");
+        Preconditions.checkArgument(rowGroupCheckMaxRecordCount >= rowGroupCheckMinRecordCount,
+            "Row group check maximum record count must be >= minimal record count");
 
         return new Context(rowGroupSize, pageSize, dictionaryPageSize, codec, compressionLevel,
             rowGroupCheckMinRecordCount, rowGroupCheckMaxRecordCount);
@@ -346,12 +359,18 @@ public class Parquet {
 
         int rowGroupSize = PropertyUtil.propertyAsInt(config,
             DELETE_PARQUET_ROW_GROUP_SIZE_BYTES, dataContext.rowGroupSize());
+        Preconditions.checkArgument(rowGroupSize > 0,
+            "Row group size must be > 0");
 
         int pageSize = PropertyUtil.propertyAsInt(config,
             DELETE_PARQUET_PAGE_SIZE_BYTES, dataContext.pageSize());
+        Preconditions.checkArgument(pageSize > 0,
+            "Page size must be > 0");
 
         int dictionaryPageSize = PropertyUtil.propertyAsInt(config,
             DELETE_PARQUET_DICT_SIZE_BYTES, dataContext.dictionaryPageSize());
+        Preconditions.checkArgument(dictionaryPageSize > 0,
+            "Dictionary page size must be > 0");
 
         String codecAsString = config.get(DELETE_PARQUET_COMPRESSION);
         CompressionCodecName codec = codecAsString != null ? toCodec(codecAsString) : dataContext.codec();
@@ -360,8 +379,15 @@ public class Parquet {
 
         int rowGroupCheckMinRecordCount = PropertyUtil.propertyAsInt(config,
             DELETE_PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT, dataContext.rowGroupCheckMinRecordCount());
+        Preconditions.checkArgument(rowGroupCheckMinRecordCount > 0,
+            "Row group check minimal record count must be > 0");
+
         int rowGroupCheckMaxRecordCount = PropertyUtil.propertyAsInt(config,
             DELETE_PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT, dataContext.rowGroupCheckMaxRecordCount());
+        Preconditions.checkArgument(rowGroupCheckMaxRecordCount > 0,
+            "Row group check maximum record count must be > 0");
+        Preconditions.checkArgument(rowGroupCheckMaxRecordCount >= rowGroupCheckMinRecordCount,
+            "Row group check maximum record count must be >= minimal record count");
 
         return new Context(rowGroupSize, pageSize, dictionaryPageSize, codec, compressionLevel,
             rowGroupCheckMinRecordCount, rowGroupCheckMaxRecordCount);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -319,18 +319,15 @@ public class Parquet {
       static Context dataContext(Map<String, String> config) {
         int rowGroupSize = PropertyUtil.propertyAsInt(config,
             PARQUET_ROW_GROUP_SIZE_BYTES, PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT);
-        Preconditions.checkArgument(rowGroupSize > 0,
-            "Row group size must be > 0");
+        Preconditions.checkArgument(rowGroupSize > 0, "Row group size must be > 0");
 
         int pageSize = PropertyUtil.propertyAsInt(config,
             PARQUET_PAGE_SIZE_BYTES, PARQUET_PAGE_SIZE_BYTES_DEFAULT);
-        Preconditions.checkArgument(pageSize > 0,
-            "Page size must be > 0");
+        Preconditions.checkArgument(pageSize > 0, "Page size must be > 0");
 
         int dictionaryPageSize = PropertyUtil.propertyAsInt(config,
             PARQUET_DICT_SIZE_BYTES, PARQUET_DICT_SIZE_BYTES_DEFAULT);
-        Preconditions.checkArgument(dictionaryPageSize > 0,
-            "Dictionary page size must be > 0");
+        Preconditions.checkArgument(dictionaryPageSize > 0, "Dictionary page size must be > 0");
 
         String codecAsString = config.getOrDefault(PARQUET_COMPRESSION, PARQUET_COMPRESSION_DEFAULT);
         CompressionCodecName codec = toCodec(codecAsString);
@@ -359,18 +356,15 @@ public class Parquet {
 
         int rowGroupSize = PropertyUtil.propertyAsInt(config,
             DELETE_PARQUET_ROW_GROUP_SIZE_BYTES, dataContext.rowGroupSize());
-        Preconditions.checkArgument(rowGroupSize > 0,
-            "Row group size must be > 0");
+        Preconditions.checkArgument(rowGroupSize > 0, "Row group size must be > 0");
 
         int pageSize = PropertyUtil.propertyAsInt(config,
             DELETE_PARQUET_PAGE_SIZE_BYTES, dataContext.pageSize());
-        Preconditions.checkArgument(pageSize > 0,
-            "Page size must be > 0");
+        Preconditions.checkArgument(pageSize > 0, "Page size must be > 0");
 
         int dictionaryPageSize = PropertyUtil.propertyAsInt(config,
             DELETE_PARQUET_DICT_SIZE_BYTES, dataContext.dictionaryPageSize());
-        Preconditions.checkArgument(dictionaryPageSize > 0,
-            "Dictionary page size must be > 0");
+        Preconditions.checkArgument(dictionaryPageSize > 0, "Dictionary page size must be > 0");
 
         String codecAsString = config.get(DELETE_PARQUET_COMPRESSION);
         CompressionCodecName codec = codecAsString != null ? toCodec(codecAsString) : dataContext.codec();

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
@@ -31,7 +31,6 @@ import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.common.DynMethods;
-import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -114,13 +113,13 @@ class ParquetWriter<T> implements FileAppender<T>, Closeable {
         this.writer = new ParquetFileWriter(
             ParquetIO.file(output, conf), parquetSchema, writeMode, targetRowGroupSize, 0);
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to create Parquet file");
+        throw new UncheckedIOException("Failed to create Parquet file", e);
       }
 
       try {
         writer.start();
       } catch (IOException e) {
-        throw new RuntimeIOException(e, "Failed to start Parquet file writer");
+        throw new UncheckedIOException("Failed to start Parquet file writer", e);
       }
     }
   }

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
@@ -71,8 +71,7 @@ public class TestParquet {
     // PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT configs.
     // Even though row group size is 16 bytes, we still have to write 101 records
     // as default PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT is 100.
-    File parquetFile = generateFileWithTwoRowGroups(null, 101, props)
-        .first();
+    File parquetFile = generateFileWithTwoRowGroups(null, 101, props).first();
 
     try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(localInput(parquetFile)))) {
       Assert.assertEquals(2, reader.getRowGroups().size());

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -49,6 +50,8 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import static org.apache.iceberg.Files.localInput;
+import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT;
+import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT;
 import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
 import static org.apache.iceberg.parquet.ParquetWritingTestUtils.createTempFile;
 import static org.apache.iceberg.parquet.ParquetWritingTestUtils.write;
@@ -61,8 +64,15 @@ public class TestParquet {
 
   @Test
   public void testRowGroupSizeConfigurable() throws IOException {
-    // Without an explicit writer function
-    File parquetFile = generateFileWithTwoRowGroups(null).first();
+    Map<String, String> props = ImmutableMap.of(
+        PARQUET_ROW_GROUP_SIZE_BYTES,
+        Integer.toString(4 * Integer.BYTES));
+    // Without an explicit writer function doesn't support PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT
+    // PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT configs.
+    // Even though row group size is 16 bytes, we still have to write 101 records
+    // as default PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT is 100.
+    File parquetFile = generateFileWithTwoRowGroups(null, 101, props)
+        .first();
 
     try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(localInput(parquetFile)))) {
       Assert.assertEquals(2, reader.getRowGroups().size());
@@ -71,7 +81,18 @@ public class TestParquet {
 
   @Test
   public void testRowGroupSizeConfigurableWithWriter() throws IOException {
-    File parquetFile = generateFileWithTwoRowGroups(ParquetAvroWriter::buildWriter).first();
+    Map<String, String> props = ImmutableMap.of(
+        PARQUET_ROW_GROUP_SIZE_BYTES,
+        Integer.toString(4 * Integer.BYTES),
+        PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT,
+        Integer.toString(1),
+        PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT,
+        Integer.toString(2));
+    // Explicit writer function supports PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT
+    // and PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT configs.
+    // We should just need to write 5 integers (20 bytes)
+    // to create two row groups with row group size configured at 16 bytes.
+    File parquetFile = generateFileWithTwoRowGroups(ParquetAvroWriter::buildWriter, 5, props).first();
 
     try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(localInput(parquetFile)))) {
       Assert.assertEquals(2, reader.getRowGroups().size());
@@ -146,15 +167,13 @@ public class TestParquet {
     Assert.assertEquals(expectedBinary, recordRead.get("topbytes"));
   }
 
-
-  private Pair<File, Long> generateFileWithTwoRowGroups(Function<MessageType, ParquetValueWriter<?>> createWriterFunc)
+  private Pair<File, Long>  generateFileWithTwoRowGroups(
+      Function<MessageType, ParquetValueWriter<?>> createWriterFunc,
+      int desiredRecordCount, Map<String, String> props)
       throws IOException {
     Schema schema = new Schema(
         optional(1, "intCol", IntegerType.get())
     );
-
-    int minimumRowGroupRecordCount = 100;
-    int desiredRecordCount = minimumRowGroupRecordCount + 1;
 
     List<GenericData.Record> records = Lists.newArrayListWithCapacity(desiredRecordCount);
     org.apache.avro.Schema avroSchema = AvroSchemaUtil.convert(schema.asStruct());
@@ -164,15 +183,10 @@ public class TestParquet {
       records.add(record);
     }
 
-    // Force multiple row groups by making the byte size very small
-    // Note there'a also minimumRowGroupRecordCount which cannot be configured so we have to write
-    // at least that many records for a new row group to occur
     File file = createTempFile(temp);
     long size = write(file,
         schema,
-        ImmutableMap.of(
-            PARQUET_ROW_GROUP_SIZE_BYTES,
-            Integer.toString(minimumRowGroupRecordCount * Integer.BYTES)),
+        props,
         createWriterFunc,
         records.toArray(new GenericData.Record[]{}));
     return Pair.of(file, size);

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
@@ -75,7 +75,7 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
       writer.addAll(nonDictionaryData);
     }
 
-    int rowGroupSize = Integer.parseInt(PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT);
+    int rowGroupSize = PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT;
     File mixedFile = temp.newFile();
     Assert.assertTrue("Delete should succeed", mixedFile.delete());
     Parquet.concat(ImmutableList.of(dictionaryEncodedFile, plainEncodingFile, dictionaryEncodedFile),

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
@@ -75,7 +75,7 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
       writer.addAll(nonDictionaryData);
     }
 
-    int rowGroupSize = Integer.parseInt(PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT);
+    int rowGroupSize = PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT;
     File mixedFile = temp.newFile();
     Assert.assertTrue("Delete should succeed", mixedFile.delete());
     Parquet.concat(ImmutableList.of(dictionaryEncodedFile, plainEncodingFile, dictionaryEncodedFile),

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
@@ -75,7 +75,7 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
       writer.addAll(nonDictionaryData);
     }
 
-    int rowGroupSize = Integer.parseInt(PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT);
+    int rowGroupSize = PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT;
     File mixedFile = temp.newFile();
     Assert.assertTrue("Delete should succeed", mixedFile.delete());
     Parquet.concat(ImmutableList.of(dictionaryEncodedFile, plainEncodingFile, dictionaryEncodedFile),

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/parquet/vectorized/TestParquetDictionaryEncodedVectorizedReads.java
@@ -75,7 +75,7 @@ public class TestParquetDictionaryEncodedVectorizedReads extends TestParquetVect
       writer.addAll(nonDictionaryData);
     }
 
-    int rowGroupSize = Integer.parseInt(PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT);
+    int rowGroupSize = PARQUET_ROW_GROUP_SIZE_BYTES_DEFAULT;
     File mixedFile = temp.newFile();
     Assert.assertTrue("Delete should succeed", mixedFile.delete());
     Parquet.concat(ImmutableList.of(dictionaryEncodedFile, plainEncodingFile, dictionaryEncodedFile),


### PR DESCRIPTION
This is useufl when we want to use smaller row group size. In the past, we also found that tuning these configurations to smaller value is important lto avoid OOM problem when there are large records (like MBs). E.g., in the past, we have set the min/max check count default to 10/100 by default for the Flink streaming ingestion part. The performance impact is very insignificant. For streams with large records, we have even set the min/max to much smaller value like 1/5.