### PR TITLE
Spark - Fix AddFilesProcedure throws NumberFormatException when no files are imported

### DIFF
--- a/spark/v3.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
+++ b/spark/v3.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
@@ -692,6 +692,61 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
         expectedRecordCount, actualRecordCount);
   }
 
+  @Test
+  public void testEmptyImportDoesNotThrow() {
+
+    String createIceberg =
+        "CREATE TABLE %s (id Integer, name String, dept String, subdept String) USING iceberg";
+    sql(createIceberg, tableName);
+
+    // Empty path based import
+    Object pathResult = scalarSql("CALL %s.system.add_files('%s', '`parquet`.`%s`')",
+        catalogName, tableName, fileTableDir.getAbsolutePath());
+    Assert.assertEquals(0L, pathResult);
+    assertEquals("Iceberg table contains no added data when importing from an empty path",
+        emptyQueryResult,
+        sql("SELECT * FROM %s ORDER BY id", tableName));
+
+    // Empty table based import
+    String createHive = "CREATE TABLE %s (id Integer, name String, dept String, subdept String) STORED AS parquet";
+    sql(createHive, sourceTableName);
+
+    Object tableResult = scalarSql("CALL %s.system.add_files('%s', '%s')",
+        catalogName, tableName, sourceTableName);
+    Assert.assertEquals(0L, tableResult);
+    assertEquals("Iceberg table contains no added data when importing from an empty table",
+        emptyQueryResult,
+        sql("SELECT * FROM %s ORDER BY id", tableName));
+  }
+
+  @Test
+  public void testPartitionedImportFromEmptyPartitionDoesNotThrow() {
+    createPartitionedHiveTable();
+
+    final int emptyPartitionId = 999;
+    // Add an empty partition to the hive table
+    sql("ALTER TABLE %s ADD PARTITION (id = '%d') LOCATION '%d'", sourceTableName,
+        emptyPartitionId, emptyPartitionId);
+
+    String createIceberg =
+        "CREATE TABLE %s (id Integer, name String, dept String, subdept String) USING iceberg PARTITIONED BY (id)";
+
+    sql(createIceberg, tableName);
+
+    Object tableResult = scalarSql("CALL %s.system.add_files(" +
+            "table => '%s', " +
+            "source_table => '%s', " +
+            "partition_filter => map('id', %d))",
+        catalogName, tableName, sourceTableName, emptyPartitionId);
+
+    Assert.assertEquals(0L, tableResult);
+    assertEquals("Iceberg table contains no added data when importing from an empty table",
+        emptyQueryResult,
+        sql("SELECT * FROM %s ORDER BY id", tableName));
+  }
+
+  private static final List<Object[]> emptyQueryResult = Lists.newArrayList();
+
   private static final StructField[] struct = {
       new StructField("id", DataTypes.IntegerType, false, Metadata.empty()),
       new StructField("name", DataTypes.StringType, false, Metadata.empty()),

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
@@ -141,7 +141,7 @@ class AddFilesProcedure extends BaseProcedure {
       }
 
       Snapshot snapshot = table.currentSnapshot();
-      return Long.parseLong(snapshot.summary().get(SnapshotSummary.ADDED_FILES_PROP));
+      return Long.parseLong(snapshot.summary().getOrDefault(SnapshotSummary.ADDED_FILES_PROP, "0"));
     });
   }
 

--- a/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
+++ b/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
@@ -692,6 +692,61 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
         expectedRecordCount, actualRecordCount);
   }
 
