### PR TITLE
Core: Add DELETE/UPDATE/MERGE distribution mode properties

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -227,11 +227,15 @@ public class TableProperties {
   public static final String DELETE_MODE = "write.delete.mode";
   public static final String DELETE_MODE_DEFAULT = "copy-on-write";
 
+  public static final String DELETE_DISTRIBUTION_MODE = "write.delete.distribution-mode";
+
   public static final String UPDATE_ISOLATION_LEVEL = "write.update.isolation-level";
   public static final String UPDATE_ISOLATION_LEVEL_DEFAULT = "serializable";
 
   public static final String UPDATE_MODE = "write.update.mode";
   public static final String UPDATE_MODE_DEFAULT = "copy-on-write";
+
+  public static final String UPDATE_DISTRIBUTION_MODE = "write.update.distribution-mode";
 
   public static final String MERGE_ISOLATION_LEVEL = "write.merge.isolation-level";
   public static final String MERGE_ISOLATION_LEVEL_DEFAULT = "serializable";
@@ -241,6 +245,8 @@ public class TableProperties {
 
   public static final String MERGE_CARDINALITY_CHECK_ENABLED = "write.merge.cardinality-check.enabled";
   public static final boolean MERGE_CARDINALITY_CHECK_ENABLED_DEFAULT = true;
+
+  public static final String MERGE_DISTRIBUTION_MODE = "write.merge.distribution-mode";
 
   public static final String UPSERT_MODE_ENABLE = "write.upsert.enable";
   public static final boolean UPSERT_MODE_ENABLE_DEFAULT = false;

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -163,6 +163,27 @@ public class SparkWriteConf {
     return DistributionMode.fromName(modeName);
   }
 
+  public DistributionMode deleteDistributionMode() {
+    return rowLevelCommandDistributionMode(TableProperties.DELETE_DISTRIBUTION_MODE);
+  }
+
+  public DistributionMode updateDistributionMode() {
+    return rowLevelCommandDistributionMode(TableProperties.UPDATE_DISTRIBUTION_MODE);
+  }
+
+  public DistributionMode mergeDistributionMode() {
+    return rowLevelCommandDistributionMode(TableProperties.MERGE_DISTRIBUTION_MODE);
+  }
+
+  private DistributionMode rowLevelCommandDistributionMode(String tableProperty) {
+    String modeName = confParser.stringConf()
+        .option(SparkWriteOptions.DISTRIBUTION_MODE)
+        .tableProperty(tableProperty)
+        .parseOptional();
+
+    return modeName != null ? DistributionMode.fromName(modeName) : distributionMode();
+  }
+
   public boolean useTableDistributionAndOrdering() {
     return confParser.booleanConf()
         .option(SparkWriteOptions.USE_TABLE_DISTRIBUTION_AND_ORDERING)


### PR DESCRIPTION
This PR adds table properties for controlling DELETE/UPDATE/MERGE distribution mode. Right now, Spark uses only one distribution mode per table. In some cases, regular writes and row-level commands have very different characteristics and would benefit from a different distribution.