### PR TITLE
Spark: SparkMergeScan should work on the latest currentSnapshotID

### DIFF
--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkMergeScan.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkMergeScan.java
@@ -73,6 +73,8 @@ class SparkMergeScan extends SparkBatchScan implements SupportsFileFilter {
     this.splitOpenFileCost = readConf.splitOpenFileCost();
 
     Preconditions.checkArgument(!options.containsKey(SparkReadOptions.SNAPSHOT_ID), "Can't set snapshot-id in options");
+    // updating the snapshot, Merge and update should work on the latest currentSnapshot
+    table.refresh();
     Snapshot currentSnapshot = table.currentSnapshot();
     this.snapshotId = currentSnapshot != null ? currentSnapshot.snapshotId() : null;
 

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkMergeScan.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkMergeScan.java
@@ -73,6 +73,8 @@ class SparkMergeScan extends SparkBatchScan implements SupportsFileFilter {
     this.splitOpenFileCost = readConf.splitOpenFileCost();
 
     Preconditions.checkArgument(!options.containsKey(SparkReadOptions.SNAPSHOT_ID), "Can't set snapshot-id in options");
+    // updating the snapshot, Merge and update should work on the latest currentSnapshot
+    table.refresh();
     Snapshot currentSnapshot = table.currentSnapshot();
     this.snapshotId = currentSnapshot != null ? currentSnapshot.snapshotId() : null;
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkMergeScan.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkMergeScan.java
@@ -70,6 +70,8 @@ class SparkMergeScan extends SparkBatchScan implements SupportsFileFilter {
     this.splitOpenFileCost = readConf.splitOpenFileCost();
 
     Preconditions.checkArgument(readConf.snapshotId() == null, "Can't set snapshot-id in options");
+    // updating the snapshot, Merge and update should work on the latest currentSnapshot
+    table.refresh();
     Snapshot currentSnapshot = table.currentSnapshot();
     this.snapshotId = currentSnapshot != null ? currentSnapshot.snapshotId() : null;
 


### PR DESCRIPTION
Why do we need this PR?

This PR is added for the issue addressed in this link https://github.com/apache/iceberg/issues/3559. There is support added in the SparkMergeScan.java , for getting the latest updated CurrentSnapshotID of the table , before performing any update/ merge operation

Existing the Unit Test is working for this change.