### PR TITLE
Labeler: Add Aliyun to the autolabeler config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -76,3 +76,5 @@ AWS:
   - aws/**/*
 NESSIE:
   - nessie/**/*
+ALIYUN:
+  - aliyun/**/*


### PR DESCRIPTION
Adds `ALIYUN` as a possible PR label as it has its own top-level folder.