### PR TITLE
Flink: Run unit tests for different versions.

### DIFF
--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -49,32 +49,6 @@ on:
     - 'site/**'
 
 jobs:
-  flink-common-tests:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        jvm: [8, 11]
-    env:
-      SPARK_LOCAL_IP: localhost
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-java@v1
-      with:
-        java-version: ${{ matrix.jvm }}
-    - uses: actions/cache@v2
-      with:
-        path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-        restore-keys: ${{ runner.os }}-gradle
-    - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-    - run: ./gradlew -DsparkVersions= -DhiveVersions= :iceberg-flink:check -Pquick=true -x javadoc
-    - uses: actions/upload-artifact@v2
-      if: failure()
-      with:
-        name: test logs
-        path: |
-          **/build/testlogs
-
   flink-tests:
     runs-on: ubuntu-latest
     strategy:

--- a/flink/v1.12/build.gradle
+++ b/flink/v1.12/build.gradle
@@ -41,6 +41,16 @@ project(':iceberg-flink:iceberg-flink-1.12') {
         "src/main/resources"
       ]
     }
+    test {
+      java.srcDirs = [
+        "${project(':iceberg-flink').projectDir}/src/test/java",
+        "src/test/java"
+      ]
+      resources.srcDirs = [
+        "${project(':iceberg-flink').projectDir}/src/test/resources",
+        "src/test/resources"
+      ]
+    }
   }
 
   dependencies {

--- a/flink/v1.13/build.gradle
+++ b/flink/v1.13/build.gradle
@@ -41,6 +41,16 @@ project(':iceberg-flink:iceberg-flink-1.13') {
           "src/main/resources"
       ]
     }
+    test {
+      java.srcDirs = [
+          "${project(':iceberg-flink').projectDir}/src/test/java",
+          "src/test/java"
+      ]
+      resources.srcDirs = [
+          "${project(':iceberg-flink').projectDir}/src/test/resources",
+          "src/test/resources"
+      ]
+    }
   }
 
   dependencies {


### PR DESCRIPTION
I think this PR: https://github.com/apache/iceberg/pull/3364 forgot to run the common flink unit tests for the given specific flink version.  So when I run the following command , it even did not run any test cases.

```bash
./gradlew  -DflinkVersions=1.13 :iceberg-flink:iceberg-flink-1.13:build -Pquick=true -x javadoc
``` 

This RP is trying to enable the unit tests check for different flink versions.