### PR TITLE
Hive: Add tests for HiveCatalog no-arg constructor, setConf, and initialize

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -95,6 +95,11 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
   @Override
   public void initialize(String inputName, Map<String, String> properties) {
     this.name = inputName;
+    if (conf == null) {
+      LOG.warn("No Hadoop Configuration was set, using the default environment Configuration");
+      this.conf = new Configuration();
+    }
+
     if (properties.containsKey(CatalogProperties.URI)) {
       this.conf.set(HiveConf.ConfVars.METASTOREURIS.varname, properties.get(CatalogProperties.URI));
     }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -38,6 +38,7 @@ import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Types;
@@ -45,6 +46,7 @@ import org.apache.thrift.TException;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.junit.rules.TemporaryFolder;
 
 import static org.apache.iceberg.NullOrder.NULLS_FIRST;
@@ -116,6 +118,34 @@ public class TestHiveCatalog extends HiveMetastoreTest {
     } finally {
       cachingCatalog.dropTable(tableIdent);
     }
+  }
+
+  @Test
+  public void testInitialize() {
+    Assertions.assertDoesNotThrow(() -> {
+      HiveCatalog catalog = new HiveCatalog();
+      catalog.initialize("hive", Maps.newHashMap());
+    });
+  }
+
+  @Test
+  public void testToStringWithoutSetConf() {
+    Assertions.assertDoesNotThrow(() -> {
+      HiveCatalog catalog = new HiveCatalog();
+      catalog.toString();
+    });
+  }
+
+  @Test
+  public void testInitializeCatalogWithProperties() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("uri", "thrift://examplehost:9083");
+    properties.put("warehouse", "/user/hive/testwarehouse");
+    HiveCatalog catalog = new HiveCatalog();
+    catalog.initialize("hive", properties);
+
+    Assert.assertEquals(catalog.getConf().get("hive.metastore.uris"), "thrift://examplehost:9083");
+    Assert.assertEquals(catalog.getConf().get("hive.metastore.warehouse.dir"), "/user/hive/testwarehouse");
   }
 
   @Test


### PR DESCRIPTION
This PR is tied to issue [#3251](https://github.com/apache/iceberg/issues/3251) and just adds a few tests around constructing a HiveCatalog. A [fix](https://github.com/apache/iceberg/commit/bcedb21c29e1b821443f0ee703505d589b187ace) was added recently that handles a NPE when using the no-arg HiveCatalog constructor and these tests may help catch this in the future.