### PR TITLE
Spark: Use quoted names in required distribution and ordering

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SortOrderToSpark.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SortOrderToSpark.java
@@ -19,44 +19,57 @@
 
 package org.apache.iceberg.spark;
 
+import java.util.Map;
 import org.apache.iceberg.NullOrder;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortDirection;
 import org.apache.iceberg.transforms.SortOrderVisitor;
 
 class SortOrderToSpark implements SortOrderVisitor<OrderField> {
+
+  private final Map<Integer, String> quotedNameById;
+
+  SortOrderToSpark(Schema schema) {
+    this.quotedNameById = SparkSchemaUtil.indexQuotedNameById(schema);
+  }
+
   @Override
   public OrderField field(String sourceName, int id, SortDirection direction, NullOrder nullOrder) {
-    return OrderField.column(sourceName, direction, nullOrder);
+    return OrderField.column(quotedName(id), direction, nullOrder);
   }
 
   @Override
   public OrderField bucket(String sourceName, int id, int width, SortDirection direction, NullOrder nullOrder) {
-    return OrderField.bucket(sourceName, width, direction, nullOrder);
+    return OrderField.bucket(quotedName(id), width, direction, nullOrder);
   }
 
   @Override
   public OrderField truncate(String sourceName, int id, int width, SortDirection direction, NullOrder nullOrder) {
-    return OrderField.truncate(sourceName, width, direction, nullOrder);
+    return OrderField.truncate(quotedName(id), width, direction, nullOrder);
   }
 
   @Override
   public OrderField year(String sourceName, int id, SortDirection direction, NullOrder nullOrder) {
-    return OrderField.year(sourceName, direction, nullOrder);
+    return OrderField.year(quotedName(id), direction, nullOrder);
   }
 
   @Override
   public OrderField month(String sourceName, int id, SortDirection direction, NullOrder nullOrder) {
-    return OrderField.month(sourceName, direction, nullOrder);
+    return OrderField.month(quotedName(id), direction, nullOrder);
   }
 
   @Override
   public OrderField day(String sourceName, int id, SortDirection direction, NullOrder nullOrder) {
-    return OrderField.day(sourceName, direction, nullOrder);
+    return OrderField.day(quotedName(id), direction, nullOrder);
   }
 
   @Override
   public OrderField hour(String sourceName, int id, SortDirection direction, NullOrder nullOrder) {
-    return OrderField.hour(sourceName, direction, nullOrder);
+    return OrderField.hour(quotedName(id), direction, nullOrder);
+  }
+
+  private String quotedName(int id) {
+    return quotedNameById.get(id);
   }
 }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -240,41 +240,42 @@ public class Spark3Util {
    * @return an array of Transforms
    */
   public static Transform[] toTransforms(PartitionSpec spec) {
+    Map<Integer, String> quotedNameById = SparkSchemaUtil.indexQuotedNameById(spec.schema());
     List<Transform> transforms = PartitionSpecVisitor.visit(spec,
         new PartitionSpecVisitor<Transform>() {
           @Override
           public Transform identity(String sourceName, int sourceId) {
-            return Expressions.identity(sourceName);
+            return Expressions.identity(quotedName(sourceId));
           }
 
           @Override
           public Transform bucket(String sourceName, int sourceId, int numBuckets) {
-            return Expressions.bucket(numBuckets, sourceName);
+            return Expressions.bucket(numBuckets, quotedName(sourceId));
           }
 
           @Override
           public Transform truncate(String sourceName, int sourceId, int width) {
-            return Expressions.apply("truncate", Expressions.column(sourceName), Expressions.literal(width));
+            return Expressions.apply("truncate", Expressions.column(quotedName(sourceId)), Expressions.literal(width));
           }
 
           @Override
           public Transform year(String sourceName, int sourceId) {
-            return Expressions.years(sourceName);
+            return Expressions.years(quotedName(sourceId));
           }
 
           @Override
           public Transform month(String sourceName, int sourceId) {
-            return Expressions.months(sourceName);
+            return Expressions.months(quotedName(sourceId));
           }
 
           @Override
           public Transform day(String sourceName, int sourceId) {
-            return Expressions.days(sourceName);
+            return Expressions.days(quotedName(sourceId));
           }
 
           @Override
           public Transform hour(String sourceName, int sourceId) {
-            return Expressions.hours(sourceName);
+            return Expressions.hours(quotedName(sourceId));
           }
 
           @Override
@@ -285,7 +286,11 @@ public class Spark3Util {
 
           @Override
           public Transform unknown(int fieldId, String sourceName, int sourceId, String transform) {
-            return Expressions.apply(transform, Expressions.column(sourceName));
+            return Expressions.apply(transform, Expressions.column(quotedName(sourceId)));
+          }
+
+          private String quotedName(int id) {
+            return quotedNameById.get(id);
           }
         });
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkDistributionAndOrderingUtil.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkDistributionAndOrderingUtil.java
@@ -71,7 +71,7 @@ public class SparkDistributionAndOrderingUtil {
   }
 
   public static SortOrder[] convert(org.apache.iceberg.SortOrder sortOrder) {
-    List<OrderField> converted = SortOrderVisitor.visit(sortOrder, new SortOrderToSpark());
+    List<OrderField> converted = SortOrderVisitor.visit(sortOrder, new SortOrderToSpark(sortOrder.schema()));
     return converted.toArray(new OrderField[0]);
   }
 }


### PR DESCRIPTION
This PR fixes our Spark references in required distribution and ordering. Previously, if a column had a special char in its name, Iceberg would request unquoted references that would break the resolution in Spark.