### PR TITLE
Build: add missing hive version variable in hive3 build file

### DIFF
--- a/hive3/build.gradle
+++ b/hive3/build.gradle
@@ -90,7 +90,7 @@ project(':iceberg-hive3') {
     testImplementation("org.apache.calcite:calcite-core")
     testImplementation("com.esotericsoftware:kryo-shaded:4.0.2")
     testImplementation("com.fasterxml.jackson.core:jackson-annotations:2.6.5")
-    testImplementation("org.apache.hive:hive-service:3.1.2") {
+    testImplementation("org.apache.hive:hive-service:${hiveVersion}") {
       exclude group: 'org.apache.hive', module: 'hive-exec'
       exclude group: 'org.apache.orc'
     }


### PR DESCRIPTION
Small fix following up on https://github.com/apache/iceberg/pull/3510