### PR TITLE
Website: PrestoDB and Trino links should open in a new tab

### DIFF
--- a/site/docs/theme_customization/nav-item.html
+++ b/site/docs/theme_customization/nav-item.html
@@ -10,13 +10,13 @@
     </span>
   </a>
   {%- elif nav_item.title == "Trino" -%}
-  <a href="{{ nav_item.url }}" class="block wm-toc-text">
+  <a href="{{ nav_item.url }}" target="_blank" rel="noopener noreferrer" class="block wm-toc-text">
     <span>
       <img src="img/trino-logo.png" class="navigation-icon fa-fw"/> {{ nav_item.title }}
     </span>
   </a>
   {%- elif nav_item.title == "PrestoDB" -%}
-  <a href="{{ nav_item.url }}" class="block wm-toc-text">
+  <a href="{{ nav_item.url }}" target="_blank" rel="noopener noreferrer" class="block wm-toc-text">
     <span>
       <img src="img/prestodb-logo.png" class="navigation-icon fa-fw"/> {{ nav_item.title }}
     </span>


### PR DESCRIPTION
solves [#3483](https://github.com/apache/iceberg/issues/3483)

Added `target="_blank" rel="noopener noreferrer"` to the anchor tag of presto / trino. 

Manually tested in local.

------
Additional resources : [how-to-use-html-to-open-link-in-new-tab](https://www.freecodecamp.org/news/how-to-use-html-to-open-link-in-new-tab/)