### PR TITLE
Conform .alterTable to the standard interface

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -222,11 +222,11 @@ public class SparkCatalog extends BaseCatalog {
     try {
       Table table = load(ident);
       commitChanges(table, setLocation, setSnapshotId, pickSnapshotId, propertyChanges, schemaChanges);
+      table.refresh();
+      return new SparkTable(table, false);
     } catch (org.apache.iceberg.exceptions.NoSuchTableException e) {
       throw new NoSuchTableException(ident);
     }
-
-    return null;
   }
 
   @Override

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -222,7 +222,7 @@ public class SparkCatalog extends BaseCatalog {
     try {
       Table table = load(ident);
       commitChanges(table, setLocation, setSnapshotId, pickSnapshotId, propertyChanges, schemaChanges);
-      return new SparkTable(table, true);
+      return new SparkTable(table, true /* refreshEagerly */);
     } catch (org.apache.iceberg.exceptions.NoSuchTableException e) {
       throw new NoSuchTableException(ident);
     }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -222,7 +222,6 @@ public class SparkCatalog extends BaseCatalog {
     try {
       Table table = load(ident);
       commitChanges(table, setLocation, setSnapshotId, pickSnapshotId, propertyChanges, schemaChanges);
-      table.refresh();
       return new SparkTable(table, false);
     } catch (org.apache.iceberg.exceptions.NoSuchTableException e) {
       throw new NoSuchTableException(ident);

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -222,7 +222,7 @@ public class SparkCatalog extends BaseCatalog {
     try {
       Table table = load(ident);
       commitChanges(table, setLocation, setSnapshotId, pickSnapshotId, propertyChanges, schemaChanges);
-      return new SparkTable(table, false);
+      return new SparkTable(table, true);
     } catch (org.apache.iceberg.exceptions.NoSuchTableException e) {
       throw new NoSuchTableException(ident);
     }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkCatalogOperations.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkCatalogOperations.java
@@ -60,6 +60,8 @@ public class TestSparkCatalogOperations extends SparkCatalogTestBase {
         TableChange.setProperty(propsKey, propsValue)
     );
 
+    Assert.assertNotNull("Should return updated table", table);
+
     StructField expectedField = DataTypes.createStructField(fieldName, DataTypes.StringType, true);
     Assert.assertEquals(table.schema().fields()[2], expectedField);
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkCatalogOperations.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkCatalogOperations.java
@@ -32,7 +32,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class TestSparkCatalogOperations extends SparkCatalogTestBase {
-  public TestSparkCatalogOperations(String catalogName, String implementation, Map<String, String> config) {
+  public TestSparkCatalogOperations(
+      String catalogName, String implementation, Map<String, String> config) {
     super(catalogName, implementation, config);
   }
 
@@ -54,21 +55,26 @@ public class TestSparkCatalogOperations extends SparkCatalogTestBase {
     String fieldName = "location";
     String propsKey = "note";
     String propsValue = "jazz";
-    Table table = catalog.alterTable(
-        identifier,
-        TableChange.addColumn(new String[] {fieldName}, DataTypes.StringType, true),
-        TableChange.setProperty(propsKey, propsValue)
-    );
+    Table table =
+        catalog.alterTable(
+            identifier,
+            TableChange.addColumn(new String[] {fieldName}, DataTypes.StringType, true),
+            TableChange.setProperty(propsKey, propsValue));
 
     Assert.assertNotNull("Should return updated table", table);
 
     StructField expectedField = DataTypes.createStructField(fieldName, DataTypes.StringType, true);
-    Assert.assertEquals(table.schema().fields()[2], expectedField);
+    Assert.assertEquals(
+        "Adding a column to a table should return the updated table with the new column",
+        table.schema().fields()[2],
+        expectedField);
 
     Assert.assertTrue(
-        "Created table missing property: " + propsKey,
+        "Adding a property to a table should return the updated table with the new property",
         table.properties().containsKey(propsKey));
-    Assert.assertEquals("Property value is not the expected value",
-        propsValue, table.properties().get(propsKey));
+    Assert.assertEquals(
+        "Altering a table to add a new property should add the correct value",
+        propsValue,
+        table.properties().get(propsKey));
   }
 }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkCatalogOperations.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkCatalogOperations.java
@@ -72,6 +72,3 @@ public class TestSparkCatalogOperations extends SparkCatalogTestBase {
         propsValue, table.properties().get(propsKey));
   }
 }
-
-
-

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkCatalogOperations.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkCatalogOperations.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.iceberg.spark;
 
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkCatalogOperations.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkCatalogOperations.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.spark;
 
+import java.util.Map;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.Table;
@@ -29,8 +30,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.Map;
 
 public class TestSparkCatalogOperations extends SparkCatalogTestBase {
   public TestSparkCatalogOperations(String catalogName, String implementation, Map<String, String> config) {


### PR DESCRIPTION
## Description

closes: #3281 

The `alterTable()` method on the SparkCatalog class always returns null. This violates the [API contract](https://spark.apache.org/docs/latest/api/java/org/apache/spark/sql/connector/catalog/TableCatalog.html#alterTable-org.apache.spark.sql.connector.catalog.Identifier-org.apache.spark.sql.connector.catalog.TableChange...-) for the `TableCatalog` interface - this method must return the updated `Table` instance.

This PR fixes this by returning an updated `SparkTable` (which implements the `Table` interface) instance.


cc: @RussellSpitzer @netvl 

### Misc questions

I have two questions when implementing this
- Why do we have multiple versions of Spark in the repo. Do I need to copy the same code to different versions of Spark?
- What's the difference between the `SparkCatalog` and `SparkSessionCatalog`