### PR TITLE
Flink: fix KryoException for serialize getters of RowDataWrapper.

### DIFF
--- a/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/RowDataWrapper.java
+++ b/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/RowDataWrapper.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.flink;
 
+import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.nio.ByteBuffer;
 import java.time.LocalDateTime;
@@ -80,7 +81,7 @@ public class RowDataWrapper implements StructLike {
     throw new UnsupportedOperationException("Could not set a field in the RowDataWrapper because rowData is read-only");
   }
 
-  private interface PositionalGetter<T> {
+  private interface PositionalGetter<T> extends Serializable {
     T get(RowData data, int pos);
   }
 

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/RowDataWrapper.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/RowDataWrapper.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.flink;
 
+import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.nio.ByteBuffer;
 import java.time.LocalDateTime;
@@ -80,7 +81,7 @@ public class RowDataWrapper implements StructLike {
     throw new UnsupportedOperationException("Could not set a field in the RowDataWrapper because rowData is read-only");
   }
 
-  private interface PositionalGetter<T> {
+  private interface PositionalGetter<T> extends Serializable {
     T get(RowData data, int pos);
   }
 


### PR DESCRIPTION
This PR is tring to fix #3551.

To fix this problem, you need to do these few steps:

Step-1: Patch this PR to your iceberg.

Step-2: Register `ClosureSerializer` to flink env to prevent NPE when Kryo serialize lambda expr.
```
import com.twitter.chill.java.ClosureSerializer;
    ...

public static void main(String[] args) throws Exception {
    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
    env.getConfig().registerTypeWithKryoSerializer(ClosureSerializer.Closure.class, ClosureSerializer.class);
}
```

