### PR TITLE
Infra - Add Python Legacy CI to Cancel Duplicate Action

### DIFF
--- a/.github/workflows/cancel-duplicate-workflow-runs.yml
+++ b/.github/workflows/cancel-duplicate-workflow-runs.yml
@@ -25,6 +25,7 @@ on:
       - 'Hive CI'
       - 'Java CI'
       - 'Python CI'
+      - 'Python Legacy CI'
       - 'Spark CI'
     types: ['requested']
 


### PR DESCRIPTION
Small nit but in case Python Legacy CI gets run, it's not in the Cancel Duplicates Workflow so we could wind up with a lot of unnecessary runs.