### PR TITLE
Parquet: avoid premature closing of FSDataInputStream object

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetIO.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetIO.java
@@ -166,9 +166,11 @@ class ParquetIO {
 
   private static class ParquetInputFile implements InputFile {
     private final org.apache.iceberg.io.InputFile file;
+    private org.apache.iceberg.io.SeekableInputStream icebergHadoopStream;
 
     private ParquetInputFile(org.apache.iceberg.io.InputFile file) {
       this.file = file;
+      this.icebergHadoopStream = null;
     }
 
     @Override
@@ -178,7 +180,8 @@ class ParquetIO {
 
     @Override
     public SeekableInputStream newStream() throws IOException {
-      return stream(file.newStream());
+      icebergHadoopStream = file.newStream();
+      return stream(icebergHadoopStream);
     }
   }
 }


### PR DESCRIPTION
https://github.com/apache/iceberg/pull/90 adds a finalizer that closes open streams when they are garbage collected. But the `org.apache.iceberg.io.SeekableStream` object is discarded in the `ParquetIO#stream`，and `HadoopStream#finalizer()` is called, which causes the `FSDataOutputStream` to be closed early. This will result in deletefile reading fails with `Failed to open Parquet file ...` or `Stream closed`.

In order to avoid this, add the member variable `icebergHadoopStream `to the `ParquetIO$ParquetInputFile` class and and use it as the parameter of the `ParquetIO#stream`.