### PR TITLE
Build - Ensure checkstyle runs for Flink for all PRs by removing `-Pquick=true`

### DIFF
--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -73,7 +73,7 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: ${{ runner.os }}-gradle
     - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-    - run: ./gradlew -DsparkVersions= -DhiveVersions= -DflinkVersions=${{ matrix.flink }} :iceberg-flink:iceberg-flink-${{ matrix.flink }}:check :iceberg-flink:iceberg-flink-${{ matrix.flink }}-runtime:check -Pquick=true -x javadoc
+    - run: ./gradlew -DsparkVersions= -DhiveVersions= -DflinkVersions=${{ matrix.flink }} :iceberg-flink:iceberg-flink-${{ matrix.flink }}:check :iceberg-flink:iceberg-flink-${{ matrix.flink }}-runtime:check -x javadoc
     - uses: actions/upload-artifact@v2
       if: failure()
       with:


### PR DESCRIPTION
This PR is trying to address this comment: [#3501 (comment)](https://github.com/apache/iceberg/pull/3501#discussion_r745401341)

Many thanks to @openinx and @stevenzwu who noticed that the checkstyle wasn't running.

I recently had to fix something similar with Spark for the 0.12.1 release build, but I thought it was due to the version split up (and that somebody's PR get in without running tests for a rebase).

Removing `quick=true` causes checkstyle to run again. For CI, we should be running all checks (and can work to disable some if we don't need them).

@openinx suggested in this PR: https://github.com/apache/iceberg/pull/3509 that we remove the path ignores in `java-ci.yaml`. But I think that would negate the work of splitting up the tests and the speed built up that we have seen from that.

If we find this takes too long (as it does run checkstyle fot transitive deps), then we can make one single check run but keep the Java CI and associated tests standalone still  as another option.

In either case, this PR will flesh out any existing checks that aren't presently passing as things have not been running. So if we decide to go the route @openinx suggested, this PR (and others like it) will still find any existing checkstyle error issues and give us a chance to fix them.