### PR TITLE
Spark: Quote only required attributes

### DIFF
--- a/core/src/main/java/org/apache/iceberg/Partitioning.java
+++ b/core/src/main/java/org/apache/iceberg/Partitioning.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expressions;
@@ -264,5 +265,11 @@ public class Partitioning {
 
   private static boolean compatibleTransforms(Transform<?, ?> t1, Transform<?, ?> t2) {
     return t1.equals(t2) || t1.equals(Transforms.alwaysNull()) || t2.equals(Transforms.alwaysNull());
+  }
+
+  public static Set<Integer> partitionFieldSourceIds(PartitionSpec spec) {
+    return spec.fields().stream()
+        .map(PartitionField::sourceId)
+        .collect(Collectors.toSet());
   }
 }

--- a/core/src/main/java/org/apache/iceberg/util/SortOrderUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SortOrderUtil.java
@@ -86,4 +86,10 @@ public class SortOrderUtil {
           .collect(Collectors.toSet());
     }
   }
+
+  public static Set<Integer> sortFieldSourceIds(SortOrder sortOrder) {
+    return sortOrder.fields().stream()
+        .map(SortField::sourceId)
+        .collect(Collectors.toSet());
+  }
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SortOrderToSpark.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SortOrderToSpark.java
@@ -20,17 +20,20 @@
 package org.apache.iceberg.spark;
 
 import java.util.Map;
+import java.util.Set;
 import org.apache.iceberg.NullOrder;
-import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortDirection;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.transforms.SortOrderVisitor;
+import org.apache.iceberg.util.SortOrderUtil;
 
 class SortOrderToSpark implements SortOrderVisitor<OrderField> {
 
   private final Map<Integer, String> quotedNameById;
 
-  SortOrderToSpark(Schema schema) {
-    this.quotedNameById = SparkSchemaUtil.indexQuotedNameById(schema);
+  SortOrderToSpark(SortOrder sortOrder) {
+    Set<Integer> sortFieldSourceIds = SortOrderUtil.sortFieldSourceIds(sortOrder);
+    this.quotedNameById = SparkSchemaUtil.indexQuotedNameById(sortOrder.schema(), sortFieldSourceIds);
   }
 
   @Override

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.MetadataTableUtils;
 import org.apache.iceberg.NullOrder;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Partitioning;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
@@ -240,7 +241,8 @@ public class Spark3Util {
    * @return an array of Transforms
    */
   public static Transform[] toTransforms(PartitionSpec spec) {
-    Map<Integer, String> quotedNameById = SparkSchemaUtil.indexQuotedNameById(spec.schema());
+    Set<Integer> partitionFieldSourceIds = Partitioning.partitionFieldSourceIds(spec);
+    Map<Integer, String> quotedNameById = SparkSchemaUtil.indexQuotedNameById(spec.schema(), partitionFieldSourceIds);
     List<Transform> transforms = PartitionSpecVisitor.visit(spec,
         new PartitionSpecVisitor<Transform>() {
           @Override

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkDistributionAndOrderingUtil.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkDistributionAndOrderingUtil.java
@@ -71,7 +71,7 @@ public class SparkDistributionAndOrderingUtil {
   }
 
   public static SortOrder[] convert(org.apache.iceberg.SortOrder sortOrder) {
-    List<OrderField> converted = SortOrderVisitor.visit(sortOrder, new SortOrderToSpark(sortOrder.schema()));
+    List<OrderField> converted = SortOrderVisitor.visit(sortOrder, new SortOrderToSpark(sortOrder));
     return converted.toArray(new OrderField[0]);
   }
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
@@ -319,7 +319,12 @@ public class SparkSchemaUtil {
   }
 
   public static Map<Integer, String> indexQuotedNameById(Schema schema) {
+    return indexQuotedNameById(schema, null);
+  }
+
+  public static Map<Integer, String> indexQuotedNameById(Schema schema, Set<Integer> fieldIds) {
     Function<String, String> quotingFunc = name -> String.format("`%s`", name.replace("`", "``"));
-    return TypeUtil.indexQuotedNameById(schema.asStruct(), quotingFunc);
+    Schema projectedSchema = fieldIds != null ? TypeUtil.select(schema, fieldIds) : schema;
+    return TypeUtil.indexQuotedNameById(projectedSchema.asStruct(), quotingFunc);
   }
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
@@ -205,7 +205,9 @@ class SparkBatchQueryScan extends SparkBatchScan implements SupportsRuntimeFilte
       }
     }
 
-    Map<Integer, String> quotedNameById = SparkSchemaUtil.indexQuotedNameById(expectedSchema());
+    Map<Integer, String> quotedNameById = SparkSchemaUtil.indexQuotedNameById(
+        expectedSchema(),
+        partitionFieldSourceIds);
 
     // the optimizer will look for an equality condition with filter attributes in a join
     // as the scan has been already planned, filtering can only be done on projected attributes


### PR DESCRIPTION
This PR optimizes the quoting in Spark and addresses [this](https://github.com/apache/iceberg/pull/3529#discussion_r746876107) comment.