### PR TITLE
Fixes read metadata failed after dropped partition for V1 format

### DIFF
--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Expression;
@@ -118,6 +119,7 @@ public class AllManifestsTable extends BaseMetadataTable {
         boolean ignoreResiduals, boolean caseSensitive, boolean colStats) {
       String schemaString = SchemaParser.toJson(schema());
       String specString = PartitionSpecParser.toJson(PartitionSpec.unpartitioned());
+      Map<Integer, PartitionSpec> specs = table().specs();
 
       return CloseableIterable.withNoopClose(Iterables.transform(ops.current().snapshots(), snap -> {
         if (snap.manifestListLocation() != null) {
@@ -128,14 +130,14 @@ public class AllManifestsTable extends BaseMetadataTable {
               .withRecordCount(1)
               .withFormat(FileFormat.AVRO)
               .build();
-          return new ManifestListReadTask(ops.io(), schema(), table().spec(), new BaseFileScanTask(
+          return new ManifestListReadTask(ops.io(), schema(), specs, new BaseFileScanTask(
               manifestListAsDataFile, null,
               schemaString, specString, residuals));
         } else {
           return StaticDataTask.of(
               ops.io().newInputFile(ops.current().metadataFileLocation()),
               MANIFEST_FILE_SCHEMA, schema(), snap.allManifests(),
-              manifest -> ManifestsTable.manifestFileToRow(table().spec(), manifest)
+              manifest -> ManifestsTable.manifestFileToRow(specs.get(manifest.partitionSpecId()), manifest)
           );
         }
       }));
@@ -145,13 +147,13 @@ public class AllManifestsTable extends BaseMetadataTable {
   static class ManifestListReadTask implements DataTask {
     private final FileIO io;
     private final Schema schema;
-    private final PartitionSpec spec;
+    private final Map<Integer, PartitionSpec> specs;
     private final FileScanTask manifestListTask;
 
-    ManifestListReadTask(FileIO io, Schema schema,  PartitionSpec spec, FileScanTask manifestListTask) {
+    ManifestListReadTask(FileIO io, Schema schema, Map<Integer, PartitionSpec> specs, FileScanTask manifestListTask) {
       this.io = io;
       this.schema = schema;
-      this.spec = spec;
+      this.specs = specs;
       this.manifestListTask = manifestListTask;
     }
 
@@ -173,7 +175,7 @@ public class AllManifestsTable extends BaseMetadataTable {
           .build()) {
 
         CloseableIterable<StructLike> rowIterable =  CloseableIterable.transform(manifests,
-            manifest -> ManifestsTable.manifestFileToRow(spec, manifest));
+            manifest -> ManifestsTable.manifestFileToRow(specs.get(manifest.partitionSpecId()), manifest));
 
         StructProjection projection = StructProjection.create(MANIFEST_FILE_SCHEMA, schema);
         return CloseableIterable.transform(rowIterable, projection::wrap);

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.StructProjection;
 
@@ -119,7 +120,7 @@ public class AllManifestsTable extends BaseMetadataTable {
         boolean ignoreResiduals, boolean caseSensitive, boolean colStats) {
       String schemaString = SchemaParser.toJson(schema());
       String specString = PartitionSpecParser.toJson(PartitionSpec.unpartitioned());
-      Map<Integer, PartitionSpec> specs = table().specs();
+      Map<Integer, PartitionSpec> specs = Maps.newHashMap(table().specs());
 
       return CloseableIterable.withNoopClose(Iterables.transform(ops.current().snapshots(), snap -> {
         if (snap.manifestListLocation() != null) {

--- a/core/src/main/java/org/apache/iceberg/ManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestsTable.java
@@ -78,8 +78,8 @@ public class ManifestsTable extends BaseMetadataTable {
         ops.io().newInputFile(location != null ? location : ops.current().metadataFileLocation()),
         schema(), scan.schema(), scan.snapshot().allManifests(),
         manifest -> {
-          PartitionSpec partitionSpec = specs.get(manifest.partitionSpecId());
-          return ManifestsTable.manifestFileToRow(partitionSpec, manifest);
+          PartitionSpec spec = specs.get(manifest.partitionSpecId());
+          return ManifestsTable.manifestFileToRow(spec, manifest);
         }
     );
   }

--- a/core/src/main/java/org/apache/iceberg/ManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestsTable.java
@@ -22,6 +22,7 @@ package org.apache.iceberg;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Types;
 
@@ -71,7 +72,7 @@ public class ManifestsTable extends BaseMetadataTable {
   protected DataTask task(TableScan scan) {
     TableOperations ops = operations();
     String location = scan.snapshot().manifestListLocation();
-    Map<Integer, PartitionSpec> specs = table().specs();
+    Map<Integer, PartitionSpec> specs = Maps.newHashMap(table().specs());
 
     return StaticDataTask.of(
         ops.io().newInputFile(location != null ? location : ops.current().metadataFileLocation()),

--- a/core/src/main/java/org/apache/iceberg/Partitioning.java
+++ b/core/src/main/java/org/apache/iceberg/Partitioning.java
@@ -211,7 +211,8 @@ public class Partitioning {
 
     Map<Integer, PartitionField> fieldMap = Maps.newHashMap();
     List<NestedField> structFields = Lists.newArrayList();
-    Map<Integer, Integer> fieldToIndex = Maps.newHashMap();
+    // Mapping from a PartitionField with void transform to the index in structFields.
+    Map<Integer, Integer> voidTransformFieldToIndex = Maps.newHashMap();
 
     // sort the spec IDs in descending order to pick up the most recent field names
     List<Integer> specIds = table.specs().keySet().stream()
@@ -231,7 +232,7 @@ public class Partitioning {
           structFields.add(structField);
 
           if (Transforms.alwaysNull().equals(field.transform())) {
-            fieldToIndex.put(fieldId, structFields.size() - 1);
+            voidTransformFieldToIndex.put(fieldId, structFields.size() - 1);
           }
         } else {
           // verify the fields are compatible as they may conflict in v1 tables
@@ -246,7 +247,7 @@ public class Partitioning {
                   !Transforms.alwaysNull().equals(field.transform())) {
             fieldMap.put(fieldId, field);
             NestedField structField = spec.partitionType().field(fieldId);
-            structFields.set(fieldToIndex.get(fieldId), structField);
+            structFields.set(voidTransformFieldToIndex.get(fieldId), structField);
           }
         }
       }

--- a/core/src/main/java/org/apache/iceberg/Partitioning.java
+++ b/core/src/main/java/org/apache/iceberg/Partitioning.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.transforms.PartitionSpecVisitor;
 import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.transforms.UnknownTransform;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.types.Types.StructType;
 
@@ -210,9 +211,8 @@ public class Partitioning {
     }
 
     Map<Integer, PartitionField> fieldMap = Maps.newHashMap();
-    List<NestedField> structFields = Lists.newArrayList();
-    // Mapping from a PartitionField with void transform to the index in structFields.
-    Map<Integer, Integer> voidTransformFieldToIndex = Maps.newHashMap();
+    Map<Integer, Type> typeMap = Maps.newHashMap();
+    Map<Integer, String> nameMap = Maps.newHashMap();
 
     // sort the spec IDs in descending order to pick up the most recent field names
     List<Integer> specIds = table.specs().keySet().stream()
@@ -224,39 +224,39 @@ public class Partitioning {
 
       for (PartitionField field : spec.fields()) {
         int fieldId = field.fieldId();
+        NestedField structField = spec.partitionType().field(fieldId);
+
         PartitionField existingField = fieldMap.get(fieldId);
 
         if (existingField == null) {
           fieldMap.put(fieldId, field);
-          NestedField structField = spec.partitionType().field(fieldId);
-          structFields.add(structField);
+          typeMap.put(fieldId, structField.type());
+          nameMap.put(fieldId, structField.name());
 
-          if (Transforms.alwaysNull().equals(field.transform())) {
-            voidTransformFieldToIndex.put(fieldId, structFields.size() - 1);
-          }
         } else {
           // verify the fields are compatible as they may conflict in v1 tables
           ValidationException.check(equivalentIgnoringNames(field, existingField),
               "Conflicting partition fields: ['%s', '%s']",
               field, existingField);
 
-          // Void Transforms always revert back to the Type of the original column being transformed. This will lead
-          // to type errors when analyzing partition fields written for earlier files with a different type. To avoid
-          // this we always restore NullTransforms to their previous non-null state.
-          if (Transforms.alwaysNull().equals(existingField.transform()) &&
-                  !Transforms.alwaysNull().equals(field.transform())) {
+          // use the correct type for dropped partitions in v1 tables
+          if (isVoidTransform(existingField) && !isVoidTransform(field)) {
             fieldMap.put(fieldId, field);
-            NestedField structField = spec.partitionType().field(fieldId);
-            structFields.set(voidTransformFieldToIndex.get(fieldId), structField);
+            typeMap.put(fieldId, structField.type());
           }
         }
       }
     }
 
-    List<NestedField> sortedStructFields = structFields.stream()
-        .sorted(Comparator.comparingInt(NestedField::fieldId))
+    List<NestedField> sortedStructFields = fieldMap.keySet().stream()
+        .sorted(Comparator.naturalOrder())
+        .map(fieldId -> NestedField.optional(fieldId, nameMap.get(fieldId), typeMap.get(fieldId)))
         .collect(Collectors.toList());
     return StructType.of(sortedStructFields);
+  }
+
+  private static boolean isVoidTransform(PartitionField field) {
+    return field.transform().equals(Transforms.alwaysNull());
   }
 
   private static List<Transform<?, ?>> collectUnknownTransforms(Table table) {

--- a/core/src/main/java/org/apache/iceberg/Partitioning.java
+++ b/core/src/main/java/org/apache/iceberg/Partitioning.java
@@ -211,6 +211,7 @@ public class Partitioning {
 
     Map<Integer, PartitionField> fieldMap = Maps.newHashMap();
     List<NestedField> structFields = Lists.newArrayList();
+    Map<Integer, Integer> fieldToIndex = Maps.newHashMap();
 
     // sort the spec IDs in descending order to pick up the most recent field names
     List<Integer> specIds = table.specs().keySet().stream()
@@ -228,11 +229,22 @@ public class Partitioning {
           fieldMap.put(fieldId, field);
           NestedField structField = spec.partitionType().field(fieldId);
           structFields.add(structField);
+
+          if (Transforms.alwaysNull().equals(field.transform())) {
+            fieldToIndex.put(fieldId, structFields.size() - 1);
+          }
         } else {
           // verify the fields are compatible as they may conflict in v1 tables
           ValidationException.check(equivalentIgnoringNames(field, existingField),
               "Conflicting partition fields: ['%s', '%s']",
               field, existingField);
+
+          if (Transforms.alwaysNull().equals(existingField.transform()) &&
+                  !Transforms.alwaysNull().equals(field.transform())) {
+            fieldMap.put(fieldId, field);
+            NestedField structField = spec.partitionType().field(fieldId);
+            structFields.set(fieldToIndex.get(fieldId), structField);
+          }
         }
       }
     }

--- a/core/src/main/java/org/apache/iceberg/Partitioning.java
+++ b/core/src/main/java/org/apache/iceberg/Partitioning.java
@@ -225,7 +225,6 @@ public class Partitioning {
       for (PartitionField field : spec.fields()) {
         int fieldId = field.fieldId();
         NestedField structField = spec.partitionType().field(fieldId);
-
         PartitionField existingField = fieldMap.get(fieldId);
 
         if (existingField == null) {

--- a/core/src/main/java/org/apache/iceberg/Partitioning.java
+++ b/core/src/main/java/org/apache/iceberg/Partitioning.java
@@ -239,6 +239,9 @@ public class Partitioning {
               "Conflicting partition fields: ['%s', '%s']",
               field, existingField);
 
+          // Void Transforms always revert back to the Type of the original column being transformed. This will lead
+          // to type errors when analyzing partition fields written for earlier files with a different type. To avoid
+          // this we always restore NullTransforms to their previous non-null state.
           if (Transforms.alwaysNull().equals(existingField.transform()) &&
                   !Transforms.alwaysNull().equals(field.transform())) {
             fieldMap.put(fieldId, field);

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -96,15 +96,19 @@ public class TestMetadataTableScans extends TableTestBase {
     table.updateSpec().removeField(Expressions.bucket("data", 16)).commit();
     table.refresh();
 
+    table.updateSpec().addField(Expressions.bucket("data", 16)).commit();
+    table.refresh();
+
+    table.updateSpec().removeField(Expressions.bucket("data", 16)).commit();
+    table.refresh();
+
+    table.updateSpec().addField(Expressions.truncate("data", 2)).commit();
+
     Table manifestsTable = new ManifestsTable(table.ops(), table);
-    TableScan scan = manifestsTable.newScan()
-        .filter(Expressions.lessThan("length", 10000L));
+    TableScan scan = manifestsTable.newScan();
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
-      Assert.assertTrue("Tasks should not be empty", Iterables.size(tasks) > 0);
-      for (FileScanTask task : tasks) {
-        Assert.assertEquals("Residuals must be ignored", Expressions.alwaysTrue(), task.residual());
-      }
+      Assert.assertEquals("Should have one task", 1, Iterables.size(tasks));
     }
   }
 
@@ -125,6 +129,32 @@ public class TestMetadataTableScans extends TableTestBase {
       for (FileScanTask task : tasks) {
         Assert.assertEquals("Residuals must be ignored", Expressions.alwaysTrue(), task.residual());
       }
+    }
+  }
+
+  @Test
+  public void testDataFilesTableWithDroppedPartition() throws IOException {
+    table.newFastAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    table.updateSpec().removeField(Expressions.bucket("data", 16)).commit();
+    table.refresh();
+
+    table.updateSpec().addField(Expressions.bucket("data", 16)).commit();
+    table.refresh();
+
+    table.updateSpec().removeField(Expressions.bucket("data", 16)).commit();
+    table.refresh();
+
+    table.updateSpec().addField(Expressions.truncate("data", 2)).commit();
+
+    Table dataFilesTable = new DataFilesTable(table.ops(), table);
+    TableScan scan = dataFilesTable.newScan();
+
+    try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
+      Assert.assertEquals("Should have one task", 1, Iterables.size(tasks));
     }
   }
 
@@ -167,6 +197,32 @@ public class TestMetadataTableScans extends TableTestBase {
   }
 
   @Test
+  public void testManifestEntriesTableWithDroppedPartition() throws IOException {
+    table.newFastAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    table.updateSpec().removeField(Expressions.bucket("data", 16)).commit();
+    table.refresh();
+
+    table.updateSpec().addField(Expressions.bucket("data", 16)).commit();
+    table.refresh();
+
+    table.updateSpec().removeField(Expressions.bucket("data", 16)).commit();
+    table.refresh();
+
+    table.updateSpec().addField(Expressions.truncate("data", 2)).commit();
+
+    Table manifestEntriesTable = new ManifestEntriesTable(table.ops(), table);
+    TableScan scan = manifestEntriesTable.newScan();
+
+    try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
+      Assert.assertEquals("Should have one task", 1, Iterables.size(tasks));
+    }
+  }
+
+  @Test
   public void testAllDataFilesTableHonorsIgnoreResiduals() throws IOException {
     table.newFastAppend()
         .appendFile(FILE_A)
@@ -183,6 +239,32 @@ public class TestMetadataTableScans extends TableTestBase {
         .filter(Expressions.equal("record_count", 1))
         .ignoreResiduals();
     validateTaskScanResiduals(scan2, true);
+  }
+
+  @Test
+  public void testAllDataFilesTableWithDroppedPartition() throws IOException {
+    table.newFastAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    table.updateSpec().removeField(Expressions.bucket("data", 16)).commit();
+    table.refresh();
+
+    table.updateSpec().addField(Expressions.bucket("data", 16)).commit();
+    table.refresh();
+
+    table.updateSpec().removeField(Expressions.bucket("data", 16)).commit();
+    table.refresh();
+
+    table.updateSpec().addField(Expressions.truncate("data", 2)).commit();
+
+    Table allDataFilesTable = new AllDataFilesTable(table.ops(), table);
+    TableScan scan = allDataFilesTable.newScan();
+
+    try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
+      Assert.assertEquals("Should have one task", 1, Iterables.size(tasks));
+    }
   }
 
   @Test
@@ -205,6 +287,32 @@ public class TestMetadataTableScans extends TableTestBase {
   }
 
   @Test
+  public void testAllEntriesTableWithDroppedPartition() throws IOException {
+    table.newFastAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    table.updateSpec().removeField(Expressions.bucket("data", 16)).commit();
+    table.refresh();
+
+    table.updateSpec().addField(Expressions.bucket("data", 16)).commit();
+    table.refresh();
+
+    table.updateSpec().removeField(Expressions.bucket("data", 16)).commit();
+    table.refresh();
+
+    table.updateSpec().addField(Expressions.truncate("data", 2)).commit();
+
+    Table allEntriesTable = new AllEntriesTable(table.ops(), table);
+    TableScan scan = allEntriesTable.newScan();
+
+    try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
+      Assert.assertEquals("Should have one task", 1, Iterables.size(tasks));
+    }
+  }
+
+  @Test
   public void testAllManifestsTableWithDroppedPartition() throws IOException {
     table.newFastAppend()
         .appendFile(FILE_A)
@@ -214,16 +322,20 @@ public class TestMetadataTableScans extends TableTestBase {
     table.updateSpec().removeField(Expressions.bucket("data", 16)).commit();
     table.refresh();
 
+    table.updateSpec().addField(Expressions.bucket("data", 16)).commit();
+    table.refresh();
+
+    table.updateSpec().removeField(Expressions.bucket("data", 16)).commit();
+    table.refresh();
+
+    table.updateSpec().addField(Expressions.truncate("data", 2)).commit();
+
     Table allManifestsTable = new AllManifestsTable(table.ops(), table);
 
-    TableScan scan = allManifestsTable.newScan()
-        .filter(Expressions.lessThan("length", 10000L));
+    TableScan scan = allManifestsTable.newScan();
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
-      Assert.assertTrue("Tasks should not be empty", Iterables.size(tasks) > 0);
-      for (FileScanTask task : tasks) {
-        Assert.assertTrue("Rows should not be empty", Iterables.size(task.asDataTask().rows()) > 0);
-      }
+      Assert.assertEquals("Should have one task", 1, Iterables.size(tasks));
     }
   }
 
@@ -382,13 +494,23 @@ public class TestMetadataTableScans extends TableTestBase {
     table.updateSpec().removeField(Expressions.bucket("data", 16)).commit();
     table.refresh();
 
+    table.updateSpec().addField(Expressions.bucket("data", 16)).commit();
+    table.refresh();
+
+    table.updateSpec().removeField(Expressions.bucket("data", 16)).commit();
+    table.refresh();
+
+    table.updateSpec().addField(Expressions.truncate("data", 2)).commit();
+
     Table dataFilesTable = new DataFilesTable(table.ops(), table);
     TableScan scan = dataFilesTable.newScan();
 
     Schema schema = dataFilesTable.schema();
     Types.StructType actualType = schema.findField(DataFile.PARTITION_ID).type().asStructType();
     Types.StructType expectedType = Types.StructType.of(
-        Types.NestedField.optional(1000, "data_bucket", Types.IntegerType.get())
+        Types.NestedField.optional(1000, "data_bucket", Types.IntegerType.get()),
+        Types.NestedField.optional(1001, "data_bucket_16", Types.IntegerType.get()),
+        Types.NestedField.optional(1002, "data_trunc_2", Types.StringType.get())
     );
     Assert.assertEquals("Partition type must match", expectedType, actualType);
     Accessor<StructLike> accessor = schema.accessorForField(1000);

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -98,7 +98,7 @@ public class TestMetadataTableScans extends TableTestBase {
 
     Table manifestsTable = new ManifestsTable(table.ops(), table);
     TableScan scan = manifestsTable.newScan()
-            .filter(Expressions.lessThan("length", 10000L));
+        .filter(Expressions.lessThan("length", 10000L));
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
       Assert.assertTrue("Tasks should not be empty", Iterables.size(tasks) > 0);

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -89,9 +89,9 @@ public class TestMetadataTableScans extends TableTestBase {
   @Test
   public void testManifestsTableWithDroppedPartition() throws IOException {
     table.newFastAppend()
-            .appendFile(FILE_A)
-            .appendFile(FILE_B)
-            .commit();
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
 
     table.updateSpec().removeField(Expressions.bucket("data", 16)).commit();
     table.refresh();
@@ -207,9 +207,9 @@ public class TestMetadataTableScans extends TableTestBase {
   @Test
   public void testAllManifestsTableWithDroppedPartition() throws IOException {
     table.newFastAppend()
-            .appendFile(FILE_A)
-            .appendFile(FILE_B)
-            .commit();
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
 
     table.updateSpec().removeField(Expressions.bucket("data", 16)).commit();
     table.refresh();
@@ -217,7 +217,7 @@ public class TestMetadataTableScans extends TableTestBase {
     Table allManifestsTable = new AllManifestsTable(table.ops(), table);
 
     TableScan scan = allManifestsTable.newScan()
-            .filter(Expressions.lessThan("length", 10000L));
+        .filter(Expressions.lessThan("length", 10000L));
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
       Assert.assertTrue("Tasks should not be empty", Iterables.size(tasks) > 0);

--- a/core/src/test/java/org/apache/iceberg/TestPartitioning.java
+++ b/core/src/test/java/org/apache/iceberg/TestPartitioning.java
@@ -141,7 +141,6 @@ public class TestPartitioning {
         .commit();
 
     // in v1, we use void transforms instead of dropping partition fields.
-    // We restored the void transforms with the original dropped partition fields.
     StructType expectedType = StructType.of(
         NestedField.optional(1000, "data", Types.StringType.get()),
         NestedField.optional(1001, "data", Types.StringType.get())

--- a/core/src/test/java/org/apache/iceberg/TestPartitioning.java
+++ b/core/src/test/java/org/apache/iceberg/TestPartitioning.java
@@ -140,9 +140,10 @@ public class TestPartitioning {
         .addField("data")
         .commit();
 
-    // in v1, we use void transforms instead of dropping partition fields
+    // in v1, we use void transforms instead of dropping partition fields.
+    // We restored the void transforms with the original dropped partition fields.
     StructType expectedType = StructType.of(
-        NestedField.optional(1000, "data_1000", Types.StringType.get()),
+        NestedField.optional(1000, "data", Types.StringType.get()),
         NestedField.optional(1001, "data", Types.StringType.get())
     );
     StructType actualType = Partitioning.partitionType(table);

--- a/core/src/test/java/org/apache/iceberg/TestPartitioning.java
+++ b/core/src/test/java/org/apache/iceberg/TestPartitioning.java
@@ -140,7 +140,7 @@ public class TestPartitioning {
         .addField("data")
         .commit();
 
-    // in v1, we use void transforms instead of dropping partition fields.
+    // in v1, we use void transforms instead of dropping partition fields
     StructType expectedType = StructType.of(
         NestedField.optional(1000, "data_1000", Types.StringType.get()),
         NestedField.optional(1001, "data", Types.StringType.get())

--- a/core/src/test/java/org/apache/iceberg/TestPartitioning.java
+++ b/core/src/test/java/org/apache/iceberg/TestPartitioning.java
@@ -142,7 +142,7 @@ public class TestPartitioning {
 
     // in v1, we use void transforms instead of dropping partition fields.
     StructType expectedType = StructType.of(
-        NestedField.optional(1000, "data", Types.StringType.get()),
+        NestedField.optional(1000, "data_1000", Types.StringType.get()),
         NestedField.optional(1001, "data", Types.StringType.get())
     );
     StructType actualType = Partitioning.partitionType(table);


### PR DESCRIPTION
This patch fixes two problems:
1. For V1 tables, we use a `VoidTransform` to replace the removed partition field. While the result type of `VoidTransform` same as the type of the field. For example, the result type of `Bucket(2, string_type_field)` is int, while is string for `VoidTransform(string_type_field)`. So we should use the original partition field type(int instead of string) to build the common partitioning type.
2. We should use the matched `PartitionSpec` to convert the `PartitionFiedlSummary` to human string, not the current table spec.

Closes #3374 