### PR TITLE
[SPARK] Make dropNamespace respect CASCADE keyword

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.spark;
 
+import java.util.Arrays;
 import java.util.Map;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.spark.sql.catalyst.analysis.NamespaceAlreadyExistsException;
@@ -102,7 +103,30 @@ public class SparkSessionCatalog<T extends TableCatalog & SupportsNamespaces>
   }
 
   @Override
+  // Spark assumes that catalogs CASCADE by default. So we have to eagerly
+  // attempt to drop namespaces and tables, but the CASCADE keyword is still
+  // required to actually drop tables and namespaces as Spark will error out
+  // if any of the recursive deletes are non-empty and the user didn't specify
+  // cascades in their query.
   public boolean dropNamespace(String[] namespace) throws NoSuchNamespaceException {
+
+    // This will eagerly throw NoSuchNamespaceException if namespace does not exist
+    // and the user used `ifNotExists`.
+    String[][] subNamespaces = getSessionCatalog().listNamespaces(namespace);
+
+    for (String[] ns : subNamespaces) {
+      try {
+        dropNamespace(ns);
+      } catch (NoSuchNamespaceException e) {
+        // Do nothing. It's possible this namespace doesn't exist at all or the user used `if not exists`.
+      }
+    }
+
+    try {
+      Arrays.stream(listTables(namespace)).forEach(tbl -> getSessionCatalog().dropTable(tbl));
+    } catch (NoSuchNamespaceException e) {
+      // Do nothing. It's possible this namespace doesn't exist at all or the user used `if not exists`.
+    }
     return getSessionCatalog().dropNamespace(namespace);
   }
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
@@ -27,10 +27,13 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.spark.SparkCatalogTestBase;
 import org.apache.spark.SparkException;
