### PR TITLE
Include provided catalog impl as known types

### DIFF
--- a/aws/src/test/java/org/apache/iceberg/aws/CatalogTest.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/CatalogTest.java
@@ -30,14 +30,16 @@ public class CatalogTest {
   @Test
   public void testGlueCatalogTypeImpl() {
     Assertions.assertThat(
-        CatalogType.getCatalogImpl(CatalogType.GLUE.getTypeName()))
+        CatalogType.of(CatalogType.GLUE.value()).impl())
+        .as("Invalid GLUE implementation class defined in %s", CatalogType.class.getName())
         .isEqualTo(GlueCatalog.class.getName());
   }
 
   @Test
   public void testDynamoCatalogTypeImpl() {
     Assertions.assertThat(
-        CatalogType.getCatalogImpl(CatalogType.DYNAMODB.getTypeName()))
+        CatalogType.of(CatalogType.DYNAMODB.value()).impl())
+        .as("Invalid DYNAMODB implementation class name defined in %s", CatalogType.class.getName())
         .isEqualTo(DynamoDbCatalog.class.getName());
   }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/CatalogTest.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/CatalogTest.java
@@ -30,14 +30,14 @@ public class CatalogTest {
   @Test
   public void testGlueCatalogTypeImpl() {
     Assertions.assertThat(
-        CatalogType.getCatalogImpl(CatalogType.GLUE.typeName()))
+        CatalogType.getCatalogImpl(CatalogType.GLUE.getTypeName()))
         .isEqualTo(GlueCatalog.class.getName());
   }
 
   @Test
   public void testDynamoCatalogTypeImpl() {
     Assertions.assertThat(
-        CatalogType.getCatalogImpl(CatalogType.DYNAMODB.typeName()))
+        CatalogType.getCatalogImpl(CatalogType.DYNAMODB.getTypeName()))
         .isEqualTo(DynamoDbCatalog.class.getName());
   }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/CatalogTest.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/CatalogTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.aws;
