### PR TITLE
AWS: Add column parameters for Glue catalog table schema

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueCatalogTableTest.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueCatalogTableTest.java
@@ -315,7 +315,7 @@ public class GlueCatalogTableTest extends GlueTestBase {
                 IcebergToGlueConverter.ICEBERG_FIELD_ID, "1",
                 IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "false",
                 IcebergToGlueConverter.ICEBERG_FIELD_TYPE_STRING, "string",
-                IcebergToGlueConverter.ICEBERG_FIELD_TYPE_ID, "STRING"
+                IcebergToGlueConverter.ICEBERG_FIELD_TYPE_TYPE_ID, "STRING"
             ))
             .build(),
         Column.builder()
@@ -327,7 +327,7 @@ public class GlueCatalogTableTest extends GlueTestBase {
                 IcebergToGlueConverter.ICEBERG_FIELD_ID, "2",
                 IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "true",
                 IcebergToGlueConverter.ICEBERG_FIELD_TYPE_STRING, "struct<z:int>",
-                IcebergToGlueConverter.ICEBERG_FIELD_TYPE_ID, "STRUCT"
+                IcebergToGlueConverter.ICEBERG_FIELD_TYPE_TYPE_ID, "STRUCT"
             ))
             .build(),
         Column.builder()
@@ -338,7 +338,7 @@ public class GlueCatalogTableTest extends GlueTestBase {
                 IcebergToGlueConverter.ICEBERG_FIELD_ID, "3",
                 IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "false",
                 IcebergToGlueConverter.ICEBERG_FIELD_TYPE_STRING, "int",
-                IcebergToGlueConverter.ICEBERG_FIELD_TYPE_ID, "INTEGER"
+                IcebergToGlueConverter.ICEBERG_FIELD_TYPE_TYPE_ID, "INTEGER"
             ))
             .build(),
         Column.builder()
