### PR TITLE
Build: Make source-release script macOS compatible

### DIFF
--- a/dev/source-release.sh
+++ b/dev/source-release.sh
@@ -109,7 +109,7 @@ git archive $release_hash --worktree-attributes --prefix $tag/ -o $projectdir/$t
 echo "Signing the tarball..."
 [[ -z "$keyid" ]] && keyopt="-u $keyid"
 gpg --detach-sig $keyopt --armor --output ${projectdir}/${tarball}.asc ${projectdir}/$tarball
-sha512sum ${projectdir}/$tarball > ${projectdir}/${tarball}.sha512
+shasum -a 512 ${projectdir}/$tarball > ${projectdir}/${tarball}.sha512
 
 
 echo "Checking out Iceberg RC subversion repo..."


### PR DESCRIPTION
The `sha512sum` doesn't exist on my relatively new macbook out of the box.

I've updated it to something equivalent that exists on both a linux computer and my macbook.