### PR TITLE
Use snapshot schema when rollback to snapshot

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -665,11 +665,6 @@ public class TableMetadata implements Serializable {
         "Last sequence number %s is less than existing snapshot sequence number %s",
         lastSequenceNumber, snapshot.sequenceNumber());
 
-    if (currentSnapshotId == snapshot.snapshotId()) {
-      // change is a noop
-      return this;
-    }
-
     long nowMillis = System.currentTimeMillis();
     List<HistoryEntry> newSnapshotLog = ImmutableList.<HistoryEntry>builder()
         .addAll(snapshotLog)
@@ -677,7 +672,7 @@ public class TableMetadata implements Serializable {
         .build();
 
     return new TableMetadata(null, formatVersion, uuid, location,
-        lastSequenceNumber, nowMillis, lastColumnId, currentSchemaId, schemas, defaultSpecId, specs,
+        lastSequenceNumber, nowMillis, lastColumnId, snapshot.schemaId(), schemas, defaultSpecId, specs,
         lastAssignedPartitionId, defaultSortOrderId, sortOrders, properties, snapshot.snapshotId(), snapshots,
         newSnapshotLog, addPreviousFile(file, lastUpdatedMillis));
   }


### PR DESCRIPTION
## Changes
Use snapshot schema when we rollback to current/older snapshot

## Current Behavior
TableMetadata.schema always return current schema even after we rollback to old snapshots, and the schema in old snapshots might be different from current schema.

