### PR TITLE
Throw better exception when dropping a Namespace with NessieCatalog

### DIFF
--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
@@ -37,7 +37,6 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
-import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.hadoop.HadoopFileIO;
@@ -274,7 +273,7 @@ public class NessieCatalog extends BaseMetastoreCatalog implements AutoCloseable
   }
 
   /**
-   * namespace metadata is not supported in Nessie and we return an empty map.
+   * namespace metadata is not supported in Nessie, thus we return an empty map.
    *
    * @param namespace a namespace. {@link Namespace}
    * @return an empty map
@@ -285,26 +284,29 @@ public class NessieCatalog extends BaseMetastoreCatalog implements AutoCloseable
   }
 
   /**
-   * Namespaces in Nessie are implicit and deleting them results in a no-op.
+   * Namespaces in Nessie are implicit and therefore cannot be dropped
    *
-   * @param namespace a namespace. {@link Namespace}
-   * @return always false.
+   * @param namespace The {@link Namespace} to drop.
+   * @throws UnsupportedOperationException Namespaces in Nessie are implicit and thus cannot be dropped.
    */
   @Override
-  public boolean dropNamespace(Namespace namespace) throws NamespaceNotEmptyException {
-    return false;
+  public boolean dropNamespace(Namespace namespace) {
+    throw new UnsupportedOperationException(
+        "Cannot drop namespace '" + namespace + "': dropNamespace is not supported by the NessieCatalog");
   }
 
   @Override
-  public boolean setProperties(Namespace namespace, Map<String, String> properties) throws NoSuchNamespaceException {
+  public boolean setProperties(Namespace namespace, Map<String, String> properties) {
     throw new UnsupportedOperationException(
-        "Cannot set namespace properties " + namespace + " : setProperties is not supported");
+        "Cannot set properties for namespace '" + namespace +
+            "': setProperties is not supported by the NessieCatalog");
   }
 
   @Override
-  public boolean removeProperties(Namespace namespace, Set<String> properties) throws NoSuchNamespaceException {
+  public boolean removeProperties(Namespace namespace, Set<String> properties) {
     throw new UnsupportedOperationException(
-        "Cannot remove properties " + namespace + " : removeProperties is not supported");
+        "Cannot remove properties for namespace '" + namespace +
+            "': removeProperties is not supported by the NessieCatalog");
   }
 
   @Override

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNamespace.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNamespace.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.nessie;
 
+import java.util.Collections;
 import java.util.List;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -58,5 +59,27 @@ public class TestNamespace extends BaseTestIceberg {
     Assertions.assertThat(namespaces).isNotNull().hasSize(2);
     namespaces = catalog.listNamespaces(Namespace.of("b"));
     Assertions.assertThat(namespaces).isNotNull().hasSize(2);
+  }
+
+  @Test
+  public void testDroppingNamespace() {
+    Assertions.assertThatThrownBy(() -> catalog.dropNamespace(Namespace.of("test")))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Cannot drop namespace 'test': dropNamespace is not supported by the NessieCatalog");
+  }
+
+  @Test
+  public void testSettingProperties() {
+    Assertions.assertThatThrownBy(() -> catalog.setProperties(Namespace.of("test"), Collections.emptyMap()))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Cannot set properties for namespace 'test': setProperties is not supported by the NessieCatalog");
+  }
+
+  @Test
+  public void testRemovingProperties() {
+    Assertions.assertThatThrownBy(() -> catalog.removeProperties(Namespace.of("test"), Collections.emptySet()))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage(
+            "Cannot remove properties for namespace 'test': removeProperties is not supported by the NessieCatalog");
   }
 }


### PR DESCRIPTION
When using the `NessieCatalog` and dropping a namespace, then things fail with a `org.apache.spark.SparkException: Failed to drop a namespace: ...`, which is a bit difficult to understand for users. It makes more sense to throw an `UnsupportedOperationException` that indicates that dropping a namespace isn't supported.