### PR TITLE
Add configurable cache expiry to caching catalog 

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -30,6 +30,29 @@ public class CatalogProperties {
   public static final String FILE_IO_IMPL = "io-impl";
   public static final String WAREHOUSE_LOCATION = "warehouse";
 
+  /**
+   * Controls whether the catalog will cache table entries upon load.
+   * <p>
+   * If {@link #CACHE_EXPIRATION_INTERVAL_MS} is set to zero, this value
+   * will be ignored and the cache will be disabled.
+   */
+  public static final String CACHE_ENABLED = "cache-enabled";
+  public static final boolean CACHE_ENABLED_DEFAULT = true;
+
+  /**
+   * Controls the duration for which entries in the catalog are cached.
+   * <p>
+   * Behavior of specific values of cache.expiration-interval-ms:
+   * <ul>
+   *   <li> Zero - Caching and cache expiration are both disabled</li>
+   *   <li> Negative Values - Cache expiration is turned off and entries expire only on refresh etc</li>
+   *   <li> Positive Values - Cache entries expire if not accessed via the cache after this many milliseconds</li>
+   * </ul>
+   */
+  public static final String CACHE_EXPIRATION_INTERVAL_MS = "cache.expiration-interval-ms";
+  public static final long CACHE_EXPIRATION_INTERVAL_MS_DEFAULT = TimeUnit.SECONDS.toMillis(30);
+  public static final long CACHE_EXPIRATION_INTERVAL_MS_OFF = -1;
+
   public static final String URI = "uri";
   public static final String CLIENT_POOL_SIZE = "clients";
   public static final int CLIENT_POOL_SIZE_DEFAULT = 2;

--- a/core/src/test/java/org/apache/iceberg/TestableCachingCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/TestableCachingCatalog.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Ticker;
+import java.time.Duration;
+import java.util.Optional;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+
+/**
+ * A wrapper around CachingCatalog that provides accessor methods to test the underlying cache,
+ * without making those fields public in the CachingCatalog itself.
+ */
+public class TestableCachingCatalog extends CachingCatalog {
+
+  public static TestableCachingCatalog wrap(Catalog catalog, Duration expirationInterval, Ticker ticker) {
+    return new TestableCachingCatalog(catalog, true /* caseSensitive */, expirationInterval, ticker);
+  }
+
+  private final Duration cacheExpirationInterval;
+
+  TestableCachingCatalog(Catalog catalog, boolean caseSensitive, Duration expirationInterval, Ticker ticker) {
+    super(catalog, caseSensitive, expirationInterval.toMillis(), ticker);
+    this.cacheExpirationInterval = expirationInterval;
+  }
+
+  public Cache<TableIdentifier, Table> cache() {
+    // cleanUp must be called as tests apply assertions directly on the underlying map, but metadata table
+    // map entries are cleaned up asynchronously.
+    tableCache.cleanUp();
+    return tableCache;
+  }
+
+  public boolean isCacheExpirationEnabled() {
+    return tableCache.policy().expireAfterAccess().isPresent() || tableCache.policy().expireAfterWrite().isPresent();
+  }
+
+  // Throws a NoSuchElementException if this entry is not in the cache (has already been TTL'd).
+  public Optional<Duration> ageOf(TableIdentifier identifier) {
+    return tableCache.policy().expireAfterAccess().get().ageOf(identifier);
+  }
+
+  // Throws a NoSuchElementException if the entry is not in the cache (has already been TTL'd).
+  public Optional<Duration> remainingAgeFor(TableIdentifier identifier) {
+    return ageOf(identifier).map(cacheExpirationInterval::minus);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestCachingCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestCachingCatalog.java
@@ -20,18 +20,44 @@
 package org.apache.iceberg.hadoop;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.util.Arrays;
 import java.util.Locale;
+import java.util.Optional;
+import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.CachingCatalog;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TestableCachingCatalog;
 import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.util.FakeTicker;
+import org.assertj.core.api.Assertions;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 public class TestCachingCatalog extends HadoopTableTestBase {
+
+  private static final Duration EXPIRATION_TTL = Duration.ofMinutes(5);
+  private static final Duration HALF_OF_EXPIRATION = EXPIRATION_TTL.dividedBy(2);
+
+  private FakeTicker ticker;
+
+  @Before
+  public void beforeEach() {
+    this.ticker = new FakeTicker();
+  }
+
+  @After
+  public void afterEach() {
+    this.ticker = null;
+  }
 
   @Test
   public void testInvalidateMetadataTablesIfBaseTableIsModified() throws Exception {
@@ -122,5 +148,137 @@ public class TestCachingCatalog extends HadoopTableTestBase {
     TableIdentifier snapshotsTableIdent = TableIdentifier.of("db", "ns1", "ns2", "tbl", "snapshots");
     Table snapshotsTable = catalog.loadTable(snapshotsTableIdent);
     Assert.assertEquals("Name must match", "hadoop.db.ns1.ns2.tbl.snapshots", snapshotsTable.name());
+  }
+
+  @Test
+  public void testTableExpiresAfterInterval() throws IOException {
+    TestableCachingCatalog catalog = TestableCachingCatalog.wrap(hadoopCatalog(), EXPIRATION_TTL, ticker);
+
+    Namespace namespace = Namespace.of("db", "ns1", "ns2");
+    TableIdentifier tableIdent = TableIdentifier.of(namespace, "tbl");
+    catalog.createTable(tableIdent, SCHEMA, SPEC, ImmutableMap.of("key", "value"));
+
+    // Ensure table is cached with full ttl remaining upon creation
+    Assertions.assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+    Assertions.assertThat(catalog.remainingAgeFor(tableIdent)).isPresent().get().isEqualTo(EXPIRATION_TTL);
+
+    ticker.advance(HALF_OF_EXPIRATION);
+    Assertions.assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+    Assertions.assertThat(catalog.ageOf(tableIdent)).isPresent().get().isEqualTo(HALF_OF_EXPIRATION);
+
+    ticker.advance(HALF_OF_EXPIRATION.plus(Duration.ofSeconds(10)));
+    Assertions.assertThat(catalog.cache().asMap()).doesNotContainKey(tableIdent);
+    Assert.assertNotSame("CachingCatalog should return a new instance after expiration",
+        table, catalog.loadTable(tableIdent));
+  }
+
+  @Test
+  public void testCatalogExpirationTtlRefreshesAfterAccessViaCatalog() throws IOException {
+    TestableCachingCatalog catalog = TestableCachingCatalog.wrap(hadoopCatalog(), EXPIRATION_TTL, ticker);
+    Namespace namespace = Namespace.of("db", "ns1", "ns2");
+    TableIdentifier tableIdent = TableIdentifier.of(namespace, "tbl");
+
+    catalog.createTable(tableIdent, SCHEMA, SPEC, ImmutableMap.of("key", "value"));
+    Assertions.assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+    Assertions.assertThat(catalog.ageOf(tableIdent)).isPresent().get().isEqualTo(Duration.ZERO);
+
+    ticker.advance(HALF_OF_EXPIRATION);
+    Assertions.assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+    Assertions.assertThat(catalog.ageOf(tableIdent)).isPresent().get().isEqualTo(HALF_OF_EXPIRATION);
+    Assertions.assertThat(catalog.remainingAgeFor(tableIdent)).isPresent().get().isEqualTo(HALF_OF_EXPIRATION);
+
+    Duration oneMinute = Duration.ofMinutes(1L);
+    ticker.advance(oneMinute);
+    Assertions.assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+    Assertions.assertThat(catalog.ageOf(tableIdent)).isPresent().get().isEqualTo(HALF_OF_EXPIRATION.plus(oneMinute));
+    Assertions.assertThat(catalog.remainingAgeFor(tableIdent)).get().isEqualTo(HALF_OF_EXPIRATION.minus(oneMinute));
+
+    // Access the table via the catalog, which should refresh the TTL
+    Table table = catalog.loadTable(tableIdent);
+    Assertions.assertThat(catalog.ageOf(tableIdent)).get().isEqualTo(Duration.ZERO);
+    Assertions.assertThat(catalog.remainingAgeFor(tableIdent)).get().isEqualTo(EXPIRATION_TTL);
+
+    ticker.advance(HALF_OF_EXPIRATION);
+    Assertions.assertThat(catalog.ageOf(tableIdent)).get().isEqualTo(HALF_OF_EXPIRATION);
+    Assertions.assertThat(catalog.remainingAgeFor(tableIdent)).get().isEqualTo(HALF_OF_EXPIRATION);
+
+    // Check that accessing the table object directly does not affect the cache TTL
+    table.refresh();
+    Assertions.assertThat(catalog.ageOf(tableIdent)).get().isEqualTo(HALF_OF_EXPIRATION);
+    Assertions.assertThat(catalog.remainingAgeFor(tableIdent)).get().isEqualTo(HALF_OF_EXPIRATION);
+
+    table.newAppend().appendFile(FILE_A).commit();
+    Assertions.assertThat(catalog.ageOf(tableIdent)).get().isEqualTo(HALF_OF_EXPIRATION);
+    Assertions.assertThat(catalog.remainingAgeFor(tableIdent)).get().isEqualTo(HALF_OF_EXPIRATION);
+  }
+
+  @Test
+  public void testCacheExpirationEagerlyRemovesMetadataTables() throws IOException {
+    TestableCachingCatalog catalog = TestableCachingCatalog.wrap(hadoopCatalog(), EXPIRATION_TTL, ticker);
+    Namespace namespace = Namespace.of("db", "ns1", "ns2");
+    TableIdentifier tableIdent = TableIdentifier.of(namespace, "tbl");
+    Table table = catalog.createTable(tableIdent, SCHEMA, SPEC, ImmutableMap.of("key2", "value2"));
+    Assertions.assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+
+    table.newAppend().appendFile(FILE_A).commit();
+    Assertions.assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+    Assertions.assertThat(catalog.ageOf(tableIdent)).get().isEqualTo(Duration.ZERO);
+
+    ticker.advance(HALF_OF_EXPIRATION);
+    Assertions.assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+    Assertions.assertThat(catalog.ageOf(tableIdent)).get().isEqualTo(HALF_OF_EXPIRATION);
+
+    // Load the metadata tables for the first time. Their age should be zero as they're new entries.
+    Arrays.stream(metadataTables(tableIdent)).forEach(catalog::loadTable);
+    Assertions.assertThat(catalog.cache().asMap()).containsKeys(metadataTables(tableIdent));
+    Assertions.assertThat(Arrays.stream(metadataTables(tableIdent)).map(catalog::ageOf))
+        .isNotEmpty()
+        .allMatch(age -> age.isPresent() && age.get().equals(Duration.ZERO));
+
+    Assert.assertEquals("Loading a non-cached metadata table should refresh the main table's age",
+        Optional.of(EXPIRATION_TTL), catalog.remainingAgeFor(tableIdent));
+
+    // Move time forward and access already cached metadata tables.
+    ticker.advance(HALF_OF_EXPIRATION);
+    Arrays.stream(metadataTables(tableIdent)).forEach(catalog::loadTable);
+    Assertions.assertThat(Arrays.stream(metadataTables(tableIdent)).map(catalog::ageOf))
+        .isNotEmpty()
+        .allMatch(age -> age.isPresent() && age.get().equals(Duration.ZERO));
+
+    Assert.assertEquals("Accessing a cached metadata table should not affect the main table's age",
+        Optional.of(HALF_OF_EXPIRATION), catalog.remainingAgeFor(tableIdent));
+
+    // Move time forward so the data table drops.
+    ticker.advance(HALF_OF_EXPIRATION);
+    Assertions.assertThat(catalog.cache().asMap()).doesNotContainKey(tableIdent);
+
+    Arrays.stream(metadataTables(tableIdent)).forEach(metadataTable ->
+        Assert.assertFalse("When a data table expires, its metadata tables should expire regardless of age",
+            catalog.cache().asMap().containsKey(metadataTable)));
+  }
+
+  @Test
+  public void testCachingCatalogRejectsExpirationIntervalOfZero() {
+    AssertHelpers
+        .assertThrows(
+        "Caching catalog should disallow an expiration interval of zero, as zero signifies not to cache at all",
+            IllegalArgumentException.class,
+            () -> TestableCachingCatalog.wrap(hadoopCatalog(), Duration.ZERO, ticker));
+  }
+
+  @Test
+  public void testCacheExpirationIsDisabledByANegativeValue() throws IOException {
+    TestableCachingCatalog catalog = TestableCachingCatalog
+        .wrap(hadoopCatalog(), Duration.ofMillis(CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS_OFF), ticker);
+
+    Assert.assertFalse(
+        "When a negative value is used as the expiration interval, the cache should not expire entries based on a TTL",
+        catalog.isCacheExpirationEnabled());
+  }
+
+  public static TableIdentifier[] metadataTables(TableIdentifier tableIdent) {
+    return Arrays.stream(MetadataTableType.values())
+        .map(type -> TableIdentifier.parse(tableIdent + "." + type.name().toLowerCase(Locale.ROOT)))
+        .toArray(TableIdentifier[]::new);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/util/FakeTicker.java
+++ b/core/src/test/java/org/apache/iceberg/util/FakeTicker.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.util;
+
+import com.github.benmanes.caffeine.cache.Ticker;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A {@code Ticker} whose value can be advanced programmatically in tests
+ */
+public class FakeTicker implements Ticker {
+
+  private final AtomicLong nanos = new AtomicLong();
+
+  public FakeTicker() {
+  }
+
+  public FakeTicker advance(Duration duration) {
+    nanos.addAndGet(duration.toNanos());
+    return this;
+  }
+
+  @Override
+  public long read() {
+    return nanos.get();
+  }
+}

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCatalogCacheExpiration.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCatalogCacheExpiration.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+import java.util.Map;
+import org.apache.iceberg.CachingCatalog;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.iceberg.spark.SparkSessionCatalog;
+import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.assertj.core.api.Assertions;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestSparkCatalogCacheExpiration extends SparkTestBaseWithCatalog {
+
+  private static final String sessionCatalogName = "spark_catalog";
+  private static final String sessionCatalogImpl = SparkSessionCatalog.class.getName();
+  private static final Map<String, String> sessionCatalogConfig = ImmutableMap.of(
+      "type", "hadoop",
+      "default-namespace", "default",
+      CatalogProperties.CACHE_ENABLED, "true",
+      CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS, "3000"
+  );
+
+  private static String asSqlConfCatalogKeyFor(String catalog, String configKey) {
+    // configKey is empty when the catalog's class is being defined
+    if (configKey.isEmpty()) {
+      return String.format("spark.sql.catalog.%s", catalog);
+    } else {
+      return String.format("spark.sql.catalog.%s.%s", catalog, configKey);
+    }
+  }
+
+  // Add more catalogs to the spark session, so we only need to start spark one time for multiple
+  // different catalog configuration tests.
+  @BeforeClass
+  public static void beforeClass() {
+    // Catalog - expiration_disabled: Catalog with caching on and expiration disabled.
+    ImmutableMap.of(
+        "", "org.apache.iceberg.spark.SparkCatalog",
+        "type", "hive",
+        CatalogProperties.CACHE_ENABLED, "true",
+        CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS, "-1"
+    ).forEach((k, v) -> spark.conf().set(asSqlConfCatalogKeyFor("expiration_disabled", k), v));
+
+    // Catalog - cache_disabled_implicitly: Catalog that does not cache, as the cache expiration interval is 0.
+    ImmutableMap.of(
+        "", "org.apache.iceberg.spark.SparkCatalog",
+        "type", "hive",
+        CatalogProperties.CACHE_ENABLED, "true",
+        CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS, "0"
+    ).forEach((k, v) -> spark.conf().set(asSqlConfCatalogKeyFor("cache_disabled_implicitly", k), v));
+  }
+
+  public TestSparkCatalogCacheExpiration() {
+    super(sessionCatalogName, sessionCatalogImpl, sessionCatalogConfig);
+  }
+
+  @Test
+  public void testSparkSessionCatalogWithExpirationEnabled() {
+    SparkSessionCatalog<?> sparkCatalog = sparkSessionCatalog();
+    Assertions.assertThat(sparkCatalog)
+        .extracting("icebergCatalog")
+        .extracting("cacheEnabled")
+        .isEqualTo(true);
+
+    Assertions
+        .assertThat(sparkCatalog)
+        .extracting("icebergCatalog")
+        .extracting("icebergCatalog")
+        .isInstanceOfSatisfying(Catalog.class, icebergCatalog -> {
+          Assertions.assertThat(icebergCatalog)
+              .isExactlyInstanceOf(CachingCatalog.class)
+              .extracting("expirationIntervalMillis")
+              .isEqualTo(3000L);
+        });
+  }
+
+  @Test
+  public void testCacheEnabledAndExpirationDisabled() {
+    SparkCatalog sparkCatalog = getSparkCatalog("expiration_disabled");
+    Assertions.assertThat(sparkCatalog)
+        .extracting("cacheEnabled")
+        .isEqualTo(true);
+
+    Assertions
+        .assertThat(sparkCatalog)
+        .extracting("icebergCatalog")
+        .isInstanceOfSatisfying(CachingCatalog.class, icebergCatalog -> {
+          Assertions.assertThat(icebergCatalog)
+              .extracting("expirationIntervalMillis")
+              .isEqualTo(-1L);
+        });
+  }
+
+  @Test
+  public void testCacheDisabledImplicitly() {
+    SparkCatalog sparkCatalog = getSparkCatalog("cache_disabled_implicitly");
+    Assertions.assertThat(sparkCatalog)
+        .extracting("cacheEnabled")
+        .isEqualTo(false);
+
+    Assertions
+        .assertThat(sparkCatalog)
+        .extracting("icebergCatalog")
+        .isInstanceOfSatisfying(
+            Catalog.class,
+            icebergCatalog -> Assertions.assertThat(icebergCatalog).isNotInstanceOf(CachingCatalog.class));
+  }
+
+  private SparkSessionCatalog<?> sparkSessionCatalog() {
+    TableCatalog catalog = (TableCatalog) spark.sessionState().catalogManager().catalog("spark_catalog");
+    return (SparkSessionCatalog<?>) catalog;
+  }
+
+  private SparkCatalog getSparkCatalog(String catalog)  {
+    return (SparkCatalog) spark.sessionState().catalogManager().catalog(catalog);
+  }
+}


### PR DESCRIPTION
Occasionally, users have reported issues that they have very specific problems with table caching.

Namely, if they're trying to read from a table, and others have written to it from another program, the cache won't be refreshed and users need to manually call `.refresh` on the table. This can be a source of confusion.

In general, the cache makes things more efficient.

But for things like long-lived session clusters or scenarios as described above, it would be desirable to expire the tables in the cache and then have them be reloaded if they're accessed via the catalog again after some period of time.

This allows for the catalog to still benefit from caching, but to discard cached entries after a configurable period of time.

Details:

- Adds a new catalog property, `cache.expiration-interval-ms`. Currently turned off.
- If users pass in zero for this value, caching will be turned off entirely (irrespective of the `cache-enabled` flag)
- If users pass in a positive value, with cache-enabled, then caching will be on and entries will expire if not accessed in that period of time.
- If users pass in a value <= -1, (with `cache-enabled=true`), then caching will be enabled and cache expiration will never happen (i.e. entries will persist unless explicitly refreshed, original behavior).
- Assuming cache-enabled is true and the user has specified a positive value for `cache.expiration-interval-ms`, the CachingCatalog will expire entries after the `cache.expiration-interval-ms`, unless they are accessed VIA the catalog (e.g. `Catalog.load` etc). Accessing the table object pulled from the cache will not affect the cache.
- Metadata tables are always expired when the main table is expired (to avoid drift where a user reloads the origin table after cache expiration but the metadata tables from the cache are pointing to a different version). This is consistent with the current behavior with renameTable etc.