### PR TITLE
Partitions table only reads stats if needed

### DIFF
--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -117,6 +117,7 @@ public class PartitionsTable extends BaseMetadataTable {
     ManifestGroup manifestGroup = new ManifestGroup(table.io(), snapshot.dataManifests(), snapshot.deleteManifests())
         .caseSensitive(caseSensitive)
         .filterPartitions(partitionFilter)
+        .select(scan.colStats() ? DataTableScan.SCAN_WITH_STATS_COLUMNS : DataTableScan.SCAN_COLUMNS)
         .specsById(scan.table().specs())
         .ignoreDeleted();
 

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -198,6 +198,23 @@ public class TestMetadataTableScans extends TableTestBase {
   }
 
   @Test
+  public void testPartitionsTableScanNoStats() {
+    table.newFastAppend()
+            .appendFile(FILE_WITH_STATS)
+            .commit();
+
+    Table partitionsTable = new PartitionsTable(table.ops(), table);
+    CloseableIterable<FileScanTask> tasksAndEq = PartitionsTable.planFiles((StaticTableScan) partitionsTable.newScan());
+    for (FileScanTask fileTask : tasksAndEq) {
+      Assert.assertNull(fileTask.file().columnSizes());
+      Assert.assertNull(fileTask.file().valueCounts());
+      Assert.assertNull(fileTask.file().nullValueCounts());
+      Assert.assertNull(fileTask.file().lowerBounds());
+      Assert.assertNull(fileTask.file().upperBounds());
+    }
+  }
+
+  @Test
   public void testPartitionsTableScanAndFilter() {
     preparePartitionedTable();
 


### PR DESCRIPTION
Partitions table should read stats column from manifests only if requested on the scan (not enabled by default). 

This allows reading partitions from large tables without having to allocate a large amount of memory. We were hitting OOM on the Spark driver side when scanning the partitions table.