### PR TITLE
Adding a contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,18 +19,32 @@
 
 # Contributing
 
-In this document, you will find some guidelines on contributing to Apache Iceberg. Please keep in mind that none of these are hard rules and they're meant as a collection of helpful suggestions to make contributing as seamless of an experience as possible.
+In this document, you will find some guidelines on contributing to Apache Iceberg. Please keep in mind that none of
+these are hard rules and they're meant as a collection of helpful suggestions to make contributing as seamless of an
+experience as possible.
 
-If you are thinking of contributing but first would like to discuss the change you wish to make, we welcome you to head over to the [Community](https://iceberg.apache.org/community/) page on the official Iceberg documentation site to find a number of ways to connect with the community, including slack and our mailing lists. Of course, always feel free to just open a [new issue](https://github.com/apache/iceberg/issues/new) in the GitHub repo.
+If you are thinking of contributing but first would like to discuss the change you wish to make, we welcome you to
+head over to the [Community](https://iceberg.apache.org/community/) page on the official Iceberg documentation site
+to find a number of ways to connect with the community, including slack and our mailing lists. Of course, always feel
+free to just open a [new issue](https://github.com/apache/iceberg/issues/new) in the GitHub repo.
 
 ## Pull Request Process
 
-Pull requests are the preferred mechanism for contributing to Iceberg. PRs will be automatically labeled based on the content by our github-actions labeling bot. Although it is not required, if the PR is related to an issue, it's helpful to prefix your PR title with the issue number surrounded by brackets, for example `[1234] <PR title>`. Another common practice is to prefix the PR title with `[WIP]` if it's a PR that you opened for visibility and may not necessarily be ready for review or merging.
-
-## Styling
-
-For Java styling, check out the section [Setting up IDE and Code Style](https://iceberg.apache.org/community/#setting-up-ide-and-code-style) from the documentation site. For Python, please use the tox command `tox -e format` to apply autoformatting to the project.
+Pull requests are the preferred mechanism for contributing to Iceberg. PRs will be automatically labeled based on
+the content by our github-actions labeling bot. Although it is not required, if the PR is related to an issue, it's
+helpful to prefix your PR title with the issue number surrounded by brackets, for example `Closes #1234 <PR title>`.
+With this format of issue reference in the PR title, the issue will be automatically closed when the PR is merged.
+It's also helpful to include additional prefixes that help provide context to PR reviewers, such as `Build:`, `Docs:`, 
+`Spark:`, `Flink:`, `Core:`, `API:`. Another thing to keep in mind is that if it's a PR that you've opened for
+visibility and may not necessarily be ready for review or merging, be sure to convert the PR to a draft.
 
 ## Building the Project Locally
 
-Please refer to the [Building](https://github.com/apache/iceberg#building) section of the main readme for instructions on how to build iceberg locally.
+Please refer to the [Building](https://github.com/apache/iceberg#building) section of the main readme for instructions
+on how to build iceberg locally.
+
+## Style
+
+For Java styling, check out the section
+[Setting up IDE and Code Style](https://iceberg.apache.org/community/#setting-up-ide-and-code-style) from the
+documentation site. For Python, please use the tox command `tox -e format` to apply autoformatting to the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing
+
+In this document, you will find some guidelines on contributing to Apache Iceberg. Please keep in mind that none of these are hard rules and they're meant as a collection of helpful suggestions to make contributing as seamless of an experience as possible.
+
+If you are thinking of contributing but first would like to discuss the change you wish to make, we welcome you to head over to the [Community](https://iceberg.apache.org/community/) page on the official Iceberg documentation site to find a number of ways to connect with the community, including slack and our mailing lists. Of course, always feel free to just open a [new issue](https://github.com/apache/iceberg/issues/new) in the GitHub repo.
+
+## Pull Request Process
+
+Pull requests are the preferred mechanism for contributing to Iceberg. PRs will be automatically labeled based on the content by our github-actions labeling bot. Although it is not required, if the PR is related to an issue, it's helpful to prefix your PR title with the issue number surrounded by brackets, for example `[1234] <PR title>`. Another common practice is to prefix the PR title with `[WIP]` if it's a PR that you opened for visibility and may not necessarily be ready for review or merging.
+
+## Styling
+
+For Java styling, check out the section [Setting up IDE and Code Style](https://iceberg.apache.org/community/#setting-up-ide-and-code-style) from the documentation site. For Python, please use the tox command `tox -e format` to apply autoformatting to the project.
+
+## Building the Project Locally
+
+Please refer to the [Building](https://github.com/apache/iceberg#building) section of the main readme for instructions on how to build iceberg locally.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,22 @@
+<!--
+  - Licensed to the Apache Software Foundation (ASF) under one
+  - or more contributor license agreements.  See the NOTICE file
+  - distributed with this work for additional information
+  - regarding copyright ownership.  The ASF licenses this file
+  - to you under the Apache License, Version 2.0 (the
+  - "License"); you may not use this file except in compliance
+  - with the License.  You may obtain a copy of the License at
+  -
+  -   http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing,
+  - software distributed under the License is distributed on an
+  - "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  - KIND, either express or implied.  See the License for the
+  - specific language governing permissions and limitations
+  - under the License.
+  -->
+
 # Contributing
 
 In this document, you will find some guidelines on contributing to Apache Iceberg. Please keep in mind that none of these are hard rules and they're meant as a collection of helpful suggestions to make contributing as seamless of an experience as possible.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,13 +30,11 @@ free to just open a [new issue](https://github.com/apache/iceberg/issues/new) in
 
 ## Pull Request Process
 
-Pull requests are the preferred mechanism for contributing to Iceberg. PRs will be automatically labeled based on
-the content by our github-actions labeling bot. Although it is not required, if the PR is related to an issue, it's
-helpful to prefix your PR title with the issue number surrounded by brackets, for example `Closes #1234 <PR title>`.
-With this format of issue reference in the PR title, the issue will be automatically closed when the PR is merged.
-It's also helpful to include additional prefixes that help provide context to PR reviewers, such as `Build:`, `Docs:`, 
-`Spark:`, `Flink:`, `Core:`, `API:`. Another thing to keep in mind is that if it's a PR that you've opened for
-visibility and may not necessarily be ready for review or merging, be sure to convert the PR to a draft.
+Pull requests are the preferred mechanism for contributing to Iceberg
+* PRs are automatically labeled based on the content by our github-actions labeling action
+* It's helpful to include a prefix in the summary that provides context to PR reviewers, such as `Build:`, `Docs:`, `Spark:`, `Flink:`, `Core:`, `API:`
+* If a PR is related to an issue, adding `Closes #1234` in the PR description will automatically close the issue and helps keep the project clean
+* If a PR is posted for visibility and isn't necessarily ready for review or merging, be sure to convert the PR to a draft
 
 ## Building the Project Locally
 


### PR DESCRIPTION
I noticed that the community profile (displayed on the Insights tab) is not all nice and green so I thought we could tackle these items (read more here: [About community profiles for public repositories](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/about-community-profiles-for-public-repositories)). This PR adds a simple contributing guideline doc, everyone please chime in with things that should be added/removed! :)

<img width="1570" alt="Screen Shot 2021-10-28 at 7 08 32 PM" src="https://user-images.githubusercontent.com/43911210/139361966-2528981c-a670-44e3-80c0-0a9cca6cea9d.png">

As for the Issue template and PR template, I'd like to suggest some variation of these templates created by Steven Mao: https://github.com/stevemao/github-issue-templates

# *Simple Issues template:*

## Expected Behavior


## Actual Behavior (please include stacktrace if possible)


## Steps to Reproduce the Problem

  1.
  2.
  3.

## Specifications

  - Version of Iceberg:
  - Platform:





# *Simple Pull Request template:*

Fixes #

## Proposed Changes

  -
  -
  -



As for the last item, a repo admin should be able to enable reported content from the settings page. Here's more info from the github docs: https://docs.github.com/en/communities/moderating-comments-and-conversations/managing-reported-content-in-your-organizations-repository