### PR TITLE
Checkstyle: prevent using unshaded Guava classes in Arrow and AssertJ

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -190,12 +190,12 @@
             <message key="import.illegal" value="Use org.apache.iceberg.relocated.* classes from bundled-guava module instead."/>
         </module>
         <module name="IllegalImport">
-            <property name="id" value="BanUnrelocatedGuavaClasses"/>
+            <property name="id" value="BanUnrelocatedAssertJClasses"/>
             <property name="illegalPkgs" value="org.assertj.core.util"/>
             <message key="import.illegal" value="Use org.apache.iceberg.relocated.* classes from bundled-guava module instead."/>
         </module>
         <module name="IllegalImport">
-            <property name="id" value="BanUnrelocatedGuavaClasses"/>
+            <property name="id" value="BanUnrelocatedArrowClasses"/>
             <property name="illegalPkgs" value="org.apache.arrow.util"/>
             <message key="import.illegal" value="Use org.apache.iceberg.relocated.* classes from bundled-guava module instead."/>
         </module>

--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -189,6 +189,16 @@
             <property name="illegalPkgs" value="com.google.common"/>
             <message key="import.illegal" value="Use org.apache.iceberg.relocated.* classes from bundled-guava module instead."/>
         </module>
+        <module name="IllegalImport">
+            <property name="id" value="BanUnrelocatedGuavaClasses"/>
+            <property name="illegalPkgs" value="org.assertj.core.util"/>
+            <message key="import.illegal" value="Use org.apache.iceberg.relocated.* classes from bundled-guava module instead."/>
+        </module>
+        <module name="IllegalImport">
+            <property name="id" value="BanUnrelocatedGuavaClasses"/>
+            <property name="illegalPkgs" value="org.apache.arrow.util"/>
+            <message key="import.illegal" value="Use org.apache.iceberg.relocated.* classes from bundled-guava module instead."/>
+        </module>
         <module name="IllegalInstantiation"> <!-- Java Coding Guidelines: Never instantiate primitive types -->
             <property name="classes" value="java.lang.Boolean"/>
             <property name="classes" value="java.lang.Byte"/>

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorHolder.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorHolder.java
@@ -19,8 +19,8 @@
 
 package org.apache.iceberg.arrow.vectorized;
 
-import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.FieldVector;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.Type;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Dictionary;

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
@@ -20,8 +20,8 @@
 package org.apache.iceberg.spark.procedures;
 
 import java.util.function.Function;
-import org.apache.arrow.util.Preconditions;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.Spark3Util.CatalogAndIdentifier;
 import org.apache.iceberg.spark.actions.SparkActions;

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkMergeBuilder.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkMergeBuilder.java
@@ -21,9 +21,9 @@ package org.apache.iceberg.spark.source;
 
 import java.util.Locale;
 import java.util.Map;
-import org.apache.arrow.util.Preconditions;
 import org.apache.iceberg.IsolationLevel;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.iceberg.write.MergeBuilder;
 import org.apache.spark.sql.connector.read.Scan;

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
@@ -20,8 +20,8 @@
 package org.apache.iceberg.spark.procedures;
 
 import java.util.function.Function;
-import org.apache.arrow.util.Preconditions;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.Spark3Util.CatalogAndIdentifier;
 import org.apache.iceberg.spark.actions.SparkActions;

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkMergeBuilder.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkMergeBuilder.java
@@ -21,9 +21,9 @@ package org.apache.iceberg.spark.source;
 
 import java.util.Locale;
 import java.util.Map;
-import org.apache.arrow.util.Preconditions;
 import org.apache.iceberg.IsolationLevel;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.iceberg.write.MergeBuilder;
 import org.apache.spark.sql.connector.read.Scan;

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
@@ -20,8 +20,8 @@
 package org.apache.iceberg.spark.procedures;
 
 import java.util.function.Function;
-import org.apache.arrow.util.Preconditions;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.Spark3Util.CatalogAndIdentifier;
 import org.apache.iceberg.spark.actions.SparkActions;

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkMergeBuilder.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkMergeBuilder.java
@@ -21,9 +21,9 @@ package org.apache.iceberg.spark.source;
 
 import java.util.Locale;
 import java.util.Map;
-import org.apache.arrow.util.Preconditions;
 import org.apache.iceberg.IsolationLevel;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.iceberg.write.MergeBuilder;
 import org.apache.spark.sql.connector.read.Scan;


### PR DESCRIPTION
add new checkstyle rules for unshaded Guava classes for recently introduced libraries. @kbendick 