### PR TITLE
INFRA - Add in new CI workflows to cancel duplicates action

### DIFF
--- a/.github/workflows/cancel-duplicate-workflow-runs.yml
+++ b/.github/workflows/cancel-duplicate-workflow-runs.yml
@@ -21,8 +21,11 @@ name: "Cancel Duplicates"
 on:
   workflow_run:
     workflows: 
+      - 'Flink CI'
+      - 'Hive CI'
       - 'Java CI'
       - 'Python CI'
+      - 'Spark CI'
     types: ['requested']
 
 jobs:


### PR DESCRIPTION
Adds the newly refactored CI structure to the `Cancel Duplicates` Github Action.

cc @nastra @RussellSpitzer @rdblue 