### PR TITLE
[SPARK] Add a note that drop namespace cascade is not supported

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -376,8 +376,7 @@ public class SparkCatalog extends BaseCatalog {
       try {
         return asNamespaceCatalog.dropNamespace(Namespace.of(namespace));
       } catch (NamespaceNotEmptyException e) {
-        throw new NamespaceNotEmptyException(
-            "Cannot drop a non-empty namespace, even with CASCADE. You must clear the namespace before dropping it", e);
+        throw new NamespaceNotEmptyException("Cannot delete non-empty namespace, even with CASCADE.", e);
       } catch (org.apache.iceberg.exceptions.NoSuchNamespaceException e) {
         throw new NoSuchNamespaceException(namespace);
       }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.hadoop.HadoopCatalog;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -374,6 +375,9 @@ public class SparkCatalog extends BaseCatalog {
     if (asNamespaceCatalog != null) {
       try {
         return asNamespaceCatalog.dropNamespace(Namespace.of(namespace));
+      } catch (NamespaceNotEmptyException e) {
+        throw new NamespaceNotEmptyException(
+            "Cannot drop a non-empty namespace, even with CASCADE. You must clear the namespace before dropping it", e);
       } catch (org.apache.iceberg.exceptions.NoSuchNamespaceException e) {
         throw new NoSuchNamespaceException(namespace);
       }


### PR DESCRIPTION
Right now, there's no way to get the `CASCADE` flag to work in a V2 catalog.

As users have asked about this, I'm adding a note that CASCADE is not supported presently.

This relates to issue: https://github.com/apache/iceberg/issues/3541

```scala
scala> spark.sql("drop namespace iceberg.accounting cascade").show
org.apache.iceberg.exceptions.NamespaceNotEmptyException: Namespace accounting is not empty. One or more tables exist.
```
