### PR TITLE
Flink: Add operator to expire snapshots

### DIFF
--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.ExpireSnapshotResult;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -60,7 +61,7 @@ import static org.apache.iceberg.TableProperties.MIN_SNAPSHOTS_TO_KEEP;
 import static org.apache.iceberg.TableProperties.MIN_SNAPSHOTS_TO_KEEP_DEFAULT;
 
 @SuppressWarnings("UnnecessaryAnonymousClass")
-class RemoveSnapshots implements ExpireSnapshots {
+public class RemoveSnapshots implements ExpireSnapshots {
   private static final Logger LOG = LoggerFactory.getLogger(RemoveSnapshots.class);
 
   // Creates an executor service that runs each task in the thread that invokes execute/submit.
@@ -79,10 +80,11 @@ class RemoveSnapshots implements ExpireSnapshots {
   private TableMetadata base;
   private long expireOlderThan;
   private int minNumSnapshots;
+  private ExpireSnapshotResult expireSnapshotResult;
   private Consumer<String> deleteFunc = defaultDelete;
   private ExecutorService deleteExecutorService = DEFAULT_DELETE_EXECUTOR_SERVICE;
 
-  RemoveSnapshots(TableOperations ops) {
+  public RemoveSnapshots(TableOperations ops) {
     this.ops = ops;
     this.base = ops.current();
 
@@ -359,10 +361,24 @@ class RemoveSnapshots implements ExpireSnapshots {
                 }
               }
             });
-    deleteDataFiles(manifestsToScan, manifestsToRevert, validIds);
-    deleteMetadataFiles(manifestsToDelete, manifestListsToDelete);
+    if (cleanExpiredFiles) {
+      deleteDataFiles(manifestsToScan, manifestsToRevert, validIds);
+      deleteMetadataFiles(manifestsToDelete, manifestListsToDelete);
+    } else {
+      Set<String> filesToDelete = findFilesToDelete(manifestsToScan, manifestsToRevert, validIds);
+      expireSnapshotResult = ExpireSnapshotResult
+          .builder()
+          .addManifestFiles(manifestsToDelete)
+          .addManifestListFiles(manifestListsToDelete)
+          .addDataFiles(filesToDelete)
+          .build();
+    }
   }
 
+  public ExpireSnapshotResult getExpiredSnapshotResult() {
+    cleanExpiredSnapshots();
+    return expireSnapshotResult;
+  }
   private void deleteMetadataFiles(Set<String> manifestsToDelete, Set<String> manifestListsToDelete) {
     LOG.warn("Manifests to delete: {}", Joiner.on(", ").join(manifestsToDelete));
     LOG.warn("Manifests Lists to delete: {}", Joiner.on(", ").join(manifestListsToDelete));

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -244,4 +244,23 @@ public class TableProperties {
 
   public static final String UPSERT_MODE_ENABLE = "write.upsert.enable";
   public static final boolean UPSERT_MODE_ENABLE_DEFAULT = false;
+
+  //  expire snapshot
+  public static final String SNAPSHOT_FLINK_AUTO_EXPIRE_ENABLED = "snapshot.flink.auto-expire.enabled";
+  public static final boolean SNAPSHOT_FLINK_AUTO_EXPIRE_ENABLED_DEFAULT = false;
+
+  public static final String FLINK_LAST_EXPIRE_SNAPSHOT_MS = "snapshot.flink.auto-expire.last-expire-snapshot-ms";
+  public static final long FLINK_LAST_EXPIRE_SNAPSHOT_MS_DEFAULT = -1;
+
+  public static final String SNAPSHOT_FLINK_AUTO_EXPIRE_INTERVAL_MS = "snapshot.flink.auto-expire.interval-ms";
+  public static final long SNAPSHOT_FLINK_AUTO_EXPIRE_INTERVAL_MS_DEFAULT = 10 * 60 * 1000;
+
+  public static final String FLINK_AUTO_MAX_SNAPSHOT_AGE_MS = "snapshot.flink.auto-expire.max-snapshot-age-ms";
+  public static final long FLINK_AUTO_MAX_SNAPSHOT_AGE_MS_DEFAULT = 5 * 24 * 60 * 60 * 1000; // 5 days
+
+  public static final String FLINK_AUTO_MIN_SNAPSHOTS_TO_KEEP = "snapshot.flink.auto-expire.min-snapshots-to-keep";
+  public static final int FLINK_AUTO_MIN_SNAPSHOTS_TO_KEEP_DEFAULT = 5;
+
+  public static final String FLINK_AUTO_SNAPSHOTS_GROUP_NUMS = "snapshot.flink.auto-expire.snapshots-group-nums";
+  public static final int FLINK_AUTO_SNAPSHOTS_GROUP_NUMS_DEFAULT = 5;
 }

--- a/core/src/main/java/org/apache/iceberg/io/ExpireSnapshotResult.java
+++ b/core/src/main/java/org/apache/iceberg/io/ExpireSnapshotResult.java
@@ -115,4 +115,8 @@ public class ExpireSnapshotResult implements Serializable {
       return new ExpireSnapshotResult(manifestsToDelete, manifestListsToDelete, filesToDelete);
     }
   }
+
+  public boolean isEmpty() {
+    return this.filesToDelete.isEmpty() && this.manifestsToDelete.isEmpty() && this.manifestListsToDelete.isEmpty();
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/io/ExpireSnapshotResult.java
+++ b/core/src/main/java/org/apache/iceberg/io/ExpireSnapshotResult.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Set;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+
+public class ExpireSnapshotResult implements Serializable {
+  private Set<String> manifestsToDelete;
+  private Set<String> manifestListsToDelete;
+
+  private Set<String> filesToDelete;
+
+  private ExpireSnapshotResult(Set<String> manifestsToDelete,
+      Set<String> manifestListsToDelete,
+      Set<String> filesToDelete) {
+    this.manifestsToDelete = manifestsToDelete;
+    this.manifestListsToDelete = manifestListsToDelete;
+    this.filesToDelete = filesToDelete;
+  }
+
+  public Set<String> getManifestsToDelete() {
+    return manifestsToDelete;
+  }
+
+  public Set<String> getManifestListsToDelete() {
+    return manifestListsToDelete;
+  }
+
+  public Set<String> getFilesToDelete() {
+    return filesToDelete;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private final Set<String> manifestsToDelete;
+    private final Set<String> manifestListsToDelete;
+
+    private final Set<String> filesToDelete;
+
+    private Builder() {
+      this.manifestsToDelete = Sets.newHashSet();
+      this.manifestListsToDelete = Sets.newHashSet();
+      this.filesToDelete = Sets.newHashSet();
+
+    }
+
+    public Builder add(ExpireSnapshotResult result) {
+      addManifestFiles(result.manifestsToDelete);
+      addManifestListFiles(result.manifestListsToDelete);
+      addDataFiles(result.filesToDelete);
+
+      return this;
+    }
+
+    public Builder addAll(Iterable<ExpireSnapshotResult> results) {
+      results.forEach(this::add);
+      return this;
+    }
+
+    public Builder addManifestFiles(String... files) {
+      Collections.addAll(manifestsToDelete, files);
+      return this;
+    }
+
+    public Builder addManifestFiles(Iterable<String> files) {
+      Iterables.addAll(manifestsToDelete, files);
+      return this;
+    }
+
+    public Builder addManifestListFiles(String... files) {
+      Collections.addAll(manifestListsToDelete, files);
+      return this;
+    }
+
+    public Builder addManifestListFiles(Iterable<String> files) {
+      Iterables.addAll(manifestListsToDelete, files);
+      return this;
+    }
+
+    public Builder addDataFiles(String... files) {
+      Collections.addAll(filesToDelete, files);
+      return this;
+    }
+
+    public Builder addDataFiles(Iterable<String> files) {
+      Iterables.addAll(filesToDelete, files);
+      return this;
+    }
+
+    public ExpireSnapshotResult build() {
+      return new ExpireSnapshotResult(manifestsToDelete, manifestListsToDelete, filesToDelete);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/util/ExpireSnapshotUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/ExpireSnapshotUtil.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import java.util.Date;
+import java.util.Map;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ExpireSnapshotUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(ExpireSnapshotUtil.class);
+
+  private ExpireSnapshotUtil() {
+
+  }
+
+  /**
+   * Returns whether expire snapshot files should be removed.
+   */
+  public static boolean shouldExpireSnapshot(Table table) {
+    boolean shouldExpire = false;
+    long currentTimeMillis = System.currentTimeMillis();
+    Map<String, String> props = table.properties();
+    boolean autoExpireSnapshotEnable = PropertyUtil.propertyAsBoolean(
+        props,
+        TableProperties.SNAPSHOT_FLINK_AUTO_EXPIRE_ENABLED,
+        TableProperties.SNAPSHOT_FLINK_AUTO_EXPIRE_ENABLED_DEFAULT);
+
+    long expireIntervalMillis = PropertyUtil.propertyAsLong(
+        props,
+        TableProperties.SNAPSHOT_FLINK_AUTO_EXPIRE_INTERVAL_MS,
+        TableProperties.SNAPSHOT_FLINK_AUTO_EXPIRE_INTERVAL_MS_DEFAULT);
+
+    long lastExpireTimestamp = PropertyUtil.propertyAsLong(
+        props,
+        TableProperties.FLINK_LAST_EXPIRE_SNAPSHOT_MS,
+        TableProperties.FLINK_LAST_EXPIRE_SNAPSHOT_MS_DEFAULT);
+
+    LOG.info("Summary: actual expire interval: {}s, expire.auto.enabled: {}, " +
+            "expire.interval: {}s, current time: {}, last expire time: {}",
+        (currentTimeMillis - lastExpireTimestamp) / 1000,
+        autoExpireSnapshotEnable,
+        expireIntervalMillis / 1000,
+        new Date(currentTimeMillis),
+        new Date(lastExpireTimestamp));
+
+    if (autoExpireSnapshotEnable &&
+        currentTimeMillis - lastExpireTimestamp >= expireIntervalMillis) {
+      LOG.info("Should expire snapshot");
+      shouldExpire = true;
+    }
+    return shouldExpire;
+  }
+}

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergFilesCommitter.java
@@ -46,6 +46,7 @@ import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotUpdate;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.sink.expire.snapshot.ExpireSnapshotMessage.EndCheckpoint;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -59,8 +60,8 @@ import org.apache.iceberg.util.PropertyUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class IcebergFilesCommitter extends AbstractStreamOperator<Void>
-    implements OneInputStreamOperator<WriteResult, Void>, BoundedOneInput {
+class IcebergFilesCommitter extends AbstractStreamOperator<EndCheckpoint>
+    implements OneInputStreamOperator<WriteResult, EndCheckpoint>, BoundedOneInput {
 
   private static final long serialVersionUID = 1L;
   private static final long INITIAL_CHECKPOINT_ID = -1L;
@@ -188,6 +189,10 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     if (checkpointId > maxCommittedCheckpointId) {
       commitUpToCheckpoint(dataFilesPerCheckpoint, flinkJobId, checkpointId);
       this.maxCommittedCheckpointId = checkpointId;
+      emit(new EndCheckpoint(
+          checkpointId,
+          getRuntimeContext().getIndexOfThisSubtask(),
+          getRuntimeContext().getNumberOfParallelSubtasks()));
     }
   }
 
@@ -375,5 +380,9 @@ class IcebergFilesCommitter extends AbstractStreamOperator<Void>
     }
 
     return lastCommittedCheckpointId;
+  }
+
+  private void emit(EndCheckpoint result) {
+    output.collect(new StreamRecord<>(result));
   }
 }

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/expire/snapshot/ExpireSnapshotGenerator.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/expire/snapshot/ExpireSnapshotGenerator.java
@@ -98,7 +98,7 @@ public class ExpireSnapshotGenerator extends AbstractStreamOperator<CommonContro
           .set(TableProperties.FLINK_LAST_EXPIRE_SNAPSHOT_MS, Long.toString(currentTimeMillis))
           .commit();
 
-      ExpireSnapshotResult result = removeSnapshots.getExpiredSnapshotResult();
+      ExpireSnapshotResult result = removeSnapshots.findExpiredSnapshotResult();
       if (result != null) {
         Set<String> manifestFiles = result.getManifestsToDelete();
         Set<String> manifestListFiles = result.getManifestListsToDelete();

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/expire/snapshot/ExpireSnapshotGenerator.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/expire/snapshot/ExpireSnapshotGenerator.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.sink.expire.snapshot;
+
+import java.util.Date;
+import java.util.Set;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.RemoveSnapshots;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.sink.expire.snapshot.ExpireSnapshotMessage.CommonControllerMessage;
+import org.apache.iceberg.flink.sink.expire.snapshot.ExpireSnapshotMessage.EndCheckpoint;
+import org.apache.iceberg.flink.sink.expire.snapshot.ExpireSnapshotMessage.EndExpireSnapshot;
+import org.apache.iceberg.flink.sink.expire.snapshot.ExpireSnapshotMessage.SnapshotsUnit;
+import org.apache.iceberg.io.ExpireSnapshotResult;
+import org.apache.iceberg.relocated.com.google.common.base.Joiner;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.util.ExpireSnapshotUtil;
+import org.apache.iceberg.util.PropertyUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ExpireSnapshotGenerator extends AbstractStreamOperator<CommonControllerMessage>
+    implements OneInputStreamOperator<EndCheckpoint, CommonControllerMessage>, BoundedOneInput {
+  private static final Logger LOG = LoggerFactory.getLogger(ExpireSnapshotGenerator.class);
+
+  private final TableLoader tableLoader;
+  private transient Table table;
+  private TableOperations ops;
+
+  private Integer retainLastValue = null;
+  private Long retainMaxAgeMs = null;
+
+  public ExpireSnapshotGenerator(TableLoader tableLoader) {
+    this.tableLoader = tableLoader;
+  }
+
+  @Override
+  public void initializeState(StateInitializationContext context) throws Exception {
+    super.initializeState(context);
+
+    this.tableLoader.open();
+    this.table = tableLoader.loadTable();
+    this.ops = ((HasTableOperations) table).operations();
+
+    this.retainMaxAgeMs = PropertyUtil.propertyAsLong(
+        table.properties(),
+        TableProperties.FLINK_AUTO_MAX_SNAPSHOT_AGE_MS,
+        TableProperties.FLINK_AUTO_MAX_SNAPSHOT_AGE_MS_DEFAULT);
+
+    this.retainLastValue = PropertyUtil
+        .propertyAsInt(
+            table.properties(),
+            TableProperties.FLINK_AUTO_MIN_SNAPSHOTS_TO_KEEP,
+            TableProperties.FLINK_AUTO_MIN_SNAPSHOTS_TO_KEEP_DEFAULT);
+  }
+
+  @Override
+  public void processElement(StreamRecord<EndCheckpoint> element) throws Exception {
+    //  received a EndCheckpoint message
+    EndCheckpoint endCheckpoint =  element.getValue();
+    long currentTimeMillis = System.currentTimeMillis();
+    LOG.info("Received an EndCheckpoint {}, begin to compute expired snapshots", endCheckpoint.getCheckpointId());
+
+    if (ExpireSnapshotUtil.shouldExpireSnapshot(table)) {
+      RemoveSnapshots removeSnapshots = new RemoveSnapshots(this.ops);
+      removeSnapshots
+          .cleanExpiredFiles(false)
+          .expireOlderThan(currentTimeMillis - this.retainMaxAgeMs)
+          .retainLast(this.retainLastValue);
+      removeSnapshots.commit();
+      LOG.info("update last expired snapshot timestamps：{}", new Date(currentTimeMillis));
+      table.updateProperties()
+          .set(TableProperties.FLINK_LAST_EXPIRE_SNAPSHOT_MS, Long.toString(currentTimeMillis))
+          .commit();
+
+      ExpireSnapshotResult result = removeSnapshots.getExpiredSnapshotResult();
+      if (result != null) {
+        Set<String> manifestFiles = result.getManifestsToDelete();
+        Set<String> manifestListFiles = result.getManifestListsToDelete();
+        Set<String> dataFiles = result.getFilesToDelete();
+
+        Set<String> allFilesToDelete = Sets.newHashSet();
+        allFilesToDelete.addAll(manifestFiles);
+        allFilesToDelete.addAll(manifestListFiles);
+        allFilesToDelete.addAll(dataFiles);
+        LOG.info("Generated {} expired files: {}", allFilesToDelete.size(), Joiner.on(", ").join(allFilesToDelete));
+
+        int groupNums = PropertyUtil.propertyAsInt(
+            table.properties(),
+            TableProperties.FLINK_AUTO_SNAPSHOTS_GROUP_NUMS,
+            TableProperties.FLINK_AUTO_SNAPSHOTS_GROUP_NUMS_DEFAULT);
+        int indexOfFile = 0;
+        int index = 0;
+        Set<String> fileBuffer = Sets.newHashSet();
+
+        for (String file : allFilesToDelete) {
+          fileBuffer.add(file);
+          indexOfFile++;
+          if (indexOfFile % groupNums == 0) {
+            emit(new SnapshotsUnit(fileBuffer, index));
+            LOG.info("Emit a SnapshotUnit (id :{}, files: {})", index, fileBuffer);
+            index++;
+            fileBuffer.clear();
+          }
+        }
+        emit(new SnapshotsUnit(fileBuffer, index));
+        LOG.info("Emit a SnapshotUnit (id :{}, files: {})", index, fileBuffer);
+        fileBuffer.clear();
+
+        //  send a expire snapshot end message
+        emit(new EndExpireSnapshot(endCheckpoint.getCheckpointId()));
+      }
+    }
+  }
+
+  /**
+   * It is notified that no more data will arrive on the input.
+   */
+  @Override
+  public void endInput() throws Exception {
+
+  }
+
+  @Override
+  public void dispose() throws Exception {
+    if (tableLoader != null) {
+      tableLoader.close();
+    }
+
+  }
+
+  private void emit(CommonControllerMessage result) {
+    output.collect(new StreamRecord<>(result));
+  }
+}

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/expire/snapshot/ExpireSnapshotMessage.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/expire/snapshot/ExpireSnapshotMessage.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.sink.expire.snapshot;
+
+import java.io.Serializable;
+import java.util.Set;
+
+public class ExpireSnapshotMessage {
+  private ExpireSnapshotMessage() {
+  }
+
+  public interface CommonControllerMessage extends Serializable {
+  }
+
+  //  checkpoint end message
+  public static class EndCheckpoint implements CommonControllerMessage {
+    private final long checkpointId;
+    private final int taskId;
+    private final int numberOfTasks;
+
+    //  checkpoint end message
+    public EndCheckpoint(long checkpointId, int taskId, int numberOfTasks) {
+      this.checkpointId = checkpointId;
+      this.taskId = taskId;
+      this.numberOfTasks = numberOfTasks;
+    }
+
+    public long getCheckpointId() {
+      return checkpointId;
+    }
+
+    public int getTaskId() {
+      return taskId;
+    }
+
+    public int getNumberOfTasks() {
+      return numberOfTasks;
+    }
+  }
+
+  //  Snapshot unit information, contains expire files to delete
+  public static class SnapshotsUnit implements CommonControllerMessage {
+    private final int unitId;
+    private final Set<String> deletedFiles;
+
+    public SnapshotsUnit(Set<String> files, int taskId) {
+      this.deletedFiles = files;
+      this.unitId = taskId;
+    }
+
+    public boolean isTaskMessage(int taskNumber, int taskId) {
+      return unitId % taskNumber == taskId;
+    }
+
+    public int getUnitId() {
+      return this.unitId;
+    }
+
+    public Set<String> getDeletedFiles() {
+      return this.deletedFiles;
+    }
+  }
+
+  //  expire snapshot end message
+  public static class EndExpireSnapshot implements CommonControllerMessage {
+    private final long checkpointId;
+
+    public EndExpireSnapshot(long checkpointId) {
+      this.checkpointId = checkpointId;
+    }
+
+    public long getCheckpointId() {
+      return checkpointId;
+    }
+  }
+
+}

--- a/flink/src/main/java/org/apache/iceberg/flink/sink/expire/snapshot/ExpireSnapshotOperator.java
+++ b/flink/src/main/java/org/apache/iceberg/flink/sink/expire/snapshot/ExpireSnapshotOperator.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink.sink.expire.snapshot;
+
+import java.util.concurrent.ExecutorService;
+import java.util.function.Consumer;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.exceptions.NotFoundException;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.sink.expire.snapshot.ExpireSnapshotMessage.CommonControllerMessage;
+import org.apache.iceberg.flink.sink.expire.snapshot.ExpireSnapshotMessage.EndExpireSnapshot;
+import org.apache.iceberg.flink.sink.expire.snapshot.ExpireSnapshotMessage.SnapshotsUnit;
+import org.apache.iceberg.relocated.com.google.common.base.Joiner;
+import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
+import org.apache.iceberg.util.Tasks;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ExpireSnapshotOperator extends AbstractStreamOperator<Void>
+    implements OneInputStreamOperator<CommonControllerMessage, Void>, BoundedOneInput {
+  private static final Logger LOG = LoggerFactory.getLogger(ExpireSnapshotOperator.class);
+
+  private final TableLoader tableLoader;
+  private transient Table table;
+  private TableOperations ops;
+
+  private Consumer<String> deleteFunc;
+  private ExecutorService deleteExecutorService;
+
+  public ExpireSnapshotOperator(TableLoader tableLoader) {
+    this.tableLoader = tableLoader;
+  }
+
+  @Override
+  public void initializeState(StateInitializationContext context) throws Exception {
+    super.initializeState(context);
+    this.tableLoader.open();
+    this.table = this.tableLoader.loadTable();
+    this.ops = ((HasTableOperations) table).operations();
+    this.deleteExecutorService = MoreExecutors.newDirectExecutorService();
+    this.deleteFunc = file -> ops.io().deleteFile(file);
+  }
+
+  @Override
+  public void processElement(StreamRecord<CommonControllerMessage> element) throws Exception {
+    CommonControllerMessage value = element.getValue();
+    if (value instanceof SnapshotsUnit) {
+      SnapshotsUnit unit = (SnapshotsUnit) value;
+      if (unit.isTaskMessage(
+          getRuntimeContext().getNumberOfParallelSubtasks(),
+          getRuntimeContext().getIndexOfThisSubtask())) {
+        LOG.info("Delete SnapshotsUnit (id: {}, to delete {} files: {})",
+            unit.getUnitId(), unit.getDeletedFiles().size(), Joiner.on(", ").join(unit.getDeletedFiles()));
+
+        Tasks.foreach(unit.getDeletedFiles())
+            .executeWith(deleteExecutorService)
+            .retry(3).stopRetryOn(NotFoundException.class).suppressFailureWhenFinished()
+            .onFailure((list, exc) -> LOG.warn("Delete failed for manifest list: {}", list, exc))
+            .run(deleteFunc::accept);
+      }
+    } else if (value instanceof EndExpireSnapshot) {
+      LOG.info("Received a EndExpireSnapshot message");
+    }
+  }
+
+  /**
+   * It is notified that no more data will arrive on the input.
+   */
+  @Override
+  public void endInput() throws Exception {
+  }
+
+  @Override
+  public void dispose() throws Exception {
+    if (tableLoader != null) {
+      tableLoader.close();
+    }
+  }
+
+}

--- a/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergFilesCommitter.java
@@ -54,6 +54,7 @@ import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.SimpleDataUtil;
 import org.apache.iceberg.flink.TestHelpers;
 import org.apache.iceberg.flink.TestTableLoader;
+import org.apache.iceberg.flink.sink.expire.snapshot.ExpireSnapshotMessage.EndCheckpoint;
 import org.apache.iceberg.io.FileAppenderFactory;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -120,7 +121,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
     long checkpointId = 0;
     long timestamp = 0;
     JobID jobId = new JobID();
-    try (OneInputStreamOperatorTestHarness<WriteResult, Void> harness = createStreamSink(jobId)) {
+    try (OneInputStreamOperatorTestHarness<WriteResult, EndCheckpoint> harness = createStreamSink(jobId)) {
       harness.setup();
       harness.open();
 
@@ -152,7 +153,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
     JobID jobId = new JobID();
     long checkpointId = 0;
     long timestamp = 0;
-    try (OneInputStreamOperatorTestHarness<WriteResult, Void> harness = createStreamSink(jobId)) {
+    try (OneInputStreamOperatorTestHarness<WriteResult, EndCheckpoint> harness = createStreamSink(jobId)) {
       harness.setup();
       harness.open();
 
@@ -183,7 +184,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
     long timestamp = 0;
 
     JobID jobID = new JobID();
-    try (OneInputStreamOperatorTestHarness<WriteResult, Void> harness = createStreamSink(jobID)) {
+    try (OneInputStreamOperatorTestHarness<WriteResult, EndCheckpoint> harness = createStreamSink(jobID)) {
       harness.setup();
       harness.open();
       assertSnapshotSize(0);
@@ -218,7 +219,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
     long timestamp = 0;
 
     JobID jobId = new JobID();
-    try (OneInputStreamOperatorTestHarness<WriteResult, Void> harness = createStreamSink(jobId)) {
+    try (OneInputStreamOperatorTestHarness<WriteResult, EndCheckpoint> harness = createStreamSink(jobId)) {
       harness.setup();
       harness.open();
 
@@ -269,7 +270,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
     long timestamp = 0;
 
     JobID jobId = new JobID();
-    try (OneInputStreamOperatorTestHarness<WriteResult, Void> harness = createStreamSink(jobId)) {
+    try (OneInputStreamOperatorTestHarness<WriteResult, EndCheckpoint> harness = createStreamSink(jobId)) {
       harness.setup();
       harness.open();
 
@@ -318,7 +319,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
     OperatorSubtaskState snapshot;
 
     JobID jobId = new JobID();
-    try (OneInputStreamOperatorTestHarness<WriteResult, Void> harness = createStreamSink(jobId)) {
+    try (OneInputStreamOperatorTestHarness<WriteResult, EndCheckpoint> harness = createStreamSink(jobId)) {
       harness.setup();
       harness.open();
 
@@ -342,7 +343,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
     }
 
     // Restore from the given snapshot
-    try (OneInputStreamOperatorTestHarness<WriteResult, Void> harness = createStreamSink(jobId)) {
+    try (OneInputStreamOperatorTestHarness<WriteResult, EndCheckpoint> harness = createStreamSink(jobId)) {
       harness.setup();
       harness.initializeState(snapshot);
       harness.open();
@@ -377,7 +378,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
     OperatorSubtaskState snapshot;
     List<RowData> expectedRows = Lists.newArrayList();
     JobID jobId = new JobID();
-    try (OneInputStreamOperatorTestHarness<WriteResult, Void> harness = createStreamSink(jobId)) {
+    try (OneInputStreamOperatorTestHarness<WriteResult, EndCheckpoint> harness = createStreamSink(jobId)) {
       harness.setup();
       harness.open();
 
@@ -395,7 +396,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
       assertFlinkManifests(1);
     }
 
-    try (OneInputStreamOperatorTestHarness<WriteResult, Void> harness = createStreamSink(jobId)) {
+    try (OneInputStreamOperatorTestHarness<WriteResult, EndCheckpoint> harness = createStreamSink(jobId)) {
       harness.setup();
       harness.initializeState(snapshot);
       harness.open();
@@ -428,7 +429,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
 
     // Redeploying flink job from external checkpoint.
     JobID newJobId = new JobID();
-    try (OneInputStreamOperatorTestHarness<WriteResult, Void> harness = createStreamSink(newJobId)) {
+    try (OneInputStreamOperatorTestHarness<WriteResult, EndCheckpoint> harness = createStreamSink(newJobId)) {
       harness.setup();
       harness.initializeState(snapshot);
       harness.open();
@@ -466,7 +467,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
     List<RowData> tableRows = Lists.newArrayList();
 
     JobID oldJobId = new JobID();
-    try (OneInputStreamOperatorTestHarness<WriteResult, Void> harness = createStreamSink(oldJobId)) {
+    try (OneInputStreamOperatorTestHarness<WriteResult, EndCheckpoint> harness = createStreamSink(oldJobId)) {
       harness.setup();
       harness.open();
 
@@ -495,7 +496,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
     checkpointId = 0;
     timestamp = 0;
     JobID newJobId = new JobID();
-    try (OneInputStreamOperatorTestHarness<WriteResult, Void> harness = createStreamSink(newJobId)) {
+    try (OneInputStreamOperatorTestHarness<WriteResult, EndCheckpoint> harness = createStreamSink(newJobId)) {
       harness.setup();
       harness.open();
 
@@ -529,7 +530,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
       int jobIndex = i % 3;
       int checkpointId = i / 3;
       JobID jobId = jobs[jobIndex];
-      try (OneInputStreamOperatorTestHarness<WriteResult, Void> harness = createStreamSink(jobId)) {
+      try (OneInputStreamOperatorTestHarness<WriteResult, EndCheckpoint> harness = createStreamSink(jobId)) {
         harness.setup();
         harness.open();
 
@@ -556,7 +557,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
   @Test
   public void testBoundedStream() throws Exception {
     JobID jobId = new JobID();
-    try (OneInputStreamOperatorTestHarness<WriteResult, Void> harness = createStreamSink(jobId)) {
+    try (OneInputStreamOperatorTestHarness<WriteResult, EndCheckpoint> harness = createStreamSink(jobId)) {
       harness.setup();
       harness.open();
 
@@ -583,7 +584,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
     final long checkpoint = 10;
 
     JobID jobId = new JobID();
-    try (OneInputStreamOperatorTestHarness<WriteResult, Void> harness = createStreamSink(jobId)) {
+    try (OneInputStreamOperatorTestHarness<WriteResult, EndCheckpoint> harness = createStreamSink(jobId)) {
       harness.setup();
       harness.open();
 
@@ -625,7 +626,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
     JobID jobId = new JobID();
     FileAppenderFactory<RowData> appenderFactory = createDeletableAppenderFactory();
 
-    try (OneInputStreamOperatorTestHarness<WriteResult, Void> harness = createStreamSink(jobId)) {
+    try (OneInputStreamOperatorTestHarness<WriteResult, EndCheckpoint> harness = createStreamSink(jobId)) {
       harness.setup();
       harness.open();
 
@@ -690,7 +691,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
     RowData insert1 = SimpleDataUtil.createInsert(1, "aaa");
     DataFile dataFile1 = writeDataFile("data-file-1", ImmutableList.of(insert1));
 
-    try (OneInputStreamOperatorTestHarness<WriteResult, Void> harness = createStreamSink(jobId)) {
+    try (OneInputStreamOperatorTestHarness<WriteResult, EndCheckpoint> harness = createStreamSink(jobId)) {
       harness.setup();
       harness.open();
 
@@ -713,7 +714,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
           .commit();
     }
 
-    try (OneInputStreamOperatorTestHarness<WriteResult, Void> harness = createStreamSink(jobId)) {
+    try (OneInputStreamOperatorTestHarness<WriteResult, EndCheckpoint> harness = createStreamSink(jobId)) {
       harness.setup();
       harness.open();
 
@@ -749,7 +750,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
     JobID jobId = new JobID();
     FileAppenderFactory<RowData> appenderFactory = createDeletableAppenderFactory();
 
-    try (OneInputStreamOperatorTestHarness<WriteResult, Void> harness = createStreamSink(jobId)) {
+    try (OneInputStreamOperatorTestHarness<WriteResult, EndCheckpoint> harness = createStreamSink(jobId)) {
       harness.setup();
       harness.open();
 
@@ -842,7 +843,7 @@ public class TestIcebergFilesCommitter extends TableTestBase {
     Assert.assertEquals(expectedSnapshotSize, Lists.newArrayList(table.snapshots()).size());
   }
 
-  private OneInputStreamOperatorTestHarness<WriteResult, Void> createStreamSink(JobID jobID)
+  private OneInputStreamOperatorTestHarness<WriteResult, EndCheckpoint> createStreamSink(JobID jobID)
       throws Exception {
     TestOperatorFactory factory = TestOperatorFactory.of(tablePath);
     return new OneInputStreamOperatorTestHarness<>(factory, createEnvironment(jobID));
@@ -861,8 +862,8 @@ public class TestIcebergFilesCommitter extends TableTestBase {
         .build();
   }
 
-  private static class TestOperatorFactory extends AbstractStreamOperatorFactory<Void>
-      implements OneInputStreamOperatorFactory<WriteResult, Void> {
+  private static class TestOperatorFactory extends AbstractStreamOperatorFactory<EndCheckpoint>
+      implements OneInputStreamOperatorFactory<WriteResult, EndCheckpoint> {
     private final String tablePath;
 
     private TestOperatorFactory(String tablePath) {
@@ -875,7 +876,8 @@ public class TestIcebergFilesCommitter extends TableTestBase {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T extends StreamOperator<Void>> T createStreamOperator(StreamOperatorParameters<Void> param) {
+    public <T extends StreamOperator<EndCheckpoint>> T createStreamOperator(
+        StreamOperatorParameters<EndCheckpoint> param) {
       IcebergFilesCommitter committer = new IcebergFilesCommitter(new TestTableLoader(tablePath), false);
       committer.setup(param.getContainingTask(), param.getStreamConfig(), param.getOutput());
       return (T) committer;

--- a/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergStreamWriter.java
+++ b/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergStreamWriter.java
@@ -48,6 +48,13 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.flink.SimpleDataUtil;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.sink.expire.snapshot.ExpireSnapshotGenerator;
+import org.apache.iceberg.flink.sink.expire.snapshot.ExpireSnapshotMessage.CommonControllerMessage;
+import org.apache.iceberg.flink.sink.expire.snapshot.ExpireSnapshotMessage.EndCheckpoint;
+import org.apache.iceberg.flink.sink.expire.snapshot.ExpireSnapshotMessage.EndExpireSnapshot;
+import org.apache.iceberg.flink.sink.expire.snapshot.ExpireSnapshotMessage.SnapshotsUnit;
+import org.apache.iceberg.flink.sink.expire.snapshot.ExpireSnapshotOperator;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -55,6 +62,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ExpireSnapshotUtil;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
@@ -333,6 +341,114 @@ public class TestIcebergStreamWriter {
     SimpleDataUtil.assertTableRecords(location, expected);
   }
 
+
+  @Test
+  public void testExpireSnapshotOperator() throws Exception {
+    try (OneInputStreamOperatorTestHarness<CommonControllerMessage, Void> harness = createExpireSnapshotOperator()) {
+      Set<String> deletedFiles = Sets.newHashSet();
+      File deleteFile1 = tempFolder.newFile("deleteFile_1");
+      File deleteFile2 = tempFolder.newFile("deleteFile_2");
+      File deleteFile3 = tempFolder.newFile("deleteFile_3");
+      deletedFiles.add(deleteFile1.getAbsolutePath());
+      deletedFiles.add(deleteFile2.getAbsolutePath());
+      deletedFiles.add(deleteFile3.getAbsolutePath());
+
+      deletedFiles.forEach(f -> Assert.assertTrue("Files exists", new File(f).exists()));
+
+      //  the snapshotsUnit whose index is 1 belongs to this task
+      long currentTimestamp = System.currentTimeMillis();
+      SnapshotsUnit snapshotsUnit = new SnapshotsUnit(deletedFiles, 1);
+      harness.processElement(snapshotsUnit, currentTimestamp);
+      deletedFiles.forEach(f -> Assert.assertFalse("All files has been deleted", new File(f).exists()));
+
+      deletedFiles.clear();
+      File deleteFile4 = tempFolder.newFile("deleteFile_4");
+      File deleteFile5 = tempFolder.newFile("deleteFile_5");
+      File deleteFile6 = tempFolder.newFile("deleteFile_6");
+      deletedFiles.add(deleteFile4.getAbsolutePath());
+      deletedFiles.add(deleteFile5.getAbsolutePath());
+      deletedFiles.add(deleteFile6.getAbsolutePath());
+
+      deletedFiles.forEach(f -> Assert.assertTrue("Files exists", new File(f).exists()));
+
+      //  the snapshotsUnit whose index is 2 doesn't belong to this task
+      snapshotsUnit = new SnapshotsUnit(deletedFiles, 2);
+      harness.processElement(snapshotsUnit, currentTimestamp);
+      deletedFiles.forEach(f -> Assert.assertTrue("All files will not be deleted", new File(f).exists()));
+    }
+  }
+
+  @Test
+  public void testExpireSnapshotGenerator() throws Exception {
+    long checkpointId = 1L;
+
+    // Adjust table properties.
+    table.updateProperties()
+        .set(TableProperties.SNAPSHOT_FLINK_AUTO_EXPIRE_ENABLED, "true")
+        .set(TableProperties.FLINK_AUTO_MIN_SNAPSHOTS_TO_KEEP, "1")
+        .set(TableProperties.SNAPSHOT_FLINK_AUTO_EXPIRE_INTERVAL_MS, "1")
+        .set(TableProperties.FLINK_AUTO_MAX_SNAPSHOT_AGE_MS, "1")
+        .set(TableProperties.FLINK_LAST_EXPIRE_SNAPSHOT_MS, "-1")
+        .commit();
+
+    try (OneInputStreamOperatorTestHarness<RowData, WriteResult> testHarness = createIcebergStreamWriter()) {
+      // The first checkpoint
+      testHarness.processElement(SimpleDataUtil.createRowData(1, "hello"), 1);
+      testHarness.processElement(SimpleDataUtil.createRowData(2, "world"), 1);
+      testHarness.processElement(SimpleDataUtil.createRowData(3, "hello"), 1);
+
+      testHarness.prepareSnapshotPreBarrier(checkpointId);
+      WriteResult result = WriteResult.builder().addAll(testHarness.extractOutputValues()).build();
+      Assert.assertEquals(0, result.deleteFiles().length);
+
+      // Commit the iceberg transaction.
+      AppendFiles appendFiles = table.newAppend();
+      Arrays.stream(result.dataFiles()).forEach(appendFiles::appendFile);
+      appendFiles.commit();
+
+      Assert.assertTrue("Should remove expire snapshots", ExpireSnapshotUtil.shouldExpireSnapshot(table));
+
+      // The second checkpoint
+      testHarness.processElement(SimpleDataUtil.createRowData(1, "hello"), 2);
+      testHarness.processElement(SimpleDataUtil.createRowData(2, "world"), 2);
+      testHarness.processElement(SimpleDataUtil.createRowData(3, "hello"), 2);
+
+      testHarness.prepareSnapshotPreBarrier(checkpointId++);
+      WriteResult result1 = WriteResult.builder().addAll(testHarness.extractOutputValues()).build();
+      Assert.assertEquals(0, result1.deleteFiles().length);
+
+      // Commit the iceberg transaction.
+      AppendFiles appendFiles1 = table.newAppend();
+      Arrays.stream(result1.dataFiles()).forEach(appendFiles1::appendFile);
+      appendFiles1.commit();
+
+      // The third checkpoint
+      testHarness.processElement(SimpleDataUtil.createRowData(1, "hello"), 3);
+      testHarness.processElement(SimpleDataUtil.createRowData(2, "world"), 3);
+      testHarness.processElement(SimpleDataUtil.createRowData(3, "hello"), 3);
+
+      testHarness.prepareSnapshotPreBarrier(checkpointId++);
+      WriteResult result2 = WriteResult.builder().addAll(testHarness.extractOutputValues()).build();
+      Assert.assertEquals(0, result2.deleteFiles().length);
+
+      // Commit the iceberg transaction.
+      AppendFiles appendFiles2 = table.newAppend();
+      Arrays.stream(result2.dataFiles()).forEach(appendFiles2::appendFile);
+      appendFiles2.commit();
+
+      OneInputStreamOperatorTestHarness<EndCheckpoint, CommonControllerMessage> harness =
+          createExpireSnapshotGenerator();
+
+      EndCheckpoint endCheckpoint = new EndCheckpoint(1, 1, 16);
+
+      long currentTimestamp = System.currentTimeMillis();
+      harness.processElement(endCheckpoint, currentTimestamp);
+      List<CommonControllerMessage> outputMessages = harness.extractOutputValues();
+
+      Assert.assertTrue(outputMessages.get(0) instanceof SnapshotsUnit);
+      Assert.assertTrue(outputMessages.get(outputMessages.size() - 1) instanceof EndExpireSnapshot);
+    }
+  }
   private OneInputStreamOperatorTestHarness<RowData, WriteResult> createIcebergStreamWriter() throws Exception {
     return createIcebergStreamWriter(table, SimpleDataUtil.FLINK_SCHEMA);
   }
@@ -349,4 +465,29 @@ public class TestIcebergStreamWriter {
 
     return harness;
   }
+
+  private OneInputStreamOperatorTestHarness<EndCheckpoint, CommonControllerMessage> createExpireSnapshotGenerator()
+      throws Exception {
+    TableLoader tableLoader = TableLoader.fromHadoopTable(tablePath);
+    ExpireSnapshotGenerator expireSnapshotGenerator = new ExpireSnapshotGenerator(tableLoader);
+
+    OneInputStreamOperatorTestHarness<EndCheckpoint, CommonControllerMessage> harness =
+        new OneInputStreamOperatorTestHarness<>(expireSnapshotGenerator, 1, 1, 0);
+    harness.setup();
+    harness.open();
+    return harness;
+  }
+
+  private OneInputStreamOperatorTestHarness<CommonControllerMessage, Void> createExpireSnapshotOperator()
+      throws Exception {
+    TableLoader tableLoader = TableLoader.fromHadoopTable(tablePath);
+    ExpireSnapshotOperator expireSnapshotOperator = new ExpireSnapshotOperator(tableLoader);
+
+    OneInputStreamOperatorTestHarness<CommonControllerMessage, Void> harness =
+        new OneInputStreamOperatorTestHarness<>(expireSnapshotOperator, 5, 5, 1);
+    harness.setup();
+    harness.open();
+    return harness;
+  }
+
 }


### PR DESCRIPTION
## What problem does this pr solved?
when we write data into icebeg table using flink, it will produce  a lot of small files. 
Merely compacting small files cannot reduce the number of small files. 
Only after compacting the small files and deleting expired snapshot files can we really reduce the number of small files overall.

This branch supports deleting expired snapshots automatically when writing data into iceberg table in flink. 

## How was this problem solved？
**We added the following configuration**
```
// auto expire snapshots
snapshot.flink.auto-expire.enabled
snapshot.flink.auto-expire.interval-ms
snapshot.flink.auto-expire.max-snapshot-age-ms
snapshot.flink.auto-expire.min-snapshots-to-keep
snapshot.flink.auto-expire.snapshots-group-nums
```

In this PR, we add 2 operators(ExpireSnapshotGenerator, ExpireSnapshotOperator) for expire snapshots function after IcebergFilesCommitter.


**expire snapshot function:**<br/>
1. In IcebergFilesCommitter.notifyCheckpointComplete(), we emit a 'EndCheckpoint' message to downstream operator 'ExpireSnapshotGenerator'.  <br/>
2. 'ExpireSnapshotGenerator' generates all files(manifest list file, menifest file, data file) that  needs to be deleted  and distributes them to downstream operator 'ExpireSnapshotOperator'. <br/>
3. 'ExpireSnapshotOperator' start to actually delete all files received from upstream in parallel.
