### PR TITLE
Build: Fix deploySite task

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -23,7 +23,7 @@ This directory contains the source for the Iceberg site.
 
 * Site structure is maintained in mkdocs.yml
 * Pages are maintained in markdown in the `docs/` folder
-* Links use bare page names: `[link text](target-page)`
+* Links use page file names: `[link text](target-page.md)`
 
 ### Installation
 
@@ -49,12 +49,9 @@ To see changes in Javadoc, run:
 
 ### Publishing
 
-After site changes are committed, you can publish the site with this command:
+After site changes are committed, you can publish the site to the `apache` remote with this command:
 
 ```
 ./gradlew deploySite
 ```
 
-This assumes that the Apache remote is named `apache` and will push to the
-`asf-site` branch. You can specify the name of a different remote by appending
-`-Premote.name=<remote-name>` to the `./gradlew deploySite` command.

--- a/site/deploy.sh
+++ b/site/deploy.sh
@@ -16,6 +16,8 @@
 # limitations under the License.
 #
 
+set -e
+
 # manualy clean site, then copy .asf.yml in so that the build is clean even
 # though --dirty is used so that .asf.yml is included in the deploy
 rm -rf site

--- a/site/deploy.sh
+++ b/site/deploy.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# manualy clean site, then copy .asf.yml in so that the build is clean even
+# though --dirty is used so that .asf.yml is included in the deploy
+rm -rf site
+mkdir site
+cp ../.asf.yaml site/
+mkdocs gh-deploy --dirty

--- a/tasks.gradle
+++ b/tasks.gradle
@@ -52,19 +52,5 @@ task refreshJavadoc(type: Exec) {
 
 task deploySite(type: Exec) {
   workingDir 'site'
-  def remoteName = 'apache'
-  if (project.hasProperty('remote.name')) {
-    remoteName = project.getProperty('remote.name')
-  }
-
-  // Normally the site directory is removed and built entirely from the docs
-  // directory when `mkdocs gh-deploy` runs. Removing the site directory,
-  // copying the file by hand, and using --dirty does basically the same thing,
-  // but allows us to end up with .asf.yaml in the output that gets copied to
-  // the asf-site branch. That's required for publishing now, which is why this
-  // workaround is necessary. For further clarification please see
-  // https://github.com/apache/iceberg/pull/2998#discussion_r693517612
-  commandLine('rm', '-rf', 'site')
-  commandLine('cp', '../.asf.yaml', 'site/')
-  commandLine('mkdocs', 'gh-deploy', '--dirty', '-r', remoteName)
+  commandLine('./deploy.sh')
 }


### PR DESCRIPTION
Only the last command in the gradle `deploySite` task was being run, which resulted in some stale pages in the site after the style update. This moves the deployment logic into `site/deploy.sh`.