### PR TITLE
Build: Enable checkstyle for all engine versions

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -77,7 +77,7 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 8
-    - run: ./gradlew build -x test -x javadoc -x integrationTest
+    - run: ./gradlew -DflinVersions=1.12,1.13 -DsparkVersions=2.4,3.0,3.1,3.2 -DhiveVersions=2,3 build -x test -x javadoc -x integrationTest
 
   build-javadoc:
     runs-on: ubuntu-latest

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -77,7 +77,7 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 8
-    - run: ./gradlew -DflinVersions=1.12,1.13 -DsparkVersions=2.4,3.0,3.1,3.2 -DhiveVersions=2,3 build -x test -x javadoc -x integrationTest
+    - run: ./gradlew -DflinkVersions=1.12,1.13 -DsparkVersions=2.4,3.0,3.1,3.2 -DhiveVersions=2,3 build -x test -x javadoc -x integrationTest
 
   build-javadoc:
     runs-on: ubuntu-latest


### PR DESCRIPTION
In this PR, we've just enabled the checkstyles check for the default engines.  As @rdblue suggested, it's better to enable checkstyles for all the engines.