@@ -346,7 +346,7 @@ public class GlueCatalogTableTest extends GlueTestBase {
             .type("string")
             .parameters(ImmutableMap.<String, String>builder()
                 .put(IcebergToGlueConverter.ICEBERG_FIELD_USAGE, IcebergToGlueConverter.PARTITION_FIELD)
-                .put(IcebergToGlueConverter.ICEBERG_FIELD_TYPE_ID, "STRING")
+                .put(IcebergToGlueConverter.ICEBERG_FIELD_TYPE_TYPE_ID, "STRING")
                 .put(IcebergToGlueConverter.ICEBERG_FIELD_TYPE_STRING, "string")
                 .put(IcebergToGlueConverter.ICEBERG_FIELD_ID, "1000")
                 .put(IcebergToGlueConverter.ICEBERG_PARTITION_FIELD_ID, "1000")

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
@@ -56,7 +56,7 @@ class IcebergToGlueConverter {
   private static final Pattern GLUE_DB_PATTERN = Pattern.compile("^[a-z0-9_]{1,252}$");
   private static final Pattern GLUE_TABLE_PATTERN = Pattern.compile("^[a-z0-9_]{1,255}$");
   public static final String ICEBERG_FIELD_USAGE = "iceberg.field.usage";
-  public static final String ICEBERG_FIELD_TYPE_ID = "iceberg.field.type.id";
+  public static final String ICEBERG_FIELD_TYPE_TYPE_ID = "iceberg.field.type.typeid";
   public static final String ICEBERG_FIELD_TYPE_STRING = "iceberg.field.type.string";
   public static final String ICEBERG_FIELD_ID = "iceberg.field.id";
   public static final String ICEBERG_FIELD_OPTIONAL = "iceberg.field.optional";
@@ -277,7 +277,7 @@ class IcebergToGlueConverter {
 
   private static Map<String, String> convertToParameters(String fieldUsage, NestedField field) {
     return ImmutableMap.of(ICEBERG_FIELD_USAGE, fieldUsage,
-        ICEBERG_FIELD_TYPE_ID, field.type().typeId().toString(),
+        ICEBERG_FIELD_TYPE_TYPE_ID, field.type().typeId().toString(),
         ICEBERG_FIELD_TYPE_STRING, toTypeString(field.type()),
         ICEBERG_FIELD_ID, Integer.toString(field.fieldId()),
         ICEBERG_FIELD_OPTIONAL, Boolean.toString(field.isOptional())
@@ -287,7 +287,7 @@ class IcebergToGlueConverter {
   private static Map<String, String> convertToPartitionFieldParameters(Type type, PartitionField partitionField) {
     return ImmutableMap.<String, String>builder()
         .put(ICEBERG_FIELD_USAGE, PARTITION_FIELD)
-        .put(ICEBERG_FIELD_TYPE_ID, type.typeId().toString())
+        .put(ICEBERG_FIELD_TYPE_TYPE_ID, type.typeId().toString())
         .put(ICEBERG_FIELD_TYPE_STRING, toTypeString(type))
         .put(ICEBERG_FIELD_ID, Integer.toString(partitionField.fieldId()))
         .put(ICEBERG_PARTITION_TRANSFORM, partitionField.transform().toString())

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/IcebergToGlueConverterTest.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/IcebergToGlueConverterTest.java
@@ -106,7 +106,7 @@ public class IcebergToGlueConverterTest {
                         IcebergToGlueConverter.ICEBERG_FIELD_ID, "1",
                         IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "false",
                         IcebergToGlueConverter.ICEBERG_FIELD_TYPE_STRING, "string",
-                        IcebergToGlueConverter.ICEBERG_FIELD_TYPE_ID, "STRING"
+                        IcebergToGlueConverter.ICEBERG_FIELD_TYPE_TYPE_ID, "STRING"
                     ))
                     .build(),
                 Column.builder()
@@ -118,7 +118,7 @@ public class IcebergToGlueConverterTest {
                         IcebergToGlueConverter.ICEBERG_FIELD_ID, "2",
                         IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "false",
                         IcebergToGlueConverter.ICEBERG_FIELD_TYPE_STRING, "struct<z:int>",
-                        IcebergToGlueConverter.ICEBERG_FIELD_TYPE_ID, "STRUCT"
+                        IcebergToGlueConverter.ICEBERG_FIELD_TYPE_TYPE_ID, "STRUCT"
                     ))
                     .build(),
                 Column.builder()
@@ -129,7 +129,7 @@ public class IcebergToGlueConverterTest {
                         IcebergToGlueConverter.ICEBERG_FIELD_ID, "3",
                         IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "false",
                         IcebergToGlueConverter.ICEBERG_FIELD_TYPE_STRING, "int",
-                        IcebergToGlueConverter.ICEBERG_FIELD_TYPE_ID, "INTEGER"
+                        IcebergToGlueConverter.ICEBERG_FIELD_TYPE_TYPE_ID, "INTEGER"
                     ))
                     .build(),
                 Column.builder()
@@ -137,7 +137,7 @@ public class IcebergToGlueConverterTest {
                     .type("string")
                     .parameters(ImmutableMap.<String, String>builder()
                         .put(IcebergToGlueConverter.ICEBERG_FIELD_USAGE, IcebergToGlueConverter.PARTITION_FIELD)
-                        .put(IcebergToGlueConverter.ICEBERG_FIELD_TYPE_ID, "STRING")
+                        .put(IcebergToGlueConverter.ICEBERG_FIELD_TYPE_TYPE_ID, "STRING")
                         .put(IcebergToGlueConverter.ICEBERG_FIELD_TYPE_STRING, "string")
                         .put(IcebergToGlueConverter.ICEBERG_FIELD_ID, "1000")
                         .put(IcebergToGlueConverter.ICEBERG_PARTITION_FIELD_ID, "1000")


### PR DESCRIPTION
Changes for #3325. This PR is to categorize information into the following column parameters for better information presentation purpose with help of [Glue column parameters](https://docs.aws.amazon.com/glue/latest/webapi/API_Column.html):

- `iceberg.field.usage`, can be `schema-column`, `schema-subfield` or `partition-field`
- `iceberg.field.type.typeid`, storing the Iceberg TypeID, such as `MAP`
- `iceberg.field.type.string`, string representation of the type, such as `map<string,string>`
- `iceberg.field.id`, storing integer ID of the field
- `iceberg.field.optional`, `true` if optional otherwise `false`. We should omit this key for `partition-field`.
- `iceberg.partition.transform`, storing partition transform string for `partition-field`, such as `bucket[16]`
- `iceberg.partition.field-id`, storing field ID of the `partition-field`
- `iceberg.partition.source-id`, storing source ID of the `partition-field`

The column `comment` field will store just the `doc` of the field.

DDL:
```
CREATE TABLE my_catalog.db_iceberg.table (
    i int comment 'comment for column i',
    l bigint comment 'comment for column l',
    d date comment 'comment for column d',
    t string comment 'comment for column t',
    ts timestamp comment 'comment for column ts',
    tstz timestamp comment 'comment for column tstz',
    dec decimal(9,2) comment 'comment for column dec',
    s string comment 'comment for column s',
    u string comment 'comment for column u',
    f binary comment 'comment for column f',
    b binary comment 'comment for column b',
    struct struct<i2:int,l2:bigint,d2:date> comment 'comment for column struct',
    list array<struct<i3:int,l3:bigint,d3:date>> comment 'comment for column list',
    map map<string,struct<i4:int,l5:bigint,d6:date>> comment 'comment for column map')
USING iceberg 
LOCATION 's3://bucket/path'
PARTITIONED BY (bucket(16, s), truncate(u, 4), years(ts));
```

`aws glue get-table --database-name db_iceberg --name table` command output:
```
{
    "Table": {
        "Name": "table",
        "DatabaseName": "db_iceberg",
        "CreateTime": 1635482689.0,
        "UpdateTime": 1635482689.0,
        "Retention": 0,
        "StorageDescriptor": {
            "Columns": [
                {
                    "Name": "i",
                    "Type": "int",
                    "Comment": "comment for column i",
                    "Parameters": {
                        "iceberg.field.id": "1",
                        "iceberg.field.optional": "true",
                        "iceberg.field.type.string": "int",
                        "iceberg.field.type.typeid": "INTEGER",
                        "iceberg.field.usage": "schema-column"
                    }
                },
                {
                    "Name": "l",
                    "Type": "bigint",
                    "Comment": "comment for column l",
                    "Parameters": {
                        "iceberg.field.id": "2",
                        "iceberg.field.optional": "true",
                        "iceberg.field.type.string": "bigint",
                        "iceberg.field.type.typeid": "LONG",
                        "iceberg.field.usage": "schema-column"
                    }
                },
                {
                    "Name": "d",
                    "Type": "date",
                    "Comment": "comment for column d",
                    "Parameters": {
                        "iceberg.field.id": "3",
                        "iceberg.field.optional": "true",
                        "iceberg.field.type.string": "date",
                        "iceberg.field.type.typeid": "DATE",
                        "iceberg.field.usage": "schema-column"
                    }
                },
                {
                    "Name": "t",
                    "Type": "string",
                    "Comment": "comment for column t",
                    "Parameters": {
                        "iceberg.field.id": "4",
                        "iceberg.field.optional": "true",
                        "iceberg.field.type.string": "string",
                        "iceberg.field.type.typeid": "STRING",
                        "iceberg.field.usage": "schema-column"
                    }
                },
                {
                    "Name": "ts",
                    "Type": "timestamp",
                    "Comment": "comment for column ts",
                    "Parameters": {
                        "iceberg.field.id": "5",
                        "iceberg.field.optional": "true",
                        "iceberg.field.type.string": "timestamp",
                        "iceberg.field.type.typeid": "TIMESTAMP",
                        "iceberg.field.usage": "schema-column"
                    }
                },
                {
                    "Name": "tstz",
                    "Type": "timestamp",
                    "Comment": "comment for column tstz",
                    "Parameters": {
                        "iceberg.field.id": "6",
                        "iceberg.field.optional": "true",
                        "iceberg.field.type.string": "timestamp",
                        "iceberg.field.type.typeid": "TIMESTAMP",
                        "iceberg.field.usage": "schema-column"
                    }
                },
                {
                    "Name": "dec",
                    "Type": "decimal(9,2)",
                    "Comment": "comment for column dec",
                    "Parameters": {
                        "iceberg.field.id": "7",
                        "iceberg.field.optional": "true",
                        "iceberg.field.type.string": "decimal(9,2)",
                        "iceberg.field.type.typeid": "DECIMAL",
                        "iceberg.field.usage": "schema-column"
                    }
                },
                {
                    "Name": "s",
                    "Type": "string",
                    "Comment": "comment for column s",
                    "Parameters": {
                        "iceberg.field.id": "8",
                        "iceberg.field.optional": "true",
                        "iceberg.field.type.string": "string",
                        "iceberg.field.type.typeid": "STRING",
                        "iceberg.field.usage": "schema-column"
                    }
                },
                {
                    "Name": "u",
                    "Type": "string",
                    "Comment": "comment for column u",
                    "Parameters": {
                        "iceberg.field.id": "9",
                        "iceberg.field.optional": "true",
                        "iceberg.field.type.string": "string",
                        "iceberg.field.type.typeid": "STRING",
                        "iceberg.field.usage": "schema-column"
                    }
                },
                {
                    "Name": "f",
                    "Type": "binary",
                    "Comment": "comment for column f",
                    "Parameters": {
                        "iceberg.field.id": "10",
                        "iceberg.field.optional": "true",
                        "iceberg.field.type.string": "binary",
                        "iceberg.field.type.typeid": "BINARY",
                        "iceberg.field.usage": "schema-column"
                    }
                },
                {
                    "Name": "b",
                    "Type": "binary",
                    "Comment": "comment for column b",
                    "Parameters": {
                        "iceberg.field.id": "11",
                        "iceberg.field.optional": "true",
                        "iceberg.field.type.string": "binary",
                        "iceberg.field.type.typeid": "BINARY",
                        "iceberg.field.usage": "schema-column"
                    }
                },
                {
                    "Name": "struct",
                    "Type": "struct<i2:int,l2:bigint,d2:date>",
                    "Comment": "comment for column struct",
                    "Parameters": {
                        "iceberg.field.id": "12",
                        "iceberg.field.optional": "true",
                        "iceberg.field.type.string": "struct<i2:int,l2:bigint,d2:date>",
                        "iceberg.field.type.typeid": "STRUCT",
                        "iceberg.field.usage": "schema-column"
                    }
                },
                {
                    "Name": "list",
                    "Type": "array<struct<i3:int,l3:bigint,d3:date>>",
                    "Comment": "comment for column list",
                    "Parameters": {
                        "iceberg.field.id": "13",
                        "iceberg.field.optional": "true",
                        "iceberg.field.type.string": "array<struct<i3:int,l3:bigint,d3:date>>",
                        "iceberg.field.type.typeid": "LIST",
                        "iceberg.field.usage": "schema-column"
                    }
                },
                {
                    "Name": "map",
                    "Type": "map<string,struct<i4:int,l5:bigint,d6:date>>",
                    "Comment": "comment for column map",
                    "Parameters": {
                        "iceberg.field.id": "14",
                        "iceberg.field.optional": "true",
                        "iceberg.field.type.string": "map<string,struct<i4:int,l5:bigint,d6:date>>",
                        "iceberg.field.type.typeid": "MAP",
                        "iceberg.field.usage": "schema-column"
                    }
                },
                {
                    "Name": "i2",
                    "Type": "int",
                    "Parameters": {
                        "iceberg.field.id": "15",
                        "iceberg.field.optional": "true",
                        "iceberg.field.type.string": "int",
                        "iceberg.field.type.typeid": "INTEGER",
                        "iceberg.field.usage": "schema-subfield"
                    }
                },
                {
                    "Name": "l2",
                    "Type": "bigint",
                    "Parameters": {
                        "iceberg.field.id": "16",
                        "iceberg.field.optional": "true",
                        "iceberg.field.type.string": "bigint",
                        "iceberg.field.type.typeid": "LONG",
                        "iceberg.field.usage": "schema-subfield"
                    }
                },
                {
                    "Name": "d2",
                    "Type": "date",
                    "Parameters": {
                        "iceberg.field.id": "17",
                        "iceberg.field.optional": "true",
                        "iceberg.field.type.string": "date",
                        "iceberg.field.type.typeid": "DATE",
                        "iceberg.field.usage": "schema-subfield"
                    }
                },
                {
                    "Name": "element",
                    "Type": "struct<i3:int,l3:bigint,d3:date>",
                    "Parameters": {
                        "iceberg.field.id": "18",
                        "iceberg.field.optional": "true",
                        "iceberg.field.type.string": "struct<i3:int,l3:bigint,d3:date>",
                        "iceberg.field.type.typeid": "STRUCT",
                        "iceberg.field.usage": "schema-subfield"
                    }
                },
                {
                    "Name": "i3",
                    "Type": "int",
                    "Parameters": {
                        "iceberg.field.id": "19",
                        "iceberg.field.optional": "true",
                        "iceberg.field.type.string": "int",
                        "iceberg.field.type.typeid": "INTEGER",
                        "iceberg.field.usage": "schema-subfield"
                    }
                },
                {
                    "Name": "l3",
                    "Type": "bigint",
                    "Parameters": {
                        "iceberg.field.id": "20",
                        "iceberg.field.optional": "true",
                        "iceberg.field.type.string": "bigint",
                        "iceberg.field.type.typeid": "LONG",
                        "iceberg.field.usage": "schema-subfield"
                    }
                },
                {
                    "Name": "d3",
                    "Type": "date",
                    "Parameters": {
                        "iceberg.field.id": "21",
                        "iceberg.field.optional": "true",
                        "iceberg.field.type.string": "date",
                        "iceberg.field.type.typeid": "DATE",
                        "iceberg.field.usage": "schema-subfield"
                    }
                },
                {
                    "Name": "key",
                    "Type": "string",
                    "Parameters": {
                        "iceberg.field.id": "22",
                        "iceberg.field.optional": "false",
                        "iceberg.field.type.string": "string",
                        "iceberg.field.type.typeid": "STRING",
                        "iceberg.field.usage": "schema-subfield"
                    }
                },
                {
                    "Name": "value",
                    "Type": "struct<i4:int,l5:bigint,d6:date>",
                    "Parameters": {
                        "iceberg.field.id": "23",
                        "iceberg.field.optional": "true",
                        "iceberg.field.type.string": "struct<i4:int,l5:bigint,d6:date>",
                        "iceberg.field.type.typeid": "STRUCT",
                        "iceberg.field.usage": "schema-subfield"
                    }
                },
                {
                    "Name": "i4",
                    "Type": "int",
                    "Parameters": {
                        "iceberg.field.id": "24",
                        "iceberg.field.optional": "true",
                        "iceberg.field.type.string": "int",
                        "iceberg.field.type.typeid": "INTEGER",
                        "iceberg.field.usage": "schema-subfield"
                    }
                },
                {
                    "Name": "l5",
                    "Type": "bigint",
                    "Parameters": {
                        "iceberg.field.id": "25",
                        "iceberg.field.optional": "true",
                        "iceberg.field.type.string": "bigint",
                        "iceberg.field.type.typeid": "LONG",
                        "iceberg.field.usage": "schema-subfield"
                    }
                },
                {
                    "Name": "d6",
                    "Type": "date",
                    "Parameters": {
                        "iceberg.field.id": "26",
                        "iceberg.field.optional": "true",
                        "iceberg.field.type.string": "date",
                        "iceberg.field.type.typeid": "DATE",
                        "iceberg.field.usage": "schema-subfield"
                    }
                },
                {
                    "Name": "s_bucket",
                    "Type": "int",
                    "Parameters": {
                        "iceberg.field.id": "1000",
                        "iceberg.field.type.string": "int",
                        "iceberg.field.type.typeid": "INTEGER",
                        "iceberg.field.usage": "partition-field",
                        "iceberg.partition.field-id": "1000",
                        "iceberg.partition.source-id": "8",
                        "iceberg.partition.transform": "bucket[16]"
                    }
                },
                {
                    "Name": "u_trunc",
                    "Type": "string",
                    "Parameters": {
                        "iceberg.field.id": "1001",
                        "iceberg.field.type.string": "string",
                        "iceberg.field.type.typeid": "STRING",
                        "iceberg.field.usage": "partition-field",
                        "iceberg.partition.field-id": "1001",
                        "iceberg.partition.source-id": "9",
                        "iceberg.partition.transform": "truncate[4]"
                    }
                },
                {
                    "Name": "ts_year",
                    "Type": "int",
                    "Parameters": {
                        "iceberg.field.id": "1002",
                        "iceberg.field.type.string": "int",
                        "iceberg.field.type.typeid": "INTEGER",
                        "iceberg.field.usage": "partition-field",
                        "iceberg.partition.field-id": "1002",
                        "iceberg.partition.source-id": "5",
                        "iceberg.partition.transform": "year"
                    }
                }
            ],
            "Location": "s3://buckey/warehouse-path",
            "Compressed": false,
            "NumberOfBuckets": 0,
            "SortColumns": [],
            "StoredAsSubDirectories": false
        },
        "TableType": "EXTERNAL_TABLE",
        "Parameters": {
            "metadata_location": "s3://bucket/path/file.json",
            "table_type": "ICEBERG"
        }
    }
}
```

Integration Test Output:
```
./gradlew :iceberg-aws:integrationTest --tests "org.apache.iceberg.aws.glue.GlueCatalogTableTest"
...
...
BUILD SUCCESSFUL in 3m 9s
```