+
+import org.apache.iceberg.CatalogType;
+import org.apache.iceberg.aws.dynamodb.DynamoDbCatalog;
+import org.apache.iceberg.aws.glue.GlueCatalog;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class CatalogTest {
+
+  @Test
+  public void testGlueCatalogTypeImpl() {
+    Assertions.assertThat(
+        CatalogType.getCatalogImpl(CatalogType.GLUE.typeName()))
+        .isEqualTo(GlueCatalog.class.getName());
+  }
+
+  @Test
+  public void testDynamoCatalogTypeImpl() {
+    Assertions.assertThat(
+        CatalogType.getCatalogImpl(CatalogType.DYNAMODB.typeName()))
+        .isEqualTo(DynamoDbCatalog.class.getName());
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -26,6 +26,7 @@ public class CatalogProperties {
   private CatalogProperties() {
   }
 
+  public static final String CATALOG_TYPE = "type";
   public static final String CATALOG_IMPL = "catalog-impl";
   public static final String FILE_IO_IMPL = "io-impl";
   public static final String WAREHOUSE_LOCATION = "warehouse";

--- a/core/src/main/java/org/apache/iceberg/CatalogType.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogType.java
@@ -32,16 +32,18 @@ public enum CatalogType {
   JDBC("org.apache.iceberg.jdbc.JdbcCatalog");
 
   private final String catalogImpl;
+  private final String value;
 
   CatalogType(String catalogImpl) {
     this.catalogImpl = catalogImpl;
+    this.value = name().toLowerCase(Locale.ENGLISH);
   }
 
-  public String getTypeName() {
-    return name().toLowerCase(Locale.ENGLISH);
+  public String value() {
+    return value;
   }
 
-  public String getCatalogImpl() {
+  public String impl() {
     return catalogImpl;
   }
 
@@ -51,14 +53,18 @@ public enum CatalogType {
    * @param inputType Non-null input type.
    * @return catalog-impl class name
    */
-  public static String getCatalogImpl(String inputType) {
+  public static CatalogType of(String inputType) {
     try {
-      CatalogType type = CatalogType.valueOf(inputType.toUpperCase(Locale.ENGLISH));
-      return type.getCatalogImpl();
+      return CatalogType.valueOf(inputType.toUpperCase(Locale.ENGLISH));
     } catch (IllegalArgumentException e) {
       throw new UnsupportedOperationException(
-          String.format("Unknown catalog type: %s. Valid values are [%s]", inputType,
-              Arrays.stream(values()).map(CatalogType::getTypeName).collect(Collectors.joining(", "))));
+          String.format(
+              "Unknown catalog type: %s. Valid values are [%s]. To use a custom catalog, please " +
+                  "use the [%s] conf instead of [%s] with the value set to a fully qualified catalog impl class name.",
+              inputType,
+              Arrays.stream(values()).map(CatalogType::value).collect(Collectors.joining(", ")),
+              CatalogProperties.CATALOG_IMPL,
+              CatalogProperties.CATALOG_TYPE));
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/CatalogType.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogType.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.Locale;
+
+public enum CatalogType {
+  HIVE("org.apache.iceberg.hive.HiveCatalog"),
+  HADOOP("org.apache.iceberg.hadoop.HadoopCatalog"),
+  GLUE("org.apache.iceberg.aws.glue.GlueCatalog"),
+  NESSIE("org.apache.iceberg.nessie.NessieCatalog"),
+  DYNAMODB("org.apache.iceberg.aws.dynamodb.DynamoDbCatalog"),
+  JDBC("org.apache.iceberg.jdbc.JdbcCatalog");
+
+  private final String catalogImpl;
+
+  CatalogType(String catalogImpl) {
+    this.catalogImpl = catalogImpl;
+  }
+
+  public String typeName() {
+    return this.name().toLowerCase(Locale.ENGLISH);
+  }
+
+  public String getCatalogImpl() {
+    return this.catalogImpl;
+  }
+
+  public static String getCatalogImpl(String inputType) {
+    if (inputType == null) {
+      return null;
+    }
+    try {
+      CatalogType type = CatalogType.valueOf(inputType.toUpperCase(Locale.ENGLISH));
+      return type.getCatalogImpl();
+    } catch (IllegalArgumentException e) {
+      throw new UnsupportedOperationException("Unknown catalog type: " + inputType);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/CatalogType.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogType.java
@@ -19,7 +19,9 @@
 
 package org.apache.iceberg;
 
+import java.util.Arrays;
 import java.util.Locale;
+import java.util.stream.Collectors;
 
 public enum CatalogType {
   HIVE("org.apache.iceberg.hive.HiveCatalog"),
@@ -35,12 +37,12 @@ public enum CatalogType {
     this.catalogImpl = catalogImpl;
   }
 
-  public String typeName() {
-    return this.name().toLowerCase(Locale.ENGLISH);
+  public String getTypeName() {
+    return name().toLowerCase(Locale.ENGLISH);
   }
 
   public String getCatalogImpl() {
-    return this.catalogImpl;
+    return catalogImpl;
   }
 
   public static String getCatalogImpl(String inputType) {
@@ -51,7 +53,9 @@ public enum CatalogType {
       CatalogType type = CatalogType.valueOf(inputType.toUpperCase(Locale.ENGLISH));
       return type.getCatalogImpl();
     } catch (IllegalArgumentException e) {
-      throw new UnsupportedOperationException("Unknown catalog type: " + inputType);
+      throw new UnsupportedOperationException(
+          String.format("Unknown catalog type: %s. Valid values are [%s]", inputType,
+              Arrays.stream(values()).map(CatalogType::getTypeName).collect(Collectors.joining(", "))));
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/CatalogType.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogType.java
@@ -45,10 +45,13 @@ public enum CatalogType {
     return catalogImpl;
   }
 
+  /**
+   * Returns catalog-impl class name for the input type name.
+   *
+   * @param inputType Non-null input type.
+   * @return catalog-impl class name
+   */
   public static String getCatalogImpl(String inputType) {
-    if (inputType == null) {
-      return null;
-    }
     try {
       CatalogType type = CatalogType.valueOf(inputType.toUpperCase(Locale.ENGLISH));
       return type.getCatalogImpl();

--- a/core/src/main/java/org/apache/iceberg/CatalogType.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogType.java
@@ -47,12 +47,6 @@ public enum CatalogType {
     return catalogImpl;
   }
 
-  /**
-   * Returns catalog-impl class name for the input type name.
-   *
-   * @param inputType Non-null input type.
-   * @return catalog-impl class name
-   */
   public static CatalogType of(String inputType) {
     try {
       return CatalogType.valueOf(inputType.toUpperCase(Locale.ENGLISH));

--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -217,7 +217,7 @@ public class CatalogUtil {
 
     if (catalogImpl == null) {
       if (catalogType == null) {
-        LOG.info("Neither {} nor {} were configured. Falling back to the default of {}",
+        LOG.info("Neither {} nor {} were configured. Falling back to the default type {}",
             CatalogProperties.CATALOG_IMPL, CatalogProperties.CATALOG_TYPE,
             CatalogType.HIVE.value());
         catalogType = CatalogType.HIVE.value();

--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -203,11 +203,11 @@ public class CatalogUtil {
     String catalogImpl = options.get(CatalogProperties.CATALOG_IMPL);
     String catalogType = options.get(CatalogProperties.CATALOG_TYPE);
     Preconditions.checkArgument(catalogImpl == null || catalogType == null,
-            "Cannot create catalog %s, both type and catalog-impl are set: type=%s, catalog-impl=%s",
-            name, catalogType, catalogImpl);
+        "Cannot create catalog %s, both type and catalog-impl are set: type=%s, catalog-impl=%s",
+        name, catalogType, catalogImpl);
 
     if (catalogImpl == null) {
-      catalogType = (catalogType == null) ? CatalogType.HIVE.typeName() : catalogType;
+      catalogType = (catalogType == null) ? CatalogType.HIVE.getTypeName() : catalogType;
       catalogImpl = CatalogType.getCatalogImpl(catalogType);
     }
 

--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -54,6 +54,15 @@ public class CatalogUtil {
    *   <li>hadoop: org.apache.iceberg.hadoop.HadoopCatalog</li>
    * </ul>
    */
+
+  // NOTE: Following property will be deprecated post 1.0.0. Use CatalogProperties.CATALOG_TYPE instead.
+  public static final String ICEBERG_CATALOG_TYPE = "type";
+  // NOTE: Following properties will be deprecated post 1.0.0. Use CatalogType instead.
+  public static final String ICEBERG_CATALOG_TYPE_HADOOP = "hadoop";
+  public static final String ICEBERG_CATALOG_TYPE_HIVE = "hive";
+  public static final String ICEBERG_CATALOG_HIVE = "org.apache.iceberg.hive.HiveCatalog";
+  public static final String ICEBERG_CATALOG_HADOOP = "org.apache.iceberg.hadoop.HadoopCatalog";
+
   private CatalogUtil() {
   }
 
@@ -207,8 +216,13 @@ public class CatalogUtil {
         name, catalogType, catalogImpl);
 
     if (catalogImpl == null) {
-      catalogType = (catalogType == null) ? CatalogType.HIVE.getTypeName() : catalogType;
-      catalogImpl = CatalogType.getCatalogImpl(catalogType);
+      if (catalogType == null) {
+        LOG.info("Neither {} nor {} were configured. Falling back to the default of {}",
+            CatalogProperties.CATALOG_IMPL, CatalogProperties.CATALOG_TYPE,
+            CatalogType.HIVE.value());
+        catalogType = CatalogType.HIVE.value();
+      }
+      catalogImpl = CatalogType.of(catalogType).impl();
     }
 
     return CatalogUtil.loadCatalog(catalogImpl, name, options, conf);

--- a/core/src/test/java/org/apache/iceberg/TestCatalogType.java
+++ b/core/src/test/java/org/apache/iceberg/TestCatalogType.java
@@ -59,7 +59,9 @@ public class TestCatalogType {
     Assertions.assertThatThrownBy(() -> CatalogType.of("FOO"))
         .isInstanceOf(UnsupportedOperationException.class)
         .hasMessage(
-            "Unknown catalog type: FOO. Valid values are [hive, hadoop, glue, nessie, dynamodb, jdbc]. To use a custom catalog, please use the [catalog-impl] conf instead of [type] with the value set to a fully qualified catalog impl class name.");
+            "Unknown catalog type: FOO. Valid values are [hive, hadoop, glue, nessie, dynamodb, " +
+                "jdbc]. To use a custom catalog, please use the [catalog-impl] conf instead of " +
+                "[type] with the value set to a fully qualified catalog impl class name.");
   }
 
   @ParameterizedTest

--- a/core/src/test/java/org/apache/iceberg/TestCatalogType.java
+++ b/core/src/test/java/org/apache/iceberg/TestCatalogType.java
@@ -19,11 +19,10 @@
 
 package org.apache.iceberg;
 
-import java.util.List;
+import java.util.stream.Stream;
 import org.apache.iceberg.hadoop.HadoopCatalog;
 import org.apache.iceberg.jdbc.JdbcCatalog;
 import org.assertj.core.api.Assertions;
-import org.assertj.core.util.Lists;
 import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -38,8 +37,8 @@ public class TestCatalogType {
     Assertions.assertThat(CatalogType.getCatalogImpl(inputType)).isEqualTo(inputCase.get()[1]);
   }
 
-  private List<Arguments> mixedCaseCatalogTypeImpls() {
-    return Lists.newArrayList(Arguments.of("hadoop", HadoopCatalog.class.getName()),
+  static Stream<Arguments> mixedCaseCatalogTypeImpls() {
+    return Stream.of(Arguments.of("hadoop", HadoopCatalog.class.getName()),
         Arguments.of("HADOOP", HadoopCatalog.class.getName()),
         Arguments.of("HaDoOp", HadoopCatalog.class.getName()),
         Arguments.of("jdbc", JdbcCatalog.class.getName()),
@@ -57,18 +56,19 @@ public class TestCatalogType {
   public void testUnknownCatalog() {
     Assertions.assertThatThrownBy(() -> CatalogType.getCatalogImpl("FOO"))
         .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessage("Unknown catalog type: FOO");
+        .hasMessage(
+            "Unknown catalog type: FOO. Valid values are [hive, hadoop, glue, nessie, dynamodb, jdbc]");
   }
 
   @ParameterizedTest
   @MethodSource("typeWithNames")
   public void testTypeNames(Arguments inputCase) {
-    Assertions.assertThat(((CatalogType) inputCase.get()[0]).typeName())
+    Assertions.assertThat(((CatalogType) inputCase.get()[0]).getTypeName())
         .isEqualTo(inputCase.get()[1]);
   }
 
-  private List<Arguments> typeWithNames() {
-    return Lists.newArrayList(
+  static Stream<Arguments> typeWithNames() {
+    return Stream.of(
         Arguments.of(CatalogType.DYNAMODB, "dynamodb"),
         Arguments.of(CatalogType.GLUE, "glue"),
         Arguments.of(CatalogType.HADOOP, "hadoop"),

--- a/core/src/test/java/org/apache/iceberg/TestCatalogType.java
+++ b/core/src/test/java/org/apache/iceberg/TestCatalogType.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.List;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.apache.iceberg.jdbc.JdbcCatalog;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.util.Lists;
+import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class TestCatalogType {
+
+  @ParameterizedTest
+  @MethodSource("mixedCaseCatalogTypeImpls")
+  public void testCaseInsensitivity(Arguments inputCase) {
+    String inputType = (inputCase.get()[0] != null) ? (String) inputCase.get()[0] : null;
+    Assertions.assertThat(CatalogType.getCatalogImpl(inputType)).isEqualTo(inputCase.get()[1]);
+  }
+
+  private List<Arguments> mixedCaseCatalogTypeImpls() {
+    return Lists.newArrayList(Arguments.of("hadoop", HadoopCatalog.class.getName()),
+        Arguments.of("HADOOP", HadoopCatalog.class.getName()),
+        Arguments.of("HaDoOp", HadoopCatalog.class.getName()),
+        Arguments.of("jdbc", JdbcCatalog.class.getName()),
+        Arguments.of("JDBC", JdbcCatalog.class.getName()),
+        Arguments.of("nessie", "org.apache.iceberg.nessie.NessieCatalog"),
+        Arguments.of("NESSIE", "org.apache.iceberg.nessie.NessieCatalog"),
+        Arguments.of("dynamodb", "org.apache.iceberg.aws.dynamodb.DynamoDbCatalog"),
+        Arguments.of("DYNAMODB", "org.apache.iceberg.aws.dynamodb.DynamoDbCatalog"),
+        Arguments.of("glue", "org.apache.iceberg.aws.glue.GlueCatalog"),
+        Arguments.of("GLUE", "org.apache.iceberg.aws.glue.GlueCatalog"),
+        Arguments.of(null, null));
+  }
+
+  @Test
+  public void testUnknownCatalog() {
+    Assertions.assertThatThrownBy(() -> CatalogType.getCatalogImpl("FOO"))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Unknown catalog type: FOO");
+  }
+
+  @ParameterizedTest
+  @MethodSource("typeWithNames")
+  public void testTypeNames(Arguments inputCase) {
+    Assertions.assertThat(((CatalogType) inputCase.get()[0]).typeName())
+        .isEqualTo(inputCase.get()[1]);
+  }
+
+  private List<Arguments> typeWithNames() {
+    return Lists.newArrayList(
+        Arguments.of(CatalogType.DYNAMODB, "dynamodb"),
+        Arguments.of(CatalogType.GLUE, "glue"),
+        Arguments.of(CatalogType.HADOOP, "hadoop"),
+        Arguments.of(CatalogType.HIVE, "hive"),
+        Arguments.of(CatalogType.JDBC, "jdbc"),
+        Arguments.of(CatalogType.NESSIE, "nessie"));
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestCatalogType.java
+++ b/core/src/test/java/org/apache/iceberg/TestCatalogType.java
@@ -34,7 +34,10 @@ public class TestCatalogType {
   @MethodSource("mixedCaseCatalogTypeImpls")
   public void testCaseInsensitivity(Arguments inputCase) {
     String inputType = (inputCase.get()[0] != null) ? (String) inputCase.get()[0] : null;
-    Assertions.assertThat(CatalogType.getCatalogImpl(inputType)).isEqualTo(inputCase.get()[1]);
+    Assertions.assertThat(CatalogType.of(inputType).impl())
+        .as("Unexpected catalog impl class detected for %s. This change can break client configuration.",
+            inputType)
+        .isEqualTo(inputCase.get()[1]);
   }
 
   static Stream<Arguments> mixedCaseCatalogTypeImpls() {
@@ -53,16 +56,19 @@ public class TestCatalogType {
 
   @Test
   public void testUnknownCatalog() {
-    Assertions.assertThatThrownBy(() -> CatalogType.getCatalogImpl("FOO"))
+    Assertions.assertThatThrownBy(() -> CatalogType.of("FOO"))
         .isInstanceOf(UnsupportedOperationException.class)
         .hasMessage(
-            "Unknown catalog type: FOO. Valid values are [hive, hadoop, glue, nessie, dynamodb, jdbc]");
+            "Unknown catalog type: FOO. Valid values are [hive, hadoop, glue, nessie, dynamodb, jdbc]. To use a custom catalog, please use the [catalog-impl] conf instead of [type] with the value set to a fully qualified catalog impl class name.");
   }
 
   @ParameterizedTest
   @MethodSource("typeWithNames")
   public void testTypeNames(Arguments inputCase) {
-    Assertions.assertThat(((CatalogType) inputCase.get()[0]).getTypeName())
+    CatalogType type = (CatalogType) inputCase.get()[0];
+    Assertions.assertThat(type.value())
+        .as("Unexpected typeName detected for %s. This change can break client configuration.",
+            type)
         .isEqualTo(inputCase.get()[1]);
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestCatalogType.java
+++ b/core/src/test/java/org/apache/iceberg/TestCatalogType.java
@@ -48,8 +48,7 @@ public class TestCatalogType {
         Arguments.of("dynamodb", "org.apache.iceberg.aws.dynamodb.DynamoDbCatalog"),
         Arguments.of("DYNAMODB", "org.apache.iceberg.aws.dynamodb.DynamoDbCatalog"),
         Arguments.of("glue", "org.apache.iceberg.aws.glue.GlueCatalog"),
-        Arguments.of("GLUE", "org.apache.iceberg.aws.glue.GlueCatalog"),
-        Arguments.of(null, null));
+        Arguments.of("GLUE", "org.apache.iceberg.aws.glue.GlueCatalog"));
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
@@ -163,7 +163,7 @@ public class TestCatalogUtil {
   public void buildCustomCatalog_withTypeSet() {
     Map<String, String> options = new HashMap<>();
     options.put(CatalogProperties.CATALOG_IMPL, "CustomCatalog");
-    options.put(CatalogUtil.ICEBERG_CATALOG_TYPE, "hive");
+    options.put(CatalogProperties.CATALOG_TYPE, "hive");
     Configuration hadoopConf = new Configuration();
     String name = "custom";
 

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
@@ -561,5 +561,4 @@ public class TestJdbcCatalog {
     String nsString = JdbcUtil.namespaceToString(ns);
     Assert.assertEquals(ns, JdbcUtil.stringToNamespace(nsString));
   }
-
 }

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
@@ -561,4 +561,5 @@ public class TestJdbcCatalog {
     String nsString = JdbcUtil.namespaceToString(ns);
     Assert.assertEquals(ns, JdbcUtil.stringToNamespace(nsString));
   }
+
 }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveMetastoreTest.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveMetastoreTest.java
@@ -51,7 +51,7 @@ public abstract class HiveMetastoreTest {
     Database db = new Database(DB_NAME, "description", dbPath, new HashMap<>());
     metastoreClient.createDatabase(db);
     HiveMetastoreTest.catalog = (HiveCatalog)
-        CatalogUtil.loadCatalog(HiveCatalog.class.getName(), CatalogType.HIVE.typeName(), ImmutableMap.of(
+        CatalogUtil.loadCatalog(HiveCatalog.class.getName(), CatalogType.HIVE.getTypeName(), ImmutableMap.of(
                 CatalogProperties.CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS, String.valueOf(EVICTION_INTERVAL)), hiveConf);
   }
 

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveMetastoreTest.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveMetastoreTest.java
@@ -51,7 +51,7 @@ public abstract class HiveMetastoreTest {
     Database db = new Database(DB_NAME, "description", dbPath, new HashMap<>());
     metastoreClient.createDatabase(db);
     HiveMetastoreTest.catalog = (HiveCatalog)
-        CatalogUtil.loadCatalog(HiveCatalog.class.getName(), CatalogType.HIVE.getTypeName(), ImmutableMap.of(
+        CatalogUtil.loadCatalog(HiveCatalog.class.getName(), CatalogType.HIVE.value(), ImmutableMap.of(
                 CatalogProperties.CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS, String.valueOf(EVICTION_INTERVAL)), hiveConf);
   }
 

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveMetastoreTest.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveMetastoreTest.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.CatalogType;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.AfterClass;
@@ -50,7 +51,7 @@ public abstract class HiveMetastoreTest {
     Database db = new Database(DB_NAME, "description", dbPath, new HashMap<>());
     metastoreClient.createDatabase(db);
     HiveMetastoreTest.catalog = (HiveCatalog)
-        CatalogUtil.loadCatalog(HiveCatalog.class.getName(), CatalogUtil.ICEBERG_CATALOG_TYPE_HIVE, ImmutableMap.of(
+        CatalogUtil.loadCatalog(HiveCatalog.class.getName(), CatalogType.HIVE.typeName(), ImmutableMap.of(
                 CatalogProperties.CLIENT_POOL_CACHE_EVICTION_INTERVAL_MS, String.valueOf(EVICTION_INTERVAL)), hiveConf);
   }
 

--- a/mr/src/main/java/org/apache/iceberg/mr/Catalogs.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/Catalogs.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.CatalogType;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
@@ -204,11 +205,11 @@ public final class Catalogs {
     String catalogName = props.getProperty(InputFormatConfig.CATALOG_NAME);
     String catalogType = getCatalogType(conf, catalogName);
     if (catalogType != null) {
-      return CatalogUtil.ICEBERG_CATALOG_TYPE_HIVE.equalsIgnoreCase(catalogType);
+      return CatalogType.HIVE.typeName().equalsIgnoreCase(catalogType);
     }
     catalogType = getCatalogType(conf, ICEBERG_DEFAULT_CATALOG_NAME);
     if (catalogType != null) {
-      return CatalogUtil.ICEBERG_CATALOG_TYPE_HIVE.equalsIgnoreCase(catalogType);
+      return CatalogType.HIVE.typeName().equalsIgnoreCase(catalogType);
     }
     return getCatalogProperties(conf, catalogName, catalogType).get(CatalogProperties.CATALOG_IMPL) == null;
   }
@@ -252,7 +253,7 @@ public final class Catalogs {
   private static Map<String, String> addCatalogPropertiesIfMissing(Configuration conf, String catalogType,
                                                                    Map<String, String> catalogProperties) {
     if (catalogType != null) {
-      catalogProperties.putIfAbsent(CatalogUtil.ICEBERG_CATALOG_TYPE, catalogType);
+      catalogProperties.putIfAbsent(CatalogProperties.CATALOG_TYPE, catalogType);
     }
 
     String legacyCatalogImpl = conf.get(InputFormatConfig.CATALOG_LOADER_CLASS);
@@ -279,7 +280,7 @@ public final class Catalogs {
   private static String getCatalogType(Configuration conf, String catalogName) {
     if (catalogName != null) {
       String catalogType = conf.get(InputFormatConfig.catalogPropertyConfigKey(
-          catalogName, CatalogUtil.ICEBERG_CATALOG_TYPE));
+          catalogName, CatalogProperties.CATALOG_TYPE));
       if (catalogName.equals(ICEBERG_HADOOP_TABLE_NAME)) {
         return NO_CATALOG_TYPE;
       } else {

--- a/mr/src/main/java/org/apache/iceberg/mr/Catalogs.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/Catalogs.java
@@ -205,11 +205,11 @@ public final class Catalogs {
     String catalogName = props.getProperty(InputFormatConfig.CATALOG_NAME);
     String catalogType = getCatalogType(conf, catalogName);
     if (catalogType != null) {
-      return CatalogType.HIVE.getTypeName().equalsIgnoreCase(catalogType);
+      return CatalogType.HIVE.value().equalsIgnoreCase(catalogType);
     }
     catalogType = getCatalogType(conf, ICEBERG_DEFAULT_CATALOG_NAME);
     if (catalogType != null) {
-      return CatalogType.HIVE.getTypeName().equalsIgnoreCase(catalogType);
+      return CatalogType.HIVE.value().equalsIgnoreCase(catalogType);
     }
     return getCatalogProperties(conf, catalogName, catalogType).get(CatalogProperties.CATALOG_IMPL) == null;
   }

--- a/mr/src/main/java/org/apache/iceberg/mr/Catalogs.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/Catalogs.java
@@ -205,11 +205,11 @@ public final class Catalogs {
     String catalogName = props.getProperty(InputFormatConfig.CATALOG_NAME);
     String catalogType = getCatalogType(conf, catalogName);
     if (catalogType != null) {
-      return CatalogType.HIVE.typeName().equalsIgnoreCase(catalogType);
+      return CatalogType.HIVE.getTypeName().equalsIgnoreCase(catalogType);
     }
     catalogType = getCatalogType(conf, ICEBERG_DEFAULT_CATALOG_NAME);
     if (catalogType != null) {
-      return CatalogType.HIVE.typeName().equalsIgnoreCase(catalogType);
+      return CatalogType.HIVE.getTypeName().equalsIgnoreCase(catalogType);
     }
     return getCatalogProperties(conf, catalogName, catalogType).get(CatalogProperties.CATALOG_IMPL) == null;
   }

--- a/mr/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
@@ -52,7 +52,7 @@ public class InputFormatConfig {
 
   /**
    * @deprecated please use {@link #catalogPropertyConfigKey(String, String)}
-   * with config key {@link org.apache.iceberg.CatalogUtil#ICEBERG_CATALOG_TYPE} to specify the type of a catalog.
+   * with config key {@link org.apache.iceberg.CatalogProperties#CATALOG_TYPE} to specify the type of a catalog.
    */
   @Deprecated
   public static final String CATALOG = "iceberg.mr.catalog";

--- a/mr/src/test/java/org/apache/iceberg/mr/TestCatalogs.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestCatalogs.java
@@ -203,7 +203,7 @@ public class TestCatalogs {
 
   @Test
   public void testLegacyLoadCatalogHive() {
-    conf.set(InputFormatConfig.CATALOG, CatalogType.HIVE.typeName());
+    conf.set(InputFormatConfig.CATALOG, CatalogType.HIVE.getTypeName());
     Optional<Catalog> hiveCatalog = Catalogs.loadCatalog(conf, null);
     Assert.assertTrue(hiveCatalog.isPresent());
     Assertions.assertThat(hiveCatalog.get()).isInstanceOf(HiveCatalog.class);
@@ -212,7 +212,7 @@ public class TestCatalogs {
 
   @Test
   public void testLegacyLoadCatalogHadoop() {
-    conf.set(InputFormatConfig.CATALOG, CatalogType.HADOOP.typeName());
+    conf.set(InputFormatConfig.CATALOG, CatalogType.HADOOP.getTypeName());
     conf.set(InputFormatConfig.HADOOP_CATALOG_WAREHOUSE_LOCATION, "/tmp/mylocation");
     Optional<Catalog> hadoopCatalog = Catalogs.loadCatalog(conf, null);
     Assert.assertTrue(hadoopCatalog.isPresent());
@@ -260,7 +260,7 @@ public class TestCatalogs {
   public void testLoadCatalogHive() {
     String catalogName = "barCatalog";
     conf.set(InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogProperties.CATALOG_TYPE),
-        CatalogType.HIVE.typeName());
+        CatalogType.HIVE.getTypeName());
     Optional<Catalog> hiveCatalog = Catalogs.loadCatalog(conf, catalogName);
     Assert.assertTrue(hiveCatalog.isPresent());
     Assertions.assertThat(hiveCatalog.get()).isInstanceOf(HiveCatalog.class);
@@ -273,7 +273,7 @@ public class TestCatalogs {
   public void testLegacyLoadCustomCatalogWithHiveCatalogTypeSet() {
     String catalogName = "barCatalog";
     conf.set(InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogProperties.CATALOG_TYPE),
-            CatalogType.HIVE.typeName());
+            CatalogType.HIVE.getTypeName());
     conf.set(InputFormatConfig.CATALOG_LOADER_CLASS, CustomHadoopCatalog.class.getName());
     conf.set(InputFormatConfig.HADOOP_CATALOG_WAREHOUSE_LOCATION, "/tmp/mylocation");
     AssertHelpers.assertThrows("Should complain about both configs being set", IllegalArgumentException.class,
@@ -284,7 +284,7 @@ public class TestCatalogs {
   public void testLoadCatalogHadoop() {
     String catalogName = "barCatalog";
     conf.set(InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogProperties.CATALOG_TYPE),
-            CatalogType.HADOOP.typeName());
+            CatalogType.HADOOP.getTypeName());
     conf.set(InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogProperties.WAREHOUSE_LOCATION),
         "/tmp/mylocation");
     Optional<Catalog> hadoopCatalog = Catalogs.loadCatalog(conf, catalogName);
@@ -300,7 +300,7 @@ public class TestCatalogs {
   public void testLoadCatalogHadoopWithLegacyWarehouseLocation() {
     String catalogName = "barCatalog";
     conf.set(InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogProperties.CATALOG_TYPE),
-            CatalogType.HADOOP.typeName());
+            CatalogType.HADOOP.getTypeName());
     conf.set(InputFormatConfig.HADOOP_CATALOG_WAREHOUSE_LOCATION, "/tmp/mylocation");
     Optional<Catalog> hadoopCatalog = Catalogs.loadCatalog(conf, catalogName);
     Assert.assertTrue(hadoopCatalog.isPresent());
@@ -343,7 +343,7 @@ public class TestCatalogs {
   @Test
   public void testCatalogTypeImpl() {
     Assertions.assertThat(
-            CatalogType.getCatalogImpl(CatalogType.JDBC.typeName())).isEqualTo(JdbcCatalog.class.getName());
+            CatalogType.getCatalogImpl(CatalogType.JDBC.getTypeName())).isEqualTo(JdbcCatalog.class.getName());
   }
 
   public static class CustomHadoopCatalog extends HadoopCatalog {

--- a/mr/src/test/java/org/apache/iceberg/mr/TestCatalogs.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestCatalogs.java
@@ -343,7 +343,8 @@ public class TestCatalogs {
   @Test
   public void testCatalogTypeImpl() {
     Assertions.assertThat(
-            CatalogType.getCatalogImpl(CatalogType.JDBC.getTypeName())).isEqualTo(JdbcCatalog.class.getName());
+        CatalogType.getCatalogImpl(CatalogType.JDBC.getTypeName()))
+        .isEqualTo(JdbcCatalog.class.getName());
   }
 
   public static class CustomHadoopCatalog extends HadoopCatalog {

--- a/mr/src/test/java/org/apache/iceberg/mr/TestCatalogs.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestCatalogs.java
@@ -203,7 +203,7 @@ public class TestCatalogs {
 
   @Test
   public void testLegacyLoadCatalogHive() {
-    conf.set(InputFormatConfig.CATALOG, CatalogType.HIVE.getTypeName());
+    conf.set(InputFormatConfig.CATALOG, CatalogType.HIVE.value());
     Optional<Catalog> hiveCatalog = Catalogs.loadCatalog(conf, null);
     Assert.assertTrue(hiveCatalog.isPresent());
     Assertions.assertThat(hiveCatalog.get()).isInstanceOf(HiveCatalog.class);
@@ -212,7 +212,7 @@ public class TestCatalogs {
 
   @Test
   public void testLegacyLoadCatalogHadoop() {
-    conf.set(InputFormatConfig.CATALOG, CatalogType.HADOOP.getTypeName());
+    conf.set(InputFormatConfig.CATALOG, CatalogType.HADOOP.value());
     conf.set(InputFormatConfig.HADOOP_CATALOG_WAREHOUSE_LOCATION, "/tmp/mylocation");
     Optional<Catalog> hadoopCatalog = Catalogs.loadCatalog(conf, null);
     Assert.assertTrue(hadoopCatalog.isPresent());
@@ -260,7 +260,7 @@ public class TestCatalogs {
   public void testLoadCatalogHive() {
     String catalogName = "barCatalog";
     conf.set(InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogProperties.CATALOG_TYPE),
-        CatalogType.HIVE.getTypeName());
+        CatalogType.HIVE.value());
     Optional<Catalog> hiveCatalog = Catalogs.loadCatalog(conf, catalogName);
     Assert.assertTrue(hiveCatalog.isPresent());
     Assertions.assertThat(hiveCatalog.get()).isInstanceOf(HiveCatalog.class);
@@ -273,7 +273,7 @@ public class TestCatalogs {
   public void testLegacyLoadCustomCatalogWithHiveCatalogTypeSet() {
     String catalogName = "barCatalog";
     conf.set(InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogProperties.CATALOG_TYPE),
-            CatalogType.HIVE.getTypeName());
+            CatalogType.HIVE.value());
     conf.set(InputFormatConfig.CATALOG_LOADER_CLASS, CustomHadoopCatalog.class.getName());
     conf.set(InputFormatConfig.HADOOP_CATALOG_WAREHOUSE_LOCATION, "/tmp/mylocation");
     AssertHelpers.assertThrows("Should complain about both configs being set", IllegalArgumentException.class,
@@ -284,7 +284,7 @@ public class TestCatalogs {
   public void testLoadCatalogHadoop() {
     String catalogName = "barCatalog";
     conf.set(InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogProperties.CATALOG_TYPE),
-            CatalogType.HADOOP.getTypeName());
+            CatalogType.HADOOP.value());
     conf.set(InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogProperties.WAREHOUSE_LOCATION),
         "/tmp/mylocation");
     Optional<Catalog> hadoopCatalog = Catalogs.loadCatalog(conf, catalogName);
@@ -300,7 +300,7 @@ public class TestCatalogs {
   public void testLoadCatalogHadoopWithLegacyWarehouseLocation() {
     String catalogName = "barCatalog";
     conf.set(InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogProperties.CATALOG_TYPE),
-            CatalogType.HADOOP.getTypeName());
+            CatalogType.HADOOP.value());
     conf.set(InputFormatConfig.HADOOP_CATALOG_WAREHOUSE_LOCATION, "/tmp/mylocation");
     Optional<Catalog> hadoopCatalog = Catalogs.loadCatalog(conf, catalogName);
     Assert.assertTrue(hadoopCatalog.isPresent());
@@ -343,7 +343,8 @@ public class TestCatalogs {
   @Test
   public void testCatalogTypeImpl() {
     Assertions.assertThat(
-        CatalogType.getCatalogImpl(CatalogType.JDBC.getTypeName()))
+        CatalogType.of(CatalogType.JDBC.value()).impl())
+        .as("Unexpected catalog implementation class found for type JDBC")
         .isEqualTo(JdbcCatalog.class.getName());
   }
 

--- a/mr/src/test/java/org/apache/iceberg/mr/TestCatalogs.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestCatalogs.java
@@ -283,8 +283,9 @@ public class TestCatalogs {
   @Test
   public void testLoadCatalogHadoop() {
     String catalogName = "barCatalog";
-    conf.set(InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogProperties.CATALOG_TYPE),
-            CatalogType.HADOOP.value());
+    conf.set(
+        InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogProperties.CATALOG_TYPE),
+        CatalogType.HADOOP.value());
     conf.set(InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogProperties.WAREHOUSE_LOCATION),
         "/tmp/mylocation");
     Optional<Catalog> hadoopCatalog = Catalogs.loadCatalog(conf, catalogName);
@@ -299,8 +300,9 @@ public class TestCatalogs {
   @Test
   public void testLoadCatalogHadoopWithLegacyWarehouseLocation() {
     String catalogName = "barCatalog";
-    conf.set(InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogProperties.CATALOG_TYPE),
-            CatalogType.HADOOP.value());
+    conf.set(
+        InputFormatConfig.catalogPropertyConfigKey(catalogName, CatalogProperties.CATALOG_TYPE),
+        CatalogType.HADOOP.value());
     conf.set(InputFormatConfig.HADOOP_CATALOG_WAREHOUSE_LOCATION, "/tmp/mylocation");
     Optional<Catalog> hadoopCatalog = Catalogs.loadCatalog(conf, catalogName);
     Assert.assertTrue(hadoopCatalog.isPresent());

--- a/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
@@ -353,7 +353,7 @@ public class TestIcebergInputFormats {
     conf.set("warehouse.location", warehouseLocation);
     conf.set(InputFormatConfig.CATALOG_NAME, Catalogs.ICEBERG_DEFAULT_CATALOG_NAME);
     conf.set(InputFormatConfig.catalogPropertyConfigKey(Catalogs.ICEBERG_DEFAULT_CATALOG_NAME,
-        CatalogProperties.CATALOG_TYPE), CatalogType.HADOOP.typeName());
+        CatalogProperties.CATALOG_TYPE), CatalogType.HADOOP.getTypeName());
     conf.set(InputFormatConfig.catalogPropertyConfigKey(Catalogs.ICEBERG_DEFAULT_CATALOG_NAME,
         CatalogProperties.WAREHOUSE_LOCATION), warehouseLocation);
 

--- a/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
@@ -39,7 +39,7 @@ import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.CatalogProperties;
-import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.CatalogType;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
@@ -353,7 +353,7 @@ public class TestIcebergInputFormats {
     conf.set("warehouse.location", warehouseLocation);
     conf.set(InputFormatConfig.CATALOG_NAME, Catalogs.ICEBERG_DEFAULT_CATALOG_NAME);
     conf.set(InputFormatConfig.catalogPropertyConfigKey(Catalogs.ICEBERG_DEFAULT_CATALOG_NAME,
-        CatalogUtil.ICEBERG_CATALOG_TYPE), CatalogUtil.ICEBERG_CATALOG_TYPE_HADOOP);
+        CatalogProperties.CATALOG_TYPE), CatalogType.HADOOP.typeName());
     conf.set(InputFormatConfig.catalogPropertyConfigKey(Catalogs.ICEBERG_DEFAULT_CATALOG_NAME,
         CatalogProperties.WAREHOUSE_LOCATION), warehouseLocation);
 

--- a/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
@@ -353,7 +353,7 @@ public class TestIcebergInputFormats {
     conf.set("warehouse.location", warehouseLocation);
     conf.set(InputFormatConfig.CATALOG_NAME, Catalogs.ICEBERG_DEFAULT_CATALOG_NAME);
     conf.set(InputFormatConfig.catalogPropertyConfigKey(Catalogs.ICEBERG_DEFAULT_CATALOG_NAME,
-        CatalogProperties.CATALOG_TYPE), CatalogType.HADOOP.getTypeName());
+        CatalogProperties.CATALOG_TYPE), CatalogType.HADOOP.value());
     conf.set(InputFormatConfig.catalogPropertyConfigKey(Catalogs.ICEBERG_DEFAULT_CATALOG_NAME,
         CatalogProperties.WAREHOUSE_LOCATION), warehouseLocation);
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
@@ -369,7 +369,7 @@ abstract class TestTables {
     public Map<String, String> properties() {
       return ImmutableMap.of(
           InputFormatConfig.catalogPropertyConfigKey(catalog, CatalogProperties.CATALOG_TYPE),
-          CatalogType.HADOOP.getTypeName(),
+          CatalogType.HADOOP.value(),
           InputFormatConfig.catalogPropertyConfigKey(catalog, CatalogProperties.WAREHOUSE_LOCATION),
           warehouseLocation
       );
@@ -415,15 +415,15 @@ abstract class TestTables {
   static class HiveTestTables extends TestTables {
 
     HiveTestTables(Configuration conf, TemporaryFolder temp, String catalogName) {
-      super(CatalogUtil.loadCatalog(HiveCatalog.class.getName(), CatalogType.HIVE.getTypeName(),
+      super(CatalogUtil.loadCatalog(HiveCatalog.class.getName(), CatalogType.HIVE.value(),
               ImmutableMap.of(), conf), temp, catalogName);
     }
 
     @Override
     public Map<String, String> properties() {
-      return ImmutableMap
-          .of(InputFormatConfig.catalogPropertyConfigKey(catalog, CatalogProperties.CATALOG_TYPE),
-              CatalogType.HIVE.getTypeName());
+      return ImmutableMap.of(
+          InputFormatConfig.catalogPropertyConfigKey(catalog, CatalogProperties.CATALOG_TYPE),
+          CatalogType.HIVE.value());
     }
 
     @Override

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.CatalogType;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
@@ -367,8 +368,8 @@ abstract class TestTables {
     @Override
     public Map<String, String> properties() {
       return ImmutableMap.of(
-          InputFormatConfig.catalogPropertyConfigKey(catalog, CatalogUtil.ICEBERG_CATALOG_TYPE),
-          CatalogUtil.ICEBERG_CATALOG_TYPE_HADOOP,
+          InputFormatConfig.catalogPropertyConfigKey(catalog, CatalogProperties.CATALOG_TYPE),
+          CatalogType.HADOOP.typeName(),
           InputFormatConfig.catalogPropertyConfigKey(catalog, CatalogProperties.WAREHOUSE_LOCATION),
           warehouseLocation
       );
@@ -414,14 +415,14 @@ abstract class TestTables {
   static class HiveTestTables extends TestTables {
 
     HiveTestTables(Configuration conf, TemporaryFolder temp, String catalogName) {
-      super(CatalogUtil.loadCatalog(HiveCatalog.class.getName(), CatalogUtil.ICEBERG_CATALOG_TYPE_HIVE,
+      super(CatalogUtil.loadCatalog(HiveCatalog.class.getName(), CatalogType.HIVE.typeName(),
               ImmutableMap.of(), conf), temp, catalogName);
     }
 
     @Override
     public Map<String, String> properties() {
-      return ImmutableMap.of(InputFormatConfig.catalogPropertyConfigKey(catalog, CatalogUtil.ICEBERG_CATALOG_TYPE),
-          CatalogUtil.ICEBERG_CATALOG_TYPE_HIVE);
+      return ImmutableMap.of(InputFormatConfig.catalogPropertyConfigKey(catalog, CatalogProperties.CATALOG_TYPE),
+              CatalogType.HIVE.typeName());
     }
 
     @Override

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
@@ -369,7 +369,7 @@ abstract class TestTables {
     public Map<String, String> properties() {
       return ImmutableMap.of(
           InputFormatConfig.catalogPropertyConfigKey(catalog, CatalogProperties.CATALOG_TYPE),
-          CatalogType.HADOOP.typeName(),
+          CatalogType.HADOOP.getTypeName(),
           InputFormatConfig.catalogPropertyConfigKey(catalog, CatalogProperties.WAREHOUSE_LOCATION),
           warehouseLocation
       );
@@ -415,14 +415,15 @@ abstract class TestTables {
   static class HiveTestTables extends TestTables {
 
     HiveTestTables(Configuration conf, TemporaryFolder temp, String catalogName) {
-      super(CatalogUtil.loadCatalog(HiveCatalog.class.getName(), CatalogType.HIVE.typeName(),
+      super(CatalogUtil.loadCatalog(HiveCatalog.class.getName(), CatalogType.HIVE.getTypeName(),
               ImmutableMap.of(), conf), temp, catalogName);
     }
 
     @Override
     public Map<String, String> properties() {
-      return ImmutableMap.of(InputFormatConfig.catalogPropertyConfigKey(catalog, CatalogProperties.CATALOG_TYPE),
-              CatalogType.HIVE.typeName());
+      return ImmutableMap
+          .of(InputFormatConfig.catalogPropertyConfigKey(catalog, CatalogProperties.CATALOG_TYPE),
+              CatalogType.HIVE.getTypeName());
     }
 
     @Override

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestCatalog.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestCatalog.java
@@ -28,7 +28,7 @@ public class TestCatalog {
   @Test
   public void testCatalogTypeImpl() {
     Assertions.assertThat(
-        CatalogType.getCatalogImpl(CatalogType.NESSIE.typeName()))
+        CatalogType.getCatalogImpl(CatalogType.NESSIE.getTypeName()))
         .isEqualTo(NessieCatalog.class.getName());
   }
 }

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestCatalog.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestCatalog.java
@@ -28,7 +28,8 @@ public class TestCatalog {
   @Test
   public void testCatalogTypeImpl() {
     Assertions.assertThat(
-        CatalogType.getCatalogImpl(CatalogType.NESSIE.getTypeName()))
+        CatalogType.of(CatalogType.NESSIE.value()).impl())
+        .as("Unexpected catalog implementation class found for type NESSIE")
         .isEqualTo(NessieCatalog.class.getName());
   }
 }

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestCatalog.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestCatalog.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.nessie;
+
+import org.apache.iceberg.CatalogType;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class TestCatalog {
+
+  @Test
+  public void testCatalogTypeImpl() {
+    Assertions.assertThat(
+        CatalogType.getCatalogImpl(CatalogType.NESSIE.typeName()))
+        .isEqualTo(NessieCatalog.class.getName());
+  }
+}

--- a/site/docs/aws.md
+++ b/site/docs/aws.md
@@ -62,7 +62,7 @@ done
 spark-sql --packages $DEPENDENCIES \
     --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCatalog \
     --conf spark.sql.catalog.my_catalog.warehouse=s3://my-bucket/my/key/prefix \
-    --conf spark.sql.catalog.my_catalog.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog \
+    --conf spark.sql.catalog.my_catalog.type=glue \
     --conf spark.sql.catalog.my_catalog.io-impl=org.apache.iceberg.aws.s3.S3FileIO \
     --conf spark.sql.catalog.my_catalog.lock-impl=org.apache.iceberg.aws.glue.DynamoLockManager \
     --conf spark.sql.catalog.my_catalog.lock.table=myGlueLockTable

--- a/site/docs/hive.md
+++ b/site/docs/hive.md
@@ -98,7 +98,7 @@ To globally register different catalogs, set the following Hadoop configurations
 
 | Config Key                                    | Description                                            |
 | --------------------------------------------- | ------------------------------------------------------ |
-| iceberg.catalog.<catalog_name\>.type          | type of catalog: `hive`, `hadoop`, or left unset if using a custom catalog  |
+| iceberg.catalog.<catalog_name\>.type          | type of catalog: `hive`, `hadoop`, `nessie`, `glue`, `dynamodb`, `jdbc` or left unset if using a custom catalog  |
 | iceberg.catalog.<catalog_name\>.catalog-impl  | catalog implementation, must not be null if type is empty |
 | iceberg.catalog.<catalog_name\>.<key\>        | any config key and value pairs for the catalog         |
 

--- a/site/docs/jdbc.md
+++ b/site/docs/jdbc.md
@@ -44,7 +44,7 @@ You can start a Spark session with a MySQL JDBC connection using the following c
 spark-sql --packages org.apache.iceberg:iceberg-spark3-runtime:{{ versions.iceberg }} \
     --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCatalog \
     --conf spark.sql.catalog.my_catalog.warehouse=s3://my-bucket/my/key/prefix \
-    --conf spark.sql.catalog.my_catalog.catalog-impl=org.apache.iceberg.jdbc.JdbcCatalog \
+    --conf spark.sql.catalog.my_catalog.type=jdbc \
     --conf spark.sql.catalog.my_catalog.uri=jdbc:mysql://test.1234567890.us-west-2.rds.amazonaws.com:3306/default \
     --conf spark.sql.catalog.my_catalog.jdbc.verifyServerCertificate=true \
     --conf spark.sql.catalog.my_catalog.jdbc.useSSL=true \

--- a/site/docs/nessie.md
+++ b/site/docs/nessie.md
@@ -73,7 +73,7 @@ and in Spark:
 conf.set("spark.sql.catalog.nessie.warehouse", "/path/to/warehouse");
 conf.set("spark.sql.catalog.nessie.uri", "http://localhost:19120/api/v1")
 conf.set("spark.sql.catalog.nessie.ref", "main")
-conf.set("spark.sql.catalog.nessie.catalog-impl", "org.apache.iceberg.nessie.NessieCatalog")
+conf.set("spark.sql.catalog.nessie.type", "nessie")
 conf.set("spark.sql.catalog.nessie", "org.apache.iceberg.spark.SparkCatalog")
 conf.set("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,org.projectnessie.spark.extensions.NessieSparkSessionExtensions")
 ```

--- a/site/docs/spark-configuration.md
+++ b/site/docs/spark-configuration.md
@@ -54,8 +54,8 @@ Both catalogs are configured using properties nested under the catalog name. Com
 
 | Property                                           | Values                        | Description                                                          |
 | -------------------------------------------------- | ----------------------------- | -------------------------------------------------------------------- |
-| spark.sql.catalog._catalog-name_.type              | `hive`, `hadoop`, `nessie`, `jdbc`, `glue` or `dynamodb`| Represents the underlying Iceberg catalog implementation. For example - `HiveCatalog` for `hive` and `HadoopCatalog` for `hadoop`.<br>Leave unset if using a custom catalog via the conf `catalog-impl`. |
-| spark.sql.catalog._catalog-name_.catalog-impl      |                               | The underlying Iceberg catalog implementation.|
+| spark.sql.catalog._catalog-name_.type              | `hive`, `hadoop`, `nessie`, `jdbc`, `glue` or `dynamodb`| Type of catalog. Leave unset if using a custom catalog. |
+| spark.sql.catalog._catalog-name_.catalog-impl      |                               | Catalog implementation, must not be null if type is empty|
 | spark.sql.catalog._catalog-name_.default-namespace | default                       | The default current namespace for the catalog |
 | spark.sql.catalog._catalog-name_.uri               | thrift://host:port            | Metastore connect URI; default from `hive-site.xml` |
 | spark.sql.catalog._catalog-name_.warehouse         | hdfs://nn:8020/warehouse/path | Base path for the warehouse directory |

--- a/site/docs/spark-configuration.md
+++ b/site/docs/spark-configuration.md
@@ -54,7 +54,7 @@ Both catalogs are configured using properties nested under the catalog name. Com
 
 | Property                                           | Values                        | Description                                                          |
 | -------------------------------------------------- | ----------------------------- | -------------------------------------------------------------------- |
-| spark.sql.catalog._catalog-name_.type              | `hive` or `hadoop`            | The underlying Iceberg catalog implementation, `HiveCatalog`, `HadoopCatalog` or left unset if using a custom catalog |
+| spark.sql.catalog._catalog-name_.type              | `hive`, `hadoop`, `nessie`, `jdbc`, `glue` or `dynamodb`| Represents the underlying Iceberg catalog implementation. For example - `HiveCatalog` for `hive` and `HadoopCatalog` for `hadoop`.<br>Leave unset if using a custom catalog via the conf `catalog-impl`. |
 | spark.sql.catalog._catalog-name_.catalog-impl      |                               | The underlying Iceberg catalog implementation.|
 | spark.sql.catalog._catalog-name_.default-namespace | default                       | The default current namespace for the catalog |
 | spark.sql.catalog._catalog-name_.uri               | thrift://host:port            | Metastore connect URI; default from `hive-site.xml` |

--- a/site/docs/spark-configuration.md
+++ b/site/docs/spark-configuration.md
@@ -54,7 +54,7 @@ Both catalogs are configured using properties nested under the catalog name. Com
 
 | Property                                           | Values                        | Description                                                          |
 | -------------------------------------------------- | ----------------------------- | -------------------------------------------------------------------- |
-| spark.sql.catalog._catalog-name_.type              | `hive`, `hadoop`, `nessie`, `jdbc`, `glue` or `dynamodb`| Type of catalog. Leave unset if using a custom catalog. |
+| spark.sql.catalog._catalog-name_.type              | `hive`, `hadoop`, `nessie`, `jdbc`, `glue` or `dynamodb`| Type of catalog. Leave unset if using a custom catalog|
 | spark.sql.catalog._catalog-name_.catalog-impl      |                               | Catalog implementation, must not be null if type is empty|
 | spark.sql.catalog._catalog-name_.default-namespace | default                       | The default current namespace for the catalog |
 | spark.sql.catalog._catalog-name_.uri               | thrift://host:port            | Metastore connect URI; default from `hive-site.xml` |


### PR DESCRIPTION
Fixes #3289 

- Extend type conf for known catalog types - nessie, jdbc, glue and dynamodb
- CatalogType enum, which carries the mapping between type and catalog-impl
- Tests, that validate the class name against the type configuration to prevent breakage on refactoring actions.