### PR TITLE
Core: add delete option for bin-packing

### DIFF
--- a/core/src/test/java/org/apache/iceberg/MockFileScanTask.java
+++ b/core/src/test/java/org/apache/iceberg/MockFileScanTask.java
@@ -47,6 +47,17 @@ public class MockFileScanTask extends BaseFileScanTask {
     return new MockFileScanTask(mockFile);
   }
 
+  public static MockFileScanTask mockTaskWithDeletes(long length, int nDeletes) {
+    DeleteFile[] mockDeletes = new DeleteFile[nDeletes];
+    for (int i = 0; i < nDeletes; i++) {
+      mockDeletes[i] = Mockito.mock(DeleteFile.class);
+    }
+
+    DataFile mockFile = Mockito.mock(DataFile.class);
+    Mockito.when(mockFile.fileSizeInBytes()).thenReturn(length);
+    return new MockFileScanTask(mockFile, mockDeletes);
+  }
+
   @Override
   public long length() {
     return length;

--- a/core/src/test/java/org/apache/iceberg/actions/TestBinPackStrategy.java
+++ b/core/src/test/java/org/apache/iceberg/actions/TestBinPackStrategy.java
@@ -33,7 +33,7 @@ import org.apache.iceberg.TableTestBase;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
-import org.assertj.core.util.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/core/src/test/java/org/apache/iceberg/actions/TestBinPackStrategy.java
+++ b/core/src/test/java/org/apache/iceberg/actions/TestBinPackStrategy.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.TableTestBase;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.assertj.core.util.Lists;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -108,6 +109,22 @@ public class TestBinPackStrategy extends TableTestBase {
   }
 
   @Test
+  public void testFilteringWithDeletes() {
+    RewriteStrategy strategy = defaultBinPack().options(ImmutableMap.of(
+            BinPackStrategy.MAX_FILE_SIZE_BYTES, Long.toString(550 * MB),
+            BinPackStrategy.MIN_FILE_SIZE_BYTES, Long.toString(490 * MB),
+            BinPackStrategy.MIN_DELETES_PER_FILE, Integer.toString(2)
+    ));
+
+    List<FileScanTask> testFiles = filesOfSize(500, 500, 480, 480, 560, 520);
+    testFiles.add(MockFileScanTask.mockTaskWithDeletes(500 * MB, 2));
+    Iterable<FileScanTask> expectedFiles = filesOfSize(480, 480, 560, 500);
+    Iterable<FileScanTask> filtered = ImmutableList.copyOf(strategy.selectFilesToRewrite(testFiles));
+
+    Assert.assertEquals("Should include file with deletes", expectedFiles, filtered);
+  }
+
+  @Test
   public void testGroupingMinInputFilesInvalid() {
     RewriteStrategy strategy = defaultBinPack().options(ImmutableMap.of(
         BinPackStrategy.MIN_INPUT_FILES, Integer.toString(5)
@@ -148,6 +165,23 @@ public class TestBinPackStrategy extends TableTestBase {
 
     Assert.assertEquals("Should plan 1 groups since there are enough input files",
         ImmutableList.of(testFiles), grouped);
+  }
+
+  @Test
+  public void testGroupingWithDeletes() {
+    RewriteStrategy strategy = defaultBinPack().options(ImmutableMap.of(
+            BinPackStrategy.MIN_INPUT_FILES, Integer.toString(5),
+            BinPackStrategy.MAX_FILE_SIZE_BYTES, Long.toString(550 * MB),
+            BinPackStrategy.MIN_FILE_SIZE_BYTES, Long.toString(490 * MB),
+            BinPackStrategy.MIN_DELETES_PER_FILE, Integer.toString(2)
+    ));
+
+    List<FileScanTask> testFiles = Lists.newArrayList();
+    testFiles.add(MockFileScanTask.mockTaskWithDeletes(500 * MB, 2));
+    Iterable<List<FileScanTask>> grouped = strategy.planFileGroups(testFiles);
+
+    Assert.assertEquals("Should plan 1 groups since there are enough input files",
+            ImmutableList.of(testFiles), grouped);
   }
 
   @Test
@@ -196,11 +230,17 @@ public class TestBinPackStrategy extends TableTestBase {
               BinPackStrategy.MIN_FILE_SIZE_BYTES, Long.toString(1000 * MB)));
         });
 
-    AssertHelpers.assertThrows("Should not allow min input size smaller tha 1",
+    AssertHelpers.assertThrows("Should not allow min input size smaller than 1",
         IllegalArgumentException.class, () -> {
           defaultBinPack().options(ImmutableMap.of(
               BinPackStrategy.MIN_INPUT_FILES, Long.toString(-5)));
         });
+
+    AssertHelpers.assertThrows("Should not allow min deletes per file smaller than 1",
+            IllegalArgumentException.class, () -> {
+              defaultBinPack().options(ImmutableMap.of(
+                      BinPackStrategy.MIN_DELETES_PER_FILE, Long.toString(-5)));
+            });
 
     AssertHelpers.assertThrows("Should not allow negative target size",
         IllegalArgumentException.class, () -> {


### PR DESCRIPTION
Add an option `min-deletes-per-file` to allow rewriting files with certain number of deletes. This does not remove the deletes. It is used to solve the situation that a file is already of optimized size and never included in for bin packing, but deletes are associated with it so the deletes cannot be expired.