### PR TITLE
Handle the case that RewriteFiles and RowDelta commit the transaction…

### DIFF
--- a/api/src/main/java/org/apache/iceberg/RewriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteFiles.java
@@ -73,4 +73,11 @@ public interface RewriteFiles extends SnapshotUpdate<RewriteFiles> {
    * @return this for method chaining
    */
   RewriteFiles validateFromSnapshot(long snapshotId);
+
+  /**
+   * Set the sequenceNumber write in manifest-list file.
+   * @param sequenceNumber
+   * @return
+   */
+  RewriteFiles setSequenceNumber(long sequenceNumber);
 }

--- a/api/src/main/java/org/apache/iceberg/RewriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteFiles.java
@@ -76,8 +76,9 @@ public interface RewriteFiles extends SnapshotUpdate<RewriteFiles> {
 
   /**
    * Set the sequenceNumber write in manifest-list file.
-   * @param sequenceNumber
-   * @return
+   *
+   * @param sequenceNumber a sequenceNumber
+   * @return this for method chaining
    */
   RewriteFiles setSequenceNumber(long sequenceNumber);
 }

--- a/api/src/main/java/org/apache/iceberg/RewriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteFiles.java
@@ -75,7 +75,7 @@ public interface RewriteFiles extends SnapshotUpdate<RewriteFiles> {
   RewriteFiles validateFromSnapshot(long snapshotId);
 
   /**
-   * Set the sequenceNumber write in manifest-list file.
+   * Set one older sequenceNumber for rewriteaction snapshot in manifest-list file.
    *
    * @param sequenceNumber a sequenceNumber
    * @return this for method chaining

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
@@ -26,7 +26,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements RewriteFiles {
   private final Set<DataFile> replacedDataFiles = Sets.newHashSet();
   private Long startingSnapshotId = null;
-  private Long sequenceNumber = null;
+  private Long replaceSequenceNumber = null;
 
   BaseRewriteFiles(String tableName, TableOperations ops) {
     super(tableName, ops);
@@ -47,7 +47,7 @@ class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements 
 
   @Override
   protected Long sequenceNumber() {
-    return sequenceNumber;
+    return replaceSequenceNumber;
   }
 
   private void verifyInputAndOutputFiles(Set<DataFile> dataFilesToDelete, Set<DeleteFile> deleteFilesToDelete,
@@ -105,7 +105,7 @@ class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements 
 
   @Override
   public RewriteFiles setSequenceNumber(long sequenceNumber) {
-    this.sequenceNumber = sequenceNumber;
+    this.replaceSequenceNumber = sequenceNumber;
     return this;
   }
 

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
@@ -23,6 +23,9 @@ import java.util.Set;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 
+import static org.apache.iceberg.TableProperties.COMPACT_NEW_DELETE_FILE_VALIDATE;
+import static org.apache.iceberg.TableProperties.COMPACT_NEW_DELETE_FILE_VALIDATE_DEFAULT;
+
 class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements RewriteFiles {
   private final Set<DataFile> replacedDataFiles = Sets.newHashSet();
   private Long startingSnapshotId = null;
@@ -111,6 +114,9 @@ class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements 
 
   @Override
   protected void validate(TableMetadata base) {
+    if (!base.propertyAsBoolean(COMPACT_NEW_DELETE_FILE_VALIDATE, COMPACT_NEW_DELETE_FILE_VALIDATE_DEFAULT)) {
+      return;
+    }
     if (replacedDataFiles.size() > 0) {
       // if there are replaced data files, there cannot be any new row-level deletes for those data files
       validateNoNewDeletesForDataFiles(base, startingSnapshotId, replacedDataFiles);

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
@@ -46,7 +46,7 @@ class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements 
   }
 
   @Override
-  protected Long sequenceNumber() {
+  protected Long sequenceNumberOverride() {
     return replaceSequenceNumber;
   }
 
@@ -111,5 +111,9 @@ class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements 
 
   @Override
   protected void validate(TableMetadata base) {
+    if (replacedDataFiles.size() > 0) {
+      // if there are replaced data files, there cannot be any new row-level deletes for those data files
+      validateNoNewDeletesForDataFiles(base, startingSnapshotId, replacedDataFiles);
+    }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements RewriteFiles {
   private final Set<DataFile> replacedDataFiles = Sets.newHashSet();
   private Long startingSnapshotId = null;
+  private Long sequenceNumber = null;
 
   BaseRewriteFiles(String tableName, TableOperations ops) {
     super(tableName, ops);
@@ -42,6 +43,11 @@ class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements 
   @Override
   protected String operation() {
     return DataOperations.REPLACE;
+  }
+
+  @Override
+  protected Long sequenceNumber() {
+    return sequenceNumber;
   }
 
   private void verifyInputAndOutputFiles(Set<DataFile> dataFilesToDelete, Set<DeleteFile> deleteFilesToDelete,
@@ -98,10 +104,12 @@ class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements 
   }
 
   @Override
+  public RewriteFiles setSequenceNumber(long sequenceNumber) {
+    this.sequenceNumber = sequenceNumber;
+    return this;
+  }
+
+  @Override
   protected void validate(TableMetadata base) {
-    if (replacedDataFiles.size() > 0) {
-      // if there are replaced data files, there cannot be any new row-level deletes for those data files
-      validateNoNewDeletesForDataFiles(base, startingSnapshotId, replacedDataFiles);
-    }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -177,7 +177,9 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
 
       try (ManifestListWriter writer = ManifestLists.write(
           ops.current().formatVersion(), manifestList, snapshotId(), parentSnapshotId,
-          operation().equals(DataOperations.REPLACE) && sequenceNumberOverride() != null ? sequenceNumberOverride() : sequenceNumber)) {
+          operation().equals(DataOperations.REPLACE) && sequenceNumberOverride() != null ?
+              sequenceNumberOverride() :
+              sequenceNumber)) {
 
         // keep track of the manifest lists created
         manifestLists.add(manifestList.location());

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -176,7 +176,8 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
       OutputFile manifestList = manifestListPath();
 
       try (ManifestListWriter writer = ManifestLists.write(
-          ops.current().formatVersion(), manifestList, snapshotId(), parentSnapshotId, operation().equals(DataOperations.REPLACE) ? sequenceNumber() : sequenceNumber)) {
+          ops.current().formatVersion(), manifestList, snapshotId(), parentSnapshotId,
+          operation().equals(DataOperations.REPLACE) && sequenceNumber() != null ? sequenceNumber() : sequenceNumber)) {
 
         // keep track of the manifest lists created
         manifestLists.add(manifestList.location());

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -134,6 +134,15 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
   protected abstract String operation();
 
   /**
+   * A Long that write sequenceNumber in manifest-list file.
+   *
+   * @return a string operation
+   */
+  protected Long sequenceNumber() {
+    return null;
+  }
+
+  /**
    * Validate the current metadata.
    * <p>
    * Child operations can override this to add custom validation.
@@ -167,7 +176,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
       OutputFile manifestList = manifestListPath();
 
       try (ManifestListWriter writer = ManifestLists.write(
-          ops.current().formatVersion(), manifestList, snapshotId(), parentSnapshotId, sequenceNumber)) {
+          ops.current().formatVersion(), manifestList, snapshotId(), parentSnapshotId, operation().equals(DataOperations.REPLACE) ? sequenceNumber() : sequenceNumber)) {
 
         // keep track of the manifest lists created
         manifestLists.add(manifestList.location());

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -138,7 +138,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
    *
    * @return a string operation
    */
-  protected Long sequenceNumber() {
+  protected Long sequenceNumberOverride() {
     return null;
   }
 
@@ -177,7 +177,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
 
       try (ManifestListWriter writer = ManifestLists.write(
           ops.current().formatVersion(), manifestList, snapshotId(), parentSnapshotId,
-          operation().equals(DataOperations.REPLACE) && sequenceNumber() != null ? sequenceNumber() : sequenceNumber)) {
+          operation().equals(DataOperations.REPLACE) && sequenceNumberOverride() != null ? sequenceNumberOverride() : sequenceNumber)) {
 
         // keep track of the manifest lists created
         manifestLists.add(manifestList.location());

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -244,4 +244,7 @@ public class TableProperties {
 
   public static final String UPSERT_MODE_ENABLE = "write.upsert.enable";
   public static final boolean UPSERT_MODE_ENABLE_DEFAULT = false;
+
+  public static final String COMPACT_NEW_DELETE_FILE_VALIDATE = "compact.new.delete.file.validate";
+  public static final boolean COMPACT_NEW_DELETE_FILE_VALIDATE_DEFAULT = false;
 }

--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RewriteFiles;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.encryption.EncryptionManager;
@@ -201,8 +202,9 @@ public abstract class BaseRewriteDataFilesAction<ThisT>
       return RewriteDataFilesActionResult.empty();
     }
 
-    long startingSnapshotId = table.currentSnapshot().snapshotId();
-    long sequenceNumber = table.currentSnapshot().sequenceNumber();
+    Snapshot currentSnapshot = table.currentSnapshot();
+    long startingSnapshotId = currentSnapshot.snapshotId();
+    long sequenceNumber = currentSnapshot.sequenceNumber();
     try {
       fileScanTasks = table.newScan()
           .useSnapshot(startingSnapshotId)

--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
@@ -202,6 +202,7 @@ public abstract class BaseRewriteDataFilesAction<ThisT>
     }
 
     long startingSnapshotId = table.currentSnapshot().snapshotId();
+    long sequenceNumber = table.currentSnapshot().sequenceNumber();
     try {
       fileScanTasks = table.newScan()
           .useSnapshot(startingSnapshotId)
@@ -243,7 +244,6 @@ public abstract class BaseRewriteDataFilesAction<ThisT>
       return RewriteDataFilesActionResult.empty();
     }
 
-    long sequenceNumber = table.currentSnapshot().sequenceNumber();
     List<DataFile> addedDataFiles = rewriteDataForTasks(combinedScanTasks);
     List<DataFile> currentDataFiles = combinedScanTasks.stream()
         .flatMap(tasks -> tasks.files().stream().map(FileScanTask::file))

--- a/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
@@ -48,15 +48,17 @@ public class RewriteDataFilesCommitManager {
 
   private final Table table;
   private final long startingSnapshotId;
+  private final long replaceSeqNumber;
 
   // constructor used for testing
   public RewriteDataFilesCommitManager(Table table) {
-    this(table, table.currentSnapshot().snapshotId());
+    this(table, table.currentSnapshot().snapshotId(), table.currentSnapshot().sequenceNumber());
   }
 
-  public RewriteDataFilesCommitManager(Table table, long startingSnapshotId) {
+  public RewriteDataFilesCommitManager(Table table, long startingSnapshotId, long replaceSeqNumber) {
     this.table = table;
     this.startingSnapshotId = startingSnapshotId;
+    this.replaceSeqNumber = replaceSeqNumber;
   }
 
   /**
@@ -74,6 +76,7 @@ public class RewriteDataFilesCommitManager {
 
     RewriteFiles rewrite = table.newRewrite()
         .validateFromSnapshot(startingSnapshotId)
+        .setSequenceNumber(replaceSeqNumber)
         .rewriteFiles(rewrittenDataFiles, addedDataFiles);
     rewrite.commit();
   }

--- a/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
@@ -612,33 +612,4 @@ public class TestRewriteFiles extends TableTestBase {
     Assert.assertEquals("Only 3 manifests should exist", 3, listManifestFiles().size());
   }
 
-  @Test
-  public void testNewDeleteFile() {
-    Assume.assumeTrue("Delete files are only supported in v2", formatVersion > 1);
-
-    table.newAppend()
-        .appendFile(FILE_A)
-        .commit();
-
-    long snapshotBeforeDeletes = table.currentSnapshot().snapshotId();
-
-    table.newRowDelta()
-        .addDeletes(FILE_A_DELETES)
-        .commit();
-
-    long snapshotAfterDeletes = table.currentSnapshot().snapshotId();
-
-    AssertHelpers.assertThrows("Should fail because deletes were added after the starting snapshot",
-        ValidationException.class, "Cannot commit, found new delete for replaced data file",
-        () -> table.newRewrite()
-            .validateFromSnapshot(snapshotBeforeDeletes)
-            .rewriteFiles(Sets.newSet(FILE_A), Sets.newSet(FILE_A2))
-            .apply());
-
-    // the rewrite should be valid when validating from the snapshot after the deletes
-    table.newRewrite()
-        .validateFromSnapshot(snapshotAfterDeletes)
-        .rewriteFiles(Sets.newSet(FILE_A), Sets.newSet(FILE_A2))
-        .apply();
-  }
 }

--- a/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
@@ -612,4 +612,33 @@ public class TestRewriteFiles extends TableTestBase {
     Assert.assertEquals("Only 3 manifests should exist", 3, listManifestFiles().size());
   }
 
+  @Test
+  public void testNewDeleteFile() {
+      Assume.assumeTrue("Delete files are only supported in v2", formatVersion > 1);
+
+    table.newAppend()
+        .appendFile(FILE_A)
+        .commit();
+
+  long snapshotBeforeDeletes = table.currentSnapshot().snapshotId();
+
+    table.newRowDelta()
+        .addDeletes(FILE_A_DELETES)
+        .commit();
+
+  long snapshotAfterDeletes = table.currentSnapshot().snapshotId();
+
+    AssertHelpers.assertThrows("Should fail because deletes were added after the starting snapshot",
+  ValidationException.class, "Cannot commit, found new delete for replaced data file",
+      () -> table.newRewrite()
+      .validateFromSnapshot(snapshotBeforeDeletes)
+            .rewriteFiles(Sets.newSet(FILE_A), Sets.newSet(FILE_A2))
+      .apply());
+
+  // the rewrite should be valid when validating from the snapshot after the deletes
+    table.newRewrite()
+        .validateFromSnapshot(snapshotAfterDeletes)
+        .rewriteFiles(Sets.newSet(FILE_A), Sets.newSet(FILE_A2))
+      .apply();
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
@@ -616,6 +616,8 @@ public class TestRewriteFiles extends TableTestBase {
   public void testNewDeleteFile() {
       Assume.assumeTrue("Delete files are only supported in v2", formatVersion > 1);
 
+    table.properties().put("compact.new.delete.file.validate", "true");
+
     table.newAppend()
         .appendFile(FILE_A)
         .commit();

--- a/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
+++ b/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
@@ -119,6 +119,7 @@ abstract class BaseRewriteDataFilesSparkAction
     }
 
     long startingSnapshotId = table.currentSnapshot().snapshotId();
+    long replaceSequenceNumber = table.currentSnapshot().sequenceNumber();
 
     validateAndInitOptions();
     strategy = strategy.options(options());
@@ -133,7 +134,7 @@ abstract class BaseRewriteDataFilesSparkAction
 
     Stream<RewriteFileGroup> groupStream = toGroupStream(ctx, fileGroupsByPartition);
 
-    RewriteDataFilesCommitManager commitManager = commitManager(startingSnapshotId);
+    RewriteDataFilesCommitManager commitManager = commitManager(startingSnapshotId, replaceSequenceNumber);
     if (partialProgressEnabled) {
       return doExecuteWithPartialProgress(ctx, groupStream, commitManager);
     } else {
@@ -195,8 +196,8 @@ abstract class BaseRewriteDataFilesSparkAction
   }
 
   @VisibleForTesting
-  RewriteDataFilesCommitManager commitManager(long startingSnapshotId) {
-    return new RewriteDataFilesCommitManager(table, startingSnapshotId);
+  RewriteDataFilesCommitManager commitManager(long startingSnapshotId, long replaceSequenceNumber) {
+    return new RewriteDataFilesCommitManager(table, startingSnapshotId, replaceSequenceNumber);
   }
 
   private Result doExecute(RewriteExecutionContext ctx, Stream<RewriteFileGroup> groupStream,

--- a/spark/src/test/java/org/apache/iceberg/spark/actions/TestNewRewriteDataFilesAction.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/actions/TestNewRewriteDataFilesAction.java
@@ -395,7 +395,7 @@ public abstract class TestNewRewriteDataFilesAction extends SparkTestBase {
 
     doReturn(util)
         .when(spyRewrite)
-        .commitManager(table.currentSnapshot().snapshotId());
+        .commitManager(table.currentSnapshot().snapshotId(), table.currentSnapshot().sequenceNumber());
 
     AssertHelpers.assertThrows("Should fail entire rewrite if commit fails", RuntimeException.class,
         () -> spyRewrite.execute());
@@ -548,7 +548,7 @@ public abstract class TestNewRewriteDataFilesAction extends SparkTestBase {
 
     doReturn(util)
         .when(spyRewrite)
-        .commitManager(table.currentSnapshot().snapshotId());
+        .commitManager(table.currentSnapshot().snapshotId(), table.currentSnapshot().sequenceNumber());
 
     RewriteDataFiles.Result result = spyRewrite.execute();
 
@@ -608,7 +608,7 @@ public abstract class TestNewRewriteDataFilesAction extends SparkTestBase {
 
     doReturn(util)
         .when(spyAction)
-        .commitManager(table.currentSnapshot().snapshotId());
+        .commitManager(table.currentSnapshot().snapshotId(), table.currentSnapshot().sequenceNumber());
 
     AssertHelpers.assertThrows("Should propagate CommitStateUnknown Exception",
         CommitStateUnknownException.class, () -> spyAction.execute());


### PR DESCRIPTION
This PR is handle the case that RewriteFiles and RowDelta commit the transaction at the same time what will cause duplicate record in table.
The approach is just like what discuss in https://github.com/apache/iceberg/issues/2308#issuecomment-801576874. We use the old seqnumber in manifest-list file same as the seqnumber of current snapshop when we start rewrite action. So when the rewrite action finished the replace snapshot will be set with one new seqnumber in metadata.json but one old seqnumber in manifest-list file. Then when we read the replace snapshot that these files what is commit during the rewrite action have bigger seqnumber than this replace snapshot, so if there is eq-delete file is commit they will apply into the replace snapshot.