### PR TITLE
[WIP] Add configurable cache expiry to caching catalog

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -80,7 +80,7 @@ public class CachingCatalog implements Catalog {
     this.expirationEnabled = isExpirationEnabled;
     this.expirationIntervalMillis = expirationIntervalMillis;
 
-    this.tableCache = createTableCache(ticker, keyLoggingRemovalListener);
+    this.tableCache = createTableCache(ticker);
   }
 
   /**
@@ -125,12 +125,11 @@ public class CachingCatalog implements Catalog {
         .map(age -> Duration.ofMillis(expirationIntervalMillis).minus(age));
   }
 
-  private Cache<TableIdentifier, Table> createTableCache(Ticker ticker,
-      RemovalListener<TableIdentifier, Table> removalListener) {
+  private Cache<TableIdentifier, Table> createTableCache(Ticker ticker) {
     Caffeine<TableIdentifier, Table> cacheBuilder = Caffeine
         .newBuilder()
         .softValues()
-        .removalListener(removalListener)
+        .removalListener(keyLoggingRemovalListener)
         .writer(new CacheWriter<TableIdentifier, Table>() {
           @Override
           // TODO - Consider expiring and syncing any metadata tables that have a different snapshotId

--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -20,12 +20,17 @@
 package org.apache.iceberg;
 
 import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.CacheWriter;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.RemovalListener;
 import com.github.benmanes.caffeine.cache.Ticker;
 import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
@@ -39,6 +44,8 @@ import org.slf4j.LoggerFactory;
 public class CachingCatalog implements Catalog {
 
   private static final Logger LOG = LoggerFactory.getLogger(CachingCatalog.class);
+  private static final RemovalListener<TableIdentifier, Table> keyLoggingRemovalListener =
+      (key, value, cause) -> LOG.info("Expired {} from the TableCache", key);
 
   public static Catalog wrap(Catalog catalog) {
     return wrap(catalog, false, 0);
@@ -53,6 +60,10 @@ public class CachingCatalog implements Catalog {
     return new CachingCatalog(catalog, caseSensitive, expirationEnabled, expirationIntervalMillis);
   }
 
+  public static Catalog wrap(Catalog catalog, boolean expirationEnabled, long expirationIntervalMillis, Ticker ticker) {
+    return new CachingCatalog(catalog, true, expirationEnabled, expirationIntervalMillis, ticker);
+  }
+
   private final Catalog catalog;
   private final boolean caseSensitive;
   private final boolean expirationEnabled;
@@ -61,42 +72,137 @@ public class CachingCatalog implements Catalog {
 
   private CachingCatalog(Catalog catalog, boolean caseSensitive, boolean isExpirationEnabled,
       long expirationIntervalInMillis) {
-    this.catalog = catalog;
-    this.caseSensitive = caseSensitive;
-    this.expirationEnabled = isExpirationEnabled;
-    this.expirationIntervalMillis = expirationIntervalInMillis;
-
-    this.tableCache = createTableCache(expirationEnabled, expirationIntervalMillis);
+    this(catalog, caseSensitive, isExpirationEnabled, expirationIntervalInMillis, Ticker.systemTicker());
   }
 
-  // The tableCache should only be passed in during tests, so that a mocked ticker can be used
-  // to control for cache entry expiration.
-  // VisibleForTesting
-  public CachingCatalog(Catalog catalog, boolean caseSensitive, boolean isExpirationEnabled,
-      long expirationIntervalMillis, Cache<TableIdentifier, Table> tableCache) {
+  private CachingCatalog(Catalog catalog, boolean caseSensitive, boolean isExpirationEnabled,
+      long expirationIntervalMillis, Ticker ticker) {
     this.catalog = catalog;
     this.caseSensitive = caseSensitive;
     this.expirationEnabled = isExpirationEnabled;
     this.expirationIntervalMillis = expirationIntervalMillis;
-    this.tableCache = tableCache;
+
+    this.tableCache = createTableCache(ticker, keyLoggingRemovalListener);
   }
 
-  private Cache<TableIdentifier, Table> createTableCache(boolean isExpirationEnabled, long expirationMillis) {
-    return createTableCache(isExpirationEnabled, expirationMillis, null, false);
+  /**
+   * For test purposes only, passing in a pre-built cache.
+   *
+   * Note that this assumes that this is using `expireAfterAccess`.
+   * We use expireAfterAccess to automatically refresh the TTL of a table after its
+   * accessed.
+   *
+   * NOTE - We might go back to expireAfterWrite, with custom handling for refreshing TTL after access,
+   *        to have more control over ensuring that metadata tables are expired at the same time as data tables.
+   *        We want to avoid having a cached metadata table that doesn't correspond to the same version of the
+   *        data table.
+   *
+   * To be more thorough, we should check all of them. Then we can possibly make the TableCache into its own
+   * class, with invalidation that happens there (and it can be invalidated in more places with writes such
+   * that if a table eagerly refreshes, the cache entry's TTL also refreshes).
+   */
+  // VisibleForTesting
+  public CachingCatalog(Catalog catalog, Cache<TableIdentifier, Table> cache) {
+    this.catalog = catalog;
+    this.caseSensitive = true;
+    // Only check for expireAfterAccess as that's what we presently use. We might need to more carefully consider that.
+    this.expirationEnabled = cache.policy().expireAfterAccess().isPresent();
+    this.expirationIntervalMillis = !expirationEnabled ? -1 :
+        cache.policy().expireAfterAccess().get().getExpiresAfter(TimeUnit.MILLISECONDS);
+    this.tableCache = cache;
+  }
+
+  /**
+   * Return the age of an entry in the cache.
+   * <p>
+   * This method is only visiable for testing the cache expiration policy, as cache invalidation is handled
+   * by the catalog and not the cache itself.
+   * <p>
+   * Returns the age of the cache entry corresponding to the identifier,  or {@code Optional.empty} if the table
+   * is not present in the cache or if no expireAfterAccess policy is present in this CachingCatalog.
+   */
+  // VisibleForTesting
+  public Optional<Duration> cachedEntryAge(TableIdentifier identifier) {
+    // TODO - This is wrong. Should use `ageOf`.
+    return tableCache.policy()
+        .expireAfterAccess()
+        .flatMap(tableExpiration -> tableExpiration.ageOf(identifier));
+  }
+
+  // VisibleForTesting
+  public Optional<Table> getIfPresentQuietly(TableIdentifier identifier) {
+    // Ensure async cleanup actions have happened.
+    tableCache.cleanUp();
+    return Optional.ofNullable(tableCache.policy().getIfPresentQuietly(identifier));
+  }
+
+  // VisibleForTesting
+  public Cache<TableIdentifier, Table> cache() {
+    return tableCache;
+  }
+
+  // Visible for testing
+  public Optional<Duration> getTimeToTTL(TableIdentifier identifier) {
+    return tableCache
+        .policy()
+        .expireAfterAccess()  // Currently assumed expireAfterAAccess, which is what we set at cache level.
+        .flatMap(tableExpiration -> tableExpiration.ageOf(identifier)) // Get the time table has been cached.
+        .map(age -> Duration.ofMillis(expirationIntervalMillis).minus(age));
+  }
+
+  // TODO - Make this private (or its own class) and then exppose
+  // VisibleForTesting
+  private Cache<TableIdentifier, Table> createTableCache(Ticker ticker,
+      RemovalListener<TableIdentifier, Table> removalListener) {
+    Caffeine<TableIdentifier, Table> cacheBuilder = Caffeine
+        .newBuilder()
+        .softValues()
+        .removalListener(removalListener)
+        .writer(new CacheWriter<TableIdentifier, Table>() {
+          @Override
+          // TODO - Consider expiring and syncing any metadata tables that have a different snapshotId
+          //        upon write.
+          public void write(TableIdentifier tableIdentifier, Table table) {
+            LOG.info("Table {} was written to the catalog at snapshot id {}", tableIdentifier,
+                table.currentSnapshot() == null ? null : table.currentSnapshot().snapshotId());
+          }
+
+          @Override
+          // On expiration, remove any associated metadata tables. If a metadata table is expired,
+          public void delete(TableIdentifier tableIdentifier, Table table, RemovalCause cause) {
+            // On expiration, remove any associated metadata tables so that subsequent catalog loads won't
+            // return stale metadata tables w.r.t. the underlying data tables they would return.
+            //
+            // TODO - Should we put metadata tables abck into the catalog if their associated table is still
+            //        cached to keep tables and metadata tables on the same snapshot?
+            if (expirationEnabled && !MetadataTableUtils.hasMetadataTableName(tableIdentifier)) {
+              onTableExpiration(tableIdentifier);
+            }
+          }
+        });
+
+    if (expirationEnabled) {
+      // Expire after write isn't going to work as we need to invalidate after writes.
+      return cacheBuilder.expireAfterAccess(Duration.ofMillis(expirationIntervalMillis)).ticker(ticker).build();
+    }
+    return cacheBuilder.build();
   }
 
   // VisibleForTesting
   public static Cache<TableIdentifier, Table> createTableCache(boolean expirationEnabled, long expirationMillis,
       Ticker ticker, boolean recordTableStats) {
-    Preconditions.checkArgument(!expirationEnabled || expirationMillis > 0L,
+    Preconditions.checkArgument(!expirationEnabled || (expirationMillis > 0L),
         "The cache expiration time must be greater than zero if cache expiration is enabled");
 
-    Caffeine<Object, Object> cacheBuilder = Caffeine.newBuilder().softValues();
+    Caffeine<TableIdentifier, Table> cacheBuilder = Caffeine
+        .newBuilder()
+        .softValues()
+        .removalListener(keyLoggingRemovalListener);
 
     if (expirationEnabled) {
       // TODO - Update this to be a write expiration so that it matches current semantics.
       LOG.info("Instantiating CachingCatalog with a cache expiration interval of {} milliseconds", expirationMillis);
-      cacheBuilder = cacheBuilder.expireAfterWrite(Duration.ofMillis(expirationMillis));
+      cacheBuilder = cacheBuilder.expireAfterAccess(Duration.ofMillis(expirationMillis));
     }
 
     if (recordTableStats) {
@@ -136,6 +242,22 @@ public class CachingCatalog implements Catalog {
     TableIdentifier canonicalized = canonicalizeIdentifier(ident);
     Table cached = tableCache.getIfPresent(canonicalized);
     if (cached != null) {
+      // Restart the cache TTL upon user access for non-metadata tables.
+      // This allows metadata tables to continue to expire when their origin table does.
+      // TODO - It might be easier to use a custom Expiry policy and check for metadata table there.
+      //
+      // TODO - This part was used when expireAfterWrite was used.
+      //
+      // if (expirationEnabled) {
+      //   if (!MetadataTableUtils.hasMetadataTableName(canonicalized)) {
+      //     tableCache.put(canonicalized, cached);
+      //     metadataTableIdentifiers(canonicalized).forEach(metadataTblIdentifier -> {
+      //       Optional<Table> metadataTable = getIfPresentQuietly(metadataTblIdentifier);
+      //       metadataTable.ifPresent(table -> tableCache.put(metadataTblIdentifier, table));
+      //       tableCache.put(metadataTblIdentifier, metadataTable.get());
+      //     });
+      //   }
+      // }
       return cached;
     }
 
@@ -176,6 +298,15 @@ public class CachingCatalog implements Catalog {
   private void invalidate(TableIdentifier ident) {
     tableCache.invalidate(ident);
     tableCache.invalidateAll(metadataTableIdentifiers(ident));
+  }
+
+  private void onTableExpiration(TableIdentifier ident) {
+    // Don't need to canonicalize as we're using the form that was written.
+    // Only invalidate metadata tables to avoid infinite recursion from cache invalidate
+    // to the CacheWriter callback on table expiration.
+    if (!MetadataTableUtils.hasMetadataTableName(ident)) {
+      tableCache.invalidateAll(metadataTableIdentifiers(ident));
+    }
   }
 
   private Iterable<TableIdentifier> metadataTableIdentifiers(TableIdentifier ident) {

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -36,7 +36,7 @@ public class CatalogProperties {
   // Keep as false to maintain backwards compatability. Eventually consider making true the default.
   public static final boolean TABLE_CACHE_EXPIRATION_ENABLED_DEFAULT = false;
   public static final String TABLE_CACHE_EXPIRATION_INTERVAL_MS = "cache.expiration-interval-ms";
-  public static final long TABLE_CACHE_EXPIRATION_INTERVAL_MS_DEFAULT = TimeUnit.MINUTES.toMillis(5);
+  public static final long TABLE_CACHE_EXPIRATION_INTERVAL_MS_DEFAULT = TimeUnit.MINUTES.toMillis(15);
 
   public static final String URI = "uri";
   public static final String CLIENT_POOL_SIZE = "clients";

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -35,8 +35,8 @@ public class CatalogProperties {
   public static final String TABLE_CACHE_EXPIRATION_ENABLED = "cache.expiration-enabled";
   // Keep as false to maintain backwards compatability. Eventually consider making true the default.
   public static final boolean TABLE_CACHE_EXPIRATION_ENABLED_DEFAULT = false;
-  public static final String TABLE_CACHE_EXPIRY_MS = "cache.expiration-interval-ms";
-  public static final long TABLE_CACHE_EXPIRY_MS_DEFAULT = TimeUnit.MINUTES.toMillis(5);
+  public static final String TABLE_CACHE_EXPIRATION_INTERVAL_MS = "cache.expiration-interval-ms";
+  public static final long TABLE_CACHE_EXPIRATION_INTERVAL_MS_DEFAULT = TimeUnit.MINUTES.toMillis(5);
 
   public static final String URI = "uri";
   public static final String CLIENT_POOL_SIZE = "clients";

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -30,6 +30,14 @@ public class CatalogProperties {
   public static final String FILE_IO_IMPL = "io-impl";
   public static final String WAREHOUSE_LOCATION = "warehouse";
 
+  public static final String TABLE_CACHE_ENABLED = "cache-enabled";
+  public static final boolean TABLE_CACHE_ENABLED_DEFAULT = true;
+  public static final String TABLE_CACHE_EXPIRATION_ENABLED = "cache.expiration-enabled";
+  // Keep as false to maintain backwards compatability. Eventually consider making true the default.
+  public static final boolean TABLE_CACHE_EXPIRATION_ENABLED_DEFAULT = false;
+  public static final String TABLE_CACHE_EXPIRY_MS = "cache.expiration-interval-ms";
+  public static final long TABLE_CACHE_EXPIRY_MS_DEFAULT = TimeUnit.MINUTES.toMillis(5);
+
   public static final String URI = "uri";
   public static final String CLIENT_POOL_SIZE = "clients";
   public static final int CLIENT_POOL_SIZE_DEFAULT = 2;

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestCachingCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestCachingCatalog.java
@@ -19,15 +19,22 @@
 
 package org.apache.iceberg.hadoop;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Locale;
+import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.CachingCatalog;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.util.FakeTicker;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -122,5 +129,190 @@ public class TestCachingCatalog extends HadoopTableTestBase {
     TableIdentifier snapshotsTableIdent = TableIdentifier.of("db", "ns1", "ns2", "tbl", "snapshots");
     Table snapshotsTable = catalog.loadTable(snapshotsTableIdent);
     Assert.assertEquals("Name must match", "hadoop.db.ns1.ns2.tbl.snapshots", snapshotsTable.name());
+  }
+
+  // TODO - Currently the "new" behavior is to restart the cache timer any time the table is touched at all.
+  //        This won't help users who continue to try to read a table somebody else wrote to.
+  //        Should we consider expiring on write instead or using a more fine-grained `Expiry`
+  @Test
+  public void testTableExpirationAfterNotAccessed() throws IOException {
+    boolean caseSensitive = true;
+    boolean expirationEnabled = true;
+    long expirationMinutes = Duration.ofMinutes(5).toMillis();
+
+    // Create CachingCatalog with a controllable ticker for testing cache expiry.
+    FakeTicker ticker = new FakeTicker();
+    Cache<TableIdentifier, Table> tableCache = CachingCatalog.createTableCache(
+        expirationEnabled, expirationMinutes, ticker, true /* recordCacheStats */);
+    Catalog catalog = new CachingCatalog(hadoopCatalog(), caseSensitive, expirationEnabled,
+        expirationMinutes, tableCache);
+
+    // Create the table and populate the catalog.
+    String tblName = "tbl";
+    Namespace namespace = Namespace.of("db", "ns1", "ns2");
+    TableIdentifier tableIdent = TableIdentifier.of(namespace, tblName);
+    Table tblAtCreate = catalog.createTable(tableIdent, SCHEMA, SPEC, ImmutableMap.of("key", "value"));
+
+    // Ensure that the table is now in the cache
+    Assert.assertEquals("Table should remain in the cache after insertion before the expiration period",
+        1, tableCache.asMap().size());
+    checkStats(tableCache, 0L /* cache hits */, 1L /* cache misses */, 1 /* total cache load attempts */);
+
+    // Check that the table is still cached if the clock hasn't passed the expiration time since last access.
+    Duration fiveSecondsToTableTTL = Duration.ofMinutes(expirationMinutes).minusSeconds(5);
+    ticker.advance(fiveSecondsToTableTTL.toNanos());
+    Assert.assertEquals(
+        "Table should remain in the cache after insertion before the expiration period if it has not been refreshed",
+        1, tableCache.asMap().size());
+    // Stats should not have changed as we haven't interacted with the table cache
+    checkStats(tableCache, 0L /* cache hits */, 1L /* cache misses */, 1 /* total cache load attempts */);
+
+    // Check that th table is still cached just until the expiration time (as we haven't accessed it in a way that
+    // would invalidate and re-cache.
+    ticker.advance(Duration.ofSeconds(4).toNanos());
+    Assert.assertEquals("CachingCatalog should keep tables in the cache until the expiration if not accessed",
+        1, tableCache.asMap().size());
+
+    // Now ensure that the table is no longer in the cache
+    ticker.advance(1, TimeUnit.MILLISECONDS);
+    Assert.assertNull(
+        "Cache should expire tables at the expiration interval if they're not accessed",
+        tableCache.getIfPresent(tableIdent));
+
+    // Force clean-up. Cache won't return stale results per our spec but might still have data in it depending on impl.
+    tableCache.cleanUp();
+    Assert.assertEquals("Cache should be empty after all entries have expired", 0, tableCache.asMap().size());
+
+    // Get the table again, which should put a new entry representing the same table identifier back in the cache.
+    // Ensure that the returned Table's reference the same thing, but are not the same object.
+    Table tblAfterCacheMiss = catalog.loadTable(tableIdent);
+    Assert.assertNotSame(
+        "CachingCatalog should return a new instance after expiration",
+        tblAtCreate,
+        tblAfterCacheMiss);
+    Assert.assertEquals("CachingCatalog should return functionally equivalent tables on load after expiration",
+        tblAtCreate.name(), tblAfterCacheMiss.name());
+    Assertions.assertThat(tblAfterCacheMiss).isNotEqualTo(tblAtCreate);
+
+    // Ensure that the cache is now re-populated from the table load
+    Assert.assertEquals("Reloading the expired table should repopulate its cache entry",
+        1, tableCache.asMap().size());
+  }
+
+  @Test
+  public void testCacheExpirationRemovesMetadataTables() throws IOException {
+    boolean caseSensitive = true;
+    boolean expirationEnabled = true;
+    boolean recordCacheStats = true;
+    long expirationMinutes = Duration.ofMinutes(5).toMillis();
+
+    // Create CachingCatalog with a controllable ticker for testing cache expiry.
+    FakeTicker ticker = new FakeTicker();
+    long nanosAtTickerCreation = ticker.read();
+    Cache<TableIdentifier, Table> tableCache = CachingCatalog.createTableCache(
+        expirationEnabled, expirationMinutes, ticker, recordCacheStats);
+    Catalog catalog = new CachingCatalog(hadoopCatalog(), caseSensitive, expirationEnabled,
+        expirationMinutes, tableCache);
+
+    // Create the table and populate the catalog.
+    String tblName = "tbl";
+    Namespace namespace = Namespace.of("db", "ns1", "ns2");
+    TableIdentifier tableIdent = TableIdentifier.of(namespace, "tbl");
+    Table table = catalog.createTable(tableIdent, SCHEMA, SPEC, ImmutableMap.of("key2", "value2"));
+
+    table.newAppend().appendFile(FILE_A).commit();
+
+    // Ensure that the table is now in the cache
+    Assert.assertEquals("Table should remain in the cache after insertion before the expiration period",
+        1, tableCache.asMap().size());
+    checkStats(tableCache, 0L /* cache hits */, 1L /* cache misses */, 1 /* total cache load attempts */);
+
+    // remember the original snapshot
+    Snapshot oldSnapshot = table.currentSnapshot();
+
+    // populate the cache with metadata tables
+    int metadataTablesLoaded = 0;
+    for (MetadataTableType type : MetadataTableType.values()) {
+      metadataTablesLoaded += 1;
+      catalog.loadTable(TableIdentifier.parse(tableIdent + "." + type.name().toLowerCase(Locale.ROOT)));
+    }
+
+    // Ensure that the metadata tables are now in the cache as well.
+    int expectedCacheTableCount = 1 + MetadataTableType.values().length;
+    Assert.assertEquals("Table should remain in the cache after insertion before the expiration period",
+        expectedCacheTableCount, tableCache.asMap().size());
+
+    // All the metadata tables should result in a cache hit as we pre-populate the metadata tables
+    //   when we load a table that has them and the original table identifier iss not already in the cache.
+    //
+    // We have called loadTable explicitly one time for each metadata table, but since we pre-populate the metadata
+    //   tables, the stats track that as only one load operation.
+    //
+    // However, given that we have called loadTable 1 time for the table itself + 1 time for each metadata table,
+    //   the number of cache requests should reflect 1 for each attempt.
+    checkStats(tableCache, metadataTablesLoaded /* cache hits */, expectedCacheTableCount /* cache misses */,
+        expectedCacheTableCount - metadataTablesLoaded /* total cache load attempts */);
+
+    tableCache.cleanUp();
+
+    Assert.assertEquals("Before the ticker is advanced, the cache should not drop tables during maintenance",
+        expectedCacheTableCount, tableCache.asMap().size());
+
+    Assert.assertEquals("The ticker should have the same time until its advanced",
+        nanosAtTickerCreation, ticker.read());
+
+    // Advance the ticker such that the tables are dropped.
+    ticker.advance(Duration.ofMinutes(expirationMinutes + 1).toNanos());
+
+    Assert.assertEquals(
+        "After advancing the ticker, it should reflect the changed time",
+        nanosAtTickerCreation + Duration.ofMinutes(expirationMinutes + 1).toNanos(),
+        ticker.read());
+
+    // Ensure that the table's are no longer being returned by the cache now that the expiration period has
+    // occurred.
+    Assert.assertNull(
+        "The cache should not return tables that have been expired",
+        tableCache.getIfPresent(tableIdent));
+    for (MetadataTableType type : MetadataTableType.values()) {
+      Assert.assertNull(
+          "Metadatatables should expire when the primary table has expired",
+          tableCache.getIfPresent(TableIdentifier.parse(tableIdent + "." + type.name().toLowerCase(Locale.ROOT))));
+    }
+
+    tableCache.cleanUp();
+    Assert.assertEquals("All of the metadata tables should be dropped after the table is dropped from the cache",
+        0, tableCache.asMap().size());
+
+    // drop the original table
+    catalog.dropTable(tableIdent);
+
+    // create a new table with the same name
+    table = catalog.createTable(tableIdent, SCHEMA, SPEC, ImmutableMap.of("key3", "value3"));
+
+    table.newAppend().appendFile(FILE_B).commit();
+
+    // remember the new snapshot
+    Snapshot newSnapshot = table.currentSnapshot();
+
+    Assert.assertNotEquals("Snapshots must be different", oldSnapshot, newSnapshot);
+
+    // validate metadata tables were correctly invalidated
+    for (MetadataTableType type : MetadataTableType.values()) {
+      TableIdentifier metadataIdent = TableIdentifier.parse(tableIdent + "." + type.name().toLowerCase(Locale.ROOT));
+      Table metadataTable = catalog.loadTable(metadataIdent);
+      Assert.assertEquals("Snapshot must be new", newSnapshot, metadataTable.currentSnapshot());
+    }
+  }
+
+  // TODO - Because of the way things are implemented, asserting on stats might not be the best idea.
+  private void checkStats(Cache<?, ?> cache, long hitCount, long missCount, long loadCount) {
+    CacheStats stats = cache.stats();
+    Assert.assertEquals("CachingCatalog should have the correct number of hits",
+        hitCount, stats.hitCount());
+    Assert.assertEquals("CachingCatalog should have the correct number of misses",
+        missCount, stats.missCount());
+    Assert.assertEquals("CachingCatalog should accurately reflect the number of times we've tried to load",
+        loadCount, stats.loadCount());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestCachingCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestCachingCatalog.java
@@ -171,7 +171,7 @@ public class TestCachingCatalog extends HadoopTableTestBase {
         catalog.getTimeToTTL(tableIdent)); // Get the time remaining until it would be evicted if
 
     // Alternate means of ensuring table is present.
-    Assertions.assertThat(catalog.getIfPresentQuietly(tableIdent)).isNotNull();
+    Assertions.assertThat(catalog.tableFromCacheQuietly(tableIdent)).isNotNull();
 
     // Move time forward by half of the duration interval
     ticker.advance(HALF_OF_EXPIRATION);
@@ -184,7 +184,7 @@ public class TestCachingCatalog extends HadoopTableTestBase {
     // table (even if the table that is loaded is functionally equivalent).
     ticker.advance(HALF_OF_EXPIRATION.plus(Duration.ofSeconds(10)));
     Assert.assertFalse("Table should be expired as it hasn't been written to for the duration of the cache interval",
-        catalog.getIfPresentQuietly(tableIdent).isPresent());
+        catalog.tableFromCacheQuietly(tableIdent).isPresent());
     Table tblAfterCacheMiss = catalog.loadTable(tableIdent);
     Assert.assertNotSame(
         "CachingCatalog should return a new instance after expiration",
@@ -291,7 +291,7 @@ public class TestCachingCatalog extends HadoopTableTestBase {
 
   private void assertTableIsCached(String assertionMessage, CachingCatalog catalog, TableIdentifier identifier) {
     catalog.cache().cleanUp();
-    Assert.assertTrue(assertionMessage, catalog.getIfPresentQuietly(identifier).isPresent());
+    Assert.assertTrue(assertionMessage, catalog.tableFromCacheQuietly(identifier).isPresent());
   }
 
   private List<TableIdentifier> medtadataTables(TableIdentifier tableIdent) {
@@ -309,17 +309,17 @@ public class TestCachingCatalog extends HadoopTableTestBase {
 
   private void assertCatalogHasExpiredTable(CachingCatalog catalog, TableIdentifier tableIdent) {
     Assert.assertFalse("The catalog should not serve table's that are past their TTL",
-        catalog.getIfPresentQuietly(tableIdent).isPresent());
+        catalog.tableFromCacheQuietly(tableIdent).isPresent());
   }
 
   private void assertCatalogHasExpiredMetadataTables(CachingCatalog catalog, TableIdentifier tableIdent) {
     // Sanity check tha the table itself is expired
     Assert.assertFalse("The table should not be served by the CachingCatalog's cache",
-        catalog.getIfPresentQuietly(tableIdent).isPresent());
+        catalog.tableFromCacheQuietly(tableIdent).isPresent());
     medtadataTables(tableIdent)
         .forEach(metadataTable ->
             Assert.assertFalse("The CachingCatalog should not return metadata tables for a TTL'd table",
-                catalog.getIfPresentQuietly(metadataTable).isPresent()));
+                catalog.tableFromCacheQuietly(metadataTable).isPresent()));
   }
 
   private void assertCatalogEntryHasAge(CachingCatalog catalog, TableIdentifier identifier, Duration expectedAge) {

--- a/core/src/test/java/org/apache/iceberg/util/CountingCacheRemovalListener.java
+++ b/core/src/test/java/org/apache/iceberg/util/CountingCacheRemovalListener.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.RemovalListener;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An implementation of {@link RemovalListener} that keeps a queue of the cache entries
+ * that are expired by a {@link com.github.benmanes.caffeine.cache.Cache}.
+ *
+ * <p>
+ * Useful for testing that caches are properly removing (and retaining) values.
+ * <p>
+ *
+ * See also {@link FakeTicker} for controlling the passage of time when expiring based on time.
+ */
+// TODO - Consider removing this since I haven't used it yet.
+public class CountingCacheRemovalListener<K, V> extends ConcurrentLinkedQueue<K>
+    implements RemovalListener<K, V> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CountingCacheRemovalListener.class);
+  private final AtomicInteger count = new AtomicInteger();
+  private volatile RemovalCause lastRemovalCause;
+
+  @Override
+  public void onRemoval(K key, V value, RemovalCause removalCause) {
+    count.incrementAndGet();
+    LOG.info("Cache removal for entry {} -> {} due to {}", key, value, removalCause);
+    lastRemovalCause = removalCause;
+    offer(key);
+  }
+
+  public int countEvicted() {
+    return count.get();
+  }
+
+  public RemovalCause lastRemovalCause() {
+    return lastRemovalCause;
+  }
+
+  public static <K, V> CountingCacheRemovalListener<K, V> newInstance() {
+    return new CountingCacheRemovalListener<>();
+  }
+}
+

--- a/core/src/test/java/org/apache/iceberg/util/FakeTicker.java
+++ b/core/src/test/java/org/apache/iceberg/util/FakeTicker.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.util;
 
 import com.github.benmanes.caffeine.cache.Ticker;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -46,6 +47,11 @@ public class FakeTicker implements Ticker {
   /** Advances the ticker value by {@code nanoseconds}. */
   public FakeTicker advance(long nanoseconds) {
     nanos.addAndGet(nanoseconds);
+    return this;
+  }
+
+  public FakeTicker advance(Duration duration) {
+    nanos.addAndGet(duration.toNanos());
     return this;
   }
 

--- a/core/src/test/java/org/apache/iceberg/util/FakeTicker.java
+++ b/core/src/test/java/org/apache/iceberg/util/FakeTicker.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import com.github.benmanes.caffeine.cache.Ticker;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A Ticker whose value can be advanced programmatically in test.
+ *
+ * This is modified from the Guava package com.google.common.testing.FakeTicker,
+ * licensed under Apache 2.0, to reduce the added Guava dependencies.
+ *
+ * This class is thread-safe.
+ */
+public class FakeTicker implements Ticker {
+
+  public FakeTicker() {
+  }
+
+  private final AtomicLong nanos = new AtomicLong();
+
+  /** Advances the ticker value by {@code time} in {@code timeUnit}. */
+  public FakeTicker advance(long time, TimeUnit timeUnit) {
+    return advance(timeUnit.toNanos(time));
+  }
+
+  /** Advances the ticker value by {@code nanoseconds}. */
+  public FakeTicker advance(long nanoseconds) {
+    nanos.addAndGet(nanoseconds);
+    return this;
+  }
+
+  @Override public long read() {
+    return nanos.get();
+  }
+}

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -83,9 +83,7 @@ public class SparkCatalog extends BaseCatalog {
 
   private String catalogName = null;
   private Catalog icebergCatalog = null;
-  private boolean cacheEnabled = CatalogProperties.TABLE_CACHE_ENABLED_DEFAULT;
-  private boolean cacheExpirationEnabled = CatalogProperties.TABLE_CACHE_EXPIRATION_ENABLED_DEFAULT;
-  private long cacheExpirationIntervalMillis = -1;  // Disabled. TODO - Maybe just set as default?
+  private boolean cacheEnabled = true;
   private SupportsNamespaces asNamespaceCatalog = null;
   private String[] defaultNamespace = null;
   private HadoopTables tables;
@@ -386,26 +384,14 @@ public class SparkCatalog extends BaseCatalog {
 
   @Override
   public final void initialize(String name, CaseInsensitiveStringMap options) {
-    this.cacheEnabled = Boolean.parseBoolean(options.getOrDefault(
-        CatalogProperties.TABLE_CACHE_ENABLED, Boolean.toString(CatalogProperties.TABLE_CACHE_ENABLED_DEFAULT)));
-    this.cacheExpirationEnabled = Boolean.parseBoolean(options.getOrDefault(
-        CatalogProperties.TABLE_CACHE_EXPIRATION_ENABLED,
-        Boolean.toString(CatalogProperties.TABLE_CACHE_EXPIRATION_ENABLED_DEFAULT)));
-
-    // TODO - Wrap this into its own utility function so it can be used by Flink.
-    Preconditions.checkArgument(!cacheEnabled || !cacheExpirationEnabled,
-        "Table cache expiration cannot be enabled for catalogs that don't have caching enabled");
-
-    this.cacheExpirationIntervalMillis = Long.parseLong(options.getOrDefault(CatalogProperties.TABLE_CACHE_EXPIRY_MS,
-        Long.toString(CatalogProperties.TABLE_CACHE_EXPIRY_MS_DEFAULT)));
+    this.cacheEnabled = Boolean.parseBoolean(options.getOrDefault("cache-enabled", "true"));
     Catalog catalog = buildIcebergCatalog(name, options);
 
     this.catalogName = name;
     SparkSession sparkSession = SparkSession.active();
     this.useTimestampsWithoutZone = SparkUtil.useTimestampWithoutZoneInNewTables(sparkSession.conf());
     this.tables = new HadoopTables(SparkUtil.hadoopConfCatalogOverrides(SparkSession.active(), name));
-    this.icebergCatalog = cacheEnabled ?
-        CachingCatalog.wrap(catalog, cacheExpirationEnabled, cacheExpirationIntervalMillis) : catalog;
+    this.icebergCatalog = cacheEnabled ? CachingCatalog.wrap(catalog) : catalog;
     if (catalog instanceof SupportsNamespaces) {
       this.asNamespaceCatalog = (SupportsNamespaces) catalog;
       if (options.containsKey("default-namespace")) {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -441,6 +441,16 @@ public class SparkCatalog extends BaseCatalog {
     return catalogName;
   }
 
+  // VisibleForTesting
+  public boolean isCacheEnabled() {
+    return cacheEnabled;
+  }
+
+  // VisibleForTesting
+  public boolean isCacheExpirationEnabled() {
+    return cacheExpirationEnabled;
+  }
+
   private static void commitChanges(Table table, SetProperty setLocation, SetProperty setSnapshotId,
                                     SetProperty pickSnapshotId, List<TableChange> propertyChanges,
                                     List<TableChange> schemaChanges) {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -400,6 +400,7 @@ public class SparkCatalog extends BaseCatalog {
 
     Preconditions.checkArgument(cacheEnabled || !cacheExpirationEnabled,
         "Table cache expiration cannot be enabled for catalogs that don't have caching enabled");
+
     if (cacheExpirationEnabled) {
       this.cacheExpirationIntervalMillis = PropertyUtil.propertyAsLong(options,
           TABLE_CACHE_EXPIRATION_INTERVAL_MS, TABLE_CACHE_EXPIRATION_INTERVAL_MS_DEFAULT);

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -413,7 +413,7 @@ public class SparkCatalog extends BaseCatalog {
       if (cacheExpirationIntervalMs != TABLE_CACHE_EXPIRATION_INTERVAL_MS_DEFAULT) {
         LOG.error(
             "The SparkCatalog {} is not configured to use cache expiration, but a cache expiration interval " +
-            "has been set via {}. This is likely an error and This property will be ignored."
+            "has been set via {}. This is likely an error and This property will be ignored.",
             name, TABLE_CACHE_EXPIRATION_INTERVAL_MS);
       }
     }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCatalogCacheExpiration.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCatalogCacheExpiration.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.iceberg.spark.SparkCatalogTestBase;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runners.Parameterized;
+
+import static org.apache.iceberg.CatalogProperties.TABLE_CACHE_ENABLED;
+import static org.apache.iceberg.CatalogProperties.TABLE_CACHE_EXPIRATION_ENABLED;
+
+public class TestSparkCatalogCacheExpiration extends SparkCatalogTestBase {
+
+  private String catalogConfigPrefix;
+  private boolean isCacheEnabled;
+  private boolean isCacheExpirationEnabled;
+
+  @Parameterized.Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+        { "testcacheexpirationnotenabled", SparkCatalog.class.getName(),
+          ImmutableMap.of(
+            "type", "hive",
+            "default-namespace", "default",
+            TABLE_CACHE_ENABLED, "false",
+            TABLE_CACHE_EXPIRATION_ENABLED, "false"
+        ) },
+        { "testhadoop", SparkCatalog.class.getName(),
+           ImmutableMap.of(
+            "type", "hadoop",
+            TABLE_CACHE_ENABLED, "true",
+            TABLE_CACHE_EXPIRATION_ENABLED, "false"
+         ) }
+    };
+  }
+
+  public TestSparkCatalogCacheExpiration(String catalogName,
+                                         String implementation,
+                                         Map<String, String> config) {
+    super(catalogName, implementation, config);
+    this.catalogConfigPrefix = "spark.sql.catalog." + catalogName + ".";
+    this.isCacheEnabled = Boolean.parseBoolean(
+        config.getOrDefault(TABLE_CACHE_ENABLED, "true"));
+    this.isCacheExpirationEnabled = Boolean.parseBoolean(
+        config.getOrDefault(TABLE_CACHE_EXPIRATION_ENABLED, "false"));
+  }
+
+  @Test
+  public void testCachingSparkCatalogRespectsCacheExpirationEnabled() {
+    boolean sparkConfHasCacheEnabled =
+        Boolean.parseBoolean(spark.conf().get(catalogConfigPrefix + TABLE_CACHE_ENABLED));
+    boolean sparkConfHasCacheExpirationEnabled =
+        Boolean.parseBoolean(spark.conf().get(catalogConfigPrefix + TABLE_CACHE_EXPIRATION_ENABLED));
+
+    Assert.assertEquals("The Spark conf should retain the value of cache-enabled",
+        isCacheEnabled, sparkConfHasCacheEnabled);
+    Assert.assertEquals("The Spark conf should retain the value of cache.expiration-enabled",
+        isCacheExpirationEnabled, sparkConfHasCacheExpirationEnabled);
+
+    SparkCatalog catalog = getSparkCatalog();
+
+    Assert.assertEquals("The SparkCatalog should have caching enabled when configured with cache-enabled",
+        isCacheEnabled, catalog.isCacheEnabled());
+
+    Assert.assertEquals("The SparkCatalog should respect cache.expiration-enabled",
+        isCacheExpirationEnabled, catalog.isCacheExpirationEnabled());
+  }
+
+  private SparkCatalog getSparkCatalog()  {
+    TableCatalog catalog = (TableCatalog) spark.sessionState().catalogManager().catalog(catalogName);
+    return (SparkCatalog) catalog;
+  }
+}


### PR DESCRIPTION
Occasionally, users have reported issues that they have very specific problems with table caching.

Namely, if they're trying to read from a table, and others have written to it from another program, the cache won't be refreshed and users need to manually call `.refresh` on the table. This can be a source of confusion.

In general, the cache makes things much more efficient. So it makes sense to keep it.

But for things like long-lived session clusters or scenarios as described above, it would be desirable to expire the tables in the cache and then have them be reloaded if they're accessed via the catalog again.

This allows for the catalog to still benefit from caching, but to discard cached entries after a configurable period of time.

Details:
- Adds a new catalog property, `cache.expiration-enabled`.
- Adds a new catalog property, `cache.expiration-interval-ms`. Defaults to 15 minutes.

Presently, it's set to expire after a configured time period after write or access via the catalog. So if a user tries to call catalog.loadTable(tableIdent) many times, this will reset the cache time.

Additionally, metadata tables are always expired when the main table is expired (so that they don't drift in the cache).