### PR TITLE
Only run publish GH action for apache repo, not forked

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -27,6 +27,7 @@ on:
 
 jobs:
   publish-snapshot:
+    if: github.repository_owner == 'apache'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The `Publish Snapshot to Maven` Github Action has been scheduled automatically in my forked repo and failing due to permission issues. 

Log: 
```
* What went wrong:
120
Execution failed for task ':iceberg-spark:publishApachePublicationToMavenRepository'.
121
> Failed to publish publication 'apache' to repository 'maven'
122
   > Could not PUT 'https://repository.apache.org/content/repositories/snapshots/org/apache/iceberg/iceberg-spark/0.13.0-SNAPSHOT/maven-metadata.xml'. Received status code 401 from server: Unauthorized
123
```
[Example GH Action run](https://github.com/kevinjqliu/iceberg/runs/4133664776?check_suite_focus=true) 

The GH Action retries automatically (every day?) and will also generate a failure email report. I had to manually disable it on my forked repo.
This PR limits the GH Action to run only on the `apache` repo. 

References:
- [Do not run GitHub Action Workflows on fork of example repository #3539](https://github.com/prisma/prisma/issues/3539)
- [No update-precommit on forks #5261](https://github.com/aio-libs/aiohttp/pull/5261)
- [Modify Github Action to only run on repo's owned by 'smaddis' #33](https://github.com/smaddis/smad-deploy-azure/issues/33)
- [Stop github actions running on a fork](https://github.community/t/stop-github-actions-running-on-a-fork/17965)