### PR TITLE
Spark: Improve performance of expire snapshot by not double-scanning retained Snapshots

### DIFF
--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -50,7 +50,9 @@ import org.apache.iceberg.util.StructProjection;
  * <p>This table may return duplicate rows.
  */
 public class AllManifestsTable extends BaseMetadataTable {
-  private static final int REF_SNAPSHOT_ID = 18;
+  public static final Types.NestedField REF_SNAPSHOT_ID =
+      Types.NestedField.required(18, "reference_snapshot_id", Types.LongType.get());
+
   private static final Schema MANIFEST_FILE_SCHEMA =
       new Schema(
           Types.NestedField.required(14, "content", Types.IntegerType.get()),
@@ -74,8 +76,7 @@ public class AllManifestsTable extends BaseMetadataTable {
                       Types.NestedField.required(11, "contains_nan", Types.BooleanType.get()),
                       Types.NestedField.optional(12, "lower_bound", Types.StringType.get()),
                       Types.NestedField.optional(13, "upper_bound", Types.StringType.get())))),
-          Types.NestedField.required(
-              REF_SNAPSHOT_ID, "reference_snapshot_id", Types.LongType.get()));
+          REF_SNAPSHOT_ID);
 
   AllManifestsTable(TableOperations ops, Table table) {
     this(ops, table, table.name() + ".all_manifests");
@@ -424,7 +425,7 @@ public class AllManifestsTable extends BaseMetadataTable {
       }
 
       private <T> boolean isSnapshotRef(BoundReference<T> ref) {
-        return ref.fieldId() == REF_SNAPSHOT_ID;
+        return ref.fieldId() == REF_SNAPSHOT_ID.fieldId();
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/ReachableFileUtil.java
+++ b/core/src/main/java/org/apache/iceberg/ReachableFileUtil.java
@@ -19,12 +19,15 @@
 package org.apache.iceberg;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.TableMetadata.MetadataLogEntry;
 import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.io.FileIO;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,15 +106,25 @@ public class ReachableFileUtil {
    * @return the location of manifest Lists
    */
   public static List<String> manifestListLocations(Table table) {
-    Iterable<Snapshot> snapshots = table.snapshots();
-    List<String> manifestListLocations = Lists.newArrayList();
-    for (Snapshot snapshot : snapshots) {
-      String manifestListLocation = snapshot.manifestListLocation();
-      if (manifestListLocation != null) {
-        manifestListLocations.add(manifestListLocation);
-      }
+    return manifestListLocations(table, null);
+  }
+
+  /**
+   * Returns locations of manifest lists in a table.
+   *
+   * @param table table for which manifestList needs to be fetched
+   * @param snapshots ids of snapshots for which manifest lists will be returned
+   * @return the location of manifest Lists
+   */
+  public static List<String> manifestListLocations(Table table, Set<Long> snapshots) {
+    Stream<Snapshot> snapshotStream = StreamSupport.stream(table.snapshots().spliterator(), false);
+    if (snapshots != null) {
+      snapshotStream = snapshotStream.filter(s -> snapshots.contains(s.snapshotId()));
     }
-    return manifestListLocations;
+    return snapshotStream
+        .map(Snapshot::manifestListLocation)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/ReachableFileUtil.java
+++ b/core/src/main/java/org/apache/iceberg/ReachableFileUtil.java
@@ -101,7 +101,7 @@ public class ReachableFileUtil {
    * Returns locations of manifest lists in a table.
    *
    * @param table table for which manifestList needs to be fetched
-   * @return the location of manifest Lists
+   * @return the location of manifest lists
    */
   public static List<String> manifestListLocations(Table table) {
     return manifestListLocations(table, null);
@@ -112,17 +112,17 @@ public class ReachableFileUtil {
    *
    * @param table table for which manifestList needs to be fetched
    * @param snapshotIds ids of snapshots for which manifest lists will be returned
-   * @return the location of manifest Lists
+   * @return the location of manifest lists
    */
   public static List<String> manifestListLocations(Table table, Set<Long> snapshotIds) {
-    Iterable<Snapshot> tableSnapshots = table.snapshots();
+    Iterable<Snapshot> snapshots = table.snapshots();
     if (snapshotIds != null) {
-      tableSnapshots = Iterables.filter(tableSnapshots, s -> snapshotIds.contains(s.snapshotId()));
+      snapshots = Iterables.filter(snapshots, s -> snapshotIds.contains(s.snapshotId()));
     }
 
     List<String> manifestListLocations = Lists.newArrayList();
-    for (Snapshot tableSnapshot : tableSnapshots) {
-      String manifestListLocation = tableSnapshot.manifestListLocation();
+    for (Snapshot snapshot : snapshots) {
+      String manifestListLocation = snapshot.manifestListLocation();
       if (manifestListLocation != null) {
         manifestListLocations.add(manifestListLocation);
       }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
@@ -149,9 +149,8 @@ abstract class BaseSparkAction<ThisT> {
     Broadcast<Table> tableBroadcast = sparkContext.broadcast(serializableTable);
     int numShufflePartitions = spark.sessionState().conf().numShufflePartitions();
 
-    Dataset<Row> manifests = manifestDF(table, snapshotIds);
-    Dataset<ManifestFileBean> manifestsBean =
-        manifests
+    Dataset<ManifestFileBean> manifestBeanDS =
+        manifestDF(table, snapshotIds)
             .selectExpr(
                 "content",
                 "path",
@@ -162,7 +161,7 @@ abstract class BaseSparkAction<ThisT> {
             .repartition(numShufflePartitions) // avoid adaptive execution combining tasks
             .as(ManifestFileBean.ENCODER);
 
-    return manifestsBean.flatMap(new ReadManifest(tableBroadcast), FileInfo.ENCODER);
+    return manifestBeanDS.flatMap(new ReadManifest(tableBroadcast), FileInfo.ENCODER);
   }
 
   protected Dataset<FileInfo> manifestDS(Table table) {

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -37,6 +37,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericData.Record;
@@ -807,5 +809,12 @@ public class TestHelpers {
     }
 
     return deleteFiles;
+  }
+
+  public static Set<String> reachableManifestPaths(Table table) {
+    return StreamSupport.stream(table.snapshots().spliterator(), false)
+        .flatMap(s -> s.allManifests(table.io()).stream())
+        .map(ManifestFile::path)
+        .collect(Collectors.toSet());
   }
 }

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
@@ -143,15 +143,16 @@ abstract class BaseSparkAction<ThisT> {
     return contentFileDS(table, null);
   }
 
-  protected Dataset<FileInfo> contentFileDS(Table table, Set<Long> snapshots) {
-    Broadcast<Table> tableBroadcast =
-        sparkContext.broadcast(SerializableTableWithSize.copyOf(table));
+  protected Dataset<FileInfo> contentFileDS(Table table, Set<Long> snapshotIds) {
+    Table serializableTable = SerializableTableWithSize.copyOf(table);
+    Broadcast<Table> tableBroadcast = sparkContext.broadcast(serializableTable);
     int numShufflePartitions = spark.sessionState().conf().numShufflePartitions();
 
     Dataset<Row> allManifests = loadMetadataTable(table, ALL_MANIFESTS);
-    if (snapshots != null) {
-      allManifests = filterAllManifests(allManifests, snapshots);
+    if (snapshotIds != null) {
+      allManifests = filterAllManifests(allManifests, snapshotIds);
     }
+
     Dataset<ManifestFileBean> allManifestsBean =
         allManifests
             .selectExpr(
@@ -171,12 +172,12 @@ abstract class BaseSparkAction<ThisT> {
     return manifestDS(table, null);
   }
 
-  protected Dataset<FileInfo> manifestDS(Table table, Set<Long> snapshots) {
-    Dataset<Row> allManifests = loadMetadataTable(table, ALL_MANIFESTS);
-    if (snapshots != null) {
-      allManifests = filterAllManifests(allManifests, snapshots);
+  protected Dataset<FileInfo> manifestDS(Table table, Set<Long> snapshotIds) {
+    Dataset<Row> manifests = loadMetadataTable(table, ALL_MANIFESTS);
+    if (snapshotIds != null) {
+      manifests = filterAllManifests(manifests, snapshotIds);
     }
-    return allManifests.select(col("path"), lit(MANIFEST).as("type")).as(FileInfo.ENCODER);
+    return manifests.select(col("path"), lit(MANIFEST).as("type")).as(FileInfo.ENCODER);
   }
 
   protected Dataset<FileInfo> manifestListDS(Table table) {
@@ -320,9 +321,9 @@ abstract class BaseSparkAction<ThisT> {
     }
   }
 
-  protected Dataset<Row> filterAllManifests(Dataset<Row> allManifestDF, Set<Long> snapshots) {
+  protected Dataset<Row> filterAllManifests(Dataset<Row> allManifestDF, Set<Long> snapshotIds) {
     return allManifestDF.filter(
-        col(AllManifestsTable.REF_SNAPSHOT_ID.name()).isInCollection(snapshots));
+        col(AllManifestsTable.REF_SNAPSHOT_ID.name()).isInCollection(snapshotIds));
   }
 
   private static class ReadManifest implements FlatMapFunction<ManifestFileBean, FileInfo> {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
@@ -149,9 +149,8 @@ abstract class BaseSparkAction<ThisT> {
     Broadcast<Table> tableBroadcast = sparkContext.broadcast(serializableTable);
     int numShufflePartitions = spark.sessionState().conf().numShufflePartitions();
 
-    Dataset<Row> manifests = manifestDF(table, snapshotIds);
-    Dataset<ManifestFileBean> manifestsBean =
-        manifests
+    Dataset<ManifestFileBean> manifestBeanDS =
+        manifestDF(table, snapshotIds)
             .selectExpr(
                 "content",
                 "path",
@@ -162,7 +161,7 @@ abstract class BaseSparkAction<ThisT> {
             .repartition(numShufflePartitions) // avoid adaptive execution combining tasks
             .as(ManifestFileBean.ENCODER);
 
-    return manifestsBean.flatMap(new ReadManifest(tableBroadcast), FileInfo.ENCODER);
+    return manifestBeanDS.flatMap(new ReadManifest(tableBroadcast), FileInfo.ENCODER);
   }
 
   protected Dataset<FileInfo> manifestDS(Table table) {
@@ -324,11 +323,6 @@ abstract class BaseSparkAction<ThisT> {
           + manifestListsCount()
           + otherFilesCount();
     }
-  }
-
-  protected Dataset<Row> filterAllManifests(Dataset<Row> allManifestDF, Set<Long> snapshotIds) {
-    return allManifestDF.filter(
-        col(AllManifestsTable.REF_SNAPSHOT_ID.name()).isInCollection(snapshotIds));
   }
 
   private static class ReadManifest implements FlatMapFunction<ManifestFileBean, FileInfo> {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
@@ -63,6 +63,7 @@ import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.FlatMapFunction;
 import org.apache.spark.broadcast.Broadcast;
+import org.apache.spark.sql.Column;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
@@ -148,13 +149,9 @@ abstract class BaseSparkAction<ThisT> {
     Broadcast<Table> tableBroadcast = sparkContext.broadcast(serializableTable);
     int numShufflePartitions = spark.sessionState().conf().numShufflePartitions();
 
-    Dataset<Row> allManifests = loadMetadataTable(table, ALL_MANIFESTS);
-    if (snapshotIds != null) {
-      allManifests = filterAllManifests(allManifests, snapshotIds);
-    }
-
-    Dataset<ManifestFileBean> allManifestsBean =
-        allManifests
+    Dataset<Row> manifests = manifestDF(table, snapshotIds);
+    Dataset<ManifestFileBean> manifestsBean =
+        manifests
             .selectExpr(
                 "content",
                 "path",
@@ -165,7 +162,7 @@ abstract class BaseSparkAction<ThisT> {
             .repartition(numShufflePartitions) // avoid adaptive execution combining tasks
             .as(ManifestFileBean.ENCODER);
 
-    return allManifestsBean.flatMap(new ReadManifest(tableBroadcast), FileInfo.ENCODER);
+    return manifestsBean.flatMap(new ReadManifest(tableBroadcast), FileInfo.ENCODER);
   }
 
   protected Dataset<FileInfo> manifestDS(Table table) {
@@ -173,11 +170,19 @@ abstract class BaseSparkAction<ThisT> {
   }
 
   protected Dataset<FileInfo> manifestDS(Table table, Set<Long> snapshotIds) {
-    Dataset<Row> manifests = loadMetadataTable(table, ALL_MANIFESTS);
+    return manifestDF(table, snapshotIds)
+        .select(col("path"), lit(MANIFEST).as("type"))
+        .as(FileInfo.ENCODER);
+  }
+
+  private Dataset<Row> manifestDF(Table table, Set<Long> snapshotIds) {
+    Dataset<Row> manifestDF = loadMetadataTable(table, ALL_MANIFESTS);
     if (snapshotIds != null) {
-      manifests = filterAllManifests(manifests, snapshotIds);
+      Column filterCond = col(AllManifestsTable.REF_SNAPSHOT_ID.name()).isInCollection(snapshotIds);
+      return manifestDF.filter(filterCond);
+    } else {
+      return manifestDF;
     }
-    return manifests.select(col("path"), lit(MANIFEST).as("type")).as(FileInfo.ENCODER);
   }
 
   protected Dataset<FileInfo> manifestListDS(Table table) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
@@ -166,9 +166,8 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
    */
   public Dataset<FileInfo> expireFiles() {
     if (expiredFileDS == null) {
-
-      // Save old metadata
-      TableMetadata originalTable = ops.current();
+      // fetch metadata before expiration
+      TableMetadata originalMetadata = ops.current();
 
       // perform expiration
       org.apache.iceberg.ExpireSnapshots expireSnapshots = table.expireSnapshots();
@@ -187,18 +186,13 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
 
       expireSnapshots.cleanExpiredFiles(false).commit();
 
-      // determine expired files
-      TableMetadata updatedTable = ops.refresh();
-      Set<Long> retainedSnapshots =
-          updatedTable.snapshots().stream().map(Snapshot::snapshotId).collect(Collectors.toSet());
-      Set<Long> expiredSnapshots =
-          originalTable.snapshots().stream()
-              .map(Snapshot::snapshotId)
-              .filter(id -> !retainedSnapshots.contains(id))
-              .collect(Collectors.toSet());
+      // fetch valid files after expiration
+      TableMetadata updatedMetadata = ops.refresh();
+      Dataset<FileInfo> validFileDS = fileDS(updatedMetadata);
 
-      Dataset<FileInfo> validFileDS = fileDS(updatedTable);
-      Dataset<FileInfo> deleteCandidateFileDS = fileDS(originalTable, expiredSnapshots);
+      // fetch files referenced by expired snapshots
+      Set<Long> removedSnapshotIds = findExpiredSnapshotIds(originalMetadata, updatedMetadata);
+      Dataset<FileInfo> deleteCandidateFileDS = fileDS(originalMetadata, removedSnapshotIds);
 
       // determine expired files
       this.expiredFileDS = deleteCandidateFileDS.except(validFileDS);
@@ -250,17 +244,24 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
   }
 
   private Dataset<FileInfo> fileDS(TableMetadata metadata) {
-    Table staticTable = newStaticTable(metadata, table.io());
-    return contentFileDS(staticTable)
-        .union(manifestDS(staticTable))
-        .union(manifestListDS(staticTable));
+    return fileDS(metadata, null);
   }
 
-  private Dataset<FileInfo> fileDS(TableMetadata metadata, Set<Long> snapshots) {
+  private Dataset<FileInfo> fileDS(TableMetadata metadata, Set<Long> snapshotIds) {
     Table staticTable = newStaticTable(metadata, table.io());
-    return contentFileDS(staticTable, snapshots)
-        .union(manifestDS(staticTable, snapshots))
-        .union(manifestListDS(staticTable, snapshots));
+    return contentFileDS(staticTable, snapshotIds)
+        .union(manifestDS(staticTable, snapshotIds))
+        .union(manifestListDS(staticTable, snapshotIds));
+  }
+
+  private Set<Long> findExpiredSnapshotIds(
+      TableMetadata originalMetadata, TableMetadata updatedMetadata) {
+    Set<Long> retainedSnapshots =
+        updatedMetadata.snapshots().stream().map(Snapshot::snapshotId).collect(Collectors.toSet());
+    return originalMetadata.snapshots().stream()
+        .map(Snapshot::snapshotId)
+        .filter(id -> !retainedSnapshots.contains(id))
+        .collect(Collectors.toSet());
   }
 
   private ExpireSnapshots.Result deleteFiles(Iterator<FileInfo> files) {

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/actions/ExpireSnapshotsSparkAction.java
@@ -191,8 +191,8 @@ public class ExpireSnapshotsSparkAction extends BaseSparkAction<ExpireSnapshotsS
       Dataset<FileInfo> validFileDS = fileDS(updatedMetadata);
 
       // fetch files referenced by expired snapshots
-      Set<Long> removedSnapshotIds = findExpiredSnapshotIds(originalMetadata, updatedMetadata);
-      Dataset<FileInfo> deleteCandidateFileDS = fileDS(originalMetadata, removedSnapshotIds);
+      Set<Long> deletedSnapshotIds = findExpiredSnapshotIds(originalMetadata, updatedMetadata);
+      Dataset<FileInfo> deleteCandidateFileDS = fileDS(originalMetadata, deletedSnapshotIds);
 
       // determine expired files
       this.expiredFileDS = deleteCandidateFileDS.except(validFileDS);

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/data/TestHelpers.java
@@ -37,6 +37,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericData.Record;
@@ -807,5 +809,12 @@ public class TestHelpers {
     }
 
     return deleteFiles;
+  }
+
+  public static Set<String> reachableManifestPaths(Table table) {
+    return StreamSupport.stream(table.snapshots().spliterator(), false)
+        .flatMap(s -> s.allManifests(table.io()).stream())
+        .map(ManifestFile::path)
+        .collect(Collectors.toSet());
   }
 }


### PR DESCRIPTION
Expire snapshots can take a long time for large tables with millions of files and thousands of snapshots/manifests.

One cause is the calculation of files to be deleted.  The current algorithm is:

-  Find the reachability graph of all snapshots before expiration
-  Find reachability graph of all snapshots after expiration
-  Subtract the second from the first, these are files to delete
 
But this explores every retained snapshot twice.  Example: any periodic expire-snapshot job that expires 1 snapshot needs to explore all n-1 snapshots twice.

Proposal:

- Find reachability graph of all snapshots after expiration
- Find reachability graph of expired snapshots (if only a few expired, should be much smaller set)
- Subtract the first from the second, these are files to delete

Implementation: For expired-snapshot scan, change the original spark query of metadata tables to custom spark jobs that only explore from expired snapshot(s).

Note: The new expired-snapshot scan duplicates manifestList scan logic to handle "write.manifest-lists.enabled"="false" flag, but unfortunately the functionality seems broken without this change and so not possible to test currently.  Added a test for demonstration purpose.