### PR TITLE
Core: Refactor SnapshotUtil using an Iterable

### DIFF
--- a/core/src/main/java/org/apache/iceberg/HistoryTable.java
+++ b/core/src/main/java/org/apache/iceberg/HistoryTable.java
@@ -91,7 +91,7 @@ public class HistoryTable extends BaseMetadataTable {
       snapshots.put(snap.snapshotId(), snap);
     }
 
-    Set<Long> ancestorIds = Sets.newHashSet(SnapshotUtil.currentAncestors(table));
+    Set<Long> ancestorIds = Sets.newHashSet(SnapshotUtil.currentAncestorIds(table));
 
     return historyEntry -> {
       long snapshotId = historyEntry.snapshotId();

--- a/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
@@ -111,10 +111,8 @@ class IncrementalDataTableScan extends DataTableScan {
   }
 
   private static List<Snapshot> snapshotsWithin(Table table, long fromSnapshotId, long toSnapshotId) {
-    List<Long> snapshotIds = SnapshotUtil.snapshotIdsBetween(table, fromSnapshotId, toSnapshotId);
     List<Snapshot> snapshots = Lists.newArrayList();
-    for (Long snapshotId : snapshotIds) {
-      Snapshot snapshot = table.snapshot(snapshotId);
+    for (Snapshot snapshot : SnapshotUtil.ancestorsBetween(toSnapshotId, fromSnapshotId, table::snapshot)) {
       // for now, incremental scan supports only appends
       if (snapshot.operation().equals(DataOperations.APPEND)) {
         snapshots.add(snapshot);
@@ -128,8 +126,8 @@ class IncrementalDataTableScan extends DataTableScan {
   }
 
   private void validateSnapshotIdsRefinement(long newFromSnapshotId, long newToSnapshotId) {
-    Set<Long> snapshotIdsRange = Sets.newHashSet(
-        SnapshotUtil.snapshotIdsBetween(table(), context().fromSnapshotId(), context().toSnapshotId()));
+    Set<Long> snapshotIdsRange = Sets.newHashSet(SnapshotUtil.toIds(
+        SnapshotUtil.ancestorsBetween(context().toSnapshotId(), context().fromSnapshotId(), table()::snapshot)));
     // since snapshotIdsBetween return ids in range (fromSnapshotId, toSnapshotId]
     snapshotIdsRange.add(context().fromSnapshotId());
     Preconditions.checkArgument(
@@ -148,7 +146,7 @@ class IncrementalDataTableScan extends DataTableScan {
         table.snapshot(fromSnapshotId) != null, "from snapshot %s does not exist", fromSnapshotId);
     Preconditions.checkArgument(
         table.snapshot(toSnapshotId) != null, "to snapshot %s does not exist", toSnapshotId);
-    Preconditions.checkArgument(SnapshotUtil.ancestorOf(table, toSnapshotId, fromSnapshotId),
+    Preconditions.checkArgument(SnapshotUtil.isAncestorOf(table, toSnapshotId, fromSnapshotId),
         "from snapshot %s is not an ancestor of to snapshot  %s", fromSnapshotId, toSnapshotId);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
@@ -126,8 +126,8 @@ class IncrementalDataTableScan extends DataTableScan {
   }
 
   private void validateSnapshotIdsRefinement(long newFromSnapshotId, long newToSnapshotId) {
-    Set<Long> snapshotIdsRange = Sets.newHashSet(SnapshotUtil.toIds(
-        SnapshotUtil.ancestorsBetween(context().toSnapshotId(), context().fromSnapshotId(), table()::snapshot)));
+    Set<Long> snapshotIdsRange = Sets.newHashSet(
+        SnapshotUtil.ancestorIdsBetween(context().toSnapshotId(), context().fromSnapshotId(), table()::snapshot));
     // since snapshotIdsBetween return ids in range (fromSnapshotId, toSnapshotId]
     snapshotIdsRange.add(context().fromSnapshotId());
     Preconditions.checkArgument(

--- a/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
@@ -101,6 +101,11 @@ public class SnapshotUtil {
     return ancestorsOf(start, lookup);
   }
 
+  public static Iterable<Long> ancestorIdsBetween(long latestSnapshotId, Long oldestSnapshotId,
+                                                  Function<Long, Snapshot> lookup) {
+    return toIds(ancestorsBetween(latestSnapshotId, oldestSnapshotId, lookup));
+  }
+
   public static Iterable<Snapshot> ancestorsBetween(long latestSnapshotId, Long oldestSnapshotId,
                                                     Function<Long, Snapshot> lookup) {
     if (oldestSnapshotId != null) {
@@ -161,7 +166,7 @@ public class SnapshotUtil {
     return Lists.newArrayList(toIds(ancestorsOf(snapshot, lookup)));
   }
 
-  public static Iterable<Long> toIds(Iterable<Snapshot> snapshots) {
+  private static Iterable<Long> toIds(Iterable<Snapshot> snapshots) {
     return Iterables.transform(snapshots, Snapshot::snapshotId);
   }
 

--- a/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
@@ -19,7 +19,10 @@
 
 package org.apache.iceberg.util;
 
+import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.function.Function;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.HistoryEntry;
@@ -28,6 +31,7 @@ import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
@@ -38,19 +42,31 @@ public class SnapshotUtil {
   /**
    * Returns whether ancestorSnapshotId is an ancestor of snapshotId.
    */
-  public static boolean ancestorOf(Table table, long snapshotId, long ancestorSnapshotId) {
-    Snapshot current = table.snapshot(snapshotId);
-    while (current != null) {
-      long id = current.snapshotId();
-      if (ancestorSnapshotId == id) {
+  public static boolean isAncestorOf(Table table, long snapshotId, long ancestorSnapshotId) {
+    for (Snapshot snapshot : ancestorsOf(snapshotId, table::snapshot)) {
+      if (snapshot.snapshotId() == ancestorSnapshotId) {
         return true;
-      } else if (current.parentId() != null) {
-        current = table.snapshot(current.parentId());
-      } else {
-        return false;
       }
     }
+
     return false;
+  }
+
+  /**
+   * Returns whether ancestorSnapshotId is an ancestor of the table's current state.
+   */
+  public static boolean isAncestorOf(Table table, long ancestorSnapshotId) {
+    return isAncestorOf(table, table.currentSnapshot().snapshotId(), ancestorSnapshotId);
+  }
+
+  /**
+   * Returns an iterable that traverses the table's snapshots from the current to the last known ancestor.
+   *
+   * @param table a Table
+   * @return an iterable from the table's current snapshot to its last known ancestor
+   */
+  public static Iterable<Snapshot> currentAncestors(Table table) {
+    return ancestorsOf(table.currentSnapshot(), table::snapshot);
   }
 
   /**
@@ -62,7 +78,7 @@ public class SnapshotUtil {
    * @param table a {@link Table}
    * @return a set of snapshot IDs of the known ancestor snapshots, including the current ID
    */
-  public static List<Long> currentAncestors(Table table) {
+  public static List<Long> currentAncestorIds(Table table) {
     return ancestorIds(table.currentSnapshot(), table::snapshot);
   }
 
@@ -70,56 +86,100 @@ public class SnapshotUtil {
    * Traverses the history of the table's current snapshot and finds the oldest Snapshot.
    * @return null if there is no current snapshot in the table, else the oldest Snapshot.
    */
-  public static Snapshot oldestSnapshot(Table table) {
-    Snapshot current = table.currentSnapshot();
-    while (current != null && current.parentId() != null) {
-      current = table.snapshot(current.parentId());
+  public static Snapshot oldestAncestor(Table table) {
+    Snapshot lastSnapshot = null;
+    for (Snapshot snapshot : currentAncestors(table)) {
+      lastSnapshot = snapshot;
     }
 
-    return current;
+    return lastSnapshot;
   }
 
-  /**
-   * Returns list of snapshot ids in the range - (fromSnapshotId, toSnapshotId]
-   * <p>
-   * This method assumes that fromSnapshotId is an ancestor of toSnapshotId.
-   */
-  public static List<Long> snapshotIdsBetween(Table table, long fromSnapshotId, long toSnapshotId) {
-    List<Long> snapshotIds = Lists.newArrayList(ancestorIds(table.snapshot(toSnapshotId),
-        snapshotId -> snapshotId != fromSnapshotId ? table.snapshot(snapshotId) : null));
-    return snapshotIds;
+  public static Iterable<Snapshot> ancestorsOf(long snapshotId, Function<Long, Snapshot> lookup) {
+    Snapshot start = lookup.apply(snapshotId);
+    Preconditions.checkArgument(start != null, "Cannot find snapshot: %s", snapshotId);
+    return ancestorsOf(start, lookup);
+  }
+
+  public static Iterable<Snapshot> ancestorsBetween(long latestSnapshotId, Long oldestSnapshotId,
+                                                    Function<Long, Snapshot> lookup) {
+    if (oldestSnapshotId != null) {
+      if (latestSnapshotId == oldestSnapshotId) {
+        return ImmutableList.of();
+      }
+
+      return ancestorsOf(latestSnapshotId,
+          snapshotId -> !oldestSnapshotId.equals(snapshotId) ? lookup.apply(snapshotId) : null);
+    } else {
+      return ancestorsOf(latestSnapshotId, lookup);
+    }
+  }
+
+  private static Iterable<Snapshot> ancestorsOf(Snapshot snapshot, Function<Long, Snapshot> lookup) {
+    if (snapshot != null) {
+      return () -> new Iterator<Snapshot>() {
+        private Snapshot next = snapshot;
+        private boolean consumed = false; // include the snapshot in its history
+
+        @Override
+        public boolean hasNext() {
+          if (!consumed) {
+            return true;
+          }
+
+          Long parentId = next.parentId();
+          if (parentId == null) {
+            return false;
+          }
+
+          this.next = lookup.apply(parentId);
+          if (next != null) {
+            this.consumed = false;
+            return true;
+          }
+
+          return false;
+        }
+
+        @Override
+        public Snapshot next() {
+          if (hasNext()) {
+            this.consumed = true;
+            return next;
+          }
+
+          throw new NoSuchElementException();
+        }
+      };
+
+    } else {
+      return ImmutableList.of();
+    }
   }
 
   public static List<Long> ancestorIds(Snapshot snapshot, Function<Long, Snapshot> lookup) {
-    List<Long> ancestorIds = Lists.newArrayList();
-    Snapshot current = snapshot;
-    while (current != null) {
-      ancestorIds.add(current.snapshotId());
-      if (current.parentId() != null) {
-        current = lookup.apply(current.parentId());
-      } else {
-        current = null;
-      }
-    }
-    return ancestorIds;
+    return Lists.newArrayList(toIds(ancestorsOf(snapshot, lookup)));
+  }
+
+  public static Iterable<Long> toIds(Iterable<Snapshot> snapshots) {
+    return Iterables.transform(snapshots, Snapshot::snapshotId);
   }
 
   public static List<DataFile> newFiles(Long baseSnapshotId, long latestSnapshotId, Function<Long, Snapshot> lookup) {
     List<DataFile> newFiles = Lists.newArrayList();
-
-    Long currentSnapshotId = latestSnapshotId;
-    while (currentSnapshotId != null && !currentSnapshotId.equals(baseSnapshotId)) {
-      Snapshot currentSnapshot = lookup.apply(currentSnapshotId);
-
-      if (currentSnapshot == null) {
-        throw new ValidationException(
-            "Cannot determine history between read snapshot %s and current %s",
-            baseSnapshotId, currentSnapshotId);
+    Snapshot lastSnapshot = null;
+    for (Snapshot currentSnapshot : ancestorsOf(latestSnapshotId, lookup)) {
+      lastSnapshot = currentSnapshot;
+      if (Objects.equals(currentSnapshot.snapshotId(), baseSnapshotId)) {
+        return newFiles;
       }
 
       Iterables.addAll(newFiles, currentSnapshot.addedFiles());
-      currentSnapshotId = currentSnapshot.parentId();
     }
+
+    ValidationException.check(Objects.equals(lastSnapshot.parentId(), baseSnapshotId),
+        "Cannot determine history between read snapshot %s and the last known ancestor %s",
+        baseSnapshotId, lastSnapshot.snapshotId());
 
     return newFiles;
   }
@@ -133,14 +193,10 @@ public class SnapshotUtil {
    */
   public static Snapshot snapshotAfter(Table table, long snapshotId) {
     Preconditions.checkArgument(table.snapshot(snapshotId) != null, "Cannot find parent snapshot: %s", snapshotId);
-
-    Snapshot current = table.currentSnapshot();
-    while (current != null) {
+    for (Snapshot current : currentAncestors(table)) {
       if (current.parentId() == snapshotId) {
         return current;
       }
-
-      current = table.snapshot(current.parentId());
     }
 
     throw new IllegalStateException(

--- a/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/source/StreamingMonitorFunction.java
+++ b/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/source/StreamingMonitorFunction.java
@@ -98,8 +98,7 @@ public class StreamingMonitorFunction extends RichSourceFunction<FlinkInputSplit
     } else if (scanContext.startSnapshotId() != null) {
       Preconditions.checkNotNull(table.currentSnapshot(), "Don't have any available snapshot in table.");
 
-      long currentSnapshotId = table.currentSnapshot().snapshotId();
-      Preconditions.checkState(SnapshotUtil.ancestorOf(table, currentSnapshotId, scanContext.startSnapshotId()),
+      Preconditions.checkState(SnapshotUtil.isAncestorOf(table, scanContext.startSnapshotId()),
           "The option start-snapshot-id %s is not an ancestor of the current snapshot.", scanContext.startSnapshotId());
 
       lastSnapshotId = scanContext.startSnapshotId();

--- a/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingReaderOperator.java
+++ b/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingReaderOperator.java
@@ -238,7 +238,7 @@ public class TestStreamingReaderOperator extends TableTestBase {
   private List<FlinkInputSplit> generateSplits() {
     List<FlinkInputSplit> inputSplits = Lists.newArrayList();
 
-    List<Long> snapshotIds = SnapshotUtil.currentAncestors(table);
+    List<Long> snapshotIds = SnapshotUtil.currentAncestorIds(table);
     for (int i = snapshotIds.size() - 1; i >= 0; i--) {
       ScanContext scanContext;
       if (i == snapshotIds.size() - 1) {

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/StreamingMonitorFunction.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/StreamingMonitorFunction.java
@@ -99,7 +99,7 @@ public class StreamingMonitorFunction extends RichSourceFunction<FlinkInputSplit
       Preconditions.checkNotNull(table.currentSnapshot(), "Don't have any available snapshot in table.");
 
       long currentSnapshotId = table.currentSnapshot().snapshotId();
-      Preconditions.checkState(SnapshotUtil.ancestorOf(table, currentSnapshotId, scanContext.startSnapshotId()),
+      Preconditions.checkState(SnapshotUtil.isAncestorOf(table, currentSnapshotId, scanContext.startSnapshotId()),
           "The option start-snapshot-id %s is not an ancestor of the current snapshot.", scanContext.startSnapshotId());
 
       lastSnapshotId = scanContext.startSnapshotId();

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingReaderOperator.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingReaderOperator.java
@@ -238,7 +238,7 @@ public class TestStreamingReaderOperator extends TableTestBase {
   private List<FlinkInputSplit> generateSplits() {
     List<FlinkInputSplit> inputSplits = Lists.newArrayList();
 
-    List<Long> snapshotIds = SnapshotUtil.currentAncestors(table);
+    List<Long> snapshotIds = SnapshotUtil.currentAncestorIds(table);
     for (int i = snapshotIds.size() - 1; i >= 0; i--) {
       ScanContext scanContext;
       if (i == snapshotIds.size() - 1) {

--- a/spark/v2.4/spark/src/main/java/org/apache/iceberg/actions/SparkActions.java
+++ b/spark/v2.4/spark/src/main/java/org/apache/iceberg/actions/SparkActions.java
@@ -28,4 +28,3 @@ class SparkActions extends Actions {
     super(spark, table);
   }
 }
- 

--- a/spark/v2.4/spark/src/main/java/org/apache/iceberg/actions/SparkActions.java
+++ b/spark/v2.4/spark/src/main/java/org/apache/iceberg/actions/SparkActions.java
@@ -28,3 +28,4 @@ class SparkActions extends Actions {
     super(spark, table);
   }
 }
+ 

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -238,7 +238,7 @@ public class TestDataSourceOptions {
           .mode("append")
           .save(tableLocation);
     }
-    List<Long> snapshotIds = SnapshotUtil.currentAncestors(table);
+    List<Long> snapshotIds = SnapshotUtil.currentAncestorIds(table);
 
     // start-snapshot-id and snapshot-id are both configured.
     AssertHelpers.assertThrows(

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/procedures/AncestorsOfProcedure.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/procedures/AncestorsOfProcedure.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.spark.procedures;
 
 import java.util.List;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.spark.sql.catalyst.InternalRow;
@@ -79,7 +80,8 @@ public class AncestorsOfProcedure extends BaseProcedure {
       toSnapshotId = icebergTable.currentSnapshot() != null ? icebergTable.currentSnapshot().snapshotId() : -1;
     }
 
-    List<Long> snapshotIds = SnapshotUtil.snapshotIdsBetween(icebergTable, 0L, toSnapshotId);
+    List<Long> snapshotIds = Lists.newArrayList(
+        SnapshotUtil.ancestorIdsBetween(toSnapshotId, null, icebergTable::snapshot));
 
     return toOutputRow(icebergTable, snapshotIds);
   }

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -166,7 +166,7 @@ public class SparkMicroBatchStream implements MicroBatchStream {
   private List<FileScanTask> planFiles(StreamingOffset startOffset, StreamingOffset endOffset) {
     List<FileScanTask> fileScanTasks = Lists.newArrayList();
     StreamingOffset batchStartOffset = StreamingOffset.START_OFFSET.equals(startOffset) ?
-        new StreamingOffset(SnapshotUtil.oldestSnapshot(table).snapshotId(), 0, false) :
+        new StreamingOffset(SnapshotUtil.oldestAncestor(table).snapshotId(), 0, false) :
         startOffset;
 
     StreamingOffset currentOffset = null;
@@ -233,7 +233,7 @@ public class SparkMicroBatchStream implements MicroBatchStream {
       table.refresh();
       StreamingOffset offset = table.currentSnapshot() == null ?
           StreamingOffset.START_OFFSET :
-          new StreamingOffset(SnapshotUtil.oldestSnapshot(table).snapshotId(), 0, false);
+          new StreamingOffset(SnapshotUtil.oldestAncestor(table).snapshotId(), 0, false);
 
       OutputFile outputFile = io.newOutputFile(initialOffsetLocation);
       writeOffset(offset, outputFile);

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -238,7 +238,7 @@ public class TestDataSourceOptions {
           .mode("append")
           .save(tableLocation);
     }
-    List<Long> snapshotIds = SnapshotUtil.currentAncestors(table);
+    List<Long> snapshotIds = SnapshotUtil.currentAncestorIds(table);
 
     // start-snapshot-id and snapshot-id are both configured.
     AssertHelpers.assertThrows(

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/AncestorsOfProcedure.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/AncestorsOfProcedure.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.spark.procedures;
 
 import java.util.List;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.spark.sql.catalyst.InternalRow;
@@ -79,7 +80,8 @@ public class AncestorsOfProcedure extends BaseProcedure {
       toSnapshotId = icebergTable.currentSnapshot() != null ? icebergTable.currentSnapshot().snapshotId() : -1;
     }
 
-    List<Long> snapshotIds = SnapshotUtil.snapshotIdsBetween(icebergTable, 0L, toSnapshotId);
+    List<Long> snapshotIds = Lists.newArrayList(
+        SnapshotUtil.ancestorIdsBetween(toSnapshotId, null, icebergTable::snapshot));
 
     return toOutputRow(icebergTable, snapshotIds);
   }

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -166,7 +166,7 @@ public class SparkMicroBatchStream implements MicroBatchStream {
   private List<FileScanTask> planFiles(StreamingOffset startOffset, StreamingOffset endOffset) {
     List<FileScanTask> fileScanTasks = Lists.newArrayList();
     StreamingOffset batchStartOffset = StreamingOffset.START_OFFSET.equals(startOffset) ?
-        new StreamingOffset(SnapshotUtil.oldestSnapshot(table).snapshotId(), 0, false) :
+        new StreamingOffset(SnapshotUtil.oldestAncestor(table).snapshotId(), 0, false) :
         startOffset;
 
     StreamingOffset currentOffset = null;
@@ -233,7 +233,7 @@ public class SparkMicroBatchStream implements MicroBatchStream {
       table.refresh();
       StreamingOffset offset = table.currentSnapshot() == null ?
           StreamingOffset.START_OFFSET :
-          new StreamingOffset(SnapshotUtil.oldestSnapshot(table).snapshotId(), 0, false);
+          new StreamingOffset(SnapshotUtil.oldestAncestor(table).snapshotId(), 0, false);
 
       OutputFile outputFile = io.newOutputFile(initialOffsetLocation);
       writeOffset(offset, outputFile);

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -238,7 +238,7 @@ public class TestDataSourceOptions {
           .mode("append")
           .save(tableLocation);
     }
-    List<Long> snapshotIds = SnapshotUtil.currentAncestors(table);
+    List<Long> snapshotIds = SnapshotUtil.currentAncestorIds(table);
 
     // start-snapshot-id and snapshot-id are both configured.
     AssertHelpers.assertThrows(

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/AncestorsOfProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/AncestorsOfProcedure.java
@@ -20,8 +20,8 @@
 package org.apache.iceberg.spark.procedures;
 
 import java.util.List;
-import org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.collect.Lists;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.spark.sql.catalyst.InternalRow;

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/AncestorsOfProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/AncestorsOfProcedure.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.spark.procedures;
 
 import java.util.List;
+import org.apache.hadoop.shaded.org.apache.curator.shaded.com.google.common.collect.Lists;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.iceberg.util.SnapshotUtil;
@@ -79,7 +80,8 @@ public class AncestorsOfProcedure extends BaseProcedure {
       toSnapshotId = icebergTable.currentSnapshot() != null ? icebergTable.currentSnapshot().snapshotId() : -1;
     }
 
-    List<Long> snapshotIds = SnapshotUtil.snapshotIdsBetween(icebergTable, 0L, toSnapshotId);
+    List<Long> snapshotIds = Lists.newArrayList(
+        SnapshotUtil.ancestorIdsBetween(toSnapshotId, null, icebergTable::snapshot));
 
     return toOutputRow(icebergTable, snapshotIds);
   }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -164,7 +164,7 @@ public class SparkMicroBatchStream implements MicroBatchStream {
   private List<FileScanTask> planFiles(StreamingOffset startOffset, StreamingOffset endOffset) {
     List<FileScanTask> fileScanTasks = Lists.newArrayList();
     StreamingOffset batchStartOffset = StreamingOffset.START_OFFSET.equals(startOffset) ?
-        new StreamingOffset(SnapshotUtil.oldestSnapshot(table).snapshotId(), 0, false) :
+        new StreamingOffset(SnapshotUtil.oldestAncestor(table).snapshotId(), 0, false) :
         startOffset;
 
     StreamingOffset currentOffset = null;
@@ -231,7 +231,7 @@ public class SparkMicroBatchStream implements MicroBatchStream {
       table.refresh();
       StreamingOffset offset = table.currentSnapshot() == null ?
           StreamingOffset.START_OFFSET :
-          new StreamingOffset(SnapshotUtil.oldestSnapshot(table).snapshotId(), 0, false);
+          new StreamingOffset(SnapshotUtil.oldestAncestor(table).snapshotId(), 0, false);
 
       OutputFile outputFile = io.newOutputFile(initialOffsetLocation);
       writeOffset(offset, outputFile);

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -238,7 +238,7 @@ public class TestDataSourceOptions {
           .mode("append")
           .save(tableLocation);
     }
-    List<Long> snapshotIds = SnapshotUtil.currentAncestors(table);
+    List<Long> snapshotIds = SnapshotUtil.currentAncestorIds(table);
 
     // start-snapshot-id and snapshot-id are both configured.
     AssertHelpers.assertThrows(


### PR DESCRIPTION
There are many places that traverse snapshot history by looping over ancestors. Instead of rebuilding this logic everywhere, `SnapshotUtil` should provide an iterable to traverse ancestors. This adds that iterable and uses it to simplify code in other places that don't need to use the `parentId` logic.