### PR TITLE
Core: support rewrite data files with starting sequence number

### DIFF
--- a/api/src/main/java/org/apache/iceberg/RewriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteFiles.java
@@ -52,6 +52,17 @@ public interface RewriteFiles extends SnapshotUpdate<RewriteFiles> {
   }
 
   /**
+   * Add a rewrite that replaces one set of data files with another set that contains the same data.
+   * The sequence number provided will be used for all the data files added.
+   *
+   * @param filesToDelete  files that will be replaced (deleted), cannot be null or empty.
+   * @param filesToAdd     files that will be added, cannot be null or empty.
+   * @param sequenceNumber sequence number to use for all data files added
+   * @return this for method chaining
+   */
+  RewriteFiles rewriteFiles(Set<DataFile> filesToDelete, Set<DataFile> filesToAdd, long sequenceNumber);
+
+  /**
    * Add a rewrite that replaces one set of files with another set that contains the same data.
    *
    * @param dataFilesToReplace   data files that will be replaced (deleted).
@@ -73,13 +84,4 @@ public interface RewriteFiles extends SnapshotUpdate<RewriteFiles> {
    * @return this for method chaining
    */
   RewriteFiles validateFromSnapshot(long snapshotId);
-
-  /**
-   * Use the specified sequence number for the new manifest of the data files added in this update,
-   * instead of inheriting the sequence number of the snapshot that will be created.
-   *
-   * @param sequenceNumber a sequence number
-   * @return this for method chaining
-   */
-  RewriteFiles overrideSequenceNumberForNewDataFiles(long sequenceNumber);
 }

--- a/api/src/main/java/org/apache/iceberg/RewriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteFiles.java
@@ -73,4 +73,13 @@ public interface RewriteFiles extends SnapshotUpdate<RewriteFiles> {
    * @return this for method chaining
    */
   RewriteFiles validateFromSnapshot(long snapshotId);
+
+  /**
+   * Use the specified sequence number for the new manifest of the data files added in this update,
+   * instead of inheriting the sequence number of the snapshot that will be created.
+   *
+   * @param sequenceNumber a sequence number
+   * @return this for method chaining
+   */
+  RewriteFiles overrideSequenceNumberForNewDataFiles(long sequenceNumber);
 }

--- a/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
@@ -78,15 +78,15 @@ public interface RewriteDataFiles extends SnapshotUpdate<RewriteDataFiles, Rewri
   String TARGET_FILE_SIZE_BYTES = "target-file-size-bytes";
 
   /**
-   * If the compaction should commit rewritten data files using the sequence number at compaction start time instead
-   * of optimistically incrementing the latest sequence number.
+   * If the compaction should use the sequence number of the snapshot at compaction start time for new data files,
+   * instead of using the sequence number of the newly produced snapshot.
    * <p>
    * This avoids commit conflicts with updates that add newer equality deletes at a higher sequence number.
    * <p>
-   * Defaults to false.
+   * Defaults to true.
    */
   String USE_STARTING_SEQUENCE_NUMBER = "use-starting-sequence-number";
-  boolean USE_STARTING_SEQUENCE_NUMBER_DEFAULT = false;
+  boolean USE_STARTING_SEQUENCE_NUMBER_DEFAULT = true;
 
   /**
    * Choose BINPACK as a strategy for this rewrite operation

--- a/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
@@ -78,6 +78,17 @@ public interface RewriteDataFiles extends SnapshotUpdate<RewriteDataFiles, Rewri
   String TARGET_FILE_SIZE_BYTES = "target-file-size-bytes";
 
   /**
+   * If the compaction should commit rewritten data files using the sequence number at compaction start time instead
+   * of optimistically incrementing the latest sequence number.
+   * <p>
+   * This avoids commit conflicts with updates that add newer equality deletes at a higher sequence number.
+   * <p>
+   * Defaults to false.
+   */
+  String USE_STARTING_SEQUENCE_NUMBER = "use-starting-sequence-number";
+  boolean USE_STARTING_SEQUENCE_NUMBER_DEFAULT = false;
+
+  /**
    * Choose BINPACK as a strategy for this rewrite operation
    * @return this for method chaining
    */

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 
 import java.util.Set;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 
 class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements RewriteFiles {
@@ -67,6 +68,12 @@ class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements 
   }
 
   @Override
