### PR TITLE
Build: Upgrade Gradle to 7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Community discussions happen primarily on the [dev mailing list][dev-list] or on
 
 ### Building
 
-Iceberg is built using Gradle 7.2 with Java 1.8 or Java 11.
+Iceberg is built using Gradle with Java 1.8 or Java 11.
 
 * To invoke a build and run tests: `./gradlew build`
 * To skip tests: `./gradlew build -x test -x integrationTest`

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -83,7 +83,7 @@ done
 APP_HOME=$( cd "${APP_HOME:-./}" && pwd -P ) || exit
 
 if [ ! -e $APP_HOME/gradle/wrapper/gradle-wrapper.jar ]; then
-    curl -o $APP_HOME/gradle/wrapper/gradle-wrapper.jar https://raw.githubusercontent.com/gradle/gradle/v7.2.0/gradle/wrapper/gradle-wrapper.jar
+    curl -o $APP_HOME/gradle/wrapper/gradle-wrapper.jar https://raw.githubusercontent.com/gradle/gradle/v7.3.0/gradle/wrapper/gradle-wrapper.jar
 fi
 
 APP_NAME="Gradle"


### PR DESCRIPTION
Gradle 7.3 has just been released, which brings support for building Java 17 projects (not relevant for Iceberg (yet)) and other improvements. This upgrade should be fairly straight-forward and not as complicated as #2826 was.

Full release notes can be seen at https://docs.gradle.org/current/release-notes.html