### PR TITLE
Core: Fix Replace Table with Changing Partition Spec

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -747,6 +747,7 @@ public class TableMetadata implements Serializable {
       for (PartitionField newField : partitionSpec.fields()) {
         newFields.put(Pair.of(newField.sourceId(), newField.transform().toString()), newField);
       }
+      List<String> newFieldNames = newFields.values().stream().map(PartitionField::name).collect(Collectors.toList());
 
       for (PartitionField field : spec().fields()) {
         // ensure each field is either carried forward or replaced with void
@@ -755,7 +756,9 @@ public class TableMetadata implements Serializable {
           // copy the new field with the existing field ID
           specBuilder.add(newField.sourceId(), field.fieldId(), newField.name(), newField.transform());
         } else {
-          specBuilder.add(field.sourceId(), field.fieldId(), field.name(), Transforms.alwaysNull());
+          // Rename old void transforms that would otherwise conflict
+          String voidName = newFieldNames.contains(field.name()) ? field.name() + "_" + field.fieldId() : field.name();
+          specBuilder.add(field.sourceId(), field.fieldId(), voidName, Transforms.alwaysNull());
         }
       }
 

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTableAsSelect.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTableAsSelect.java
@@ -311,4 +311,53 @@ public class TestCreateTableAsSelect extends SparkCatalogTestBase {
     Assert.assertEquals("Table should have expected snapshots",
         2, Iterables.size(rtasTable.snapshots()));
   }
+
+  @Test
+  public void testCreateRTASWithPartitionSpecChanging() {
+    sql("CREATE OR REPLACE TABLE %s USING iceberg PARTITIONED BY (part) AS " +
+        "SELECT id, data, CASE WHEN (id %% 2) = 0 THEN 'even' ELSE 'odd' END AS part " +
+        "FROM %s ORDER BY 3, 1", tableName, sourceName);
+
+    Table rtasTable = validationCatalog.loadTable(tableIdent);
+
+    assertEquals("Should have rows matching the source table",
+        sql("SELECT id, data, CASE WHEN (id %% 2) = 0 THEN 'even' ELSE 'odd' END AS part " +
+            "FROM %s ORDER BY id", sourceName),
+        sql("SELECT * FROM %s ORDER BY id", tableName));
+
+    // Change the partitioning of the table
+    rtasTable.updateSpec().removeField("part").commit(); // Spec 1
+
+    sql("CREATE OR REPLACE TABLE %s USING iceberg PARTITIONED BY (part, id) AS " +
+        "SELECT 2 * id as id, data, CASE WHEN ((2 * id) %% 2) = 0 THEN 'even' ELSE 'odd' END AS part " +
+        "FROM %s ORDER BY 3, 1", tableName, sourceName);
+
+    Schema expectedSchema = new Schema(
+        Types.NestedField.optional(1, "id", Types.LongType.get()),
+        Types.NestedField.optional(2, "data", Types.StringType.get()),
+        Types.NestedField.optional(3, "part", Types.StringType.get())
+    );
+
+    PartitionSpec expectedSpec = PartitionSpec.builderFor(expectedSchema)
+        .alwaysNull("part", "part_1000")
+        .identity("part")
+        .identity("id")
+        .withSpecId(2) // The Spec is new
+        .build();
+
+    Assert.assertEquals("Should be partitioned by part and id",
+        expectedSpec, rtasTable.spec());
+
+    // the replacement table has a different schema and partition spec than the original
+    Assert.assertEquals("Should have expected nullable schema",
+        expectedSchema.asStruct(), rtasTable.schema().asStruct());
+
+    assertEquals("Should have rows matching the source table",
+        sql("SELECT 2 * id, data, CASE WHEN ((2 * id) %% 2) = 0 THEN 'even' ELSE 'odd' END AS part " +
+            "FROM %s ORDER BY id", sourceName),
+        sql("SELECT * FROM %s ORDER BY id", tableName));
+
+    Assert.assertEquals("Table should have expected snapshots",
+        2, Iterables.size(rtasTable.snapshots()));
+  }
 }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTableAsSelect.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTableAsSelect.java
@@ -311,4 +311,53 @@ public class TestCreateTableAsSelect extends SparkCatalogTestBase {
     Assert.assertEquals("Table should have expected snapshots",
         2, Iterables.size(rtasTable.snapshots()));
   }
+
+  @Test
+  public void testCreateRTASWithPartitionSpecChanging() {
+    sql("CREATE OR REPLACE TABLE %s USING iceberg PARTITIONED BY (part) AS " +
+        "SELECT id, data, CASE WHEN (id %% 2) = 0 THEN 'even' ELSE 'odd' END AS part " +
+        "FROM %s ORDER BY 3, 1", tableName, sourceName);
+
+    Table rtasTable = validationCatalog.loadTable(tableIdent);
+
+    assertEquals("Should have rows matching the source table",
+        sql("SELECT id, data, CASE WHEN (id %% 2) = 0 THEN 'even' ELSE 'odd' END AS part " +
+            "FROM %s ORDER BY id", sourceName),
+        sql("SELECT * FROM %s ORDER BY id", tableName));
+
+    // Change the partitioning of the table
+    rtasTable.updateSpec().removeField("part").commit(); // Spec 1
+
+    sql("CREATE OR REPLACE TABLE %s USING iceberg PARTITIONED BY (part, id) AS " +
+        "SELECT 2 * id as id, data, CASE WHEN ((2 * id) %% 2) = 0 THEN 'even' ELSE 'odd' END AS part " +
+        "FROM %s ORDER BY 3, 1", tableName, sourceName);
+
+    Schema expectedSchema = new Schema(
+        Types.NestedField.optional(1, "id", Types.LongType.get()),
+        Types.NestedField.optional(2, "data", Types.StringType.get()),
+        Types.NestedField.optional(3, "part", Types.StringType.get())
+    );
+
+    PartitionSpec expectedSpec = PartitionSpec.builderFor(expectedSchema)
+        .alwaysNull("part", "part_1000")
+        .identity("part")
+        .identity("id")
+        .withSpecId(2) // The Spec is new
+        .build();
+
+    Assert.assertEquals("Should be partitioned by part and id",
+        expectedSpec, rtasTable.spec());
+
+    // the replacement table has a different schema and partition spec than the original
+    Assert.assertEquals("Should have expected nullable schema",
+        expectedSchema.asStruct(), rtasTable.schema().asStruct());
+
+    assertEquals("Should have rows matching the source table",
+        sql("SELECT 2 * id, data, CASE WHEN ((2 * id) %% 2) = 0 THEN 'even' ELSE 'odd' END AS part " +
+            "FROM %s ORDER BY id", sourceName),
+        sql("SELECT * FROM %s ORDER BY id", tableName));
+
+    Assert.assertEquals("Table should have expected snapshots",
+        2, Iterables.size(rtasTable.snapshots()));
+  }
 }


### PR DESCRIPTION
Originally when we rebuild the partition spec for V1 tables we automatically
include void transforms for and source column which is not be transformed
identically in the new replacement table. This has issues if the column's
partitioning transform has changed leading to errors because a spec can
only transform a given column a single time. To fix this we instead replace
any transform in the previous spec that was modifying the same source column
as the new spec. Voids are still propagated for source columns which are
untransformed in the new spec.