### PR TITLE
Core: enable setting table property as action config option default

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
@@ -78,6 +78,13 @@ public interface RewriteDataFiles extends SnapshotUpdate<RewriteDataFiles, Rewri
   String TARGET_FILE_SIZE_BYTES = "target-file-size-bytes";
 
   /**
+   * Name of the action.
+   * User can define table properties in the form actions.rewrite-data-files.[config-option-key]
+   * to provide default values for a table when executing this action.
+   */
+  String NAME = "rewrite-data-files";
+
+  /**
    * Choose BINPACK as a strategy for this rewrite operation
    * @return this for method chaining
    */

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg;
 
+import java.util.Locale;
 import java.util.Set;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 
@@ -244,4 +245,41 @@ public class TableProperties {
 
   public static final String UPSERT_MODE_ENABLE = "write.upsert.enable";
   public static final boolean UPSERT_MODE_ENABLE_DEFAULT = false;
+
+  /**
+   * Get a table property for a specific Iceberg action's config option.
+   * <p>
+   * For example, {@link org.apache.iceberg.actions.RewriteDataFiles#TARGET_FILE_SIZE_BYTES} corresponds to
+   * table property actions.rewrite-data-files.target-file-size-bytes
+   *
+   * @param action name of the iceberg action, retrieved from the NAME variable of the specific action if exists.
+   *               The name is assumed to be in lower-case-kebab-style.
+   * @param option config option name, typically defined as public static variables in the specific action.
+   *               The name is assumed to be in lower-case-kebab-style.
+   * @return table property name
+   */
+  public static String actionTableProperty(String action, String option) {
+    return String.format("actions.%s.%s", action, option);
+  }
+
+  /**
+   * Get a table property for a specific Iceberg action and strategy's config option.
+   * <p>
+   * For example, {@link org.apache.iceberg.actions.BinPackStrategy#MIN_INPUT_FILES} corresponds to
+   * table property actions.rewrite-data-files.strategies.binpack.min-input-files
+   *
+   * @param action name of the iceberg action, retrieved from the NAME variable of the specific action if exists.
+   *               The name is assumed to be in lower-case-kebab-style.
+   * @param strategy name of the strategy, retrieved from the name method of the specific strategy,
+   *                 such as {@link org.apache.iceberg.actions.RewriteStrategy#name()}.
+   *                 The name is assumed to be in CAPITALIZED_CASE_SNAKE_STYLE, and is converted to
+   *                 lower-case-kebab-style in the config key.
+   * @param option config option name, typically defined as public static variables in the specific strategy.
+   *               The name is assumed to be in lower-case-kebab-style.
+   * @return table property name
+   */
+  public static String actionStrategyTableProperty(String action, String strategy, String option) {
+    return String.format("actions.%s.strategies.%s.%s", action,
+            strategy.toLowerCase(Locale.ENGLISH).replace("_", "-"), option);
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/actions/BinPackStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BinPackStrategy.java
@@ -97,27 +97,37 @@ public abstract class BinPackStrategy implements RewriteStrategy {
 
   @Override
   public RewriteStrategy options(Map<String, String> options) {
-    targetFileSize = PropertyUtil.propertyAsLong(options,
-        RewriteDataFiles.TARGET_FILE_SIZE_BYTES,
-        PropertyUtil.propertyAsLong(
-            table().properties(),
-            TableProperties.WRITE_TARGET_FILE_SIZE_BYTES,
-            TableProperties.WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT));
+    Map<String, String> tableProperties = table().properties();
 
-    minFileSize = PropertyUtil.propertyAsLong(options,
-        MIN_FILE_SIZE_BYTES,
+    targetFileSize = PropertyUtil.resolveLongProperty(
+        options, RewriteDataFiles.TARGET_FILE_SIZE_BYTES,
+        tableProperties, TableProperties.actionTableProperty(
+            RewriteDataFiles.NAME, RewriteDataFiles.TARGET_FILE_SIZE_BYTES),
+        tableProperties, TableProperties.WRITE_TARGET_FILE_SIZE_BYTES,
+        TableProperties.WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT);
+
+    minFileSize = PropertyUtil.resolveLongProperty(
+        options, MIN_FILE_SIZE_BYTES,
+        tableProperties, TableProperties.actionStrategyTableProperty(
+            RewriteDataFiles.NAME, name(), MIN_FILE_SIZE_BYTES),
         (long) (targetFileSize * MIN_FILE_SIZE_DEFAULT_RATIO));
 
-    maxFileSize = PropertyUtil.propertyAsLong(options,
-        MAX_FILE_SIZE_BYTES,
+    maxFileSize = PropertyUtil.resolveLongProperty(
+        options, MAX_FILE_SIZE_BYTES,
+        tableProperties, TableProperties.actionStrategyTableProperty(
+            RewriteDataFiles.NAME, name(), MAX_FILE_SIZE_BYTES),
         (long) (targetFileSize * MAX_FILE_SIZE_DEFAULT_RATIO));
 
-    maxGroupSize = PropertyUtil.propertyAsLong(options,
-        RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES,
+    maxGroupSize = PropertyUtil.resolveLongProperty(
+        options, RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES,
+        tableProperties, TableProperties.actionTableProperty(
+            RewriteDataFiles.NAME, RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES),
         RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES_DEFAULT);
 
-    minInputFiles = PropertyUtil.propertyAsInt(options,
-        MIN_INPUT_FILES,
+    minInputFiles = PropertyUtil.resolveIntProperty(
+        options, MIN_INPUT_FILES,
+        tableProperties, TableProperties.actionStrategyTableProperty(
+            RewriteDataFiles.NAME, name(), MIN_INPUT_FILES),
         MIN_INPUT_FILES_DEFAULT);
 
     validateOptions();

--- a/core/src/main/java/org/apache/iceberg/actions/SortStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/actions/SortStrategy.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.util.BinPacking;
@@ -94,8 +95,10 @@ public abstract class SortStrategy extends BinPackStrategy {
   public RewriteStrategy options(Map<String, String> options) {
     super.options(options); // Also checks validity of BinPack options
 
-    rewriteAll = PropertyUtil.propertyAsBoolean(options,
-        REWRITE_ALL,
+    rewriteAll = PropertyUtil.resolveBooleanProperty(
+        options, REWRITE_ALL,
+        table().properties(), TableProperties.actionStrategyTableProperty(
+            RewriteDataFiles.NAME, name(), REWRITE_ALL),
         REWRITE_ALL_DEFAULT);
 
     if (sortOrder == null) {

--- a/core/src/main/java/org/apache/iceberg/util/PropertyUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/PropertyUtil.java
@@ -70,4 +70,45 @@ public class PropertyUtil {
     }
     return defaultValue;
   }
+
+  @FunctionalInterface
+  private interface PropertyResolver<A, B, C, R> {
+    R apply(A argA, B argB, C argC);
+  }
+
+  private static <T> T resolveProperty(PropertyResolver<Map<String, String>, String, T, T> resolver,
+                                    Map<String, String> options, String optionKey,
+                                    Map<String, String> properties, String propertyKey, T defaultVal) {
+    return resolver.apply(options, optionKey, resolver.apply(properties, propertyKey, defaultVal));
+  }
+
+  private static <T> T resolveProperty(PropertyResolver<Map<String, String>, String, T, T> resolver,
+                                      Map<String, String> options, String optionKey,
+                                      Map<String, String> properties1, String propertyKey1,
+                                      Map<String, String> properties2, String propertyKey2, T defaultVal) {
+    return resolver.apply(options, optionKey, resolver.apply(properties1, propertyKey1,
+            resolver.apply(properties2, propertyKey2, defaultVal)));
+  }
+
+  public static long resolveLongProperty(Map<String, String> options, String optionKey,
+                                         Map<String, String> properties, String propertyKey, long defaultVal) {
+    return resolveProperty(PropertyUtil::propertyAsLong, options, optionKey, properties, propertyKey, defaultVal);
+  }
+
+  public static long resolveLongProperty(Map<String, String> options, String optionKey,
+                                         Map<String, String> properties1, String propertyKey1,
+                                         Map<String, String> properties2, String propertyKey2, long defaultVal) {
+    return resolveProperty(PropertyUtil::propertyAsLong, options, optionKey, properties1, propertyKey1,
+            properties2, propertyKey2, defaultVal);
+  }
+
+  public static int resolveIntProperty(Map<String, String> options, String optionKey,
+                                       Map<String, String> properties, String propertyKey, int defaultVal) {
+    return resolveProperty(PropertyUtil::propertyAsInt, options, optionKey, properties, propertyKey, defaultVal);
+  }
+
+  public static boolean resolveBooleanProperty(Map<String, String> options, String optionKey,
+                                               Map<String, String> properties, String propertyKey, boolean defaultVal) {
+    return resolveProperty(PropertyUtil::propertyAsBoolean, options, optionKey, properties, propertyKey, defaultVal);
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/util/TestPropertyUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestPropertyUtil.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestPropertyUtil {
+
+  @Test
+  public void testResolveLong2LevelOptionExists() {
+    Map<String, String> options = ImmutableMap.of("option-key", "1");
+    Map<String, String> properties = ImmutableMap.of("property-key", "2");
+    Assert.assertEquals("Option value should be used if exists", 1L,
+        PropertyUtil.resolveLongProperty(options, "option-key", properties, "property-key", 3L));
+  }
+
+  @Test
+  public void testResolveLong2LevelPropertyExists() {
+    Map<String, String> options = ImmutableMap.of();
+    Map<String, String> properties = ImmutableMap.of("property-key", "2");
+    Assert.assertEquals("Property value should be used if exists", 2L,
+        PropertyUtil.resolveLongProperty(options, "option-key", properties, "property-key", 3L));
+  }
+
+  @Test
+  public void testResolveLong2LevelDefault() {
+    Map<String, String> options = ImmutableMap.of();
+    Map<String, String> properties = ImmutableMap.of();
+    Assert.assertEquals("Default should be used if no override exists", 3L,
+        PropertyUtil.resolveLongProperty(options, "option-key", properties, "property-key", 3L));
+  }
+
+  @Test
+  public void testResolveLong3LevelOptionExists() {
+    Map<String, String> options = ImmutableMap.of("option-key", "1");
+    Map<String, String> properties = ImmutableMap.of("property-key", "2");
+    Map<String, String> properties2 = ImmutableMap.of("property-key2", "3");
+    Assert.assertEquals("Option value should be used if exists", 1L,
+        PropertyUtil.resolveLongProperty(options, "option-key",
+            properties, "property-key", properties2, "property-key2", 4L));
+  }
+
+  @Test
+  public void testResolveLong3LevelProperty1Exists() {
+    Map<String, String> options = ImmutableMap.of();
+    Map<String, String> properties = ImmutableMap.of("property-key", "2");
+    Map<String, String> properties2 = ImmutableMap.of("property-key2", "3");
+    Assert.assertEquals("Property1 value should be used if exists", 2L,
+        PropertyUtil.resolveLongProperty(options, "option-key",
+            properties, "property-key", properties2, "property-key2", 4L));
+  }
+
+  @Test
+  public void testResolveLong3LevelProperty2Exists() {
+    Map<String, String> options = ImmutableMap.of();
+    Map<String, String> properties = ImmutableMap.of();
+    Map<String, String> properties2 = ImmutableMap.of("property-key2", "3");
+    Assert.assertEquals("Property2 value should be used if exists", 3L,
+        PropertyUtil.resolveLongProperty(options, "option-key",
+            properties, "property-key", properties2, "property-key2", 4L));
+  }
+
+  @Test
+  public void testResolveLong3LevelDefault() {
+    Map<String, String> options = ImmutableMap.of();
+    Map<String, String> properties = ImmutableMap.of();
+    Map<String, String> properties2 = ImmutableMap.of();
+    Assert.assertEquals("Default should be used if no override exists", 4L,
+        PropertyUtil.resolveLongProperty(options, "option-key",
+            properties, "property-key", properties2, "property-key2", 4L));
+  }
+
+  @Test
+  public void testResolveInt2LevelOptionExists() {
+    Map<String, String> options = ImmutableMap.of("option-key", "1");
+    Map<String, String> properties = ImmutableMap.of("property-key", "2");
+    Assert.assertEquals("Option value should be used if exists", 1,
+        PropertyUtil.resolveIntProperty(options, "option-key", properties, "property-key", 3));
+  }
+
+  @Test
+  public void testResolveInt2LevelPropertyExists() {
+    Map<String, String> options = ImmutableMap.of();
+    Map<String, String> properties = ImmutableMap.of("property-key", "2");
+    Assert.assertEquals("Property value should be used if exists", 2,
+        PropertyUtil.resolveIntProperty(options, "option-key", properties, "property-key", 3));
+  }
+
+  @Test
+  public void testResolveInt2LevelDefault() {
+    Map<String, String> options = ImmutableMap.of();
+    Map<String, String> properties = ImmutableMap.of();
+    Assert.assertEquals("Default should be used if no override exists", 3,
+        PropertyUtil.resolveIntProperty(options, "option-key", properties, "property-key", 3));
+  }
+
+  @Test
+  public void testResolveBoolean2LevelOptionExists() {
+    Map<String, String> options = ImmutableMap.of("option-key", "true");
+    Map<String, String> properties = ImmutableMap.of("property-key", "false");
+    Assert.assertTrue("Option value should be used if exists",
+        PropertyUtil.resolveBooleanProperty(options, "option-key", properties, "property-key", false));
+  }
+
+  @Test
+  public void testResolveBoolean2LevelPropertyExists() {
+    Map<String, String> options = ImmutableMap.of();
+    Map<String, String> properties = ImmutableMap.of("property-key", "true");
+    Assert.assertTrue("Property value should be used if exists",
+        PropertyUtil.resolveBooleanProperty(options, "option-key", properties, "property-key", false));
+  }
+
+  @Test
+  public void testResolveBoolean2LevelDefault() {
+    Map<String, String> options = ImmutableMap.of();
+    Map<String, String> properties = ImmutableMap.of();
+    Assert.assertTrue("Default should be used if no override exists",
+        PropertyUtil.resolveBooleanProperty(options, "option-key", properties, "property-key", true));
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/util/TestPropertyUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestPropertyUtil.java
@@ -1,21 +1,26 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.iceberg.util;
 
-import com.google.common.collect.ImmutableMap;
 import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
@@ -37,6 +37,7 @@ import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.actions.BaseRewriteDataFilesFileGroupInfo;
 import org.apache.iceberg.actions.BaseRewriteDataFilesResult;
 import org.apache.iceberg.actions.BinPackStrategy;
@@ -363,16 +364,24 @@ abstract class BaseRewriteDataFilesSparkAction
         "Cannot use options %s, they are not supported by the action or the strategy %s",
         invalidKeys, strategy.name());
 
-    maxConcurrentFileGroupRewrites = PropertyUtil.propertyAsInt(options(),
-        MAX_CONCURRENT_FILE_GROUP_REWRITES,
+    Map<String, String> tableProperties = table().properties();
+
+    maxConcurrentFileGroupRewrites = PropertyUtil.resolveIntProperty(
+        options(), MAX_CONCURRENT_FILE_GROUP_REWRITES,
+        tableProperties, TableProperties.actionTableProperty(
+            RewriteDataFiles.NAME, MAX_CONCURRENT_FILE_GROUP_REWRITES),
         MAX_CONCURRENT_FILE_GROUP_REWRITES_DEFAULT);
 
-    maxCommits = PropertyUtil.propertyAsInt(options(),
-        PARTIAL_PROGRESS_MAX_COMMITS,
+    maxCommits = PropertyUtil.resolveIntProperty(
+        options(), PARTIAL_PROGRESS_MAX_COMMITS,
+        tableProperties, TableProperties.actionTableProperty(
+            RewriteDataFiles.NAME, PARTIAL_PROGRESS_MAX_COMMITS),
         PARTIAL_PROGRESS_MAX_COMMITS_DEFAULT);
 
-    partialProgressEnabled = PropertyUtil.propertyAsBoolean(options(),
-        PARTIAL_PROGRESS_ENABLED,
+    partialProgressEnabled = PropertyUtil.resolveBooleanProperty(
+        options(), PARTIAL_PROGRESS_ENABLED,
+        tableProperties, TableProperties.actionTableProperty(
+            RewriteDataFiles.NAME, PARTIAL_PROGRESS_ENABLED),
         PARTIAL_PROGRESS_ENABLED_DEFAULT);
 
     Preconditions.checkArgument(maxConcurrentFileGroupRewrites >= 1,


### PR DESCRIPTION
Similar to the design pattern of Spark read and write options, introduce table properties for all the options in `RewriteDataFiles`, so that users can configure default compaction behavior for a table through table properties and avoid the need to specify those options for each execution.