### PR TITLE
Build: Ensure checkstyle and all checks run for Spark PRs

### DIFF
--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -69,7 +69,7 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: ${{ runner.os }}-gradle
     - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-    - run: ./gradlew -DsparkVersions=2.4 -DhiveVersions= -DflinkVersions= :iceberg-spark:check :iceberg-spark:iceberg-spark2:check :iceberg-spark:iceberg-spark-runtime:check -Pquick=true -x javadoc
+    - run: ./gradlew -DsparkVersions=2.4 -DhiveVersions= -DflinkVersions= :iceberg-spark:check :iceberg-spark:iceberg-spark2:check :iceberg-spark:iceberg-spark-runtime:check -x javadoc
     - uses: actions/upload-artifact@v2
       if: failure()
       with:
@@ -96,7 +96,7 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: ${{ runner.os }}-gradle
     - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-    - run: ./gradlew -DsparkVersions=${{ matrix.spark }} -DhiveVersions= -DflinkVersions= :iceberg-spark:check :iceberg-spark:iceberg-spark3:check :iceberg-spark:iceberg-spark3-extensions:check :iceberg-spark:iceberg-spark3-runtime:check -Pquick=true -x javadoc
+    - run: ./gradlew -DsparkVersions=${{ matrix.spark }} -DhiveVersions= -DflinkVersions= :iceberg-spark:check :iceberg-spark:iceberg-spark3:check :iceberg-spark:iceberg-spark3-extensions:check :iceberg-spark:iceberg-spark3-runtime:check -x javadoc
     - uses: actions/upload-artifact@v2
       if: failure()
       with:
@@ -123,7 +123,7 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
       - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-      - run: ./gradlew -DsparkVersions=${{ matrix.spark }} -DhiveVersions= -DflinkVersions= :iceberg-spark:iceberg-spark-${{ matrix.spark }}:check :iceberg-spark:iceberg-spark-${{ matrix.spark }}-extensions:check :iceberg-spark:iceberg-spark-${{ matrix.spark }}-runtime:check -Pquick=true -x javadoc
+      - run: ./gradlew -DsparkVersions=${{ matrix.spark }} -DhiveVersions= -DflinkVersions= :iceberg-spark:iceberg-spark-${{ matrix.spark }}:check :iceberg-spark:iceberg-spark-${{ matrix.spark }}-extensions:check :iceberg-spark:iceberg-spark-${{ matrix.spark }}-runtime:check -x javadoc
       - uses: actions/upload-artifact@v2
         if: failure()
         with:


### PR DESCRIPTION
This PR is trying to address this comment: [#3501 (comment)](https://github.com/apache/iceberg/pull/3501#discussion_r745401341)

It seems that checkstyle has not been running for some (or all) of the Java / Scala code outside of `java-ci.yml` due to `-Pquick=true`.

I had noticed and fixed a rogue checkstyle issue that made it in, but I thought it slipped in during the refactoring of tests as a one time thing.

@openinx suggested in this PR: [#3509](https://github.com/apache/iceberg/pull/3509) that we remove the path ignores in java-ci.yaml. But I think that would negate the work of splitting up the tests and the speed built up that we have seen from that.

I'm happy to revert this PR if we go with that decision, but I wanted to ensure all checks are passing in CI currently.
