### PR TITLE
Extensions to the JdbcCatalog.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalogNamespace.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalogNamespace.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.jdbc;
+
+public class JdbcCatalogNamespace {
+  protected static final String CATALOG_NAMESPACE_TABLE_NAME = "iceberg_namespaces";
+  protected static final String CATALOG_NAME = "catalog_name";
+  protected static final String NAMESPACE_NAME = "namespace_name";
+  protected static final String NAMESPACE_LOCATION = "location";
+  protected static final String NAMESPACE_METADATA = "metadata";
+  protected static final String NAMESPACE_PROPERTIES = "properties";
+
+  protected static final String CREATE_NAMESPACE_TABLE =
+          "CREATE TABLE " + CATALOG_NAMESPACE_TABLE_NAME +
+                  "(" +
+                  CATALOG_NAME + " VARCHAR(255) NOT NULL," +
+                  NAMESPACE_NAME + " VARCHAR(255) NOT NULL," +
+                  NAMESPACE_LOCATION + " VARCHAR(5500)," +
+                  NAMESPACE_METADATA + " VARCHAR(65535)," +
+                  NAMESPACE_PROPERTIES + " VARCHAR(65535)," +
+                  "PRIMARY KEY (" + CATALOG_NAME + ", " + NAMESPACE_NAME + ")" +
+                  ")";
+
+  protected static final String GET_NAMESPACE_SQL = "SELECT " + NAMESPACE_NAME + " FROM " +
+          CATALOG_NAMESPACE_TABLE_NAME + " WHERE " + CATALOG_NAME + " = ? AND " + NAMESPACE_NAME +
+          " LIKE ? LIMIT 1";
+
+  protected static final String LIST_NAMESPACES_SQL = "SELECT DISTINCT " + NAMESPACE_NAME +
+          " FROM " + CATALOG_NAMESPACE_TABLE_NAME +
+          " WHERE " + CATALOG_NAME + " = ? AND " + NAMESPACE_NAME + " LIKE ?";
+
+  protected static final String DO_COMMIT_CREATE_NAMESPACE_SQL = "INSERT INTO " + CATALOG_NAMESPACE_TABLE_NAME +
+          " (" + CATALOG_NAME + ", " + NAMESPACE_NAME + ", " + NAMESPACE_LOCATION + ", " + NAMESPACE_METADATA +
+          ", " + NAMESPACE_PROPERTIES + ") " +
+          " VALUES (?,?,?,?,?)";
+
+  protected static final String DELETE_NAMESPACE_SQL = "DELETE FROM " + CATALOG_NAMESPACE_TABLE_NAME +
+          " WHERE " + CATALOG_NAME + " = ? AND " + NAMESPACE_NAME + " = ?";
+
+  protected static final String UPDATE_NAMESPACE_PROPERTIES_SQL = "UPDATE " + CATALOG_NAMESPACE_TABLE_NAME +
+          " SET " + NAMESPACE_PROPERTIES + " = ? " + " WHERE " + CATALOG_NAME + " = ? AND " + NAMESPACE_NAME +
+          " = ? ";
+
+  protected static final String GET_NAMESPACE_PROPERTIES_SQL = "SELECT " + NAMESPACE_NAME + " , " +
+          NAMESPACE_PROPERTIES + " FROM " +
+          CATALOG_NAMESPACE_TABLE_NAME + " WHERE " + CATALOG_NAME + " = ? AND " + NAMESPACE_NAME + " = ? ";
+
+  private JdbcCatalogNamespace() {
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalogTable.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalogTable.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.jdbc;
+
+public class JdbcCatalogTable {
+  protected static final String CATALOG_TABLE_NAME = "iceberg_tables";
+  protected static final String CATALOG_NAME = "catalog_name";
+  protected static final String TABLE_NAMESPACE = "table_namespace";
+  protected static final String TABLE_NAME = "table_name";
+  protected static final String METADATA_LOCATION = "metadata_location";
+  protected static final String PREVIOUS_METADATA_LOCATION = "previous_metadata_location";
+
+  public static final String DO_COMMIT_SQL = "UPDATE " + CATALOG_TABLE_NAME +
+          " SET " + METADATA_LOCATION + " = ? , " + PREVIOUS_METADATA_LOCATION + " = ? " +
+          " WHERE " + CATALOG_NAME + " = ? AND " +
+          TABLE_NAMESPACE + " = ? AND " +
+          TABLE_NAME + " = ? AND " +
+          METADATA_LOCATION + " = ?";
+  protected static final String CREATE_CATALOG_TABLE =
+          "CREATE TABLE " + CATALOG_TABLE_NAME +
+                  "(" +
+                  CATALOG_NAME + " VARCHAR(255) NOT NULL," +
+                  TABLE_NAMESPACE + " VARCHAR(255) NOT NULL," +
+                  TABLE_NAME + " VARCHAR(255) NOT NULL," +
+                  METADATA_LOCATION + " VARCHAR(5500)," +
+                  PREVIOUS_METADATA_LOCATION + " VARCHAR(5500)," +
+                  "PRIMARY KEY (" + CATALOG_NAME + ", " + TABLE_NAMESPACE + ", " + TABLE_NAME + ")" +
+                  ")";
+  protected static final String GET_TABLE_SQL = "SELECT * FROM " + CATALOG_TABLE_NAME +
+          " WHERE " + CATALOG_NAME + " = ? AND " + TABLE_NAMESPACE + " = ? AND " + TABLE_NAME + " = ? ";
+  protected static final String LIST_TABLES_SQL = "SELECT * FROM " + CATALOG_TABLE_NAME +
+          " WHERE " + CATALOG_NAME + " = ? AND " + TABLE_NAMESPACE + " = ?";
+  protected static final String RENAME_TABLE_SQL = "UPDATE " + CATALOG_TABLE_NAME +
+          " SET " + TABLE_NAMESPACE + " = ? , " + TABLE_NAME + " = ? " +
+          " WHERE " + CATALOG_NAME + " = ? AND " + TABLE_NAMESPACE + " = ? AND " + TABLE_NAME + " = ? ";
+  protected static final String DROP_TABLE_SQL = "DELETE FROM " + CATALOG_TABLE_NAME +
+          " WHERE " + CATALOG_NAME + " = ? AND " + TABLE_NAMESPACE + " = ? AND " + TABLE_NAME + " = ? ";
+
+  protected static final String DO_COMMIT_CREATE_TABLE_SQL = "INSERT INTO " + CATALOG_TABLE_NAME +
+          " (" + CATALOG_NAME + ", " + TABLE_NAMESPACE + ", " + TABLE_NAME +
+          ", " + METADATA_LOCATION + ", " + PREVIOUS_METADATA_LOCATION + ") " +
+          " VALUES (?,?,?,?,null)";
+
+  private JdbcCatalogTable() {
+  }
+}
+

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcUtil.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcUtil.java
@@ -45,4 +45,26 @@ public class TestJdbcUtil {
 
     Assertions.assertThat(expected).isEqualTo(actual);
   }
+
+  @Test
+  public void testCovertJsonStringToMap() {
+    String inputJsonString = "{\"name\":\"foo\",\"age\":\"37\"}";
+    Map<String, String> expectedMap = new HashMap<>();
+    expectedMap.put("name", "foo");
+    expectedMap.put("age", "37");
+    Map<String, String> actualMap = JdbcUtil.convertJsonStringToMap(inputJsonString);
+
+    Assertions.assertThat(expectedMap).isEqualTo(actualMap);
+  }
+
+  @Test
+  public void testConvertMapToJsonString() {
+    Map<String, String> inputMap = new HashMap<>();
+    inputMap.put("name", "foo");
+    inputMap.put("age", "37");
+    String expectedJsonString = "{\"name\":\"foo\",\"age\":\"37\"}";
+    String actualJsonString = JdbcUtil.convertMapToJsonString(inputMap);
+
+    Assertions.assertThat(expectedJsonString).isEqualTo(actualJsonString);
+  }
 }


### PR DESCRIPTION
PR description:

Overall goal: Extensions to the JDBC Catalog including namespace in a separate sql table with properties. Similar to the POC in: https://github.com/apache/iceberg/pull/3177 

Changes:
1. Split the JdbcUtil constants to JdbcCatalogNamespace and JdbcCatalogTable respectively to correspond to the sql statements for namespace and table respectively.
2. Modified JdbcCatalog and JdbcTableOperations to support Namespace creation, add/ remove properties and Checking for namespace existence prior to table creation.
3. Updated tests to test for the new methods. And some of them needed modifications since createNamespace wasn't fully implemented. 

Possible concern/ breaking change:
1. Had to add a dbProperties field to allow the JdbcTableOperations to read the namespace db and do so with the right credentials. Any alternative to this?

Questions and possible help needed:
1. Is the design ok to proceed with to help incorporate the changes?
2. The Concurrency tests keep failing but it's not clear what is the cause. Could use some help here?
3. Since this is my first PR, please excuse any obvious things I may have missed. 

