### PR TITLE
Core: Implement FanoutPositionDeleteWriter

### DIFF
--- a/core/src/main/java/org/apache/iceberg/io/FanoutDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/FanoutDeleteWriter.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io;
+
+import java.util.List;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.deletes.PositionDelete;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.CharSequenceSet;
+
+/**
+ * A delete writer capable of writing to multiple specs and partitions that keeps delete writers for each
+ * seen spec/partition pair open until this writer is closed.
+ */
+public class FanoutDeleteWriter<T> extends FanoutWriter<PositionDelete<T>, DeleteWriteResult> {
+
+  private final FileWriterFactory<T> writerFactory;
+  private final OutputFileFactory fileFactory;
+  private final FileIO io;
+  private final long targetFileSizeInBytes;
+  private final List<DeleteFile> deleteFiles;
+  private final CharSequenceSet referencedDataFiles;
+
+  public FanoutDeleteWriter(FileWriterFactory<T> writerFactory, OutputFileFactory fileFactory,
+                            FileIO io, long targetFileSizeInBytes) {
+    this.writerFactory = writerFactory;
+    this.fileFactory = fileFactory;
+    this.io = io;
+    this.targetFileSizeInBytes = targetFileSizeInBytes;
+    this.deleteFiles = Lists.newArrayList();
+    this.referencedDataFiles = CharSequenceSet.empty();
+  }
+
+  @Override
+  protected FileWriter<PositionDelete<T>, DeleteWriteResult> newWriter(PartitionSpec spec, StructLike partition) {
+    return new RollingPositionDeleteWriter<>(writerFactory, fileFactory, io, targetFileSizeInBytes, spec, partition);
+  }
+
+  @Override
+  protected void addResult(DeleteWriteResult result) {
+    deleteFiles.addAll(result.deleteFiles());
+    referencedDataFiles.addAll(result.referencedDataFiles());
+  }
+
+  @Override
+  protected DeleteWriteResult aggregatedResult() {
+    return new DeleteWriteResult(deleteFiles, referencedDataFiles);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/io/FanoutPositionDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/FanoutPositionDeleteWriter.java
@@ -28,10 +28,10 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.CharSequenceSet;
 
 /**
- * A delete writer capable of writing to multiple specs and partitions that keeps delete writers for each
- * seen spec/partition pair open until this writer is closed.
+ * A position delete writer capable of writing to multiple specs and partitions that keeps position delete writers
+ * for each seen spec/partition pair open until this writer is closed.
  */
-public class FanoutDeleteWriter<T> extends FanoutWriter<PositionDelete<T>, DeleteWriteResult> {
+public class FanoutPositionDeleteWriter<T> extends FanoutWriter<PositionDelete<T>, DeleteWriteResult> {
 
   private final FileWriterFactory<T> writerFactory;
   private final OutputFileFactory fileFactory;
@@ -40,8 +40,8 @@ public class FanoutDeleteWriter<T> extends FanoutWriter<PositionDelete<T>, Delet
   private final List<DeleteFile> deleteFiles;
   private final CharSequenceSet referencedDataFiles;
 
-  public FanoutDeleteWriter(FileWriterFactory<T> writerFactory, OutputFileFactory fileFactory,
-                            FileIO io, long targetFileSizeInBytes) {
+  public FanoutPositionDeleteWriter(FileWriterFactory<T> writerFactory, OutputFileFactory fileFactory,
+                                    FileIO io, long targetFileSizeInBytes) {
     this.writerFactory = writerFactory;
     this.fileFactory = fileFactory;
     this.io = io;

--- a/data/src/test/java/org/apache/iceberg/io/TestPartitioningWriters.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestPartitioningWriters.java
@@ -471,7 +471,8 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
   @Test
   public void testFanoutDeleteWriterNoRecords() throws IOException {
     FileWriterFactory<T> writerFactory = newWriterFactory(table.schema());
-    FanoutDeleteWriter<T> writer = new FanoutDeleteWriter<>(writerFactory, fileFactory, table.io(), TARGET_FILE_SIZE);
+    FanoutPositionDeleteWriter<T> writer =
+        new FanoutPositionDeleteWriter<>(writerFactory, fileFactory, table.io(), TARGET_FILE_SIZE);
 
     writer.close();
     DeleteWriteResult result = writer.result();
@@ -573,7 +574,8 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
     PartitionSpec bucketedSpec = table.specs().get(2);
 
     // delete some records
-    FanoutDeleteWriter<T> writer = new FanoutDeleteWriter<>(writerFactory, fileFactory, table.io(), TARGET_FILE_SIZE);
+    FanoutPositionDeleteWriter<T> writer =
+        new FanoutPositionDeleteWriter<>(writerFactory, fileFactory, table.io(), TARGET_FILE_SIZE);
     writer.write(positionDelete(dataFile1.path(), 0L, null), unpartitionedSpec, null);
     writer.write(positionDelete(dataFile2.path(), 0L, null), identitySpec, partitionKey(identitySpec, "fff"));
     writer.write(positionDelete(dataFile2.path(), 1L, null), identitySpec, partitionKey(identitySpec, "fff"));

--- a/data/src/test/java/org/apache/iceberg/io/TestPartitioningWriters.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestPartitioningWriters.java
@@ -578,10 +578,11 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
         new FanoutPositionDeleteWriter<>(writerFactory, fileFactory, table.io(), TARGET_FILE_SIZE);
     writer.write(positionDelete(dataFile1.path(), 0L, null), unpartitionedSpec, null);
     writer.write(positionDelete(dataFile2.path(), 0L, null), identitySpec, partitionKey(identitySpec, "fff"));
-    writer.write(positionDelete(dataFile2.path(), 1L, null), identitySpec, partitionKey(identitySpec, "fff"));
     writer.write(positionDelete(dataFile3.path(), 2L, null), identitySpec, partitionKey(identitySpec, "rrr"));
+    // test out-of-order partition
+    writer.write(positionDelete(dataFile2.path(), 1L, null), identitySpec, partitionKey(identitySpec, "fff"));
     writer.write(positionDelete(dataFile4.path(), 0L, null), bucketedSpec, partitionKey(bucketedSpec, "rrr"));
-    // pepper in some out-of-order spec deletes, which shouldn't cause problems for fanout writer
+    // test out-of-order spec
     writer.write(positionDelete(dataFile1.path(), 1L, null), unpartitionedSpec, null);
     writer.write(positionDelete(dataFile2.path(), 2L, null), identitySpec, partitionKey(identitySpec, "fff"));
     writer.close();


### PR DESCRIPTION
Implement new `FanoutPositionDeleteWriter`, similar to the already-existing `FanoutDataWriter` class. 
This new DeleteWriter implementation should provide an alternative to `ClusteredPositionDeleteWriter`  for those users who are not inserting their data clustered by partition spec/partition values.

@aokolnychyi @openinx @pvary - can you please take a look? Thanks!