### PR TITLE
Core: Fix check for new deleted files in manifests

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
@@ -345,7 +345,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
     Evaluator inclusive = inclusiveDeleteEvaluator(reader.spec());
     Evaluator strict = strictDeleteEvaluator(reader.spec());
     boolean hasDeletedFiles = false;
-    for (ManifestEntry<F> entry : reader.entries()) {
+    for (ManifestEntry<F> entry : reader.liveEntries()) {
       F file = entry.file();
       boolean fileDelete = deletePaths.contains(file.path()) ||
           dropPartitions.contains(file.specId(), file.partition()) ||


### PR DESCRIPTION
This PR fixes the logic for checking whether manifests have new files to delete. Specifically, we should ignore files that were previously deleted.