### PR TITLE
Build: Publish SNAPSHOT releases

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -34,4 +34,4 @@ jobs:
         with:
           java-version: 8
       - run: |
-          ./gradlew publishApachePublicationToMavenRepository -PversionSuffix=SNAPSHOT -PmavenUser=${{ secrets.NEXUS_USER }} -PmavenPassword=${{ secrets.NEXUS_PW }}
+          ./gradlew publishApachePublicationToMavenRepository -PmavenUser=${{ secrets.NEXUS_USER }} -PmavenPassword=${{ secrets.NEXUS_PW }}

--- a/build.gradle
+++ b/build.gradle
@@ -581,10 +581,7 @@ String getProjectVersion() {
     Matcher matcher = pattern.matcher(version)
     if (matcher.matches()) {
       // bump the MINOR version and always set the PATCH version to 0
-      version = matcher.group(1) + "." + (Integer.valueOf(matcher.group(2)) + 1) + ".0"
-    }
-    if (project.hasProperty('versionSuffix')) {
-      return version + "-" + project.getProperties().get("versionSuffix")
+      return matcher.group(1) + "." + (Integer.valueOf(matcher.group(2)) + 1) + ".0-SNAPSHOT"
     }
     return version
   } catch (Exception e) {


### PR DESCRIPTION
The idea is that we do `x.y.z-SNAPSHOT` releases whenever something is pushed to `master`. This requires that we have `NEXUS_USER` / `NEXUS_PW` secrets stored.

I also created https://issues.apache.org/jira/browse/INFRA-22437 in order to have a general Maven user/password for publishing the snapshots.