### PR TITLE
Disable ErrorProne ConsistentLoggerName as we use alternative name

### DIFF
--- a/baseline.gradle
+++ b/baseline.gradle
@@ -66,6 +66,7 @@ subprojects {
           // error-prone is slow, don't run on tests and generated src
           '-XepExcludedPaths:.*/(test|generated-src)/.*',
           // specific to Palantir
+          '-Xep:ConsistentLoggerName:OFF',  // Uses name `log` but we use name `LOG`
           '-Xep:FinalClass:OFF',
           '-Xep:PreferSafeLoggingPreconditions:OFF',
           '-Xep:PreferSafeLoggableExceptions:OFF',


### PR DESCRIPTION
When we recently upgraded the error prone library (I believe as part of the Gradle upgrade), a new ErrorProne rule that's unique to the palantir repo has been added, `ConsistentLoggerName`.

As we typically use `LOG` for the logger name, but the warning wants it to be `log`, I have chosen to turn it off.

I only found about 5-6 instances where it wasn't called `LOG` (a handful of `log` and one or two `logger`).

While this is a nice goal, the palantir fork of error-prone doesn't seem to allow us to configure the expected name [as it's hard coded.](https://github.com/palantir/gradle-baseline/blob/779c6db14689b312bbdb2f4bc705cdfe2f61f078/baseline-error-prone/src/main/java/com/palantir/baseline/errorprone/ConsistentLoggerName.java#L64)

@nastra if you know of a way that we can change this to be `LOG`, that would be great.

Otherwise, I'm happy to update this to be `log` everywhere, but that will be a very large code change for not much benefit and adds a strain on people who maintain forks. Will leave this up to others to weigh in on as well.

Here's an example of the log:

```
/Users/kbendick/iceberg/api/src/main/java/org/apache/iceberg/io/CloseableGroup.java:42: warning: [ConsistentLoggerName] Loggers created using getLogger(Class<?>) must be named 'log'.
  private static final Logger LOG = LoggerFactory.getLogger(CloseableGroup.class);
                              ^
    (see https://github.com/palantir/gradle-baseline#baseline-error-prone-checks)
  Did you mean 'private static final Logger log = LoggerFactory.getLogger(CloseableGroup.class);'?
```