### PR TITLE
Hive: Fix RetryingMetaStoreClient for Hive 2.1

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveClientPool.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveClientPool.java
@@ -35,7 +35,8 @@ import org.apache.thrift.transport.TTransportException;
 public class HiveClientPool extends ClientPoolImpl<IMetaStoreClient, TException> {
 
   private static final DynMethods.StaticMethod GET_CLIENT = DynMethods.builder("getProxy")
-      .impl(RetryingMetaStoreClient.class, HiveConf.class, HiveMetaHookLoader.class, String.class) // Hive 1 and 2
+      .impl(RetryingMetaStoreClient.class, HiveConf.class) // Hive 1 (HiveMetaHookLoader cannot be null)
+      .impl(RetryingMetaStoreClient.class, HiveConf.class, HiveMetaHookLoader.class, String.class) // Hive 2
       .impl(RetryingMetaStoreClient.class, Configuration.class, HiveMetaHookLoader.class, String.class) // Hive 3
       .buildStatic();
 

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveClientPool.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveClientPool.java
@@ -35,8 +35,7 @@ import org.apache.thrift.transport.TTransportException;
 public class HiveClientPool extends ClientPoolImpl<IMetaStoreClient, TException> {
 
   private static final DynMethods.StaticMethod GET_CLIENT = DynMethods.builder("getProxy")
-      .impl(RetryingMetaStoreClient.class, HiveConf.class) // Hive 1 (HiveMetaHookLoader cannot be null)
-      .impl(RetryingMetaStoreClient.class, HiveConf.class, HiveMetaHookLoader.class, String.class) // Hive 2
+      .impl(RetryingMetaStoreClient.class, HiveConf.class, HiveMetaHookLoader.class, String.class) // Hive 1 and 2
       .impl(RetryingMetaStoreClient.class, Configuration.class, HiveMetaHookLoader.class, String.class) // Hive 3
       .buildStatic();
 
@@ -53,7 +52,7 @@ public class HiveClientPool extends ClientPoolImpl<IMetaStoreClient, TException>
   protected IMetaStoreClient newClient()  {
     try {
       try {
-        return GET_CLIENT.invoke(hiveConf, null, HiveMetaStoreClient.class.getName());
+        return GET_CLIENT.invoke(hiveConf, (HiveMetaHookLoader) tbl -> null, HiveMetaStoreClient.class.getName());
       } catch (RuntimeException e) {
         // any MetaException would be wrapped into RuntimeException during reflection, so let's double-check type here
         if (e.getCause() instanceof MetaException) {


### PR DESCRIPTION
Fixes : https://github.com/apache/iceberg/issues/3363, RetryingMetaStoreClient broken for Hive 2.1.

The root cause is this commit: https://issues.apache.org/jira/browse/HIVE-12918, fixed in Hive 2.3 (the version we build against) by https://issues.apache.org/jira/browse/HIVE-15081

Change to use this more stable method in RetryingMetaStoreClient: https://github.com/apache/hive/blob/rel/release-2.3.8/metastore/src/java/org/apache/hadoop/hive/metastore/RetryingMetaStoreClient.java#L95.  

I'm usually hesitant to use @VisibleForTesting methods, but as @sunchao pointed out offline to me, for Hive it means the method is at least tested :), unlike the non marked one.