+import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -38,13 +41,22 @@ import org.junit.Test;
 
 public class TestNamespaceSQL extends SparkCatalogTestBase {
   private static final Namespace NS = Namespace.of("db");
+  private static final Namespace NESTED_NS1 = Namespace.of("db", "ns1");
+  private static final Namespace NESTED_NS2 = Namespace.of("db", "ns2");
+  private static final Namespace DOUBLE_NESTED_NS = Namespace.of("db", "ns2", "ns3");
 
   private final String fullNamespace;
+  private final String fullNestedNamespace1;
+  private final String fullNestedNamespace2;
+  private final String fullDoubleNestedNamespace;
   private final boolean isHadoopCatalog;
 
   public TestNamespaceSQL(String catalogName, String implementation, Map<String, String> config) {
     super(catalogName, implementation, config);
     this.fullNamespace = ("spark_catalog".equals(catalogName) ? "" : catalogName + ".") + NS;
+    this.fullNestedNamespace1 = ("spark_catalog".equals(catalogName) ? "" : catalogName + ".") + NESTED_NS1;
+    this.fullNestedNamespace2 = ("spark_catalog".equals(catalogName) ? "" : catalogName + ".") + NESTED_NS2;
+    this.fullDoubleNestedNamespace = ("spark_catalog".equals(catalogName) ? "" : catalogName + ".") + DOUBLE_NESTED_NS;
     this.isHadoopCatalog = "testhadoop".equals(catalogName);
   }
 
@@ -89,8 +101,6 @@ public class TestNamespaceSQL extends SparkCatalogTestBase {
 
   @Test
   public void testDropNonEmptyNamespace() {
-    Assume.assumeFalse("Session catalog has flaky behavior", "spark_catalog".equals(catalogName));
-
     Assert.assertFalse("Namespace should not already exist", validationNamespaceCatalog.namespaceExists(NS));
 
     sql("CREATE NAMESPACE %s", fullNamespace);
@@ -104,6 +114,119 @@ public class TestNamespaceSQL extends SparkCatalogTestBase {
         () -> sql("DROP NAMESPACE %s", fullNamespace));
 
     sql("DROP TABLE %s.table", fullNamespace);
+  }
+
+  @Test
+  public void testDropNonEmptyNamespaceWithSomeEmptySubNamespaces() {
+    Assume.assumeTrue("Only hadoop catalog allows for multi-level namespaces", isHadoopCatalog);
+
+    Assert.assertFalse("Namespace should not already exist", validationNamespaceCatalog.namespaceExists(NS));
+
+    sql("CREATE NAMESPACE %s", fullNamespace);
+    sql("CREATE NAMESPACE %s", fullNestedNamespace2);
+    sql("CREATE NAMESPACE %s", fullDoubleNestedNamespace);
+    sql("CREATE NAMESPACE %s", fullNestedNamespace1);
+    sql("CREATE TABLE %s.table (id bigint) USING iceberg", fullDoubleNestedNamespace);
+
+    // Sanity check
+    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(NS)).isTrue();
+    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(NESTED_NS1)).isTrue();
+    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(NESTED_NS2)).isTrue();
+    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(DOUBLE_NESTED_NS)).isTrue();
+    Assertions.assertThat(validationCatalog.tableExists(TableIdentifier.of(DOUBLE_NESTED_NS, "table"))).isTrue();
+
+    AssertHelpers.assertThrows("Should fail if trying to delete a non-empty namespace",
+        SparkException.class, "non-empty namespace",
+        () -> sql("DROP NAMESPACE %s", fullNamespace));
+
+    // Ensure we had no partial drops
+    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(NS)).isTrue();
+    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(NESTED_NS1)).isTrue();
+    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(NESTED_NS2)).isTrue();
+    Assertions.assertThat(validationNamespaceCatalog.namespaceExists(DOUBLE_NESTED_NS)).isTrue();
+    Assertions.assertThat(validationCatalog.tableExists(TableIdentifier.of(DOUBLE_NESTED_NS, "table"))).isTrue();
+
+    // Full quick clean-up
+    Assertions.assertThatCode(() -> sql("DROP NAMESPACE %s CASCADE", fullNamespace))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void testDropNonEmptyNamespaceOnCascade() {
+    Assert.assertFalse("Namespace should not already exist", validationNamespaceCatalog.namespaceExists(NS));
+
+    sql("CREATE NAMESPACE %s", fullNamespace);
+    sql("CREATE TABLE %s.table (id bigint) USING iceberg", fullNamespace);
+    sql("INSERT INTO %s.table VALUES (1), (2), (3), (4), (5)", fullNamespace);
+
+    Assert.assertTrue("Namespace should exist", validationNamespaceCatalog.namespaceExists(NS));
+    Assert.assertTrue("Table should exist", validationCatalog.tableExists(TableIdentifier.of(NS, "table")));
+
+    AssertHelpers.assertThrows(
+        "Should fail if trying to delete a non-empty namespace",
+        SparkException.class, "non-empty namespace",
+        () -> sql("DROP NAMESPACE %s", fullNamespace));
+
+    Assert.assertTrue("Namespace should still exist after a failed drop",
+        validationNamespaceCatalog.namespaceExists(NS));
+    Assert.assertTrue("Table should still exist after a failed drop",
+        validationCatalog.tableExists(TableIdentifier.of(NS, "table")));
+
+    sql("DROP NAMESPACE %s CASCADE", fullNamespace);
+
+    Assert.assertFalse(
+        "Namespace should not exist after deleting with CASCADE",
+        validationNamespaceCatalog.namespaceExists(NS));
+    Assert.assertFalse(
+        "Table should not exist after deleting its parent namespace with CASCADE",
+        validationCatalog.tableExists(TableIdentifier.of(NS, "table")));
+  }
+
+  @Test
+  public void testDropNamespaceRespectsRestrictKeyword() {
+    Assert.assertFalse("Namespace should not already exist", validationNamespaceCatalog.namespaceExists(NS));
+
+    sql("CREATE NAMESPACE %s", fullNamespace);
+    sql("CREATE TABLE %s.table (id bigint) USING iceberg", fullNamespace);
+
+    Assert.assertTrue("Namespace should exist", validationNamespaceCatalog.namespaceExists(NS));
+    Assert.assertTrue("Table should exist", validationCatalog.tableExists(TableIdentifier.of(NS, "table")));
+
+    AssertHelpers.assertThrows("Should fail if trying to delete a non-empty namespace with RESTRICT",
+        SparkException.class, "non-empty namespace",
+        () -> sql("DROP NAMESPACE %s RESTRICT", fullNamespace));
+
+    Assert.assertTrue("Non-empty namespace should not drop with RESTRICT",
+        validationNamespaceCatalog.namespaceExists(NS));
+    Assert.assertTrue("Table should still exist after a failed drop",
+        validationCatalog.tableExists(TableIdentifier.of(NS, "table")));
+
+    // Drop the table and then try using RESTRICT again.
+    sql("DROP TABLE %s.table", fullNamespace);
+    Assert.assertFalse(validationCatalog.tableExists(TableIdentifier.of(NS, "table")));
+
+    sql("DROP NAMESPACE %s RESTRICT", fullNamespace);
+    Assert.assertFalse(
+        "Namespace should get dropped when using RESTRICT if it's empty",
+        validationNamespaceCatalog.namespaceExists(NS));
+  }
+
+  @Test
+  public void testDropNamespaceIfExists() {
+    Assert.assertFalse("Namespace should not already exist", validationNamespaceCatalog.namespaceExists(NS));
+
+    Assertions
+        .assertThatCode(() -> sql("DROP NAMESPACE IF EXISTS %s", NS))
+        .doesNotThrowAnyException();
+
+    Assertions
+        .assertThat(sql("DROP NAMESPACE IF EXISTS %s", NS))
+        .isEqualTo(ImmutableList.of());
+
+    AssertHelpers.assertThrows(
+        "Attempting to drop a non-existing namespace without IF EXISTS should throw",
+        NoSuchNamespaceException.class, "not found",
+        () -> sql("DROP NAMESPACE %s", NS));
   }
 
   @Test


