### PR TITLE
API: Stricter TableIdentifier creation

### DIFF
--- a/api/src/main/java/org/apache/iceberg/catalog/Namespace.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Namespace.java
@@ -22,6 +22,8 @@ package org.apache.iceberg.catalog;
 import java.util.Arrays;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Splitter;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 
 /**
  * A namespace in a {@link Catalog}.
@@ -29,6 +31,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 public class Namespace {
   private static final Namespace EMPTY_NAMESPACE = new Namespace(new String[] {});
   private static final Joiner DOT = Joiner.on('.');
+  private static final Splitter DOT_SPLITTER = Splitter.on('.');
 
   public static Namespace empty() {
     return EMPTY_NAMESPACE;
@@ -41,6 +44,14 @@ public class Namespace {
     }
 
     return new Namespace(levels);
+  }
+
+  public static Namespace of(String namespace) {
+    Preconditions.checkArgument(null != namespace, "Invalid namespace: null");
+    if ("".equals(namespace)) {
+      return empty();
+    }
+    return new Namespace(Iterables.toArray(DOT_SPLITTER.split(namespace), String.class));
   }
 
   private final String[] levels;

--- a/api/src/main/java/org/apache/iceberg/catalog/TableIdentifier.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/TableIdentifier.java
@@ -35,16 +35,54 @@ public class TableIdentifier {
   private final Namespace namespace;
   private final String name;
 
+  /**
+   * Creates a {@link TableIdentifier} from the given array of name.
+   *
+   * @param names The names to create the {@link TableIdentifier} from.
+   * @return A {@link TableIdentifier} instance from the given array of names.
+   * @deprecated Please use {@link TableIdentifier#of(Namespace)} and {@link TableIdentifier#of(Namespace, String)}.
+   */
+  @Deprecated
   public static TableIdentifier of(String... names) {
     Preconditions.checkArgument(names != null, "Cannot create table identifier from null array");
     Preconditions.checkArgument(names.length > 0, "Cannot create table identifier without a table name");
     return new TableIdentifier(Namespace.of(Arrays.copyOf(names, names.length - 1)), names[names.length - 1]);
   }
 
+  /**
+   * Creates a {@link TableIdentifier} from the given {@link Namespace} and simple table name.
+   *
+   * @param namespace The {@link Namespace} to use for the {@link TableIdentifier}.
+   * @param name      The simple table name.
+   * @return A {@link TableIdentifier} from the given {@link Namespace} and simple table name.
+   */
   public static TableIdentifier of(Namespace namespace, String name) {
     return new TableIdentifier(namespace, name);
   }
 
