### PR TITLE
Spark: Leverage SPARK-32056 in Spark 3.1

### DIFF
--- a/spark3/src/main/scala/org/apache/spark/sql/catalyst/utils/PlanUtils.scala
+++ b/spark3/src/main/scala/org/apache/spark/sql/catalyst/utils/PlanUtils.scala
@@ -61,8 +61,8 @@ object PlanUtils {
     if (Spark3VersionUtil.isSpark30) {
       repartitionByExpressionCtor.newInstance(partitionExpressions, child, Integer.valueOf(numPartitions))
     } else {
-      // SPARK-32056: Coalesce partitions for repartition by expressions when AQE is enabled
-      repartitionByExpressionCtor.newInstance(partitionExpressions, child)
+      // Do not pass numPartitions because it is set automatically for AQE
+      repartitionByExpressionCtor.newInstance(partitionExpressions, child, None)
     }
   }
 }

--- a/spark3/src/main/scala/org/apache/spark/sql/catalyst/utils/PlanUtils.scala
+++ b/spark3/src/main/scala/org/apache/spark/sql/catalyst/utils/PlanUtils.scala
@@ -61,7 +61,8 @@ object PlanUtils {
     if (Spark3VersionUtil.isSpark30) {
       repartitionByExpressionCtor.newInstance(partitionExpressions, child, Integer.valueOf(numPartitions))
     } else {
-      repartitionByExpressionCtor.newInstance(partitionExpressions, child, Some(numPartitions))
+      // SPARK-32056: Coalesce partitions for repartition by expressions when AQE is enabled
+      repartitionByExpressionCtor.newInstance(partitionExpressions, child)
     }
   }
 }


### PR DESCRIPTION
Leverage SPARK-32056 to coalesce partitions for repartition by expressions when AQE is enabled in Spark 3.1

Because that `RequiresDistributionAndOrdering` is introduced in SPARK-33779, which is part of Spark 3.2, https://github.com/apache/iceberg/pull/2512#discussion_r658040759 is not suitable for Spark 3.1

This PR pick the idea of https://github.com/apache/iceberg/pull/2512#discussion_r657095040