### PR TITLE
Build: ./gradlew printVersion should print correct Iceberg version

### DIFF
--- a/tasks.gradle
+++ b/tasks.gradle
@@ -19,8 +19,6 @@
 
 
 task aggregateJavadoc(type: Javadoc) {
-  project.rootProject.version = getJavadocVersion()
-
   dependsOn subprojects.javadoc
   source subprojects.javadoc.source
   destinationDir project.rootProject.file("site/docs/javadoc/${getJavadocVersion()}")


### PR DESCRIPTION
The problem is that `./gradlew printVersion` is currently showing the
branch name instead of the actual Iceberg version, because the version
is being overwritten here.