### PR TITLE
Spec: Document NameMapping

### DIFF
--- a/site/docs/spec.md
+++ b/site/docs/spec.md
@@ -212,7 +212,7 @@ Columns in Iceberg data files are selected by field id. The table schema's colum
 
 For example, a file may be written with schema `1: a int, 2: b string, 3: c double` and read using projection schema `3: measurement, 2: name, 4: a`. This must select file columns `c` (renamed to `measurement`), `b` (now called `name`), and a column of `null` values called `a`; in that order.
 
-Tables may also define a property `schema.name-mapping.default` with a JSON `name mapping` containing a list of `field mapping` objects. These mappings provide fallback field ids to be used when a data file does not contain field id information. Each object should contain
+Tables may also define a property `schema.name-mapping.default` with a JSON name mapping containing a list of field mapping objects. These mappings provide fallback field ids to be used when a data file does not contain field id information. Each object should contain
 
 * `names`: A required list of 0 or more names for a field. 
 * `field-id`: An optional Iceberg field ID used when a field's name is present in `names`
@@ -221,7 +221,7 @@ Tables may also define a property `schema.name-mapping.default` with a JSON `nam
 Field mapping fields are constrained by the following rules:
 
 * A name may contain `.` but this refers to a literal name, not a nested field. For example, `a.b` refers to a field named `a.b`, not child field `b` of field `a`. 
-* Each child field should be defined with their own `field-mapping` under `fields`. 
+* Each child field should be defined with their own field mapping under `fields`. 
 * Multiple values for `names` may be mapped to a single field ID to support cases where a field may have different names in different data files. For example, all Avro field aliases should be listed in `names`.
 * Fields which exist only in the Iceberg schema and not in imported data files may use an empty `names` list.
 * Fields that exist in imported files but not in the Iceberg schema may omit `field-id`.

--- a/site/docs/spec.md
+++ b/site/docs/spec.md
@@ -1114,3 +1114,13 @@ Name mapping is serialized as a list of field mapping JSON Objects which are ser
 |**`names`**|`JSON list of strings`|`["latitude", "lat"]`|
 |**`field_id`**|`JSON int`|`1`|
 |**`fields`**|`JSON field mappings (list of objects)`|`[{ `<br />&nbsp;&nbsp;`"field-id": 4,`<br />&nbsp;&nbsp;`"names": ["latitude", "lat"]`<br />`}, {`<br />&nbsp;&nbsp;`"field-id": 5,`<br />&nbsp;&nbsp;`"names": ["longitude", "long"]`<br />`}]`|
+
+Example
+```json
+[ { "field-id": 1, "names": ["id", "record_id"] },
+   { "field-id": 2, "names": ["data"] },
+   { "field-id": 3, "names": ["location"], "fields": [
+       { "field-id": 4, "names": ["latitude", "lat"] },
+       { "field-id": 5, "names": ["longitude", "long"] }
+     ] } ]
+```

--- a/site/docs/spec.md
+++ b/site/docs/spec.md
@@ -214,13 +214,9 @@ For example, a file may be written with schema `1: a int, 2: b string, 3: c doub
 
 Tables may also define a property `schema.name-mapping.default` with a JSON `name mapping` containing a list of `field mapping` objects. These mappings provide fallback field ids to be used when a data file does not contain field id information. Each object should contain
 
-##### field mapping
-
 * `names`: A required list of 0 or more names for a field. 
 * `field-id`: An optional Iceberg field ID used when a field's name is present in `names`
 * `fields`: An optional list of field mappings for child field of structs, maps, and lists.
-
-##### names
 
 A name may contain `.` but this refers to a literal name, not a nested field. For example, `a.b` refers to a field named `a.b`, not child field `b` of field `a`. Each child field should be defined with their own `field-mapping` under `fields`
 
@@ -228,17 +224,15 @@ Multiple values for `names` may be mapped to a single field ID to support cases 
 
 Fields which exist only in the Iceberg schema and not in imported data files may be included as `field-mapping`s with an empty `names` list.
 
