### PR TITLE
Build: Only build one Spark, Flink, and Hive version by default

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,11 +15,11 @@
 
 jmhOutputPath=build/reports/jmh/human-readable-output.txt
 jmhIncludeRegex=.*
-systemProp.defaultFlinkVersions=1.12,1.13
+systemProp.defaultFlinkVersions=1.13
 systemProp.knownFlinkVersions=1.12,1.13
-systemProp.defaultHiveVersions=2,3
+systemProp.defaultHiveVersions=2
 systemProp.knownHiveVersions=2,3
-systemProp.defaultSparkVersions=2.4,3.0,3.1,3.2
+systemProp.defaultSparkVersions=3.2
 systemProp.knownSparkVersions=2.4,3.0,3.1,3.2
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx768m


### PR DESCRIPTION
This updates the default versions included in the build for Spark, Flink, and Hive to only build one version by default: Spark 3.2, Flink 1.13, and Hive 2.

This does not affect CI workflows, which already control versions explicitly and test each version individually.