### PR TITLE
Core: Replace Set with Bitmap to make delete filtering simpler and faster

### DIFF
--- a/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
@@ -39,7 +39,12 @@ class BitmapPositionDeleteIndex implements PositionDeleteIndex {
   }
 
   @Override
-  public boolean deleted(long position) {
+  public boolean isDeleted(long position) {
     return roaring64Bitmap.contains(position);
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return roaring64Bitmap.isEmpty();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteIndex.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteIndex.java
@@ -38,5 +38,11 @@ public interface PositionDeleteIndex {
    * @param position deleted row position
    * @return whether the position is deleted
    */
-  boolean deleted(long position);
+  boolean isDeleted(long position);
+
+  /**
+   * Returns true if this collection contains no element.
+   * @return true if this collection contains no element.
+   */
+  boolean isEmpty();
 }

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteIndex.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteIndex.java
@@ -42,7 +42,6 @@ public interface PositionDeleteIndex {
 
   /**
    * Returns true if this collection contains no element.
-   * @return true if this collection contains no element.
    */
   boolean isEmpty();
 }

--- a/core/src/test/java/org/apache/iceberg/deletes/TestPositionFilter.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestPositionFilter.java
@@ -218,7 +218,7 @@ public class TestPositionFilter {
 
     CloseableIterable<StructLike> actual = Deletes.filter(
         rows, row -> row.get(0, Long.class),
-        Deletes.toPositionSet(deletes));
+        Deletes.toPositionIndex(deletes));
     Assert.assertEquals("Filter should produce expected rows",
         Lists.newArrayList(1L, 2L, 5L, 6L, 8L),
         Lists.newArrayList(Iterables.transform(actual, row -> row.get(0, Long.class))));
@@ -256,7 +256,7 @@ public class TestPositionFilter {
 
     CloseableIterable<StructLike> actual = Deletes.filter(
         rows, row -> row.get(0, Long.class),
-        Deletes.toPositionSet("file_a.avro", ImmutableList.of(positionDeletes1, positionDeletes2)));
+        Deletes.toPositionIndex("file_a.avro", ImmutableList.of(positionDeletes1, positionDeletes2)));
 
     Assert.assertEquals("Filter should produce expected rows",
         Lists.newArrayList(1L, 2L, 5L, 6L, 8L),

--- a/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
@@ -214,7 +214,7 @@ public abstract class DeleteFilter<T> {
 
     if (deleteRowPositions == null) {
       List<CloseableIterable<Record>> deletes = Lists.transform(posDeletes, this::openPosDeletes);
-      deleteRowPositions = Deletes.toPositionBitmap(dataFile.path(), deletes);
+      deleteRowPositions = Deletes.toPositionIndex(dataFile.path(), deletes);
     }
     return deleteRowPositions;
   }
@@ -228,9 +228,7 @@ public abstract class DeleteFilter<T> {
 
     // if there are fewer deletes than a reasonable number to keep in memory, use a set
     if (posDeletes.stream().mapToLong(DeleteFile::recordCount).sum() < setFilterThreshold) {
-      return Deletes.filter(
-          records, this::pos,
-          Deletes.toPositionSet(dataFile.path(), CloseableIterable.concat(deletes)));
+      return Deletes.filter(records, this::pos, Deletes.toPositionIndex(dataFile.path(), deletes));
     }
 
     return Deletes.streamingFilter(records, this::pos, Deletes.deletePositions(dataFile.path(), deletes));

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnarBatchReader.java
@@ -159,7 +159,7 @@ public class ColumnarBatchReader extends BaseBatchReader<ColumnarBatch> {
       int originalRowId = 0;
       int currentRowId = 0;
       while (originalRowId < numRowsToRead) {
-        if (!deletedRowPositions.deleted(originalRowId + rowStartPosInBatch)) {
+        if (!deletedRowPositions.isDeleted(originalRowId + rowStartPosInBatch)) {
           posDelRowIdMapping[currentRowId] = originalRowId;
           currentRowId++;
         }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
@@ -217,8 +217,13 @@ public class TestSparkParquetReadMetadataColumns {
     }
 
     @Override
-    public boolean deleted(long position) {
+    public boolean isDeleted(long position) {
       return deleteIndex.contains(position);
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return deleteIndex.isEmpty();
     }
   }
 


### PR DESCRIPTION
This PR replaces `Set<Long>` with `Roaring64Bitmap` to store the deleted positions for filtering. Bitmap use significant less memory than a set, here is a [benchmark](https://github.com/apache/iceberg/pull/3287#discussion_r733910082). With that, we don't have to use streaming filter in case of large amount of positions, we can keep all deleted positions in memory.
cc @aokolnychyi @rdblue @RussellSpitzer @karuppayya  @szehon-ho