### PR TITLE
Infra - Add Spark v3.1 JMH benchmarks to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ spark/v2.4/spark/benchmark/*
 !spark/v2.4/spark/benchmark/.gitkeep
 spark/v3.0/spark/benchmark/*
 !spark/v3.0/spark/benchmark/.gitkeep
+spark/v3.1/spark/benchmark/*
+!spark/v3.1/spark/benckmark/.gitkeep
 spark/v3.2/spark/benchmark/*
 !spark/v3.2/spark/benchmark/.gitkeep
 


### PR DESCRIPTION
Adds the spark/v3.1/benchmarks directory to the .gitignore file.

Eventually we should see if we can have a single-level glob so we can ignore spark/v*/spark/benchmarks, but for now I just wanted to bring this up to parity with the others. 