+  public RewriteFiles rewriteFiles(Set<DataFile> filesToDelete, Set<DataFile> filesToAdd, long sequenceNumber) {
+    setNewFilesSequenceNumber(sequenceNumber);
+    return rewriteFiles(filesToDelete, ImmutableSet.of(), filesToAdd, ImmutableSet.of());
+  }
+
+  @Override
   public RewriteFiles rewriteFiles(Set<DataFile> dataFilesToReplace, Set<DeleteFile> deleteFilesToReplace,
                                    Set<DataFile> dataFilesToAdd, Set<DeleteFile> deleteFilesToAdd) {
     verifyInputAndOutputFiles(dataFilesToReplace, deleteFilesToReplace, dataFilesToAdd, deleteFilesToAdd);
@@ -94,12 +101,6 @@ class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements 
   @Override
   public RewriteFiles validateFromSnapshot(long snapshotId) {
     this.startingSnapshotId = snapshotId;
-    return this;
-  }
-
-  @Override
-  public RewriteFiles overrideSequenceNumberForNewDataFiles(long sequenceNumber) {
-    setSequenceNumberForNewDataFiles(sequenceNumber);
     return this;
   }
 

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
@@ -98,6 +98,12 @@ class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements 
   }
 
   @Override
+  public RewriteFiles overrideSequenceNumberForNewDataFiles(long sequenceNumber) {
+    setSequenceNumberForNewDataFiles(sequenceNumber);
+    return this;
+  }
+
+  @Override
   protected void validate(TableMetadata base) {
     if (replacedDataFiles.size() > 0) {
       // if there are replaced data files, there cannot be any new row-level deletes for those data files

--- a/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
+++ b/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
@@ -62,9 +62,13 @@ class GenericManifestEntry<F extends ContentFile<F>>
   }
 
   ManifestEntry<F> wrapAppend(Long newSnapshotId, F newFile) {
+    return wrapAppend(newSnapshotId, null, newFile);
+  }
+
+  ManifestEntry<F> wrapAppend(Long newSnapshotId, Long newSequenceNumber, F newFile) {
     this.status = Status.ADDED;
     this.snapshotId = newSnapshotId;
-    this.sequenceNumber = null;
+    this.sequenceNumber = newSequenceNumber;
     this.file = newFile;
     return this;
   }

--- a/core/src/main/java/org/apache/iceberg/ManifestWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestWriter.java
@@ -103,6 +103,18 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
     addEntry(reused.wrapAppend(snapshotId, addedFile));
   }
 
+  /**
+   * Add an added entry for a file at a specific sequence number.
+   * <p>
+   * The entry's snapshot ID will be this manifest's snapshot ID.
+   *
+   * @param addedFile a data file
+   * @param sequenceNumber sequence number for the data file
+   */
+  public void add(F addedFile, Long sequenceNumber) {
+    addEntry(reused.wrapAppend(snapshotId, sequenceNumber, addedFile));
+  }
+
   void add(ManifestEntry<F> entry) {
     addEntry(reused.wrapAppend(snapshotId, entry.file()));
   }

--- a/core/src/main/java/org/apache/iceberg/ManifestWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestWriter.java
@@ -104,9 +104,10 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
   }
 
   /**
-   * Add an added entry for a file at a specific sequence number.
+   * Add an added entry for a file with a specific sequence number.
    * <p>
    * The entry's snapshot ID will be this manifest's snapshot ID.
+   * The entry's sequence number will be the provided sequence number.
    *
    * @param addedFile a data file
    * @param sequenceNumber sequence number for the data file

--- a/core/src/main/java/org/apache/iceberg/ManifestWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestWriter.java
@@ -111,7 +111,7 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
    * @param addedFile a data file
    * @param sequenceNumber sequence number for the data file
    */
