### PR TITLE
Spark: Move more read configs to SparkReadConf

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -81,7 +81,6 @@ import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation;
 import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
 import org.apache.spark.sql.types.StructType;
-import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import scala.Option;
 import scala.Predef;
 import scala.Some;
@@ -442,45 +441,6 @@ public class Spark3Util {
 
   public static String describe(org.apache.iceberg.SortOrder order) {
     return Joiner.on(", ").join(SortOrderVisitor.visit(order, DescribeSortOrderVisitor.INSTANCE));
-  }
-
-  public static Long propertyAsLong(CaseInsensitiveStringMap options, String property, Long defaultValue) {
-    if (defaultValue != null) {
-      return options.getLong(property, defaultValue);
-    }
-
-    String value = options.get(property);
-    if (value != null) {
-      return Long.parseLong(value);
-    }
-
-    return null;
-  }
-
-  public static Integer propertyAsInt(CaseInsensitiveStringMap options, String property, Integer defaultValue) {
-    if (defaultValue != null) {
-      return options.getInt(property, defaultValue);
-    }
-
-    String value = options.get(property);
-    if (value != null) {
-      return Integer.parseInt(value);
-    }
-
-    return null;
-  }
-
-  public static Boolean propertyAsBoolean(CaseInsensitiveStringMap options, String property, Boolean defaultValue) {
-    if (defaultValue != null) {
-      return options.getBoolean(property, defaultValue);
-    }
-
-    String value = options.get(property);
-    if (value != null) {
-      return Boolean.parseBoolean(value);
-    }
-
-    return null;
   }
 
   public static boolean extensionsEnabled(SparkSession spark) {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -48,14 +48,20 @@ public class SparkReadConf {
 
   private static final Set<String> LOCALITY_WHITELIST_FS = ImmutableSet.of("hdfs");
 
+  private final SparkSession spark;
   private final Table table;
   private final Map<String, String> readOptions;
   private final SparkConfParser confParser;
 
   public SparkReadConf(SparkSession spark, Table table, Map<String, String> readOptions) {
+    this.spark = spark;
     this.table = table;
     this.readOptions = readOptions;
     this.confParser = new SparkConfParser(spark, table, readOptions);
+  }
+
+  public boolean caseSensitive() {
+    return Boolean.parseBoolean(spark.conf().get("spark.sql.caseSensitive"));
   }
 
   public boolean localityEnabled() {
@@ -95,6 +101,19 @@ public class SparkReadConf {
     return confParser.longConf()
         .option(SparkReadOptions.END_SNAPSHOT_ID)
         .parseOptional();
+  }
+
+  public String fileScanTaskSetId() {
+    return confParser.stringConf()
+        .option(SparkReadOptions.FILE_SCAN_TASK_SET_ID)
+        .parseOptional();
+  }
+
+  public boolean streamingSkipDeleteSnapshots() {
+    return confParser.booleanConf()
+        .option(SparkReadOptions.STREAMING_SKIP_DELETE_SNAPSHOTS)
+        .defaultValue(SparkReadOptions.STREAMING_SKIP_DELETE_SNAPSHOTS_DEFAULT)
+        .parse();
   }
 
   public boolean parquetVectorizationEnabled() {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java
@@ -59,6 +59,7 @@ public class SparkReadOptions {
 
   // skip snapshots of type delete while reading stream out of iceberg table
   public static final String STREAMING_SKIP_DELETE_SNAPSHOTS = "streaming-skip-delete-snapshots";
+  public static final boolean STREAMING_SKIP_DELETE_SNAPSHOTS_DEFAULT = false;
 
   // Controls whether to allow reading timestamps without zone info
   public static final String HANDLE_TIMESTAMP_WITHOUT_TIMEZONE = "handle-timestamp-without-timezone";

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
@@ -54,7 +54,6 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.expressions.NamedReference;
 import org.apache.spark.sql.connector.read.SupportsRuntimeFiltering;
 import org.apache.spark.sql.sources.Filter;
-import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,10 +75,10 @@ class SparkBatchQueryScan extends SparkBatchScan implements SupportsRuntimeFilte
   private List<FileScanTask> files = null; // lazy cache of files
   private List<CombinedScanTask> tasks = null; // lazy cache of tasks
 
-  SparkBatchQueryScan(SparkSession spark, Table table, SparkReadConf readConf, boolean caseSensitive,
-                      Schema expectedSchema, List<Expression> filters, CaseInsensitiveStringMap options) {
+  SparkBatchQueryScan(SparkSession spark, Table table, SparkReadConf readConf,
+                      Schema expectedSchema, List<Expression> filters) {
 
-    super(spark, table, readConf, caseSensitive, expectedSchema, filters, options);
+    super(spark, table, readConf, expectedSchema, filters);
 
     this.snapshotId = readConf.snapshotId();
     this.asOfTimestamp = readConf.asOfTimestamp();

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
@@ -57,7 +57,6 @@ import org.apache.spark.sql.connector.read.Statistics;
 import org.apache.spark.sql.connector.read.SupportsReportStatistics;
 import org.apache.spark.sql.connector.read.streaming.MicroBatchStream;
 import org.apache.spark.sql.types.StructType;
-import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,25 +72,23 @@ abstract class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
   private final Schema expectedSchema;
   private final List<Expression> filterExpressions;
   private final boolean readTimestampWithoutZone;
-  private final CaseInsensitiveStringMap options;
 
   // lazy variables
   private StructType readSchema = null;
 
-  SparkBatchScan(SparkSession spark, Table table, SparkReadConf readConf, boolean caseSensitive,
-                 Schema expectedSchema, List<Expression> filters, CaseInsensitiveStringMap options) {
+  SparkBatchScan(SparkSession spark, Table table, SparkReadConf readConf,
+                 Schema expectedSchema, List<Expression> filters) {
 
     SparkSchemaUtil.validateMetadataColumnReferences(table.schema(), expectedSchema);
 
     this.sparkContext = JavaSparkContext.fromSparkContext(spark.sparkContext());
     this.table = table;
     this.readConf = readConf;
-    this.caseSensitive = caseSensitive;
+    this.caseSensitive = readConf.caseSensitive();
     this.expectedSchema = expectedSchema;
     this.filterExpressions = filters != null ? filters : Collections.emptyList();
     this.localityPreferred = readConf.localityEnabled();
     this.readTimestampWithoutZone = readConf.handleTimestampWithoutZone();
-    this.options = options;
   }
 
   protected Table table() {
@@ -120,7 +117,7 @@ abstract class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
   @Override
   public MicroBatchStream toMicroBatchStream(String checkpointLocation) {
     return new SparkMicroBatchStream(
-        sparkContext, table, readConf, caseSensitive, expectedSchema, options, checkpointLocation);
+        sparkContext, table, readConf, caseSensitive, expectedSchema, checkpointLocation);
   }
 
   @Override

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkFilesScan.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkFilesScan.java
@@ -30,10 +30,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.FileScanTaskSetManager;
 import org.apache.iceberg.spark.SparkReadConf;
-import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.util.TableScanUtil;
 import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
 class SparkFilesScan extends SparkBatchScan {
   private final String taskSetID;
@@ -43,11 +41,10 @@ class SparkFilesScan extends SparkBatchScan {
 
   private List<CombinedScanTask> tasks = null; // lazy cache of tasks
 
-  SparkFilesScan(SparkSession spark, Table table, SparkReadConf readConf,
-                 boolean caseSensitive, CaseInsensitiveStringMap options) {
-    super(spark, table, readConf, caseSensitive, table.schema(), ImmutableList.of(), options);
+  SparkFilesScan(SparkSession spark, Table table, SparkReadConf readConf) {
+    super(spark, table, readConf, table.schema(), ImmutableList.of());
 
-    this.taskSetID = options.get(SparkReadOptions.FILE_SCAN_TASK_SET_ID);
+    this.taskSetID = readConf.fileScanTaskSetId();
     this.splitSize = readConf.splitSize();
     this.splitLookback = readConf.splitLookback();
     this.splitOpenFileCost = readConf.splitOpenFileCost();

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkFilesScanBuilder.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkFilesScanBuilder.java
@@ -31,19 +31,15 @@ class SparkFilesScanBuilder implements ScanBuilder {
   private final SparkSession spark;
   private final Table table;
   private final SparkReadConf readConf;
-  private final boolean caseSensitive;
-  private final CaseInsensitiveStringMap options;
 
   SparkFilesScanBuilder(SparkSession spark, Table table, CaseInsensitiveStringMap options) {
     this.spark = spark;
     this.table = table;
     this.readConf = new SparkReadConf(spark, table, options);
-    this.caseSensitive = Boolean.parseBoolean(spark.conf().get("spark.sql.caseSensitive"));
-    this.options = options;
   }
 
   @Override
   public Scan build() {
-    return new SparkFilesScan(spark, table, readConf, caseSensitive, options);
+    return new SparkFilesScan(spark, table, readConf);
   }
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkMergeScan.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkMergeScan.java
@@ -37,12 +37,10 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.SparkReadConf;
-import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.util.TableScanUtil;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.iceberg.read.SupportsFileFilter;
 import org.apache.spark.sql.connector.read.Statistics;
-import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
 class SparkMergeScan extends SparkBatchScan implements SupportsFileFilter {
 
@@ -59,11 +57,10 @@ class SparkMergeScan extends SparkBatchScan implements SupportsFileFilter {
   private List<CombinedScanTask> tasks = null; // lazy cache of tasks
   private Set<String> filteredLocations = null;
 
-  SparkMergeScan(SparkSession spark, Table table, SparkReadConf readConf,
-                 boolean caseSensitive, boolean ignoreResiduals,
-                 Schema expectedSchema, List<Expression> filters, CaseInsensitiveStringMap options) {
+  SparkMergeScan(SparkSession spark, Table table, SparkReadConf readConf, boolean ignoreResiduals,
+                 Schema expectedSchema, List<Expression> filters) {
 
-    super(spark, table, readConf, caseSensitive, expectedSchema, filters, options);
+    super(spark, table, readConf, expectedSchema, filters);
 
     this.table = table;
     this.ignoreResiduals = ignoreResiduals;
@@ -72,7 +69,7 @@ class SparkMergeScan extends SparkBatchScan implements SupportsFileFilter {
     this.splitLookback = readConf.splitLookback();
     this.splitOpenFileCost = readConf.splitOpenFileCost();
 
-    Preconditions.checkArgument(!options.containsKey(SparkReadOptions.SNAPSHOT_ID), "Can't set snapshot-id in options");
+    Preconditions.checkArgument(readConf.snapshotId() == null, "Can't set snapshot-id in options");
     Snapshot currentSnapshot = table.currentSnapshot();
     this.snapshotId = currentSnapshot != null ? currentSnapshot.snapshotId() : null;
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -46,7 +46,6 @@ import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.spark.source.SparkBatchScan.ReadTask;
@@ -61,7 +60,6 @@ import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.connector.read.PartitionReaderFactory;
 import org.apache.spark.sql.connector.read.streaming.MicroBatchStream;
 import org.apache.spark.sql.connector.read.streaming.Offset;
-import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,7 +79,7 @@ public class SparkMicroBatchStream implements MicroBatchStream {
   private final boolean skipDelete;
 
   SparkMicroBatchStream(JavaSparkContext sparkContext, Table table, SparkReadConf readConf, boolean caseSensitive,
-                        Schema expectedSchema, CaseInsensitiveStringMap options, String checkpointLocation) {
+                        Schema expectedSchema, String checkpointLocation) {
     this.table = table;
     this.caseSensitive = caseSensitive;
     this.expectedSchema = SchemaParser.toJson(expectedSchema);
@@ -94,7 +92,7 @@ public class SparkMicroBatchStream implements MicroBatchStream {
     InitialOffsetStore initialOffsetStore = new InitialOffsetStore(table, checkpointLocation);
     this.initialOffset = initialOffsetStore.initialOffset();
 
-    this.skipDelete = Spark3Util.propertyAsBoolean(options, SparkReadOptions.STREAMING_SKIP_DELETE_SNAPSHOTS, false);
+    this.skipDelete = readConf.streamingSkipDeleteSnapshots();
   }
 
   @Override

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -52,7 +52,6 @@ public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
   private final SparkSession spark;
   private final Table table;
   private final SparkReadConf readConf;
-  private final CaseInsensitiveStringMap options;
   private final List<String> metaColumns = Lists.newArrayList();
 
   private Schema schema = null;
@@ -66,8 +65,7 @@ public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
     this.spark = spark;
     this.table = table;
     this.readConf = new SparkReadConf(spark, table, options);
-    this.options = options;
-    this.caseSensitive = Boolean.parseBoolean(spark.conf().get("spark.sql.caseSensitive"));
+    this.caseSensitive = readConf.caseSensitive();
   }
 
   private Schema lazySchema() {
@@ -163,12 +161,12 @@ public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
   @Override
   public Scan build() {
     return new SparkBatchQueryScan(
-        spark, table, readConf, caseSensitive, schemaWithMetadataColumns(), filterExpressions, options);
+        spark, table, readConf, schemaWithMetadataColumns(), filterExpressions);
   }
 
   public Scan buildMergeScan() {
     return new SparkMergeScan(
-        spark, table, readConf, caseSensitive, ignoreResiduals,
-        schemaWithMetadataColumns(), filterExpressions, options);
+        spark, table, readConf, ignoreResiduals,
+        schemaWithMetadataColumns(), filterExpressions);
   }
 }


### PR DESCRIPTION
This PR moves more read configs to `SparkReadConf`.