### PR TITLE
Move openCurrentWriter to base class

### DIFF
--- a/core/src/main/java/org/apache/iceberg/io/RollingDataWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/RollingDataWriter.java
@@ -41,7 +41,6 @@ public class RollingDataWriter<T> extends RollingFileWriter<T, DataWriter<T>, Da
     super(fileFactory, io, targetFileSizeInBytes, spec, partition);
     this.writerFactory = writerFactory;
     this.dataFiles = Lists.newArrayList();
-    openCurrentWriter();
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/io/RollingEqualityDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/RollingEqualityDeleteWriter.java
@@ -43,7 +43,6 @@ public class RollingEqualityDeleteWriter<T> extends RollingFileWriter<T, Equalit
     super(fileFactory, io, targetFileSizeInBytes, spec, partition);
     this.writerFactory = writerFactory;
     this.deleteFiles = Lists.newArrayList();
-    openCurrentWriter();
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/io/RollingFileWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/RollingFileWriter.java
@@ -52,6 +52,7 @@ abstract class RollingFileWriter<T, W extends FileWriter<T, R>, R> implements Fi
     this.targetFileSizeInBytes = targetFileSizeInBytes;
     this.spec = spec;
     this.partition = partition;
+    openCurrentWriter();
   }
 
   protected abstract W newWriter(EncryptedOutputFile file);

--- a/core/src/main/java/org/apache/iceberg/io/RollingPositionDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/RollingPositionDeleteWriter.java
@@ -47,7 +47,6 @@ public class RollingPositionDeleteWriter<T>
     this.writerFactory = writerFactory;
     this.deleteFiles = Lists.newArrayList();
     this.referencedDataFiles = CharSequenceSet.empty();
-    openCurrentWriter();
   }
 
   @Override


### PR DESCRIPTION
The openCurrentWriter is related to the method of write, so I think that it is more appropriate to move it here.