### PR TITLE
[CORE] Specification for an HTTP REST catalog

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/http/IcebergHttpResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/http/IcebergHttpResponse.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest.http;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * All responses for the first version of the Iceberg REST API will be JSON objects, a top-level envelope object with two fields,
+ * `error` and `data`, which are themselves JSON objects.
+ *
+ * data: represents the JSON encoded response for a successful path or for a valid / expected failure. JSON representation of various response types
+ * error: a standardized obect on error, containing the error code, message, type, and  additional metadata (an optional JSON object of metadata) as defined below.
+ *
+ * All responses for the REST catalog should be wrapped this way, vs using primitives. For example, for a ListTableResponse, listing tables under a namespace "accounting",
+ * we'd get a JSON object back like the following:
+ *
+ * { "data": { "identifiers": [ "accounting.tax", "accounting.currency_conversions"] }, "error", {} }
+ *
+ * If the namesapce `accounting` didn't request, the response from that call would have a body like the following,
+ * where the `code` 40401 is a two-part identifier:
+ *    - HTTP response code: 404
+ *    - Two digit internal application defined error code for further detail: 01 - Namespace not found.
+ *
+ * { "data": {}, "error": { "message": "Failed to list tables. The Namespace 'accounting' does not exist", "type": "NamespaceNotFoundException", "code": 40401 }
+ *
+ * We could also embed the HTTP response code plainly by itself, without internally documented codes, as a separate field. I have found having a documented list of internal
+ * error codes to be very helpful previously, but am open to discussion on this.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class IcebergHttpResponse<T> {
+
+  private final T data;
+  private final Error error;
+
+  @JsonCreator
+  public IcebergHttpResponse(
+      @JsonProperty("data") T data,
+      @JsonProperty("error") Error error) {
+    this.data = data;
+    this.error = error;
+  }
+
+  public Error error() {
+    return error;
+  }
+
+  public T data() {
+    return data;
+  }
+
+  /**
+   * An error object embedded in every HTTP response.
+   *
+   * On error, this contains:
+   *   - message: A short, human-readable description of the error.
+   *   - type: Type of exception - more specifically a class name, e.g. NamespaceNotFoundException)
+   *   - code: An (optional) application specific error code, to distinguish between causes
+   *           of the same HTTP response code (eg possibly different types of Unauthorized exceptions).
+   *
+   *   #################### Optional fields to consider ######################################
+   *   - status: HTTP response code (optional).
+   *   - traceId: Unique specific identifier for this error and request, for monitoring purposes.
+   *              Presumably this would be an OpenTracing Span (optional).
+   *              Will almost certainly add tracing headers as an optional follow-up.
+   *   - metadata: Further map of optional metadata (such as further directions to users etc) (optional - unsure?).
+   *   #######################################################################################
+   *
+   *  Example:
+   *    "error": {
+   *         "message": "Authorization denied: Missing Bearer header",
+   *         "type": "OAuthException",
+   *         "code": 40102
+   *    }
+   */
+  public static class Error {
+
+    private final String message;
+    private final String type;
+    private final int code;
+
+    @JsonCreator
+    public Error(
+        @JsonProperty("message") String message,
+        @JsonProperty("type") String type,
+        @JsonProperty("code") int code) {
+      this.message = message;
+      this.type = type;
+      this.code = code;
+    }
+  }
+}
+

--- a/core/src/main/java/org/apache/iceberg/rest/http/IcebergHttpResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/http/IcebergHttpResponse.java
@@ -24,6 +24,11 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
+ *
+ * NOTE: This document isn't intended as part of the Spec, and was
+ *       intended for showing something to somebody. As there is on-going
+ *       discssion, I'm leaving it, but then I will likely remove it for now.
+ *
  * All responses for the first version of the Iceberg REST API will be JSON objects, a top-level envelope object with two fields,
  * `error` and `data`, which are themselves JSON objects.
  *
@@ -32,8 +37,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *
  * All responses for the REST catalog should be wrapped this way, vs using primitives. For example, for a ListTableResponse, listing tables under a namespace "accounting",
  * we'd get a JSON object back like the following:
+ *   (the field `error`, having a value of null, has not been serialized).
  *
- * { "data": { "identifiers": [ "accounting.tax", "accounting.currency_conversions"] }, "error", {} }
+ * { "data": { "identifiers": [ "accounting.tax", "accounting.currency_conversions"] }   }
+ *
+ * NOTE: The direction now is to head to just using HTTP response codes and
+ *       not internal codes, as we have `Type`. If anybody feels strongly about
+ *       using internal codes, please bring that up.
  *
  * If the namesapce `accounting` didn't request, the response from that call would have a body like the following,
  * where the `code` 40401 is a two-part identifier:

--- a/dev/.rat-excludes
+++ b/dev/.rat-excludes
@@ -24,3 +24,5 @@ gradle/*
 package-list
 sitemap.xml
 derby.log
+rest_docs/*
+

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -169,9 +169,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/IcebergResponseObject'
               example: '{ "data": { "dropped": true } }'
-        # TODO - Not empty exception, No such namespace exception
         '401':
           description: Unauthorized
+        '404':
+          description: Not Found
 
 
   /namespaces/{namespace}/properties:

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -96,14 +96,13 @@ paths:
                 $ref: '#/components/schemas/GetTableResponse'
         '401':
           description: Unauthorized
-        # Using 412, `Precondition Failed`, instead of 404, as 404 makes monitoring response codes from ELBs
-        #  very difficult - Hard to tell if clients or servers are misconfigured and calling non-existent routes
-        #  or missing routes versus expected error cases such as NoSuchTableException (expected meaning that
-        #  a person who is on call shouldn't be paged for this but 404 they might need to be).
-        '412':
-          description: NoSuchTableException
+        '404':
+          description: Not Found (NoSuchNamespaceException)
+        '404':
+          description: Not Found (NoSuchTableException)
           content:
             application/json:
+              # The REST catalog's JSON format to represent NoSuchTableException.
               schema:
                 $ref: '#/components/schemas/NoSuchTableError'
     delete:
@@ -136,7 +135,7 @@ paths:
       summary: Check if a table exists
       operationId: tableExists
       description:
-        Check if a table exists within a given namespace. Returns the standard response with `true` when found. Will return a TableNotFound error if not present.
+        Check if a table exists within a given namespace. Returns the standard response with `true` when found. Will throw a NoSuchTableException if not present.
       parameters:
         - name: namespace
           in: path
@@ -152,8 +151,8 @@ paths:
       responses:
         '200':
           description: OK
-        '412':
-          description: Table Not Found
+        '404':
+          description: Not Found (NoSuchTableException)
   /v1/namespaces/{namespace}/tables:
     parameters:
       - name: namespace
@@ -219,32 +218,32 @@ paths:
           description: OK
         '401':
           description: Unauthorized
-        '406':
-          description: Not Acceptable (Unsupported Operation)
-        # Not using 404 as 404 is very hard to monitor.
-        # There's no way to tell by monitoring returned response codes
-        # if a client made a valid request but the table didn't exist,
-        # or if a client or server has been misconfigured or some bug exists
-        # and the client is actually calling endpoints that the server doesn't
-        # have.
-        #
-        # We can consider a different response code to use than 412.
-        '412':
-          description: Table to rename from does not exist
+        '404':
+          description: Not Found (NoSuchTableException - Table to rename does not exist)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/NoSuchTableError'
               example:
-                '{ error: { message: "Table does not exist", type: "NoSuchTableException", code: 41202 }'
+                '{ error: { message: "Table does not exist", type: "NoSuchTableException", code: 40402 }'
+        '404':
+          description: Not Found (NoSuchNamespaceException - The target namespace of the table rename does not exist)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NoSuchNamespaceError'
+              example:
+                '{ error: { message: "Namespace does not exist", type: "NoSuchNameSpaceException", code: 40401 }'
+        '406':
+          description: Not Acceptable (UnsupportedOperationException)
         '409':
-          description: The new table identifier, the to table rename to, already exists.
+          description: Conflict (AlreadyExistsException - The new target table identifier already exists)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/TableAlreadyExistsError'
               example:
-                '{ error: { message: "Namespace already exists", type: "AlreadyExistsException", code: 40902 }'
+                '{ error: { message: "Tale already exists", type: "AlreadyExistsException", code: 40902 }'
   /v1/namespaces/{namespace}/properties:
     parameters:
       - name: namespace
@@ -276,14 +275,14 @@ paths:
                 type: boolean
         '406':
           description: Not Acceptable (Unsupported Operation)
-        '412':
-          description: Namespace not found
+        '404':
+          description: Not Found (NoSuchNamespaceException)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/NoSuchNamespaceError'
               example:
-                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 41201 }'
+                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 40401 }'
     put:
       tags:
         - Catalog API
@@ -308,14 +307,14 @@ paths:
                 type: boolean
         '406':
           description: Not Acceptable (Unsupported Operation)
-        '412':
-          description: Namespace not found
+        '404':
+          description: Not Found (No Such Namespace)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/NoSuchNamespaceError'
               example:
-                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 41201 }'
+                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 40401 }'
 
   /v1/namespaces:
     get:
@@ -362,7 +361,7 @@ paths:
         '401':
           description: Unauthorized
         '409':
-          description: Namespace already exists
+          description: Conflict (AlreadyExistsException)
           content:
             application/json:
               schema:
@@ -389,14 +388,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetNamespaceResponse'
-        '412':
-          description: Namespace not found
+        '404':
+          description: Not Found (NoSuchNamespaceException)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/NoSuchNamespaceError'
               example:
-                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 41201 }'
+                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 40401 }'
     delete:
       tags:
         - Catalog API
@@ -652,7 +651,7 @@ components:
         {
           message: "The given table does not exist",
           type: "NoSuchTableException",
-          code: 41201
+          code: 40401
         }
 
   securitySchemes:

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -201,7 +201,9 @@ paths:
       tags:
         - Catalog API
       summary: Rename a table from its current name to a new name
-      description: Rename a table within the same catalog
+      description:
+        Rename a table from one identifier to another. It's valid to move a table
+        across namespaces, but the server implementation doesn't need to support it.
       operationId: renameTable
       requestBody:
         description: Current table identifier to rename and new table identifier to rename to
@@ -215,6 +217,9 @@ paths:
           description: OK
         '401':
           description: Unauthorized
+        '406':
+          # UnsupportedOperationException
+          description: Not Acceptable
         # Not using 404 as 404 is very hard to monitor.
         # There's no way to tell by monitoring returned response codes
         # if a client made a valid request but the table didn't exist,

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -27,9 +27,18 @@ info:
   version: 1.0.0
   description:
     Defines the specification for the first version of the REST Catalog API. Implementations should support both Iceberg table specs v1 and v2, with priority given to v2.
-# TODO - Add ServerVariable so user's can control the routes and ports etc and have mutli-env etc.
 servers:
-  - url: http://127.0.0.1:1080
+  - url: https://{host}:{port}/{basePath}
+    variables:
+      host:
+        description: The host address for the specified server
+        default: localhost
+      port:
+        description: The port used when addressing the host
+        default: "443"
+      basePath:
+        default: v1
+  - url: http://127.0.0.1:1080/v1
     description: URL Used for Mock-Server Unit Tests
 # All routes are currently configured using an Authorization header.
 security:
@@ -109,13 +118,7 @@ paths:
         '401':
           description: Unauthorized
         '409':
-          description: Conflict (AlreadyExistsException)
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NamespaceAlreadyExistsError'
-              example:
-                { "error": { "message": "Namespace already exists", "type": "AlreadyExistsException", code: 409 } }
+          $ref: '#/components/responses/NamespaceAlreadyExistsResponse'
 
   /namespaces/{namespace}:
     parameters:
@@ -138,13 +141,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/GetNamespaceResponse'
         '404':
-          description: Not Found (NoSuchNamespaceException)
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/IcebergResponseObject'
-              example:
-                { "data": {}, "error": { "message": "Namespace does not exist", "type": "NoSuchNamespaceException", code: 404 } }
+          $ref: '#/components/responses/NoSuchNamespaceResponse'
     head:
       tags:
         - Catalog API
@@ -169,7 +166,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IcebergResponseObject'
+                $ref: '#/components/responses/IcebergResponseObject'
               example: { "data": { "dropped": true } }
         '401':
           description: Unauthorized
@@ -224,7 +221,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IcebergResponseObject'
+                $ref: '#/components/responses/IcebergResponseObject'
               example:
                 { "error": { "message": "Namespace does not exist", "type": "NoSuchNamespaceException", "code": 404 } }
         406:
@@ -263,7 +260,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IcebergResponseObject'
+                $ref: '#/components/responses/IcebergResponseObject'
               example:
                 '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 404 }'
 
@@ -303,18 +300,18 @@ paths:
             type: boolean
             default: false
       responses:
-        '200':
+        200:
           description: OK
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/DropTableResponse'
               example: { "data": { "dropped": true, "purged": false } }
-        '202':
+        202:
           # TODO - Add a callback or handle to check on the state of an async purge request
           description: Accepted - for use if purgeRequested is implemented as an asynchronous action.
-        '404':
-          description: Not Found
+        404:
+          $ref: '#/components/responses/NoSuchTableResponse'
 
     head:
       tags:
@@ -323,14 +320,12 @@ paths:
       operationId: tableExists
       description:
         Check if a table exists within a given namespace.
-        Returns the standard Iceberg response data wrapper with exists set to `true` when found, `false` if not found.
-        If the namespace for the table does not exist, returns a 404 NoSuchNamespaceException.
       responses:
-        '200':
+        200:
           description: OK - Table Exists
-        '401':
+        401:
           description: Unauthorized
-        '404':
+        404:
           description: Not Found
 
   /tables/rename:
@@ -363,20 +358,20 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/NoSuchTableError'
-                  - $ref: '#/components/schemas/NoSuchNamespaceError'
+                  - $ref: '#/components/responses/NoSuchTableResponse'
+                  - $ref: '#/components/responses/NoSuchNamespaceResponse'
               examples:
                 table_to_rename_does_not_exist:
                   value: {
                     "error": {
-                      "message": "Table does not exist",
+                      "message": "Table to rename does not exist",
                       "type": "NoSuchTableException",
                       "code": 404
                     } }
                 namespace_to_rename_to_does_not_exist:
                   value: {
                     "error": {
-                      "message": "Namespace does not exist",
+                      "message": "Namespace to rename to does not exist",
                       "type": "NoSuchNameSpaceException",
                       "code": 404
                     } }
@@ -396,16 +391,11 @@ paths:
                 } }
 
 components:
+
+  ##############################
+  # Application Schema Objects #
+  ##############################
   schemas:
-    IcebergResponseObject:
-      type: object
-      description: JSON wrapper for all response bodies, with a data object and / or an error object
-      properties:
-        data:
-          $ref: '#/components/schemas/ResponseDataObject'
-        error:
-          $ref: '#/components/schemas/ResponseErrorObject'
-      example: { "data": { "namespaces": [ [ "ns1", "foo_db" ], [ "ns1", "bar_db" ] ] }, "error": { } }
     ResponseDataObject:
       type: object
       description: JSON data payload returned in a successful response body
@@ -571,22 +561,59 @@ components:
             are stored server side. This could be beneifical to an administrator,
             for example to enforce that a given LocationProvider is used or to
             enforce that a certain FileIO implementation is used.
-    NoSuchNamespaceError:
-      allOf:
-        - $ref: '#/components/schemas/ResponseErrorObject'
-      description: Namespace provided in the request does not exist
-    NamespaceAlreadyExistsError:
-      allOf:
-        - $ref: '#/components/schemas/ResponseErrorObject'
-      description: Namespace provided in the request already exists
-    NoSuchTableError:
-      allOf:
-        - $ref: '#/components/schemas/ResponseErrorObject'
-      description: The given table identifier does not exist
+
     TableAlreadyExistsError:
       allOf:
         - $ref: '#/components/schemas/ResponseErrorObject'
       description: the given table identifier already exists and cannot be created / renamed to
+
+  #############################
+  # Reusable Response Objects #
+  #############################
+  responses:
+
+    IcebergResponseObject:
+      description: JSON wrapper for all response bodies, with a data object and / or an error object
+      content:
+        application/json:
+          schema:
+            anyOf:
+              - $ref: '#/components/schemas/ResponseDataObject'
+              - $ref: '#/components/schemas/ResponseErrorObject'
+          example: { "data": { "namespaces": [ [ "ns1", "foo_db" ], [ "ns1", "bar_db" ] ] }, "error": { } }
+
+    NamespaceAlreadyExistsResponse:
+      description: The specified namespace provided in the request already exists
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ResponseErrorObject'
+          example:
+            { "error": { "message": "Namespace already exists", "type": "AlreadyExistsException", code: 409 } }
+
+
+    NoSuchNamespaceResponse:
+      description: Not Found (The specified namespace was not found)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ResponseErrorObject'
+          example: {
+            "error": {
+              "message": "Namespace does not exist", "type": "NoSuchNamespaceException", "code": 404
+            } }
+
+    NoSuchTableResponse:
+      description: Not Found (The specified table identifier was not found)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ResponseErrorObject'
+          example: {
+            "error": {
+              "message": "The given table does not exist", "type": "NoSuchTableException", code: 404
+            } }
+
   examples:
     catalogName:
       value: prod

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -50,16 +50,27 @@ paths:
         - Configuration API
       summary: List all catalog configuration settings
       operationId: getConfig
-      description:
-        All REST catalog clients will first call this route to get some configuration provided by the server.
-        This route will return any server specified default configuration values for the catalog, such as
-        configuration values used to setup the catalog for usage with Spark (e.g. vectorization-enabled).
+      description: >
+        All REST catalog clients will first call this route to get possible catalog-specific
+        configuration values provided by the server, that the catalog (and its HTTP client)
+        can use to complete the `initialize` step.
 
-        Users should be able to override these values with client specified values.
+        This call is similar to the initial set-up calls that some catalogs already do for
+        domain-specific information, such as the Nessie catalog or the Glue catalog.
+        This is to allow for services that would like to integrate with Iceberg to do so,
+        and to be able to add their own domain-specific information into the REST catalog without
+        requiring them to write and distribute a catalog themselves.
 
-        The server might be able to request that the client use its value over a value that has been
-        configured in the client application. How and if it will do that is an open question, and thus
-        not currently specified in this documents schema.
+        There will be two sets of values provided -
+
+        - overrides
+          * An object containing values that the client must use.
+            For example, auth headers that the client will receive from the server
+            as temporary credentials.
+        - defaults
+          * Catalog-specific configuration that the client may use as a default value.
+            These are optional and the client is free to use its own value for these.
+
       responses:
         default:
           description: Server-Specific Configuration Values (or Overrides)
@@ -67,6 +78,23 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/IcebergConfiguration'
+              example: {
+                "data": {
+                  "overrides": {
+                    "prefix": "/raul",
+                    "headers": {
+                      "User-Agent": "Raul",
+                      "Authorization": "Basic Ym9zY236Ym9zY28=",
+                    }
+                  },
+                  "defaults": {
+                    "clients": 5,
+                    "headers": {
+                      "Upgrade-Insecure-Requests": "1"
+                    }
+                  }
+                }
+              }
         "400":
           description: Unknown Error
         "401":
@@ -207,7 +235,7 @@ paths:
           content:
             'application/json':
               schema:
-                # This is an IcebergResponseObject<SetPropertiesResponse>, in that it uses the standard wrapper.
+                # This is an IcebergResponseObject<SetPropertiesResponse>, in that it uses the standard wrapper of { "data": toJson(SetPropertiesResponse) }
                 $ref: '#/components/schemas/UpdatePropertiesResponse'
               example: {
                 "data": {
@@ -425,10 +453,6 @@ components:
           maximum: 600
           description: HTTP response code
           example: 404
-        metadata:
-          type: object
-          description: Additional metadata to accompany this error, such as server side stack traces or user instructions
-          nullable: true
     TableIdentifier:
       type: object
       required:

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -107,7 +107,7 @@ paths:
       description:
         List all namespaces at a certain level, optionally starting from a given parent namespace.
         For example, if table a.b.t exists, using 'SELECT NAMESPACE IN a' this would translate into
-        `GET /namespaces?parent=a` and must return Namepace.of("a","b").
+        `GET /namespaces?parent=a` and must return Namepace.of("a","b")
       operationId: listNamespaces
       parameters:
         - name: parent

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -154,7 +154,8 @@ paths:
           content:
             application/json:
               schema:
-                type: boolean
+                type: IcebergResponseObject
+                example: '{ "data": { "dropped": true } }'
         # TODO - Not empty exception, No such namespace exception
         '401':
           description: Unauthorized

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -77,7 +77,7 @@ paths:
             value: "accounting.tax"
       - name: table
         in: path
-        description: Name of the table to load
+        description: A table name
         required: true
         schema:
           type: string

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -258,6 +258,7 @@ paths:
       description:
         Set a collection of properties on a namespace in the catalog.
         Properties that are not in the given map are not modified or removed by this call.
+        Server implementations are not required to support namespace properties.
       requestBody:
         content:
           application/json:
@@ -271,6 +272,8 @@ paths:
             'application/json':
               schema:
                 type: boolean
+        '406':
+          description: Not Acceptable (Unsupported Operation)
         '412':
           description: Namespace not found
           content:

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -218,8 +218,7 @@ paths:
         '401':
           description: Unauthorized
         '406':
-          # UnsupportedOperationException
-          description: Not Acceptable
+          description: Not Acceptable (Unsupported Operation)
         # Not using 404 as 404 is very hard to monitor.
         # There's no way to tell by monitoring returned response codes
         # if a client made a valid request but the table didn't exist,
@@ -272,22 +271,47 @@ paths:
             'application/json':
               schema:
                 type: boolean
-        '417':
+        '412':
           description: Namespace not found
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/NoSuchNamespaceError'
               example:
-                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 41701 }'
-        '409':
-          description: Namespace already exists
+                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 41201 }'
+    delete:
+      tags:
+        - Catalog API
+      summary: Remove a set of property keys from a namespace in the catalog
+      operationId: removeProperties
+      description:
+        Remove a set of property keys from a namespace in the catalog.
+        Properties that are not in the given set are not modified or removed by this call.
+        Server implementations are not required to support namespace properties.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RemovePropertiesRequest'
+        required: true
+      responses:
+        '200':
+          description: OK
           content:
-            applicaton/json:
+            'application/json':
               schema:
-                $ref: '#/components/schemas/NamespaceAlreadyExistsError'
+                type: boolean
+        '406':
+          description: Not Acceptable (Unsupported Operation)
+        '412':
+          description: Namespace not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NoSuchNamespaceError'
               example:
-                '{ error: { message: "Namespace already exists", type: "AlreadyExistsException", code: 40901 }'
+                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 41201 }'
+
   /v1/namespaces:
     parameters:
       - name: parent
@@ -396,7 +420,7 @@ components:
           type: string
         properties:
           uniqueItems: true
-          type: array
+          type: object
           items:
             type: string
     CreateNamespaceRequest:

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -209,9 +209,11 @@ paths:
                   - $ref: '#/components/schemas/NoSuchNamespaceError'
               examples:
                 table_to_rename_does_not_exist:
-                  '{ error: { message: "Table does not exist", type: "NoSuchTableException", code: 40402 }'
+                  value:
+                    '{ error: { message: "Table does not exist", type: "NoSuchTableException", code: 40402 }'
                 namespace_to_rename_to_does_not_exist:
-                  '{ error: { message: "Namespace does not exist", type: "NoSuchNameSpaceException", code: 40401 }'
+                  value:
+                    '{ error: { message: "Namespace does not exist", type: "NoSuchNameSpaceException", code: 40401 }'
         '406':
           description: Not Acceptable (UnsupportedOperationException)
         '409':

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -576,10 +576,10 @@ components:
             that the REST catalog client will do.
         catalogProperties:
           type: object
-          nullable: true
+          nullable: false
           description:
             An optional field for storing catalog configuration properties that
-            are stored server side. This could be beneifical to an administrator,
+            are stored server side. This could be beneficial to an administrator,
             for example to enforce that a given LocationProvider is used or to
             enforce that a certain FileIO implementation is used.
 

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -442,7 +442,7 @@ components:
           description: Human-readable error message
         type:
           type: string
-          description: Internal type of the error, such as an exception class
+          description: Internal type definition of the error
           example: NoSuchNamespaceException
         code:
           type: integer

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -169,13 +169,14 @@ paths:
     delete:
       tags:
         - Catalog API
-      summary: Drop a table from the catalog, optionally purging the underlying data
+      summary: Drop a table from the catalog
       operationId: dropTable
-      description: Remove a table from the catalog, optionally dropping the underlying data
+      description: Remove a table from the catalog
       parameters:
-        - name: purge
+        - name: purgeRequested
           in: query
           required: false
+          description: Whether the user requested to purge the underlying table's data and metadata
           schema:
             type: boolean
             default: false

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -37,9 +37,7 @@ servers:
         description: The port used when addressing the host
         default: "443"
       basePath:
-        default: v1
-  - url: http://127.0.0.1:1080/
-    description: URL Used for Mock-Server Unit Tests
+        default: ""
 # All routes are currently configured using an Authorization header.
 security:
   - BearerAuth: []
@@ -336,7 +334,6 @@ paths:
                 $ref: '#/components/schemas/DropTableResponse'
               example: { "data": { "dropped": true, "purged": false } }
         202:
-          # TODO - Add a callback or handle to check on the state of an async purge request
           description: Accepted - for use if purgeRequested is implemented as an asynchronous action.
         404:
           $ref: '#/components/responses/NoSuchTableResponse'
@@ -449,7 +446,7 @@ components:
           example: NoSuchNamespaceException
         code:
           type: integer
-          minimum: 100
+          minimum: 400
           maximum: 600
           description: HTTP response code
           example: 404

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -75,7 +75,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/IcebergConfiguration'
+                $ref: '#/components/schemas/CatalogConfiguration'
               example: {
                 "data": {
                   "overrides": {
@@ -561,7 +561,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TableIdentifier'
-    IcebergConfiguration:
+    CatalogConfiguration:
       type: object
       description: "Server-provided configuration for the catalog."
       properties:
@@ -575,15 +575,25 @@ components:
             are free to use another choice for root path, but must conform to the
             specification otherwise in order to interoperate with the URI generation
             that the REST catalog client will do.
-        catalogProperties:
+        overrrides:
           type: object
           nullable: false
           description:
-            An optional field for storing catalog configuration properties that
-            are stored server side. This could be beneficial to an administrator,
+            Catalog configuration properties that are stored server-side.
+            The client must respect these values when configuring the catalog during
+            initialization. This could be beneficial to an administrator,
             for example to enforce that a given LocationProvider is used or to
             enforce that a certain FileIO implementation is used.
-
+        defaults:
+          type: object
+          nullable: false
+          description:
+            Catalog configuration properties that are stored server-side.
+            The client does not have to use thse values, and they are simply default
+            values that the user might choose to omit in their configuration. This could
+            be beneficial for users who don't want to have to configure every single property
+            available to them in their job, or for an administrator to centrally set the
+            suggested default values for certain catalog settings.
     TableAlreadyExistsError:
       allOf:
         - $ref: '#/components/schemas/ResponseErrorObject'

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -170,7 +170,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/IcebergResponseObject'
-              example: '{ "data": { "dropped": true } }'
+              example: { "data": { "dropped": true } }
         '401':
           description: Unauthorized
         '404':
@@ -191,8 +191,8 @@ paths:
       operationId: setProperties / removeProperties
       description:
         Set and/or remove a collection or properties on a namespae.
-        The request body specifies a list of properties `toRemove` and a map
-        of key value pairs `toUpsert`.
+        The request body specifies a list of properties to remove and a map
+        of key value pairs to update.
 
         Properties that are not in the request are not modified or removed by this call.
         Server implementations are not required to support namespace properties.
@@ -224,7 +224,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NoSuchNamespaceError'
+                $ref: '#/components/schemas/IcebergResponseObject'
               example:
                 { "error": { "message": "Namespace does not exist", "type": "NoSuchNamespaceException", "code": 404 } }
         406:
@@ -350,7 +350,12 @@ paths:
         '401':
           description: Unauthorized
         '404':
-          description: Not Found (NoSuchTableException - Table to rename does not exist | NoSuchTableException - The target namespace of the new table identifier does not exist))
+          description: >
+            Not Found, either
+              - NoSuchTableException
+                - Table to rename does not exist
+              - NoSuchNamespaceException
+                - The target namespace of the new table identifier does not exist
           content:
             application/json:
               schema:
@@ -359,11 +364,19 @@ paths:
                   - $ref: '#/components/schemas/NoSuchNamespaceError'
               examples:
                 table_to_rename_does_not_exist:
-                  value:
-                    '{ error: { message: "Table does not exist", type: "NoSuchTableException", code: 404 } }'
+                  value: {
+                    "error": {
+                      "message": "Table does not exist",
+                      "type": "NoSuchTableException",
+                      "code": 404
+                    } }
                 namespace_to_rename_to_does_not_exist:
-                  value:
-                    '{ error: { message: "Namespace does not exist", type: "NoSuchNameSpaceException", code: 404 } }'
+                  value: {
+                    "error": {
+                      "message": "Namespace does not exist",
+                      "type": "NoSuchNameSpaceException",
+                      "code": 404
+                    } }
         '406':
           description: Not Acceptable (UnsupportedOperationException)
         '409':
@@ -372,8 +385,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TableAlreadyExistsError'
-              example:
-                '{ "error": { "message": "Tale already exists", "type": "AlreadyExistsException", code: 409 } }'
+              example: {
+                "error": {
+                  "message": "Table already exists",
+                  "type": "AlreadyExistsException",
+                  "code": 409
+                } }
 
 components:
   schemas:
@@ -540,6 +557,8 @@ components:
           example: NoSuchNamespaceException
         code:
           type: integer
+          minimum: 100
+          maximum: 600
           description: HTTP response code
           example: 404
         metadata:

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -179,25 +179,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ListTablesResponse'
-    post:
-      tags:
-        - Catalog API
-      summary: Create a table with the identifier given in the body
-      operationId: createTable
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateTableRequest'
-        required: true
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CreateTableResponse'
-  /v1/tables/renameTable:
+  /v1/tables/rename:
     post:
       tags:
         - Catalog API
@@ -455,25 +437,6 @@ components:
           $ref: '#/components/schemas/TableIdentifier'
         destinationTableIdentifier:
           $ref: '#/components/schemas/TableIdentifier'
-    CreateTableRequest:
-      type: object
-      properties:
-        identifier:
-          $ref: '#/components/schemas/TableIdentifier'
-        schema:
-          $ref: '#/components/schemas/Schema'
-        partitionSpec:
-          $ref: '#/components/schemas/PartitionSpec'
-        sortOrder:
-          $ref: '#/components/schemas/SortOrder'
-        properties:
-          type: object
-          additionalProperties:
-            type: string
-        metadataJson:
-          type: string
-        commit:
-          type: boolean
     PartitionSpec:
       type: object
       properties:
@@ -487,27 +450,6 @@ components:
           additionalProperties:
             type: integer
             format: int32
-    SortOrder:
-      type: object
-      properties:
-        unsorted:
-          type: boolean
-    CreateTableResponse:
-      type: object
-      properties:
-        identifier:
-          $ref: '#/components/schemas/TableIdentifier'
-        metadataLocation:
-          type: string
-          description: "Location of the most current primary metadata file for the table"
-          example: s3://bucket/prod/accounting.db/monthly_sales/metadata/00001-0d4ef14f-ef7d-43e7-9af-5f4ad40a1103.metadata.json
-        metadataJson:
-          type: string
-          description: "Stringified JSON representing the tables metadata"
-          example:
-            "TODO"
-        tableToken:
-          type: string
     SetPropertiesRequest:
       type: object
       properties:
@@ -617,11 +559,11 @@ components:
       example: "{ data: { }, error: { } }"
     ResponseDataObject:
       type: object
-      description: JSON data payload returned in a successful response body.
+      description: JSON data payload returned in a successful response body
       example: '{ data: { identifiers: [ "office.employees", "office.dogs", "office.cats" ] }'
     ResponseErrorObject:
       type: object
-      description: Error portion embedded in all JSON responses with further details of the error
+      description: JSON error payload returned in a response with further details on the error
       properties:
         message:
           type: string
@@ -640,7 +582,6 @@ components:
       required:
         - message
         - type
-        - code
   examples:
     catalogName:
       value: prod

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -89,6 +89,8 @@ paths:
                 $ref: '#/components/schemas/ListNamespacesResponse'
         '401':
           description: Unauthorized
+        '404':
+          description: Not Found (Parent namespace does not exist)
     post:
       tags:
         - Catalog API
@@ -113,7 +115,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/NamespaceAlreadyExistsError'
               example:
-                '{ error: { message: "Namespace already exists", type: "AlreadyExistsException", code: 409 }'
+                { "error": { "message": "Namespace already exists", "type": "AlreadyExistsException", code: 409 } }
 
   /namespaces/{namespace}:
     parameters:
@@ -140,9 +142,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NoSuchNamespaceError'
+                $ref: '#/components/schemas/IcebergResponseObject'
               example:
-                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 404 }'
+                { "data": {}, "error": { "message": "Namespace does not exist", "type": "NoSuchNamespaceException", code: 404 } }
     head:
       tags:
         - Catalog API
@@ -185,69 +187,48 @@ paths:
     post:
       tags:
         - Catalog API
-      summary: Set a collection of properties on a namespace
-      operationId: setProperties
+      summary: Set or remove properties on a namespace
+      operationId: setProperties / removeProperties
       description:
-        Set a collection of properties on a namespace in the catalog.
-        Properties that are not in the given map are not modified or removed by this call.
+        Set and/or remove a collection or properties on a namespae.
+        The request body specifies a list of properties `toRemove` and a map
+        of key value pairs `toUpsert`.
+
+        Properties that are not in the request are not modified or removed by this call.
         Server implementations are not required to support namespace properties.
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SetPropertiesRequest'
+              $ref: '#/components/schemas/UpdatePropertiesRequest'
+            example:
+              { "toRemove": [ "foo", "bar" ], "toUpdate": { "owner": "Raoul" } }
         required: true
       responses:
-        '200':
+        200:
           description: OK
           content:
             'application/json':
               schema:
                 # This is an IcebergResponseObject<SetPropertiesResponse>, in that it uses the standard wrapper.
-                $ref: '#/components/schemas/SetPropertiesResponse'
-                example: '{ "data": { "updated": true }, "error": null }'
-        '406':
-          description: Not Acceptable (Unsupported Operation)
-        '404':
+                $ref: '#/components/schemas/UpdatePropertiesResponse'
+              example: {
+                "data": {
+                  "updated": [ "owner" ],
+                  "removed": [ "foo" ],
+                  "notPresent": [ "bar" ]
+                }
+              }
+        404:
           description: Not Found (NoSuchNamespaceException)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/NoSuchNamespaceError'
               example:
-                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 404 }'
-    put:
-      tags:
-        - Catalog API
-      summary: Remove a set of property keys from a namespace in the catalog
-      operationId: removeProperties
-      description:
-        Remove a set of property keys from a namespace in the catalog.
-        Properties that are not in the given set are not modified or removed by this call.
-        Server implementations are not required to support namespace properties.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RemovePropertiesRequest'
-        required: true
-      responses:
-        '200':
-          description: OK
-          content:
-            'application/json':
-              schema:
-                type: boolean
-        '406':
+                { "error": { "message": "Namespace does not exist", "type": "NoSuchNamespaceException", "code": 404 } }
+        406:
           description: Not Acceptable (Unsupported Operation)
-        '404':
-          description: Not Found (No Such Namespace)
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NoSuchNamespaceError'
-              example:
-                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 404 }'
 
   /namespaces/{namespace}/tables:
     parameters:
@@ -276,8 +257,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/ListTablesResponse'
         '404':
-          description: Not Found (NamespaceNotFound)
-          example: '{ "error": { "
+          description: Not Found (NoSuchNamespaceException)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergResponseObject'
+              example:
+                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 404 }'
 
   /namespaces/{namespace}/tables/{table}:
     parameters:
@@ -374,10 +360,10 @@ paths:
               examples:
                 table_to_rename_does_not_exist:
                   value:
-                    '{ error: { message: "Table does not exist", type: "NoSuchTableException", code: 404 }'
+                    '{ error: { message: "Table does not exist", type: "NoSuchTableException", code: 404 } }'
                 namespace_to_rename_to_does_not_exist:
                   value:
-                    '{ error: { message: "Namespace does not exist", type: "NoSuchNameSpaceException", code: 404 }'
+                    '{ error: { message: "Namespace does not exist", type: "NoSuchNameSpaceException", code: 404 } }'
         '406':
           description: Not Acceptable (UnsupportedOperationException)
         '409':
@@ -387,7 +373,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/TableAlreadyExistsError'
               example:
-                '{ error: { message: "Tale already exists", type: "AlreadyExistsException", code: 409 }'
+                '{ "error": { "message": "Tale already exists", "type": "AlreadyExistsException", code: 409 } }'
 
 components:
   schemas:
@@ -404,16 +390,6 @@ components:
         name:
           type: string
           nullable: false
-    RemovePropertiesRequest:
-      type: object
-      properties:
-        namespace:
-          type: string
-        properties:
-          uniqueItems: true
-          type: object
-          items:
-            type: string
     CreateNamespaceRequest:
       type: object
       properties:
@@ -433,20 +409,44 @@ components:
           $ref: '#/components/schemas/TableIdentifier'
         destinationTableIdentifier:
           $ref: '#/components/schemas/TableIdentifier'
-    SetPropertiesRequest:
+    UpdatePropertiesRequest:
       type: object
       properties:
-        namespace:
-          type: string
-        properties:
+        toRemove:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+          example: '[ "department", "access_group" ]'
+        toUpdate:
+          uniqueItems: true
           type: object
-    SetPropertiesResponse:
+          items:
+            type: string
+          example: { "owner": "Hank Bendickson" }
+    UpdatePropertiesResponse:
       type: object
-      description: JSON data response on a successful set properties call.
+      description: JSON data response for a synchronous update properties request.
       properties:
         updated:
-          type: boolean
-          description: true if the set properties request was accepted and is reflected on the server
+          type: array
+          items:
+            type: string
+            description: List of property keys that were added or udpated
+        removed:
+          type: array
+          items:
+            type: string
+          description: List of properties that were removed (and not updated)
+        notPresent:
+          type: array
+          items:
+            type: string
+            description:
+              List of properties requested for removal that were not found
+              in the namespace's properties.
+              Represents a partial success response.
+              Server's do not need to implement this.
     ListNamespacesResponse:
       type: object
       properties:
@@ -476,11 +476,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TableIdentifier'
-    TableMetadata:
-      type: object
-      properties:
-        currentSnapshotTo:
-          $ref: '#/components/schemas/TableMetadata'
     IcebergConfiguration:
       type: object
       description: "Server-provided configuration for the catalog."

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -60,45 +60,9 @@ paths:
           description: Unknown Error
         "401":
           description: Unauthorized
-  # This might be optional for now as it's not really supported in
-  # the normal Catalog spec, but we might want to include it for
-  # convenience.
-  /v1/catalogs/{catalog}:
-    parameters:
-      - name: catalog
-        in: path
-        required: true
-        description: Name of the catalog being configured
-        schema:
-          type: string
-          minLength: 1
-    post:
-      tags:
-        - Configuration API
-      summary: Persist catalog specific configuration, which can be retrieved
-        for later use.
-      operationId: postConfig
-      description:
-        Persist some catalog specific configurations, which will be returned by \
-        calls to /v1/config in the future. This is basically all of the data \
-        that would go into the Catalog's `initialize` call.
-      # TODO - Make this into a CatalogConfiguration
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Catalog'
-        required: true
-      responses:
-        '200':
-          description: OK
-        '401':
-          description: Unauthorized
 
   /v1/namespaces/{namespace}/tables/{table}:
     parameters:
-      # Consider moving this to query parameters,so it can be more easily URL encoded
-      # in case of dots or special characters
       - name: namespace
         in: path
         description: Namespace the table is in

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -143,6 +143,22 @@ paths:
                 $ref: '#/components/schemas/NoSuchNamespaceError'
               example:
                 '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 40401 }'
+    head:
+      tags:
+        - Catalog API
+      summary: Check if a namespace exists
+      operationId: namespaceExists
+      description: Check if a namespace exists.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergResponseObject'
+              example: '{ "data": { "exists": false } }'
+        '401':
+          description: Unauthorized
     delete:
       tags:
         - Catalog API
@@ -235,6 +251,33 @@ paths:
               example:
                 '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 40401 }'
 
+  /namespaces/{namespace}/tables:
+    parameters:
+      - name: namespace
+        description: A namespace identifier under which to list tables
+        in: path
+        required: true
+        schema:
+          type: string
+        examples:
+          singlepart_namespace:
+            value: "accounting"
+          multipart_namespace:
+            value: "accounting.tax"
+    get:
+      tags:
+        - Catalog API
+      summary: List all table identifiers underneath a given namespace
+      description: Return all table identifiers under this namespace
+      operationId: listTables
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListTablesResponse'
+
   /namespaces/{namespace}/tables/{table}:
     parameters:
       - name: namespace
@@ -307,50 +350,32 @@ paths:
       summary: Check if a table exists
       operationId: tableExists
       description:
-        Check if a table exists within a given namespace. Returns the standard response with `true` when found. Will throw a NoSuchTableException if not present.
-      parameters:
-        - name: namespace
-          in: path
-          required: true
-          description: A namespace identifier
-          schema:
-            type: string
-        - name: table
-          in: path
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: OK
-        '404':
-          description: Not Found (NoSuchTableException)
-  /namespaces/{namespace}/tables:
-    parameters:
-      - name: namespace
-        description: A namespace identifier under which to list tables
-        in: path
-        required: true
-        schema:
-          type: string
-        examples:
-          singlepart_namespace:
-            value: "accounting"
-          multipart_namespace:
-            value: "accounting.tax"
-    get:
-      tags:
-        - Catalog API
-      summary: List all table identifiers underneath a given namespace
-      description: Return all table identifiers under this namespace
-      operationId: listTables
+        Check if a table exists within a given namespace.
+        Returns the standard Iceberg response data wrapper with exists set to `true` when found, `false` if not found.
+        If the namespace for the table does not exist, returns a 404 NoSuchNamespaceException.
       responses:
         '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListTablesResponse'
+                $ref: '#/components/schemas/IcebergResponseObject'
+              examples:
+                table_exists_response:
+                  value: '{ "data": { "exists": true } }'
+                table_does_not_exist:
+                  value: '{ "data": { "exists: false } }'
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergResponseObject'
+              example:
+                '{ "error": { "message": "The namespace does not exist", type: "NoSuchTableException", code: 40401 } }'
+
   /tables/rename:
     post:
       tags:

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -24,7 +24,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 1.0.0
+  version: 0.0.1
   description:
     Defines the specification for the first version of the REST Catalog API. Implementations should support both Iceberg table specs v1 and v2, with priority given to v2.
 servers:

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -27,6 +27,7 @@ info:
   version: 1.0.0
   description:
     Defines the specification for the first version of the REST Catalog API. Implementations should support both Iceberg table specs v1 and v2, with priority given to v2.
+# TODO - Add ServerVariable so that users can configure this themselves.
 servers:
   - url: http://127.0.0.1:1080
     description: URL Used for Mock-Server Unit Tests

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -106,31 +106,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NoSuchTableError'
-    put:
-      tags:
-        - Catalog API
-      summary: Commit an in progress create (or replace) table transaction
-      operationId: commitTable
-      description: Commit a pending create (or replace) table transaction, e.g. for doCommit.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CommitTableRequest'
-        required: true
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CommitTableResponse'
-        '401':
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/IcebergResponseObject'
     delete:
       tags:
         - Catalog API

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -425,7 +425,7 @@ components:
         properties:
           type: object
           description: Configuration properties for the namespace
-          example: '{ owner: "Hank Bendickson" }'
+          example: '{ "owner": "Hank Bendickson" }'
     RenameTableRequest:
       type: object
       properties:

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -213,7 +213,7 @@ paths:
       tags:
         - Catalog API
       summary: Set or remove properties on a namespace
-      operationId: setProperties / removeProperties
+      operationId: updateProperties
       description:
         Set and/or remove a collection or properties on a namespae.
         The request body specifies a list of properties to remove and a map

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -496,12 +496,6 @@ components:
       properties:
         identifier:
           $ref: '#/components/schemas/TableIdentifier'
-        tableLocation:
-          type: string
-          description: "Path of of the table just before the standard \
-            metadata / data folders. This is useful in cases where a different location
-            provider might be used"
-          example: s3://bucket/prod/accounting.db/monthly_sales
         metadataLocation:
           type: string
           description: "Location of the most current primary metadata file for the table"
@@ -511,7 +505,7 @@ components:
           description: "Stringified JSON representing the tables metadata"
           example:
             "TODO"
-        accessToken:
+        tableToken:
           type: string
     SetPropertiesRequest:
       type: object

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -97,14 +97,13 @@ paths:
         '401':
           description: Unauthorized
         '404':
-          description: Not Found (NoSuchNamespaceException)
-        '404':
-          description: Not Found (NoSuchTableException)
+          description: Not Found (NoSuchTableException | NoSuchNamespaceException)
           content:
             application/json:
-              # The REST catalog's JSON format to represent NoSuchTableException.
               schema:
-                $ref: '#/components/schemas/NoSuchTableError'
+                oneOf:
+                  - $ref: '#/components/schemas/NoSuchTableError'
+                  - $ref: '#/components/schemas/NoSuchNamespaceError'
     delete:
       tags:
         - Catalog API
@@ -201,21 +200,18 @@ paths:
         '401':
           description: Unauthorized
         '404':
-          description: Not Found (NoSuchTableException - Table to rename does not exist)
+          description: Not Found (NoSuchTableException - Table to rename does not exist | NoSuchTableException - The target namespace of the new table identifier does not exist))
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NoSuchTableError'
-              example:
-                '{ error: { message: "Table does not exist", type: "NoSuchTableException", code: 40402 }'
-        '404':
-          description: Not Found (NoSuchNamespaceException - The target namespace of the table rename does not exist)
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NoSuchNamespaceError'
-              example:
-                '{ error: { message: "Namespace does not exist", type: "NoSuchNameSpaceException", code: 40401 }'
+                oneOf:
+                  - $ref: '#/components/schemas/NoSuchTableError'
+                  - $ref: '#/components/schemas/NoSuchNamespaceError'
+              examples:
+                table_to_rename_does_not_exist:
+                  '{ error: { message: "Table does not exist", type: "NoSuchTableException", code: 40402 }'
+                namespace_to_rename_to_does_not_exist:
+                  '{ error: { message: "Namespace does not exist", type: "NoSuchNameSpaceException", code: 40401 }'
         '406':
           description: Not Acceptable (UnsupportedOperationException)
         '409':

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -128,6 +128,8 @@ paths:
               schema:
                 type: boolean
                 description: true if the table was dropped and false if the table did not exist
+        '202':
+          description: Accepted - for use if purgeRequested is implemented as an asynchronous action.
     head:
       tags:
         - Catalog API

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -151,14 +151,11 @@ paths:
       description: Check if a namespace exists.
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/IcebergResponseObject'
-              example: '{ "data": { "exists": false } }'
+          description: OK - Namesapce exists
         '401':
           description: Unauthorized
+        '404':
+          description: Not Found
     delete:
       tags:
         - Catalog API
@@ -335,26 +332,11 @@ paths:
         If the namespace for the table does not exist, returns a 404 NoSuchNamespaceException.
       responses:
         '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/IcebergResponseObject'
-              examples:
-                table_exists_response:
-                  value: '{ "data": { "exists": true } }'
-                table_does_not_exist:
-                  value: '{ "data": { "exists: false } }'
+          description: OK - Table Exists
         '401':
           description: Unauthorized
         '404':
           description: Not Found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/IcebergResponseObject'
-              example:
-                '{ "error": { "message": "The namespace does not exist", type: "NoSuchTableException", code: 40401 } }'
 
   /tables/rename:
     post:

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -229,6 +229,8 @@ paths:
                 { "error": { "message": "Namespace does not exist", "type": "NoSuchNamespaceException", "code": 404 } }
         406:
           description: Not Acceptable (Unsupported Operation)
+        422:
+          description: Unprocessable Entity. A property key was included in both toRemove and toUpdate.
 
   /namespaces/{namespace}/tables:
     parameters:
@@ -350,12 +352,10 @@ paths:
         '401':
           description: Unauthorized
         '404':
-          description: >
-            Not Found, either
-              - NoSuchTableException
-                - Table to rename does not exist
-              - NoSuchNamespaceException
-                - The target namespace of the new table identifier does not exist
+          description:
+            Not Found
+            - NoSuchTableException, Table to rename does not exist
+            - NoSuchNamespaceException, The target namespace of the new table identifier does not exist
           content:
             application/json:
               schema:
@@ -401,14 +401,17 @@ components:
       properties:
         namespace:
           type: array
+          description: Individual levels of the namespace
           items:
             type: string
-          nullable: false  # Note this is ignored
+          nullable: false
         name:
           type: string
           nullable: false
     CreateNamespaceRequest:
       type: object
+      required:
+        - namespace
       properties:
         namespace:
           type: array

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -333,14 +333,14 @@ paths:
         - Catalog API
       summary: Load the metadata properties for a namespace
       operationId: loadNamespaceMetadata
-      description: Return all stored properties for a given namespace
+      description: Return all stored metadata properties for a given namespace
       responses:
         '200':
           description: OK
           content:
-            application/json:
+            application:
               schema:
-                type: object
+                $ref: '#/components/schemas/GetNamespaceResponse'
         '417':
           description: Namespace not found
           content:
@@ -418,7 +418,7 @@ paths:
     get:
       tags:
         - Catalog API
-      summary: List all namespaces, or all namespaces underneat a given namespace
+      summary: List all namespaces, or all namespaces underneath a given namespace
       description: List namespaces underneath a given namespace
       operationId: listNamespaces
       responses:
@@ -452,18 +452,8 @@ paths:
       responses:
         '200':
           description: OK
-    get:
-      tags:
-        - Catalog API
-      summary: Get the configured properties of a namespace
-      operationId: getNamespace
-      responses:
-        '200':
-          description: OK
-          content:
-            'Application/JSON':
-              schema:
-                $ref: '#/components/schemas/GetNamespaceResponse'
+        '401':
+          description: Unauthorized
     delete:
       tags:
         - Catalog API

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -113,7 +113,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/NamespaceAlreadyExistsError'
               example:
-                '{ error: { message: "Namespace already exists", type: "AlreadyExistsException", code: 40901 }'
+                '{ error: { message: "Namespace already exists", type: "AlreadyExistsException", code: 409 }'
 
   /namespaces/{namespace}:
     parameters:
@@ -142,7 +142,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/NoSuchNamespaceError'
               example:
-                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 40401 }'
+                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 404 }'
     head:
       tags:
         - Catalog API
@@ -215,7 +215,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/NoSuchNamespaceError'
               example:
-                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 40401 }'
+                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 404 }'
     put:
       tags:
         - Catalog API
@@ -247,7 +247,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/NoSuchNamespaceError'
               example:
-                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 40401 }'
+                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 404 }'
 
   /namespaces/{namespace}/tables:
     parameters:
@@ -275,6 +275,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ListTablesResponse'
+        '404':
+          description: Not Found (NamespaceNotFound)
+          example: '{ "error": { "
 
   /namespaces/{namespace}/tables/{table}:
     parameters:
@@ -371,10 +374,10 @@ paths:
               examples:
                 table_to_rename_does_not_exist:
                   value:
-                    '{ error: { message: "Table does not exist", type: "NoSuchTableException", code: 40402 }'
+                    '{ error: { message: "Table does not exist", type: "NoSuchTableException", code: 404 }'
                 namespace_to_rename_to_does_not_exist:
                   value:
-                    '{ error: { message: "Namespace does not exist", type: "NoSuchNameSpaceException", code: 40401 }'
+                    '{ error: { message: "Namespace does not exist", type: "NoSuchNameSpaceException", code: 404 }'
         '406':
           description: Not Acceptable (UnsupportedOperationException)
         '409':
@@ -384,7 +387,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/TableAlreadyExistsError'
               example:
-                '{ error: { message: "Tale already exists", type: "AlreadyExistsException", code: 40902 }'
+                '{ error: { message: "Tale already exists", type: "AlreadyExistsException", code: 409 }'
 
 components:
   schemas:
@@ -538,11 +541,12 @@ components:
           description: Human-readable error message
         type:
           type: string
-          description: Machine-type of the error, such as an exception class
+          description: Internal type of the error, such as an exception class
+          example: NoSuchNamespaceException
         code:
           type: integer
-          description: Application specific error code, to disambiguage amongst subclasses of HTTP responses
-          example: 40401, Table not found vs 40402, Namespace not found.
+          description: HTTP response code
+          example: 404
         metadata:
           type: object
           description: Additional metadata to accompany this error, such as server side stack traces or user instructions
@@ -560,7 +564,7 @@ components:
         {
           message: "The given table does not exist",
           type: "NoSuchTableException",
-          code: 40401
+          code: 404
         }
 
   securitySchemes:

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -258,7 +258,8 @@ paths:
   /v1/namespaces/{namespace}/tables:
     parameters:
       - name: namespace
-        description: A namespace identifier under which to list tables
+        description:
+          A namespace identifier under which to list tables. Multipart namespaces should be separated with a dot. Parts which contain a dot in them should encode this using a null byte character, i.e. %00.
         in: path
         required: true
         schema:

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -41,17 +41,18 @@ paths:
       summary: List all catalog configuration settings
       operationId: getConfig
       description:
-        All REST catalogs will be initialized by calling this route. This route
-        will return at least the minimum necessary metadata to initialize the
-        catalog. Optionally, it can also include server-side specific overrides.
-        For example, it might also include information used to initialize this catalog
-        such as the details of the Http connection pooling, etc. This route might
-        also advertise information about operations that are not implemented
-        so that the catalog can eagerly throw or go about another way of performing
-        the desired action.
+        All REST catalog clients will first call this route to get some configuration provided by the server.
+        This route will return any server specified default configuration values for the catalog, such as
+        configuration values used to setup the catalog for usage with Spark (e.g. vectorization-enabled).
+
+        Users should be able to override these values with client specified values.
+
+        The server might be able to request that the client use its value over a value that has been
+        configured in the client application. How and if it will do that is an open question, and thus
+        not currently specified in this documents schema.
       responses:
         default:
-          description: Server-Specific Configuration Overrides
+          description: Server-Specific Configuration Values (or Overrides)
           content:
             application/json:
               schema:

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -114,7 +114,7 @@ paths:
           required: false
           schema:
             type: string
-          example: ?parent=accounting.tax
+          example: accounting.tax
       responses:
         '200':
           description: OK

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -160,6 +160,81 @@ paths:
         '401':
           description: Unauthorized
 
+
+  /namespaces/{namespace}/properties:
+    parameters:
+      - name: namespace
+        in: path
+        required: true
+        schema:
+          type: string
+    post:
+      tags:
+        - Catalog API
+      summary: Set a collection of properties on a namespace
+      operationId: setProperties
+      description:
+        Set a collection of properties on a namespace in the catalog.
+        Properties that are not in the given map are not modified or removed by this call.
+        Server implementations are not required to support namespace properties.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetPropertiesRequest'
+        required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            'application/json':
+              schema:
+                # This is an IcebergResponseObject<SetPropertiesResponse>, in that it uses the standard wrapper.
+                type: SetPropertiesResponse
+                example: '{ "data": { "updated": true }, "error": null }'
+        '406':
+          description: Not Acceptable (Unsupported Operation)
+        '404':
+          description: Not Found (NoSuchNamespaceException)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NoSuchNamespaceError'
+              example:
+                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 40401 }'
+    put:
+      tags:
+        - Catalog API
+      summary: Remove a set of property keys from a namespace in the catalog
+      operationId: removeProperties
+      description:
+        Remove a set of property keys from a namespace in the catalog.
+        Properties that are not in the given set are not modified or removed by this call.
+        Server implementations are not required to support namespace properties.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RemovePropertiesRequest'
+        required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            'application/json':
+              schema:
+                type: boolean
+        '406':
+          description: Not Acceptable (Unsupported Operation)
+        '404':
+          description: Not Found (No Such Namespace)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NoSuchNamespaceError'
+              example:
+                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 40401 }'
+
   /namespaces/{namespace}/tables/{table}:
     parameters:
       - name: namespace
@@ -322,77 +397,6 @@ paths:
                 $ref: '#/components/schemas/TableAlreadyExistsError'
               example:
                 '{ error: { message: "Tale already exists", type: "AlreadyExistsException", code: 40902 }'
-  /namespaces/{namespace}/properties:
-    parameters:
-      - name: namespace
-        in: path
-        required: true
-        schema:
-          type: string
-    post:
-      tags:
-        - Catalog API
-      summary: Set a collection of properties on a namespace
-      operationId: setProperties
-      description:
-        Set a collection of properties on a namespace in the catalog.
-        Properties that are not in the given map are not modified or removed by this call.
-        Server implementations are not required to support namespace properties.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SetPropertiesRequest'
-        required: true
-      responses:
-        '200':
-          description: OK
-          content:
-            'application/json':
-              schema:
-                type: boolean
-        '406':
-          description: Not Acceptable (Unsupported Operation)
-        '404':
-          description: Not Found (NoSuchNamespaceException)
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NoSuchNamespaceError'
-              example:
-                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 40401 }'
-    put:
-      tags:
-        - Catalog API
-      summary: Remove a set of property keys from a namespace in the catalog
-      operationId: removeProperties
-      description:
-        Remove a set of property keys from a namespace in the catalog.
-        Properties that are not in the given set are not modified or removed by this call.
-        Server implementations are not required to support namespace properties.
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/RemovePropertiesRequest'
-        required: true
-      responses:
-        '200':
-          description: OK
-          content:
-            'application/json':
-              schema:
-                type: boolean
-        '406':
-          description: Not Acceptable (Unsupported Operation)
-        '404':
-          description: Not Found (No Such Namespace)
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NoSuchNamespaceError'
-              example:
-                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 40401 }'
 
 components:
   schemas:
@@ -458,6 +462,14 @@ components:
           type: string
         properties:
           type: object
+    SetPropertiesResponse:
+      type: object
+      description: JSON data response on a successful set properties call.
+      properties:
+        updated:
+          type: boolean
+          description: true if the set properties request was accepted and is reflected on the server
+          required: true
     ListNamespacesResponse:
       type: object
       properties:

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -151,6 +151,7 @@ paths:
             'application/json':
               schema:
                 type: boolean
+                description: true if the table was dropped and false if the table did not exist
     head:
       tags:
         - Catalog API
@@ -374,17 +375,20 @@ paths:
   # TODO - Pagination
   /v1/namespaces:
     parameters:
-      - name: namespace
+      - name: parent
         in: query
-        description: Namespace under which to list namespaces. Leave empty to list all namespaces in the catalog
+        description: Optional parent namespace under which to list namespaces. When empty, list top-level namespaces.
         required: false
         schema:
           type: string
     get:
       tags:
         - Catalog API
-      summary: List all namespaces, or all namespaces underneath a given namespace
-      description: List namespaces underneath a given namespace
+      summary: List namespaces, optionally providing a parent namespace to list underneaath
+      description:
+        List all namespaces at a certain level, optionally starting from a given parent namespace.
+        For example, if table a.b.t exists, using 'SELECT NAMESPACE IN a' this would translate into
+        `GET /v1/namespaces?parent=a` and must return Namepace.of("a","b").
       operationId: listNamespaces
       responses:
         '200':
@@ -717,13 +721,6 @@ components:
           code: 40101
         }
 
-    no_such_iceberg_table_eror:
-      value: |-
-        {
-          message: "The given table does not exist",
-          type: "NoSuchTableException",
-          code: 40101
-        }
   securitySchemes:
     BearerAuth:
       type: http

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -308,9 +308,10 @@ paths:
           content:
             'application/json':
               schema:
-                type: boolean
-                description: true if the table was dropped and false if the table did not exist
+                $ref: '#/components/schemas/IcebergResponseObject'
+              example: { "data": { "dropped": true, "purged": false } }
         '202':
+          # TODO - Add a callback or handle to check on the state of an async purge request
           description: Accepted - for use if purgeRequested is implemented as an asynchronous action.
 
     head:
@@ -398,6 +399,7 @@ components:
       type: object
       required:
         - namespace
+        - name
       properties:
         namespace:
           type: array
@@ -415,7 +417,7 @@ components:
       properties:
         namespace:
           type: array
-          description: individual levels of the namespace
+          description: Individual levels of the namespace
           items:
             type: string
         properties:
@@ -470,16 +472,16 @@ components:
     ListNamespacesResponse:
       type: object
       properties:
-        databases:
+        namespaces:
           type: array
           items:
             $ref: '#/components/schemas/Namespace'
     Namespace:
-      type: object
+      type: array
       description: Reference to one or more levels of a namespace
-      properties:
-        empty:
-          type: boolean
+      items:
+        type: string
+      example: [ "accounting", "tax" ]
     GetNamespaceResponse:
       type: object
       properties:
@@ -487,8 +489,7 @@ components:
           $ref: '#/components/schemas/Namespace'
         properties:
           type: object
-          additionalProperties:
-            type: string
+          example: { "owner": "Ralph", 'transient_lastDdlTime': '1452120468' }
     ListTablesResponse:
       type: object
       properties:
@@ -542,11 +543,11 @@ components:
           $ref: '#/components/schemas/ResponseDataObject'
         error:
           $ref: '#/components/schemas/ResponseErrorObject'
-      example: '{ "data": { "namespaces": ["ns1.foo_db", "ns1.bar_db"] }, "error": {} }'
+      example: { "data": { "namespaces": [ ["ns1", "foo_db"], ["ns1", "bar_db"] ] }, "error": {} }
     ResponseDataObject:
       type: object
       description: JSON data payload returned in a successful response body
-      example: '{ "data": { "identifiers": [ "office.employees", "office.dogs", "office.cats" ] }'
+      example: { "data": { "identifiers": [ "office.employees", "office.dogs", "office.cats" ] } }
     ResponseErrorObject:
       type: object
       description: JSON error payload returned in a response with further details on the error
@@ -577,7 +578,7 @@ components:
     namespace:
       value: accounting
     no_such_table_error:
-      value: |-
+      value:
         {
           message: "The given table does not exist",
           type: "NoSuchTableException",

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -308,11 +308,13 @@ paths:
           content:
             'application/json':
               schema:
-                $ref: '#/components/schemas/IcebergResponseObject'
+                $ref: '#/components/schemas/DropTableResponse'
               example: { "data": { "dropped": true, "purged": false } }
         '202':
           # TODO - Add a callback or handle to check on the state of an async purge request
           description: Accepted - for use if purgeRequested is implemented as an asynchronous action.
+        '404':
+          description: Not Found
 
     head:
       tags:
@@ -395,11 +397,52 @@ paths:
 
 components:
   schemas:
+    IcebergResponseObject:
+      type: object
+      description: JSON wrapper for all response bodies, with a data object and / or an error object
+      properties:
+        data:
+          $ref: '#/components/schemas/ResponseDataObject'
+        error:
+          $ref: '#/components/schemas/ResponseErrorObject'
+      example: { "data": { "namespaces": [ [ "ns1", "foo_db" ], [ "ns1", "bar_db" ] ] }, "error": { } }
+    ResponseDataObject:
+      type: object
+      description: JSON data payload returned in a successful response body
+      properties:
+        data:
+          type: object
+          description: Wrapper for the response of a successful request
+      example: { "data": { "identifiers": [ "office.employees", "office.dogs", "office.cats" ] } }
+    ResponseErrorObject:
+      type: object
+      description: JSON error payload returned in a response with further details on the error
+      required:
+        - message
+        - type
+        - code
+      properties:
+        message:
+          type: string
+          description: Human-readable error message
+        type:
+          type: string
+          description: Internal type of the error, such as an exception class
+          example: NoSuchNamespaceException
+        code:
+          type: integer
+          minimum: 100
+          maximum: 600
+          description: HTTP response code
+          example: 404
+        metadata:
+          type: object
+          description: Additional metadata to accompany this error, such as server side stack traces or user instructions
+          nullable: true
     TableIdentifier:
       type: object
       required:
         - namespace
-        - name
       properties:
         namespace:
           type: array
@@ -476,6 +519,15 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Namespace'
+    DropTableResponse:
+      type: object
+      properties:
+        dropped:
+          type: boolean
+          description: true if the table was found and removed from the catalog
+        purged:
+          type: boolean
+          description: whether the underlying data was purged or is being purged
     Namespace:
       type: array
       description: Reference to one or more levels of a namespace
@@ -535,43 +587,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/ResponseErrorObject'
       description: the given table identifier already exists and cannot be created / renamed to
-    IcebergResponseObject:
-      type: object
-      description: JSON wrapper for all response bodies, with a data object and / or an error object
-      properties:
-        data:
-          $ref: '#/components/schemas/ResponseDataObject'
-        error:
-          $ref: '#/components/schemas/ResponseErrorObject'
-      example: { "data": { "namespaces": [ ["ns1", "foo_db"], ["ns1", "bar_db"] ] }, "error": {} }
-    ResponseDataObject:
-      type: object
-      description: JSON data payload returned in a successful response body
-      example: { "data": { "identifiers": [ "office.employees", "office.dogs", "office.cats" ] } }
-    ResponseErrorObject:
-      type: object
-      description: JSON error payload returned in a response with further details on the error
-      properties:
-        message:
-          type: string
-          description: Human-readable error message
-        type:
-          type: string
-          description: Internal type of the error, such as an exception class
-          example: NoSuchNamespaceException
-        code:
-          type: integer
-          minimum: 100
-          maximum: 600
-          description: HTTP response code
-          example: 404
-        metadata:
-          type: object
-          description: Additional metadata to accompany this error, such as server side stack traces or user instructions
-          nullable: true
-      required:
-        - message
-        - type
   examples:
     catalogName:
       value: prod

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -251,27 +251,6 @@ paths:
         required: true
         schema:
           type: string
-    get:
-      tags:
-        - Catalog API
-      summary: Load the metadata properties for a namespace
-      operationId: loadNamespaceMetadata
-      description: Return all stored metadata properties for a given namespace
-      responses:
-        '200':
-          description: OK
-          content:
-            application:
-              schema:
-                $ref: '#/components/schemas/GetNamespaceResponse'
-        '417':
-          description: Namespace not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NoSuchNamespaceError'
-              example:
-                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 41701 }'
     put:
       tags:
         - Catalog API
@@ -362,6 +341,27 @@ paths:
         required: true
         schema:
           type: string
+    get:
+      tags:
+        - Catalog API
+      summary: Load the metadata properties for a namespace
+      operationId: loadNamespaceMetadata
+      description: Return all stored metadata properties for a given namespace
+      responses:
+        '200':
+          description: OK
+          content:
+            application:
+              schema:
+                $ref: '#/components/schemas/GetNamespaceResponse'
+        '417':
+          description: Namespace not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NoSuchNamespaceError'
+              example:
+                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 41701 }'
     post:
       tags:
         - Catalog API
@@ -396,13 +396,6 @@ paths:
           description: Unauthorized
 components:
   schemas:
-    CommitTableRequest:
-      type: object
-      properties:
-        tableIdentifier:
-          $ref: '#/components/schemas/TableIdentifier'
-        metadataJson:
-          type: string
     TableIdentifier:
       type: object
       required:
@@ -414,16 +407,8 @@ components:
             type: string
           nullable: false  # Note this is ignored
         name:
-          pattern: \S
           type: string
           nullable: false
-    CommitTableResponse:
-      type: object
-      properties:
-        metadataLocation:
-          type: string
-        metadataJson:
-          type: string
     RemovePropertiesRequest:
       type: object
       properties:
@@ -434,25 +419,6 @@ components:
           type: array
           items:
             type: string
-    Catalog:
-      type: object
-      properties:
-        id:
-          type: string
-          format: uuid
-          description: Unique identifier for this catalog
-        name:
-          type: string
-        location:
-          type: string
-          description: Warehouse location for this catalog or URI of metastore or other identifying location
-        properties:
-          type: object
-          description: Additional catalog level properties
-          default: {}
-      required:
-        - name
-        - properties
     CreateNamespaceRequest:
       type: object
       properties:

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -27,7 +27,7 @@ info:
   version: 1.0.0
   description:
     Defines the specification for the first version of the REST Catalog API. Implementations should support both Iceberg table specs v1 and v2, with priority given to v2.
-# TODO - Add ServerVariable so that users can configure this themselves.
+# TODO - Add ServerVariable so user's can control the routes and ports etc and have mutli-env etc.
 servers:
   - url: http://127.0.0.1:1080
     description: URL Used for Mock-Server Unit Tests
@@ -61,6 +61,102 @@ paths:
         "400":
           description: Unknown Error
         "401":
+          description: Unauthorized
+  /namespaces:
+    get:
+      tags:
+        - Catalog API
+      summary: List namespaces, optionally providing a parent namespace to list underneaath
+      description:
+        List all namespaces at a certain level, optionally starting from a given parent namespace.
+        For example, if table a.b.t exists, using 'SELECT NAMESPACE IN a' this would translate into
+        `GET /namespaces?parent=a` and must return Namepace.of("a","b").
+      operationId: listNamespaces
+      parameters:
+        - name: parent
+          in: query
+          description: Optional parent namespace under which to list namespaces. When empty, list top-level namespaces.
+          required: false
+          schema:
+            type: string
+          example: ?parent=accounting.tax
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListNamespacesResponse'
+        '401':
+          description: Unauthorized
+    post:
+      tags:
+        - Catalog API
+      summary: Create a namespace
+      description: Create a namespace, with an optional set of properties. The server might also add properties, such as last_modified_time etc.
+      operationId: createNamespace
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateNamespaceRequest'
+        required: true
+      responses:
+        '200':
+          description: OK
+        '401':
+          description: Unauthorized
+        '409':
+          description: Conflict (AlreadyExistsException)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NamespaceAlreadyExistsError'
+              example:
+                '{ error: { message: "Namespace already exists", type: "AlreadyExistsException", code: 40901 }'
+
+  /namespaces/{namespace}:
+    parameters:
+      - name: namespace
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags:
+        - Catalog API
+      summary: Load the metadata properties for a namespace
+      operationId: loadNamespaceMetadata
+      description: Return all stored metadata properties for a given namespace
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetNamespaceResponse'
+        '404':
+          description: Not Found (NoSuchNamespaceException)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NoSuchNamespaceError'
+              example:
+                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 40401 }'
+    delete:
+      tags:
+        - Catalog API
+      summary: Drop a namespace from the catalog. Namespace must be empty.
+      operationId: dropNamespace
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: boolean
+        # TODO - Not empty exception, No such namespace exception
+        '401':
           description: Unauthorized
 
   /namespaces/{namespace}/tables/{table}:
@@ -297,101 +393,6 @@ paths:
               example:
                 '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 40401 }'
 
-  /namespaces:
-    get:
-      tags:
-        - Catalog API
-      summary: List namespaces, optionally providing a parent namespace to list underneaath
-      description:
-        List all namespaces at a certain level, optionally starting from a given parent namespace.
-        For example, if table a.b.t exists, using 'SELECT NAMESPACE IN a' this would translate into
-        `GET /namespaces?parent=a` and must return Namepace.of("a","b").
-      operationId: listNamespaces
-      parameters:
-        - name: parent
-          in: query
-          description: Optional parent namespace under which to list namespaces. When empty, list top-level namespaces.
-          required: false
-          schema:
-            type: string
-          example: ?parent=accounting.tax
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListNamespacesResponse'
-        '401':
-          description: Unauthorized
-    post:
-      tags:
-        - Catalog API
-      summary: Create a namespace
-      description: Create a namespace, with an optional set of properties. The server might also add properties, such as last_modified_time etc.
-      operationId: createNamespace
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CreateNamespaceRequest'
-        required: true
-      responses:
-        '200':
-          description: OK
-        '401':
-          description: Unauthorized
-        '409':
-          description: Conflict (AlreadyExistsException)
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NamespaceAlreadyExistsError'
-              example:
-                '{ error: { message: "Namespace already exists", type: "AlreadyExistsException", code: 40901 }'
-  /namespaces/{namespace}:
-    parameters:
-      - name: namespace
-        in: path
-        required: true
-        schema:
-          type: string
-    get:
-      tags:
-        - Catalog API
-      summary: Load the metadata properties for a namespace
-      operationId: loadNamespaceMetadata
-      description: Return all stored metadata properties for a given namespace
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetNamespaceResponse'
-        '404':
-          description: Not Found (NoSuchNamespaceException)
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NoSuchNamespaceError'
-              example:
-                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 40401 }'
-    delete:
-      tags:
-        - Catalog API
-      summary: Drop a namespace from the catalog. Namespace must be empty.
-      operationId: dropNamespace
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: boolean
-        # TODO - Not empty exception, No such namespace exception
-        '401':
-          description: Unauthorized
 components:
   schemas:
     TableIdentifier:

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -568,11 +568,11 @@ components:
           description: Human-readable error message
         type:
           type: string
-          description: Machine-type of the errror, such as an exception class
+          description: Machine-type of the error, such as an exception class
         code:
           type: integer
           description: Application specific error code, to disambiguage amongst subclasses of HTTP responses
-          example: 40101
+          example: 40401, Table not found vs 40402, Namespace not found.
         metadata:
           type: object
           description: Additional metadata to accompany this error, such as server side stack traces or user instructions

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -316,13 +316,6 @@ paths:
                 '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 41201 }'
 
   /v1/namespaces:
-    parameters:
-      - name: parent
-        in: query
-        description: Optional parent namespace under which to list namespaces. When empty, list top-level namespaces.
-        required: false
-        schema:
-          type: string
     get:
       tags:
         - Catalog API
@@ -332,6 +325,14 @@ paths:
         For example, if table a.b.t exists, using 'SELECT NAMESPACE IN a' this would translate into
         `GET /v1/namespaces?parent=a` and must return Namepace.of("a","b").
       operationId: listNamespaces
+      parameters:
+        - name: parent
+          in: query
+          description: Optional parent namespace under which to list namespaces. When empty, list top-level namespaces.
+          required: false
+          schema:
+            type: string
+          example: ?parent=accounting.tax
       responses:
         '200':
           description: OK
@@ -341,34 +342,6 @@ paths:
                 $ref: '#/components/schemas/ListNamespacesResponse'
         '401':
           description: Unauthorized
-  /v1/namespaces/{namespace}:
-    parameters:
-      - name: namespace
-        in: path
-        required: true
-        schema:
-          type: string
-    get:
-      tags:
-        - Catalog API
-      summary: Load the metadata properties for a namespace
-      operationId: loadNamespaceMetadata
-      description: Return all stored metadata properties for a given namespace
-      responses:
-        '200':
-          description: OK
-          content:
-            application:
-              schema:
-                $ref: '#/components/schemas/GetNamespaceResponse'
-        '412':
-          description: Namespace not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/NoSuchNamespaceError'
-              example:
-                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 41201 }'
     post:
       tags:
         - Catalog API
@@ -386,6 +359,42 @@ paths:
           description: OK
         '401':
           description: Unauthorized
+        '409':
+          description: Namespace already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NamespaceAlreadyExistsError'
+              example:
+                '{ error: { message: "Namespace already exists", type: "AlreadyExistsException", code: 40901 }'
+  /v1/namespaces/{namespace}:
+    parameters:
+      - name: namespace
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags:
+        - Catalog API
+      summary: Load the metadata properties for a namespace
+      operationId: loadNamespaceMetadata
+      description: Return all stored metadata properties for a given namespace
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetNamespaceResponse'
+        '412':
+          description: Namespace not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NoSuchNamespaceError'
+              example:
+                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 41201 }'
     delete:
       tags:
         - Catalog API
@@ -647,7 +656,7 @@ components:
         {
           message: "The given table does not exist",
           type: "NoSuchTableException",
-          code: 40101
+          code: 41201
         }
 
   securitySchemes:

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -454,6 +454,7 @@ components:
       type: object
       required:
         - namespace
+        - name
       properties:
         namespace:
           type: array

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -196,7 +196,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CreateTableResponse'
-    put:
+  /v1/tables/renameTable:
+    post:
       tags:
         - Catalog API
       summary: Rename a table from its current name to a new name

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -251,19 +251,19 @@ paths:
         required: true
         schema:
           type: string
-    put:
+    post:
       tags:
         - Catalog API
-      summary: Add or overwrite properties to an existing namespace
-      operationId: setNamespaceProperties
+      summary: Set a collection of properties on a namespace
+      operationId: setProperties
       description:
-        Adds propertiess for a namespace. This will overwrite any existing properties,
-        and merge with the others.
+        Set a collection of properties on a namespace in the catalog.
+        Properties that are not in the given map are not modified or removed by this call.
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RemovePropertiesRequest'
+              $ref: '#/components/schemas/SetPropertiesRequest'
         required: true
       responses:
         '200':
@@ -288,26 +288,6 @@ paths:
                 $ref: '#/components/schemas/NamespaceAlreadyExistsError'
               example:
                 '{ error: { message: "Namespace already exists", type: "AlreadyExistsException", code: 40901 }'
-    post:
-      tags:
-        - Catalog API
-      summary: Overwrite a namespace's properties with a new set of properties
-      description: Set properties on a namespace
-      operationId: setProperties
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SetPropertiesRequest'
-        required: true
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: object
-                example: '{ data: { success: true }, error: { } }'
   /v1/namespaces:
     parameters:
       - name: parent
@@ -354,14 +334,14 @@ paths:
             application:
               schema:
                 $ref: '#/components/schemas/GetNamespaceResponse'
-        '417':
+        '412':
           description: Namespace not found
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/NoSuchNamespaceError'
               example:
-                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 41701 }'
+                '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 41201 }'
     post:
       tags:
         - Catalog API

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -224,7 +224,7 @@ paths:
     put:
       tags:
         - Catalog API
-      summary: Rename a table from its current name to a new name within the same catalog
+      summary: Rename a table from its current name to a new name
       description: Rename a table within the same catalog
       operationId: renameTable
       requestBody:

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -479,7 +479,7 @@ components:
             type: string
         properties:
           type: object
-          description: Configuration properties for the namespace
+          description: Configured properties for the namespace
           example: '{ "owner": "Hank Bendickson" }'
     RenameTableRequest:
       type: object

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -107,7 +107,7 @@ paths:
       description:
         List all namespaces at a certain level, optionally starting from a given parent namespace.
         For example, if table a.b.t exists, using 'SELECT NAMESPACE IN a' this would translate into
-        `GET /namespaces?parent=a` and must return Namepace.of("a","b")
+        `GET /namespaces?parent=a` and must return Namepace.of("a", "b").
       operationId: listNamespaces
       parameters:
         - name: parent

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -154,8 +154,8 @@ paths:
           content:
             application/json:
               schema:
-                type: IcebergResponseObject
-                example: '{ "data": { "dropped": true } }'
+                $ref: '#/components/schemas/IcebergResponseObject'
+              example: '{ "data": { "dropped": true } }'
         # TODO - Not empty exception, No such namespace exception
         '401':
           description: Unauthorized
@@ -190,7 +190,7 @@ paths:
             'application/json':
               schema:
                 # This is an IcebergResponseObject<SetPropertiesResponse>, in that it uses the standard wrapper.
-                type: SetPropertiesResponse
+                $ref: '#/components/schemas/SetPropertiesResponse'
                 example: '{ "data": { "updated": true }, "error": null }'
         '406':
           description: Not Acceptable (Unsupported Operation)
@@ -469,7 +469,6 @@ components:
         updated:
           type: boolean
           description: true if the set properties request was accepted and is reflected on the server
-          required: true
     ListNamespacesResponse:
       type: object
       properties:

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -298,28 +298,7 @@ paths:
         schema:
           type: string
         example: "sales"
-    get:
-      tags:
-        - Catalog API
-      summary: Load a given table from a given namespace
-      operationId: loadTable
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetTableResponse'
-        '401':
-          description: Unauthorized
-        '404':
-          description: Not Found (NoSuchTableException | NoSuchNamespaceException)
-          content:
-            application/json:
-              schema:
-                oneOf:
-                  - $ref: '#/components/schemas/NoSuchTableError'
-                  - $ref: '#/components/schemas/NoSuchNamespaceError'
+
     delete:
       tags:
         - Catalog API
@@ -344,6 +323,7 @@ paths:
                 description: true if the table was dropped and false if the table did not exist
         '202':
           description: Accepted - for use if purgeRequested is implemented as an asynchronous action.
+
     head:
       tags:
         - Catalog API
@@ -467,19 +447,6 @@ components:
           $ref: '#/components/schemas/TableIdentifier'
         destinationTableIdentifier:
           $ref: '#/components/schemas/TableIdentifier'
-    PartitionSpec:
-      type: object
-      properties:
-        unpartitioned:
-          type: boolean
-    Schema:
-      type: object
-      properties:
-        aliases:
-          type: object
-          additionalProperties:
-            type: integer
-            format: int32
     SetPropertiesRequest:
       type: object
       properties:
@@ -523,25 +490,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TableIdentifier'
-    GetTableResponse:
-      type: object
-      properties:
-        identifier:
-          $ref: '#/components/schemas/TableIdentifier'
-        location:
-          type: string
-        metadataLocation:
-          type: string
-        metadataJson:
-          type: string
-        schema:
-          $ref: '#/components/schemas/Schema'
-        partitionSpec:
-          $ref: '#/components/schemas/PartitionSpec'
-        properties:
-          type: object
-          additionalProperties:
-            type: string
     TableMetadata:
       type: object
       properties:

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -407,7 +407,7 @@ paths:
                 type: object
                 example: '{ data: { success: true }, error: { } }'
   # TODO - Pagination
-  /v1/namespaces/list:
+  /v1/namespaces:
     parameters:
       - name: namespace
         in: query

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -66,7 +66,7 @@ paths:
     parameters:
       - name: namespace
         in: path
-        description: Namespace the table is in
+        description: A namespace identifier
         required: true
         schema:
           type: string
@@ -164,6 +164,7 @@ paths:
         - name: namespace
           in: path
           required: true
+          description: A namespace identifier
           schema:
             type: string
         - name: table
@@ -179,7 +180,7 @@ paths:
   /v1/namespaces/{namespace}/tables:
     parameters:
       - name: namespace
-        description: Namespace under which to list tables.
+        description: A namespace identifier under which to list tables
         in: path
         required: true
         schema:
@@ -195,32 +196,6 @@ paths:
       summary: List all table identifiers underneath a given namespace
       description: Return all table identifiers under this namespace
       operationId: listTables
-      parameters:
-        - name: namespace
-          description: Namespace under which to list tables.
-          in: path
-          required: true
-          schema:
-            type: string
-          examples:
-            singlepart_namespace:
-              value: "accounting"
-            multipart_namespace:
-              value: "accounting.tax"
-        # TODO - There's a much more native way to handle pagination
-        - name: limit
-          description: number of values to return in one request
-          in: query
-          required: false
-          schema:
-            type: integer
-          example: 10
-        - name: offset
-          description: Place in the response to continue from if paginating
-          in: query
-          required: false
-          schema:
-            type: integer
       responses:
         '200':
           description: OK
@@ -373,7 +348,6 @@ paths:
               schema:
                 type: object
                 example: '{ data: { success: true }, error: { } }'
-  # TODO - Pagination
   /v1/namespaces:
     parameters:
       - name: parent
@@ -411,7 +385,7 @@ paths:
       tags:
         - Catalog API
       summary: Create a namespace
-      description: Create a namespace, with an optional set of properties. The server might also add properties.
+      description: Create a namespace, with an optional set of properties. The server might also add properties, such as last_modified_time etc.
       operationId: createNamespace
       requestBody:
         content:

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -38,13 +38,13 @@ servers:
         default: "443"
       basePath:
         default: v1
-  - url: http://127.0.0.1:1080/v1
+  - url: http://127.0.0.1:1080/
     description: URL Used for Mock-Server Unit Tests
 # All routes are currently configured using an Authorization header.
 security:
   - BearerAuth: []
 paths:
-  /config:
+  /v1/config:
     get:
       tags:
         - Configuration API
@@ -99,7 +99,7 @@ paths:
           description: Unknown Error
         "401":
           description: Unauthorized
-  /namespaces:
+  /v1/namespaces:
     get:
       tags:
         - Catalog API
@@ -148,7 +148,7 @@ paths:
         '409':
           $ref: '#/components/responses/NamespaceAlreadyExistsResponse'
 
-  /namespaces/{namespace}:
+  /v1/namespaces/{namespace}:
     parameters:
       - name: namespace
         in: path
@@ -178,7 +178,7 @@ paths:
       description: Check if a namespace exists.
       responses:
         '200':
-          description: OK - Namesapce exists
+          description: Namesapce exists
         '401':
           description: Unauthorized
         '404':
@@ -202,7 +202,7 @@ paths:
           description: Not Found
 
 
-  /namespaces/{namespace}/properties:
+  /v1/namespaces/{namespace}/properties:
     parameters:
       - name: namespace
         in: path
@@ -257,7 +257,7 @@ paths:
         422:
           description: Unprocessable Entity. A property key was included in both toRemove and toUpdate.
 
-  /namespaces/{namespace}/tables:
+  /v1/namespaces/{namespace}/tables:
     parameters:
       - name: namespace
         description: A namespace identifier under which to list tables
@@ -292,7 +292,7 @@ paths:
               example:
                 '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 404 }'
 
-  /namespaces/{namespace}/tables/{table}:
+  /v1/namespaces/{namespace}/tables/{table}:
     parameters:
       - name: namespace
         in: path
@@ -356,7 +356,7 @@ paths:
         404:
           description: Not Found
 
-  /tables/rename:
+  /v1/tables/rename:
     post:
       tags:
         - Catalog API

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -34,7 +34,7 @@ servers:
 security:
   - BearerAuth: []
 paths:
-  /v1/config:
+  /config:
     get:
       tags:
         - Configuration API
@@ -62,7 +62,7 @@ paths:
         "401":
           description: Unauthorized
 
-  /v1/namespaces/{namespace}/tables/{table}:
+  /namespaces/{namespace}/tables/{table}:
     parameters:
       - name: namespace
         in: path
@@ -152,7 +152,7 @@ paths:
           description: OK
         '404':
           description: Not Found (NoSuchTableException)
-  /v1/namespaces/{namespace}/tables:
+  /namespaces/{namespace}/tables:
     parameters:
       - name: namespace
         description: A namespace identifier under which to list tables
@@ -178,7 +178,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ListTablesResponse'
-  /v1/tables/rename:
+  /tables/rename:
     post:
       tags:
         - Catalog API
@@ -224,7 +224,7 @@ paths:
                 $ref: '#/components/schemas/TableAlreadyExistsError'
               example:
                 '{ error: { message: "Tale already exists", type: "AlreadyExistsException", code: 40902 }'
-  /v1/namespaces/{namespace}/properties:
+  /namespaces/{namespace}/properties:
     parameters:
       - name: namespace
         in: path
@@ -296,7 +296,7 @@ paths:
               example:
                 '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 40401 }'
 
-  /v1/namespaces:
+  /namespaces:
     get:
       tags:
         - Catalog API
@@ -304,7 +304,7 @@ paths:
       description:
         List all namespaces at a certain level, optionally starting from a given parent namespace.
         For example, if table a.b.t exists, using 'SELECT NAMESPACE IN a' this would translate into
-        `GET /v1/namespaces?parent=a` and must return Namepace.of("a","b").
+        `GET /namespaces?parent=a` and must return Namepace.of("a","b").
       operationId: listNamespaces
       parameters:
         - name: parent
@@ -348,7 +348,7 @@ paths:
                 $ref: '#/components/schemas/NamespaceAlreadyExistsError'
               example:
                 '{ error: { message: "Namespace already exists", type: "AlreadyExistsException", code: 40901 }'
-  /v1/namespaces/{namespace}:
+  /namespaces/{namespace}:
     parameters:
       - name: namespace
         in: path
@@ -515,7 +515,7 @@ components:
         rootPath:
           minLength: 1
           type: string
-          default: /v1
+          default: /
           nullable: false
           description:
             Root path to be used for all other requests. Server-side implementations
@@ -554,11 +554,11 @@ components:
           $ref: '#/components/schemas/ResponseDataObject'
         error:
           $ref: '#/components/schemas/ResponseErrorObject'
-      example: "{ data: { }, error: { } }"
+      example: '{ "data": { "namespaces": ["ns1.foo_db", "ns1.bar_db"] }, "error": {} }'
     ResponseDataObject:
       type: object
       description: JSON data payload returned in a successful response body
-      example: '{ data: { identifiers: [ "office.employees", "office.dogs", "office.cats" ] }'
+      example: '{ "data": { "identifiers": [ "office.employees", "office.dogs", "office.cats" ] }'
     ResponseErrorObject:
       type: object
       description: JSON error payload returned in a response with further details on the error

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -282,7 +282,7 @@ paths:
                 $ref: '#/components/schemas/NoSuchNamespaceError'
               example:
                 '{ error: { message: "Namespace does not exist", type: "NoSuchNamespaceException", code: 41201 }'
-    delete:
+    put:
       tags:
         - Catalog API
       summary: Remove a set of property keys from a namespace in the catalog

--- a/rest_docs/rest-catalog-open-api-v0.1.yaml
+++ b/rest_docs/rest-catalog-open-api-v0.1.yaml
@@ -279,8 +279,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CreateTableResponse'
-  /v1/tables/renameTable:
-    post:
+    put:
       tags:
         - Catalog API
       summary: Rename a table from its current name to a new name within the same catalog
@@ -298,10 +297,14 @@ paths:
           description: OK
         '401':
           description: Unauthorized
-        # TODO - Probably 404 will cause monitoring headaches as it's very hard to monitor if a client made
-        #        a valid request, but the table didn't exist, or if a client has been misconfigured or has
-        #        some other sort of bug and is calling endpoints that don't exist.
-        #        Need to settle on a non-404 error code.
+        # Not using 404 as 404 is very hard to monitor.
+        # There's no way to tell by monitoring returned response codes
+        # if a client made a valid request but the table didn't exist,
+        # or if a client or server has been misconfigured or some bug exists
+        # and the client is actually calling endpoints that the server doesn't
+        # have.
+        #
+        # We can consider a different response code to use than 412.
         '412':
           description: Table to rename from does not exist
           content:

--- a/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
+++ b/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
@@ -450,11 +450,11 @@ Rename a table from one identifier to another. It's valid to move a table across
 > Not Found (NoSuchTableException - Table to rename does not exist | NoSuchTableException - The target namespace of the new table identifier does not exist))
 
 ```json
-{}
+"{ error: { message: \"Table does not exist\", type: \"NoSuchTableException\", code: 40402 }"
 ```
 
 ```json
-{}
+"{ error: { message: \"Namespace does not exist\", type: \"NoSuchNameSpaceException\", code: 40401 }"
 ```
 
 > 409 Response

--- a/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
+++ b/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
@@ -178,7 +178,9 @@ System.out.println(response.toString());
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[GetTableResponse](#schemagettableresponse)|
 |401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|None|
-|412|[Precondition Failed](https://tools.ietf.org/html/rfc7232#section-4.2)|NoSuchTableException|[NoSuchTableError](#schemanosuchtableerror)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found (NoSuchTableException | NoSuchNamespaceException)|Inline|
+
+<h3 id="loadtable-responseschema">Response Schema</h3>
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
@@ -284,7 +286,7 @@ System.out.println(response.toString());
 
 *Check if a table exists*
 
-Check if a table exists within a given namespace. Returns the standard response with `true` when found. Will return a TableNotFound error if not present.
+Check if a table exists within a given namespace. Returns the standard response with `true` when found. Will throw a NoSuchTableException if not present.
 
 <h3 id="tableexists-parameters">Parameters</h3>
 
@@ -298,7 +300,7 @@ Check if a table exists within a given namespace. Returns the standard response 
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|None|
-|412|[Precondition Failed](https://tools.ietf.org/html/rfc7232#section-4.2)|Table Not Found|None|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found (NoSuchTableException)|None|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
@@ -376,123 +378,6 @@ To perform this operation, you must be authenticated by means of one of the foll
 BearerAuth
 </aside>
 
-## createTable
-
-<a id="opIdcreateTable"></a>
-
-> Code samples
-
-```shell
-# You can also use wget
-curl -X POST http://127.0.0.1:1080/v1/namespaces/{namespace}/tables \
-  -H 'Content-Type: application/json' \
-  -H 'Accept: application/json' \
-  -H 'Authorization: Bearer {access-token}'
-
-```
-
-```java
-URL obj = new URL("http://127.0.0.1:1080/v1/namespaces/{namespace}/tables");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-
-```
-
-`POST /v1/namespaces/{namespace}/tables`
-
-*Create a table with the identifier given in the body*
-
-> Body parameter
-
-```json
-{
-  "identifier": {
-    "namespace": [
-      "string"
-    ],
-    "name": "string"
-  },
-  "schema": {
-    "aliases": {
-      "property1": 0,
-      "property2": 0
-    }
-  },
-  "partitionSpec": {
-    "unpartitioned": true
-  },
-  "sortOrder": {
-    "unsorted": true
-  },
-  "properties": {
-    "property1": "string",
-    "property2": "string"
-  },
-  "metadataJson": "string",
-  "commit": true
-}
-```
-
-<h3 id="createtable-parameters">Parameters</h3>
-
-|Name|In|Type|Required|Description|
-|---|---|---|---|---|
-|body|body|[CreateTableRequest](#schemacreatetablerequest)|true|none|
-|» identifier|body|[TableIdentifier](#schematableidentifier)|false|none|
-|»» namespace|body|[string]|true|none|
-|»» name|body|string|false|none|
-|» schema|body|[Schema](#schemaschema)|false|none|
-|»» aliases|body|object|false|none|
-|»»» **additionalProperties**|body|integer(int32)|false|none|
-|» partitionSpec|body|[PartitionSpec](#schemapartitionspec)|false|none|
-|»» unpartitioned|body|boolean|false|none|
-|» sortOrder|body|[SortOrder](#schemasortorder)|false|none|
-|»» unsorted|body|boolean|false|none|
-|» properties|body|object|false|none|
-|»» **additionalProperties**|body|string|false|none|
-|» metadataJson|body|string|false|none|
-|» commit|body|boolean|false|none|
-|namespace|path|string|true|A namespace identifier under which to list tables|
-
-> Example responses
-
-> 200 Response
-
-```json
-{
-  "identifier": {
-    "namespace": [
-      "string"
-    ],
-    "name": "string"
-  },
-  "metadataLocation": "s3://bucket/prod/accounting.db/monthly_sales/metadata/00001-0d4ef14f-ef7d-43e7-9af-5f4ad40a1103.metadata.json",
-  "metadataJson": "TODO",
-  "tableToken": "string"
-}
-```
-
-<h3 id="createtable-responses">Responses</h3>
-
-|Status|Meaning|Description|Schema|
-|---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[CreateTableResponse](#schemacreatetableresponse)|
-
-<aside class="warning">
-To perform this operation, you must be authenticated by means of one of the following methods:
-BearerAuth
-</aside>
-
 ## renameTable
 
 <a id="opIdrenameTable"></a>
@@ -501,7 +386,7 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X POST http://127.0.0.1:1080/v1/tables/renameTable \
+curl -X POST http://127.0.0.1:1080/v1/tables/rename \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -509,7 +394,7 @@ curl -X POST http://127.0.0.1:1080/v1/tables/renameTable \
 ```
 
 ```java
-URL obj = new URL("http://127.0.0.1:1080/v1/tables/renameTable");
+URL obj = new URL("http://127.0.0.1:1080/v1/tables/rename");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("POST");
 int responseCode = con.getResponseCode();
@@ -525,7 +410,7 @@ System.out.println(response.toString());
 
 ```
 
-`POST /v1/tables/renameTable`
+`POST /v1/tables/rename`
 
 *Rename a table from its current name to a new name*
 
@@ -562,16 +447,20 @@ Rename a table from one identifier to another. It's valid to move a table across
 
 > Example responses
 
+> Not Found (NoSuchTableException - Table to rename does not exist | NoSuchTableException - The target namespace of the new table identifier does not exist))
+
+```json
+{}
+```
+
+```json
+{}
+```
+
 > 409 Response
 
 ```json
-"{ error: { message: \"Namespace already exists\", type: \"AlreadyExistsException\", code: 40902 }"
-```
-
-> 412 Response
-
-```json
-"{ error: { message: \"Table does not exist\", type: \"NoSuchTableException\", code: 41202 }"
+"{ error: { message: \"Tale already exists\", type: \"AlreadyExistsException\", code: 40902 }"
 ```
 
 <h3 id="renametable-responses">Responses</h3>
@@ -580,9 +469,11 @@ Rename a table from one identifier to another. It's valid to move a table across
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|None|
 |401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|None|
-|406|[Not Acceptable](https://tools.ietf.org/html/rfc7231#section-6.5.6)|Not Acceptable (Unsupported Operation)|None|
-|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|The new table identifier, the to table rename to, already exists.|[TableAlreadyExistsError](#schematablealreadyexistserror)|
-|412|[Precondition Failed](https://tools.ietf.org/html/rfc7232#section-4.2)|Table to rename from does not exist|[NoSuchTableError](#schemanosuchtableerror)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found (NoSuchTableException - Table to rename does not exist | NoSuchTableException - The target namespace of the new table identifier does not exist))|Inline|
+|406|[Not Acceptable](https://tools.ietf.org/html/rfc7231#section-6.5.6)|Not Acceptable (UnsupportedOperationException)|None|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict (AlreadyExistsException - The new target table identifier already exists)|[TableAlreadyExistsError](#schematablealreadyexistserror)|
+
+<h3 id="renametable-responseschema">Response Schema</h3>
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
@@ -653,10 +544,10 @@ Set a collection of properties on a namespace in the catalog. Properties that ar
 true
 ```
 
-> 412 Response
+> 404 Response
 
 ```json
-"{ error: { message: \"Namespace does not exist\", type: \"NoSuchNamespaceException\", code: 41201 }"
+"{ error: { message: \"Namespace does not exist\", type: \"NoSuchNamespaceException\", code: 40401 }"
 ```
 
 <h3 id="setproperties-responses">Responses</h3>
@@ -664,8 +555,8 @@ true
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|boolean|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found (NoSuchNamespaceException)|[NoSuchNamespaceError](#schemanosuchnamespaceerror)|
 |406|[Not Acceptable](https://tools.ietf.org/html/rfc7231#section-6.5.6)|Not Acceptable (Unsupported Operation)|None|
-|412|[Precondition Failed](https://tools.ietf.org/html/rfc7232#section-4.2)|Namespace not found|[NoSuchNamespaceError](#schemanosuchnamespaceerror)|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
@@ -736,10 +627,10 @@ Remove a set of property keys from a namespace in the catalog. Properties that a
 true
 ```
 
-> 412 Response
+> 404 Response
 
 ```json
-"{ error: { message: \"Namespace does not exist\", type: \"NoSuchNamespaceException\", code: 41201 }"
+"{ error: { message: \"Namespace does not exist\", type: \"NoSuchNamespaceException\", code: 40401 }"
 ```
 
 <h3 id="removeproperties-responses">Responses</h3>
@@ -747,8 +638,8 @@ true
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|boolean|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found (No Such Namespace)|[NoSuchNamespaceError](#schemanosuchnamespaceerror)|
 |406|[Not Acceptable](https://tools.ietf.org/html/rfc7231#section-6.5.6)|Not Acceptable (Unsupported Operation)|None|
-|412|[Precondition Failed](https://tools.ietf.org/html/rfc7232#section-4.2)|Namespace not found|[NoSuchNamespaceError](#schemanosuchnamespaceerror)|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
@@ -895,7 +786,7 @@ Create a namespace, with an optional set of properties. The server might also ad
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|None|
 |401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|None|
-|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Namespace already exists|[NamespaceAlreadyExistsError](#schemanamespacealreadyexistserror)|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict (AlreadyExistsException)|[NamespaceAlreadyExistsError](#schemanamespacealreadyexistserror)|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
@@ -961,10 +852,10 @@ Return all stored metadata properties for a given namespace
 }
 ```
 
-> 412 Response
+> 404 Response
 
 ```json
-"{ error: { message: \"Namespace does not exist\", type: \"NoSuchNamespaceException\", code: 41201 }"
+"{ error: { message: \"Namespace does not exist\", type: \"NoSuchNamespaceException\", code: 40401 }"
 ```
 
 <h3 id="loadnamespacemetadata-responses">Responses</h3>
@@ -972,7 +863,7 @@ Return all stored metadata properties for a given namespace
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[GetNamespaceResponse](#schemagetnamespaceresponse)|
-|412|[Precondition Failed](https://tools.ietf.org/html/rfc7232#section-4.2)|Namespace not found|[NoSuchNamespaceError](#schemanosuchnamespaceerror)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found (NoSuchNamespaceException)|[NoSuchNamespaceError](#schemanosuchnamespaceerror)|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
@@ -1144,56 +1035,6 @@ BearerAuth
 |sourceTableIdentifier|[TableIdentifier](#schematableidentifier)|false|none|none|
 |destinationTableIdentifier|[TableIdentifier](#schematableidentifier)|false|none|none|
 
-<h2 id="tocS_CreateTableRequest">CreateTableRequest</h2>
-<!-- backwards compatibility -->
-<a id="schemacreatetablerequest"></a>
-<a id="schema_CreateTableRequest"></a>
-<a id="tocScreatetablerequest"></a>
-<a id="tocscreatetablerequest"></a>
-
-```json
-{
-  "identifier": {
-    "namespace": [
-      "string"
-    ],
-    "name": "string"
-  },
-  "schema": {
-    "aliases": {
-      "property1": 0,
-      "property2": 0
-    }
-  },
-  "partitionSpec": {
-    "unpartitioned": true
-  },
-  "sortOrder": {
-    "unsorted": true
-  },
-  "properties": {
-    "property1": "string",
-    "property2": "string"
-  },
-  "metadataJson": "string",
-  "commit": true
-}
-
-```
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|identifier|[TableIdentifier](#schematableidentifier)|false|none|none|
-|schema|[Schema](#schemaschema)|false|none|none|
-|partitionSpec|[PartitionSpec](#schemapartitionspec)|false|none|none|
-|sortOrder|[SortOrder](#schemasortorder)|false|none|none|
-|properties|object|false|none|none|
-|» **additionalProperties**|string|false|none|none|
-|metadataJson|string|false|none|none|
-|commit|boolean|false|none|none|
-
 <h2 id="tocS_PartitionSpec">PartitionSpec</h2>
 <!-- backwards compatibility -->
 <a id="schemapartitionspec"></a>
@@ -1237,57 +1078,6 @@ BearerAuth
 |---|---|---|---|---|
 |aliases|object|false|none|none|
 |» **additionalProperties**|integer(int32)|false|none|none|
-
-<h2 id="tocS_SortOrder">SortOrder</h2>
-<!-- backwards compatibility -->
-<a id="schemasortorder"></a>
-<a id="schema_SortOrder"></a>
-<a id="tocSsortorder"></a>
-<a id="tocssortorder"></a>
-
-```json
-{
-  "unsorted": true
-}
-
-```
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|unsorted|boolean|false|none|none|
-
-<h2 id="tocS_CreateTableResponse">CreateTableResponse</h2>
-<!-- backwards compatibility -->
-<a id="schemacreatetableresponse"></a>
-<a id="schema_CreateTableResponse"></a>
-<a id="tocScreatetableresponse"></a>
-<a id="tocscreatetableresponse"></a>
-
-```json
-{
-  "identifier": {
-    "namespace": [
-      "string"
-    ],
-    "name": "string"
-  },
-  "metadataLocation": "s3://bucket/prod/accounting.db/monthly_sales/metadata/00001-0d4ef14f-ef7d-43e7-9af-5f4ad40a1103.metadata.json",
-  "metadataJson": "TODO",
-  "tableToken": "string"
-}
-
-```
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|identifier|[TableIdentifier](#schematableidentifier)|false|none|none|
-|metadataLocation|string|false|none|Location of the most current primary metadata file for the table|
-|metadataJson|string|false|none|Stringified JSON representing the tables metadata|
-|tableToken|string|false|none|none|
 
 <h2 id="tocS_SetPropertiesRequest">SetPropertiesRequest</h2>
 <!-- backwards compatibility -->
@@ -1616,8 +1406,8 @@ JSON wrapper for all response bodies, with a data object and / or an error objec
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|data|[ResponseDataObject](#schemaresponsedataobject)|false|none|JSON data payload returned in a successful response body.|
-|error|[ResponseErrorObject](#schemaresponseerrorobject)|false|none|Error portion embedded in all JSON responses with further details of the error|
+|data|[ResponseDataObject](#schemaresponsedataobject)|false|none|JSON data payload returned in a successful response body|
+|error|[ResponseErrorObject](#schemaresponseerrorobject)|false|none|JSON error payload returned in a response with further details on the error|
 
 <h2 id="tocS_ResponseDataObject">ResponseDataObject</h2>
 <!-- backwards compatibility -->
@@ -1631,7 +1421,7 @@ JSON wrapper for all response bodies, with a data object and / or an error objec
 
 ```
 
-JSON data payload returned in a successful response body.
+JSON data payload returned in a successful response body
 
 ### Properties
 
@@ -1654,7 +1444,7 @@ JSON data payload returned in a successful response body.
 
 ```
 
-Error portion embedded in all JSON responses with further details of the error
+JSON error payload returned in a response with further details on the error
 
 ### Properties
 
@@ -1662,6 +1452,6 @@ Error portion embedded in all JSON responses with further details of the error
 |---|---|---|---|---|
 |message|string|true|none|Human-readable error message|
 |type|string|true|none|Machine-type of the errror, such as an exception class|
-|code|integer|true|none|Application specific error code, to disambiguage amongst subclasses of HTTP responses|
+|code|integer|false|none|Application specific error code, to disambiguage amongst subclasses of HTTP responses|
 |metadata|object¦null|false|none|Additional metadata to accompany this error, such as server side stack traces or user instructions|
 

--- a/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
+++ b/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
@@ -77,9 +77,16 @@ System.out.println(response.toString());
 
 *List all catalog configuration settings*
 
-All REST catalog clients will first call this route to get some configuration provided by the server. This route will return any server specified default configuration values for the catalog, such as configuration values used to setup the catalog for usage with Spark (e.g. vectorization-enabled).
-Users should be able to override these values with client specified values.
-The server might be able to request that the client use its value over a value that has been configured in the client application. How and if it will do that is an open question, and thus not currently specified in this documents schema.
+All REST catalog clients will first call this route to get possible catalog-specific configuration values provided by the server, that the catalog (and its HTTP client) can use to complete the `initialize` step.
+This call is similar to the initial set-up calls that some catalogs already do for domain-specific information, such as the Nessie catalog or the Glue catalog. This is to allow for services that would like to integrate with Iceberg to do so, and to be able to add their own domain-specific information into the REST catalog without requiring them to write and distribute a catalog themselves.
+There will be two sets of values provided -
+- overrides
+  * An object containing values that the client must use.
+    For example, auth headers that the client will receive from the server
+    as temporary credentials.
+- defaults
+  * Catalog-specific configuration that the client may use as a default value.
+    These are optional and the client is free to use its own value for these.
 
 > Example responses
 
@@ -87,8 +94,21 @@ The server might be able to request that the client use its value over a value t
 
 ```json
 {
-  "rootPath": "/",
-  "catalogProperties": {}
+  "data": {
+    "overrides": {
+      "prefix": "/raul",
+      "headers": {
+        "User-Agent": "Raul",
+        "Authorization": "Basic Ym9zY236Ym9zY28="
+      }
+    },
+    "defaults": {
+      "clients": 5,
+      "headers": {
+        "Upgrade-Insecure-Requests": "1"
+      }
+    }
+  }
 }
 ```
 
@@ -950,8 +970,7 @@ JSON data payload returned in a successful response body
 {
   "message": "string",
   "type": "NoSuchNamespaceException",
-  "code": 404,
-  "metadata": {}
+  "code": 404
 }
 
 ```
@@ -965,7 +984,6 @@ JSON error payload returned in a response with further details on the error
 |message|string|true|none|Human-readable error message|
 |type|string|true|none|Internal type of the error, such as an exception class|
 |code|integer|true|none|HTTP response code|
-|metadata|object¦null|false|none|Additional metadata to accompany this error, such as server side stack traces or user instructions|
 
 <h2 id="tocS_TableIdentifier">TableIdentifier</h2>
 <!-- backwards compatibility -->
@@ -1261,8 +1279,7 @@ Server-provided configuration for the catalog.
 {
   "message": "string",
   "type": "NoSuchNamespaceException",
-  "code": 404,
-  "metadata": {}
+  "code": 404
 }
 
 ```

--- a/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
+++ b/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
@@ -980,7 +980,7 @@ JSON error payload returned in a response with further details on the error
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |message|string|true|none|Human-readable error message|
-|type|string|true|none|Internal type of the error, such as an exception class|
+|type|string|true|none|Internal type definition of the error|
 |code|integer|true|none|HTTP response code|
 
 <h2 id="tocS_TableIdentifier">TableIdentifier</h2>

--- a/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
+++ b/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
@@ -148,10 +148,11 @@ List all namespaces at a certain level, optionally starting from a given parent 
 
 ```json
 {
-  "databases": [
-    {
-      "empty": true
-    }
+  "namespaces": [
+    [
+      "accounting",
+      "tax"
+    ]
   ]
 }
 ```
@@ -223,7 +224,7 @@ Create a namespace, with an optional set of properties. The server might also ad
 |Name|In|Type|Required|Description|
 |---|---|---|---|---|
 |body|body|[CreateNamespaceRequest](#schemacreatenamespacerequest)|true|none|
-|» namespace|body|[string]|true|individual levels of the namespace|
+|» namespace|body|[string]|true|Individual levels of the namespace|
 |» properties|body|object|false|Configuration properties for the namespace|
 
 > Example responses
@@ -302,12 +303,13 @@ Return all stored metadata properties for a given namespace
 
 ```json
 {
-  "namespace": {
-    "empty": true
-  },
+  "namespace": [
+    "accounting",
+    "tax"
+  ],
   "properties": {
-    "property1": "string",
-    "property2": "string"
+    "owner": "Ralph",
+    "transient_lastDdlTime": "1452120468"
   }
 }
 ```
@@ -691,15 +693,21 @@ Remove a table from the catalog
 > 200 Response
 
 ```json
-true
+{
+  "data": {
+    "dropped": true,
+    "purged": false
+  }
+}
 ```
 
 <h3 id="droptable-responses">Responses</h3>
 
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|boolean|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[DropTableResponse](#schemadroptableresponse)|
 |202|[Accepted](https://tools.ietf.org/html/rfc7231#section-6.3.3)|Accepted - for use if purgeRequested is implemented as an asynchronous action.|None|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|None|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
@@ -884,6 +892,97 @@ BearerAuth
 
 # Schemas
 
+<h2 id="tocS_IcebergResponseObject">IcebergResponseObject</h2>
+<!-- backwards compatibility -->
+<a id="schemaicebergresponseobject"></a>
+<a id="schema_IcebergResponseObject"></a>
+<a id="tocSicebergresponseobject"></a>
+<a id="tocsicebergresponseobject"></a>
+
+```json
+{
+  "data": {
+    "namespaces": [
+      [
+        "ns1",
+        "foo_db"
+      ],
+      [
+        "ns1",
+        "bar_db"
+      ]
+    ]
+  },
+  "error": {}
+}
+
+```
+
+JSON wrapper for all response bodies, with a data object and / or an error object
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|data|[ResponseDataObject](#schemaresponsedataobject)|false|none|JSON data payload returned in a successful response body|
+|error|[ResponseErrorObject](#schemaresponseerrorobject)|false|none|JSON error payload returned in a response with further details on the error|
+
+<h2 id="tocS_ResponseDataObject">ResponseDataObject</h2>
+<!-- backwards compatibility -->
+<a id="schemaresponsedataobject"></a>
+<a id="schema_ResponseDataObject"></a>
+<a id="tocSresponsedataobject"></a>
+<a id="tocsresponsedataobject"></a>
+
+```json
+{
+  "data": {
+    "identifiers": [
+      "office.employees",
+      "office.dogs",
+      "office.cats"
+    ]
+  }
+}
+
+```
+
+JSON data payload returned in a successful response body
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|data|object|false|none|Wrapper for the response of a successful request|
+
+<h2 id="tocS_ResponseErrorObject">ResponseErrorObject</h2>
+<!-- backwards compatibility -->
+<a id="schemaresponseerrorobject"></a>
+<a id="schema_ResponseErrorObject"></a>
+<a id="tocSresponseerrorobject"></a>
+<a id="tocsresponseerrorobject"></a>
+
+```json
+{
+  "message": "string",
+  "type": "NoSuchNamespaceException",
+  "code": 404,
+  "metadata": {}
+}
+
+```
+
+JSON error payload returned in a response with further details on the error
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|message|string|true|none|Human-readable error message|
+|type|string|true|none|Internal type of the error, such as an exception class|
+|code|integer|true|none|HTTP response code|
+|metadata|object¦null|false|none|Additional metadata to accompany this error, such as server side stack traces or user instructions|
+
 <h2 id="tocS_TableIdentifier">TableIdentifier</h2>
 <!-- backwards compatibility -->
 <a id="schematableidentifier"></a>
@@ -929,7 +1028,7 @@ BearerAuth
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|namespace|[string]|true|none|individual levels of the namespace|
+|namespace|[string]|true|none|Individual levels of the namespace|
 |properties|object|false|none|Configuration properties for the namespace|
 
 <h2 id="tocS_RenameTableRequest">RenameTableRequest</h2>
@@ -1029,10 +1128,11 @@ JSON data response for a synchronous update properties request.
 
 ```json
 {
-  "databases": [
-    {
-      "empty": true
-    }
+  "namespaces": [
+    [
+      "accounting",
+      "tax"
+    ]
   ]
 }
 
@@ -1042,7 +1142,29 @@ JSON data response for a synchronous update properties request.
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|databases|[[Namespace](#schemanamespace)]|false|none|[Reference to one or more levels of a namespace]|
+|namespaces|[[Namespace](#schemanamespace)]|false|none|[Reference to one or more levels of a namespace]|
+
+<h2 id="tocS_DropTableResponse">DropTableResponse</h2>
+<!-- backwards compatibility -->
+<a id="schemadroptableresponse"></a>
+<a id="schema_DropTableResponse"></a>
+<a id="tocSdroptableresponse"></a>
+<a id="tocsdroptableresponse"></a>
+
+```json
+{
+  "dropped": true,
+  "purged": true
+}
+
+```
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|dropped|boolean|false|none|true if the table was found and removed from the catalog|
+|purged|boolean|false|none|whether the underlying data was purged or is being purged|
 
 <h2 id="tocS_Namespace">Namespace</h2>
 <!-- backwards compatibility -->
@@ -1052,9 +1174,10 @@ JSON data response for a synchronous update properties request.
 <a id="tocsnamespace"></a>
 
 ```json
-{
-  "empty": true
-}
+[
+  "accounting",
+  "tax"
+]
 
 ```
 
@@ -1062,9 +1185,7 @@ Reference to one or more levels of a namespace
 
 ### Properties
 
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|empty|boolean|false|none|none|
+*None*
 
 <h2 id="tocS_GetNamespaceResponse">GetNamespaceResponse</h2>
 <!-- backwards compatibility -->
@@ -1075,12 +1196,13 @@ Reference to one or more levels of a namespace
 
 ```json
 {
-  "namespace": {
-    "empty": true
-  },
+  "namespace": [
+    "accounting",
+    "tax"
+  ],
   "properties": {
-    "property1": "string",
-    "property2": "string"
+    "owner": "Ralph",
+    "transient_lastDdlTime": "1452120468"
   }
 }
 
@@ -1092,7 +1214,6 @@ Reference to one or more levels of a namespace
 |---|---|---|---|---|
 |namespace|[Namespace](#schemanamespace)|false|none|Reference to one or more levels of a namespace|
 |properties|object|false|none|none|
-|» **additionalProperties**|string|false|none|none|
 
 <h2 id="tocS_ListTablesResponse">ListTablesResponse</h2>
 <!-- backwards compatibility -->
@@ -1236,71 +1357,4 @@ the given table identifier already exists and cannot be created / renamed to
 ### Properties
 
 *None*
-
-<h2 id="tocS_IcebergResponseObject">IcebergResponseObject</h2>
-<!-- backwards compatibility -->
-<a id="schemaicebergresponseobject"></a>
-<a id="schema_IcebergResponseObject"></a>
-<a id="tocSicebergresponseobject"></a>
-<a id="tocsicebergresponseobject"></a>
-
-```json
-"{ \"data\": { \"namespaces\": [\"ns1.foo_db\", \"ns1.bar_db\"] }, \"error\": {} }"
-
-```
-
-JSON wrapper for all response bodies, with a data object and / or an error object
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|data|[ResponseDataObject](#schemaresponsedataobject)|false|none|JSON data payload returned in a successful response body|
-|error|[ResponseErrorObject](#schemaresponseerrorobject)|false|none|JSON error payload returned in a response with further details on the error|
-
-<h2 id="tocS_ResponseDataObject">ResponseDataObject</h2>
-<!-- backwards compatibility -->
-<a id="schemaresponsedataobject"></a>
-<a id="schema_ResponseDataObject"></a>
-<a id="tocSresponsedataobject"></a>
-<a id="tocsresponsedataobject"></a>
-
-```json
-"{ \"data\": { \"identifiers\": [ \"office.employees\", \"office.dogs\", \"office.cats\" ] }"
-
-```
-
-JSON data payload returned in a successful response body
-
-### Properties
-
-*None*
-
-<h2 id="tocS_ResponseErrorObject">ResponseErrorObject</h2>
-<!-- backwards compatibility -->
-<a id="schemaresponseerrorobject"></a>
-<a id="schema_ResponseErrorObject"></a>
-<a id="tocSresponseerrorobject"></a>
-<a id="tocsresponseerrorobject"></a>
-
-```json
-{
-  "message": "string",
-  "type": "NoSuchNamespaceException",
-  "code": 404,
-  "metadata": {}
-}
-
-```
-
-JSON error payload returned in a response with further details on the error
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|message|string|true|none|Human-readable error message|
-|type|string|true|none|Internal type of the error, such as an exception class|
-|code|integer|false|none|HTTP response code|
-|metadata|object¦null|false|none|Additional metadata to accompany this error, such as server side stack traces or user instructions|
 

--- a/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
+++ b/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
@@ -323,6 +323,73 @@ To perform this operation, you must be authenticated by means of one of the foll
 BearerAuth
 </aside>
 
+## namespaceExists
+
+<a id="opIdnamespaceExists"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X HEAD http://127.0.0.1:1080/namespaces/{namespace} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+```java
+URL obj = new URL("http://127.0.0.1:1080/namespaces/{namespace}");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("HEAD");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+`HEAD /namespaces/{namespace}`
+
+*Check if a namespace exists*
+
+Check if a namespace exists.
+
+<h3 id="namespaceexists-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|namespace|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "data": {
+    "exists": false
+  }
+}
+```
+
+<h3 id="namespaceexists-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[IcebergResponseObject](#schemaicebergresponseobject)|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|None|
+
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+BearerAuth
+</aside>
+
 ## dropNamespace
 
 <a id="opIddropNamespace"></a>
@@ -556,22 +623,22 @@ To perform this operation, you must be authenticated by means of one of the foll
 BearerAuth
 </aside>
 
-## loadTable
+## listTables
 
-<a id="opIdloadTable"></a>
+<a id="opIdlistTables"></a>
 
 > Code samples
 
 ```shell
 # You can also use wget
-curl -X GET http://127.0.0.1:1080/namespaces/{namespace}/tables/{table} \
+curl -X GET http://127.0.0.1:1080/namespaces/{namespace}/tables \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```java
-URL obj = new URL("http://127.0.0.1:1080/namespaces/{namespace}/tables/{table}");
+URL obj = new URL("http://127.0.0.1:1080/namespaces/{namespace}/tables");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("GET");
 int responseCode = con.getResponseCode();
@@ -587,16 +654,17 @@ System.out.println(response.toString());
 
 ```
 
-`GET /namespaces/{namespace}/tables/{table}`
+`GET /namespaces/{namespace}/tables`
 
-*Load a given table from a given namespace*
+*List all table identifiers underneath a given namespace*
 
-<h3 id="loadtable-parameters">Parameters</h3>
+Return all table identifiers under this namespace
+
+<h3 id="listtables-parameters">Parameters</h3>
 
 |Name|In|Type|Required|Description|
 |---|---|---|---|---|
-|namespace|path|string|true|A namespace identifier|
-|table|path|string|true|A table name|
+|namespace|path|string|true|A namespace identifier under which to list tables|
 
 > Example responses
 
@@ -604,40 +672,22 @@ System.out.println(response.toString());
 
 ```json
 {
-  "identifier": {
-    "namespace": [
-      "string"
-    ],
-    "name": "string"
-  },
-  "location": "string",
-  "metadataLocation": "string",
-  "metadataJson": "string",
-  "schema": {
-    "aliases": {
-      "property1": 0,
-      "property2": 0
+  "identifiers": [
+    {
+      "namespace": [
+        "string"
+      ],
+      "name": "string"
     }
-  },
-  "partitionSpec": {
-    "unpartitioned": true
-  },
-  "properties": {
-    "property1": "string",
-    "property2": "string"
-  }
+  ]
 }
 ```
 
-<h3 id="loadtable-responses">Responses</h3>
+<h3 id="listtables-responses">Responses</h3>
 
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[GetTableResponse](#schemagettableresponse)|
-|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|None|
-|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found (NoSuchTableException | NoSuchNamespaceException)|Inline|
-
-<h3 id="loadtable-responseschema">Response Schema</h3>
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ListTablesResponse](#schemalisttablesresponse)|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
@@ -718,6 +768,7 @@ BearerAuth
 ```shell
 # You can also use wget
 curl -X HEAD http://127.0.0.1:1080/namespaces/{namespace}/tables/{table} \
+  -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
 ```
@@ -743,92 +794,50 @@ System.out.println(response.toString());
 
 *Check if a table exists*
 
-Check if a table exists within a given namespace. Returns the standard response with `true` when found. Will throw a NoSuchTableException if not present.
+Check if a table exists within a given namespace. Returns the standard Iceberg response data wrapper with exists set to `true` when found, `false` if not found. If the namespace for the table does not exist, returns a 404 NoSuchNamespaceException.
 
 <h3 id="tableexists-parameters">Parameters</h3>
 
 |Name|In|Type|Required|Description|
 |---|---|---|---|---|
 |namespace|path|string|true|A namespace identifier|
-|table|path|string|true|none|
+|table|path|string|true|A table name|
+
+> Example responses
+
+> OK
+
+```json
+{
+  "data": {
+    "exists": true
+  }
+}
+```
+
+```json
+"{ \"data\": { \"exists: false } }"
+```
+
+> 404 Response
+
+```json
+{
+  "error": {
+    "message": "The namespace does not exist",
+    "type": "NoSuchTableException",
+    "code": 40401
+  }
+}
+```
 
 <h3 id="tableexists-responses">Responses</h3>
 
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|None|
-|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found (NoSuchTableException)|None|
-
-<aside class="warning">
-To perform this operation, you must be authenticated by means of one of the following methods:
-BearerAuth
-</aside>
-
-## listTables
-
-<a id="opIdlistTables"></a>
-
-> Code samples
-
-```shell
-# You can also use wget
-curl -X GET http://127.0.0.1:1080/namespaces/{namespace}/tables \
-  -H 'Accept: application/json' \
-  -H 'Authorization: Bearer {access-token}'
-
-```
-
-```java
-URL obj = new URL("http://127.0.0.1:1080/namespaces/{namespace}/tables");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-
-```
-
-`GET /namespaces/{namespace}/tables`
-
-*List all table identifiers underneath a given namespace*
-
-Return all table identifiers under this namespace
-
-<h3 id="listtables-parameters">Parameters</h3>
-
-|Name|In|Type|Required|Description|
-|---|---|---|---|---|
-|namespace|path|string|true|A namespace identifier under which to list tables|
-
-> Example responses
-
-> 200 Response
-
-```json
-{
-  "identifiers": [
-    {
-      "namespace": [
-        "string"
-      ],
-      "name": "string"
-    }
-  ]
-}
-```
-
-<h3 id="listtables-responses">Responses</h3>
-
-|Status|Meaning|Description|Schema|
-|---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ListTablesResponse](#schemalisttablesresponse)|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[IcebergResponseObject](#schemaicebergresponseobject)|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|None|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|[IcebergResponseObject](#schemaicebergresponseobject)|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
@@ -1041,50 +1050,6 @@ BearerAuth
 |sourceTableIdentifier|[TableIdentifier](#schematableidentifier)|false|none|none|
 |destinationTableIdentifier|[TableIdentifier](#schematableidentifier)|false|none|none|
 
-<h2 id="tocS_PartitionSpec">PartitionSpec</h2>
-<!-- backwards compatibility -->
-<a id="schemapartitionspec"></a>
-<a id="schema_PartitionSpec"></a>
-<a id="tocSpartitionspec"></a>
-<a id="tocspartitionspec"></a>
-
-```json
-{
-  "unpartitioned": true
-}
-
-```
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|unpartitioned|boolean|false|none|none|
-
-<h2 id="tocS_Schema">Schema</h2>
-<!-- backwards compatibility -->
-<a id="schemaschema"></a>
-<a id="schema_Schema"></a>
-<a id="tocSschema"></a>
-<a id="tocsschema"></a>
-
-```json
-{
-  "aliases": {
-    "property1": 0,
-    "property2": 0
-  }
-}
-
-```
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|aliases|object|false|none|none|
-|» **additionalProperties**|integer(int32)|false|none|none|
-
 <h2 id="tocS_SetPropertiesRequest">SetPropertiesRequest</h2>
 <!-- backwards compatibility -->
 <a id="schemasetpropertiesrequest"></a>
@@ -1229,54 +1194,6 @@ Reference to one or more levels of a namespace
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |identifiers|[[TableIdentifier](#schematableidentifier)]|false|none|none|
-
-<h2 id="tocS_GetTableResponse">GetTableResponse</h2>
-<!-- backwards compatibility -->
-<a id="schemagettableresponse"></a>
-<a id="schema_GetTableResponse"></a>
-<a id="tocSgettableresponse"></a>
-<a id="tocsgettableresponse"></a>
-
-```json
-{
-  "identifier": {
-    "namespace": [
-      "string"
-    ],
-    "name": "string"
-  },
-  "location": "string",
-  "metadataLocation": "string",
-  "metadataJson": "string",
-  "schema": {
-    "aliases": {
-      "property1": 0,
-      "property2": 0
-    }
-  },
-  "partitionSpec": {
-    "unpartitioned": true
-  },
-  "properties": {
-    "property1": "string",
-    "property2": "string"
-  }
-}
-
-```
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|identifier|[TableIdentifier](#schematableidentifier)|false|none|none|
-|location|string|false|none|none|
-|metadataLocation|string|false|none|none|
-|metadataJson|string|false|none|none|
-|schema|[Schema](#schemaschema)|false|none|none|
-|partitionSpec|[PartitionSpec](#schemapartitionspec)|false|none|none|
-|properties|object|false|none|none|
-|» **additionalProperties**|string|false|none|none|
 
 <h2 id="tocS_TableMetadata">TableMetadata</h2>
 <!-- backwards compatibility -->

--- a/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
+++ b/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
@@ -162,7 +162,7 @@ System.out.println(response.toString());
 
 *List namespaces, optionally providing a parent namespace to list underneaath*
 
-List all namespaces at a certain level, optionally starting from a given parent namespace. For example, if table a.b.t exists, using 'SELECT NAMESPACE IN a' this would translate into `GET /namespaces?parent=a` and must return Namepace.of("a","b")
+List all namespaces at a certain level, optionally starting from a given parent namespace. For example, if table a.b.t exists, using 'SELECT NAMESPACE IN a' this would translate into `GET /namespaces?parent=a` and must return Namepace.of("a", "b").
 
 <h3 id="listnamespaces-parameters">Parameters</h3>
 
@@ -487,9 +487,9 @@ To perform this operation, you must be authenticated by means of one of the foll
 BearerAuth
 </aside>
 
-## setProperties _ removeProperties
+## updateProperties
 
-<a id="opIdsetProperties / removeProperties"></a>
+<a id="opIdupdateProperties"></a>
 
 > Code samples
 
@@ -537,7 +537,7 @@ Properties that are not in the request are not modified or removed by this call.
 }
 ```
 
-<h3 id="setproperties-_-removeproperties-parameters">Parameters</h3>
+<h3 id="updateproperties-parameters">Parameters</h3>
 
 |Name|In|Type|Required|Description|
 |---|---|---|---|---|
@@ -578,7 +578,7 @@ Properties that are not in the request are not modified or removed by this call.
 }
 ```
 
-<h3 id="setproperties-_-removeproperties-responses">Responses</h3>
+<h3 id="updateproperties-responses">Responses</h3>
 
 |Status|Meaning|Description|Schema|
 |---|---|---|---|

--- a/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
+++ b/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
@@ -223,7 +223,7 @@ Create a namespace, with an optional set of properties. The server might also ad
 |Name|In|Type|Required|Description|
 |---|---|---|---|---|
 |body|body|[CreateNamespaceRequest](#schemacreatenamespacerequest)|true|none|
-|» namespace|body|[string]|false|individual levels of the namespace|
+|» namespace|body|[string]|true|individual levels of the namespace|
 |» properties|body|object|false|Configuration properties for the namespace|
 
 > Example responses
@@ -556,6 +556,7 @@ Properties that are not in the request are not modified or removed by this call.
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[UpdatePropertiesResponse](#schemaupdatepropertiesresponse)|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found (NoSuchNamespaceException)|[IcebergResponseObject](#schemaicebergresponseobject)|
 |406|[Not Acceptable](https://tools.ietf.org/html/rfc7231#section-6.5.6)|Not Acceptable (Unsupported Operation)|None|
+|422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Unprocessable Entity. A property key was included in both toRemove and toUpdate.|None|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
@@ -824,17 +825,13 @@ Rename a table from one identifier to another. It's valid to move a table across
 |---|---|---|---|---|
 |body|body|[RenameTableRequest](#schemarenametablerequest)|true|Current table identifier to rename and new table identifier to rename to|
 |» sourceTableIdentifier|body|[TableIdentifier](#schematableidentifier)|false|none|
-|»» namespace|body|[string]|true|none|
+|»» namespace|body|[string]|true|Individual levels of the namespace|
 |»» name|body|string|false|none|
 |» destinationTableIdentifier|body|[TableIdentifier](#schematableidentifier)|false|none|
 
 > Example responses
 
-> Not Found, either
-  - NoSuchTableException
-    - Table to rename does not exist
-  - NoSuchNamespaceException
-    - The target namespace of the new table identifier does not exist
+> Not Found - NoSuchTableException, Table to rename does not exist - NoSuchNamespaceException, The target namespace of the new table identifier does not exist
 
 ```json
 {
@@ -874,11 +871,7 @@ Rename a table from one identifier to another. It's valid to move a table across
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|None|
 |401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|None|
-|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found, either
-  - NoSuchTableException
-    - Table to rename does not exist
-  - NoSuchNamespaceException
-    - The target namespace of the new table identifier does not exist|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found - NoSuchTableException, Table to rename does not exist - NoSuchNamespaceException, The target namespace of the new table identifier does not exist|Inline|
 |406|[Not Acceptable](https://tools.ietf.org/html/rfc7231#section-6.5.6)|Not Acceptable (UnsupportedOperationException)|None|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict (AlreadyExistsException - The new target table identifier already exists)|[TableAlreadyExistsError](#schematablealreadyexistserror)|
 
@@ -912,7 +905,7 @@ BearerAuth
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|namespace|[string]|true|none|none|
+|namespace|[string]|true|none|Individual levels of the namespace|
 |name|string|false|none|none|
 
 <h2 id="tocS_CreateNamespaceRequest">CreateNamespaceRequest</h2>
@@ -936,7 +929,7 @@ BearerAuth
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|namespace|[string]|false|none|individual levels of the namespace|
+|namespace|[string]|true|none|individual levels of the namespace|
 |properties|object|false|none|Configuration properties for the namespace|
 
 <h2 id="tocS_RenameTableRequest">RenameTableRequest</h2>

--- a/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
+++ b/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
@@ -24,7 +24,15 @@ Defines the specification for the first version of the REST Catalog API. Impleme
 
 Base URLs:
 
-* <a href="http://127.0.0.1:1080">http://127.0.0.1:1080</a>
+* <a href="https://{host}:{port}/{basePath}">https://{host}:{port}/{basePath}</a>
+
+    * **host** - The host address for the specified server Default: localhost
+
+    * **port** - The port used when addressing the host Default: 443
+
+    * **basePath** -  Default: v1
+
+* <a href="http://127.0.0.1:1080/v1">http://127.0.0.1:1080/v1</a>
 
 License: <a href="https://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0</a>
 
@@ -42,14 +50,14 @@ License: <a href="https://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0</
 
 ```shell
 # You can also use wget
-curl -X GET http://127.0.0.1:1080/config \
+curl -X GET https://{host}:{port}/{basePath}/config \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```java
-URL obj = new URL("http://127.0.0.1:1080/config");
+URL obj = new URL("https://{host}:{port}/{basePath}/config");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("GET");
 int responseCode = con.getResponseCode();
@@ -107,14 +115,14 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X GET http://127.0.0.1:1080/namespaces \
+curl -X GET https://{host}:{port}/{basePath}/namespaces \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```java
-URL obj = new URL("http://127.0.0.1:1080/namespaces");
+URL obj = new URL("https://{host}:{port}/{basePath}/namespaces");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("GET");
 int responseCode = con.getResponseCode();
@@ -178,7 +186,7 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X POST http://127.0.0.1:1080/namespaces \
+curl -X POST https://{host}:{port}/{basePath}/namespaces \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -186,7 +194,7 @@ curl -X POST http://127.0.0.1:1080/namespaces \
 ```
 
 ```java
-URL obj = new URL("http://127.0.0.1:1080/namespaces");
+URL obj = new URL("https://{host}:{port}/{basePath}/namespaces");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("POST");
 int responseCode = con.getResponseCode();
@@ -247,7 +255,7 @@ Create a namespace, with an optional set of properties. The server might also ad
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|None|
 |401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|None|
-|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict (AlreadyExistsException)|[NamespaceAlreadyExistsError](#schemanamespacealreadyexistserror)|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|The specified namespace provided in the request already exists|[ResponseErrorObject](#schemaresponseerrorobject)|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
@@ -262,14 +270,14 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X GET http://127.0.0.1:1080/namespaces/{namespace} \
+curl -X GET https://{host}:{port}/{basePath}/namespaces/{namespace} \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```java
-URL obj = new URL("http://127.0.0.1:1080/namespaces/{namespace}");
+URL obj = new URL("https://{host}:{port}/{basePath}/namespaces/{namespace}");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("GET");
 int responseCode = con.getResponseCode();
@@ -318,7 +326,6 @@ Return all stored metadata properties for a given namespace
 
 ```json
 {
-  "data": {},
   "error": {
     "message": "Namespace does not exist",
     "type": "NoSuchNamespaceException",
@@ -332,7 +339,7 @@ Return all stored metadata properties for a given namespace
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[GetNamespaceResponse](#schemagetnamespaceresponse)|
-|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found (NoSuchNamespaceException)|[IcebergResponseObject](#schemaicebergresponseobject)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found (The specified namespace was not found)|[ResponseErrorObject](#schemaresponseerrorobject)|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
@@ -347,13 +354,13 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X HEAD http://127.0.0.1:1080/namespaces/{namespace} \
+curl -X HEAD https://{host}:{port}/{basePath}/namespaces/{namespace} \
   -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```java
-URL obj = new URL("http://127.0.0.1:1080/namespaces/{namespace}");
+URL obj = new URL("https://{host}:{port}/{basePath}/namespaces/{namespace}");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("HEAD");
 int responseCode = con.getResponseCode();
@@ -402,14 +409,14 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X DELETE http://127.0.0.1:1080/namespaces/{namespace} \
+curl -X DELETE https://{host}:{port}/{basePath}/namespaces/{namespace} \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```java
-URL obj = new URL("http://127.0.0.1:1080/namespaces/{namespace}");
+URL obj = new URL("https://{host}:{port}/{basePath}/namespaces/{namespace}");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("DELETE");
 int responseCode = con.getResponseCode();
@@ -451,7 +458,7 @@ System.out.println(response.toString());
 
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[IcebergResponseObject](#schemaicebergresponseobject)|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[#/components/responses/IcebergResponseObject](#schema#/components/responses/icebergresponseobject)|
 |401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|None|
 
@@ -468,7 +475,7 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X POST http://127.0.0.1:1080/namespaces/{namespace}/properties \
+curl -X POST https://{host}:{port}/{basePath}/namespaces/{namespace}/properties \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -476,7 +483,7 @@ curl -X POST http://127.0.0.1:1080/namespaces/{namespace}/properties \
 ```
 
 ```java
-URL obj = new URL("http://127.0.0.1:1080/namespaces/{namespace}/properties");
+URL obj = new URL("https://{host}:{port}/{basePath}/namespaces/{namespace}/properties");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("POST");
 int responseCode = con.getResponseCode();
@@ -556,7 +563,7 @@ Properties that are not in the request are not modified or removed by this call.
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[UpdatePropertiesResponse](#schemaupdatepropertiesresponse)|
-|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found (NoSuchNamespaceException)|[IcebergResponseObject](#schemaicebergresponseobject)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found (NoSuchNamespaceException)|[#/components/responses/IcebergResponseObject](#schema#/components/responses/icebergresponseobject)|
 |406|[Not Acceptable](https://tools.ietf.org/html/rfc7231#section-6.5.6)|Not Acceptable (Unsupported Operation)|None|
 |422|[Unprocessable Entity](https://tools.ietf.org/html/rfc2518#section-10.3)|Unprocessable Entity. A property key was included in both toRemove and toUpdate.|None|
 
@@ -573,14 +580,14 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X GET http://127.0.0.1:1080/namespaces/{namespace}/tables \
+curl -X GET https://{host}:{port}/{basePath}/namespaces/{namespace}/tables \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```java
-URL obj = new URL("http://127.0.0.1:1080/namespaces/{namespace}/tables");
+URL obj = new URL("https://{host}:{port}/{basePath}/namespaces/{namespace}/tables");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("GET");
 int responseCode = con.getResponseCode();
@@ -636,7 +643,7 @@ Return all table identifiers under this namespace
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ListTablesResponse](#schemalisttablesresponse)|
-|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found (NoSuchNamespaceException)|[IcebergResponseObject](#schemaicebergresponseobject)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found (NoSuchNamespaceException)|[#/components/responses/IcebergResponseObject](#schema#/components/responses/icebergresponseobject)|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
@@ -651,14 +658,14 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X DELETE http://127.0.0.1:1080/namespaces/{namespace}/tables/{table} \
+curl -X DELETE https://{host}:{port}/{basePath}/namespaces/{namespace}/tables/{table} \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```java
-URL obj = new URL("http://127.0.0.1:1080/namespaces/{namespace}/tables/{table}");
+URL obj = new URL("https://{host}:{port}/{basePath}/namespaces/{namespace}/tables/{table}");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("DELETE");
 int responseCode = con.getResponseCode();
@@ -701,13 +708,25 @@ Remove a table from the catalog
 }
 ```
 
+> 404 Response
+
+```json
+{
+  "error": {
+    "message": "The given table does not exist",
+    "type": "NoSuchTableException",
+    "code": 404
+  }
+}
+```
+
 <h3 id="droptable-responses">Responses</h3>
 
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[DropTableResponse](#schemadroptableresponse)|
 |202|[Accepted](https://tools.ietf.org/html/rfc7231#section-6.3.3)|Accepted - for use if purgeRequested is implemented as an asynchronous action.|None|
-|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|None|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found (The specified table identifier was not found)|[ResponseErrorObject](#schemaresponseerrorobject)|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
@@ -722,13 +741,13 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X HEAD http://127.0.0.1:1080/namespaces/{namespace}/tables/{table} \
+curl -X HEAD https://{host}:{port}/{basePath}/namespaces/{namespace}/tables/{table} \
   -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```java
-URL obj = new URL("http://127.0.0.1:1080/namespaces/{namespace}/tables/{table}");
+URL obj = new URL("https://{host}:{port}/{basePath}/namespaces/{namespace}/tables/{table}");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("HEAD");
 int responseCode = con.getResponseCode();
@@ -748,7 +767,7 @@ System.out.println(response.toString());
 
 *Check if a table exists*
 
-Check if a table exists within a given namespace. Returns the standard Iceberg response data wrapper with exists set to `true` when found, `false` if not found. If the namespace for the table does not exist, returns a 404 NoSuchNamespaceException.
+Check if a table exists within a given namespace.
 
 <h3 id="tableexists-parameters">Parameters</h3>
 
@@ -778,7 +797,7 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X POST http://127.0.0.1:1080/tables/rename \
+curl -X POST https://{host}:{port}/{basePath}/tables/rename \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -786,7 +805,7 @@ curl -X POST http://127.0.0.1:1080/tables/rename \
 ```
 
 ```java
-URL obj = new URL("http://127.0.0.1:1080/tables/rename");
+URL obj = new URL("https://{host}:{port}/{basePath}/tables/rename");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("POST");
 int responseCode = con.getResponseCode();
@@ -844,7 +863,7 @@ Rename a table from one identifier to another. It's valid to move a table across
 ```json
 {
   "error": {
-    "message": "Table does not exist",
+    "message": "Table to rename does not exist",
     "type": "NoSuchTableException",
     "code": 404
   }
@@ -854,7 +873,7 @@ Rename a table from one identifier to another. It's valid to move a table across
 ```json
 {
   "error": {
-    "message": "Namespace does not exist",
+    "message": "Namespace to rename to does not exist",
     "type": "NoSuchNameSpaceException",
     "code": 404
   }
@@ -891,41 +910,6 @@ BearerAuth
 </aside>
 
 # Schemas
-
-<h2 id="tocS_IcebergResponseObject">IcebergResponseObject</h2>
-<!-- backwards compatibility -->
-<a id="schemaicebergresponseobject"></a>
-<a id="schema_IcebergResponseObject"></a>
-<a id="tocSicebergresponseobject"></a>
-<a id="tocsicebergresponseobject"></a>
-
-```json
-{
-  "data": {
-    "namespaces": [
-      [
-        "ns1",
-        "foo_db"
-      ],
-      [
-        "ns1",
-        "bar_db"
-      ]
-    ]
-  },
-  "error": {}
-}
-
-```
-
-JSON wrapper for all response bodies, with a data object and / or an error object
-
-### Properties
-
-|Name|Type|Required|Restrictions|Description|
-|---|---|---|---|---|
-|data|[ResponseDataObject](#schemaresponsedataobject)|false|none|JSON data payload returned in a successful response body|
-|error|[ResponseErrorObject](#schemaresponseerrorobject)|false|none|JSON error payload returned in a response with further details on the error|
 
 <h2 id="tocS_ResponseDataObject">ResponseDataObject</h2>
 <!-- backwards compatibility -->
@@ -1265,75 +1249,6 @@ Server-provided configuration for the catalog.
 |---|---|---|---|---|
 |rootPath|string|false|none|Root path to be used for all other requests. Server-side implementations are free to use another choice for root path, but must conform to the specification otherwise in order to interoperate with the URI generation that the REST catalog client will do.|
 |catalogProperties|object¦null|false|none|An optional field for storing catalog configuration properties that are stored server side. This could be beneifical to an administrator, for example to enforce that a given LocationProvider is used or to enforce that a certain FileIO implementation is used.|
-
-<h2 id="tocS_NoSuchNamespaceError">NoSuchNamespaceError</h2>
-<!-- backwards compatibility -->
-<a id="schemanosuchnamespaceerror"></a>
-<a id="schema_NoSuchNamespaceError"></a>
-<a id="tocSnosuchnamespaceerror"></a>
-<a id="tocsnosuchnamespaceerror"></a>
-
-```json
-{
-  "message": "string",
-  "type": "NoSuchNamespaceException",
-  "code": 404,
-  "metadata": {}
-}
-
-```
-
-Namespace provided in the request does not exist
-
-### Properties
-
-*None*
-
-<h2 id="tocS_NamespaceAlreadyExistsError">NamespaceAlreadyExistsError</h2>
-<!-- backwards compatibility -->
-<a id="schemanamespacealreadyexistserror"></a>
-<a id="schema_NamespaceAlreadyExistsError"></a>
-<a id="tocSnamespacealreadyexistserror"></a>
-<a id="tocsnamespacealreadyexistserror"></a>
-
-```json
-{
-  "message": "string",
-  "type": "NoSuchNamespaceException",
-  "code": 404,
-  "metadata": {}
-}
-
-```
-
-Namespace provided in the request already exists
-
-### Properties
-
-*None*
-
-<h2 id="tocS_NoSuchTableError">NoSuchTableError</h2>
-<!-- backwards compatibility -->
-<a id="schemanosuchtableerror"></a>
-<a id="schema_NoSuchTableError"></a>
-<a id="tocSnosuchtableerror"></a>
-<a id="tocsnosuchtableerror"></a>
-
-```json
-{
-  "message": "string",
-  "type": "NoSuchNamespaceException",
-  "code": 404,
-  "metadata": {}
-}
-
-```
-
-The given table identifier does not exist
-
-### Properties
-
-*None*
 
 <h2 id="tocS_TableAlreadyExistsError">TableAlreadyExistsError</h2>
 <!-- backwards compatibility -->

--- a/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
+++ b/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
@@ -938,15 +938,15 @@ System.out.println(response.toString());
 
 `GET /v1/namespaces`
 
-*List all namespaces, or all namespaces underneath a given namespace*
+*List namespaces, optionally providing a parent namespace to list underneaath*
 
-List namespaces underneath a given namespace
+List all namespaces at a certain level, optionally starting from a given parent namespace. For example, if table a.b.t exists, using 'SELECT NAMESPACE IN a' this would translate into `GET /v1/namespaces?parent=a` and must return Namepace.of("a","b").
 
 <h3 id="listnamespaces-parameters">Parameters</h3>
 
 |Name|In|Type|Required|Description|
 |---|---|---|---|---|
-|namespace|query|string|false|Namespace under which to list namespaces. Leave empty to list all namespaces in the catalog|
+|parent|query|string|false|Optional parent namespace under which to list namespaces. When empty, list top-level namespaces.|
 
 > Example responses
 

--- a/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
+++ b/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
@@ -95,77 +95,6 @@ To perform this operation, you must be authenticated by means of one of the foll
 BearerAuth
 </aside>
 
-## postConfig
-
-<a id="opIdpostConfig"></a>
-
-> Code samples
-
-```shell
-# You can also use wget
-curl -X POST http://127.0.0.1:1080/v1/catalogs/{catalog} \
-  -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer {access-token}'
-
-```
-
-```java
-URL obj = new URL("http://127.0.0.1:1080/v1/catalogs/{catalog}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-
-```
-
-`POST /v1/catalogs/{catalog}`
-
-*Persist catalog specific configuration, which can be retrieved for later use.*
-
-Persist some catalog specific configurations, which will be returned by \ calls to /v1/config in the future. This is basically all of the data \ that would go into the Catalog's `initialize` call.
-
-> Body parameter
-
-```json
-{
-  "id": "497f6eca-6276-4993-bfeb-53cbbbba6f08",
-  "name": "string",
-  "location": "string",
-  "properties": {}
-}
-```
-
-<h3 id="postconfig-parameters">Parameters</h3>
-
-|Name|In|Type|Required|Description|
-|---|---|---|---|---|
-|body|body|[Catalog](#schemacatalog)|true|none|
-|» id|body|string(uuid)|false|Unique identifier for this catalog|
-|» name|body|string|true|none|
-|» location|body|string|false|Warehouse location for this catalog or URI of metastore or other identifying location|
-|» properties|body|object|true|Additional catalog level properties|
-|catalog|path|string|true|Name of the catalog being configured|
-
-<h3 id="postconfig-responses">Responses</h3>
-
-|Status|Meaning|Description|Schema|
-|---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|None|
-|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|None|
-
-<aside class="warning">
-To perform this operation, you must be authenticated by means of one of the following methods:
-BearerAuth
-</aside>
-
 <h1 id="apache-iceberg-rest-catalog-api-catalog-api">Catalog API</h1>
 
 ## loadTable
@@ -374,15 +303,15 @@ System.out.println(response.toString());
 
 `DELETE /v1/namespaces/{namespace}/tables/{table}`
 
-*Drop a table from the catalog, optionally purging the underlying data*
+*Drop a table from the catalog*
 
-Remove a table from the catalog, optionally dropping the underlying data
+Remove a table from the catalog
 
 <h3 id="droptable-parameters">Parameters</h3>
 
 |Name|In|Type|Required|Description|
 |---|---|---|---|---|
-|purge|query|boolean|false|none|
+|purgeRequested|query|boolean|false|Whether the user requested to purge the underlying table's data and metadata|
 |namespace|path|string|true|Namespace the table is in|
 |table|path|string|true|Name of the table to load|
 

--- a/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
+++ b/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
@@ -243,6 +243,7 @@ true
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|boolean|
+|202|[Accepted](https://tools.ietf.org/html/rfc7231#section-6.3.3)|Accepted - for use if purgeRequested is implemented as an asynchronous action.|None|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
@@ -475,10 +476,9 @@ System.out.println(response.toString());
     ],
     "name": "string"
   },
-  "tableLocation": "s3://bucket/prod/accounting.db/monthly_sales",
   "metadataLocation": "s3://bucket/prod/accounting.db/monthly_sales/metadata/00001-0d4ef14f-ef7d-43e7-9af-5f4ad40a1103.metadata.json",
   "metadataJson": "TODO",
-  "accessToken": "string"
+  "tableToken": "string"
 }
 ```
 
@@ -680,7 +680,7 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X DELETE http://127.0.0.1:1080/v1/namespaces/{namespace}/properties \
+curl -X PUT http://127.0.0.1:1080/v1/namespaces/{namespace}/properties \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -690,7 +690,7 @@ curl -X DELETE http://127.0.0.1:1080/v1/namespaces/{namespace}/properties \
 ```java
 URL obj = new URL("http://127.0.0.1:1080/v1/namespaces/{namespace}/properties");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("DELETE");
+con.setRequestMethod("PUT");
 int responseCode = con.getResponseCode();
 BufferedReader in = new BufferedReader(
     new InputStreamReader(con.getInputStream()));
@@ -704,7 +704,7 @@ System.out.println(response.toString());
 
 ```
 
-`DELETE /v1/namespaces/{namespace}/properties`
+`PUT /v1/namespaces/{namespace}/properties`
 
 *Remove a set of property keys from a namespace in the catalog*
 
@@ -1273,10 +1273,9 @@ BearerAuth
     ],
     "name": "string"
   },
-  "tableLocation": "s3://bucket/prod/accounting.db/monthly_sales",
   "metadataLocation": "s3://bucket/prod/accounting.db/monthly_sales/metadata/00001-0d4ef14f-ef7d-43e7-9af-5f4ad40a1103.metadata.json",
   "metadataJson": "TODO",
-  "accessToken": "string"
+  "tableToken": "string"
 }
 
 ```
@@ -1286,10 +1285,9 @@ BearerAuth
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |identifier|[TableIdentifier](#schematableidentifier)|false|none|none|
-|tableLocation|string|false|none|Path of of the table just before the standard metadata / data folders. This is useful in cases where a different location provider might be used|
 |metadataLocation|string|false|none|Location of the most current primary metadata file for the table|
 |metadataJson|string|false|none|Stringified JSON representing the tables metadata|
-|accessToken|string|false|none|none|
+|tableToken|string|false|none|none|
 
 <h2 id="tocS_SetPropertiesRequest">SetPropertiesRequest</h2>
 <!-- backwards compatibility -->

--- a/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
+++ b/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
@@ -99,6 +99,463 @@ BearerAuth
 
 <h1 id="apache-iceberg-rest-catalog-api-catalog-api">Catalog API</h1>
 
+## listNamespaces
+
+<a id="opIdlistNamespaces"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET http://127.0.0.1:1080/namespaces \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+```java
+URL obj = new URL("http://127.0.0.1:1080/namespaces");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+`GET /namespaces`
+
+*List namespaces, optionally providing a parent namespace to list underneaath*
+
+List all namespaces at a certain level, optionally starting from a given parent namespace. For example, if table a.b.t exists, using 'SELECT NAMESPACE IN a' this would translate into `GET /namespaces?parent=a` and must return Namepace.of("a","b").
+
+<h3 id="listnamespaces-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|parent|query|string|false|Optional parent namespace under which to list namespaces. When empty, list top-level namespaces.|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "databases": [
+    {
+      "empty": true
+    }
+  ]
+}
+```
+
+<h3 id="listnamespaces-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ListNamespacesResponse](#schemalistnamespacesresponse)|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|None|
+
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+BearerAuth
+</aside>
+
+## createNamespace
+
+<a id="opIdcreateNamespace"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X POST http://127.0.0.1:1080/namespaces \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+```java
+URL obj = new URL("http://127.0.0.1:1080/namespaces");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("POST");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+`POST /namespaces`
+
+*Create a namespace*
+
+Create a namespace, with an optional set of properties. The server might also add properties, such as last_modified_time etc.
+
+> Body parameter
+
+```json
+{
+  "namespace": [
+    "string"
+  ],
+  "properties": "{ owner: \"Hank Bendickson\" }"
+}
+```
+
+<h3 id="createnamespace-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[CreateNamespaceRequest](#schemacreatenamespacerequest)|true|none|
+|» namespace|body|[string]|false|individual levels of the namespace|
+|» properties|body|object|false|Configuration properties for the namespace|
+
+> Example responses
+
+> 409 Response
+
+```json
+"{ error: { message: \"Namespace already exists\", type: \"AlreadyExistsException\", code: 40901 }"
+```
+
+<h3 id="createnamespace-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|None|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|None|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict (AlreadyExistsException)|[NamespaceAlreadyExistsError](#schemanamespacealreadyexistserror)|
+
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+BearerAuth
+</aside>
+
+## loadNamespaceMetadata
+
+<a id="opIdloadNamespaceMetadata"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X GET http://127.0.0.1:1080/namespaces/{namespace} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+```java
+URL obj = new URL("http://127.0.0.1:1080/namespaces/{namespace}");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("GET");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+`GET /namespaces/{namespace}`
+
+*Load the metadata properties for a namespace*
+
+Return all stored metadata properties for a given namespace
+
+<h3 id="loadnamespacemetadata-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|namespace|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "namespace": {
+    "empty": true
+  },
+  "properties": {
+    "property1": "string",
+    "property2": "string"
+  }
+}
+```
+
+> 404 Response
+
+```json
+"{ error: { message: \"Namespace does not exist\", type: \"NoSuchNamespaceException\", code: 40401 }"
+```
+
+<h3 id="loadnamespacemetadata-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[GetNamespaceResponse](#schemagetnamespaceresponse)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found (NoSuchNamespaceException)|[NoSuchNamespaceError](#schemanosuchnamespaceerror)|
+
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+BearerAuth
+</aside>
+
+## dropNamespace
+
+<a id="opIddropNamespace"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X DELETE http://127.0.0.1:1080/namespaces/{namespace} \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+```java
+URL obj = new URL("http://127.0.0.1:1080/namespaces/{namespace}");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("DELETE");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+`DELETE /namespaces/{namespace}`
+
+*Drop a namespace from the catalog. Namespace must be empty.*
+
+<h3 id="dropnamespace-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|namespace|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "data": {
+    "dropped": true
+  }
+}
+```
+
+<h3 id="dropnamespace-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[IcebergResponseObject](#schemaicebergresponseobject)|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|None|
+
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+BearerAuth
+</aside>
+
+## setProperties
+
+<a id="opIdsetProperties"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X POST http://127.0.0.1:1080/namespaces/{namespace}/properties \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+```java
+URL obj = new URL("http://127.0.0.1:1080/namespaces/{namespace}/properties");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("POST");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+`POST /namespaces/{namespace}/properties`
+
+*Set a collection of properties on a namespace*
+
+Set a collection of properties on a namespace in the catalog. Properties that are not in the given map are not modified or removed by this call. Server implementations are not required to support namespace properties.
+
+> Body parameter
+
+```json
+{
+  "namespace": "string",
+  "properties": {}
+}
+```
+
+<h3 id="setproperties-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[SetPropertiesRequest](#schemasetpropertiesrequest)|true|none|
+|» namespace|body|string|false|none|
+|» properties|body|object|false|none|
+|namespace|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+{
+  "updated": true
+}
+```
+
+> 404 Response
+
+```json
+"{ error: { message: \"Namespace does not exist\", type: \"NoSuchNamespaceException\", code: 40401 }"
+```
+
+<h3 id="setproperties-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[SetPropertiesResponse](#schemasetpropertiesresponse)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found (NoSuchNamespaceException)|[NoSuchNamespaceError](#schemanosuchnamespaceerror)|
+|406|[Not Acceptable](https://tools.ietf.org/html/rfc7231#section-6.5.6)|Not Acceptable (Unsupported Operation)|None|
+
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+BearerAuth
+</aside>
+
+## removeProperties
+
+<a id="opIdremoveProperties"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X PUT http://127.0.0.1:1080/namespaces/{namespace}/properties \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+```java
+URL obj = new URL("http://127.0.0.1:1080/namespaces/{namespace}/properties");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("PUT");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+`PUT /namespaces/{namespace}/properties`
+
+*Remove a set of property keys from a namespace in the catalog*
+
+Remove a set of property keys from a namespace in the catalog. Properties that are not in the given set are not modified or removed by this call. Server implementations are not required to support namespace properties.
+
+> Body parameter
+
+```json
+{
+  "namespace": "string",
+  "properties": {}
+}
+```
+
+<h3 id="removeproperties-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[RemovePropertiesRequest](#schemaremovepropertiesrequest)|true|none|
+|» namespace|body|string|false|none|
+|» properties|body|object|false|none|
+|namespace|path|string|true|none|
+
+> Example responses
+
+> 200 Response
+
+```json
+true
+```
+
+> 404 Response
+
+```json
+"{ error: { message: \"Namespace does not exist\", type: \"NoSuchNamespaceException\", code: 40401 }"
+```
+
+<h3 id="removeproperties-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|boolean|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found (No Such Namespace)|[NoSuchNamespaceError](#schemanosuchnamespaceerror)|
+|406|[Not Acceptable](https://tools.ietf.org/html/rfc7231#section-6.5.6)|Not Acceptable (Unsupported Operation)|None|
+
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+BearerAuth
+</aside>
+
 ## loadTable
 
 <a id="opIdloadTable"></a>
@@ -480,457 +937,6 @@ To perform this operation, you must be authenticated by means of one of the foll
 BearerAuth
 </aside>
 
-## setProperties
-
-<a id="opIdsetProperties"></a>
-
-> Code samples
-
-```shell
-# You can also use wget
-curl -X POST http://127.0.0.1:1080/namespaces/{namespace}/properties \
-  -H 'Content-Type: application/json' \
-  -H 'Accept: application/json' \
-  -H 'Authorization: Bearer {access-token}'
-
-```
-
-```java
-URL obj = new URL("http://127.0.0.1:1080/namespaces/{namespace}/properties");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-
-```
-
-`POST /namespaces/{namespace}/properties`
-
-*Set a collection of properties on a namespace*
-
-Set a collection of properties on a namespace in the catalog. Properties that are not in the given map are not modified or removed by this call. Server implementations are not required to support namespace properties.
-
-> Body parameter
-
-```json
-{
-  "namespace": "string",
-  "properties": {}
-}
-```
-
-<h3 id="setproperties-parameters">Parameters</h3>
-
-|Name|In|Type|Required|Description|
-|---|---|---|---|---|
-|body|body|[SetPropertiesRequest](#schemasetpropertiesrequest)|true|none|
-|» namespace|body|string|false|none|
-|» properties|body|object|false|none|
-|namespace|path|string|true|none|
-
-> Example responses
-
-> 200 Response
-
-```json
-true
-```
-
-> 404 Response
-
-```json
-"{ error: { message: \"Namespace does not exist\", type: \"NoSuchNamespaceException\", code: 40401 }"
-```
-
-<h3 id="setproperties-responses">Responses</h3>
-
-|Status|Meaning|Description|Schema|
-|---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|boolean|
-|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found (NoSuchNamespaceException)|[NoSuchNamespaceError](#schemanosuchnamespaceerror)|
-|406|[Not Acceptable](https://tools.ietf.org/html/rfc7231#section-6.5.6)|Not Acceptable (Unsupported Operation)|None|
-
-<aside class="warning">
-To perform this operation, you must be authenticated by means of one of the following methods:
-BearerAuth
-</aside>
-
-## removeProperties
-
-<a id="opIdremoveProperties"></a>
-
-> Code samples
-
-```shell
-# You can also use wget
-curl -X PUT http://127.0.0.1:1080/namespaces/{namespace}/properties \
-  -H 'Content-Type: application/json' \
-  -H 'Accept: application/json' \
-  -H 'Authorization: Bearer {access-token}'
-
-```
-
-```java
-URL obj = new URL("http://127.0.0.1:1080/namespaces/{namespace}/properties");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("PUT");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-
-```
-
-`PUT /namespaces/{namespace}/properties`
-
-*Remove a set of property keys from a namespace in the catalog*
-
-Remove a set of property keys from a namespace in the catalog. Properties that are not in the given set are not modified or removed by this call. Server implementations are not required to support namespace properties.
-
-> Body parameter
-
-```json
-{
-  "namespace": "string",
-  "properties": {}
-}
-```
-
-<h3 id="removeproperties-parameters">Parameters</h3>
-
-|Name|In|Type|Required|Description|
-|---|---|---|---|---|
-|body|body|[RemovePropertiesRequest](#schemaremovepropertiesrequest)|true|none|
-|» namespace|body|string|false|none|
-|» properties|body|object|false|none|
-|namespace|path|string|true|none|
-
-> Example responses
-
-> 200 Response
-
-```json
-true
-```
-
-> 404 Response
-
-```json
-"{ error: { message: \"Namespace does not exist\", type: \"NoSuchNamespaceException\", code: 40401 }"
-```
-
-<h3 id="removeproperties-responses">Responses</h3>
-
-|Status|Meaning|Description|Schema|
-|---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|boolean|
-|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found (No Such Namespace)|[NoSuchNamespaceError](#schemanosuchnamespaceerror)|
-|406|[Not Acceptable](https://tools.ietf.org/html/rfc7231#section-6.5.6)|Not Acceptable (Unsupported Operation)|None|
-
-<aside class="warning">
-To perform this operation, you must be authenticated by means of one of the following methods:
-BearerAuth
-</aside>
-
-## listNamespaces
-
-<a id="opIdlistNamespaces"></a>
-
-> Code samples
-
-```shell
-# You can also use wget
-curl -X GET http://127.0.0.1:1080/namespaces \
-  -H 'Accept: application/json' \
-  -H 'Authorization: Bearer {access-token}'
-
-```
-
-```java
-URL obj = new URL("http://127.0.0.1:1080/namespaces");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-
-```
-
-`GET /namespaces`
-
-*List namespaces, optionally providing a parent namespace to list underneaath*
-
-List all namespaces at a certain level, optionally starting from a given parent namespace. For example, if table a.b.t exists, using 'SELECT NAMESPACE IN a' this would translate into `GET /namespaces?parent=a` and must return Namepace.of("a","b").
-
-<h3 id="listnamespaces-parameters">Parameters</h3>
-
-|Name|In|Type|Required|Description|
-|---|---|---|---|---|
-|parent|query|string|false|Optional parent namespace under which to list namespaces. When empty, list top-level namespaces.|
-
-> Example responses
-
-> 200 Response
-
-```json
-{
-  "databases": [
-    {
-      "empty": true
-    }
-  ]
-}
-```
-
-<h3 id="listnamespaces-responses">Responses</h3>
-
-|Status|Meaning|Description|Schema|
-|---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[ListNamespacesResponse](#schemalistnamespacesresponse)|
-|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|None|
-
-<aside class="warning">
-To perform this operation, you must be authenticated by means of one of the following methods:
-BearerAuth
-</aside>
-
-## createNamespace
-
-<a id="opIdcreateNamespace"></a>
-
-> Code samples
-
-```shell
-# You can also use wget
-curl -X POST http://127.0.0.1:1080/namespaces \
-  -H 'Content-Type: application/json' \
-  -H 'Accept: application/json' \
-  -H 'Authorization: Bearer {access-token}'
-
-```
-
-```java
-URL obj = new URL("http://127.0.0.1:1080/namespaces");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-
-```
-
-`POST /namespaces`
-
-*Create a namespace*
-
-Create a namespace, with an optional set of properties. The server might also add properties, such as last_modified_time etc.
-
-> Body parameter
-
-```json
-{
-  "namespace": [
-    "string"
-  ],
-  "properties": "{ owner: \"Hank Bendickson\" }"
-}
-```
-
-<h3 id="createnamespace-parameters">Parameters</h3>
-
-|Name|In|Type|Required|Description|
-|---|---|---|---|---|
-|body|body|[CreateNamespaceRequest](#schemacreatenamespacerequest)|true|none|
-|» namespace|body|[string]|false|individual levels of the namespace|
-|» properties|body|object|false|Configuration properties for the namespace|
-
-> Example responses
-
-> 409 Response
-
-```json
-"{ error: { message: \"Namespace already exists\", type: \"AlreadyExistsException\", code: 40901 }"
-```
-
-<h3 id="createnamespace-responses">Responses</h3>
-
-|Status|Meaning|Description|Schema|
-|---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|None|
-|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|None|
-|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict (AlreadyExistsException)|[NamespaceAlreadyExistsError](#schemanamespacealreadyexistserror)|
-
-<aside class="warning">
-To perform this operation, you must be authenticated by means of one of the following methods:
-BearerAuth
-</aside>
-
-## loadNamespaceMetadata
-
-<a id="opIdloadNamespaceMetadata"></a>
-
-> Code samples
-
-```shell
-# You can also use wget
-curl -X GET http://127.0.0.1:1080/namespaces/{namespace} \
-  -H 'Accept: application/json' \
-  -H 'Authorization: Bearer {access-token}'
-
-```
-
-```java
-URL obj = new URL("http://127.0.0.1:1080/namespaces/{namespace}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-
-```
-
-`GET /namespaces/{namespace}`
-
-*Load the metadata properties for a namespace*
-
-Return all stored metadata properties for a given namespace
-
-<h3 id="loadnamespacemetadata-parameters">Parameters</h3>
-
-|Name|In|Type|Required|Description|
-|---|---|---|---|---|
-|namespace|path|string|true|none|
-
-> Example responses
-
-> 200 Response
-
-```json
-{
-  "namespace": {
-    "empty": true
-  },
-  "properties": {
-    "property1": "string",
-    "property2": "string"
-  }
-}
-```
-
-> 404 Response
-
-```json
-"{ error: { message: \"Namespace does not exist\", type: \"NoSuchNamespaceException\", code: 40401 }"
-```
-
-<h3 id="loadnamespacemetadata-responses">Responses</h3>
-
-|Status|Meaning|Description|Schema|
-|---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[GetNamespaceResponse](#schemagetnamespaceresponse)|
-|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found (NoSuchNamespaceException)|[NoSuchNamespaceError](#schemanosuchnamespaceerror)|
-
-<aside class="warning">
-To perform this operation, you must be authenticated by means of one of the following methods:
-BearerAuth
-</aside>
-
-## dropNamespace
-
-<a id="opIddropNamespace"></a>
-
-> Code samples
-
-```shell
-# You can also use wget
-curl -X DELETE http://127.0.0.1:1080/namespaces/{namespace} \
-  -H 'Accept: application/json' \
-  -H 'Authorization: Bearer {access-token}'
-
-```
-
-```java
-URL obj = new URL("http://127.0.0.1:1080/namespaces/{namespace}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("DELETE");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-
-```
-
-`DELETE /namespaces/{namespace}`
-
-*Drop a namespace from the catalog. Namespace must be empty.*
-
-<h3 id="dropnamespace-parameters">Parameters</h3>
-
-|Name|In|Type|Required|Description|
-|---|---|---|---|---|
-|namespace|path|string|true|none|
-
-> Example responses
-
-> 200 Response
-
-```json
-true
-```
-
-<h3 id="dropnamespace-responses">Responses</h3>
-
-|Status|Meaning|Description|Schema|
-|---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|boolean|
-|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|None|
-
-<aside class="warning">
-To perform this operation, you must be authenticated by means of one of the following methods:
-BearerAuth
-</aside>
-
 # Schemas
 
 <h2 id="tocS_TableIdentifier">TableIdentifier</h2>
@@ -1100,6 +1106,28 @@ BearerAuth
 |---|---|---|---|---|
 |namespace|string|false|none|none|
 |properties|object|false|none|none|
+
+<h2 id="tocS_SetPropertiesResponse">SetPropertiesResponse</h2>
+<!-- backwards compatibility -->
+<a id="schemasetpropertiesresponse"></a>
+<a id="schema_SetPropertiesResponse"></a>
+<a id="tocSsetpropertiesresponse"></a>
+<a id="tocssetpropertiesresponse"></a>
+
+```json
+{
+  "updated": true
+}
+
+```
+
+JSON data response on a successful set properties call.
+
+### Properties
+
+|Name|Type|Required|Restrictions|Description|
+|---|---|---|---|---|
+|updated|boolean|false|none|true if the set properties request was accepted and is reflected on the server|
 
 <h2 id="tocS_ListNamespacesResponse">ListNamespacesResponse</h2>
 <!-- backwards compatibility -->

--- a/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
+++ b/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
@@ -756,7 +756,7 @@ BearerAuth
 ```shell
 # You can also use wget
 curl -X GET http://127.0.0.1:1080/v1/namespaces/{namespace}/properties \
-  -H 'Accept: application/json' \
+  -H 'Accept: application' \
   -H 'Authorization: Bearer {access-token}'
 
 ```
@@ -782,7 +782,7 @@ System.out.println(response.toString());
 
 *Load the metadata properties for a namespace*
 
-Return all stored properties for a given namespace
+Return all stored metadata properties for a given namespace
 
 <h3 id="loadnamespacemetadata-parameters">Parameters</h3>
 
@@ -794,10 +794,6 @@ Return all stored properties for a given namespace
 
 > 200 Response
 
-```json
-{}
-```
-
 > 417 Response
 
 ```json
@@ -808,10 +804,8 @@ Return all stored properties for a given namespace
 
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|Inline|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[GetNamespaceResponse](#schemagetnamespaceresponse)|
 |417|[Expectation Failed](https://tools.ietf.org/html/rfc7231#section-6.5.14)|Namespace not found|[NoSuchNamespaceError](#schemanosuchnamespaceerror)|
-
-<h3 id="loadnamespacemetadata-responseschema">Response Schema</h3>
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:
@@ -990,14 +984,14 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X GET http://127.0.0.1:1080/v1/namespaces/list \
+curl -X GET http://127.0.0.1:1080/v1/namespaces \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```java
-URL obj = new URL("http://127.0.0.1:1080/v1/namespaces/list");
+URL obj = new URL("http://127.0.0.1:1080/v1/namespaces");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("GET");
 int responseCode = con.getResponseCode();
@@ -1013,9 +1007,9 @@ System.out.println(response.toString());
 
 ```
 
-`GET /v1/namespaces/list`
+`GET /v1/namespaces`
 
-*List all namespaces, or all namespaces underneat a given namespace*
+*List all namespaces, or all namespaces underneath a given namespace*
 
 List namespaces underneath a given namespace
 
@@ -1113,62 +1107,7 @@ Create a namespace, with an optional set of properties. The server might also ad
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|None|
-
-<aside class="warning">
-To perform this operation, you must be authenticated by means of one of the following methods:
-BearerAuth
-</aside>
-
-## getNamespace
-
-<a id="opIdgetNamespace"></a>
-
-> Code samples
-
-```shell
-# You can also use wget
-curl -X GET http://127.0.0.1:1080/v1/namespaces/{namespace} \
-  -H 'Accept: Application/JSON' \
-  -H 'Authorization: Bearer {access-token}'
-
-```
-
-```java
-URL obj = new URL("http://127.0.0.1:1080/v1/namespaces/{namespace}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("GET");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-
-```
-
-`GET /v1/namespaces/{namespace}`
-
-*Get the configured properties of a namespace*
-
-<h3 id="getnamespace-parameters">Parameters</h3>
-
-|Name|In|Type|Required|Description|
-|---|---|---|---|---|
-|namespace|path|string|true|none|
-
-> Example responses
-
-> 200 Response
-
-<h3 id="getnamespace-responses">Responses</h3>
-
-|Status|Meaning|Description|Schema|
-|---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[GetNamespaceResponse](#schemagetnamespaceresponse)|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|None|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:

--- a/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
+++ b/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
@@ -1264,7 +1264,7 @@ Server-provided configuration for the catalog.
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |rootPath|string|false|none|Root path to be used for all other requests. Server-side implementations are free to use another choice for root path, but must conform to the specification otherwise in order to interoperate with the URI generation that the REST catalog client will do.|
-|catalogProperties|object¦null|false|none|An optional field for storing catalog configuration properties that are stored server side. This could be beneifical to an administrator, for example to enforce that a given LocationProvider is used or to enforce that a certain FileIO implementation is used.|
+|catalogProperties|object|false|none|An optional field for storing catalog configuration properties that are stored server side. This could be beneficial to an administrator, for example to enforce that a given LocationProvider is used or to enforce that a certain FileIO implementation is used.|
 
 <h2 id="tocS_TableAlreadyExistsError">TableAlreadyExistsError</h2>
 <!-- backwards compatibility -->

--- a/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
+++ b/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
@@ -494,7 +494,7 @@ System.out.println(response.toString());
 
 *Set or remove properties on a namespace*
 
-Set and/or remove a collection or properties on a namespae. The request body specifies a list of properties `toRemove` and a map of key value pairs `toUpsert`.
+Set and/or remove a collection or properties on a namespae. The request body specifies a list of properties to remove and a map of key value pairs to update.
 Properties that are not in the request are not modified or removed by this call. Server implementations are not required to support namespace properties.
 
 > Body parameter
@@ -554,7 +554,7 @@ Properties that are not in the request are not modified or removed by this call.
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[UpdatePropertiesResponse](#schemaupdatepropertiesresponse)|
-|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found (NoSuchNamespaceException)|[NoSuchNamespaceError](#schemanosuchnamespaceerror)|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found (NoSuchNamespaceException)|[IcebergResponseObject](#schemaicebergresponseobject)|
 |406|[Not Acceptable](https://tools.ietf.org/html/rfc7231#section-6.5.6)|Not Acceptable (Unsupported Operation)|None|
 
 <aside class="warning">
@@ -830,7 +830,11 @@ Rename a table from one identifier to another. It's valid to move a table across
 
 > Example responses
 
-> Not Found (NoSuchTableException - Table to rename does not exist | NoSuchTableException - The target namespace of the new table identifier does not exist))
+> Not Found, either
+  - NoSuchTableException
+    - Table to rename does not exist
+  - NoSuchNamespaceException
+    - The target namespace of the new table identifier does not exist
 
 ```json
 {
@@ -857,7 +861,7 @@ Rename a table from one identifier to another. It's valid to move a table across
 ```json
 {
   "error": {
-    "message": "Tale already exists",
+    "message": "Table already exists",
     "type": "AlreadyExistsException",
     "code": 409
   }
@@ -870,7 +874,11 @@ Rename a table from one identifier to another. It's valid to move a table across
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|None|
 |401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|None|
-|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found (NoSuchTableException - Table to rename does not exist | NoSuchTableException - The target namespace of the new table identifier does not exist))|Inline|
+|404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found, either
+  - NoSuchTableException
+    - Table to rename does not exist
+  - NoSuchNamespaceException
+    - The target namespace of the new table identifier does not exist|Inline|
 |406|[Not Acceptable](https://tools.ietf.org/html/rfc7231#section-6.5.6)|Not Acceptable (UnsupportedOperationException)|None|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Conflict (AlreadyExistsException - The new target table identifier already exists)|[TableAlreadyExistsError](#schematablealreadyexistserror)|
 

--- a/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
+++ b/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
@@ -30,9 +30,7 @@ Base URLs:
 
     * **port** - The port used when addressing the host Default: 443
 
-    * **basePath** -  Default: v1
-
-* <a href="http://127.0.0.1:1080/">http://127.0.0.1:1080/</a>
+    * **basePath** -  Default: 
 
 License: <a href="https://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0</a>
 

--- a/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
+++ b/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
@@ -42,14 +42,14 @@ License: <a href="https://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0</
 
 ```shell
 # You can also use wget
-curl -X GET http://127.0.0.1:1080/v1/config \
+curl -X GET http://127.0.0.1:1080/config \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```java
-URL obj = new URL("http://127.0.0.1:1080/v1/config");
+URL obj = new URL("http://127.0.0.1:1080/config");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("GET");
 int responseCode = con.getResponseCode();
@@ -65,7 +65,7 @@ System.out.println(response.toString());
 
 ```
 
-`GET /v1/config`
+`GET /config`
 
 *List all catalog configuration settings*
 
@@ -79,7 +79,7 @@ The server might be able to request that the client use its value over a value t
 
 ```json
 {
-  "rootPath": "/v1",
+  "rootPath": "/",
   "catalogProperties": {}
 }
 ```
@@ -107,14 +107,14 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X GET http://127.0.0.1:1080/v1/namespaces/{namespace}/tables/{table} \
+curl -X GET http://127.0.0.1:1080/namespaces/{namespace}/tables/{table} \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```java
-URL obj = new URL("http://127.0.0.1:1080/v1/namespaces/{namespace}/tables/{table}");
+URL obj = new URL("http://127.0.0.1:1080/namespaces/{namespace}/tables/{table}");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("GET");
 int responseCode = con.getResponseCode();
@@ -130,7 +130,7 @@ System.out.println(response.toString());
 
 ```
 
-`GET /v1/namespaces/{namespace}/tables/{table}`
+`GET /namespaces/{namespace}/tables/{table}`
 
 *Load a given table from a given namespace*
 
@@ -195,14 +195,14 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X DELETE http://127.0.0.1:1080/v1/namespaces/{namespace}/tables/{table} \
+curl -X DELETE http://127.0.0.1:1080/namespaces/{namespace}/tables/{table} \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```java
-URL obj = new URL("http://127.0.0.1:1080/v1/namespaces/{namespace}/tables/{table}");
+URL obj = new URL("http://127.0.0.1:1080/namespaces/{namespace}/tables/{table}");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("DELETE");
 int responseCode = con.getResponseCode();
@@ -218,7 +218,7 @@ System.out.println(response.toString());
 
 ```
 
-`DELETE /v1/namespaces/{namespace}/tables/{table}`
+`DELETE /namespaces/{namespace}/tables/{table}`
 
 *Drop a table from the catalog*
 
@@ -260,13 +260,13 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X HEAD http://127.0.0.1:1080/v1/namespaces/{namespace}/tables/{table} \
+curl -X HEAD http://127.0.0.1:1080/namespaces/{namespace}/tables/{table} \
   -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```java
-URL obj = new URL("http://127.0.0.1:1080/v1/namespaces/{namespace}/tables/{table}");
+URL obj = new URL("http://127.0.0.1:1080/namespaces/{namespace}/tables/{table}");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("HEAD");
 int responseCode = con.getResponseCode();
@@ -282,7 +282,7 @@ System.out.println(response.toString());
 
 ```
 
-`HEAD /v1/namespaces/{namespace}/tables/{table}`
+`HEAD /namespaces/{namespace}/tables/{table}`
 
 *Check if a table exists*
 
@@ -315,14 +315,14 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X GET http://127.0.0.1:1080/v1/namespaces/{namespace}/tables \
+curl -X GET http://127.0.0.1:1080/namespaces/{namespace}/tables \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```java
-URL obj = new URL("http://127.0.0.1:1080/v1/namespaces/{namespace}/tables");
+URL obj = new URL("http://127.0.0.1:1080/namespaces/{namespace}/tables");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("GET");
 int responseCode = con.getResponseCode();
@@ -338,7 +338,7 @@ System.out.println(response.toString());
 
 ```
 
-`GET /v1/namespaces/{namespace}/tables`
+`GET /namespaces/{namespace}/tables`
 
 *List all table identifiers underneath a given namespace*
 
@@ -386,7 +386,7 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X POST http://127.0.0.1:1080/v1/tables/rename \
+curl -X POST http://127.0.0.1:1080/tables/rename \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -394,7 +394,7 @@ curl -X POST http://127.0.0.1:1080/v1/tables/rename \
 ```
 
 ```java
-URL obj = new URL("http://127.0.0.1:1080/v1/tables/rename");
+URL obj = new URL("http://127.0.0.1:1080/tables/rename");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("POST");
 int responseCode = con.getResponseCode();
@@ -410,7 +410,7 @@ System.out.println(response.toString());
 
 ```
 
-`POST /v1/tables/rename`
+`POST /tables/rename`
 
 *Rename a table from its current name to a new name*
 
@@ -488,7 +488,7 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X POST http://127.0.0.1:1080/v1/namespaces/{namespace}/properties \
+curl -X POST http://127.0.0.1:1080/namespaces/{namespace}/properties \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -496,7 +496,7 @@ curl -X POST http://127.0.0.1:1080/v1/namespaces/{namespace}/properties \
 ```
 
 ```java
-URL obj = new URL("http://127.0.0.1:1080/v1/namespaces/{namespace}/properties");
+URL obj = new URL("http://127.0.0.1:1080/namespaces/{namespace}/properties");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("POST");
 int responseCode = con.getResponseCode();
@@ -512,7 +512,7 @@ System.out.println(response.toString());
 
 ```
 
-`POST /v1/namespaces/{namespace}/properties`
+`POST /namespaces/{namespace}/properties`
 
 *Set a collection of properties on a namespace*
 
@@ -571,7 +571,7 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X PUT http://127.0.0.1:1080/v1/namespaces/{namespace}/properties \
+curl -X PUT http://127.0.0.1:1080/namespaces/{namespace}/properties \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -579,7 +579,7 @@ curl -X PUT http://127.0.0.1:1080/v1/namespaces/{namespace}/properties \
 ```
 
 ```java
-URL obj = new URL("http://127.0.0.1:1080/v1/namespaces/{namespace}/properties");
+URL obj = new URL("http://127.0.0.1:1080/namespaces/{namespace}/properties");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("PUT");
 int responseCode = con.getResponseCode();
@@ -595,7 +595,7 @@ System.out.println(response.toString());
 
 ```
 
-`PUT /v1/namespaces/{namespace}/properties`
+`PUT /namespaces/{namespace}/properties`
 
 *Remove a set of property keys from a namespace in the catalog*
 
@@ -654,14 +654,14 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X GET http://127.0.0.1:1080/v1/namespaces \
+curl -X GET http://127.0.0.1:1080/namespaces \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```java
-URL obj = new URL("http://127.0.0.1:1080/v1/namespaces");
+URL obj = new URL("http://127.0.0.1:1080/namespaces");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("GET");
 int responseCode = con.getResponseCode();
@@ -677,11 +677,11 @@ System.out.println(response.toString());
 
 ```
 
-`GET /v1/namespaces`
+`GET /namespaces`
 
 *List namespaces, optionally providing a parent namespace to list underneaath*
 
-List all namespaces at a certain level, optionally starting from a given parent namespace. For example, if table a.b.t exists, using 'SELECT NAMESPACE IN a' this would translate into `GET /v1/namespaces?parent=a` and must return Namepace.of("a","b").
+List all namespaces at a certain level, optionally starting from a given parent namespace. For example, if table a.b.t exists, using 'SELECT NAMESPACE IN a' this would translate into `GET /namespaces?parent=a` and must return Namepace.of("a","b").
 
 <h3 id="listnamespaces-parameters">Parameters</h3>
 
@@ -723,7 +723,7 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X POST http://127.0.0.1:1080/v1/namespaces \
+curl -X POST http://127.0.0.1:1080/namespaces \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -731,7 +731,7 @@ curl -X POST http://127.0.0.1:1080/v1/namespaces \
 ```
 
 ```java
-URL obj = new URL("http://127.0.0.1:1080/v1/namespaces");
+URL obj = new URL("http://127.0.0.1:1080/namespaces");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("POST");
 int responseCode = con.getResponseCode();
@@ -747,7 +747,7 @@ System.out.println(response.toString());
 
 ```
 
-`POST /v1/namespaces`
+`POST /namespaces`
 
 *Create a namespace*
 
@@ -801,14 +801,14 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X GET http://127.0.0.1:1080/v1/namespaces/{namespace} \
+curl -X GET http://127.0.0.1:1080/namespaces/{namespace} \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```java
-URL obj = new URL("http://127.0.0.1:1080/v1/namespaces/{namespace}");
+URL obj = new URL("http://127.0.0.1:1080/namespaces/{namespace}");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("GET");
 int responseCode = con.getResponseCode();
@@ -824,7 +824,7 @@ System.out.println(response.toString());
 
 ```
 
-`GET /v1/namespaces/{namespace}`
+`GET /namespaces/{namespace}`
 
 *Load the metadata properties for a namespace*
 
@@ -878,14 +878,14 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X DELETE http://127.0.0.1:1080/v1/namespaces/{namespace} \
+curl -X DELETE http://127.0.0.1:1080/namespaces/{namespace} \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```java
-URL obj = new URL("http://127.0.0.1:1080/v1/namespaces/{namespace}");
+URL obj = new URL("http://127.0.0.1:1080/namespaces/{namespace}");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("DELETE");
 int responseCode = con.getResponseCode();
@@ -901,7 +901,7 @@ System.out.println(response.toString());
 
 ```
 
-`DELETE /v1/namespaces/{namespace}`
+`DELETE /namespaces/{namespace}`
 
 *Drop a namespace from the catalog. Namespace must be empty.*
 
@@ -1281,7 +1281,7 @@ Reference to one or more levels of a namespace
 
 ```json
 {
-  "rootPath": "/v1",
+  "rootPath": "/",
   "catalogProperties": {}
 }
 
@@ -1307,7 +1307,7 @@ Server-provided configuration for the catalog.
 {
   "message": "string",
   "type": "string",
-  "code": 40101,
+  "code": "40401, Table not found vs 40402, Namespace not found.",
   "metadata": {}
 }
 
@@ -1330,7 +1330,7 @@ Namespace provided in the request does not exist
 {
   "message": "string",
   "type": "string",
-  "code": 40101,
+  "code": "40401, Table not found vs 40402, Namespace not found.",
   "metadata": {}
 }
 
@@ -1353,7 +1353,7 @@ Namespace provided in the request already exists
 {
   "message": "string",
   "type": "string",
-  "code": 40101,
+  "code": "40401, Table not found vs 40402, Namespace not found.",
   "metadata": {}
 }
 
@@ -1376,7 +1376,7 @@ The given table identifier does not exist
 {
   "message": "string",
   "type": "string",
-  "code": 40101,
+  "code": "40401, Table not found vs 40402, Namespace not found.",
   "metadata": {}
 }
 
@@ -1396,7 +1396,7 @@ the given table identifier already exists and cannot be created / renamed to
 <a id="tocsicebergresponseobject"></a>
 
 ```json
-"{ data: { }, error: { } }"
+"{ \"data\": { \"namespaces\": [\"ns1.foo_db\", \"ns1.bar_db\"] }, \"error\": {} }"
 
 ```
 
@@ -1417,7 +1417,7 @@ JSON wrapper for all response bodies, with a data object and / or an error objec
 <a id="tocsresponsedataobject"></a>
 
 ```json
-"{ data: { identifiers: [ \"office.employees\", \"office.dogs\", \"office.cats\" ] }"
+"{ \"data\": { \"identifiers\": [ \"office.employees\", \"office.dogs\", \"office.cats\" ] }"
 
 ```
 
@@ -1438,7 +1438,7 @@ JSON data payload returned in a successful response body
 {
   "message": "string",
   "type": "string",
-  "code": 40101,
+  "code": "40401, Table not found vs 40402, Namespace not found.",
   "metadata": {}
 }
 
@@ -1451,7 +1451,7 @@ JSON error payload returned in a response with further details on the error
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |message|string|true|none|Human-readable error message|
-|type|string|true|none|Machine-type of the errror, such as an exception class|
+|type|string|true|none|Machine-type of the error, such as an exception class|
 |code|integer|false|none|Application specific error code, to disambiguage amongst subclasses of HTTP responses|
 |metadata|object¦null|false|none|Additional metadata to accompany this error, such as server side stack traces or user instructions|
 

--- a/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
+++ b/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
@@ -1,5 +1,5 @@
 ---
-title: Apache Iceberg REST Catalog API v1.0.0
+title: Apache Iceberg REST Catalog API v0.0.1
 language_tabs:
   - shell: Shell
   - java: Java
@@ -16,7 +16,7 @@ headingLevel: 2
 
 <!-- Generator: Widdershins v4.0.1 -->
 
-<h1 id="apache-iceberg-rest-catalog-api">Apache Iceberg REST Catalog API v1.0.0</h1>
+<h1 id="apache-iceberg-rest-catalog-api">Apache Iceberg REST Catalog API v0.0.1</h1>
 
 > Scroll down for code samples, example requests and responses. Select a language for code samples from the tabs above or the mobile navigation menu.
 
@@ -32,7 +32,7 @@ Base URLs:
 
     * **basePath** -  Default: v1
 
-* <a href="http://127.0.0.1:1080/v1">http://127.0.0.1:1080/v1</a>
+* <a href="http://127.0.0.1:1080/">http://127.0.0.1:1080/</a>
 
 License: <a href="https://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0</a>
 
@@ -50,14 +50,14 @@ License: <a href="https://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0</
 
 ```shell
 # You can also use wget
-curl -X GET https://{host}:{port}/{basePath}/config \
+curl -X GET https://{host}:{port}/{basePath}/v1/config \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```java
-URL obj = new URL("https://{host}:{port}/{basePath}/config");
+URL obj = new URL("https://{host}:{port}/{basePath}/v1/config");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("GET");
 int responseCode = con.getResponseCode();
@@ -73,7 +73,7 @@ System.out.println(response.toString());
 
 ```
 
-`GET /config`
+`GET /v1/config`
 
 *List all catalog configuration settings*
 
@@ -135,14 +135,14 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X GET https://{host}:{port}/{basePath}/namespaces \
+curl -X GET https://{host}:{port}/{basePath}/v1/namespaces \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```java
-URL obj = new URL("https://{host}:{port}/{basePath}/namespaces");
+URL obj = new URL("https://{host}:{port}/{basePath}/v1/namespaces");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("GET");
 int responseCode = con.getResponseCode();
@@ -158,11 +158,11 @@ System.out.println(response.toString());
 
 ```
 
-`GET /namespaces`
+`GET /v1/namespaces`
 
 *List namespaces, optionally providing a parent namespace to list underneaath*
 
-List all namespaces at a certain level, optionally starting from a given parent namespace. For example, if table a.b.t exists, using 'SELECT NAMESPACE IN a' this would translate into `GET /namespaces?parent=a` and must return Namepace.of("a","b").
+List all namespaces at a certain level, optionally starting from a given parent namespace. For example, if table a.b.t exists, using 'SELECT NAMESPACE IN a' this would translate into `GET /namespaces?parent=a` and must return Namepace.of("a","b")
 
 <h3 id="listnamespaces-parameters">Parameters</h3>
 
@@ -206,7 +206,7 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X POST https://{host}:{port}/{basePath}/namespaces \
+curl -X POST https://{host}:{port}/{basePath}/v1/namespaces \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -214,7 +214,7 @@ curl -X POST https://{host}:{port}/{basePath}/namespaces \
 ```
 
 ```java
-URL obj = new URL("https://{host}:{port}/{basePath}/namespaces");
+URL obj = new URL("https://{host}:{port}/{basePath}/v1/namespaces");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("POST");
 int responseCode = con.getResponseCode();
@@ -230,7 +230,7 @@ System.out.println(response.toString());
 
 ```
 
-`POST /namespaces`
+`POST /v1/namespaces`
 
 *Create a namespace*
 
@@ -253,7 +253,7 @@ Create a namespace, with an optional set of properties. The server might also ad
 |---|---|---|---|---|
 |body|body|[CreateNamespaceRequest](#schemacreatenamespacerequest)|true|none|
 |» namespace|body|[string]|true|Individual levels of the namespace|
-|» properties|body|object|false|Configuration properties for the namespace|
+|» properties|body|object|false|Configured properties for the namespace|
 
 > Example responses
 
@@ -290,14 +290,14 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X GET https://{host}:{port}/{basePath}/namespaces/{namespace} \
+curl -X GET https://{host}:{port}/{basePath}/v1/namespaces/{namespace} \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```java
-URL obj = new URL("https://{host}:{port}/{basePath}/namespaces/{namespace}");
+URL obj = new URL("https://{host}:{port}/{basePath}/v1/namespaces/{namespace}");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("GET");
 int responseCode = con.getResponseCode();
@@ -313,7 +313,7 @@ System.out.println(response.toString());
 
 ```
 
-`GET /namespaces/{namespace}`
+`GET /v1/namespaces/{namespace}`
 
 *Load the metadata properties for a namespace*
 
@@ -374,13 +374,13 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X HEAD https://{host}:{port}/{basePath}/namespaces/{namespace} \
+curl -X HEAD https://{host}:{port}/{basePath}/v1/namespaces/{namespace} \
   -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```java
-URL obj = new URL("https://{host}:{port}/{basePath}/namespaces/{namespace}");
+URL obj = new URL("https://{host}:{port}/{basePath}/v1/namespaces/{namespace}");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("HEAD");
 int responseCode = con.getResponseCode();
@@ -396,7 +396,7 @@ System.out.println(response.toString());
 
 ```
 
-`HEAD /namespaces/{namespace}`
+`HEAD /v1/namespaces/{namespace}`
 
 *Check if a namespace exists*
 
@@ -412,7 +412,7 @@ Check if a namespace exists.
 
 |Status|Meaning|Description|Schema|
 |---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK - Namesapce exists|None|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|Namesapce exists|None|
 |401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|None|
 |404|[Not Found](https://tools.ietf.org/html/rfc7231#section-6.5.4)|Not Found|None|
 
@@ -429,14 +429,14 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X DELETE https://{host}:{port}/{basePath}/namespaces/{namespace} \
+curl -X DELETE https://{host}:{port}/{basePath}/v1/namespaces/{namespace} \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```java
-URL obj = new URL("https://{host}:{port}/{basePath}/namespaces/{namespace}");
+URL obj = new URL("https://{host}:{port}/{basePath}/v1/namespaces/{namespace}");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("DELETE");
 int responseCode = con.getResponseCode();
@@ -452,7 +452,7 @@ System.out.println(response.toString());
 
 ```
 
-`DELETE /namespaces/{namespace}`
+`DELETE /v1/namespaces/{namespace}`
 
 *Drop a namespace from the catalog. Namespace must be empty.*
 
@@ -495,7 +495,7 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X POST https://{host}:{port}/{basePath}/namespaces/{namespace}/properties \
+curl -X POST https://{host}:{port}/{basePath}/v1/namespaces/{namespace}/properties \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -503,7 +503,7 @@ curl -X POST https://{host}:{port}/{basePath}/namespaces/{namespace}/properties 
 ```
 
 ```java
-URL obj = new URL("https://{host}:{port}/{basePath}/namespaces/{namespace}/properties");
+URL obj = new URL("https://{host}:{port}/{basePath}/v1/namespaces/{namespace}/properties");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("POST");
 int responseCode = con.getResponseCode();
@@ -519,7 +519,7 @@ System.out.println(response.toString());
 
 ```
 
-`POST /namespaces/{namespace}/properties`
+`POST /v1/namespaces/{namespace}/properties`
 
 *Set or remove properties on a namespace*
 
@@ -600,14 +600,14 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X GET https://{host}:{port}/{basePath}/namespaces/{namespace}/tables \
+curl -X GET https://{host}:{port}/{basePath}/v1/namespaces/{namespace}/tables \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```java
-URL obj = new URL("https://{host}:{port}/{basePath}/namespaces/{namespace}/tables");
+URL obj = new URL("https://{host}:{port}/{basePath}/v1/namespaces/{namespace}/tables");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("GET");
 int responseCode = con.getResponseCode();
@@ -623,7 +623,7 @@ System.out.println(response.toString());
 
 ```
 
-`GET /namespaces/{namespace}/tables`
+`GET /v1/namespaces/{namespace}/tables`
 
 *List all table identifiers underneath a given namespace*
 
@@ -678,14 +678,14 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X DELETE https://{host}:{port}/{basePath}/namespaces/{namespace}/tables/{table} \
+curl -X DELETE https://{host}:{port}/{basePath}/v1/namespaces/{namespace}/tables/{table} \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```java
-URL obj = new URL("https://{host}:{port}/{basePath}/namespaces/{namespace}/tables/{table}");
+URL obj = new URL("https://{host}:{port}/{basePath}/v1/namespaces/{namespace}/tables/{table}");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("DELETE");
 int responseCode = con.getResponseCode();
@@ -701,7 +701,7 @@ System.out.println(response.toString());
 
 ```
 
-`DELETE /namespaces/{namespace}/tables/{table}`
+`DELETE /v1/namespaces/{namespace}/tables/{table}`
 
 *Drop a table from the catalog*
 
@@ -761,13 +761,13 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X HEAD https://{host}:{port}/{basePath}/namespaces/{namespace}/tables/{table} \
+curl -X HEAD https://{host}:{port}/{basePath}/v1/namespaces/{namespace}/tables/{table} \
   -H 'Authorization: Bearer {access-token}'
 
 ```
 
 ```java
-URL obj = new URL("https://{host}:{port}/{basePath}/namespaces/{namespace}/tables/{table}");
+URL obj = new URL("https://{host}:{port}/{basePath}/v1/namespaces/{namespace}/tables/{table}");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("HEAD");
 int responseCode = con.getResponseCode();
@@ -783,7 +783,7 @@ System.out.println(response.toString());
 
 ```
 
-`HEAD /namespaces/{namespace}/tables/{table}`
+`HEAD /v1/namespaces/{namespace}/tables/{table}`
 
 *Check if a table exists*
 
@@ -817,7 +817,7 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X POST https://{host}:{port}/{basePath}/tables/rename \
+curl -X POST https://{host}:{port}/{basePath}/v1/tables/rename \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -825,7 +825,7 @@ curl -X POST https://{host}:{port}/{basePath}/tables/rename \
 ```
 
 ```java
-URL obj = new URL("https://{host}:{port}/{basePath}/tables/rename");
+URL obj = new URL("https://{host}:{port}/{basePath}/v1/tables/rename");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
 con.setRequestMethod("POST");
 int responseCode = con.getResponseCode();
@@ -841,7 +841,7 @@ System.out.println(response.toString());
 
 ```
 
-`POST /tables/rename`
+`POST /v1/tables/rename`
 
 *Rename a table from its current name to a new name*
 
@@ -1031,7 +1031,7 @@ JSON error payload returned in a response with further details on the error
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |namespace|[string]|true|none|Individual levels of the namespace|
-|properties|object|false|none|Configuration properties for the namespace|
+|properties|object|false|none|Configured properties for the namespace|
 
 <h2 id="tocS_RenameTableRequest">RenameTableRequest</h2>
 <!-- backwards compatibility -->

--- a/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
+++ b/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
@@ -824,6 +824,84 @@ To perform this operation, you must be authenticated by means of one of the foll
 BearerAuth
 </aside>
 
+## createNamespace
+
+<a id="opIdcreateNamespace"></a>
+
+> Code samples
+
+```shell
+# You can also use wget
+curl -X POST http://127.0.0.1:1080/v1/namespaces \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json' \
+  -H 'Authorization: Bearer {access-token}'
+
+```
+
+```java
+URL obj = new URL("http://127.0.0.1:1080/v1/namespaces");
+HttpURLConnection con = (HttpURLConnection) obj.openConnection();
+con.setRequestMethod("POST");
+int responseCode = con.getResponseCode();
+BufferedReader in = new BufferedReader(
+    new InputStreamReader(con.getInputStream()));
+String inputLine;
+StringBuffer response = new StringBuffer();
+while ((inputLine = in.readLine()) != null) {
+    response.append(inputLine);
+}
+in.close();
+System.out.println(response.toString());
+
+```
+
+`POST /v1/namespaces`
+
+*Create a namespace*
+
+Create a namespace, with an optional set of properties. The server might also add properties, such as last_modified_time etc.
+
+> Body parameter
+
+```json
+{
+  "namespace": [
+    "string"
+  ],
+  "properties": "{ owner: \"Hank Bendickson\" }"
+}
+```
+
+<h3 id="createnamespace-parameters">Parameters</h3>
+
+|Name|In|Type|Required|Description|
+|---|---|---|---|---|
+|body|body|[CreateNamespaceRequest](#schemacreatenamespacerequest)|true|none|
+|» namespace|body|[string]|false|individual levels of the namespace|
+|» properties|body|object|false|Configuration properties for the namespace|
+
+> Example responses
+
+> 409 Response
+
+```json
+"{ error: { message: \"Namespace already exists\", type: \"AlreadyExistsException\", code: 40901 }"
+```
+
+<h3 id="createnamespace-responses">Responses</h3>
+
+|Status|Meaning|Description|Schema|
+|---|---|---|---|
+|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|None|
+|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|None|
+|409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Namespace already exists|[NamespaceAlreadyExistsError](#schemanamespacealreadyexistserror)|
+
+<aside class="warning">
+To perform this operation, you must be authenticated by means of one of the following methods:
+BearerAuth
+</aside>
+
 ## loadNamespaceMetadata
 
 <a id="opIdloadNamespaceMetadata"></a>
@@ -833,7 +911,7 @@ BearerAuth
 ```shell
 # You can also use wget
 curl -X GET http://127.0.0.1:1080/v1/namespaces/{namespace} \
-  -H 'Accept: application' \
+  -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
 
 ```
@@ -871,6 +949,18 @@ Return all stored metadata properties for a given namespace
 
 > 200 Response
 
+```json
+{
+  "namespace": {
+    "empty": true
+  },
+  "properties": {
+    "property1": "string",
+    "property2": "string"
+  }
+}
+```
+
 > 412 Response
 
 ```json
@@ -883,75 +973,6 @@ Return all stored metadata properties for a given namespace
 |---|---|---|---|
 |200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|[GetNamespaceResponse](#schemagetnamespaceresponse)|
 |412|[Precondition Failed](https://tools.ietf.org/html/rfc7232#section-4.2)|Namespace not found|[NoSuchNamespaceError](#schemanosuchnamespaceerror)|
-
-<aside class="warning">
-To perform this operation, you must be authenticated by means of one of the following methods:
-BearerAuth
-</aside>
-
-## createNamespace
-
-<a id="opIdcreateNamespace"></a>
-
-> Code samples
-
-```shell
-# You can also use wget
-curl -X POST http://127.0.0.1:1080/v1/namespaces/{namespace} \
-  -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer {access-token}'
-
-```
-
-```java
-URL obj = new URL("http://127.0.0.1:1080/v1/namespaces/{namespace}");
-HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
-int responseCode = con.getResponseCode();
-BufferedReader in = new BufferedReader(
-    new InputStreamReader(con.getInputStream()));
-String inputLine;
-StringBuffer response = new StringBuffer();
-while ((inputLine = in.readLine()) != null) {
-    response.append(inputLine);
-}
-in.close();
-System.out.println(response.toString());
-
-```
-
-`POST /v1/namespaces/{namespace}`
-
-*Create a namespace*
-
-Create a namespace, with an optional set of properties. The server might also add properties, such as last_modified_time etc.
-
-> Body parameter
-
-```json
-{
-  "namespace": [
-    "string"
-  ],
-  "properties": "{ owner: \"Hank Bendickson\" }"
-}
-```
-
-<h3 id="createnamespace-parameters">Parameters</h3>
-
-|Name|In|Type|Required|Description|
-|---|---|---|---|---|
-|body|body|[CreateNamespaceRequest](#schemacreatenamespacerequest)|true|none|
-|» namespace|body|[string]|false|individual levels of the namespace|
-|» properties|body|object|false|Configuration properties for the namespace|
-|namespace|path|string|true|none|
-
-<h3 id="createnamespace-responses">Responses</h3>
-
-|Status|Meaning|Description|Schema|
-|---|---|---|---|
-|200|[OK](https://tools.ietf.org/html/rfc7231#section-6.3.1)|OK|None|
-|401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|None|
 
 <aside class="warning">
 To perform this operation, you must be authenticated by means of one of the following methods:

--- a/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
+++ b/rest_docs/rest-catalog-v0.1-SNAPSHOT.md
@@ -659,7 +659,7 @@ BearerAuth
 
 ```shell
 # You can also use wget
-curl -X POST http://127.0.0.1:1080/v1/tables/renameTable \
+curl -X PUT http://127.0.0.1:1080/v1/namespaces/{namespace}/tables \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer {access-token}'
@@ -667,9 +667,9 @@ curl -X POST http://127.0.0.1:1080/v1/tables/renameTable \
 ```
 
 ```java
-URL obj = new URL("http://127.0.0.1:1080/v1/tables/renameTable");
+URL obj = new URL("http://127.0.0.1:1080/v1/namespaces/{namespace}/tables");
 HttpURLConnection con = (HttpURLConnection) obj.openConnection();
-con.setRequestMethod("POST");
+con.setRequestMethod("PUT");
 int responseCode = con.getResponseCode();
 BufferedReader in = new BufferedReader(
     new InputStreamReader(con.getInputStream()));
@@ -683,7 +683,7 @@ System.out.println(response.toString());
 
 ```
 
-`POST /v1/tables/renameTable`
+`PUT /v1/namespaces/{namespace}/tables`
 
 *Rename a table from its current name to a new name within the same catalog*
 
@@ -717,6 +717,7 @@ Rename a table within the same catalog
 |»» namespace|body|[string]|true|none|
 |»» name|body|string|false|none|
 |» destinationTableIdentifier|body|[TableIdentifier](#schematableidentifier)|false|none|
+|namespace|path|string|true|Namespace under which to list tables.|
 
 > Example responses
 


### PR DESCRIPTION
Adds an OpenAPI definition for a proposal for an HTTP-based REST catalog, as well as including generated markdown documentation that is searchable with `curl` samples.

The **_easiest way to review_** this is via [editor.swagger.io](https://editor.swagger.io). The raw YAML file can be pasted in, or even imported directly from the (raw github) URL, and is much easier to read that way.