### PR TITLE
Build: Opt in to hacktoberfest

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -26,6 +26,7 @@ github:
   labels:
     - iceberg
     - apache
+    - hacktoberfest
   features:
     wiki: true
     issues: true


### PR DESCRIPTION
This should opt in the Iceberg project to participate in Hacktoberfest 2021