### PR TITLE
Spark: vectorized/non-vectorized read compound constant type exception (#3139)

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ConstantColumnVector.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ConstantColumnVector.java
@@ -21,7 +21,10 @@ package org.apache.iceberg.spark.data.vectorized;
 
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.types.Type;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarArray;
 import org.apache.spark.sql.vectorized.ColumnarMap;
@@ -119,6 +122,8 @@ class ConstantColumnVector extends ColumnVector {
 
   @Override
   public ColumnVector getChild(int ordinal) {
-    throw new UnsupportedOperationException("ConstantColumnVector only supports primitives");
+    DataType sparkType = ((StructType) type).fields()[ordinal].dataType();
+    Type childType = SparkSchemaUtil.convert(sparkType);
+    return new ConstantColumnVector(childType, batchSize, ((InternalRow) constant).get(ordinal, sparkType));
   }
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -74,7 +74,8 @@ class RowDataReader extends BaseDataReader<InternalRow> {
     // update the current file for Spark's filename() function
     InputFileBlockHolder.set(file.path().toString(), task.start(), task.length());
 
-    return deletes.filter(open(task, requiredSchema, idToConstant)).iterator();
+    return deletes.filter(open(task, requiredSchema, findMoreCompoundConstants(expectedSchema, idToConstant)))
+            .iterator();
   }
 
   protected Schema tableSchema() {

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
@@ -57,6 +57,7 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import static org.apache.iceberg.spark.SparkWriteOptions.WRITE_FORMAT;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
@@ -421,6 +422,7 @@ public class TestPartitionValues {
     // write into iceberg
     sourceDF.write()
         .format("iceberg")
+        .option(WRITE_FORMAT, format)
         .mode(SaveMode.Append)
         .save(baseLocation);
 


### PR DESCRIPTION
This patch fixes a bug in Spark reading ORC compound type constants.

This bug can be reproduced by modifying test TestPartitionValues::testPartitionedByNestedString, to let it write with ORC format instead of parquet, e.g. with the following change:

    // write into iceberg
    sourceDF.write()
        .format("iceberg")
        .option(WRITE_FORMAT, format) // add this line
        .mode(SaveMode.Append)
        .save(baseLocation);
And the test would fail with:

```
java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
	at java.util.ArrayList.rangeCheck(ArrayList.java:659)
	at java.util.ArrayList.get(ArrayList.java:435)
	at org.apache.iceberg.orc.OrcValueReaders$StructReader.<init>(OrcValueReaders.java:161)
	at org.apache.iceberg.spark.data.SparkOrcValueReaders$StructReader.<init>(SparkOrcValueReaders.java:143)
	at org.apache.iceberg.spark.data.SparkOrcValueReaders.struct(SparkOrcValueReaders.java:70)
	at org.apache.iceberg.spark.data.SparkOrcReader$ReadBuilder.record(SparkOrcReader.java:75)
	at org.apache.iceberg.spark.data.SparkOrcReader$ReadBuilder.record(SparkOrcReader.java:65)
	at org.apache.iceberg.orc.OrcSchemaWithTypeVisitor.visitRecord(OrcSchemaWithTypeVisitor.java:71)
	at org.apache.iceberg.orc.OrcSchemaWithTypeVisitor.visit(OrcSchemaWithTypeVisitor.java:38)
	at org.apache.iceberg.orc.OrcSchemaWithTypeVisitor.visit(OrcSchemaWithTypeVisitor.java:32)
	at org.apache.iceberg.spark.data.SparkOrcReader.<init>(SparkOrcReader.java:52)
	at org.apache.iceberg.spark.source.RowDataReader.lambda$newOrcIterable$2(RowDataReader.java:164)
	at org.apache.iceberg.orc.OrcIterable.iterator(OrcIterable.java:108)
	at org.apache.iceberg.orc.OrcIterable.iterator(OrcIterable.java:45)
	at org.apache.iceberg.util.Filter.lambda$filter$0(Filter.java:35)
	at org.apache.iceberg.io.CloseableIterable$2.iterator(CloseableIterable.java:73)
	at org.apache.iceberg.spark.source.RowDataReader.open(RowDataReader.java:78)
```
In ```RowDataReader::newOrcIterable```, we exclude the struct field and create an OrcIterable with an empty schema, because the inner string is a constant (partition value). And later on we hit the exception when constructing the readers.