### PR TITLE
Spark: Fix IllegarlArgumentException when filtering on BinaryType column

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/Literals.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Literals.java
@@ -34,6 +34,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.Objects;
 import java.util.UUID;
+import javax.xml.bind.DatatypeConverter;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Conversions;
@@ -599,6 +600,13 @@ class Literals {
     Object writeReplace() throws ObjectStreamException {
       return new SerializationProxies.FixedLiteralProxy(value());
     }
+
+    @Override
+    public String toString() {
+      byte[] binary = new byte[value().remaining()];
+      value().duplicate().get(binary);
+      return "0x" + DatatypeConverter.printHexBinary(binary);
+    }
   }
 
   static class BinaryLiteral extends BaseLiteral<ByteBuffer> {
@@ -638,6 +646,13 @@ class Literals {
     @Override
     protected Type.TypeID typeId() {
       return Type.TypeID.BINARY;
+    }
+
+    @Override
+    public String toString() {
+      byte[] binary = new byte[value().remaining()];
+      value().duplicate().get(binary);
+      return "0x" + DatatypeConverter.printHexBinary(binary);
     }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/Literals.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Literals.java
@@ -35,11 +35,11 @@ import java.util.Comparator;
 import java.util.Objects;
 import java.util.UUID;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ByteBuffers;
 import org.apache.iceberg.util.NaNUtil;
 
 class Literals {
@@ -603,9 +603,7 @@ class Literals {
 
     @Override
     public String toString() {
-      byte[] binary = new byte[value().remaining()];
-      value().duplicate().get(binary);
-      return "0x" + BaseEncoding.base16().encode(binary);
+      return "0x" + ByteBuffers.encodeHexString(value());
     }
   }
 
@@ -650,9 +648,7 @@ class Literals {
 
     @Override
     public String toString() {
-      byte[] binary = new byte[value().remaining()];
-      value().duplicate().get(binary);
-      return "0x" + BaseEncoding.base16().encode(binary);
+      return "0x" + ByteBuffers.encodeHexString(value());
     }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/Literals.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Literals.java
@@ -34,8 +34,8 @@ import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
 import java.util.Objects;
 import java.util.UUID;
-import javax.xml.bind.DatatypeConverter;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Type;
@@ -605,7 +605,7 @@ class Literals {
     public String toString() {
       byte[] binary = new byte[value().remaining()];
       value().duplicate().get(binary);
-      return "0x" + DatatypeConverter.printHexBinary(binary);
+      return "0x" + BaseEncoding.base16().encode(binary);
     }
   }
 
@@ -652,7 +652,7 @@ class Literals {
     public String toString() {
       byte[] binary = new byte[value().remaining()];
       value().duplicate().get(binary);
-      return "0x" + DatatypeConverter.printHexBinary(binary);
+      return "0x" + BaseEncoding.base16().encode(binary);
     }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/util/ByteBuffers.java
+++ b/api/src/main/java/org/apache/iceberg/util/ByteBuffers.java
@@ -60,7 +60,7 @@ public class ByteBuffers {
   }
 
   public static String encodeHexString(ByteBuffer buffer) {
-    byte[] bytes = toByteArray(buffer.duplicate());
+    byte[] bytes = toByteArray(buffer);
     return BaseEncoding.base16().encode(bytes);
   }
 

--- a/api/src/main/java/org/apache/iceberg/util/ByteBuffers.java
+++ b/api/src/main/java/org/apache/iceberg/util/ByteBuffers.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.util;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
 
 public class ByteBuffers {
 
@@ -56,6 +57,11 @@ public class ByteBuffers {
     readerBuffer.get(copyArray);
 
     return ByteBuffer.wrap(copyArray);
+  }
+
+  public static String encodeHexString(ByteBuffer buffer) {
+    byte[] bytes = toByteArray(buffer.duplicate());
+    return BaseEncoding.base16().encode(bytes);
   }
 
   private ByteBuffers() {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.spark;
 
-import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -636,17 +635,17 @@ public class Spark3Util {
         case NOT_NAN:
           return "not_nan(" + pred.ref().name() + ")";
         case LT:
-          return pred.ref().name() + " < " + sqlString(pred.literal());
+          return pred.ref().name() + " < " + pred.literal();
         case LT_EQ:
-          return pred.ref().name() + " <= " + sqlString(pred.literal());
+          return pred.ref().name() + " <= " + pred.literal();
         case GT:
-          return pred.ref().name() + " > " + sqlString(pred.literal());
+          return pred.ref().name() + " > " + pred.literal();
         case GT_EQ:
-          return pred.ref().name() + " >= " + sqlString(pred.literal());
+          return pred.ref().name() + " >= " + pred.literal();
         case EQ:
-          return pred.ref().name() + " = " + sqlString(pred.literal());
+          return pred.ref().name() + " = " + pred.literal();
         case NOT_EQ:
-          return pred.ref().name() + " != " + sqlString(pred.literal());
+          return pred.ref().name() + " != " + pred.literal();
         case STARTS_WITH:
           return pred.ref().name() + " LIKE '" + pred.literal() + "%'";
         case IN:
@@ -659,17 +658,7 @@ public class Spark3Util {
     }
 
     private static <T> String sqlString(List<org.apache.iceberg.expressions.Literal<T>> literals) {
-      return literals.stream().map(DescribeExpressionVisitor::sqlString).collect(Collectors.joining(", "));
-    }
-
-    private static String sqlString(org.apache.iceberg.expressions.Literal<?> lit) {
-      if (lit.value() instanceof String) {
-        return "'" + lit.value() + "'";
-      } else if (lit.value() instanceof ByteBuffer) {
-        throw new IllegalArgumentException("Cannot convert bytes to SQL literal: " + lit);
-      } else {
-        return lit.value().toString();
-      }
+      return literals.stream().map(Object::toString).collect(Collectors.joining(", "));
     }
   }
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -39,6 +39,7 @@ import org.apache.spark.sql.internal.SQLConf;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.internal.ExactComparisonCriteria;
 
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS;
 
@@ -157,7 +158,11 @@ public abstract class SparkTestBase {
       Object actualValue = actualRow[col];
       if (expectedValue != null && expectedValue.getClass().isArray()) {
         String newContext = String.format("%s (nested col %d)", context, col + 1);
-        assertEquals(newContext, (Object[]) expectedValue, (Object[]) actualValue);
+        if (expectedValue.getClass().getComponentType().isPrimitive()) {
+          new ExactComparisonCriteria().arrayEquals(newContext, expectedValue, actualValue);
+        } else {
+          assertEquals(newContext, (Object[]) expectedValue, (Object[]) actualValue);
+        }
       } else if (expectedValue != ANY) {
         Assert.assertEquals(context + " contents should match", expectedValue, actualValue);
       }


### PR DESCRIPTION
The test case reproducing the exception：

```sql
CREATE TABLE filter_binary_test (cbinary BINARY) USING ICEBERG;
SELECT cbinary FROM filter_binary_test WHERE cbinary > X'110F';
```

```
java.lang.IllegalArgumentException: Cannot convert bytes to SQL literal: java.nio.HeapByteBuffer[pos=0 lim=2 cap=2]
```

Like this SQL, BinaryLiteral(ByteBuffer) is not an illegal value.

in addition, the BinaryLiteral string format in this PR is the same as spark.

https://github.com/apache/spark/blob/b874bf5dca4f1b7272f458350eb153e7b272f8c8/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala#L347