### PR TITLE
Python: Add tox commands for code format and type checking #3282

### DIFF
--- a/python/src/iceberg/types.py
+++ b/python/src/iceberg/types.py
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from typing import Optional
+
 
 class Type(object):
     def __init__(self, type_string: str, repr_string: str, is_primitive=False):
@@ -71,7 +73,7 @@ class NestedField(object):
         field_id: int,
         name: str,
         field_type: Type,
-        doc: str = None,
+        doc: Optional[str] = None,
     ):
         self._is_optional = is_optional
         self._id = field_id

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -23,7 +23,6 @@ usedevelop = true
 deps =
     coverage
     mock
-    nose
     pytest
 setenv =
     COVERAGE_FILE = test-reports/{envname}/.coverage
@@ -34,79 +33,39 @@ commands =
     coverage report -m --fail-under=90
     coverage html -d test-reports/{envname}/coverage-html
     coverage xml -o test-reports/{envname}/coverage.xml
-[testenv:format]
-description = reformat all source code
-basepython = python3
-deps =
-    black
-    isort
-    flake8
-skip_install = true
-commands =
-    isort --project iceberg --profile black setup.py src tests
-    black setup.py src tests
-    flake8 setup.py src tests
 
 [testenv:linters]
-basepython = python3
-skip_install = true
+usedevelop = true
 deps =
-    .
-    {[testenv:isort]deps}
-    {[testenv:black]deps}
-    {[testenv:flake8]deps}
-    {[testenv:bandit]deps}
-    {[testenv:mypy]deps}
+    {[testenv:format-check]deps}
+    {[testenv:type-check]deps}
 commands =
-    {[testenv:isort]deps}
-    {[testenv:black]deps}
-    {[testenv:flake8]commands}
-    {[testenv:bandit]commands}
-    {[testenv:mypy]commands}
+    {[testenv:format-check]commands}
+    {[testenv:type-check]commands}
 
-[testenv:isort]
-basepython = python3
-skip_install = true
-deps =
-    isort
-commands =
-    isort --recursive --project iceberg --profile black --check-only setup.py src tests
-
-[testenv:black]
-basepython = python3
-skip_install = true
+[testenv:format-check]
 deps =
     black
+    isort
+    autoflake
 commands =
-    black --check --diff src setup.py tests
+    autoflake -r --check --ignore-init-module-imports --remove-all-unused-imports setup.py src tests
+    isort --profile black --check-only setup.py src tests
+    black --check setup.py src tests
 
-[testenv:flake8]
-basepython = python3
-skip_install = true
+[testenv:format]
 deps =
-    flake8>=3.8.4
-    flake8-import-order>=0.9
-    flake8-bugbear
+    {[testenv:format-check]deps}
 commands =
-    flake8 src setup.py tests
+    autoflake -r --in-place --ignore-init-module-imports --remove-all-unused-imports setup.py src tests
+    isort --profile black setup.py src tests
+    black setup.py src tests
 
-[testenv:mypy]
-basepython = python3
-skip_install = true
+[testenv:type-check]
 deps =
     mypy
-    types-pytz
-    types-python-dateutil
 commands =
-    mypy --ignore-missing-imports src/
-
-[testenv:bandit]
-basepython = python3
-skip_install = true
-deps =
-    bandit
-commands =
-    bandit --ini tox.ini -r src
+    mypy --no-implicit-optional src
 
 [testenv:docs]
 basepython = python3
@@ -123,22 +82,6 @@ changedir = docs/build/html
 deps =
 commands =
     python -m http.server {posargs}
-
-[flake8]
-ignore = E501,I100,I202,W503
-exclude =
-    *.egg-info,
-    *.pyc,
-    .cache,
-    .coverage.*,
-    .gradle,
-    .tox,
-    build,
-    dist,
-    htmlcov.*
-max-complexity = 10
-import-order-style = google
-application-import-names = flake8
 
 [pytest]
 norecursedirs=.*


### PR DESCRIPTION
* This PR adds tox commands to automate code formatting and type checking.
* tox uses following 
> - black for code formatting
> - isort for import ordering
> - autoflake for removing unused imports
> - mypy for static type checking

* Core tox commands
> - `tox` will run tests and linters (code format and type checks). This is the central command that'll be most used.
> - `tox -e linters` will check if the code adheres to the standard and passes type checking
>- `tox -e format` automates code reformatting


* Future enhancements
>- Add tox commands for documentation creation
>- Perhaps add git pre-recommit hooks to make it more seamless?

* We'll need a follow PR to run these commands over the codebase. 