### PR TITLE
Arrow: Don't close vectors in VectorizedArrowReader

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -367,9 +367,7 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
 
   @Override
   public void close() {
-    if (vec != null) {
-      vec.close();
-    }
+    // don't close vectors as they are not owned by readers
   }
 
   @Override


### PR DESCRIPTION
This PR removes the logic to close underlying vectors in `VectorizedArrowReader` as the reader does not control the lifecycle of the vectors. Instead, `BaseBatchReader` closes both the readers and vectors. See [this](https://github.com/apache/iceberg/pull/3533#discussion_r747723024) discussion for details.