### PR DESCRIPTION
This closes issue https://github.com/apache/iceberg/issues/3541

The Spark Catalog assumes that implementations will cascade by default. Currently, we don't do that, and so if users attempt to drop a namespace, they get a rather unhelpful error message.

```scala
scala> spark.sql("drop namespace iceberg.accounting cascade").show
org.apache.iceberg.exceptions.NamespaceNotEmptyException: Namespace accounting is not empty. One or more tables exist.
```

Unfortunately, Spark doesn't expose `ifNotExists` or `cascade` in the form of parameters to the `SupportsNamespace` interface, so we simply have to try dropping things and rely on Spark to respect `cascade` etc (see sample code from Spark below). It _does_ know about all of these things (as evidenced by the tests as well as walking through the code), so it won't drop things unless `CASCADE` is used.

We should be diligent about ensuring that this is well tested and there are no regressions in the future, so please, if you think of tests cases, let me know.

This still maintains the default behavior of respecting `RESTRICT` (not dropping non-empty namespaces) by default.

Relevant code in Spark can be seen here:
- The original PR that made this design shows that it's for performance - https://github.com/apache/spark/pull/26476.
- Sample catalog source that is used in all of the tests in Spark that does have `cascade` in them - https://github.com/apache/spark/blob/e99fdf9654481dd9b691a3c10e52f3f3db6ed2ba/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableCatalog.scala#L216-L224

I have tested that the `DropNamespaceExec`  is called properly  (referenced in the first PR and still in Spark's master branch).

The one thing I'm still worried about is the fact that we don't call `cascade` when using HMS, but the tests seem to be working. We should likely check HMS manually to see if things are cleared out or not: https://github.com/apache/iceberg/blob/f68d8d426661efc0d7e5686fe833b573b74eadab/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java#L271-L284