-##### field-id
-
 Fields that exist in imported files but not in the Iceberg schema may omit `field-id`.
-
-##### fields
 
 List types should contain a mapping in `fields` for `element`
 
 Map types should contain mappings in `fields` for `key` and `value`.
 
 Struct types should contain mappings for their child fields.
+
+For details on serialization see [Appendix F](#appendix-f-name-mapping-serialization)
 
 #### Identifier Field IDs
 
@@ -1110,3 +1104,13 @@ Writing v2 metadata:
     * `sort_columns` was removed
 
 Note that these requirements apply when writing data to a v2 table. Tables that are upgraded from v1 may contain metadata that does not follow these requirements. Implementations should remain backward-compatible with v1 metadata requirements.
+
+## Appendix F: Name Mapping Serialization
+
+Name mapping is serialized as a list of field mapping JSON Objects which are serialized as follows
+
+|Field mapping field|JSON representation|Example|
+|--- |--- |--- |
+|**`names`**|`JSON list of strings`|`["latitude", "lat"]`|
+|**`field_id`**|`JSON int`|`1`|
+|**`fields`**|`JSON field mappings (list of objects)`|`[{ `<br />&nbsp;&nbsp;`"field-id": 4,`<br />&nbsp;&nbsp;`"names": ["latitude", "lat"]`<br />`}, {`<br />&nbsp;&nbsp;`"field-id": 5,`<br />&nbsp;&nbsp;`"names": ["longitude", "long"]`<br />`}]`|

--- a/site/docs/spec.md
+++ b/site/docs/spec.md
@@ -212,6 +212,9 @@ Columns in Iceberg data files are selected by field id. The table schema's colum
 
 For example, a file may be written with schema `1: a int, 2: b string, 3: c double` and read using projection schema `3: measurement, 2: name, 4: a`. This must select file columns `c` (renamed to `measurement`), `b` (now called `name`), and a column of `null` values called `a`; in that order.
 
+Tables may also define a property `schema.name-mapping.default` with a JSON map of `columnName` -> `fieldId` which will be used if a data file was written without field ids. This `NameMapping` will **only** be used on files without field ids. Files imported or added to an Iceberg table from a system that does not generate field ids will fall back to using the table's name mapping to map columns to field ids.
+
+
 
 #### Identifier Field IDs
 

--- a/site/docs/spec.md
+++ b/site/docs/spec.md
@@ -226,7 +226,7 @@ A name may contain `.` but this refers to a literal name, not a nested field. Fo
 
 Multiple values for `names` may be mapped to a single field ID to support cases where a field may have different names in different data files. For example, all Avro field aliases should be listed in `names`.
 
-Fields which exist only in the Iceberg schema and not in imported data files may be included as a `field-mapping` with an empty list of `names`.
+Fields which exist only in the Iceberg schema and not in imported data files may be included as `field-mapping`s with an empty `names` list.
 
 ##### field-id
 

--- a/site/docs/spec.md
+++ b/site/docs/spec.md
@@ -218,18 +218,18 @@ Tables may also define a property `schema.name-mapping.default` with a JSON `nam
 * `field-id`: An optional Iceberg field ID used when a field's name is present in `names`
 * `fields`: An optional list of field mappings for child field of structs, maps, and lists.
 
-Field mapping fields are constrained by the following rules
+Field mapping fields are constrained by the following rules:
 
 * A name may contain `.` but this refers to a literal name, not a nested field. For example, `a.b` refers to a field named `a.b`, not child field `b` of field `a`. 
-* Each child field should be defined with their own `field-mapping` under `fields`. Multiple values for `names` may be mapped to a single field ID to support cases where a field may have different names in different data files. 
-* For example, all Avro field aliases should be listed in `names`.
-* Fields which exist only in the Iceberg schema and not in imported data files may be included as `field-mapping`s with an empty `names` list.
+* Each child field should be defined with their own `field-mapping` under `fields`. 
+* Multiple values for `names` may be mapped to a single field ID to support cases where a field may have different names in different data files. For example, all Avro field aliases should be listed in `names`.
+* Fields which exist only in the Iceberg schema and not in imported data files may use an empty `names` list.
 * Fields that exist in imported files but not in the Iceberg schema may omit `field-id`.
 * List types should contain a mapping in `fields` for `element`. 
 * Map types should contain mappings in `fields` for `key` and `value`. 
-* Struct types should contain mappings inf `fields` for their child fields.
+* Struct types should contain mappings in `fields` for their child fields.
 
-For details on serialization see [Appendix C](#name-mapping-serialization)
+For details on serialization, see [Appendix C](#name-mapping-serialization).
 
 #### Identifier Field IDs
 
@@ -1006,6 +1006,7 @@ Table metadata is serialized as a JSON object according to the following table. 
 |**`metadata-log`**|`JSON list of objects: [`<br />&nbsp;&nbsp;`{`<br />&nbsp;&nbsp;`"metadata-file": ,`<br />&nbsp;&nbsp;`"timestamp-ms": `<br />&nbsp;&nbsp;`},`<br />&nbsp;&nbsp;`...`<br />`]`|`[ {`<br />&nbsp;&nbsp;`"metadata-file": "s3://bucket/.../v1.json",`<br />&nbsp;&nbsp;`"timestamp-ms": 1515100...`<br />`} ]` |
 |**`sort-orders`**|`JSON sort orders (list of sort field object)`|`See above`|
 |**`default-sort-order-id`**|`JSON int`|`0`|
+
 
 ### Name Mapping Serialization
 

--- a/site/docs/spec.md
+++ b/site/docs/spec.md
@@ -212,9 +212,33 @@ Columns in Iceberg data files are selected by field id. The table schema's colum
 
 For example, a file may be written with schema `1: a int, 2: b string, 3: c double` and read using projection schema `3: measurement, 2: name, 4: a`. This must select file columns `c` (renamed to `measurement`), `b` (now called `name`), and a column of `null` values called `a`; in that order.
 
-Tables may also define a property `schema.name-mapping.default` with a JSON map of `columnName` -> `fieldId` which will be used if a data file was written without field ids. This `NameMapping` will **only** be used on files without field ids. Files imported or added to an Iceberg table from a system that does not generate field ids will fall back to using the table's name mapping to map columns to field ids.
+Tables may also define a property `schema.name-mapping.default` with a JSON `name mapping` containing a list of `field mapping` objects. These mappings provide fallback field ids to be used when a data file does not contain field id information. Each object should contain
 
+##### field mapping
 
+* `names`: A required list of 0 or more names for a field. 
+* `field-id`: An optional Iceberg field ID used when a field's name is present in `names`
+* `fields`: An optional list of field mappings for child field of structs, maps, and lists.
+
+##### names
+
+A name may contain `.` but this refers to a literal name, not a nested field. For example, `a.b` refers to a field named `a.b`, not child field `b` of field `a`. Each child field should be defined with their own `field-mapping` under `fields`
+
+Multiple values for `names` may be mapped to a single field ID to support cases where a field may have different names in different data files. For example, all Avro field aliases should be listed in `names`.
+
+Fields which exist only in the Iceberg schema and not in imported data files may be included as a `field-mapping` with an empty list of `names`.
+
+##### field-id
+
+Fields that exist in imported files but not in the Iceberg schema may omit `field-id`.
+
+##### fields
+
+List types should contain a mapping in `fields` for `element`
+
+Map types should contain mappings in `fields` for `key` and `value`.
+
+Struct types should contain mappings for their child fields.
 
 #### Identifier Field IDs
 


### PR DESCRIPTION
While we have a significant amount of code relying on the `NameMapping` of a table, we don't actually include any information on this table property in the Spec. This PR aims to codify what we already do in most implementations of Iceberg.