### PR TITLE
Hive : BACKPORT Hive-25377 :  Creating Iceberg table where some columns has omments but the last one does not fails

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaConverter.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaConverter.java
@@ -64,7 +64,7 @@ class HiveSchemaConverter {
     List<Types.NestedField> result = new ArrayList<>(names.size());
     for (int i = 0; i < names.size(); ++i) {
       result.add(Types.NestedField.optional(id++, names.get(i), convertType(typeInfos.get(i)),
-          comments.isEmpty() ? null : comments.get(i)));
+          (comments.isEmpty() || i >= comments.size()) ? null : comments.get(i)));
     }
 
     return result;

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveSchemaUtil.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveSchemaUtil.java
@@ -154,6 +154,22 @@ public class TestHiveSchemaUtil {
     }
   }
 
+  @Test
+  public void testConversionWithoutLastComment() {
+    Schema expected = new Schema(
+        optional(0, "customer_id", Types.LongType.get(), "customer comment"),
+        optional(1, "first_name", Types.StringType.get(), null)
+    );
+
+    Schema schema = HiveSchemaUtil.convert(
+        Arrays.asList("customer_id", "first_name"),
+        Arrays.asList(TypeInfoUtils.getTypeInfoFromTypeString(serdeConstants.BIGINT_TYPE_NAME),
+          TypeInfoUtils.getTypeInfoFromTypeString(serdeConstants.STRING_TYPE_NAME)),
+        Arrays.asList("customer comment"));
+
+    Assert.assertEquals(expected.asStruct(), schema.asStruct());
+  }
+
   protected List<FieldSchema> getSupportedFieldSchemas() {
     List<FieldSchema> fields = new ArrayList<>();
     fields.add(new FieldSchema("c_float", serdeConstants.FLOAT_TYPE_NAME, "float comment"));

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -547,7 +547,8 @@ public class TestHiveIcebergStorageHandlerNoScan {
     TableIdentifier identifier = TableIdentifier.of("default", "comment_table");
     shell.executeStatement("CREATE EXTERNAL TABLE comment_table (" +
         "t_int INT COMMENT 'int column',  " +
-        "t_string STRING COMMENT 'string column') " +
+        "t_string STRING COMMENT 'string column', " +
+        "t_string_2 STRING) " +
         "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
         testTables.locationForCreateTableSQL(identifier) +
         testTables.propertiesForCreateTableSQL(ImmutableMap.of()));
@@ -558,7 +559,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
     for (int i = 0; i < icebergTable.schema().columns().size(); i++) {
       Types.NestedField field = icebergTable.schema().columns().get(i);
       Assert.assertArrayEquals(new Object[] {field.name(), HiveSchemaUtil.convert(field.type()).getTypeName(),
-          field.doc()}, rows.get(i));
+          (field.doc() != null ? field.doc() : "from deserializer")}, rows.get(i));
     }
   }
 


### PR DESCRIPTION
This PR backport https://issues.apache.org/jira/browse/HIVE-25377 for user still using Hive 2 ou 3.