### PR TITLE
Spark: Rewrite if no commit succeeded throw commit failed exception

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
@@ -327,6 +327,8 @@ abstract class BaseRewriteDataFilesSparkAction
       LOG.error("{} is true but no rewrite commits succeeded. Check the logs to determine why the individual " +
           "commits failed. If this is persistent it may help to increase {} which will break the rewrite operation " +
           "into smaller commits.", PARTIAL_PROGRESS_ENABLED, PARTIAL_PROGRESS_MAX_COMMITS);
+      throw new ValidationException(
+          "No rewrite commits succeeded after " + PARTIAL_PROGRESS_MAX_COMMITS + " times committed");
     }
 
     List<FileGroupRewriteResult> rewriteResults = commitResults.stream()

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
@@ -327,8 +327,7 @@ abstract class BaseRewriteDataFilesSparkAction
       LOG.error("{} is true but no rewrite commits succeeded. Check the logs to determine why the individual " +
           "commits failed. If this is persistent it may help to increase {} which will break the rewrite operation " +
           "into smaller commits.", PARTIAL_PROGRESS_ENABLED, PARTIAL_PROGRESS_MAX_COMMITS);
-      throw new ValidationException(
-          "No rewrite commits succeeded after " + PARTIAL_PROGRESS_MAX_COMMITS + " times committed");
+      throw new ValidationException("No rewrite commits succeeded after max commits");
     }
 
     List<FileGroupRewriteResult> rewriteResults = commitResults.stream()

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
@@ -327,7 +327,7 @@ abstract class BaseRewriteDataFilesSparkAction
       LOG.error("{} is true but no rewrite commits succeeded. Check the logs to determine why the individual " +
           "commits failed. If this is persistent it may help to increase {} which will break the rewrite operation " +
           "into smaller commits.", PARTIAL_PROGRESS_ENABLED, PARTIAL_PROGRESS_MAX_COMMITS);
-      throw new ValidationException("No rewrite commits succeeded after max commits");
+      throw new CommitFailedException("No rewrite commits succeeded after max commits");
     }
 
     List<FileGroupRewriteResult> rewriteResults = commitResults.stream()

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestNewRewriteDataFilesAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestNewRewriteDataFilesAction.java
@@ -56,8 +56,8 @@ import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedFiles;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.encryption.EncryptionKeyMetadata;
+import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
-import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.CloseableIterable;
@@ -506,7 +506,7 @@ public class TestNewRewriteDataFilesAction extends SparkTestBase {
         .when(spyRewrite)
         .commitManager(table.currentSnapshot().snapshotId());
 
-    AssertHelpers.assertThrows("Should fail entire rewrite if commit fails", ValidationException.class,
+    AssertHelpers.assertThrows("Should fail entire rewrite if commit fails", CommitFailedException.class,
         () -> spyRewrite.execute());
 
     table.refresh();


### PR DESCRIPTION
If parital commit was enabled but no commits succeeded at the end, we should throw exception and have no need to collect result.
cc @aokolnychyi @rdblue What do you think about it? thx!