### PR TITLE
Make Configurable.setConf call dynamic in CatalogUtil

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseMetastoreCatalog;
 import org.apache.iceberg.BaseMetastoreTableOperations;
@@ -43,6 +42,7 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.hadoop.Configurable;
 import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
@@ -71,12 +71,13 @@ import software.amazon.awssdk.services.glue.model.Table;
 import software.amazon.awssdk.services.glue.model.TableInput;
 import software.amazon.awssdk.services.glue.model.UpdateDatabaseRequest;
 
-public class GlueCatalog extends BaseMetastoreCatalog implements Closeable, SupportsNamespaces, Configurable {
+public class GlueCatalog extends BaseMetastoreCatalog
+    implements Closeable, SupportsNamespaces, Configurable<Configuration> {
 
   private static final Logger LOG = LoggerFactory.getLogger(GlueCatalog.class);
 
   private GlueClient glue;
-  private Configuration hadoopConf;
+  private Object hadoopConf;
   private String catalogName;
   private String warehousePath;
   private AwsProperties awsProperties;
@@ -441,10 +442,5 @@ public class GlueCatalog extends BaseMetastoreCatalog implements Closeable, Supp
   @Override
   public void setConf(Configuration conf) {
     this.hadoopConf = conf;
-  }
-
-  @Override
-  public Configuration getConf() {
-    return hadoopConf;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -23,11 +23,12 @@ import java.io.IOException;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import org.apache.hadoop.conf.Configurable;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.common.DynClasses;
 import org.apache.iceberg.common.DynConstructors;
+import org.apache.iceberg.common.DynMethods;
 import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -152,8 +153,7 @@ public class CatalogUtil {
    * Load a custom catalog implementation.
    * <p>
    * The catalog must have a no-arg constructor.
-   * If the class implements {@link Configurable},
-   * a Hadoop config will be passed using {@link Configurable#setConf(Configuration)}.
+   * If the class implements Configurable, a Hadoop config will be passed using Configurable.setConf.
    * {@link Catalog#initialize(String catalogName, Map options)} is called to complete the initialization.
    *
    * @param impl catalog implementation full class name
@@ -167,7 +167,7 @@ public class CatalogUtil {
       String impl,
       String catalogName,
       Map<String, String> properties,
-      Configuration hadoopConf) {
+      Object hadoopConf) {
     Preconditions.checkNotNull(impl, "Cannot initialize custom Catalog, impl class name is null");
     DynConstructors.Ctor<Catalog> ctor;
     try {
@@ -186,9 +186,7 @@ public class CatalogUtil {
           String.format("Cannot initialize Catalog, %s does not implement Catalog.", impl), e);
     }
 
-    if (catalog instanceof Configurable) {
-      ((Configurable) catalog).setConf(hadoopConf);
-    }
+    configureHadoopConf(catalog, hadoopConf);
 
     catalog.initialize(catalogName, properties);
     return catalog;
@@ -203,10 +201,10 @@ public class CatalogUtil {
    *
    * @param name catalog name
    * @param options catalog properties
-   * @param conf Hadoop configuration
+   * @param conf a Hadoop Configuration
    * @return initialized catalog
    */
-  public static Catalog buildIcebergCatalog(String name, Map<String, String> options, Configuration conf) {
+  public static Catalog buildIcebergCatalog(String name, Map<String, String> options, Object conf) {
     String catalogImpl = options.get(CatalogProperties.CATALOG_IMPL);
     if (catalogImpl == null) {
       String catalogType = PropertyUtil.propertyAsString(options, ICEBERG_CATALOG_TYPE, ICEBERG_CATALOG_TYPE_HIVE);
@@ -234,12 +232,11 @@ public class CatalogUtil {
    * Load a custom {@link FileIO} implementation.
    * <p>
    * The implementation must have a no-arg constructor.
-   * If the class implements {@link Configurable},
-   * a Hadoop config will be passed using {@link Configurable#setConf(Configuration)}.
+   * If the class implements Configurable, a Hadoop config will be passed using Configurable.setConf.
    * {@link FileIO#initialize(Map properties)} is called to complete the initialization.
    *
    * @param impl full class name of a custom FileIO implementation
-   * @param hadoopConf hadoop configuration
+   * @param hadoopConf a hadoop Configuration
    * @return FileIO class
    * @throws IllegalArgumentException if class path not found or
    *  right constructor not found or
@@ -248,7 +245,7 @@ public class CatalogUtil {
   public static FileIO loadFileIO(
       String impl,
       Map<String, String> properties,
-      Configuration hadoopConf) {
+      Object hadoopConf) {
     LOG.info("Loading custom FileIO implementation: {}", impl);
     DynConstructors.Ctor<FileIO> ctor;
     try {
@@ -266,11 +263,68 @@ public class CatalogUtil {
           String.format("Cannot initialize FileIO, %s does not implement FileIO.", impl), e);
     }
 
-    if (fileIO instanceof Configurable) {
-      ((Configurable) fileIO).setConf(hadoopConf);
-    }
+    configureHadoopConf(fileIO, hadoopConf);
 
     fileIO.initialize(properties);
     return fileIO;
+  }
+
+  /**
+   * Dynamically detects whether an object is a Hadoop Configurable and calls setConf.
+   * @param maybeConfigurable an object that may be Configurable
+   * @param conf a Configuration
+   */
+  public static void configureHadoopConf(Object maybeConfigurable, Object conf) {
+    Preconditions.checkArgument(maybeConfigurable != null, "Cannot configure: null Configurable");
+    if (conf == null) {
+      return;
+    }
+
+    // use the classloader of the object that may be configurable
+    ClassLoader maybeConfigurableLoader = maybeConfigurable.getClass().getClassLoader();
+
+    Class<?> configurableInterface;
+    try {
+      // load the Configurable interface
+      configurableInterface = DynClasses.builder()
+          .loader(maybeConfigurableLoader)
+          .impl("org.apache.hadoop.conf.Configurable")
+          .buildChecked();
+    } catch (ClassNotFoundException e) {
+      // not Configurable because it was loaded and Configurable is not present in its classloader
+      return;
+    }
+
+    if (!configurableInterface.isInstance(maybeConfigurable)) {
+      // not Configurable because the object does not implement the Configurable interface
+      return;
+    }
+
+    Class<?> configurationClass;
+    try {
+      configurationClass = DynClasses.builder()
+          .loader(maybeConfigurableLoader)
+          .impl("org.apache.hadoop.conf.Configuration")
+          .buildChecked();
+    } catch (ClassNotFoundException e) {
+      // this shouldn't happen because Configurable cannot be loaded without first loading Configuration
+      throw new UnsupportedOperationException("Failed to load Configuration after loading Configurable", e);
+    }
+
+    ValidationException.check(configurationClass.isInstance(conf),
+        "%s is not an instance of Configuration from the classloader for %s", conf, maybeConfigurable);
+
+    DynMethods.BoundMethod setConf;
+    try {
+      setConf = DynMethods.builder("setConf")
+          .impl(configurableInterface, configurationClass)
+          .buildChecked()
+          .bind(maybeConfigurable);
+    } catch (NoSuchMethodException e) {
+      // this shouldn't happen because Configurable cannot be loaded without first loading Configuration
+      throw new UnsupportedOperationException("Failed to load Configuration.setConf after loading Configurable", e);
+    }
+
+    setConf.invoke(conf);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/hadoop/Configurable.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/Configurable.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.hadoop;
+
+/**
+ * Interface used to avoid runtime dependencies on Hadoop Configurable
+ */
+public interface Configurable<C> {
+  void setConf(C conf);
+}

--- a/core/src/main/java/org/apache/iceberg/hadoop/Configurable.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/Configurable.java
@@ -1,15 +1,20 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.iceberg.hadoop;

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseMetastoreCatalog;
 import org.apache.iceberg.CatalogProperties;
@@ -47,7 +46,7 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
-import org.apache.iceberg.hadoop.HadoopFileIO;
+import org.apache.iceberg.hadoop.Configurable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -56,7 +55,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class JdbcCatalog extends BaseMetastoreCatalog implements Configurable, SupportsNamespaces, Closeable {
+public class JdbcCatalog extends BaseMetastoreCatalog
+    implements Configurable<Configuration>, SupportsNamespaces, Closeable {
 
   public static final String PROPERTY_PREFIX = "jdbc.";
   private static final Logger LOG = LoggerFactory.getLogger(JdbcCatalog.class);
@@ -65,7 +65,7 @@ public class JdbcCatalog extends BaseMetastoreCatalog implements Configurable, S
   private FileIO io;
   private String catalogName = "jdbc";
   private String warehouseLocation;
-  private Configuration conf;
+  private Object conf;
   private JdbcClientPool connections;
 
   public JdbcCatalog() {
@@ -84,8 +84,9 @@ public class JdbcCatalog extends BaseMetastoreCatalog implements Configurable, S
       this.catalogName = name;
     }
 
-    String fileIOImpl = properties.get(CatalogProperties.FILE_IO_IMPL);
-    this.io = fileIOImpl == null ? new HadoopFileIO(conf) : CatalogUtil.loadFileIO(fileIOImpl, properties, conf);
+    String fileIOImpl = properties.getOrDefault(
+        CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.hadoop.HadoopFileIO");
+    this.io = CatalogUtil.loadFileIO(fileIOImpl, properties, conf);
 
     try {
       LOG.debug("Connecting to JDBC database {}", properties.get(CatalogProperties.URI));
@@ -238,11 +239,6 @@ public class JdbcCatalog extends BaseMetastoreCatalog implements Configurable, S
   @Override
   public String name() {
     return catalogName;
-  }
-
-  @Override
-  public Configuration getConf() {
-    return conf;
   }
 
   @Override


### PR DESCRIPTION
This removes needing to have Hadoop `Configurable` or `Configuration` in the classpath to use `CatalogUtil`. It also adds a new `Configurable<C>` interface that can be implemented by pass-through catalogs that dynamically instantiate `FileIO` so there is no need for those catalogs to implement Hadoop's `Configurable` interface.