### PR TITLE
Docs: Fix date function in spark procedures docs

### DIFF
--- a/site/docs/spark-procedures.md
+++ b/site/docs/spark-procedures.md
@@ -95,9 +95,9 @@ Roll back a table to the snapshot that was current at some time.
 
 #### Example
 
-Roll back `db.sample` to a day ago
+Roll back `db.sample` to one day
 ```sql
-CALL catalog_name.system.rollback_to_timestamp('db.sample', date_sub(current_date(), 1))
+CALL catalog_name.system.rollback_to_timestamp('db.sample', TIMESTAMP '2021-06-30 00:00:00.000')
 ```
 
 ### `set_current_snapshot`
@@ -197,10 +197,10 @@ the `expire_snapshots` procedure will never remove files which are still require
 
 #### Examples
 
-Remove snapshots older than 10 days ago, but retain the last 100 snapshots:
+Remove snapshots older than one day, but retain the last 100 snapshots:
 
 ```sql
-CALL hive_prod.system.expire_snapshots('db.sample', date_sub(current_date(), 10), 100)
+CALL hive_prod.system.expire_snapshots('db.sample', TIMESTAMP '2021-06-30 00:00:00.000', 100)
 ```
 
 Erase all snapshots older than the current timestamp but retain the last 5 snapshots:


### PR DESCRIPTION
## What problem is solved by this MR？Why this MR is needed?
It doesn`t work when I use 'date_sub(current_date(), 10)' in 'spark_catalog.system.expire_snapshots'.

because we use a parser extension, the procedures do not allow arbitrary expressions.

I think that we'd better modify the document first to prevent users from encountering errors.

environment: 
|  Spark   | Iceberg |
|  ----  | ----  |
| 3.0  | 0.12|


```shell
scala> spark.sql("CALL spark_catalog.system.expire_snapshots('db.table', date_sub(current_date(), 10), 5)")
```
```shell
org.apache.spark.sql.catalyst.parser.extensions.IcebergParseException:
no viable alternative at input 'date_sub('(line 1, pos 81)

== SQL ==
CALL spark_catalog.system.expire_snapshots('db.table', date_sub(current_date(), 10), 5)
---------------------------------------------------------------------------------^^^

  at org.apache.spark.sql.catalyst.parser.extensions.IcebergParseException.withCommand(IcebergSparkSqlExtensionsParser.scala:294)
  at org.apache.spark.sql.catalyst.parser.extensions.IcebergSparkSqlExtensionsParser.parse(IcebergSparkSqlExtensionsParser.scala:158)
  at org.apache.spark.sql.catalyst.parser.extensions.IcebergSparkSqlExtensionsParser.parsePlan(IcebergSparkSqlExtensionsParser.scala:105)
  at org.apache.spark.sql.SparkSession.$anonfun$sql$2(SparkSession.scala:605)
  at org.apache.spark.sql.catalyst.QueryPlanningTracker.measurePhase(QueryPlanningTracker.scala:111)
  at org.apache.spark.sql.SparkSession.$anonfun$sql$1(SparkSession.scala:605)
  at org.apache.spark.sql.SparkSession.withActive(SparkSession.scala:764)
  at org.apache.spark.sql.SparkSession.sql(SparkSession.scala:602)
  ... 47 elided
```

## How to solve this problem?
I think that we'd better modify the document first to prevent users from encountering errors.

## Related issue
https://github.com/apache/iceberg/issues/2341
