### PR TITLE
Lazily initialize the writer inside ParquetWriter

### DIFF
--- a/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
+++ b/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
@@ -220,8 +220,14 @@ public class TestDeltaTaskWriter extends TableTestBase {
     writer.write(createUpdateBefore(1, "aaa"));
     writer.write(createUpdateAfter(1, "bbb"));
 
+    if (partitioned) {
+      writer.complete();
+    }
+
     writer.write(createUpdateBefore(2, "aaa"));
     writer.write(createUpdateAfter(2, "bbb"));
+
+    writer.complete();
 
     // Assert the current data/delete file count.
     List<Path> files = Files.walk(Paths.get(tableDir.getPath(), "data"))


### PR DESCRIPTION
Noticed that the inner writer is not needed during construction and in add().
Allocating it can - depending on the selected implementation - cause many other
objects to be initialized.
This is particularly true with the Hadoop GCS connector, which immediately
allocates a 64 MiB `byte[]`.
As long as code is tight-looping over the `add()` method while adding additional
data rows to the parquet file, there is no reason why
`ParquetWriter` needs to initialize these instances.

All usages of `this.writer` have been changed to use `getWriter()` instead.
`getWriter()` will allocate a single writer object when needed.

Also improved `startRowGroup()`, which previously needed access to the writer
object but no longer does.
The only call was to `nextRowGroupSize`, which returns the result from an
`AlignmentStrategy`.
However, Iceberg's code initializes a `ParquetFileWriter` with a `maxPaddingSize
= 0`. No matter the particular alignment strategy, this will cause
`rowGroupSize` to always be returns as the value of `nextRowGroupSize`.
Hence, we can remove the indirection through the writer object entirely.