### PR TITLE
Spark: Enforce the netty buffer version to fix jmh test failures in Spark 3.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -489,7 +489,10 @@ project(':iceberg-arrow') {
     implementation("org.apache.arrow:arrow-memory-netty") {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
       exclude group: 'io.netty', module: 'netty-common'
+      exclude group: 'io.netty', module: 'netty-buffer'
     }
+
+    runtimeOnly("io.netty:netty-buffer")
 
     implementation("org.apache.parquet:parquet-avro") {
       exclude group: 'org.apache.avro', module: 'avro'

--- a/spark/v3.2/build.gradle
+++ b/spark/v3.2/build.gradle
@@ -33,8 +33,6 @@ configure(sparkProjects) {
       resolutionStrategy {
         force 'com.fasterxml.jackson.module:jackson-module-scala_2.12:2.12.3'
         force 'com.fasterxml.jackson.module:jackson-module-paranamer:2.12.3'
-        // enforce the newer version of netty buffer in test
-        force 'io.netty:netty-buffer:4.1.68.Final'
       }
     }
   }
@@ -86,6 +84,8 @@ project(':iceberg-spark:iceberg-spark-3.2') {
 
     testImplementation("org.apache.hadoop:hadoop-minicluster") {
       exclude group: 'org.apache.avro', module: 'avro'
+      // to make sure io.netty.buffer only comes from project(':iceberg-arrow')
+      exclude group: 'io.netty', module: 'netty-buffer'
     }
     testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')

--- a/spark/v3.2/build.gradle
+++ b/spark/v3.2/build.gradle
@@ -136,6 +136,8 @@ project(":iceberg-spark:iceberg-spark-3.2-extensions") {
     compileOnly("org.apache.spark:spark-hive_2.12:${sparkVersion}") {
       exclude group: 'org.apache.avro', module: 'avro'
       exclude group: 'org.apache.arrow'
+      // to make sure io.netty.buffer only comes from project(':iceberg-arrow')
+      exclude group: 'io.netty', module: 'netty-buffer'
     }
 
     testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')

--- a/spark/v3.2/build.gradle
+++ b/spark/v3.2/build.gradle
@@ -33,6 +33,8 @@ configure(sparkProjects) {
       resolutionStrategy {
         force 'com.fasterxml.jackson.module:jackson-module-scala_2.12:2.12.3'
         force 'com.fasterxml.jackson.module:jackson-module-paranamer:2.12.3'
+        // enforce the newer version of netty buffer in test
+        force 'io.netty:netty-buffer:4.1.68.Final'
       }
     }
   }
@@ -64,6 +66,8 @@ project(':iceberg-spark:iceberg-spark-3.2') {
     compileOnly("org.apache.spark:spark-hive_2.12:${sparkVersion}") {
       exclude group: 'org.apache.avro', module: 'avro'
       exclude group: 'org.apache.arrow'
+      // to make sure io.netty.buffer only comes from project(':iceberg-arrow')
+      exclude group: 'io.netty', module: 'netty-buffer'
     }
 
     implementation("org.apache.orc:orc-core::nohive") {

--- a/versions.props
+++ b/versions.props
@@ -16,6 +16,7 @@ com.google.guava:guava = 28.0-jre
 com.github.ben-manes.caffeine:caffeine = 2.8.4
 org.apache.arrow:arrow-vector = 5.0.0
 org.apache.arrow:arrow-memory-netty = 5.0.0
+io.netty:netty-buffer = 4.1.63.Final
 com.github.stephenc.findbugs:findbugs-annotations = 1.3.9-1
 com.aliyun.oss:aliyun-sdk-oss = 3.10.2
 javax.xml.bind:jaxb-api = 2.3.1


### PR DESCRIPTION
To fix #3405. 
According to https://github.com/apache/iceberg/blob/d08a1f7dcf878bae5e96eef8510c34ff644a7f79/spark/v3.2/build.gradle#L235, the netty buffer should only come from project(':iceberg-arrow'). So we need to exclude any other libs which depend on netty buffer.

hadoop-minicluster depends on netty buffer, but we don't need to exclude Netty buffer here since it is only for test, it won't come across with relocation of Netty buffer
```
    testImplementation("org.apache.hadoop:hadoop-minicluster") {
      exclude group: 'org.apache.avro', module: 'avro'
    }
```

cc @rdblue @aokolnychyi @RussellSpitzer @karuppayya @szehon-ho 