### PR TITLE
Build: Ensure checkstyle and all check run for Flink PRs

### DIFF
--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -73,7 +73,7 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: ${{ runner.os }}-gradle
     - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-    - run: ./gradlew -DsparkVersions= -DhiveVersions= -DflinkVersions=${{ matrix.flink }} :iceberg-flink:iceberg-flink-${{ matrix.flink }}:check :iceberg-flink:iceberg-flink-${{ matrix.flink }}-runtime:check -Pquick=true -x javadoc
+    - run: ./gradlew -DsparkVersions= -DhiveVersions= -DflinkVersions=${{ matrix.flink }} :iceberg-flink:iceberg-flink-${{ matrix.flink }}:check :iceberg-flink:iceberg-flink-${{ matrix.flink }}-runtime:check -x javadoc
     - uses: actions/upload-artifact@v2
       if: failure()
       with:


### PR DESCRIPTION
This PR is trying to address this comment: [#3501 (comment)](https://github.com/apache/iceberg/pull/3501#discussion_r745401341)

It seems that checkstyle has not been running for some (or all) of the Java / Scala code outside of `java-ci.yml` due to `-Pquick=true`.

I had noticed and fixed a rogue checkstyle issue that made it in, but I thought it slipped in during the refactoring of tests as a one time thing.

@openinx suggested in this PR: [#3509](https://github.com/apache/iceberg/pull/3509) that we remove the path ignores in java-ci.yaml. But I think that would negate the work of splitting up the tests and the speed built up that we have seen from that.

Co-authored-by: huzheng <openinx@gmail.com>