### PR TITLE
Core: rename min-deletes-per-file in BinPackStrategy

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/BinPackStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BinPackStrategy.java
@@ -84,8 +84,8 @@ public abstract class BinPackStrategy implements RewriteStrategy {
    * <p>
    * Defaults to Integer.MAX_VALUE, which means this feature is not enabled by default.
    */
-  public static final String MIN_DELETES_PER_FILE = "min-deletes-per-file";
-  public static final int MIN_DELETES_PER_FILE_DEFAULT = Integer.MAX_VALUE;
+  public static final String DELETE_FILE_THRESHOLD = "delete-file-threshold";
+  public static final int DELETE_FILE_THRESHOLD_DEFAULT = Integer.MAX_VALUE;
 
   private int minInputFiles;
   private int minDeletesPerFile;
@@ -103,7 +103,7 @@ public abstract class BinPackStrategy implements RewriteStrategy {
   public Set<String> validOptions() {
     return ImmutableSet.of(
         MIN_INPUT_FILES,
-        MIN_DELETES_PER_FILE,
+        DELETE_FILE_THRESHOLD,
         MIN_FILE_SIZE_BYTES,
         MAX_FILE_SIZE_BYTES
     );
@@ -135,8 +135,8 @@ public abstract class BinPackStrategy implements RewriteStrategy {
         MIN_INPUT_FILES_DEFAULT);
 
     minDeletesPerFile = PropertyUtil.propertyAsInt(options,
-        MIN_DELETES_PER_FILE,
-        MIN_DELETES_PER_FILE_DEFAULT);
+        DELETE_FILE_THRESHOLD,
+        DELETE_FILE_THRESHOLD_DEFAULT);
 
     validateOptions();
     return this;
@@ -265,6 +265,6 @@ public abstract class BinPackStrategy implements RewriteStrategy {
 
     Preconditions.checkArgument(minDeletesPerFile > 0,
         "Cannot set %s is less than 1. All values less than 1 have the same effect as 1. %d < 1",
-        MIN_DELETES_PER_FILE, minDeletesPerFile);
+        DELETE_FILE_THRESHOLD, minDeletesPerFile);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/actions/TestBinPackStrategy.java
+++ b/core/src/test/java/org/apache/iceberg/actions/TestBinPackStrategy.java
@@ -113,7 +113,7 @@ public class TestBinPackStrategy extends TableTestBase {
     RewriteStrategy strategy = defaultBinPack().options(ImmutableMap.of(
             BinPackStrategy.MAX_FILE_SIZE_BYTES, Long.toString(550 * MB),
             BinPackStrategy.MIN_FILE_SIZE_BYTES, Long.toString(490 * MB),
-            BinPackStrategy.MIN_DELETES_PER_FILE, Integer.toString(2)
+            BinPackStrategy.DELETE_FILE_THRESHOLD, Integer.toString(2)
     ));
 
     List<FileScanTask> testFiles = filesOfSize(500, 500, 480, 480, 560, 520);
@@ -173,7 +173,7 @@ public class TestBinPackStrategy extends TableTestBase {
             BinPackStrategy.MIN_INPUT_FILES, Integer.toString(5),
             BinPackStrategy.MAX_FILE_SIZE_BYTES, Long.toString(550 * MB),
             BinPackStrategy.MIN_FILE_SIZE_BYTES, Long.toString(490 * MB),
-            BinPackStrategy.MIN_DELETES_PER_FILE, Integer.toString(2)
+            BinPackStrategy.DELETE_FILE_THRESHOLD, Integer.toString(2)
     ));
 
     List<FileScanTask> testFiles = Lists.newArrayList();
@@ -239,7 +239,7 @@ public class TestBinPackStrategy extends TableTestBase {
     AssertHelpers.assertThrows("Should not allow min deletes per file smaller than 1",
             IllegalArgumentException.class, () -> {
               defaultBinPack().options(ImmutableMap.of(
-                      BinPackStrategy.MIN_DELETES_PER_FILE, Long.toString(-5)));
+                      BinPackStrategy.DELETE_FILE_THRESHOLD, Long.toString(-5)));
             });
 
     AssertHelpers.assertThrows("Should not allow negative target size",

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestNewRewriteDataFilesAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestNewRewriteDataFilesAction.java
@@ -231,7 +231,7 @@ public class TestNewRewriteDataFilesAction extends SparkTestBase {
         .option(BinPackStrategy.MIN_FILE_SIZE_BYTES, "0")
         .option(RewriteDataFiles.TARGET_FILE_SIZE_BYTES, Long.toString(Long.MAX_VALUE - 1))
         .option(BinPackStrategy.MAX_FILE_SIZE_BYTES, Long.toString(Long.MAX_VALUE))
-        .option(BinPackStrategy.MIN_DELETES_PER_FILE, "4")
+        .option(BinPackStrategy.DELETE_FILE_THRESHOLD, "4")
         .execute();
     Assert.assertEquals("Action should rewrite 4 data files", 4, result.rewrittenDataFilesCount());
 


### PR DESCRIPTION
based on conversation in https://github.com/apache/iceberg/pull/3454#issuecomment-962681328, use a different name for `min-deletes-per-file` to avoid confusion. Currently my idea is to use `delete-file-threshold`. Any thoughts? @rdblue @RussellSpitzer 