### PR TITLE
[SPARK] Simplify shouldProcess check in Spark3 streaming source

### DIFF
--- a/spark3/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark3/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -219,8 +219,8 @@ public class SparkMicroBatchStream implements MicroBatchStream {
         return false;
       case DataOperations.DELETE:
         Preconditions.checkState(skipDelete,
-            "Cannot process %s snapshot when read option %s is %b : %s", op.toLowerCase(Locale.ROOT),
-            SparkReadOptions.STREAMING_SKIP_DELETE_SNAPSHOTS, skipDelete, snapshot.snapshotId());
+            "Cannot process delete snapshot : %s. Set read option %s to allow skipping snapshots of type delete",
+            snapshot.snapshotId(), SparkReadOptions.STREAMING_SKIP_DELETE_SNAPSHOTS);
         return false;
       default:
         throw new IllegalStateException(String.format(


### PR DESCRIPTION
Replaces a somewhat complicated set of calls to Preconditions.checkState in the Spark 3 MicroBatchStream `shouldProcess` method with a simpler switch statement for readability.

Also places the most common checks first (instead of doing a string comparison check twice against both `"DELETE"` and `"APPEND"`).

This method was a bit confusing for me on first read and given that the APPEND check is the most common case, processing it first and reducing the number of string comparison checks will likely be more performant. It is more readable in my opinion.

I was going to allow for also skipping OVERWRITE if users set a flag, but there is already open discussion around this and some older PRs. So I closed my original PR in favor of just simplify the check and continuing the discussion elsewhere: https://github.com/apache/iceberg/pull/3267