### PR TITLE
[Python] support iceberg transforms in python

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -19,7 +19,7 @@ from setuptools import setup
 
 setup(
     name="py-iceberg",
-    install_requires=[],
+    install_requires=["mmh3", "pytz"],
     extras_require={
         "dev": [
             "tox-travis==0.12",

--- a/python/src/iceberg/transforms.py
+++ b/python/src/iceberg/transforms.py
@@ -1,0 +1,510 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import base64
+import math
+import re
+import struct
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+import mmh3
+import pytz
+
+from .types import (
+    BinaryType,
+    DateType,
+    DecimalType,
+    DoubleType,
+    FixedType,
+    FloatType,
+    IntegerType,
+    LongType,
+    StringType,
+    TimestampType,
+    TimestamptzType,
+    TimeType,
+    Type,
+    UUIDType,
+)
+
+
+class Transform(object):
+    """
+    Transform base class for concrete transforms. The default implementation is for VoidTransform.
+    """
+
+    _EPOCH = datetime.utcfromtimestamp(0)
+
+    @staticmethod
+    def _human_day(day_ordinal):
+        time = Transform._EPOCH + timedelta(days=day_ordinal)
+        return "{0:0=4d}-{1:0=2d}-{2:0=2d}".format(time.year, time.month, time.day)
+
+    @staticmethod
+    def _unscale_decimal(decimal_value: Decimal):
+        value_tuple = decimal_value.as_tuple()
+        return int(
+            ("-" if value_tuple.sign else "")
+            + "".join([str(d) for d in value_tuple.digits])
+        )
+
+    def __init__(self, transform_string: str, repr_string: str):
+        self._transform_string = transform_string
+        self._repr_string = repr_string
+
+    def __repr__(self):
+        return self._repr_string
+
+    def __str__(self):
+        return self._transform_string
+
+    def apply(self, value):
+        return None
+
+    def can_transform(self, target: Type) -> bool:
+        return True
+
+    def get_result_type(self, source: Type) -> Type:
+        return source
+
+    def preserve_order(self) -> bool:
+        return False
+
+    def satisfy_order(self, other) -> bool:
+        return self == other
+
+    def to_human_string(self, value) -> str:
+        return "null"
+
+    def dedup_name(self) -> str:
+        return self.__str__()
+
+
+class Bucket(Transform):
+    _MURMUR3 = mmh3
+    _MAX_32_BITS_INT = 2147483647
+    _FUNCTIONS_MAP = {  # [0] is hash function and [1] is can_transform check function
+        DateType: (
+            lambda v: Bucket._MURMUR3.hash(struct.pack("q", v)),
+            lambda t: t in [IntegerType, DateType],
+        ),
+        IntegerType: (
+            lambda v: Bucket._MURMUR3.hash(struct.pack("q", v)),
+            lambda t: t in [IntegerType, DateType],
+        ),
+        TimeType: (
+            lambda v: Bucket._MURMUR3.hash(struct.pack("q", v)),
+            lambda t: t in {LongType, TimeType, TimestampType, TimestamptzType},
+        ),
+        TimestampType: (
+            lambda v: Bucket._MURMUR3.hash(struct.pack("q", v)),
+            lambda t: t in {LongType, TimeType, TimestampType, TimestamptzType},
+        ),
+        TimestamptzType: (
+            lambda v: Bucket._MURMUR3.hash(struct.pack("q", v)),
+            lambda t: t in {LongType, TimeType, TimestampType, TimestamptzType},
+        ),
+        LongType: (
+            lambda v: Bucket._MURMUR3.hash(struct.pack("q", v)),
+            lambda t: t in [LongType, TimeType, TimestampType, TimestamptzType],
+        ),
+        StringType: (
+            lambda v: Bucket._MURMUR3.hash(v),
+            lambda t: t == StringType,
+        ),
+        BinaryType: (
+            lambda v: Bucket._MURMUR3.hash(v),
+            lambda t: t == BinaryType or isinstance(t, FixedType),
+        ),
+        UUIDType: (
+            lambda v: struct.pack(
+                ">QQ", (v.int >> 64) & 0xFFFFFFFFFFFFFFFF, v.int & 0xFFFFFFFFFFFFFFFF
+            ),
+            lambda t: t == UUIDType,
+        ),
+        # bucketing by Float/Double is not allowed by the spec, but they have hash implementation
+        FloatType: (
+            lambda v: Bucket._MURMUR3.hash(struct.pack("d", v)),
+            lambda t: t == FloatType,
+        ),
+        DoubleType: (
+            lambda v: Bucket._MURMUR3.hash(struct.pack("d", v)),
+            lambda t: t == DoubleType,
+        ),
+    }
+
+    @staticmethod
+    def _decimal_to_bytes(value: Decimal):
+        unscaled_value = Transform._unscale_decimal(value)
+        number_of_bytes = int(math.ceil(unscaled_value.bit_length() / 8))
+        return unscaled_value.to_bytes(length=number_of_bytes, byteorder="big")
+
+    def __init__(self, transform_type: Type, num_buckets: int):
+        if (
+            transform_type not in Bucket._FUNCTIONS_MAP
+            and isinstance(transform_type, FixedType)
+            and isinstance(transform_type, DecimalType)
+        ):
+            raise ValueError(f"Cannot bucket by type: {transform_type}")
+
+        super().__init__(
+            f"bucket[{bucket}",
+            f"Bucket(transform_type={repr(transform_type)}, num_buckets={bucket})",
+        )
+        self._type = transform_type
+        self._num_buckets = num_buckets
+
+    @property
+    def num_buckets(self) -> int:
+        return self._num_buckets
+
+    def apply(self, value):
+        if value is None:
+            return None
+
+        if isinstance(self._type, FixedType):
+            return (
+                Bucket._MURMUR3.hash(value) & Bucket._MAX_32_BITS_INT
+            ) % self._num_buckets
+        elif isinstance(self._type, DecimalType):
+            return (
+                Bucket._MURMUR3.hash(Bucket._decimal_to_bytes(value))
+                & Bucket._MAX_32_BITS_INT
+            ) % self._num_buckets
+
+        return (
+            Bucket._FUNCTIONS_MAP[self._type][0](value) & Bucket._MAX_32_BITS_INT
+        ) % self._num_buckets
+
+    def can_transform(self, target: Type) -> bool:
+        if isinstance(self._type, FixedType):
+            return target == BinaryType or isinstance(target, FixedType)
+        elif isinstance(self._type, DecimalType):
+            return isinstance(target, DecimalType)
+
+        return Bucket._FUNCTIONS_MAP[self._type][1](target)
+
+    def get_result_type(self, source: Type):
+        return IntegerType
+
+    def to_human_string(self, value):
+        return str(value)
+
+
+class Time(Transform):
+    """
+    Time class is for both Date transforms and Timestamp transforms.
+    """
+
+    _TIME_ORDER = datetime(year=3, month=2, day=1, hour=0)
+    _VALID_TIME_GRANULARITY = {
+        DateType: {"year", "month", "day"},
+        TimestampType: {"year", "month", "day", "hour"},
+        TimestamptzType: {"year", "month", "day", "hour"},
+    }
+    _DIFF_MAP = {
+        "year": lambda t1, t2: (t1.year - t2.year)
+        - (
+            1
+            if t1.month < t2.month or (t1.month == t2.month and t1.day < t2.day)
+            else 0
+        ),
+        "month": lambda t1, t2: (t1.year - t2.year) * 12
+        + (t1.month - t2.month)
+        - (1 if t1.day < t2.day else 0),
+        "day": lambda t1, t2: (t1 - t2).days,
+        "hour": lambda t1, t2: int((t1 - t2).total_seconds() / 3600),
+    }
+
+    def __init__(self, transform_type: Type, name: str):
+        if name not in Time._VALID_TIME_GRANULARITY.get(transform_type, {}):
+            raise ValueError(f"Cannot transform type: {transform_type} by {name}")
+
+        super().__init__(
+            name, f"Time(transform_type={repr(transform_type)}, name={name})"
+        )
+        self._type = transform_type
+        self._name = name
+
+    def apply(self, value: int) -> int:
+        if self._name == "day" and self._type == DateType:
+            return value
+
+        if self._type == DateType:
+            value_time = datetime.utcfromtimestamp(value * 86400)
+        else:
+            value_time = datetime.utcfromtimestamp(value / 1000000)
+
+        return Time._DIFF_MAP[self._name](value_time, Transform._EPOCH)
+
+    def can_transform(self, target: Type) -> bool:
+        if self._type == DateType:
+            return target == DateType
+        else:  # self._type is either TimestampType or TimestamptzType
+            return target == TimestampType or target == TimestamptzType
+
+    def get_result_type(self, source_type: Type) -> Type:
+        if self._name == "day":
+            return DateType
+
+        return IntegerType
+
+    def preserve_order(self) -> bool:
+        return True
+
+    def satisfy_order(self, other: Transform) -> bool:
+        if self == other:
+            return True
+
+        if isinstance(other, Time):
+            return getattr(Time._TIME_ORDER, self._name) <= getattr(
+                Time._TIME_ORDER, other._name
+            )
+
+        return False
+
+    def to_human_string(self, value: int) -> str:
+        if value is None:
+            return "null"
+
+        if self._name == "year":
+            return "{0:0=4d}".format(Transform._EPOCH.year + value)
+        elif self._name == "month":
+            return "{0:0=4d}-{1:0=2d}".format(
+                Transform._EPOCH.year + int(value / 12), 1 + int(value % 12)
+            )
+        elif self._name == "day":
+            return Transform._human_day(value)
+        else:  # self._name == "hour":
+            dt = Transform._EPOCH + timedelta(hours=value)
+            return "{0:0=4d}-{1:0=2d}-{2:0=2d}-{3:0=2d}".format(
+                dt.year, dt.month, dt.day, dt.hour
+            )
+
+    def dedup_name(self) -> str:
+        return "time"
+
+
+class Identity(Transform):
+    _HUMAN_STRING_MAP = {
+        DateType: lambda v: Transform._human_day(v),
+        TimeType: lambda v: f"{(Transform._EPOCH + timedelta(microseconds=v)).time()}",
+        TimestampType: lambda v: (
+            Transform._EPOCH + timedelta(microseconds=v)
+        ).isoformat(),
+        TimestamptzType: lambda v: pytz.timezone("UTC")
+        .localize(Transform._EPOCH + timedelta(microseconds=v))
+        .strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+        BinaryType: lambda v: str(base64.b64encode(v)),
+    }
+
+    def __init__(self, transform_type: Type):
+        super().__init__("identity", f"Identity(transform_type={repr(transform_type)})")
+        self._type = transform_type
+
+    def apply(self, value):
+        return value
+
+    def can_transform(self, target: Type) -> bool:
+        return target.is_primitive
+
+    def preserve_order(self) -> bool:
+        return True
+
+    def satisfy_order(self, other: Transform) -> bool:
+        return other.preserve_order()
+
+    def to_human_string(self, value) -> str:
+        if value is None:
+            return "null"
+
+        if isinstance(self._type, FixedType):
+            return str(base64.b64encode(value))
+
+        return Identity._HUMAN_STRING_MAP.get(self._type, str)(value)
+
+
+class Truncate(Transform):
+    _VALID_TYPES = {IntegerType, LongType, StringType, BinaryType}
+
+    def __init__(self, transform_type: Type, width: int):
+        if transform_type not in Truncate._VALID_TYPES and not isinstance(
+            transform_type, DecimalType
+        ):
+            raise ValueError(f"Cannot truncate type: {transform_type}")
+
+        super().__init__(
+            f"truncate[{width}]",
+            f"Truncate(transform_type={repr(transform_type)}, width={width})",
+        )
+        self._type = transform_type
+        self._width = width
+
+    @property
+    def width(self):
+        return self._width
+
+    def apply(self, value):
+        if value is None:
+            return None
+        if self._type == IntegerType or self._type == LongType:
+            return value - (((value % self._width) + self._width) % self._width)
+        elif self._type == StringType or self._type == BinaryType:
+            return value[0 : min(self._width, len(value))]
+        else:  # decimal case
+            unscaled_value = Transform._unscale_decimal(value)
+            applied_value = unscaled_value - (
+                ((unscaled_value % self._width) + self._width) % self._width
+            )
+            return Decimal(f"{applied_value}e{value.as_tuple().exponent}")
+
+    def can_transform(self, target: Type) -> bool:
+        return self._type == target
+
+    def preserve_order(self) -> bool:
+        return True
+
+    def satisfy_order(self, other: Transform) -> bool:
+        if self._type == other:
+            return True
+        elif (
+            StringType == self._type
+            and isinstance(other, Truncate)
+            and StringType == other._type
+        ):
+            return self._width >= other._width
+
+        return False
+
+    def to_human_string(self, value) -> str:
+        if value is None:
+            return "null"
+
+        return str(base64.b64encode(value)) if self._type == BinaryType else str(value)
+
+
+class UnknownTransform(Transform):
+    def __init__(self, transform_type: Type, transform: str):
+        super().__init__(
+            transform,
+            f"UnknownTransform(transform_type={repr(transform_type)}, transform={transform})",
+        )
+        self._type = transform_type
+        self._transform = transform
+
+    def apply(self, value):
+        raise AttributeError(f"Cannot apply unsupported transform: {self.__str__()}")
+
+    def can_transform(self, target: Type) -> bool:
+        return self._type == target
+
+    def get_result_type(self, source: Type) -> Type:
+        return StringType
+
+
+VoidTransform = Transform("void", "VoidTransform")
+
+_HAS_WIDTH = re.compile("(\\w+)\\[(\\d+)\\]")
+_TIME_TRANSFORMS = {
+    DateType: {
+        "year": Time(DateType, "year"),
+        "month": Time(DateType, "month"),
+        "day": Time(DateType, "day"),
+    },
+    TimestampType: {
+        "year": Time(TimestampType, "year"),
+        "month": Time(TimestampType, "month"),
+        "day": Time(TimestampType, "day"),
+        "hour": Time(TimestampType, "hour"),
+    },
+    TimestamptzType: {
+        "year": Time(TimestamptzType, "year"),
+        "month": Time(TimestamptzType, "month"),
+        "day": Time(TimestamptzType, "day"),
+        "hour": Time(TimestamptzType, "hour"),
+    },
+}
+
+
+def from_string(transform_type: Type, transform: str) -> Transform:
+    match = _HAS_WIDTH.match(transform)
+
+    if match is not None:
+        name = match.group(1)
+        w = int(match.group(2))
+        if name.lower() == "truncate":
+            return Truncate(transform_type, w)
+        elif name.lower() == "bucket":
+            return Bucket(transform_type, w)
+
+    if transform.lower() == "identity":
+        return Identity(transform_type)
+
+    try:
+        return _TIME_TRANSFORMS[transform_type][transform.lower()]
+    except KeyError:
+        pass  # fall through to return unknown transform
+
+    if transform.lower() == "void":
+        return VoidTransform
+
+    return UnknownTransform(transform_type, transform)
+
+
+def identity(transform_type: Type) -> Transform:
+    return Identity(transform_type)
+
+
+def year(transform_type: Type) -> Transform:
+    try:
+        return _TIME_TRANSFORMS[transform_type]["year"]
+    except KeyError:
+        raise ValueError(f"Cannot partition type {transform_type} by year")
+
+
+def month(transform_type: Type) -> Transform:
+    try:
+        return _TIME_TRANSFORMS[transform_type]["month"]
+    except KeyError:
+        raise ValueError(f"Cannot partition type {transform_type} by month")
+
+
+def day(transform_type: Type) -> Transform:
+    try:
+        return _TIME_TRANSFORMS[transform_type]["day"]
+    except KeyError:
+        raise ValueError(f"Cannot partition type {transform_type} by day")
+
+
+def hour(transform_type: Type) -> Transform:
+    try:
+        return _TIME_TRANSFORMS[transform_type]["hour"]
+    except KeyError:
+        raise ValueError(f"Cannot partition type {transform_type} by hour")
+
+
+def bucket(transform_type: Type, num_buckets: int) -> Transform:
+    return Bucket(transform_type, num_buckets)
+
+
+def truncate(transform_type: Type, width: int) -> Transform:
+    return Truncate(transform_type, width)
+
+
+def always_null() -> Transform:
+    return VoidTransform

--- a/python/src/iceberg/transforms.py
+++ b/python/src/iceberg/transforms.py
@@ -41,7 +41,17 @@ from iceberg.utils import transform_util
 
 
 class Transform:
-    """Transform base class for concrete transforms."""
+    """Transform base class for concrete transforms.
+
+    A base class to transform values and project predicates on partition values.
+    This class is not used directly. Instead, use one of module method to create the child classes.
+
+    Args:
+        transform_string (str): name of the transform type
+        repr_string (str): string representation of a transform instance
+        to_human_str (callable, optional): A function that returns the human-readable string
+          given a value. By default, the built-in `str` method is used.
+    """
 
     def __init__(
         self,
@@ -84,6 +94,20 @@ class Transform:
 
 
 class Bucket(Transform):
+    """Transforms a value into a bucket partition value
+
+    Transforms are parameterized by a number of buckets. Bucket partition transforms use a 32-bit
+    hash of the source value to produce a positive value by mod the bucket number.
+
+    Args:
+      source_type (Type): An Iceberg Type of IntegerType, LongType, DecimalType, DateType, TimeType,
+      TimestampType, TimestamptzType, StringType, BinaryType, UUIDType, FloatType, or DoubleType.
+      num_buckets (int): The number of buckets.
+
+    Raises:
+      ValueError: If a type is provided that is incompatible with a Bucket transform
+    """
+
     _MAX_32_BITS_INT = 2147483647
     _INT_TRANSFORMABLE_TYPES = {
         IntegerType,
@@ -233,6 +257,16 @@ class Identity(Transform):
 
 
 class Truncate(Transform):
+    """A transform for truncating a value to a specified width.
+
+    Args:
+      source_type (Type): An Iceberg Type of IntegerType, LongType, StringType, or BinaryType
+      width (int): The truncate width
+
+    Raises:
+      ValueError: If a type is provided that is incompatible with a Truncate transform
+    """
+
     _VALID_TYPES = {IntegerType, LongType, StringType, BinaryType}
     _TO_HUMAN_STR = {BinaryType: transform_util.base64encode}
 
@@ -286,6 +320,16 @@ class Truncate(Transform):
 
 
 class UnknownTransform(Transform):
+    """A transform that represents when an unknown transform is provided
+
+    Args:
+      source_type (Type): An Iceberg `Type`
+      transform (str): A string name of a transform
+
+    Raises:
+      AttributeError: If the apply method is called.
+    """
+
     def __init__(self, source_type: Type, transform: str):
         super().__init__(
             transform,
@@ -305,6 +349,8 @@ class UnknownTransform(Transform):
 
 
 class VoidTransform(Transform):
+    """A transform that always returns null"""
+
     _instance = None
 
     def __new__(cls):

--- a/python/src/iceberg/transforms.py
+++ b/python/src/iceberg/transforms.py
@@ -15,17 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import base64
-import math
 import re
 import struct
-from datetime import datetime, timedelta
-from decimal import Decimal
+from datetime import datetime
+from typing import Any, Callable, Optional
 
 import mmh3  # type: ignore
-import pytz
 
-from .types import (
+from iceberg.types import (
     BinaryType,
     DateType,
     DecimalType,
@@ -41,31 +38,23 @@ from .types import (
     Type,
     UUIDType,
 )
+from iceberg.utils import transform_util
 
 
-class Transform(object):
+class Transform:
     """
     Transform base class for concrete transforms. The default implementation is for VoidTransform.
     """
 
-    _EPOCH = datetime.utcfromtimestamp(0)
-
-    @staticmethod
-    def _human_day(day_ordinal):
-        time = Transform._EPOCH + timedelta(days=day_ordinal)
-        return "{0:0=4d}-{1:0=2d}-{2:0=2d}".format(time.year, time.month, time.day)
-
-    @staticmethod
-    def _unscale_decimal(decimal_value: Decimal):
-        value_tuple = decimal_value.as_tuple()
-        return int(
-            ("-" if value_tuple.sign else "")
-            + "".join([str(d) for d in value_tuple.digits])
-        )
-
-    def __init__(self, transform_string: str, repr_string: str):
+    def __init__(
+        self,
+        transform_string: str,
+        repr_string: str,
+        to_human_str: Callable[[Any], str] = transform_util.to_string,
+    ):
         self._transform_string = transform_string
         self._repr_string = repr_string
+        self._to_human_string = to_human_str
 
     def __repr__(self):
         return self._repr_string
@@ -74,65 +63,66 @@ class Transform(object):
         return self._transform_string
 
     def apply(self, value):
-        return None
+        raise NotImplementedError()
 
     def can_transform(self, target: Type) -> bool:
-        return True
-
-    def get_result_type(self, source: Type) -> Type:
-        return source
-
-    def preserve_order(self) -> bool:
         return False
 
-    def satisfy_order(self, other) -> bool:
+    def result_type(self, source: Type) -> Type:
+        return source
+
+    def preserves_order(self) -> bool:
+        return False
+
+    def satisfies_order_of(self, other) -> bool:
         return self == other
 
     def to_human_string(self, value) -> str:
-        return "null"
+        if value is None:
+            return "null"
+        return self._to_human_string(value)
 
     def dedup_name(self) -> str:
-        return self.__str__()
+        return self._transform_string
 
 
 class Bucket(Transform):
-    _MURMUR3 = mmh3
     _MAX_32_BITS_INT = 2147483647
     _FUNCTIONS_MAP = {  # [0] is hash function and [1] is can_transform check function
         DateType: (
-            lambda v: Bucket._MURMUR3.hash(struct.pack("q", v)),
+            lambda v: mmh3.hash(struct.pack("q", v)),
             lambda t: t in [IntegerType, DateType],
         ),
         IntegerType: (
-            lambda v: Bucket._MURMUR3.hash(struct.pack("q", v)),
+            lambda v: mmh3.hash(struct.pack("q", v)),
             lambda t: t in [IntegerType, DateType],
         ),
         TimeType: (
-            lambda v: Bucket._MURMUR3.hash(struct.pack("q", v)),
+            lambda v: mmh3.hash(struct.pack("q", v)),
             lambda t: t in {LongType, TimeType, TimestampType, TimestamptzType},
         ),
         TimestampType: (
-            lambda v: Bucket._MURMUR3.hash(struct.pack("q", v)),
+            lambda v: mmh3.hash(struct.pack("q", v)),
             lambda t: t in {LongType, TimeType, TimestampType, TimestamptzType},
         ),
         TimestamptzType: (
-            lambda v: Bucket._MURMUR3.hash(struct.pack("q", v)),
+            lambda v: mmh3.hash(struct.pack("q", v)),
             lambda t: t in {LongType, TimeType, TimestampType, TimestamptzType},
         ),
         LongType: (
-            lambda v: Bucket._MURMUR3.hash(struct.pack("q", v)),
+            lambda v: mmh3.hash(struct.pack("q", v)),
             lambda t: t in [LongType, TimeType, TimestampType, TimestamptzType],
         ),
         StringType: (
-            lambda v: Bucket._MURMUR3.hash(v),
+            lambda v: mmh3.hash(v),
             lambda t: t == StringType,
         ),
         BinaryType: (
-            lambda v: Bucket._MURMUR3.hash(v),
-            lambda t: t == BinaryType or isinstance(t, FixedType),
+            lambda v: mmh3.hash(v),
+            lambda t: t == BinaryType,
         ),
         UUIDType: (
-            lambda v: Bucket._MURMUR3.hash(
+            lambda v: mmh3.hash(
                 struct.pack(
                     ">QQ",
                     (v.int >> 64) & 0xFFFFFFFFFFFFFFFF,
@@ -143,71 +133,55 @@ class Bucket(Transform):
         ),
         # bucketing by Float/Double is not allowed by the spec, but they have hash implementation
         FloatType: (
-            lambda v: Bucket._MURMUR3.hash(struct.pack("d", v)),
+            lambda v: mmh3.hash(struct.pack("d", v)),
             lambda t: t == FloatType,
         ),
         DoubleType: (
-            lambda v: Bucket._MURMUR3.hash(struct.pack("d", v)),
+            lambda v: mmh3.hash(struct.pack("d", v)),
             lambda t: t == DoubleType,
         ),
     }
 
-    @staticmethod
-    def _decimal_to_bytes(value: Decimal):
-        unscaled_value = Transform._unscale_decimal(value)
-        number_of_bytes = int(math.ceil(unscaled_value.bit_length() / 8))
-        return unscaled_value.to_bytes(length=number_of_bytes, byteorder="big")
-
-    def __init__(self, transform_type: Type, num_buckets: int):
+    def __init__(self, source_type: Type, num_buckets: int):
         if (
-            transform_type not in Bucket._FUNCTIONS_MAP
-            and not isinstance(transform_type, FixedType)
-            and not isinstance(transform_type, DecimalType)
+            source_type not in Bucket._FUNCTIONS_MAP
+            and not isinstance(source_type, FixedType)
+            and not isinstance(source_type, DecimalType)
         ):
-            raise ValueError(f"Cannot bucket by type: {transform_type}")
+            raise ValueError(f"Cannot bucket by type: {source_type}")
 
         super().__init__(
-            f"bucket[{num_buckets}",
-            f"transforms.bucket(transform_type={repr(transform_type)}, num_buckets={num_buckets})",
+            f"bucket[{num_buckets}]",
+            f"transforms.bucket(source_type={repr(source_type)}, num_buckets={num_buckets})",
         )
-        self._type = transform_type
+        self._type = source_type
         self._num_buckets = num_buckets
+
+        if isinstance(self._type, FixedType):
+            self._hash_func = lambda v: mmh3.hash(v)
+            self._can_transform = lambda t: isinstance(t, FixedType)
+        elif isinstance(self._type, DecimalType):
+            self._hash_func = lambda v: mmh3.hash(transform_util.decimal_to_bytes(v))
+            self._can_transform = lambda t: isinstance(t, DecimalType)
+        else:
+            self._hash_func = Bucket._FUNCTIONS_MAP[self._type][0]
+            self._can_transform = Bucket._FUNCTIONS_MAP[self._type][1]
 
     @property
     def num_buckets(self) -> int:
         return self._num_buckets
 
-    def apply(self, value):
+    def apply(self, value) -> Optional[int]:
         if value is None:
             return None
 
-        if isinstance(self._type, FixedType):
-            return (
-                Bucket._MURMUR3.hash(value) & Bucket._MAX_32_BITS_INT
-            ) % self._num_buckets
-        elif isinstance(self._type, DecimalType):
-            return (
-                Bucket._MURMUR3.hash(Bucket._decimal_to_bytes(value))
-                & Bucket._MAX_32_BITS_INT
-            ) % self._num_buckets
-
-        return (
-            Bucket._FUNCTIONS_MAP[self._type][0](value) & Bucket._MAX_32_BITS_INT
-        ) % self._num_buckets
+        return (self._hash_func(value) & Bucket._MAX_32_BITS_INT) % self._num_buckets
 
     def can_transform(self, target: Type) -> bool:
-        if isinstance(self._type, FixedType):
-            return target == BinaryType or isinstance(target, FixedType)
-        elif isinstance(self._type, DecimalType):
-            return isinstance(target, DecimalType)
+        return self._can_transform(target)
 
-        return Bucket._FUNCTIONS_MAP[self._type][1](target)
-
-    def get_result_type(self, source: Type):
+    def result_type(self, source: Type):
         return IntegerType
-
-    def to_human_string(self, value):
-        return str(value)
 
 
 class Time(Transform):
@@ -215,46 +189,46 @@ class Time(Transform):
     Time class is for both Date transforms and Timestamp transforms.
     """
 
-    _TIME_ORDER = datetime(year=3, month=2, day=1, hour=0)
+    _TIME_SATISFIED_ORDER = dict(year=3, month=2, day=1, hour=0)
     _VALID_TIME_GRANULARITY = {
         DateType: {"year", "month", "day"},
         TimestampType: {"year", "month", "day", "hour"},
         TimestamptzType: {"year", "month", "day", "hour"},
     }
-    _DIFF_MAP = {
-        "year": lambda t1, t2: (t1.year - t2.year)
-        - (
-            1
-            if t1.month < t2.month or (t1.month == t2.month and t1.day < t2.day)
-            else 0
-        ),
-        "month": lambda t1, t2: (t1.year - t2.year) * 12
-        + (t1.month - t2.month)
-        - (1 if t1.day < t2.day else 0),
-        "day": lambda t1, t2: (t1 - t2).days,
-        "hour": lambda t1, t2: int((t1 - t2).total_seconds() / 3600),
-    }
+    _INSTANCES: dict = {DateType: {}, TimestampType: {}, TimestamptzType: {}}
 
-    def __init__(self, transform_type: Type, name: str):
-        if name not in Time._VALID_TIME_GRANULARITY.get(transform_type, {}):
-            raise ValueError(f"Cannot transform type: {transform_type} by {name}")
+    def __new__(cls, source_type: Type, name: str):
+        if cls._INSTANCES.get(source_type, {}).get(name) is None:
+            if name not in Time._VALID_TIME_GRANULARITY.get(source_type, {}):
+                raise ValueError(f"Cannot partition type: {source_type} by {name}")
+            cls._INSTANCES[source_type][name] = super(Time, cls).__new__(cls)
+        return cls._INSTANCES[source_type][name]
 
+    def __init__(self, source_type: Type, name: str):
         super().__init__(
-            name, f"transforms.{name}(transform_type={repr(transform_type)})"
+            name,
+            f"transforms.{name}(source_type={repr(source_type)})",
+            getattr(transform_util, f"human_{name}"),
         )
-        self._type = transform_type
+        self._type = source_type
         self._name = name
 
-    def apply(self, value: int) -> int:
+        self._diff_func = getattr(transform_util, f"diff_{self._name}")
         if self._name == "day" and self._type == DateType:
-            return value
-
-        if self._type == DateType:
-            value_time = datetime.utcfromtimestamp(value * 86400)
+            self._apply = lambda v: v
+        elif self._type == DateType:
+            self._apply = lambda v: self._diff_func(
+                datetime.utcfromtimestamp(v * 86400)
+            )
         else:
-            value_time = datetime.utcfromtimestamp(value / 1000000)
+            self._apply = lambda v: self._diff_func(
+                datetime.utcfromtimestamp(v / 1000000)
+            )
 
-        return Time._DIFF_MAP[self._name](value_time, Transform._EPOCH)
+        self._result_type = DateType if self._name == "day" else IntegerType
+
+    def apply(self, value: int) -> int:
+        return self._apply(value)
 
     def can_transform(self, target: Type) -> bool:
         if self._type == DateType:
@@ -262,43 +236,23 @@ class Time(Transform):
         else:  # self._type is either TimestampType or TimestamptzType
             return target == TimestampType or target == TimestamptzType
 
-    def get_result_type(self, source_type: Type) -> Type:
-        if self._name == "day":
-            return DateType
+    def result_type(self, source_type: Type) -> Type:
+        return self._result_type
 
-        return IntegerType
-
-    def preserve_order(self) -> bool:
+    def preserves_order(self) -> bool:
         return True
 
-    def satisfy_order(self, other: Transform) -> bool:
+    def satisfies_order_of(self, other: Transform) -> bool:
         if self == other:
             return True
 
         if isinstance(other, Time):
-            return getattr(Time._TIME_ORDER, self._name) <= getattr(
-                Time._TIME_ORDER, other._name
+            return (
+                Time._TIME_SATISFIED_ORDER[self._name]
+                <= Time._TIME_SATISFIED_ORDER[other._name]
             )
 
         return False
-
-    def to_human_string(self, value: int) -> str:
-        if value is None:
-            return "null"
-
-        if self._name == "year":
-            return "{0:0=4d}".format(Transform._EPOCH.year + value)
-        elif self._name == "month":
-            return "{0:0=4d}-{1:0=2d}".format(
-                Transform._EPOCH.year + int(value / 12), 1 + int(value % 12)
-            )
-        elif self._name == "day":
-            return Transform._human_day(value)
-        else:  # self._name == "hour":
-            dt = Transform._EPOCH + timedelta(hours=value)
-            return "{0:0=4d}-{1:0=2d}-{2:0=2d}-{3:0=2d}".format(
-                dt.year, dt.month, dt.day, dt.hour
-            )
 
     def dedup_name(self) -> str:
         return "time"
@@ -306,22 +260,26 @@ class Time(Transform):
 
 class Identity(Transform):
     _HUMAN_STRING_MAP = {
-        DateType: lambda v: Transform._human_day(v),
-        TimeType: lambda v: f"{(Transform._EPOCH + timedelta(microseconds=v)).time()}",
-        TimestampType: lambda v: (
-            Transform._EPOCH + timedelta(microseconds=v)
-        ).isoformat(),
-        TimestamptzType: lambda v: pytz.timezone("UTC")
-        .localize(Transform._EPOCH + timedelta(microseconds=v))
-        .strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
-        BinaryType: lambda v: base64.b64encode(v).decode("ISO-8859-1"),
+        DateType: lambda v: transform_util.human_day(v),
+        TimeType: lambda v: transform_util.human_time(v),
+        TimestampType: lambda v: transform_util.human_timestamp(v),
+        TimestamptzType: lambda v: transform_util.human_timestamptz(v),
+        BinaryType: lambda v: transform_util.base64encode(v),
     }
 
-    def __init__(self, transform_type: Type):
+    def __init__(self, source_type: Type):
+        if isinstance(source_type, FixedType):
+            to_human_string = transform_util.base64encode
+        else:
+            to_human_string = Identity._HUMAN_STRING_MAP.get(
+                source_type, transform_util.to_string
+            )
         super().__init__(
-            "identity", f"transforms.identity(transform_type={repr(transform_type)})"
+            "identity",
+            f"transforms.identity(source_type={repr(source_type)})",
+            to_human_string,
         )
-        self._type = transform_type
+        self._type = source_type
 
     def apply(self, value):
         return value
@@ -329,37 +287,38 @@ class Identity(Transform):
     def can_transform(self, target: Type) -> bool:
         return target.is_primitive
 
-    def preserve_order(self) -> bool:
+    def preserves_order(self) -> bool:
         return True
 
-    def satisfy_order(self, other: Transform) -> bool:
-        return other.preserve_order()
-
-    def to_human_string(self, value) -> str:
-        if value is None:
-            return "null"
-
-        if isinstance(self._type, FixedType):
-            return base64.b64encode(value).decode("ISO-8859-1")
-
-        return Identity._HUMAN_STRING_MAP.get(self._type, str)(value)
+    def satisfies_order_of(self, other: Transform) -> bool:
+        return other.preserves_order()
 
 
 class Truncate(Transform):
     _VALID_TYPES = {IntegerType, LongType, StringType, BinaryType}
 
-    def __init__(self, transform_type: Type, width: int):
-        if transform_type not in Truncate._VALID_TYPES and not isinstance(
-            transform_type, DecimalType
+    def __init__(self, source_type: Type, width: int):
+        if source_type not in Truncate._VALID_TYPES and not isinstance(
+            source_type, DecimalType
         ):
-            raise ValueError(f"Cannot truncate type: {transform_type}")
+            raise ValueError(f"Cannot truncate type: {source_type}")
 
         super().__init__(
             f"truncate[{width}]",
-            f"transforms.truncate(transform_type={repr(transform_type)}, width={width})",
+            f"transforms.truncate(source_type={repr(source_type)}, width={width})",
+            transform_util.base64encode
+            if source_type == BinaryType
+            else transform_util.to_string,
         )
-        self._type = transform_type
+        self._type = source_type
         self._width = width
+
+        if self._type == IntegerType or self._type == LongType:
+            self._apply = lambda v, w: v - (((v % w) + w) % w)
+        elif self._type == StringType or self._type == BinaryType:
+            self._apply = lambda v, w: v[0 : min(w, len(v))]
+        else:  # decimal case
+            self._apply = transform_util.truncate_decimal
 
     @property
     def width(self):
@@ -368,24 +327,15 @@ class Truncate(Transform):
     def apply(self, value):
         if value is None:
             return None
-        if self._type == IntegerType or self._type == LongType:
-            return value - (((value % self._width) + self._width) % self._width)
-        elif self._type == StringType or self._type == BinaryType:
-            return value[0 : min(self._width, len(value))]
-        else:  # decimal case
-            unscaled_value = Transform._unscale_decimal(value)
-            applied_value = unscaled_value - (
-                ((unscaled_value % self._width) + self._width) % self._width
-            )
-            return Decimal(f"{applied_value}e{value.as_tuple().exponent}")
+        return self._apply(value, self._width)
 
     def can_transform(self, target: Type) -> bool:
         return self._type == target
 
-    def preserve_order(self) -> bool:
+    def preserves_order(self) -> bool:
         return True
 
-    def satisfy_order(self, other: Transform) -> bool:
+    def satisfies_order_of(self, other: Transform) -> bool:
         if self == other:
             return True
         elif (
@@ -397,24 +347,14 @@ class Truncate(Transform):
 
         return False
 
-    def to_human_string(self, value) -> str:
-        if value is None:
-            return "null"
-
-        return (
-            (base64.b64encode(value)).decode("ISO-8859-1")
-            if self._type == BinaryType
-            else str(value)
-        )
-
 
 class UnknownTransform(Transform):
-    def __init__(self, transform_type: Type, transform: str):
+    def __init__(self, source_type: Type, transform: str):
         super().__init__(
             transform,
-            f"UnknownTransform(transform_type={repr(transform_type)}, transform='{transform}')",
+            f"UnknownTransform(source_type={repr(source_type)}, transform='{transform}')",
         )
-        self._type = transform_type
+        self._type = source_type
         self._transform = transform
 
     def apply(self, value):
@@ -423,98 +363,84 @@ class UnknownTransform(Transform):
     def can_transform(self, target: Type) -> bool:
         return repr(self._type) == repr(target)
 
-    def get_result_type(self, source: Type) -> Type:
+    def result_type(self, source: Type) -> Type:
         return StringType
 
 
-VoidTransform = Transform("void", "transforms.always_null()")
+class VoidTransform(Transform):
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(VoidTransform, cls).__new__(cls)
+        return cls._instance
+
+    def __init__(self):
+        super().__init__("void", "transforms.always_null()", lambda v: "null")
+
+    def apply(self, value):
+        return None
+
+    def can_transform(self, target: Type) -> bool:
+        return True
+
 
 _HAS_WIDTH = re.compile("(\\w+)\\[(\\d+)\\]")
-_TIME_TRANSFORMS = {
-    DateType: {
-        "year": Time(DateType, "year"),
-        "month": Time(DateType, "month"),
-        "day": Time(DateType, "day"),
-    },
-    TimestampType: {
-        "year": Time(TimestampType, "year"),
-        "month": Time(TimestampType, "month"),
-        "day": Time(TimestampType, "day"),
-        "hour": Time(TimestampType, "hour"),
-    },
-    TimestamptzType: {
-        "year": Time(TimestamptzType, "year"),
-        "month": Time(TimestamptzType, "month"),
-        "day": Time(TimestamptzType, "day"),
-        "hour": Time(TimestamptzType, "hour"),
-    },
-}
 
 
-def from_string(transform_type: Type, transform: str) -> Transform:
-    match = _HAS_WIDTH.match(transform)
+def from_string(source_type: Type, transform: str) -> Transform:
+    transform_lower = transform.lower()
+    match = _HAS_WIDTH.match(transform_lower)
 
     if match is not None:
         name = match.group(1)
         w = int(match.group(2))
-        if name.lower() == "truncate":
-            return Truncate(transform_type, w)
-        elif name.lower() == "bucket":
-            return Bucket(transform_type, w)
+        if name == "truncate":
+            return Truncate(source_type, w)
+        elif name == "bucket":
+            return Bucket(source_type, w)
 
-    if transform.lower() == "identity":
-        return Identity(transform_type)
+    if transform_lower == "identity":
+        return Identity(source_type)
 
     try:
-        return _TIME_TRANSFORMS[transform_type][transform.lower()]
-    except KeyError:
+        return Time(source_type, transform_lower)
+    except ValueError:
         pass  # fall through to return unknown transform
 
-    if transform.lower() == "void":
-        return VoidTransform
+    if transform_lower == "void":
+        return VoidTransform()
 
-    return UnknownTransform(transform_type, transform)
-
-
-def identity(transform_type: Type) -> Identity:
-    return Identity(transform_type)
+    return UnknownTransform(source_type, transform)
 
 
-def year(transform_type: Type) -> Time:
-    try:
-        return _TIME_TRANSFORMS[transform_type]["year"]
-    except KeyError:
-        raise ValueError(f"Cannot partition type {transform_type} by year")
+def identity(source_type: Type) -> Identity:
+    return Identity(source_type)
 
 
-def month(transform_type: Type) -> Time:
-    try:
-        return _TIME_TRANSFORMS[transform_type]["month"]
-    except KeyError:
-        raise ValueError(f"Cannot partition type {transform_type} by month")
+def year(source_type: Type) -> Time:
+    return Time(source_type, "year")
 
 
-def day(transform_type: Type) -> Time:
-    try:
-        return _TIME_TRANSFORMS[transform_type]["day"]
-    except KeyError:
-        raise ValueError(f"Cannot partition type {transform_type} by day")
+def month(source_type: Type) -> Time:
+    return Time(source_type, "month")
 
 
-def hour(transform_type: Type) -> Time:
-    try:
-        return _TIME_TRANSFORMS[transform_type]["hour"]
-    except KeyError:
-        raise ValueError(f"Cannot partition type {transform_type} by hour")
+def day(source_type: Type) -> Time:
+    return Time(source_type, "day")
 
 
-def bucket(transform_type: Type, num_buckets: int) -> Bucket:
-    return Bucket(transform_type, num_buckets)
+def hour(source_type: Type) -> Time:
+    return Time(source_type, "hour")
 
 
-def truncate(transform_type: Type, width: int) -> Truncate:
-    return Truncate(transform_type, width)
+def bucket(source_type: Type, num_buckets: int) -> Bucket:
+    return Bucket(source_type, num_buckets)
+
+
+def truncate(source_type: Type, width: int) -> Truncate:
+    return Truncate(source_type, width)
 
 
 def always_null() -> Transform:
-    return VoidTransform
+    return VoidTransform()

--- a/python/src/iceberg/types.py
+++ b/python/src/iceberg/types.py
@@ -31,9 +31,11 @@ Notes:
 
 from abc import ABC, abstractmethod
 from decimal import Decimal
-from typing import Dict, Optional, Tuple
+from typing import Dict, Generic, Optional, Tuple, TypeVar
 
 from iceberg.utils import transform_util
+
+T = TypeVar("T")
 
 
 class Singleton:
@@ -45,9 +47,9 @@ class Singleton:
         return cls._instance
 
 
-class Truncatable(ABC):
+class Truncatable(ABC, Generic[T]):
     @abstractmethod
-    def truncate(self, value, width: int):
+    def truncate(self, value: T, width: int) -> T:
         ...
 
 
@@ -102,7 +104,7 @@ class FixedType(PrimitiveType):
         return self._length
 
 
-class DecimalType(PrimitiveType, Truncatable):
+class DecimalType(PrimitiveType, Truncatable[Decimal]):
     """A fixed data type in Iceberg.
 
     Example:
@@ -354,7 +356,7 @@ class BooleanType(PrimitiveType, Singleton):
             super().__init__("boolean", "BooleanType()")
 
 
-class IntegerType(PrimitiveType, Singleton, Truncatable):
+class IntegerType(PrimitiveType, Singleton, Truncatable[int]):
     """An Integer data type in Iceberg can be represented using an instance of this class. Integers in Iceberg are
     32-bit signed and can be promoted to Longs.
 
@@ -383,7 +385,7 @@ class IntegerType(PrimitiveType, Singleton, Truncatable):
         return value - value % width
 
 
-class LongType(PrimitiveType, Singleton, Truncatable):
+class LongType(PrimitiveType, Singleton, Truncatable[int]):
     """A Long data type in Iceberg can be represented using an instance of this class. Longs in Iceberg are
     64-bit signed integers.
 
@@ -502,7 +504,7 @@ class TimestamptzType(PrimitiveType, Singleton):
             super().__init__("timestamptz", "TimestamptzType()")
 
 
-class StringType(PrimitiveType, Singleton, Truncatable):
+class StringType(PrimitiveType, Singleton, Truncatable[str]):
     """A String data type in Iceberg can be represented using an instance of this class. Strings in
     Iceberg are arbitrary-length character sequences and are encoded with UTF-8.
 
@@ -517,7 +519,7 @@ class StringType(PrimitiveType, Singleton, Truncatable):
             super().__init__("string", "StringType()")
 
     def truncate(self, value: str, width: int) -> str:
-        """Truncate a given string into a given width."""
+        """Truncate a given string to a given width."""
         return value[0 : min(width, len(value))]
 
 
@@ -536,7 +538,7 @@ class UUIDType(PrimitiveType, Singleton):
             super().__init__("uuid", "UUIDType()")
 
 
-class BinaryType(PrimitiveType, Singleton, Truncatable):
+class BinaryType(PrimitiveType, Singleton, Truncatable[bytearray]):
     """A Binary data type in Iceberg can be represented using an instance of this class. Binarys in
     Iceberg are arbitrary-length byte arrays.
 

--- a/python/src/iceberg/types.py
+++ b/python/src/iceberg/types.py
@@ -29,9 +29,10 @@ Notes:
   - https://iceberg.apache.org/#spec/#primitive-types
 """
 
-from typing import Dict, Optional, Tuple
+from abc import ABC, abstractmethod
 from decimal import Decimal
-from typing import Optional
+from typing import Dict, Optional, Tuple
+
 from iceberg.utils import transform_util
 
 
@@ -44,9 +45,10 @@ class Singleton:
         return cls._instance
 
 
-class Truncatable:
+class Truncatable(ABC):
+    @abstractmethod
     def truncate(self, value, width: int):
-        raise ValueError(f"Cannot truncate type: {self}")
+        ...
 
 
 class IcebergType:

--- a/python/src/iceberg/utils/transform_util.py
+++ b/python/src/iceberg/utils/transform_util.py
@@ -24,6 +24,8 @@ import pytz
 
 _EPOCH = datetime.utcfromtimestamp(0)
 _EPOCH_YEAR = _EPOCH.year
+_EPOCH_MONTH = _EPOCH.month
+_EPOCH_DAY = _EPOCH.day
 
 
 def human_year(year_ordinal: int) -> str:
@@ -87,30 +89,47 @@ def truncate_decimal(value: Decimal, width: int) -> Decimal:
     return Decimal(f"{applied_value}e{value.as_tuple().exponent}")
 
 
-def diff_hour(date1: datetime):
-    return int((date1 - _EPOCH).total_seconds() / 3600)
-
-
-def diff_day(date1: datetime):
-    return (date1 - _EPOCH).days
-
-
-def diff_month(date1: datetime):
-    return (
-        (date1.year - _EPOCH.year) * 12
-        + (date1.month - _EPOCH.month)
-        - (1 if date1.day < _EPOCH.day else 0)
+def hours_for_ts(timestamp: int) -> int:
+    return int(
+        (datetime.utcfromtimestamp(timestamp / 1000000) - _EPOCH).total_seconds() / 3600
     )
 
 
-def diff_year(date1: datetime):
-    return (date1.year - _EPOCH.year) - (
+def days_for_ts(timestamp: int) -> int:
+    return (datetime.utcfromtimestamp(timestamp / 1000000) - _EPOCH).days
+
+
+def months_for_days(days: int) -> int:
+    dt = datetime.utcfromtimestamp(days * 86400)
+    return (
+        (dt.year - _EPOCH_YEAR) * 12
+        + (dt.month - _EPOCH_MONTH)
+        - (1 if dt.day < _EPOCH_DAY else 0)
+    )
+
+
+def months_for_ts(timestamp: int) -> int:
+    dt = datetime.utcfromtimestamp(timestamp / 1000000)
+    return (
+        (dt.year - _EPOCH_YEAR) * 12
+        + (dt.month - _EPOCH_MONTH)
+        - (1 if dt.day < _EPOCH_DAY else 0)
+    )
+
+
+def years_for_days(days: int) -> int:
+    dt = datetime.utcfromtimestamp(days * 86400)
+    return (dt.year - _EPOCH_YEAR) - (
         1
-        if date1.month < _EPOCH.month
-        or (date1.month == _EPOCH.month and date1.day < _EPOCH.day)
+        if dt.month < _EPOCH_MONTH or (dt.month == _EPOCH_MONTH and dt.day < _EPOCH_DAY)
         else 0
     )
 
 
-def to_string(value) -> str:
-    return str(value)
+def years_for_ts(timestamp: int) -> int:
+    dt = datetime.utcfromtimestamp(timestamp / 1000000)
+    return (dt.year - _EPOCH_YEAR) - (
+        1
+        if dt.month < _EPOCH_MONTH or (dt.month == _EPOCH_MONTH and dt.day < _EPOCH_DAY)
+        else 0
+    )

--- a/python/src/iceberg/utils/transform_util.py
+++ b/python/src/iceberg/utils/transform_util.py
@@ -33,9 +33,7 @@ def human_year(year_ordinal: int) -> str:
 
 
 def human_month(month_ordinal: int) -> str:
-    return "{0:0=4d}-{1:0=2d}".format(
-        _EPOCH_YEAR + int(month_ordinal / 12), 1 + int(month_ordinal % 12)
-    )
+    return "{0:0=4d}-{1:0=2d}".format(_EPOCH_YEAR + int(month_ordinal / 12), 1 + int(month_ordinal % 12))
 
 
 def human_day(day_ordinal: int) -> str:
@@ -45,9 +43,7 @@ def human_day(day_ordinal: int) -> str:
 
 def human_hour(hour_ordinal: int) -> str:
     time = _EPOCH + timedelta(hours=hour_ordinal)
-    return "{0:0=4d}-{1:0=2d}-{2:0=2d}-{3:0=2d}".format(
-        time.year, time.month, time.day, time.hour
-    )
+    return "{0:0=4d}-{1:0=2d}-{2:0=2d}-{3:0=2d}".format(time.year, time.month, time.day, time.hour)
 
 
 def human_time(micros_from_midnight: int) -> str:
@@ -71,10 +67,7 @@ def base64encode(buffer: bytes) -> str:
 
 def _unscale_decimal(decimal_value: Decimal) -> int:
     value_tuple = decimal_value.as_tuple()
-    return int(
-        ("-" if value_tuple.sign else "")
-        + "".join([str(d) for d in value_tuple.digits])
-    )
+    return int(("-" if value_tuple.sign else "") + "".join([str(d) for d in value_tuple.digits]))
 
 
 def decimal_to_bytes(value: Decimal) -> bytes:
@@ -90,9 +83,7 @@ def truncate_decimal(value: Decimal, width: int) -> Decimal:
 
 
 def hours_for_ts(timestamp: int) -> int:
-    return int(
-        (datetime.utcfromtimestamp(timestamp / 1000000) - _EPOCH).total_seconds() / 3600
-    )
+    return int((datetime.utcfromtimestamp(timestamp / 1000000) - _EPOCH).total_seconds() / 3600)
 
 
 def days_for_ts(timestamp: int) -> int:
@@ -101,35 +92,19 @@ def days_for_ts(timestamp: int) -> int:
 
 def months_for_days(days: int) -> int:
     dt = datetime.utcfromtimestamp(days * 86400)
-    return (
-        (dt.year - _EPOCH_YEAR) * 12
-        + (dt.month - _EPOCH_MONTH)
-        - (1 if dt.day < _EPOCH_DAY else 0)
-    )
+    return (dt.year - _EPOCH_YEAR) * 12 + (dt.month - _EPOCH_MONTH) - (1 if dt.day < _EPOCH_DAY else 0)
 
 
 def months_for_ts(timestamp: int) -> int:
     dt = datetime.utcfromtimestamp(timestamp / 1000000)
-    return (
-        (dt.year - _EPOCH_YEAR) * 12
-        + (dt.month - _EPOCH_MONTH)
-        - (1 if dt.day < _EPOCH_DAY else 0)
-    )
+    return (dt.year - _EPOCH_YEAR) * 12 + (dt.month - _EPOCH_MONTH) - (1 if dt.day < _EPOCH_DAY else 0)
 
 
 def years_for_days(days: int) -> int:
     dt = datetime.utcfromtimestamp(days * 86400)
-    return (dt.year - _EPOCH_YEAR) - (
-        1
-        if dt.month < _EPOCH_MONTH or (dt.month == _EPOCH_MONTH and dt.day < _EPOCH_DAY)
-        else 0
-    )
+    return (dt.year - _EPOCH_YEAR) - (1 if dt.month < _EPOCH_MONTH or (dt.month == _EPOCH_MONTH and dt.day < _EPOCH_DAY) else 0)
 
 
 def years_for_ts(timestamp: int) -> int:
     dt = datetime.utcfromtimestamp(timestamp / 1000000)
-    return (dt.year - _EPOCH_YEAR) - (
-        1
-        if dt.month < _EPOCH_MONTH or (dt.month == _EPOCH_MONTH and dt.day < _EPOCH_DAY)
-        else 0
-    )
+    return (dt.year - _EPOCH_YEAR) - (1 if dt.month < _EPOCH_MONTH or (dt.month == _EPOCH_MONTH and dt.day < _EPOCH_DAY) else 0)

--- a/python/src/iceberg/utils/transform_util.py
+++ b/python/src/iceberg/utils/transform_util.py
@@ -1,0 +1,116 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import base64
+import math
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+import pytz
+
+_EPOCH = datetime.utcfromtimestamp(0)
+_EPOCH_YEAR = _EPOCH.year
+
+
+def human_year(year_ordinal: int) -> str:
+    return "{0:0=4d}".format(_EPOCH_YEAR + year_ordinal)
+
+
+def human_month(month_ordinal: int) -> str:
+    return "{0:0=4d}-{1:0=2d}".format(
+        _EPOCH_YEAR + int(month_ordinal / 12), 1 + int(month_ordinal % 12)
+    )
+
+
+def human_day(day_ordinal: int) -> str:
+    time = _EPOCH + timedelta(days=day_ordinal)
+    return "{0:0=4d}-{1:0=2d}-{2:0=2d}".format(time.year, time.month, time.day)
+
+
+def human_hour(hour_ordinal: int) -> str:
+    time = _EPOCH + timedelta(hours=hour_ordinal)
+    return "{0:0=4d}-{1:0=2d}-{2:0=2d}-{3:0=2d}".format(
+        time.year, time.month, time.day, time.hour
+    )
+
+
+def human_time(micros_from_midnight: int) -> str:
+    day = _EPOCH + timedelta(microseconds=micros_from_midnight)
+    return f"{day.time()}"
+
+
+def human_timestamptz(timestamp_micros: int) -> str:
+    day = _EPOCH + timedelta(microseconds=timestamp_micros)
+    return pytz.timezone("UTC").localize(day).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def human_timestamp(timestamp_micros: int) -> str:
+    day = _EPOCH + timedelta(microseconds=timestamp_micros)
+    return day.isoformat()
+
+
+def base64encode(buffer: bytes) -> str:
+    return base64.b64encode(buffer).decode("ISO-8859-1")
+
+
+def _unscale_decimal(decimal_value: Decimal) -> int:
+    value_tuple = decimal_value.as_tuple()
+    return int(
+        ("-" if value_tuple.sign else "")
+        + "".join([str(d) for d in value_tuple.digits])
+    )
+
+
+def decimal_to_bytes(value: Decimal) -> bytes:
+    unscaled_value = _unscale_decimal(value)
+    number_of_bytes = int(math.ceil(unscaled_value.bit_length() / 8))
+    return unscaled_value.to_bytes(length=number_of_bytes, byteorder="big")
+
+
+def truncate_decimal(value: Decimal, width: int) -> Decimal:
+    unscaled_value = _unscale_decimal(value)
+    applied_value = unscaled_value - (((unscaled_value % width) + width) % width)
+    return Decimal(f"{applied_value}e{value.as_tuple().exponent}")
+
+
+def diff_hour(date1: datetime):
+    return int((date1 - _EPOCH).total_seconds() / 3600)
+
+
+def diff_day(date1: datetime):
+    return (date1 - _EPOCH).days
+
+
+def diff_month(date1: datetime):
+    return (
+        (date1.year - _EPOCH.year) * 12
+        + (date1.month - _EPOCH.month)
+        - (1 if date1.day < _EPOCH.day else 0)
+    )
+
+
+def diff_year(date1: datetime):
+    return (date1.year - _EPOCH.year) - (
+        1
+        if date1.month < _EPOCH.month
+        or (date1.month == _EPOCH.month and date1.day < _EPOCH.day)
+        else 0
+    )
+
+
+def to_string(value) -> str:
+    return str(value)

--- a/python/tests/test_transforms.py
+++ b/python/tests/test_transforms.py
@@ -15,19 +15,33 @@
 # specific language governing permissions and limitations
 # under the License.
 
-
-from decimal import Decimal
+from datetime import datetime
+from decimal import Decimal, getcontext
+from uuid import UUID
 
 import pytest
 
 from iceberg import transforms
+from iceberg.transforms import UnknownTransform
 from iceberg.types import (
+    BinaryType,
+    BooleanType,
+    DateType,
     DecimalType,
     DoubleType,
+    FixedType,
     FloatType,
     IntegerType,
+    ListType,
     LongType,
+    MapType,
+    NestedField,
     StringType,
+    StructType,
+    TimestampType,
+    TimestamptzType,
+    TimeType,
+    UUIDType,
 )
 
 
@@ -39,10 +53,165 @@ from iceberg.types import (
         (34, LongType, 2017239379),
         (1, FloatType, -142385009),
         (1, DoubleType, -142385009),
+        (17486, DateType, -653330422),
+        (81068000000, TimeType, -662762989),
+        (
+            int(
+                datetime.fromisoformat("2017-11-16T22:31:08+00:00").timestamp()
+                * 1000000
+            ),
+            TimestampType,
+            -2047944441,
+        ),
+        (
+            int(
+                datetime.fromisoformat("2017-11-16T14:31:08-08:00").timestamp()
+                * 1000000
+            ),
+            TimestamptzType,
+            -2047944441,
+        ),
     ],
 )
 def test_spec_values_int(test_input, test_type, expected):
     assert transforms.Bucket._FUNCTIONS_MAP[test_type][0](test_input) == expected
+
+
+@pytest.mark.parametrize(
+    "test_input,test_type,scale_factor,expected",
+    [
+        (Decimal("14.20"), DecimalType(9, 2), Decimal(10) ** -2, 59),
+        (
+            Decimal("137302769811943318102518958871258.37580"),
+            DecimalType(38, 5),
+            Decimal(10) ** -5,
+            63,
+        ),
+    ],
+)
+def test_decimal_bucket(test_input, test_type, scale_factor, expected):
+    getcontext().prec = 38
+    assert (
+        transforms.bucket(test_type, 100).apply(test_input.quantize(scale_factor))
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    "bucket,value,expected",
+    [
+        (transforms.bucket(IntegerType, 100), 34, 79),
+        (transforms.bucket(LongType, 100), 34, 79),
+        (transforms.bucket(DateType, 100), 17486, 26),
+        (transforms.bucket(TimeType, 100), 81068000000, 59),
+        (transforms.bucket(TimestampType, 100), 1510871468000000, 7),
+        (transforms.bucket(DecimalType(9, 2), 100), Decimal("14.20"), 59),
+        (transforms.bucket(StringType, 100), "iceberg", 89),
+        (
+            transforms.bucket(UUIDType, 100),
+            UUID("f79c3e09-677c-4bbd-a479-3f349cb785e7"),
+            40,
+        ),
+        (transforms.bucket(FixedType(3), 128), b"foo", 32),
+        (transforms.bucket(BinaryType, 128), b"\x00\x01\x02\x03", 57),
+    ],
+)
+def test_buckets(bucket, value, expected):
+    assert bucket.apply(value) == expected
+
+
+@pytest.mark.parametrize(
+    "date,time_transform_name,expected",
+    [
+        (47, "year", "2017"),
+        (575, "month", "2017-12"),
+        (17501, "day", "2017-12-01"),
+    ],
+)
+def test_time_to_human_string(date, time_transform_name, expected):
+    assert (
+        getattr(transforms, time_transform_name)(DateType).to_human_string(date)
+        == expected
+    )
+
+
+@pytest.mark.parametrize("time_transform_name", ["year", "month", "day", "hour"])
+def test_null_human_string(time_transform_name):
+    assert (
+        getattr(transforms, time_transform_name)(TimestamptzType).to_human_string(None)
+        == "null"
+    )
+
+
+@pytest.mark.parametrize(
+    "timestamp,time_transform_name,expected",
+    [
+        (47, "year", "2017"),
+        (575, "month", "2017-12"),
+        (17501, "day", "2017-12-01"),
+        (420042, "hour", "2017-12-01-18"),
+    ],
+)
+def test_ts_to_human_string(timestamp, time_transform_name, expected):
+    assert (
+        getattr(transforms, time_transform_name)(TimestampType).to_human_string(
+            timestamp
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize("time_transform_name", ["year", "month", "day", "hour"])
+def test_null_human_string(time_transform_name):
+    assert (
+        getattr(transforms, time_transform_name)(TimestampType).to_human_string(None)
+        == "null"
+    )
+
+
+@pytest.mark.parametrize(
+    "timestamp,time_transform_name,expected",
+    [
+        (47, "year", "2017"),
+        (575, "month", "2017-12"),
+        (17501, "day", "2017-12-01"),
+        (420042, "hour", "2017-12-01-18"),
+    ],
+)
+def test_ts_to_human_string(timestamp, time_transform_name, expected):
+    assert (
+        getattr(transforms, time_transform_name)(TimestamptzType).to_human_string(
+            timestamp
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize("time_transform_name", ["year", "month", "day", "hour"])
+def test_null_human_string(time_transform_name):
+    assert (
+        getattr(transforms, time_transform_name)(TimestamptzType).to_human_string(None)
+        == "null"
+    )
+
+
+@pytest.mark.parametrize(
+    "type_var,value,expected",
+    [
+        (LongType, None, "null"),
+        (DateType, 17501, "2017-12-01"),
+        (TimeType, 36775038194, "10:12:55.038194"),
+        (TimestamptzType, 1512151975038194, "2017-12-01T18:12:55.038194Z"),
+        (TimestampType, 1512151975038194, "2017-12-01T18:12:55.038194"),
+        (LongType, -1234567890000, "-1234567890000"),
+        (StringType, "a/b/c=d", "a/b/c=d"),
+        (DecimalType(9, 2), Decimal("-1.50"), "-1.50"),
+        (FixedType(100), b"foo", "Zm9v"),
+    ],
+)
+def test_identity_human_string(type_var, value, expected):
+    identity = transforms.identity(type_var)
+    assert identity.to_human_string(value) == expected
 
 
 @pytest.mark.parametrize("type_var", [IntegerType, LongType])
@@ -74,3 +243,285 @@ def test_truncate_decimal(input_var, expected):
 def test_truncate_string(input_var, expected):
     trunc = transforms.truncate(StringType, 5)
     assert trunc.apply(input_var) == expected
+
+
+@pytest.mark.parametrize(
+    "type_var",
+    [
+        BinaryType,
+        DateType,
+        DecimalType(8, 5),
+        DoubleType,
+        FixedType(8),
+        FloatType,
+        IntegerType,
+        LongType,
+        StringType,
+        TimestampType,
+        TimestamptzType,
+        TimeType,
+        UUIDType,
+    ],
+)
+def test_bucket_method(type_var):
+    bucket_transform = transforms.bucket(type_var, 8)
+    assert str(bucket_transform) == str(eval(repr(bucket_transform)))
+    assert bucket_transform.can_transform(type_var)
+    assert bucket_transform.get_result_type(type_var) == IntegerType
+    assert bucket_transform.num_buckets == 8
+    assert bucket_transform.apply(None) is None
+    assert bucket_transform.to_human_string("test") == "test"
+
+
+@pytest.mark.parametrize(
+    "type_var,value,expected",
+    [
+        (BinaryType, b"foo", "Zm9v"),
+        (DecimalType(8, 5), Decimal("14.20"), "14.20"),
+        (IntegerType, 123, "123"),
+        (LongType, 123, "123"),
+        (StringType, "foo", "foo"),
+    ],
+)
+def test_truncate_method(type_var, value, expected):
+    truncate_transform = transforms.truncate(type_var, 8)
+    assert str(truncate_transform) == str(eval(repr(truncate_transform)))
+    assert truncate_transform.can_transform(type_var)
+    assert truncate_transform.get_result_type(type_var) == type_var
+    assert truncate_transform.to_human_string(None) == "null"
+    assert truncate_transform.to_human_string(value) == expected
+    assert truncate_transform.width == 8
+    assert truncate_transform.apply(None) is None
+    assert truncate_transform.preserve_order()
+    assert truncate_transform.satisfy_order(truncate_transform)
+
+
+@pytest.mark.parametrize(
+    "type_var",
+    [
+        DateType,
+        TimestampType,
+        TimestamptzType,
+    ],
+)
+def test_time_methods(type_var):
+    assert str(transforms.year(type_var)) == str(eval(repr(transforms.year(type_var))))
+    assert str(transforms.month(type_var)) == str(
+        eval(repr(transforms.month(type_var)))
+    )
+    assert str(transforms.day(type_var)) == str(eval(repr(transforms.day(type_var))))
+    assert transforms.year(type_var).can_transform(type_var)
+    assert transforms.month(type_var).can_transform(type_var)
+    assert transforms.day(type_var).can_transform(type_var)
+    assert transforms.year(type_var).preserve_order()
+    assert transforms.month(type_var).preserve_order()
+    assert transforms.day(type_var).preserve_order()
+    assert transforms.year(type_var).get_result_type(type_var) == IntegerType
+    assert transforms.month(type_var).get_result_type(type_var) == IntegerType
+    assert transforms.day(type_var).get_result_type(type_var) == DateType
+    assert transforms.year(type_var).dedup_name() == "time"
+    assert transforms.month(type_var).dedup_name() == "time"
+    assert transforms.day(type_var).dedup_name() == "time"
+
+
+@pytest.mark.parametrize(
+    "transform,value,expected",
+    [
+        (transforms.day(DateType), 17501, 17501),
+        (transforms.month(DateType), 17501, 575),
+        (transforms.year(DateType), 17501, 47),
+        (transforms.year(TimestampType), 1512151975038194, 47),
+        (transforms.month(TimestamptzType), 1512151975038194, 575),
+        (transforms.day(TimestampType), 1512151975038194, 17501),
+    ],
+)
+def test_time_apply_method(transform, value, expected):
+    assert transform.apply(value) == expected
+
+
+@pytest.mark.parametrize(
+    "type_var",
+    [
+        TimestampType,
+        TimestamptzType,
+    ],
+)
+def test_hour_method(type_var):
+    assert str(transforms.hour(type_var)) == str(eval(repr(transforms.hour(type_var))))
+    assert transforms.hour(type_var).can_transform(type_var)
+    assert transforms.hour(type_var).get_result_type(type_var) == IntegerType
+    assert transforms.hour(type_var).apply(1512151975038194) == 420042
+    assert transforms.hour(type_var).dedup_name() == "time"
+
+
+@pytest.mark.parametrize(
+    "type_var",
+    [
+        BinaryType,
+        BooleanType,
+        DateType,
+        DecimalType(8, 2),
+        DoubleType,
+        FixedType(16),
+        FloatType,
+        IntegerType,
+        LongType,
+        StringType,
+        TimestampType,
+        TimestamptzType,
+        TimeType,
+        UUIDType,
+    ],
+)
+def test_identity_method(type_var):
+    identity_transform = transforms.identity(type_var)
+    assert str(identity_transform) == str(eval(repr(identity_transform)))
+    assert identity_transform.can_transform(type_var)
+    assert identity_transform.get_result_type(type_var) == type_var
+    assert identity_transform.apply("test") == "test"
+
+
+@pytest.mark.parametrize(
+    "type_var",
+    [
+        ListType(
+            NestedField(
+                False,
+                1,
+                "required_field",
+                StructType(
+                    [
+                        NestedField(True, 2, "optional_field", DecimalType(8, 2)),
+                        NestedField(False, 3, "required_field", LongType),
+                    ]
+                ),
+            )
+        ),
+        MapType(
+            NestedField(True, 1, "optional_field", DoubleType),
+            NestedField(False, 2, "required_field", UUIDType),
+        ),
+        StructType(
+            [
+                NestedField(True, 1, "optional_field", IntegerType),
+                NestedField(False, 2, "required_field", FixedType(5)),
+                NestedField(
+                    False,
+                    3,
+                    "required_field",
+                    StructType(
+                        [
+                            NestedField(True, 4, "optional_field", DecimalType(8, 2)),
+                            NestedField(False, 5, "required_field", LongType),
+                        ]
+                    ),
+                ),
+            ]
+        ),
+    ],
+)
+def test_identity_nested_type(type_var):
+    identity_transform = transforms.identity(type_var)
+    assert str(identity_transform) == str(eval(repr(identity_transform)))
+    assert not identity_transform.can_transform(type_var)
+
+
+def test_void_transform():
+    void_transform = transforms.always_null()
+    assert str(void_transform) == str(eval(repr(void_transform)))
+    assert void_transform.apply("test") is None
+    assert void_transform.can_transform(BooleanType)
+    assert void_transform.get_result_type(BooleanType) == BooleanType
+    assert not void_transform.preserve_order()
+    assert void_transform.satisfy_order(transforms.always_null())
+    assert not void_transform.satisfy_order(transforms.year(DateType))
+    assert void_transform.to_human_string("test") == "null"
+    assert void_transform.dedup_name() == "void"
+
+
+def test_unknown_transform():
+    unknown_transform = UnknownTransform(FixedType(8), "unknown")
+    assert str(unknown_transform) == str(eval(repr(unknown_transform)))
+    with pytest.raises(AttributeError):
+        unknown_transform.apply("test")
+    assert unknown_transform.can_transform(FixedType(8))
+    assert not unknown_transform.can_transform(FixedType(5))
+    assert unknown_transform.get_result_type(BooleanType) == StringType
+
+
+@pytest.mark.parametrize(
+    "type_var,transform,expected",
+    [
+        (BinaryType, "bucket[100]", transforms.bucket(BinaryType, 100)),
+        (BooleanType, "identity", transforms.identity(BooleanType)),
+        (DateType, "year", transforms.year(DateType)),
+        (DecimalType(8, 2), "truncate[5]", transforms.truncate(DecimalType(8, 2), 5)),
+        (DoubleType, "identity", transforms.identity(DoubleType)),
+        (FixedType(16), "bucket[32]", transforms.bucket(FixedType(16), 32)),
+        (FloatType, "identity", transforms.identity(FloatType)),
+        (IntegerType, "void", transforms.always_null()),
+        (LongType, "bucket[16]", transforms.bucket(LongType, 16)),
+        (StringType, "truncate[8]", transforms.truncate(StringType, 8)),
+        (TimestampType, "month", transforms.month(TimestampType)),
+        (TimestamptzType, "hour", transforms.hour(TimestamptzType)),
+        (TimeType, "day", UnknownTransform(TimeType, "day")),
+        (UUIDType, "bucket[16]", transforms.bucket(UUIDType, 16)),
+    ],
+)
+def test_from_string(type_var, transform, expected):
+    assert repr(transforms.from_string(type_var, transform)) == repr(expected)
+
+
+@pytest.mark.parametrize(
+    "transform,other_transform,expected",
+    [
+        (transforms.identity(BooleanType), transforms.identity(IntegerType), True),
+        (transforms.identity(BooleanType), transforms.always_null(), False),
+        (transforms.year(DateType), transforms.year(DateType), True),
+        (transforms.year(DateType), transforms.month(DateType), False),
+        (transforms.year(DateType), transforms.day(DateType), False),
+        (transforms.year(DateType), transforms.hour(TimestampType), False),
+        (transforms.hour(TimestampType), transforms.month(DateType), True),
+        (transforms.day(TimestamptzType), transforms.month(DateType), True),
+        (transforms.day(TimestamptzType), transforms.always_null(), False),
+        (
+            transforms.truncate(StringType, 8),
+            transforms.truncate(StringType, 16),
+            False,
+        ),
+        (
+            transforms.truncate(StringType, 16),
+            transforms.truncate(StringType, 16),
+            True,
+        ),
+        (
+            transforms.truncate(StringType, 32),
+            transforms.truncate(StringType, 16),
+            True,
+        ),
+        (
+            transforms.truncate(StringType, 16),
+            transforms.truncate(IntegerType, 8),
+            False,
+        ),
+    ],
+)
+def test_satisfy_order(transform, other_transform, expected):
+    assert transform.satisfy_order(other_transform) == expected
+
+
+def test_invalid_cases():
+    with pytest.raises(ValueError):
+        transforms.hour(DateType)
+    with pytest.raises(ValueError):
+        transforms.day(IntegerType)
+    with pytest.raises(ValueError):
+        transforms.month(BinaryType)
+    with pytest.raises(ValueError):
+        transforms.year(UUIDType)
+    with pytest.raises(ValueError):
+        transforms.bucket(BooleanType, 8)
+    with pytest.raises(ValueError):
+        transforms.truncate(UUIDType, 8)
+    with pytest.raises(ValueError):
+        transforms.Time(DateType, "hour")

--- a/python/tests/test_transforms.py
+++ b/python/tests/test_transforms.py
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+from decimal import Decimal
+
+import pytest
+
+from iceberg import transforms
+from iceberg.types import (
+    DecimalType,
+    DoubleType,
+    FloatType,
+    IntegerType,
+    LongType,
+    StringType,
+)
+
+
+@pytest.mark.parametrize(
+    "test_input,test_type,expected",
+    [
+        (1, IntegerType, 1392991556),
+        (34, IntegerType, 2017239379),
+        (34, LongType, 2017239379),
+        (1, FloatType, -142385009),
+        (1, DoubleType, -142385009),
+    ],
+)
+def test_spec_values_int(test_input, test_type, expected):
+    assert transforms.Bucket._FUNCTIONS_MAP[test_type][0](test_input) == expected
+
+
+@pytest.mark.parametrize("type_var", [IntegerType, LongType])
+@pytest.mark.parametrize(
+    "input_var,expected",
+    [(1, 0), (5, 0), (9, 0), (10, 10), (11, 10), (-1, -10), (-10, -10), (-12, -20)],
+)
+def test_truncate_integer(type_var, input_var, expected):
+    trunc = transforms.truncate(type_var, 10)
+    assert trunc.apply(input_var) == expected
+
+
+@pytest.mark.parametrize(
+    "input_var,expected",
+    [
+        (Decimal(12.34).quantize(Decimal(".01")), Decimal("12.30")),
+        (Decimal(12.30).quantize(Decimal(".01")), Decimal("12.30")),
+        (Decimal(12.20).quantize(Decimal(".01")), Decimal("12.20")),
+        (Decimal(0.05).quantize(Decimal(".01")), Decimal("0.00")),
+        (Decimal(-0.05).quantize(Decimal(".01")), Decimal("-0.10")),
+    ],
+)
+def test_truncate_decimal(input_var, expected):
+    trunc = transforms.truncate(DecimalType(9, 2), 10)
+    assert trunc.apply(input_var) == expected
+
+
+@pytest.mark.parametrize("input_var,expected", [("abcdefg", "abcde"), ("abc", "abc")])
+def test_truncate_string(input_var, expected):
+    trunc = transforms.truncate(StringType, 5)
+    assert trunc.apply(input_var) == expected

--- a/python/tests/test_transforms.py
+++ b/python/tests/test_transforms.py
@@ -267,7 +267,7 @@ def test_bucket_method(type_var):
     bucket_transform = transforms.bucket(type_var, 8)
     assert str(bucket_transform) == str(eval(repr(bucket_transform)))
     assert bucket_transform.can_transform(type_var)
-    assert bucket_transform.get_result_type(type_var) == IntegerType
+    assert bucket_transform.result_type(type_var) == IntegerType
     assert bucket_transform.num_buckets == 8
     assert bucket_transform.apply(None) is None
     assert bucket_transform.to_human_string("test") == "test"
@@ -287,13 +287,13 @@ def test_truncate_method(type_var, value, expected):
     truncate_transform = transforms.truncate(type_var, 8)
     assert str(truncate_transform) == str(eval(repr(truncate_transform)))
     assert truncate_transform.can_transform(type_var)
-    assert truncate_transform.get_result_type(type_var) == type_var
+    assert truncate_transform.result_type(type_var) == type_var
     assert truncate_transform.to_human_string(None) == "null"
     assert truncate_transform.to_human_string(value) == expected
     assert truncate_transform.width == 8
     assert truncate_transform.apply(None) is None
-    assert truncate_transform.preserve_order()
-    assert truncate_transform.satisfy_order(truncate_transform)
+    assert truncate_transform.preserves_order()
+    assert truncate_transform.satisfies_order_of(truncate_transform)
 
 
 @pytest.mark.parametrize(
@@ -305,20 +305,18 @@ def test_truncate_method(type_var, value, expected):
     ],
 )
 def test_time_methods(type_var):
-    assert str(transforms.year(type_var)) == str(eval(repr(transforms.year(type_var))))
-    assert str(transforms.month(type_var)) == str(
-        eval(repr(transforms.month(type_var)))
-    )
-    assert str(transforms.day(type_var)) == str(eval(repr(transforms.day(type_var))))
+    assert transforms.year(type_var) == eval(repr(transforms.year(type_var)))
+    assert transforms.month(type_var) == eval(repr(transforms.month(type_var)))
+    assert transforms.day(type_var) == eval(repr(transforms.day(type_var)))
     assert transforms.year(type_var).can_transform(type_var)
     assert transforms.month(type_var).can_transform(type_var)
     assert transforms.day(type_var).can_transform(type_var)
-    assert transforms.year(type_var).preserve_order()
-    assert transforms.month(type_var).preserve_order()
-    assert transforms.day(type_var).preserve_order()
-    assert transforms.year(type_var).get_result_type(type_var) == IntegerType
-    assert transforms.month(type_var).get_result_type(type_var) == IntegerType
-    assert transforms.day(type_var).get_result_type(type_var) == DateType
+    assert transforms.year(type_var).preserves_order()
+    assert transforms.month(type_var).preserves_order()
+    assert transforms.day(type_var).preserves_order()
+    assert transforms.year(type_var).result_type(type_var) == IntegerType
+    assert transforms.month(type_var).result_type(type_var) == IntegerType
+    assert transforms.day(type_var).result_type(type_var) == DateType
     assert transforms.year(type_var).dedup_name() == "time"
     assert transforms.month(type_var).dedup_name() == "time"
     assert transforms.day(type_var).dedup_name() == "time"
@@ -347,9 +345,9 @@ def test_time_apply_method(transform, value, expected):
     ],
 )
 def test_hour_method(type_var):
-    assert str(transforms.hour(type_var)) == str(eval(repr(transforms.hour(type_var))))
+    assert transforms.hour(type_var) == eval(repr(transforms.hour(type_var)))
     assert transforms.hour(type_var).can_transform(type_var)
-    assert transforms.hour(type_var).get_result_type(type_var) == IntegerType
+    assert transforms.hour(type_var).result_type(type_var) == IntegerType
     assert transforms.hour(type_var).apply(1512151975038194) == 420042
     assert transforms.hour(type_var).dedup_name() == "time"
 
@@ -377,7 +375,7 @@ def test_identity_method(type_var):
     identity_transform = transforms.identity(type_var)
     assert str(identity_transform) == str(eval(repr(identity_transform)))
     assert identity_transform.can_transform(type_var)
-    assert identity_transform.get_result_type(type_var) == type_var
+    assert identity_transform.result_type(type_var) == type_var
     assert identity_transform.apply("test") == "test"
 
 
@@ -428,13 +426,13 @@ def test_identity_nested_type(type_var):
 
 def test_void_transform():
     void_transform = transforms.always_null()
-    assert str(void_transform) == str(eval(repr(void_transform)))
+    assert void_transform == eval(repr(void_transform))
     assert void_transform.apply("test") is None
     assert void_transform.can_transform(BooleanType)
-    assert void_transform.get_result_type(BooleanType) == BooleanType
-    assert not void_transform.preserve_order()
-    assert void_transform.satisfy_order(transforms.always_null())
-    assert not void_transform.satisfy_order(transforms.year(DateType))
+    assert void_transform.result_type(BooleanType) == BooleanType
+    assert not void_transform.preserves_order()
+    assert void_transform.satisfies_order_of(transforms.always_null())
+    assert not void_transform.satisfies_order_of(transforms.year(DateType))
     assert void_transform.to_human_string("test") == "null"
     assert void_transform.dedup_name() == "void"
 
@@ -446,7 +444,7 @@ def test_unknown_transform():
         unknown_transform.apply("test")
     assert unknown_transform.can_transform(FixedType(8))
     assert not unknown_transform.can_transform(FixedType(5))
-    assert unknown_transform.get_result_type(BooleanType) == StringType
+    assert unknown_transform.result_type(BooleanType) == StringType
 
 
 @pytest.mark.parametrize(
@@ -470,6 +468,7 @@ def test_unknown_transform():
 )
 def test_from_string(type_var, transform, expected):
     assert repr(transforms.from_string(type_var, transform)) == repr(expected)
+    assert transform == str(expected)
 
 
 @pytest.mark.parametrize(
@@ -506,8 +505,8 @@ def test_from_string(type_var, transform, expected):
         ),
     ],
 )
-def test_satisfy_order(transform, other_transform, expected):
-    assert transform.satisfy_order(other_transform) == expected
+def test_satisfies_order_of(transform, other_transform, expected):
+    assert transform.satisfies_order_of(other_transform) == expected
 
 
 def test_invalid_cases():

--- a/python/tests/test_transforms.py
+++ b/python/tests/test_transforms.py
@@ -366,38 +366,26 @@ def test_identity_method(type_var):
     "type_var",
     [
         ListType(
+            1,
+            StructType(
+                NestedField(2, "optional_field", DecimalType(8, 2), is_optional=True),
+                NestedField(3, "required_field", LongType(), is_optional=False),
+            ),
+            False,
+        ),
+        MapType(1, DoubleType(), 2, UUIDType(), False),
+        StructType(
+            NestedField(1, "optional_field", IntegerType(), is_optional=True),
+            NestedField(2, "required_field", FixedType(5), is_optional=False),
             NestedField(
-                False,
-                1,
+                3,
                 "required_field",
                 StructType(
-                    [
-                        NestedField(True, 2, "optional_field", DecimalType(8, 2)),
-                        NestedField(False, 3, "required_field", LongType()),
-                    ]
+                    NestedField(4, "optional_field", DecimalType(8, 2), is_optional=True),
+                    NestedField(5, "required_field", LongType(), is_optional=False),
                 ),
-            )
-        ),
-        MapType(
-            NestedField(True, 1, "optional_field", DoubleType()),
-            NestedField(False, 2, "required_field", UUIDType()),
-        ),
-        StructType(
-            [
-                NestedField(True, 1, "optional_field", IntegerType()),
-                NestedField(False, 2, "required_field", FixedType(5)),
-                NestedField(
-                    False,
-                    3,
-                    "required_field",
-                    StructType(
-                        [
-                            NestedField(True, 4, "optional_field", DecimalType(8, 2)),
-                            NestedField(False, 5, "required_field", LongType()),
-                        ]
-                    ),
-                ),
-            ]
+                is_optional=False,
+            ),
         ),
     ],
 )

--- a/python/tests/test_transforms.py
+++ b/python/tests/test_transforms.py
@@ -249,7 +249,7 @@ def test_bucket_method(type_var):
     bucket_transform = transforms.bucket(type_var, 8)
     assert str(bucket_transform) == str(eval(repr(bucket_transform)))
     assert bucket_transform.can_transform(type_var)
-    # assert bucket_transform.result_type(type_var) == IntegerType()
+    assert bucket_transform.result_type(type_var) == IntegerType()
     assert bucket_transform.num_buckets == 8
     assert bucket_transform.apply(None) is None
     assert bucket_transform.to_human_string("test") == "test"
@@ -288,19 +288,18 @@ def test_truncate_method(type_var, value, expected_human_str, expected):
     ],
 )
 def test_time_methods(type_var):
-    # todo uncomment them once __eq__ is added to Type classes
-    # assert transforms.year(type_var) == eval(repr(transforms.year(type_var)))
-    # assert transforms.month(type_var) == eval(repr(transforms.month(type_var)))
-    # assert transforms.day(type_var) == eval(repr(transforms.day(type_var)))
+    assert transforms.year(type_var) == eval(repr(transforms.year(type_var)))
+    assert transforms.month(type_var) == eval(repr(transforms.month(type_var)))
+    assert transforms.day(type_var) == eval(repr(transforms.day(type_var)))
     assert transforms.year(type_var).can_transform(type_var)
     assert transforms.month(type_var).can_transform(type_var)
     assert transforms.day(type_var).can_transform(type_var)
     assert transforms.year(type_var).preserves_order()
     assert transforms.month(type_var).preserves_order()
     assert transforms.day(type_var).preserves_order()
-    # assert transforms.year(type_var).result_type(type_var) == IntegerType()
-    # assert transforms.month(type_var).result_type(type_var) == IntegerType()
-    # assert transforms.day(type_var).result_type(type_var) == DateType()
+    assert transforms.year(type_var).result_type(type_var) == IntegerType()
+    assert transforms.month(type_var).result_type(type_var) == IntegerType()
+    assert transforms.day(type_var).result_type(type_var) == DateType()
     assert transforms.year(type_var).dedup_name() == "time"
     assert transforms.month(type_var).dedup_name() == "time"
     assert transforms.day(type_var).dedup_name() == "time"
@@ -329,9 +328,9 @@ def test_time_apply_method(transform, value, expected):
     ],
 )
 def test_hour_method(type_var):
-    # assert transforms.hour(type_var) == eval(repr(transforms.hour(type_var)))
+    assert transforms.hour(type_var) == eval(repr(transforms.hour(type_var)))
     assert transforms.hour(type_var).can_transform(type_var)
-    # assert transforms.hour(type_var).result_type(type_var) == IntegerType()
+    assert transforms.hour(type_var).result_type(type_var) == IntegerType()
     assert transforms.hour(type_var).apply(1512151975038194) == 420042
     assert transforms.hour(type_var).dedup_name() == "time"
 
@@ -426,7 +425,7 @@ def test_unknown_transform():
     assert str(unknown_transform) == str(eval(repr(unknown_transform)))
     with pytest.raises(AttributeError):
         unknown_transform.apply("test")
-    # assert unknown_transform.can_transform(FixedType(8))
+    assert unknown_transform.can_transform(FixedType(8))
     assert not unknown_transform.can_transform(FixedType(5))
     assert isinstance(unknown_transform.result_type(BooleanType()), StringType)
 

--- a/python/tests/test_types.py
+++ b/python/tests/test_types.py
@@ -56,7 +56,6 @@ non_parameterized_types = [
 
 @pytest.mark.parametrize("input_index, input_type", non_parameterized_types)
 def test_repr_primitive_types(input_index, input_type):
-    assert input_type.is_primitive
     assert isinstance(eval(repr(input_type())), input_type)
 
 
@@ -98,7 +97,6 @@ def test_is_primitive(input_type, result):
 
 def test_fixed_type():
     type_var = FixedType(length=5)
-    assert type_var.is_primitive
     assert type_var.length == 5
     assert str(type_var) == "fixed[5]"
     assert repr(type_var) == "FixedType(length=5)"
@@ -109,7 +107,6 @@ def test_fixed_type():
 
 def test_decimal_type():
     type_var = DecimalType(precision=9, scale=2)
-    assert type_var.is_primitive
     assert type_var.precision == 9
     assert type_var.scale == 2
     assert str(type_var) == "decimal(9, 2)"
@@ -133,7 +130,6 @@ def test_struct_type():
             is_optional=False,
         ),
     )
-    assert not type_var.is_primitive
     assert len(type_var.fields) == 3
     assert str(type_var) == str(eval(repr(type_var)))
     assert type_var == eval(repr(type_var))
@@ -149,7 +145,6 @@ def test_list_type():
         ),
         False,
     )
-    assert not type_var.is_primitive
     assert isinstance(type_var.element.type, StructType)
     assert len(type_var.element.type.fields) == 2
     assert type_var.element.field_id == 1
@@ -197,7 +192,6 @@ def test_nested_field():
     assert field_var.is_optional
     assert not field_var.is_required
     assert field_var.field_id == 1
-    assert field_var.name == "optional_field1"
     assert isinstance(field_var.type, StructType)
     assert str(field_var) == str(eval(repr(field_var)))
 

--- a/python/tests/test_types.py
+++ b/python/tests/test_types.py
@@ -56,6 +56,7 @@ non_parameterized_types = [
 
 @pytest.mark.parametrize("input_index, input_type", non_parameterized_types)
 def test_repr_primitive_types(input_index, input_type):
+    assert input_type.is_primitive
     assert isinstance(eval(repr(input_type())), input_type)
 
 
@@ -97,6 +98,7 @@ def test_is_primitive(input_type, result):
 
 def test_fixed_type():
     type_var = FixedType(length=5)
+    assert type_var.is_primitive
     assert type_var.length == 5
     assert str(type_var) == "fixed[5]"
     assert repr(type_var) == "FixedType(length=5)"
@@ -107,6 +109,7 @@ def test_fixed_type():
 
 def test_decimal_type():
     type_var = DecimalType(precision=9, scale=2)
+    assert type_var.is_primitive
     assert type_var.precision == 9
     assert type_var.scale == 2
     assert str(type_var) == "decimal(9, 2)"
@@ -130,6 +133,7 @@ def test_struct_type():
             is_optional=False,
         ),
     )
+    assert not type_var.is_primitive
     assert len(type_var.fields) == 3
     assert str(type_var) == str(eval(repr(type_var)))
     assert type_var == eval(repr(type_var))
@@ -145,6 +149,7 @@ def test_list_type():
         ),
         False,
     )
+    assert not type_var.is_primitive
     assert isinstance(type_var.element.type, StructType)
     assert len(type_var.element.type.fields) == 2
     assert type_var.element.field_id == 1
@@ -192,6 +197,7 @@ def test_nested_field():
     assert field_var.is_optional
     assert not field_var.is_required
     assert field_var.field_id == 1
+    assert field_var.name == "optional_field1"
     assert isinstance(field_var.type, StructType)
     assert str(field_var) == str(eval(repr(field_var)))
 

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -23,8 +23,8 @@ usedevelop = true
 deps =
     coverage
     mock
-    pytest
     pyarrow
+extras = dev
 setenv =
     COVERAGE_FILE = test-reports/{envname}/.coverage
     PYTEST_ADDOPTS = --junitxml=test-reports/{envname}/junit.xml -vv

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -23,8 +23,8 @@ usedevelop = true
 deps =
     coverage
     mock
+    pytest
     pyarrow
-extras = dev
 setenv =
     COVERAGE_FILE = test-reports/{envname}/.coverage
     PYTEST_ADDOPTS = --junitxml=test-reports/{envname}/junit.xml -vv
@@ -66,7 +66,7 @@ commands =
 deps =
     mypy
 commands =
-    mypy --no-implicit-optional --config tox.ini src
+    mypy --install-types --non-interactive --no-implicit-optional --config tox.ini src
 
 [testenv:docs]
 basepython = python3


### PR DESCRIPTION
Support iceberg transforms in python for the issue https://github.com/apache/iceberg/issues/3218
Reimplement it in a similar way as Types. This is more concise and have a few hundred lines of code less than the one in legacy folder.

project and project_strict methods are currently missing as the `UnboundPredicate` and `BoundPredicate` are missing. will add it later and also check if there is any cyclic dependency.

Will add the tests to complete the PR.