### PR TITLE
Core: Fix null handling in NOT IN in StrictMetricsEvaluator

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
@@ -392,7 +392,12 @@ public class StrictMetricsEvaluator {
       Types.NestedField field = struct.field(id);
       Preconditions.checkNotNull(field, "Cannot filter by nested column: %s", schema.findField(id));
 
-      if (containsNullsOnly(id) || containsNaNsOnly(id)) {
+      if (canContainNulls(id)) {
+        // NOT null IN (1, 2) -> NOT null -> null -> false in filters
+        return ROWS_MIGHT_NOT_MATCH;
+      }
+
+      if (containsNaNsOnly(id)) {
         return ROWS_MUST_MATCH;
       }
 

--- a/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
@@ -530,14 +530,22 @@ public class TestStrictMetricsEvaluator {
 
     shouldRead = new StrictMetricsEvaluator(SCHEMA,
         notIn("all_nulls", "abc", "def")).eval(FILE);
-    Assert.assertTrue("Should match: notIn on all nulls column", shouldRead);
+    Assert.assertFalse("Should not match: notIn on all nulls column", shouldRead);
 
     shouldRead = new StrictMetricsEvaluator(SCHEMA,
         notIn("some_nulls", "abc", "def")).eval(FILE_3);
-    Assert.assertTrue("Should match: notIn on some nulls column, 'bbb' > 'abc' and 'bbb' < 'def'", shouldRead);
+    Assert.assertFalse("Should match: notIn on some nulls column, 'bbb' > 'abc' and 'bbb' < 'def'", shouldRead);
 
     shouldRead = new StrictMetricsEvaluator(SCHEMA,
         notIn("no_nulls", "abc", "def")).eval(FILE);
     Assert.assertFalse("Should not match: no_nulls field does not have bounds", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA,
+        notIn("some_nulls", "abc")).eval(FILE_3);
+    Assert.assertFalse("Should match: notIn on some nulls column, 'bbb' > 'abc' and 'bbb' < 'def'", shouldRead);
+
+    shouldRead = new StrictMetricsEvaluator(SCHEMA,
+        notIn("all_nulls", "a")).eval(FILE);
+    Assert.assertFalse("Should not match: notIn with one element on all null column", shouldRead);
   }
 }


### PR DESCRIPTION
This PR fixes NULL handling in NOT IN expressions in `StrictMetricsEvaluator`.