### PR TITLE
Hive handler estimate file size

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -163,17 +163,11 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
 
   /**
    * Estimate input size based on filter and projection on table scan operator
-   *
-   *
-   */
-
-  /**
-   * Estimate input size based on filter and projection on table scan operator
    * @param job The configuration used to get the data from
    * @param ts The name of the table we need as returned by TableDesc.getTableName()
    * @param remaining Early exit condition. If it has positive value, further estimation
-   *    can be canceled on the point of exceeding it. In this case,
-   *    return any bigger length value then this (Long.MAX_VALUE, for eaxmple).
+   *        can be canceled on the point of exceeding it. In this case,
+   *        return any bigger length value then this (Long.MAX_VALUE, for eaxmple).
    * @return The Estimation
    */
   @Override


### PR DESCRIPTION
### Hive query on Iceberg tables 
MapRedTask will get full file inputSummary to setNumberOfReducers .
when Iceberg table is big, getContentSummary operator will put a lot of pressure on the namenode.
so we need estimate the file total size in HiveIcebergStorageHandler.