+  /**
+   * Creates a {@link TableIdentifier} with the same name as the given {@link Namespace} instance. This is mostly
+   * being used when one wants to create a base {@link TableIdentifier}, such as
+   * <code>TableIdentifier baseTableIdentifier = TableIdentifier.of(identifier.namespace())</code>
+   *
+   * @param namespace The {@link Namespace} to create the base {@link TableIdentifier} from.
+   * @return A {@link TableIdentifier} with the same name as the given {@link Namespace} instance
+   */
+  public static TableIdentifier of(Namespace namespace) {
+    Preconditions.checkArgument(namespace != null, "Invalid Namespace: null");
+    Preconditions.checkArgument(!namespace.isEmpty(), "Cannot create table identifier from empty namespace");
+    String[] levels = namespace.levels();
+    return new TableIdentifier(Namespace.of(Arrays.copyOf(levels, levels.length - 1)), levels[levels.length - 1]);
+  }
+
+  /**
+   * Parses the given identifier into a {@link TableIdentifier} instance.
+   *
+   * @param identifier The table identifier to parse to a {@link TableIdentifier}
+   * @return A {@link TableIdentifier} instance based on the given string.
+   * @deprecated Please use {@link TableIdentifier#of(Namespace)} and {@link TableIdentifier#of(Namespace, String)}.
+   */
+  @Deprecated
   public static TableIdentifier parse(String identifier) {
     Preconditions.checkArgument(identifier != null, "Cannot parse table identifier: null");
     Iterable<String> parts = DOT.split(identifier);

--- a/api/src/test/java/org/apache/iceberg/catalog/TestNamespace.java
+++ b/api/src/test/java/org/apache/iceberg/catalog/TestNamespace.java
@@ -31,6 +31,12 @@ public class TestNamespace {
         .hasMessage("Cannot create Namespace from null array");
 
     Assertions.assertThat(Namespace.of()).isEqualTo(Namespace.empty());
+
+    Assertions.assertThatThrownBy(() -> Namespace.of((String) null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid namespace: null");
+
+    Assertions.assertThat(Namespace.of("")).isEqualTo(Namespace.empty());
   }
 
   @Test
@@ -39,6 +45,18 @@ public class TestNamespace {
     Namespace namespace = Namespace.of(levels);
     Assertions.assertThat(namespace).isNotNull();
     Assertions.assertThat(namespace.levels()).isNotNull().hasSize(4);
+    Assertions.assertThat(namespace.toString()).isEqualTo("a.b.c.d");
+    for (int i = 0; i < levels.length; i++) {
+      Assertions.assertThat(namespace.level(i)).isEqualTo(levels[i]);
+    }
+  }
+
+  @Test
+  public void testNamespaceFromString() {
+    String[] levels = {"a", "b", "c", "d"};
+    Namespace namespace = Namespace.of("a.b.c.d");
+    Assertions.assertThat(namespace).isNotNull();
+    Assertions.assertThat(namespace.levels()).isNotNull().hasSize(levels.length);
     Assertions.assertThat(namespace.toString()).isEqualTo("a.b.c.d");
     for (int i = 0; i < levels.length; i++) {
       Assertions.assertThat(namespace.level(i)).isEqualTo(levels[i]);

--- a/api/src/test/java/org/apache/iceberg/catalog/TestTableIdentifier.java
+++ b/api/src/test/java/org/apache/iceberg/catalog/TestTableIdentifier.java
@@ -46,14 +46,14 @@ public class TestTableIdentifier {
   @Test
   public void testToLowerCase() {
     Assert.assertEquals(
-        TableIdentifier.of("Tbl").toLowerCase(),
-        TableIdentifier.of("tbl"));
+        TableIdentifier.of(Namespace.empty(), "Tbl").toLowerCase(),
+        TableIdentifier.of(Namespace.empty(), "tbl"));
     Assert.assertEquals(
-        TableIdentifier.of("dB", "TBL").toLowerCase(),
-        TableIdentifier.of("db", "tbl"));
+        TableIdentifier.of(Namespace.of("dB"), "TBL").toLowerCase(),
+        TableIdentifier.of(Namespace.of("db"), "tbl"));
     Assert.assertEquals(
-        TableIdentifier.of("Catalog", "dB", "TBL").toLowerCase(),
-        TableIdentifier.of("catalog", "db", "tbl"));
+        TableIdentifier.of(Namespace.of("Catalog", "dB"), "TBL").toLowerCase(),
+        TableIdentifier.of(Namespace.of("catalog", "db"), "tbl"));
   }
 
   @Test
@@ -80,5 +80,20 @@ public class TestTableIdentifier {
     Assertions.assertThatThrownBy(() -> TableIdentifier.of(null, "name"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid Namespace: null");
+
+    Assertions.assertThatThrownBy(() -> TableIdentifier.of((Namespace) null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid Namespace: null");
+  }
+
+  @Test
+  public void testFromNamespace() {
+    Assertions.assertThatThrownBy(() -> TableIdentifier.of(Namespace.empty()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot create table identifier from empty namespace");
+
+    Assertions.assertThat(TableIdentifier.of(Namespace.of("db")).toString()).isEqualTo("db");
+    Assertions.assertThat(TableIdentifier.of(Namespace.of("db.ns1")).toString()).isEqualTo("db.ns1");
+    Assertions.assertThat(TableIdentifier.of(Namespace.of("db.ns1.tbl.x")).toString()).isEqualTo("db.ns1.tbl.x");
   }
 }

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/GlueTestBase.java
@@ -100,7 +100,7 @@ public class GlueTestBase {
   }
 
   public static String createTable(String namespace, String tableName) {
-    glueCatalog.createTable(TableIdentifier.of(namespace, tableName), schema, partitionSpec);
+    glueCatalog.createTable(TableIdentifier.of(Namespace.of(namespace), tableName), schema, partitionSpec);
     return tableName;
   }
 }

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogCommitFailure.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.aws.s3.S3TestUtil;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
@@ -221,7 +222,7 @@ public class TestGlueCatalogCommitFailure extends GlueTestBase {
   private Table setupTable() {
     String namespace = createNamespace();
     String tableName = createTable(namespace);
-    return glueCatalog.loadTable(TableIdentifier.of(namespace, tableName));
+    return glueCatalog.loadTable(TableIdentifier.of(Namespace.of(namespace), tableName));
   }
 
   private TableMetadata updateTable(Table table, GlueTableOperations ops) {

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogLock.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogLock.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.aws.s3.S3FileIO;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.iceberg.util.Tasks;
@@ -74,7 +75,7 @@ public class TestGlueCatalogLock extends GlueTestBase {
     String namespace = createNamespace();
     String tableName = getRandomName();
     createTable(namespace, tableName);
-    Table table = glueCatalog.loadTable(TableIdentifier.of(namespace, tableName));
+    Table table = glueCatalog.loadTable(TableIdentifier.of(Namespace.of(namespace), tableName));
     DataFile dataFile = DataFiles.builder(partitionSpec)
         .withPath("/path/to/data-a.parquet")
         .withFileSizeInBytes(1)
@@ -104,7 +105,7 @@ public class TestGlueCatalogLock extends GlueTestBase {
     String namespace = createNamespace();
     String tableName = getRandomName();
     createTable(namespace, tableName);
-    Table table = glueCatalog.loadTable(TableIdentifier.of(namespace, tableName));
+    Table table = glueCatalog.loadTable(TableIdentifier.of(Namespace.of(namespace), tableName));
     String fileName = UUID.randomUUID().toString();
     DataFile file = DataFiles.builder(table.spec())
         .withPath(FileFormat.PARQUET.addExtension(fileName))

--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
@@ -322,7 +322,7 @@ public class DynamoDbCatalog extends BaseMetastoreCatalog implements Closeable, 
         for (Map<String, AttributeValue> item : response.items()) {
           String identifier = item.get(COL_IDENTIFIER).s();
           if (!COL_IDENTIFIER_NAMESPACE.equals(identifier)) {
-            identifiers.add(TableIdentifier.of(identifier.split("\\.")));
+            identifiers.add(TableIdentifier.parse(identifier));
           }
         }
       }

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueToIcebergConverter.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueToIcebergConverter.java
@@ -36,7 +36,7 @@ class GlueToIcebergConverter {
   }
 
   static TableIdentifier toTableId(Table table) {
-    return TableIdentifier.of(table.databaseName(), table.name());
+    return TableIdentifier.of(Namespace.of(table.databaseName()), table.name());
   }
 
   /**

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueToIcebergConverter.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueToIcebergConverter.java
@@ -48,7 +48,7 @@ public class TestGlueToIcebergConverter {
         .databaseName("db")
         .name("name")
         .build();
-    TableIdentifier icebergId = TableIdentifier.of("db", "name");
+    TableIdentifier icebergId = TableIdentifier.of(Namespace.of("db"), "name");
     Assert.assertEquals(icebergId, GlueToIcebergConverter.toTableId(table));
   }
 

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -72,7 +72,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
     String tableName = identifier.name();
     MetadataTableType type = MetadataTableType.from(tableName);
     if (type != null) {
-      TableIdentifier baseTableIdentifier = TableIdentifier.of(identifier.namespace().levels());
+      TableIdentifier baseTableIdentifier = TableIdentifier.of(identifier.namespace());
       TableOperations ops = newTableOps(baseTableIdentifier);
       if (ops.current() == null) {
         throw new NoSuchTableException("Table does not exist: %s", baseTableIdentifier);
@@ -86,7 +86,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
 
   private boolean isValidMetadataIdentifier(TableIdentifier identifier) {
     return MetadataTableType.from(identifier.name()) != null &&
-        isValidIdentifier(TableIdentifier.of(identifier.namespace().levels()));
+        isValidIdentifier(TableIdentifier.of(identifier.namespace()));
   }
 
   protected boolean isValidIdentifier(TableIdentifier tableIdentifier) {
@@ -230,11 +230,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
       sb.append(catalogName).append(".");
     }
 
-    for (String level : identifier.namespace().levels()) {
-      sb.append(level).append(".");
-    }
-
-    sb.append(identifier.name());
+    sb.append(identifier.toString());
 
     return sb.toString();
   }

--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -76,7 +76,7 @@ public class CachingCatalog implements Catalog {
     }
 
     if (MetadataTableUtils.hasMetadataTableName(canonicalized)) {
-      TableIdentifier originTableIdentifier = TableIdentifier.of(canonicalized.namespace().levels());
+      TableIdentifier originTableIdentifier = TableIdentifier.of(canonicalized.namespace());
       Table originTable = tableCache.get(originTableIdentifier, catalog::loadTable);
 
       // share TableOperations instance of origin table for all metadata tables, so that metadata table instances are
@@ -119,8 +119,8 @@ public class CachingCatalog implements Catalog {
 
     for (MetadataTableType type : MetadataTableType.values()) {
       // metadata table resolution is case insensitive right now
-      builder.add(TableIdentifier.parse(ident + "." + type.name()));
-      builder.add(TableIdentifier.parse(ident + "." + type.name().toLowerCase(Locale.ROOT)));
+      builder.add(TableIdentifier.of(Namespace.of(ident.toString()), type.name()));
+      builder.add(TableIdentifier.of(Namespace.of(ident.toString()), type.name().toLowerCase(Locale.ROOT)));
     }
 
     return builder.build();

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcTableConcurrency.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcTableConcurrency.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
@@ -53,7 +54,7 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class TestJdbcTableConcurrency {
 
-  static final TableIdentifier TABLE_IDENTIFIER = TableIdentifier.of("db", "test_table");
+  static final TableIdentifier TABLE_IDENTIFIER = TableIdentifier.of(Namespace.of("db"), "test_table");
   static final Schema SCHEMA = new Schema(
       required(1, "id", Types.IntegerType.get(), "unique ID"),
       required(2, "data", Types.StringType.get())

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -38,6 +38,7 @@ import org.apache.flink.table.factories.DynamicTableSinkFactory;
 import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.utils.TableSchemaUtils;
 import org.apache.flink.util.Preconditions;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.common.DynMethods;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
@@ -191,7 +192,8 @@ public class FlinkDynamicTableFactory implements DynamicTableSinkFactory, Dynami
       }
     }
 
-    return TableLoader.fromCatalog(flinkCatalog.getCatalogLoader(), TableIdentifier.of(catalogDatabase, catalogTable));
+    return TableLoader.fromCatalog(flinkCatalog.getCatalogLoader(), TableIdentifier.of(
+        Namespace.of(catalogDatabase), catalogTable));
   }
 
   private static TableLoader createTableLoader(FlinkCatalog catalog, ObjectPath objectPath) {

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/TableLoader.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/TableLoader.java
@@ -94,13 +94,13 @@ public interface TableLoader extends Closeable, Serializable {
     private static final long serialVersionUID = 1L;
 
     private final CatalogLoader catalogLoader;
-    private final String identifier;
+    private final TableIdentifier identifier;
 
     private transient Catalog catalog;
 
     private CatalogTableLoader(CatalogLoader catalogLoader, TableIdentifier tableIdentifier) {
       this.catalogLoader = catalogLoader;
-      this.identifier = tableIdentifier.toString();
+      this.identifier = tableIdentifier;
     }
 
     @Override
@@ -110,7 +110,7 @@ public interface TableLoader extends Closeable, Serializable {
 
     @Override
     public Table loadTable() {
-      return catalog.loadTable(TableIdentifier.parse(identifier));
+      return catalog.loadTable(identifier);
     }
 
     @Override

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestCatalogTableLoader.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestCatalogTableLoader.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.hadoop.HadoopTables;
@@ -47,7 +48,7 @@ import org.junit.Test;
 public class TestCatalogTableLoader extends FlinkTestBase {
 
   private static File warehouse = null;
-  private static final TableIdentifier IDENTIFIER = TableIdentifier.of("default", "my_table");
+  private static final TableIdentifier IDENTIFIER = TableIdentifier.of(Namespace.of("default"), "my_table");
   private static final Schema SCHEMA = new Schema(Types.NestedField.required(1, "f1", Types.StringType.get()));
 
   @BeforeClass

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestChangeLogTable.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestChangeLogTable.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.flink.source.BoundedTableFactory;
@@ -251,7 +252,7 @@ public class TestChangeLogTable extends ChangeLogTableTestBase {
     CatalogLoader loader = CatalogLoader.hadoop("my_catalog", CONF, ImmutableMap.of(
         CatalogProperties.WAREHOUSE_LOCATION, warehouse
     ));
-    Table table = loader.loadCatalog().loadTable(TableIdentifier.of(DATABASE_NAME, TABLE_NAME));
+    Table table = loader.loadCatalog().loadTable(TableIdentifier.of(Namespace.of(DATABASE_NAME), TABLE_NAME));
     TableOperations ops = ((BaseTable) table).operations();
     TableMetadata meta = ops.current();
     ops.commit(meta, meta.upgradeToFormatVersion(2));

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestFixtures.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestFixtures.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.flink;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.types.Types;
 
@@ -48,5 +49,5 @@ public class TestFixtures {
   public static final String DATABASE = "default";
   public static final String TABLE = "t";
 
-  public static final TableIdentifier TABLE_IDENTIFIER = TableIdentifier.of(DATABASE, TABLE);
+  public static final TableIdentifier TABLE_IDENTIFIER = TableIdentifier.of(Namespace.of(DATABASE), TABLE);
 }

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkInputFormat.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkInputFormat.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.Row;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.GenericAppenderHelper;
 import org.apache.iceberg.data.RandomGenericData;
@@ -71,7 +72,7 @@ public class TestFlinkInputFormat extends TestFlinkSource {
             Types.NestedField.required(5, "f3", Types.LongType.get()))),
         required(6, "id", Types.LongType.get()));
 
-    Table table = catalog.createTable(TableIdentifier.of("default", "t"), schema);
+    Table table = catalog.createTable(TableIdentifier.of(Namespace.of("default"), "t"), schema);
 
     List<Record> writeRecords = RandomGenericData.generate(schema, 2, 0L);
     new GenericAppenderHelper(table, fileFormat, TEMPORARY_FOLDER).appendToTable(writeRecords);
@@ -106,7 +107,7 @@ public class TestFlinkInputFormat extends TestFlinkSource {
         Types.NestedField.optional(2, "time", Types.TimestampType.withZone())
     );
 
-    Table table = catalog.createTable(TableIdentifier.of("default", "t"), writeSchema);
+    Table table = catalog.createTable(TableIdentifier.of(Namespace.of("default"), "t"), writeSchema);
 
     List<Record> writeRecords = RandomGenericData.generate(writeSchema, 2, 0L);
     new GenericAppenderHelper(table, fileFormat, TEMPORARY_FOLDER).appendToTable(writeRecords);

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkInputFormatReaderDeletes.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkInputFormatReaderDeletes.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.flink.CatalogLoader;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
@@ -53,7 +54,7 @@ public class TestFlinkInputFormatReaderDeletes extends TestFlinkReaderDeletesBas
         Integer.toString(hiveConf.getInt("iceberg.hive.client-pool-size", 5)));
     CatalogLoader hiveCatalogLoader = CatalogLoader.hive(catalog.name(), hiveConf, properties);
     FlinkInputFormat inputFormat = FlinkSource.forRowData()
-        .tableLoader(TableLoader.fromCatalog(hiveCatalogLoader, TableIdentifier.of("default", tableName)))
+        .tableLoader(TableLoader.fromCatalog(hiveCatalogLoader, TableIdentifier.of(Namespace.of("default"), tableName)))
         .project(FlinkSchemaUtil.toSchema(rowType)).buildFormat();
 
     StructLikeSet set = StructLikeSet.create(projected.asStruct());

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkReaderDeletesBase.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkReaderDeletesBase.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.DeleteReadTests;
 import org.apache.iceberg.hive.HiveCatalog;
@@ -90,7 +91,7 @@ public abstract class TestFlinkReaderDeletesBase extends DeleteReadTests {
     Map<String, String> props = Maps.newHashMap();
     props.put(TableProperties.DEFAULT_FILE_FORMAT, format.name());
 
-    Table table = catalog.createTable(TableIdentifier.of(databaseName, name), schema, spec, props);
+    Table table = catalog.createTable(TableIdentifier.of(Namespace.of(databaseName), name), schema, spec, props);
     TableOperations ops = ((BaseTable) table).operations();
     TableMetadata meta = ops.current();
     ops.commit(meta, meta.upgradeToFormatVersion(2));
@@ -100,7 +101,7 @@ public abstract class TestFlinkReaderDeletesBase extends DeleteReadTests {
 
   @Override
   protected void dropTable(String name) {
-    catalog.dropTable(TableIdentifier.of(databaseName, name));
+    catalog.dropTable(TableIdentifier.of(Namespace.of(databaseName), name));
   }
 
   @Override

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkScanSql.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkScanSql.java
@@ -32,6 +32,7 @@ import org.apache.flink.util.CloseableIterator;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.GenericAppenderHelper;
 import org.apache.iceberg.data.RandomGenericData;
@@ -101,7 +102,8 @@ public class TestFlinkScanSql extends TestFlinkSource {
 
   @Test
   public void testResiduals() throws Exception {
-    Table table = catalog.createTable(TableIdentifier.of("default", "t"), TestFixtures.SCHEMA, TestFixtures.SPEC);
+    Table table =
+        catalog.createTable(TableIdentifier.of(Namespace.of("default"), "t"), TestFixtures.SCHEMA, TestFixtures.SPEC);
 
     List<Record> writeRecords = RandomGenericData.generate(TestFixtures.SCHEMA, 2, 0L);
     writeRecords.get(0).set(1, 123L);
@@ -126,7 +128,8 @@ public class TestFlinkScanSql extends TestFlinkSource {
 
   @Test
   public void testInferedParallelism() throws IOException {
-    Table table = catalog.createTable(TableIdentifier.of("default", "t"), TestFixtures.SCHEMA, TestFixtures.SPEC);
+    Table table =
+        catalog.createTable(TableIdentifier.of(Namespace.of("default"), "t"), TestFixtures.SCHEMA, TestFixtures.SPEC);
 
     TableLoader tableLoader = TableLoader.fromHadoopTable(table.location());
     FlinkInputFormat flinkInputFormat = FlinkSource.forRowData().tableLoader(tableLoader).table(table).buildFormat();

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkSource.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkSource.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 import org.apache.flink.table.api.TableColumn;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.types.Row;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
@@ -41,7 +42,7 @@ public abstract class TestFlinkSource extends TestFlinkScan {
   protected List<Row> runWithProjection(String... projected) throws Exception {
     TableSchema.Builder builder = TableSchema.builder();
     TableSchema schema = FlinkSchemaUtil.toSchema(FlinkSchemaUtil.convert(
-        catalog.loadTable(TableIdentifier.of("default", "t")).schema()));
+        catalog.loadTable(TableIdentifier.of(Namespace.of("default"), "t")).schema()));
     for (String field : projected) {
       TableColumn column = schema.getTableColumn(field).get();
       builder.field(column.getName(), column.getType());

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveCreateReplaceTableTest.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveCreateReplaceTableTest.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.Transaction;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
@@ -48,7 +49,7 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 public class HiveCreateReplaceTableTest extends HiveMetastoreTest {
 
   private static final String TABLE_NAME = "tbl";
-  private static final TableIdentifier TABLE_IDENTIFIER = TableIdentifier.of(DB_NAME, TABLE_NAME);
+  private static final TableIdentifier TABLE_IDENTIFIER = TableIdentifier.of(Namespace.of(DB_NAME), TABLE_NAME);
   private static final Schema SCHEMA = new Schema(
       required(3, "id", Types.IntegerType.get()),
       required(4, "data", Types.StringType.get())

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveTableBaseTest.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveTableBaseTest.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableMetadataParser;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.types.Types;
 import org.junit.After;
@@ -42,7 +43,7 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 public class HiveTableBaseTest extends HiveMetastoreTest {
 
   static final String TABLE_NAME =  "tbl";
-  static final TableIdentifier TABLE_IDENTIFIER = TableIdentifier.of(DB_NAME, TABLE_NAME);
+  static final TableIdentifier TABLE_IDENTIFIER = TableIdentifier.of(Namespace.of(DB_NAME), TABLE_NAME);
 
   static final Schema schema = new Schema(Types.StructType.of(
       required(1, "id", Types.LongType.get())).fields());

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -72,7 +72,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
     PartitionSpec spec = PartitionSpec.builderFor(schema)
         .bucket("data", 16)
         .build();
-    TableIdentifier tableIdent = TableIdentifier.of(DB_NAME, "tbl");
+    TableIdentifier tableIdent = TableIdentifier.of(Namespace.of(DB_NAME), "tbl");
     String location = temp.newFolder("tbl").toString();
 
     try {
@@ -102,7 +102,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
     PartitionSpec spec = PartitionSpec.builderFor(schema)
         .bucket("data", 16)
         .build();
-    TableIdentifier tableIdent = TableIdentifier.of(DB_NAME, "tbl");
+    TableIdentifier tableIdent = TableIdentifier.of(Namespace.of(DB_NAME), "tbl");
     String location = temp.newFolder("tbl").toString();
     ImmutableMap<String, String> properties = ImmutableMap.of("key1", "value1", "key2", "value2");
     Catalog cachingCatalog = CachingCatalog.wrap(catalog);
@@ -154,7 +154,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
         required(1, "id", Types.IntegerType.get(), "unique ID"),
         required(2, "data", Types.StringType.get())
     );
-    TableIdentifier tableIdent = TableIdentifier.of(DB_NAME, "tbl");
+    TableIdentifier tableIdent = TableIdentifier.of(Namespace.of(DB_NAME), "tbl");
     String location = temp.newFolder("tbl").toString();
 
     try {
@@ -181,7 +181,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
     PartitionSpec spec = PartitionSpec.builderFor(schema)
         .bucket("data", 16)
         .build();
-    TableIdentifier tableIdent = TableIdentifier.of(DB_NAME, "tbl");
+    TableIdentifier tableIdent = TableIdentifier.of(Namespace.of(DB_NAME), "tbl");
     String location = temp.newFolder("tbl").toString();
 
     try {
@@ -229,7 +229,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
     PartitionSpec spec = PartitionSpec.builderFor(schema)
         .bucket("data", 16)
         .build();
-    TableIdentifier tableIdent = TableIdentifier.of(DB_NAME, "tbl");
+    TableIdentifier tableIdent = TableIdentifier.of(Namespace.of(DB_NAME), "tbl");
 
     try {
       Table table = catalog.createTable(tableIdent, schema, spec);
@@ -252,7 +252,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
     SortOrder order = SortOrder.builderFor(schema)
         .asc("id", NULLS_FIRST)
         .build();
-    TableIdentifier tableIdent = TableIdentifier.of(DB_NAME, "tbl");
+    TableIdentifier tableIdent = TableIdentifier.of(Namespace.of(DB_NAME), "tbl");
 
     try {
       Table table = catalog.buildTable(tableIdent, schema)
@@ -418,7 +418,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
     PartitionSpec spec = PartitionSpec.builderFor(schema)
         .bucket("data", 16)
         .build();
-    TableIdentifier tableIdent = TableIdentifier.of(DB_NAME, "tbl");
+    TableIdentifier tableIdent = TableIdentifier.of(Namespace.of(DB_NAME), "tbl");
 
     try {
       catalog.buildTable(tableIdent, schema)
@@ -428,7 +428,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
       Table table = catalog.loadTable(tableIdent);
       Assert.assertEquals("Name must match", "hive.hivedb.tbl", table.name());
 
-      TableIdentifier snapshotsTableIdent = TableIdentifier.of(DB_NAME, "tbl", "snapshots");
+      TableIdentifier snapshotsTableIdent = TableIdentifier.of(Namespace.of(DB_NAME, "tbl"), "snapshots");
       Table snapshotsTable = catalog.loadTable(snapshotsTableIdent);
       Assert.assertEquals("Name must match", "hive.hivedb.tbl.snapshots", snapshotsTable.name());
     } finally {

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.hive.HiveSchemaUtil;
@@ -223,7 +224,8 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
     }
 
     if (properties.get(Catalogs.NAME) == null) {
-      properties.put(Catalogs.NAME, TableIdentifier.of(hmsTable.getDbName(), hmsTable.getTableName()).toString());
+      properties.put(Catalogs.NAME,
+          TableIdentifier.of(Namespace.of(hmsTable.getDbName()), hmsTable.getTableName()).toString());
     }
 
     // Remove HMS table parameters we don't want to propagate to Iceberg

--- a/mr/src/test/java/org/apache/iceberg/mr/TestCatalogs.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestCatalogs.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.hadoop.HadoopCatalog;
@@ -89,7 +90,7 @@ public class TestCatalogs {
             "identifier not set", () -> Catalogs.loadTable(conf));
 
     HadoopCatalog catalog = new CustomHadoopCatalog(conf, warehouseLocation);
-    Table hadoopCatalogTable = catalog.createTable(TableIdentifier.of("table"), SCHEMA);
+    Table hadoopCatalogTable = catalog.createTable(TableIdentifier.of(Namespace.empty(), "table"), SCHEMA);
 
     conf.set(InputFormatConfig.TABLE_IDENTIFIER, "table");
 
@@ -142,7 +143,7 @@ public class TestCatalogs {
 
   @Test
   public void testCreateDropTableToCatalog() throws IOException {
-    TableIdentifier identifier = TableIdentifier.of("test", "table");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("test"), "table");
     String defaultCatalogName = "default";
     String warehouseLocation = temp.newFolder("hadoop", "warehouse").toString();
 

--- a/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
@@ -47,6 +47,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TestHelpers.Row;
 import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.expressions.Expressions;
@@ -358,7 +359,7 @@ public class TestIcebergInputFormats {
         CatalogProperties.WAREHOUSE_LOCATION), warehouseLocation);
 
     Catalog catalog = new HadoopCatalog(conf, conf.get("warehouse.location"));
-    TableIdentifier identifier = TableIdentifier.of("db", "t");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("db"), "t");
     Table table = catalog.createTable(identifier, SCHEMA, SPEC, helper.properties());
     helper.setTable(table);
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerLocalScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerLocalScan.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.TestHelpers.Row;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
@@ -243,7 +244,7 @@ public class TestHiveIcebergStorageHandlerLocalScan {
 
   @Test
   public void testCreateTableWithColumnSpecification() throws IOException {
-    TableIdentifier identifier = TableIdentifier.of("default", "customers");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("default"), "customers");
     Map<StructLike, List<Record>> data = new HashMap<>(1);
     data.put(null, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
     String createSql = "CREATE EXTERNAL TABLE " + identifier +
@@ -258,7 +259,7 @@ public class TestHiveIcebergStorageHandlerLocalScan {
 
   @Test
   public void testCreateTableWithColumnSpecificationPartitioned() throws IOException {
-    TableIdentifier identifier = TableIdentifier.of("default", "customers");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("default"), "customers");
     PartitionSpec spec =
         PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA).identity("last_name").build();
     Map<StructLike, List<Record>> data = ImmutableMap.of(
@@ -276,7 +277,7 @@ public class TestHiveIcebergStorageHandlerLocalScan {
 
   @Test
   public void testCreatePartitionedTableByProperty() throws IOException {
-    TableIdentifier identifier = TableIdentifier.of("default", "customers");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("default"), "customers");
     PartitionSpec spec =
         PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA).identity("last_name").build();
     Map<StructLike, List<Record>> data = ImmutableMap.of(
@@ -295,7 +296,7 @@ public class TestHiveIcebergStorageHandlerLocalScan {
 
   @Test
   public void testCreateTableWithColumnSpecificationMultilevelPartitioned() throws IOException {
-    TableIdentifier identifier = TableIdentifier.of("default", "customers");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("default"), "customers");
     PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
         .identity("first_name").identity("last_name").build();
     Map<StructLike, List<Record>> data = ImmutableMap.of(

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -44,6 +44,7 @@ import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.exceptions.NoSuchTableException;
@@ -156,7 +157,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
   @Test
   public void testCreateDropTable() throws TException, IOException, InterruptedException {
-    TableIdentifier identifier = TableIdentifier.of("default", "customers");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("default"), "customers");
 
     shell.executeStatement("CREATE EXTERNAL TABLE customers " +
         "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
@@ -214,7 +215,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
   @Test
   public void testCreateDropTableNonDefaultCatalog() throws TException, InterruptedException {
-    TableIdentifier identifier = TableIdentifier.of("default", "customers");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("default"), "customers");
     String catalogName = "nondefaultcatalog";
     testTables.properties().entrySet()
         .forEach(e -> shell.setHiveSessionValue(e.getKey().replace(testTables.catalog, catalogName), e.getValue()));
@@ -241,7 +242,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
   @Test
   public void testCreateTableWithoutSpec() {
-    TableIdentifier identifier = TableIdentifier.of("default", "customers");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("default"), "customers");
 
     shell.executeStatement("CREATE EXTERNAL TABLE customers " +
         "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
@@ -257,7 +258,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
   @Test
   public void testCreateTableWithUnpartitionedSpec() {
-    TableIdentifier identifier = TableIdentifier.of("default", "customers");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("default"), "customers");
     // We need the location for HadoopTable based tests only
     shell.executeStatement("CREATE EXTERNAL TABLE customers " +
         "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
@@ -275,7 +276,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
   @Test
   public void testCreateTableWithFormatV2ThroughTableProperty() {
-    TableIdentifier identifier = TableIdentifier.of("default", "customers");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("default"), "customers");
     // We need the location for HadoopTable based tests only
     shell.executeStatement("CREATE EXTERNAL TABLE customers " +
         "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
@@ -295,7 +296,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
   @Test
   public void testDeleteBackingTable() throws TException, IOException, InterruptedException {
-    TableIdentifier identifier = TableIdentifier.of("default", "customers");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("default"), "customers");
 
     shell.executeStatement("CREATE EXTERNAL TABLE customers " +
         "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
@@ -342,7 +343,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
         testTableType == TestTables.TestTableType.HIVE_CATALOG);
 
     // create test table
-    TableIdentifier identifier = TableIdentifier.of("default", "customers");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("default"), "customers");
     testTables.createTable(shell, identifier.name(),
         HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, FileFormat.PARQUET, ImmutableList.of());
 
@@ -366,7 +367,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
   @Test
   public void testCreateTableError() {
-    TableIdentifier identifier = TableIdentifier.of("default", "withShell2");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("default"), "withShell2");
 
     // Wrong schema
     AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
@@ -424,7 +425,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
       // With other catalogs, table creation should succeed
       shell.executeStatement("CREATE EXTERNAL TABLE customers " +
           "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
-          testTables.locationForCreateTableSQL(TableIdentifier.of("default", "customers")) +
+          testTables.locationForCreateTableSQL(TableIdentifier.of(Namespace.of("default"), "customers")) +
           testTables.propertiesForCreateTableSQL(ImmutableMap.of()));
     }
   }
@@ -439,7 +440,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
           shell.executeStatement("CREATE EXTERNAL TABLE customers (customer_id BIGINT) " +
               "PARTITIONED BY (first_name STRING) " +
               "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
-              testTables.locationForCreateTableSQL(TableIdentifier.of("default", "customers")) +
+              testTables.locationForCreateTableSQL(TableIdentifier.of(Namespace.of("default"), "customers")) +
               " TBLPROPERTIES ('" + InputFormatConfig.PARTITION_SPEC + "'='" +
               PartitionSpecParser.toJson(spec) + "')");
         }
@@ -448,7 +449,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
   @Test
   public void testCreateTableWithColumnSpecificationHierarchy() {
-    TableIdentifier identifier = TableIdentifier.of("default", "customers");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("default"), "customers");
 
     shell.executeStatement("CREATE EXTERNAL TABLE customers (" +
         "id BIGINT, name STRING, " +
@@ -468,7 +469,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
   @Test
   public void testCreateTableWithAllSupportedTypes() {
-    TableIdentifier identifier = TableIdentifier.of("default", "all_types");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("default"), "all_types");
     Schema allSupportedSchema = new Schema(
         optional(1, "t_float", Types.FloatType.get()),
         optional(2, "t_double", Types.DoubleType.get()),
@@ -497,7 +498,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
   @Test
   public void testCreateTableWithNotSupportedTypes() {
-    TableIdentifier identifier = TableIdentifier.of("default", "not_supported_types");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("default"), "not_supported_types");
     // Can not create INTERVAL types from normal create table, so leave them out from this test
     Map<String, Type> notSupportedTypes = ImmutableMap.of(
         "TINYINT", Types.IntegerType.get(),
@@ -520,7 +521,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
   @Test
   public void testCreateTableWithNotSupportedTypesWithAutoConversion() {
-    TableIdentifier identifier = TableIdentifier.of("default", "not_supported_types");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("default"), "not_supported_types");
     // Can not create INTERVAL types from normal create table, so leave them out from this test
     Map<String, Type> notSupportedTypes = ImmutableMap.of(
         "TINYINT", Types.IntegerType.get(),
@@ -544,7 +545,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
   @Test
   public void testCreateTableWithColumnComments() {
-    TableIdentifier identifier = TableIdentifier.of("default", "comment_table");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("default"), "comment_table");
     shell.executeStatement("CREATE EXTERNAL TABLE comment_table (" +
         "t_int INT COMMENT 'int column',  " +
         "t_string STRING COMMENT 'string column', " +
@@ -565,7 +566,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
   @Test
   public void testCreateTableWithoutColumnComments() {
-    TableIdentifier identifier = TableIdentifier.of("default", "without_comment_table");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("default"), "without_comment_table");
     shell.executeStatement("CREATE EXTERNAL TABLE without_comment_table (" +
             "t_int INT,  " +
             "t_string STRING) " +
@@ -586,7 +587,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
   @Test
   public void testIcebergAndHmsTableProperties() throws Exception {
-    TableIdentifier identifier = TableIdentifier.of("default", "customers");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("default"), "customers");
 
     shell.executeStatement(String.format("CREATE EXTERNAL TABLE default.customers " +
         "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' %s" +
@@ -704,7 +705,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
     Assume.assumeTrue("Iceberg - HMS property translation is only relevant for HiveCatalog",
         testTableType == TestTables.TestTableType.HIVE_CATALOG);
 
-    TableIdentifier identifier = TableIdentifier.of("default", "customers");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("default"), "customers");
 
     // Create HMS table with with a property to be translated
     shell.executeStatement(String.format("CREATE EXTERNAL TABLE default.customers " +
@@ -732,7 +733,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
   @Test
   public void testDropTableWithAppendedData() throws IOException {
-    TableIdentifier identifier = TableIdentifier.of("default", "customers");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("default"), "customers");
 
     testTables.createTable(shell, identifier.name(), HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, SPEC,
         FileFormat.PARQUET, ImmutableList.of());
@@ -749,7 +750,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
     Assume.assumeFalse("Not relevant for HiveCatalog",
             testTableType.equals(TestTables.TestTableType.HIVE_CATALOG));
 
-    TableIdentifier identifier = TableIdentifier.of("default", "customers");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("default"), "customers");
     // Create the Iceberg table in non-HiveCatalog
     testTables.createIcebergTable(shell.getHiveConf(), identifier.name(),
         HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, FileFormat.PARQUET,

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
@@ -706,7 +707,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
         executionEngine.equals("mr") && testTableType == TestTables.TestTableType.HIVE_CATALOG &&
                 fileFormat == FileFormat.ORC);
 
-    TableIdentifier identifier = TableIdentifier.of("default", "customers");
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("default"), "customers");
 
     // create Iceberg table without specifying a write format in the tbl properties
     // it should fall back to using the default file format

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithMultipleCatalogs.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithMultipleCatalogs.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.List;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.mr.InputFormatConfig;
@@ -115,9 +116,9 @@ public class TestHiveIcebergStorageHandlerWithMultipleCatalogs {
 
   @Test
   public void testJoinTablesFromDifferentCatalogs() throws IOException {
-    createAndAddRecords(testTables1, fileFormat1, TableIdentifier.of("default", "customers1"),
+    createAndAddRecords(testTables1, fileFormat1, TableIdentifier.of(Namespace.of("default"), "customers1"),
         HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-    createAndAddRecords(testTables2, fileFormat2, TableIdentifier.of("default", "customers2"),
+    createAndAddRecords(testTables2, fileFormat2, TableIdentifier.of(Namespace.of("default"), "customers2"),
         HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
 
     List<Object[]> rows = shell.executeStatement("SELECT c2.customer_id, c2.first_name, c2.last_name " +

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
@@ -44,6 +44,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.Tables;
 import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.expressions.Expressions;
@@ -167,7 +168,8 @@ abstract class TestTables {
   public Table createTable(TestHiveShell shell, String tableName, Schema schema, FileFormat fileFormat,
       List<Record> records) throws IOException {
     Table table = createIcebergTable(shell.getHiveConf(), tableName, schema, fileFormat, records);
-    String createHiveSQL = createHiveTableSQL(TableIdentifier.of("default", tableName), ImmutableMap.of());
+    String createHiveSQL =
+        createHiveTableSQL(TableIdentifier.of(Namespace.of("default"), tableName), ImmutableMap.of());
     if (createHiveSQL != null) {
       shell.executeStatement(createHiveSQL);
     }
@@ -189,7 +191,7 @@ abstract class TestTables {
    */
   public Table createTable(TestHiveShell shell, String tableName, Schema schema, PartitionSpec spec,
       FileFormat fileFormat, List<Record> records)  {
-    TableIdentifier identifier = TableIdentifier.of("default", tableName);
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("default"), tableName);
     shell.executeStatement("CREATE EXTERNAL TABLE " + identifier +
         " STORED BY '" + HiveIcebergStorageHandler.class.getName() + "' " +
         locationForCreateTableSQL(identifier) +

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
@@ -63,8 +63,9 @@ public final class NessieUtil {
   }
 
   static TableIdentifier toIdentifier(EntriesResponse.Entry entry) {
-    List<String> elements = entry.getName().getElements();
-    return TableIdentifier.of(elements.toArray(new String[elements.size()]));
+    return TableIdentifier.of(
+        Namespace.of(entry.getName().getNamespace().name()),
+        entry.getName().getElements().get(entry.getName().getElements().size() - 1));
   }
 
   static TableIdentifier removeCatalogName(TableIdentifier to, String name) {

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestBranchVisibility.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestBranchVisibility.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.nessie;
 
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.types.Types;
 import org.assertj.core.api.Assertions;
@@ -30,8 +31,8 @@ import org.projectnessie.error.NessieNotFoundException;
 
 public class TestBranchVisibility extends BaseTestIceberg {
 
-  private final TableIdentifier tableIdentifier1 = TableIdentifier.of("test-ns", "table1");
-  private final TableIdentifier tableIdentifier2 = TableIdentifier.of("test-ns", "table2");
+  private final TableIdentifier tableIdentifier1 = TableIdentifier.of(Namespace.of("test-ns"), "table1");
+  private final TableIdentifier tableIdentifier2 = TableIdentifier.of(Namespace.of("test-ns"), "table2");
   private NessieCatalog testCatalog;
   private int schemaCounter = 1;
 
@@ -99,14 +100,14 @@ public class TestBranchVisibility extends BaseTestIceberg {
     String mainName = "main";
 
     // asking for table@branch gives expected regardless of catalog
-    Assertions.assertThat(metadataLocation(catalog, TableIdentifier.of("test-ns", "table1@test")))
+    Assertions.assertThat(metadataLocation(catalog, TableIdentifier.of(Namespace.of("test-ns"), "table1@test")))
         .isEqualTo(metadataLocation(testCatalog, tableIdentifier1));
 
     // Asking for table@branch gives expected regardless of catalog.
     // Earlier versions used "table1@" + tree.getReferenceByName("main").getHash() before, but since
     // Nessie 0.8.2 the branch name became mandatory and specifying a hash within a branch is not
     // possible.
-    Assertions.assertThat(metadataLocation(catalog, TableIdentifier.of("test-ns", "table1@" + mainName)))
+    Assertions.assertThat(metadataLocation(catalog, TableIdentifier.of(Namespace.of("test-ns"), "table1@" + mainName)))
         .isEqualTo(metadataLocation(testCatalog, tableIdentifier1));
   }
 

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNamespace.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNamespace.java
@@ -35,12 +35,12 @@ public class TestNamespace extends BaseTestIceberg {
 
   @Test
   public void testListNamespaces() {
-    createTable(TableIdentifier.parse("a.b.c.t1"));
-    createTable(TableIdentifier.parse("a.b.t2"));
-    createTable(TableIdentifier.parse("a.t3"));
-    createTable(TableIdentifier.parse("b.c.t4"));
-    createTable(TableIdentifier.parse("b.t5"));
-    createTable(TableIdentifier.parse("t6"));
+    createTable(TableIdentifier.of(Namespace.of("a.b.c"), "t1"));
+    createTable(TableIdentifier.of(Namespace.of("a.b"), "t2"));
+    createTable(TableIdentifier.of(Namespace.of("a"), "t3"));
+    createTable(TableIdentifier.of(Namespace.of("b.c"), "t4"));
+    createTable(TableIdentifier.of(Namespace.of("b"), "t5"));
+    createTable(TableIdentifier.of(Namespace.empty(), "t6"));
 
     List<TableIdentifier> tables = catalog.listTables(Namespace.of("a", "b", "c"));
     Assertions.assertThat(tables).isNotNull().hasSize(1);

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
@@ -39,6 +39,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.io.FileAppender;
@@ -67,7 +68,7 @@ public class TestNessieTable extends BaseTestIceberg {
 
   private static final String DB_NAME = "db";
   private static final String TABLE_NAME = "tbl";
-  private static final TableIdentifier TABLE_IDENTIFIER = TableIdentifier.of(DB_NAME, TABLE_NAME);
+  private static final TableIdentifier TABLE_IDENTIFIER = TableIdentifier.of(Namespace.of(DB_NAME), TABLE_NAME);
   private static final ContentsKey KEY = ContentsKey.of(DB_NAME, TABLE_NAME);
   private static final Schema schema = new Schema(Types.StructType.of(
       required(1, "id", Types.LongType.get())).fields());

--- a/spark/v3.2/spark-runtime/src/integration/java/org/apache/iceberg/spark/SmokeTest.java
+++ b/spark/v3.2/spark-runtime/src/integration/java/org/apache/iceberg/spark/SmokeTest.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.spark;
 import java.io.IOException;
 import java.util.Map;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.spark.extensions.SparkExtensionsTestBase;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
@@ -150,7 +151,7 @@ public class SmokeTest extends SparkExtensionsTestBase {
   }
 
   private Table getTable(String name) {
-    return validationCatalog.loadTable(TableIdentifier.of("default", name));
+    return validationCatalog.loadTable(TableIdentifier.of(Namespace.of("default"), name));
   }
 
   private Table getTable() {

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/actions/TestRemoveOrphanFilesAction.java
@@ -574,8 +574,8 @@ public abstract class TestRemoveOrphanFilesAction extends SparkTestBase {
 
   @Test
   public void testHiveCatalogTable() throws IOException {
-    Table table = catalog.createTable(TableIdentifier.of("default", "hivetestorphan"), SCHEMA, SPEC, tableLocation,
-        Maps.newHashMap());
+    Table table = catalog.createTable(TableIdentifier.of(Namespace.of("default"), "hivetestorphan"), SCHEMA, SPEC,
+        tableLocation, Maps.newHashMap());
 
     List<ThreeColumnRecord> records = Lists.newArrayList(
         new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA")

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceHiveTables.java
@@ -59,7 +59,9 @@ public class TestIcebergSourceHiveTables extends TestIcebergSourceTablesBase {
 
   @Override
   public Table loadTable(TableIdentifier ident, String entriesSuffix) {
-    TableIdentifier identifier = TableIdentifier.of(ident.namespace().level(0), ident.name(), entriesSuffix);
+    TableIdentifier identifier = TableIdentifier.of(
+        Namespace.of(ident.namespace().level(0) + "." + ident.name()),
+        entriesSuffix);
     return TestIcebergSourceHiveTables.catalog.loadTable(identifier);
   }
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.actions.Actions;
 import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
@@ -84,7 +85,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
   @Test
   public synchronized void testTablesSupport() {
-    TableIdentifier tableIdentifier = TableIdentifier.of("db", "table");
+    TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db"), "table");
     createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
 
     List<SimpleRecord> expectedRecords = Lists.newArrayList(
@@ -110,7 +111,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
   @Test
   public void testEntriesTable() throws Exception {
-    TableIdentifier tableIdentifier = TableIdentifier.of("db", "entries_test");
+    TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db"), "entries_test");
     Table table = createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
     Table entriesTable = loadTable(tableIdentifier, "entries");
 
@@ -152,7 +153,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
   @Test
   public void testEntriesTablePartitionedPrune() throws Exception {
-    TableIdentifier tableIdentifier = TableIdentifier.of("db", "entries_test");
+    TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db"), "entries_test");
     Table table = createTable(tableIdentifier, SCHEMA, SPEC);
 
     List<SimpleRecord> records = Lists.newArrayList(new SimpleRecord(1, "1"));
@@ -177,7 +178,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
   @Test
   public void testEntriesTableDataFilePrune() throws Exception {
-    TableIdentifier tableIdentifier = TableIdentifier.of("db", "entries_test");
+    TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db"), "entries_test");
     Table table = createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
 
     List<SimpleRecord> records = Lists.newArrayList(new SimpleRecord(1, "1"));
@@ -204,7 +205,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
   @Test
   public void testEntriesTableDataFilePruneMulti() throws Exception {
-    TableIdentifier tableIdentifier = TableIdentifier.of("db", "entries_test");
+    TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db"), "entries_test");
     Table table = createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
 
     List<SimpleRecord> records = Lists.newArrayList(new SimpleRecord(1, "1"));
@@ -232,7 +233,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
   @Test
   public void testFilesSelectMap() throws Exception {
-    TableIdentifier tableIdentifier = TableIdentifier.of("db", "entries_test");
+    TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db"), "entries_test");
     Table table = createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
 
     List<SimpleRecord> records = Lists.newArrayList(new SimpleRecord(1, "1"));
@@ -260,7 +261,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
   @Test
   public void testAllEntriesTable() throws Exception {
-    TableIdentifier tableIdentifier = TableIdentifier.of("db", "entries_test");
+    TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db"), "entries_test");
     Table table = createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
     Table entriesTable = loadTable(tableIdentifier, "all_entries");
 
@@ -315,7 +316,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
   @Test
   public void testCountEntriesTable() {
-    TableIdentifier tableIdentifier = TableIdentifier.of("db", "count_entries_test");
+    TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db"), "count_entries_test");
     createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
 
     // init load
@@ -339,7 +340,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
   @Test
   public void testFilesTable() throws Exception {
-    TableIdentifier tableIdentifier = TableIdentifier.of("db", "files_test");
+    TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db"), "files_test");
     Table table = createTable(tableIdentifier, SCHEMA, SPEC);
     Table entriesTable = loadTable(tableIdentifier, "entries");
     Table filesTable = loadTable(tableIdentifier, "files");
@@ -389,7 +390,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
   public void testFilesTableWithSnapshotIdInheritance() throws Exception {
     spark.sql("DROP TABLE IF EXISTS parquet_table");
 
-    TableIdentifier tableIdentifier = TableIdentifier.of("db", "files_inheritance_test");
+    TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db"), "files_inheritance_test");
     Table table = createTable(tableIdentifier, SCHEMA, SPEC);
     table.updateProperties()
         .set(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, "true")
@@ -449,7 +450,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
   public void testEntriesTableWithSnapshotIdInheritance() throws Exception {
     spark.sql("DROP TABLE IF EXISTS parquet_table");
 
-    TableIdentifier tableIdentifier = TableIdentifier.of("db", "entries_inheritance_test");
+    TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db"), "entries_inheritance_test");
     PartitionSpec spec = SPEC;
     Table table = createTable(tableIdentifier, SCHEMA, spec);
 
@@ -499,7 +500,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
   @Test
   public void testFilesUnpartitionedTable() throws Exception {
-    TableIdentifier tableIdentifier = TableIdentifier.of("db", "unpartitioned_files_test");
+    TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db"), "unpartitioned_files_test");
     Table table = createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
     Table entriesTable = loadTable(tableIdentifier, "entries");
     Table filesTable = loadTable(tableIdentifier, "files");
@@ -550,7 +551,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
   @Test
   public void testAllMetadataTablesWithStagedCommits() throws Exception {
-    TableIdentifier tableIdentifier = TableIdentifier.of("db", "stage_aggregate_table_test");
+    TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db"), "stage_aggregate_table_test");
     Table table = createTable(tableIdentifier, SCHEMA, SPEC);
 
     table.updateProperties().set(TableProperties.WRITE_AUDIT_PUBLISH_ENABLED, "true").commit();
@@ -594,7 +595,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
   @Test
   public void testAllDataFilesTable() throws Exception {
-    TableIdentifier tableIdentifier = TableIdentifier.of("db", "files_test");
+    TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db"), "files_test");
     Table table = createTable(tableIdentifier, SCHEMA, SPEC);
     Table entriesTable = loadTable(tableIdentifier, "entries");
     Table filesTable = loadTable(tableIdentifier, "all_data_files");
@@ -651,7 +652,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
   @Test
   public void testHistoryTable() {
-    TableIdentifier tableIdentifier = TableIdentifier.of("db", "history_test");
+    TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db"), "history_test");
     Table table = createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
     Table historyTable = loadTable(tableIdentifier, "history");
 
@@ -726,7 +727,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
   @Test
   public void testSnapshotsTable() {
-    TableIdentifier tableIdentifier = TableIdentifier.of("db", "snapshots_test");
+    TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db"), "snapshots_test");
     Table table = createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
     Table snapTable = loadTable(tableIdentifier, "snapshots");
 
@@ -794,7 +795,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
   @Test
   public void testPrunedSnapshotsTable() {
-    TableIdentifier tableIdentifier = TableIdentifier.of("db", "snapshots_test");
+    TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db"), "snapshots_test");
     Table table = createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
 
     List<SimpleRecord> records = Lists.newArrayList(new SimpleRecord(1, "1"));
@@ -858,7 +859,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
   @Test
   public void testManifestsTable() {
-    TableIdentifier tableIdentifier = TableIdentifier.of("db", "manifests_test");
+    TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db"), "manifests_test");
     Table table = createTable(tableIdentifier, SCHEMA, SPEC);
     Table manifestTable = loadTable(tableIdentifier, "manifests");
     Dataset<Row> df1 = spark.createDataFrame(
@@ -905,7 +906,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
   @Test
   public void testPruneManifestsTable() {
-    TableIdentifier tableIdentifier = TableIdentifier.of("db", "manifests_test");
+    TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db"), "manifests_test");
     Table table = createTable(tableIdentifier, SCHEMA, SPEC);
     Table manifestTable = loadTable(tableIdentifier, "manifests");
     Dataset<Row> df1 = spark.createDataFrame(
@@ -965,7 +966,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
   @Test
   public void testAllManifestsTable() {
-    TableIdentifier tableIdentifier = TableIdentifier.of("db", "manifests_test");
+    TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db"), "manifests_test");
     Table table = createTable(tableIdentifier, SCHEMA, SPEC);
     Table manifestTable = loadTable(tableIdentifier, "all_manifests");
     Dataset<Row> df1 = spark.createDataFrame(Lists.newArrayList(new SimpleRecord(1, "a")), SimpleRecord.class);
@@ -1024,7 +1025,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
   @Test
   public void testUnpartitionedPartitionsTable() {
-    TableIdentifier tableIdentifier = TableIdentifier.of("db", "unpartitioned_partitions_test");
+    TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db"), "unpartitioned_partitions_test");
     createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
 
     Dataset<Row> df = spark.createDataFrame(Lists.newArrayList(new SimpleRecord(1, "a")), SimpleRecord.class);
@@ -1061,7 +1062,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
   @Test
   public void testPartitionsTable() {
-    TableIdentifier tableIdentifier = TableIdentifier.of("db", "partitions_test");
+    TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db"), "partitions_test");
     Table table = createTable(tableIdentifier, SCHEMA, SPEC);
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
     Dataset<Row> df1 = spark.createDataFrame(Lists.newArrayList(new SimpleRecord(1, "a")), SimpleRecord.class);
@@ -1142,7 +1143,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
   @Test
   public void testRemoveOrphanFilesActionSupport() throws InterruptedException {
-    TableIdentifier tableIdentifier = TableIdentifier.of("db", "table");
+    TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db"), "table");
     Table table = createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
 
     List<SimpleRecord> records = Lists.newArrayList(
@@ -1185,7 +1186,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
   @Test
   public void testFilesTablePartitionId() throws Exception {
-    TableIdentifier tableIdentifier = TableIdentifier.of("db", "files_test");
+    TableIdentifier tableIdentifier = TableIdentifier.of(Namespace.of("db"), "files_test");
     Table table = createTable(tableIdentifier, SCHEMA, PartitionSpec.builderFor(SCHEMA).identity("id").build());
     int spec0 = table.spec().specId();
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -120,7 +120,7 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
 
   @Override
   protected Table createTable(String name, Schema schema, PartitionSpec spec) {
-    Table table = catalog.createTable(TableIdentifier.of("default", name), schema);
+    Table table = catalog.createTable(TableIdentifier.of(Namespace.of("default"), name), schema);
     TableOperations ops = ((BaseTable) table).operations();
     TableMetadata meta = ops.current();
     ops.commit(meta, meta.upgradeToFormatVersion(2));
@@ -135,14 +135,14 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
 
   @Override
   protected void dropTable(String name) {
-    catalog.dropTable(TableIdentifier.of("default", name));
+    catalog.dropTable(TableIdentifier.of(Namespace.of("default"), name));
   }
 
   @Override
   public StructLikeSet rowSet(String name, Table table, String... columns) {
     Dataset<Row> df = spark.read()
         .format("iceberg")
-        .load(TableIdentifier.of("default", name).toString())
+        .load(TableIdentifier.of(Namespace.of("default"), name).toString())
         .selectExpr(columns);
 
     Types.StructType projection = table.schema().select(columns).asStruct();
@@ -176,7 +176,7 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
     Types.StructType projection = table.schema().select("*").asStruct();
     Dataset<Row> df = spark.read()
         .format("iceberg")
-        .load(TableIdentifier.of("default", tableName).toString())
+        .load(TableIdentifier.of(Namespace.of("default"), tableName).toString())
         .filter("data = 'a'") // select a deleted row
         .selectExpr("*");
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestTimestampWithoutZone.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestTimestampWithoutZone.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -144,7 +145,7 @@ public class TestTimestampWithoutZone extends SparkCatalogTestBase {
               sql("SELECT * FROM %s ORDER BY id", tableName),
               sql("SELECT * FROM %s ORDER BY id", newTableName));
 
-      Table createdTable = validationCatalog.loadTable(TableIdentifier.of("default", newTableName));
+      Table createdTable = validationCatalog.loadTable(TableIdentifier.of(Namespace.of("default"), newTableName));
       assertFieldsType(createdTable.schema(), Types.TimestampType.withZone(), "ts", "tsz");
     });
   }
@@ -166,7 +167,7 @@ public class TestTimestampWithoutZone extends SparkCatalogTestBase {
         assertEquals("Row data should match expected",
               sql("SELECT * FROM %s ORDER BY id", tableName),
               sql("SELECT * FROM %s ORDER BY id", newTableName));
-        Table createdTable = validationCatalog.loadTable(TableIdentifier.of("default", newTableName));
+        Table createdTable = validationCatalog.loadTable(TableIdentifier.of(Namespace.of("default"), newTableName));
         assertFieldsType(createdTable.schema(), Types.TimestampType.withoutZone(), "ts", "tsz");
       });
   }


### PR DESCRIPTION
This is in preparation of supporting reference names and timestamps in the `TableIdentifier` as proposed in [this doc](https://docs.google.com/document/d/1KSgkVYnIMlWEbAT1qSnnnLS-gc0kdgHlWR6Ud08HOhA/edit?usp=sharing).

This changeset does the following things:
* removes `TableIdentifier.of(String… names)` as this gives too much of a flexibility in creating a `TableIdentifier` and makes it more difficult to figure out if the simple table name contains a reference or a timestamp
* deprecates `TableIdentifier.parse(identifier)` to encourage usage of `TableIdentifier.of(Namespace, String)`
* changes most places that were using `TableIdentifier.parse(identifier)` to `TableIdentifier.of(Namespace, String)`. A few places are still left that rely on a string representation of the table identifier in `Tables` and its subclasses
* allows to create a `Namespace` instance from a plain string

**EDIT**: I actually realized that there's older Spark code that still relies on `TableIdentifier.of(String… names)`, so I marked it as `@Deprecated`