+  @Test
+  public void testEmptyImportDoesNotThrow() {
+
+    String createIceberg =
+        "CREATE TABLE %s (id Integer, name String, dept String, subdept String) USING iceberg";
+    sql(createIceberg, tableName);
+
+    // Empty path based import
+    Object pathResult = scalarSql("CALL %s.system.add_files('%s', '`parquet`.`%s`')",
+        catalogName, tableName, fileTableDir.getAbsolutePath());
+    Assert.assertEquals(0L, pathResult);
+    assertEquals("Iceberg table contains no added data when importing from an empty path",
+        emptyQueryResult,
+        sql("SELECT * FROM %s ORDER BY id", tableName));
+
+    // Empty table based import
+    String createHive = "CREATE TABLE %s (id Integer, name String, dept String, subdept String) STORED AS parquet";
+    sql(createHive, sourceTableName);
+
+    Object tableResult = scalarSql("CALL %s.system.add_files('%s', '%s')",
+        catalogName, tableName, sourceTableName);
+    Assert.assertEquals(0L, tableResult);
+    assertEquals("Iceberg table contains no added data when importing from an empty table",
+        emptyQueryResult,
+        sql("SELECT * FROM %s ORDER BY id", tableName));
+  }
+
+  @Test
+  public void testPartitionedImportFromEmptyPartitionDoesNotThrow() {
+    createPartitionedHiveTable();
+
+    final int emptyPartitionId = 999;
+    // Add an empty partition to the hive table
+    sql("ALTER TABLE %s ADD PARTITION (id = '%d') LOCATION '%d'", sourceTableName,
+        emptyPartitionId, emptyPartitionId);
+
+    String createIceberg =
+        "CREATE TABLE %s (id Integer, name String, dept String, subdept String) USING iceberg PARTITIONED BY (id)";
+
+    sql(createIceberg, tableName);
+
+    Object tableResult = scalarSql("CALL %s.system.add_files(" +
+            "table => '%s', " +
+            "source_table => '%s', " +
+            "partition_filter => map('id', %d))",
+        catalogName, tableName, sourceTableName, emptyPartitionId);
+
+    Assert.assertEquals(0L, tableResult);
+    assertEquals("Iceberg table contains no added data when importing from an empty table",
+        emptyQueryResult,
+        sql("SELECT * FROM %s ORDER BY id", tableName));
+  }
+
+  private static final List<Object[]> emptyQueryResult = Lists.newArrayList();
+
   private static final StructField[] struct = {
       new StructField("id", DataTypes.IntegerType, false, Metadata.empty()),
       new StructField("name", DataTypes.StringType, false, Metadata.empty()),

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
@@ -141,7 +141,7 @@ class AddFilesProcedure extends BaseProcedure {
       }
 
       Snapshot snapshot = table.currentSnapshot();
-      return Long.parseLong(snapshot.summary().get(SnapshotSummary.ADDED_FILES_PROP));
+      return Long.parseLong(snapshot.summary().getOrDefault(SnapshotSummary.ADDED_FILES_PROP, "0"));
     });
   }
 

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
@@ -646,6 +646,61 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
 
   }
 
+  @Test
+  public void testEmptyImportDoesNotThrow() {
+
+    String createIceberg =
+        "CREATE TABLE %s (id Integer, name String, dept String, subdept String) USING iceberg";
+    sql(createIceberg, tableName);
+
+    // Empty path based import
+    Object pathResult = scalarSql("CALL %s.system.add_files('%s', '`parquet`.`%s`')",
+        catalogName, tableName, fileTableDir.getAbsolutePath());
+    Assert.assertEquals(0L, pathResult);
+    assertEquals("Iceberg table contains no added data when importing from an empty path",
+        emptyQueryResult,
+        sql("SELECT * FROM %s ORDER BY id", tableName));
+
+    // Empty table based import
+    String createHive = "CREATE TABLE %s (id Integer, name String, dept String, subdept String) STORED AS parquet";
+    sql(createHive, sourceTableName);
+
+    Object tableResult = scalarSql("CALL %s.system.add_files('%s', '%s')",
+        catalogName, tableName, sourceTableName);
+    Assert.assertEquals(0L, tableResult);
+    assertEquals("Iceberg table contains no added data when importing from an empty table",
+        emptyQueryResult,
+        sql("SELECT * FROM %s ORDER BY id", tableName));
+  }
+
+  @Test
+  public void testPartitionedImportFromEmptyPartitionDoesNotThrow() {
+    createPartitionedHiveTable();
+
+    final int emptyPartitionId = 999;
+    // Add an empty partition to the hive table
+    sql("ALTER TABLE %s ADD PARTITION (id = '%d') LOCATION '%d'", sourceTableName,
+        emptyPartitionId, emptyPartitionId);
+
+    String createIceberg =
+        "CREATE TABLE %s (id Integer, name String, dept String, subdept String) USING iceberg PARTITIONED BY (id)";
+
+    sql(createIceberg, tableName);
+
+    Object tableResult = scalarSql("CALL %s.system.add_files(" +
+            "table => '%s', " +
+            "source_table => '%s', " +
+            "partition_filter => map('id', %d))",
+        catalogName, tableName, sourceTableName, emptyPartitionId);
+
+    Assert.assertEquals(0L, tableResult);
+    assertEquals("Iceberg table contains no added data when importing from an empty table",
+        emptyQueryResult,
+        sql("SELECT * FROM %s ORDER BY id", tableName));
+  }
+
+  private static final List<Object[]> emptyQueryResult = Lists.newArrayList();
+
   private static final StructField[] struct = {
       new StructField("id", DataTypes.IntegerType, false, Metadata.empty()),
       new StructField("name", DataTypes.StringType, false, Metadata.empty()),

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
@@ -141,7 +141,7 @@ class AddFilesProcedure extends BaseProcedure {
       }
 
       Snapshot snapshot = table.currentSnapshot();
-      return Long.parseLong(snapshot.summary().get(SnapshotSummary.ADDED_FILES_PROP));
+      return Long.parseLong(snapshot.summary().getOrDefault(SnapshotSummary.ADDED_FILES_PROP, "0"));
     });
   }
 


### PR DESCRIPTION
This fixes https://github.com/apache/iceberg/issues/3453

However, we should probably return earlier if a user passes a path that has no files, but for now at least we can be more helpful than throwing an NPE which could kill a running job.