-  public void add(F addedFile, Long sequenceNumber) {
+  public void add(F addedFile, long sequenceNumber) {
     addEntry(reused.wrapAppend(snapshotId, sequenceNumber, addedFile));
   }
 

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -322,6 +322,11 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
   /**
    * Validates that no new delete files that must be applied to the given data files have been added to the table since
    * a starting snapshot, with the option to ignore equality deletes during the validation.
+   * <p>
+   * For example, in the case of rewriting data files, if the added data files have the same sequence number as the
+   * replaced data files, equality deletes added at a higher sequence number are still effective against the added
+   * data files, so there is no risk of commit conflict between RewriteFiles and RowDelta. In cases like this,
+   * validation against equality delete files can be omitted.
    *
    * @param base table metadata to validate
    * @param startingSnapshotId id of the snapshot current at the start of the operation

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -621,7 +621,11 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
       try {
         ManifestWriter<DataFile> writer = newManifestWriter(dataSpec());
         try {
-          newFiles.forEach(f -> writer.add(f, newFilesSequenceNumber));
+          if (newFilesSequenceNumber == null) {
+            writer.addAll(newFiles);
+          } else {
+            newFiles.forEach(f -> writer.add(f, newFilesSequenceNumber));
+          }
         } finally {
           writer.close();
         }

--- a/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
@@ -48,6 +48,7 @@ public class RewriteDataFilesCommitManager {
 
   private final Table table;
   private final long startingSnapshotId;
+  private final boolean useStartingSequenceNumber;
 
   // constructor used for testing
   public RewriteDataFilesCommitManager(Table table) {
@@ -55,8 +56,13 @@ public class RewriteDataFilesCommitManager {
   }
 
   public RewriteDataFilesCommitManager(Table table, long startingSnapshotId) {
+    this(table, startingSnapshotId, RewriteDataFiles.USE_STARTING_SEQUENCE_NUMBER_DEFAULT);
+  }
+
+  public RewriteDataFilesCommitManager(Table table, long startingSnapshotId, boolean useStartingSequenceNumber) {
     this.table = table;
     this.startingSnapshotId = startingSnapshotId;
+    this.useStartingSequenceNumber = useStartingSequenceNumber;
   }
 
   /**
@@ -75,6 +81,11 @@ public class RewriteDataFilesCommitManager {
     RewriteFiles rewrite = table.newRewrite()
         .validateFromSnapshot(startingSnapshotId)
         .rewriteFiles(rewrittenDataFiles, addedDataFiles);
+
+    if (useStartingSequenceNumber) {
+      rewrite = rewrite.overrideSequenceNumberForNewDataFiles(table.snapshot(startingSnapshotId).sequenceNumber());
+    }
+
     rewrite.commit();
   }
 

--- a/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
@@ -78,12 +78,12 @@ public class RewriteDataFilesCommitManager {
       addedDataFiles = Sets.union(addedDataFiles, group.addedFiles());
     }
 
-    RewriteFiles rewrite = table.newRewrite()
-        .validateFromSnapshot(startingSnapshotId)
-        .rewriteFiles(rewrittenDataFiles, addedDataFiles);
-
+    RewriteFiles rewrite = table.newRewrite().validateFromSnapshot(startingSnapshotId);
     if (useStartingSequenceNumber) {
-      rewrite = rewrite.overrideSequenceNumberForNewDataFiles(table.snapshot(startingSnapshotId).sequenceNumber());
+      long sequenceNumber = table.snapshot(startingSnapshotId).sequenceNumber();
+      rewrite.rewriteFiles(rewrittenDataFiles, addedDataFiles, sequenceNumber);
+    } else {
+      rewrite.rewriteFiles(rewrittenDataFiles, addedDataFiles);
     }
 
     rewrite.commit();

--- a/core/src/test/java/org/apache/iceberg/TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TableTestBase.java
@@ -469,6 +469,17 @@ public class TableTestBase {
         .build();
   }
 
+  protected DeleteFile newEqualityDeleteFile(int specId, String partitionPath, int... fieldIds) {
+    PartitionSpec spec = table.specs().get(specId);
+    return FileMetadata.deleteFileBuilder(spec)
+        .ofEqualityDeletes(fieldIds)
+        .withPath("/path/to/delete-" + UUID.randomUUID() + ".parquet")
+        .withFileSizeInBytes(10)
+        .withPartitionPath(partitionPath)
+        .withRecordCount(1)
+        .build();
+  }
+
   protected <T> PositionDelete<T> positionDelete(CharSequence path, long pos, T row) {
     PositionDelete<T> positionDelete = PositionDelete.create();
     return positionDelete.set(path, pos, row);

--- a/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
@@ -269,6 +269,73 @@ public class TestRewriteFiles extends TableTestBase {
   }
 
   @Test
+  public void testRewriteDataAndAssignOldSequenceNumber() {
+    Assume.assumeTrue("Rewriting delete files is only supported in iceberg format v2. ", formatVersion > 1);
+    Assert.assertEquals("Table should start empty", 0, listManifestFiles().size());
+
+    table.newRowDelta()
+        .addRows(FILE_A)
+        .addRows(FILE_B)
+        .addRows(FILE_C)
+        .addDeletes(FILE_A_DELETES)
+        .addDeletes(FILE_B_DELETES)
+        .commit();
+
+    TableMetadata base = readMetadata();
+    Snapshot baseSnap = base.currentSnapshot();
+    long baseSnapshotId = baseSnap.snapshotId();
+    Assert.assertEquals("Should create 2 manifests for initial write", 2, baseSnap.allManifests().size());
+    List<ManifestFile> initialManifests = baseSnap.allManifests();
+
+    validateManifestEntries(initialManifests.get(0),
+        ids(baseSnapshotId, baseSnapshotId, baseSnapshotId),
+        files(FILE_A, FILE_B, FILE_C),
+        statuses(ADDED, ADDED, ADDED));
+    validateDeleteManifest(initialManifests.get(1),
+        seqs(1, 1),
+        ids(baseSnapshotId, baseSnapshotId),
+        files(FILE_A_DELETES, FILE_B_DELETES),
+        statuses(ADDED, ADDED));
+
+    // Rewrite the files.
+    long oldSequenceNumber = table.currentSnapshot().sequenceNumber();
+    Snapshot pending = table.newRewrite()
+        .validateFromSnapshot(table.currentSnapshot().snapshotId())
+        .overrideSequenceNumberForNewDataFiles(oldSequenceNumber)
+        .rewriteFiles(ImmutableSet.of(FILE_A), ImmutableSet.of(FILE_A_DELETES),
+            ImmutableSet.of(FILE_D), ImmutableSet.of())
+        .apply();
+
+    Assert.assertEquals("Should contain 3 manifest", 3, pending.allManifests().size());
+    Assert.assertFalse("Should not contain manifest from initial write",
+        pending.allManifests().stream().anyMatch(initialManifests::contains));
+
+    long pendingId = pending.snapshotId();
+    ManifestFile newManifest = pending.allManifests().get(0);
+    validateManifestEntries(newManifest, ids(pendingId), files(FILE_D), statuses(ADDED));
+    for (ManifestEntry<DataFile> entry : ManifestFiles.read(newManifest, FILE_IO).entries()) {
+      Assert.assertEquals("Should have old sequence number for manifest entries",
+          oldSequenceNumber, (long) entry.sequenceNumber());
+    }
+    Assert.assertEquals("Should use new sequence number for the manifest file",
+        oldSequenceNumber + 1, newManifest.sequenceNumber());
+
+    validateManifestEntries(pending.allManifests().get(1),
+        ids(pendingId, baseSnapshotId, baseSnapshotId),
+        files(FILE_A, FILE_B, FILE_C),
+        statuses(DELETED, EXISTING, EXISTING));
+
+    validateDeleteManifest(pending.allManifests().get(2),
+        seqs(2, 1),
+        ids(pendingId, baseSnapshotId),
+        files(FILE_A_DELETES, FILE_B_DELETES),
+        statuses(DELETED, EXISTING));
+
+    // We should only get the 3 manifests that this test is expected to add.
+    Assert.assertEquals("Only 5 manifests should exist", 5, listManifestFiles().size());
+  }
+
+  @Test
   public void testFailure() {
     table.newAppend()
         .appendFile(FILE_A)

--- a/core/src/test/java/org/apache/iceberg/TestRowDelta.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowDelta.java
@@ -1168,9 +1168,8 @@ public class TestRowDelta extends V2TableTestBase {
     DataFile dataFile2 = newDataFile("data=a");
 
     RewriteFiles rewriteFiles = table.newRewrite()
-        .rewriteFiles(ImmutableSet.of(dataFile1), ImmutableSet.of(dataFile2))
-        .validateFromSnapshot(baseSnapshot.snapshotId())
-        .overrideSequenceNumberForNewDataFiles(baseSnapshot.sequenceNumber());
+        .rewriteFiles(ImmutableSet.of(dataFile1), ImmutableSet.of(dataFile2), baseSnapshot.sequenceNumber())
+        .validateFromSnapshot(baseSnapshot.snapshotId());
 
     rowDelta.commit();
     rewriteFiles.commit();
@@ -1210,9 +1209,8 @@ public class TestRowDelta extends V2TableTestBase {
     DataFile dataFile2 = newDataFile("data=a");
 
     RewriteFiles rewriteFiles = table.newRewrite()
-        .rewriteFiles(ImmutableSet.of(dataFile1), ImmutableSet.of(dataFile2))
-        .validateFromSnapshot(baseSnapshot.snapshotId())
-        .overrideSequenceNumberForNewDataFiles(baseSnapshot.sequenceNumber());
+        .rewriteFiles(ImmutableSet.of(dataFile1), ImmutableSet.of(dataFile2), baseSnapshot.sequenceNumber())
+        .validateFromSnapshot(baseSnapshot.snapshotId());
 
     rowDelta.commit();
 

--- a/core/src/test/java/org/apache/iceberg/TestRowDelta.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowDelta.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.junit.Assert;
 import org.junit.Test;
@@ -1133,5 +1134,91 @@ public class TestRowDelta extends V2TableTestBase {
     rowDelta.commit();
 
     validateTableDeleteFiles(table, deleteFile1, deleteFile2);
+  }
+
+  @Test
+  public void testConcurrentNonConflictingRowDeltaAndRewriteFilesWithSequenceNumber() {
+    // change the spec to be partitioned by data
+    table.updateSpec()
+        .removeField(Expressions.bucket("data", 16))
+        .addField(Expressions.ref("data"))
+        .commit();
+
+    // add a data file to partition A
+    DataFile dataFile1 = newDataFile("data=a");
+
+    table.newAppend()
+        .appendFile(dataFile1)
+        .commit();
+
+    Snapshot baseSnapshot = table.currentSnapshot();
+
+    // add an equality delete file
+    DeleteFile deleteFile1 = newEqualityDeleteFile(table.spec().specId(), "data=a",
+        table.schema().asStruct().fields().get(0).fieldId());
+
+    // mock a DELETE operation with serializable isolation
+    RowDelta rowDelta = table.newRowDelta()
+        .addDeletes(deleteFile1)
+        .validateFromSnapshot(baseSnapshot.snapshotId())
+        .validateNoConflictingDataFiles()
+        .validateNoConflictingDeleteFiles();
+
+    // mock a REWRITE operation with serializable isolation
+    DataFile dataFile2 = newDataFile("data=a");
+
+    RewriteFiles rewriteFiles = table.newRewrite()
+        .rewriteFiles(ImmutableSet.of(dataFile1), ImmutableSet.of(dataFile2))
+        .validateFromSnapshot(baseSnapshot.snapshotId())
+        .overrideSequenceNumberForNewDataFiles(baseSnapshot.sequenceNumber());
+
+    rowDelta.commit();
+    rewriteFiles.commit();
+
+    validateTableDeleteFiles(table, deleteFile1);
+    validateTableFiles(table, dataFile2);
+  }
+
+  @Test
+  public void testConcurrentConflictingRowDeltaAndRewriteFilesWithSequenceNumber() {
+    // change the spec to be partitioned by data
+    table.updateSpec()
+        .removeField(Expressions.bucket("data", 16))
+        .addField(Expressions.ref("data"))
+        .commit();
+
+    // add a data file to partition A
+    DataFile dataFile1 = newDataFile("data=a");
+
+    table.newAppend()
+        .appendFile(dataFile1)
+        .commit();
+
+    Snapshot baseSnapshot = table.currentSnapshot();
+
+    // add an position delete file
+    DeleteFile deleteFile1 = newDeleteFile(table.spec().specId(), "data=a");
+
+    // mock a DELETE operation with serializable isolation
+    RowDelta rowDelta = table.newRowDelta()
+        .addDeletes(deleteFile1)
+        .validateFromSnapshot(baseSnapshot.snapshotId())
+        .validateNoConflictingDataFiles()
+        .validateNoConflictingDeleteFiles();
+
+    // mock a REWRITE operation with serializable isolation
+    DataFile dataFile2 = newDataFile("data=a");
+
+    RewriteFiles rewriteFiles = table.newRewrite()
+        .rewriteFiles(ImmutableSet.of(dataFile1), ImmutableSet.of(dataFile2))
+        .validateFromSnapshot(baseSnapshot.snapshotId())
+        .overrideSequenceNumberForNewDataFiles(baseSnapshot.sequenceNumber());
+
+    rowDelta.commit();
+
+    AssertHelpers.assertThrows("Should not allow any new position delete associated with the data file",
+        ValidationException.class,
+        "Cannot commit, found new position delete for replaced data file",
+        rewriteFiles::commit);
   }
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
@@ -79,7 +79,8 @@ abstract class BaseRewriteDataFilesSparkAction
       MAX_FILE_GROUP_SIZE_BYTES,
       PARTIAL_PROGRESS_ENABLED,
       PARTIAL_PROGRESS_MAX_COMMITS,
-      TARGET_FILE_SIZE_BYTES
+      TARGET_FILE_SIZE_BYTES,
+      USE_STARTING_SEQUENCE_NUMBER
   );
 
   private final Table table;
@@ -88,6 +89,7 @@ abstract class BaseRewriteDataFilesSparkAction
   private int maxConcurrentFileGroupRewrites;
   private int maxCommits;
   private boolean partialProgressEnabled;
+  private boolean useStartingSequenceNumber;
   private RewriteStrategy strategy = null;
 
   protected BaseRewriteDataFilesSparkAction(SparkSession spark, Table table) {
@@ -245,7 +247,7 @@ abstract class BaseRewriteDataFilesSparkAction
 
   @VisibleForTesting
   RewriteDataFilesCommitManager commitManager(long startingSnapshotId) {
-    return new RewriteDataFilesCommitManager(table, startingSnapshotId);
+    return new RewriteDataFilesCommitManager(table, startingSnapshotId, useStartingSequenceNumber);
   }
 
   private Result doExecute(RewriteExecutionContext ctx, Stream<RewriteFileGroup> groupStream,
@@ -374,6 +376,10 @@ abstract class BaseRewriteDataFilesSparkAction
     partialProgressEnabled = PropertyUtil.propertyAsBoolean(options(),
         PARTIAL_PROGRESS_ENABLED,
         PARTIAL_PROGRESS_ENABLED_DEFAULT);
+
+    useStartingSequenceNumber = PropertyUtil.propertyAsBoolean(options(),
+        USE_STARTING_SEQUENCE_NUMBER,
+        USE_STARTING_SEQUENCE_NUMBER_DEFAULT);
 
     Preconditions.checkArgument(maxConcurrentFileGroupRewrites >= 1,
         "Cannot set %s to %s, the value must be positive.",

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestNewRewriteDataFilesAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestNewRewriteDataFilesAction.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.Schema;
@@ -68,6 +69,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.FileRewriteCoordinator;
 import org.apache.iceberg.spark.FileScanTaskSetManager;
+import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.SparkTestBase;
 import org.apache.iceberg.spark.source.ThreeColumnRecord;
 import org.apache.iceberg.types.Comparators;
@@ -238,6 +240,37 @@ public class TestNewRewriteDataFilesAction extends SparkTestBase {
     List<Object[]> actualRecords = currentData();
     assertEquals("Rows must match", expectedRecords, actualRecords);
     Assert.assertEquals("12 rows are removed", total - 12, actualRecords.size());
+  }
+
+  @Test
+  public void testBinPackWithStartingSequenceNumber() {
+    Table table = createTablePartitioned(4, 2);
+    shouldHaveFiles(table, 8);
+    List<Object[]> expectedRecords = currentData();
+    table.updateProperties().set(TableProperties.FORMAT_VERSION, "2").commit();
+    table.refresh();
+    long oldSequenceNumber = table.currentSnapshot().sequenceNumber();
+
+    Result result = basicRewrite(table)
+        .option(RewriteDataFiles.USE_STARTING_SEQUENCE_NUMBER, "true")
+        .execute();
+    Assert.assertEquals("Action should rewrite 8 data files", 8, result.rewrittenDataFilesCount());
+    Assert.assertEquals("Action should add 4 data file", 4, result.addedDataFilesCount());
+
+    shouldHaveFiles(table, 4);
+    List<Object[]> actualRecords = currentData();
+    assertEquals("Rows must match", expectedRecords, actualRecords);
+
+    table.refresh();
+    Assert.assertTrue("Table sequence number should be incremented",
+        oldSequenceNumber < table.currentSnapshot().sequenceNumber());
+
+    Dataset<Row> rows = SparkTableUtil.loadMetadataTable(spark, table, MetadataTableType.ENTRIES);
+    for (Row row : rows.collectAsList()) {
+      if (row.getInt(0) == 1) {
+        Assert.assertEquals("Expect old sequence number for added entries", oldSequenceNumber, row.getLong(2));
+      }
+    }
   }
 
   @Test

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestNewRewriteDataFilesAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestNewRewriteDataFilesAction.java
@@ -274,6 +274,36 @@ public class TestNewRewriteDataFilesAction extends SparkTestBase {
   }
 
   @Test
+  public void testBinPackWithStartingSequenceNumberV1Compatibility() {
+    Table table = createTablePartitioned(4, 2);
+    shouldHaveFiles(table, 8);
+    List<Object[]> expectedRecords = currentData();
+    table.refresh();
+    long oldSequenceNumber = table.currentSnapshot().sequenceNumber();
+    Assert.assertEquals("Table sequence number should be 0", 0, oldSequenceNumber);
+
+    Result result = basicRewrite(table)
+        .option(RewriteDataFiles.USE_STARTING_SEQUENCE_NUMBER, "true")
+        .execute();
+    Assert.assertEquals("Action should rewrite 8 data files", 8, result.rewrittenDataFilesCount());
+    Assert.assertEquals("Action should add 4 data file", 4, result.addedDataFilesCount());
+
+    shouldHaveFiles(table, 4);
+    List<Object[]> actualRecords = currentData();
+    assertEquals("Rows must match", expectedRecords, actualRecords);
+
+    table.refresh();
+    Assert.assertEquals("Table sequence number should still be 0",
+        oldSequenceNumber, table.currentSnapshot().sequenceNumber());
+
+    Dataset<Row> rows = SparkTableUtil.loadMetadataTable(spark, table, MetadataTableType.ENTRIES);
+    for (Row row : rows.collectAsList()) {
+      Assert.assertEquals("Expect sequence number 0 for all entries",
+          oldSequenceNumber, row.getLong(2));
+    }
+  }
+
+  @Test
   public void testRewriteLargeTableHasResiduals() {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).build();
     Map<String, String> options = Maps.newHashMap();


### PR DESCRIPTION
Add new hook in `RewriteFiles` snapshot update to allow accepting a sequence number that is used for all new data files. That will force the manifest writer to produce `ManifestFile` with the provided sequence number instead of `-1`.

Also add a new property in `RewriteDataFiles` to use this feature through config `use-starting-sequence-number`. When enabled, the sequence number when compaction starts will be used for commit.

This whole mechanism solves the issue today in CDC where compaction has conflicts with new equality delete files. With this change, `RewriteFiles` can go through as long as the newly added data files don't have new position deletes.