### PR TITLE
Build: Fetch all tags before publishing SNAPSHOT

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -30,8 +30,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          # we need to fetch all tags so that getProjectVersion() in build.gradle correctly determines the next SNAPSHOT version from the newest tag
+          fetch-depth: 0
       - uses: actions/setup-java@v1
         with:
           java-version: 8
       - run: |
+          ./gradlew printVersion
           ./gradlew publishApachePublicationToMavenRepository -PmavenUser=${{ secrets.NEXUS_USER }} -PmavenPassword=${{ secrets.NEXUS_PW }}


### PR DESCRIPTION
https://github.com/apache/iceberg/runs/4028935323?check_suite_focus=true failed with 
```
* What went wrong:
Execution failed for task ':iceberg-spark:publishApachePublicationToMavenRepository'.
> Failed to publish publication 'apache' to repository 'maven'
   > Could not PUT 'https://repository.apache.org/content/repositories/snapshots/org/apache/iceberg/iceberg-spark/f68d8d4/iceberg-spark-f68d8d4.jar'. Received status code 400 from server: Bad Request

```
Notice that it uses `f68d8d4` as the version and not `0.13.0-SNAPSHOT`. Running `./gradlew publishApachePublicationToMavenLocal` publishes artifacts correctly as `0.13.0-SNAPSHOT` so it's likely that the issue happens on GH because[ we're not fetching tags during checkout](https://github.com/actions/checkout#Fetch-all-history-for-all-tags-and-branches) and therefore `getProjectVersion()` in `build.gradle` cannot derive the next SNAPSHOT version.

