### PR TITLE
Docs: Changing java api quickstart to use recommended no-arg constructor

### DIFF
--- a/site/docs/java-api-quickstart.md
+++ b/site/docs/java-api-quickstart.md
@@ -27,7 +27,7 @@ The Hive catalog connects to a Hive metastore to keep track of Iceberg tables.
 You can initialize a Hive catalog with a name and some properties.
 (see: [Catalog properties](https://iceberg.apache.org/configuration/#catalog-properties))
 
-**note:** Currently, `setConf` is always required for hive catalogs, but this will change in the future.
+**Note:** Currently, `setConf` is always required for hive catalogs, but this will change in the future.
 
 ```java
 import org.apache.iceberg.hive.HiveCatalog;


### PR DESCRIPTION
This is tied to [#3235](https://github.com/apache/iceberg/issues/3235) and updates the [Java Quickstart](https://iceberg.apache.org/java-api-quickstart/) to use the recommended constructor (instead of the deprecated one). The logic in the quickstart is also dependent on a NPE [fix](https://github.com/apache/iceberg/commit/bcedb21c29e1b821443f0ee703505d589b187ace) recently merged in.