### PR TITLE
Hotfix - Remove additional parens to satisfy checkstyle for 1.12.1 cherry-picking

### DIFF
--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
@@ -147,7 +147,7 @@ public class TestIcebergSpark {
         spark.sql("SELECT iceberg_bucket_binary_16(X'0020001F')").collectAsList();
     Assert.assertEquals(1, results.size());
     Assert.assertEquals((int) Transforms.bucket(Types.BinaryType.get(), 16)
-            .apply(ByteBuffer.wrap((new byte[]{0x00, 0x20, 0x00, 0x1F}))),
+            .apply(ByteBuffer.wrap(new byte[]{0x00, 0x20, 0x00, 0x1F})),
         results.get(0).getInt(0));
   }
 


### PR DESCRIPTION
While working on the cherry-picking for creating the initial release candidate for 1.12.1, while trying to cherry-pick this PR, https://github.com/apache/iceberg/pull/3368, a checkstyle error fails the build.

```
> Task :iceberg-spark:checkstyleTest
[ant:checkstyle] [ERROR] /Users/kylebendickson/repos/iceberg-kyle/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java:150:36: Unnecessary parentheses around expression. [UnnecessaryParentheses]
```

For some reason, this doesn't come up during the current build / CI, but I need to apply this hotfix to be able to cherry-pick the above PR as cleanly as possible into the 1.12.x branch (and I have a feeling that this might be hinting at some underlying CI tests that aren't being run entirely, for example the Spark v3.2 tests possibly).

cc @rdblue 