### PR TITLE
filter idea test outputs from the source code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ python/.mypy_cache/
 
 # idea test output
 out
+

--- a/.gitignore
+++ b/.gitignore
@@ -63,4 +63,3 @@ derby.log
 # Python stuff
 python_legacy/.mypy_cache/
 python/.mypy_cache/
-

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ tmp/
 *.ipr
 *.iws
 *.iml
+out
 
 # gradle build
 .gradle
@@ -62,7 +63,4 @@ derby.log
 # Python stuff
 python_legacy/.mypy_cache/
 python/.mypy_cache/
-
-# idea test output
-out
 

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ derby.log
 # Python stuff
 python_legacy/.mypy_cache/
 python/.mypy_cache/
+
+# idea test output
+out


### PR DESCRIPTION
### Motivation
When run tests using Intellij idea, it will create many output files list as follow
```
api/out/
common/out/
core/out/
data/out/
flink/out/
hive-metastore/out/
orc/out/
parquet/out/
```
Those output files will be traced by git

### Modification
1. add `out` into `.gitignore` to filter those output files.