### PR TITLE
Core: Add methods to parse TableMetadata from JSON strings

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -132,6 +132,10 @@ class BaseSnapshot implements Snapshot {
   }
 
   private void cacheManifests() {
+    if (io == null) {
+      throw new IllegalStateException("Cannot cache changes: FileIO is null");
+    }
+
     if (allManifests == null) {
       // if manifests isn't set, then the snapshotFile is set and should be read to get the list
       this.allManifests = ManifestLists.read(io.newInputFile(manifestListLocation));
@@ -191,6 +195,10 @@ class BaseSnapshot implements Snapshot {
   }
 
   private void cacheChanges() {
+    if (io == null) {
+      throw new IllegalStateException("Cannot cache changes: FileIO is null");
+    }
+
     ImmutableList.Builder<DataFile> adds = ImmutableList.builder();
     ImmutableList.Builder<DataFile> deletes = ImmutableList.builder();
 

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.StringWriter;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.List;
@@ -253,8 +254,42 @@ public class TableMetadataParser {
     }
   }
 
-  @SuppressWarnings("checkstyle:CyclomaticComplexity")
+  /**
+   * Read TableMetadata from a JSON string.
+   * <p>
+   * The TableMetadata's metadata file location will be unset.
+   *
+   * @param io a FileIO used by {@link Snapshot} instances
+   * @param json a JSON string of table metadata
+   * @return a TableMetadata object
+   */
+  public static TableMetadata fromJson(FileIO io, String json) {
+    return fromJson(io, null, json);
+  }
+
+  /**
+   * Read TableMetadata from a JSON string.
+   *
+   * @param io a FileIO used by {@link Snapshot} instances
+   * @param metadataLocation metadata location for the returned {@link TableMetadata}
+   * @param json a JSON string of table metadata
+   * @return a TableMetadata object
+   */
+  public static TableMetadata fromJson(FileIO io, String metadataLocation, String json) {
+    try {
+      JsonNode node = JsonUtil.mapper().readValue(json, JsonNode.class);
+      return fromJson(io, metadataLocation, node);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to read JSON string: " + json, e);
+    }
+  }
+
   static TableMetadata fromJson(FileIO io, InputFile file, JsonNode node) {
+    return fromJson(io, file.location(), node);
+  }
+
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
+  static TableMetadata fromJson(FileIO io, String metadataLocation, JsonNode node) {
     Preconditions.checkArgument(node.isObject(),
         "Cannot parse metadata from a non-object: %s", node);
 
@@ -395,7 +430,7 @@ public class TableMetadataParser {
       }
     }
 
-    return new TableMetadata(file, formatVersion, uuid, location,
+    return new TableMetadata(metadataLocation, formatVersion, uuid, location,
         lastSequenceNumber, lastUpdatedMillis, lastAssignedColumnId, currentSchemaId, schemas, defaultSpecId, specs,
         lastAssignedPartitionId, defaultSortOrderId, sortOrders, properties, currentVersionId,
         snapshots, entries.build(), metadataEntries.build());

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -112,8 +112,7 @@ public class TestTableMetadata {
         Arrays.asList(previousSnapshot, currentSnapshot), snapshotLog, ImmutableList.of());
 
     String asJson = TableMetadataParser.toJson(expected);
-    TableMetadata metadata = TableMetadataParser.fromJson(ops.io(), null,
-        JsonUtil.mapper().readValue(asJson, JsonNode.class));
+    TableMetadata metadata = TableMetadataParser.fromJson(ops.io(), asJson);
 
     Assert.assertEquals("Format version should match",
         expected.formatVersion(), metadata.formatVersion());
@@ -185,8 +184,7 @@ public class TestTableMetadata {
         currentSnapshotId, Arrays.asList(previousSnapshot, currentSnapshot), ImmutableList.of(), ImmutableList.of());
 
     String asJson = toJsonWithoutSpecAndSchemaList(expected);
-    TableMetadata metadata = TableMetadataParser
-        .fromJson(ops.io(), null, JsonUtil.mapper().readValue(asJson, JsonNode.class));
+    TableMetadata metadata = TableMetadataParser.fromJson(ops.io(), asJson);
 
     Assert.assertEquals("Format version should match",
         expected.formatVersion(), metadata.formatVersion());
@@ -308,8 +306,7 @@ public class TestTableMetadata {
         ImmutableList.copyOf(previousMetadataLog));
 
     String asJson = TableMetadataParser.toJson(base);
-    TableMetadata metadataFromJson = TableMetadataParser.fromJson(ops.io(), null,
-        JsonUtil.mapper().readValue(asJson, JsonNode.class));
+    TableMetadata metadataFromJson = TableMetadataParser.fromJson(ops.io(), asJson);
 
     Assert.assertEquals("Metadata logs should match", previousMetadataLog, metadataFromJson.previousFiles());
   }
@@ -336,7 +333,7 @@ public class TestTableMetadata {
     MetadataLogEntry latestPreviousMetadata = new MetadataLogEntry(currentTimestamp - 80,
         "/tmp/000003-" + UUID.randomUUID().toString() + ".metadata.json");
 
-    TableMetadata base = new TableMetadata(localInput(latestPreviousMetadata.file()), 1, UUID.randomUUID().toString(),
+    TableMetadata base = new TableMetadata(latestPreviousMetadata.file(), 1, UUID.randomUUID().toString(),
         TEST_LOCATION, 0, currentTimestamp - 80, 3,
         7, ImmutableList.of(TEST_SCHEMA), 5, ImmutableList.of(SPEC_5), SPEC_5.lastAssignedFieldId(),
         3, ImmutableList.of(SORT_ORDER_3), ImmutableMap.of("property", "value"), currentSnapshotId,
@@ -382,7 +379,7 @@ public class TestTableMetadata {
     MetadataLogEntry latestPreviousMetadata = new MetadataLogEntry(currentTimestamp - 50,
         "/tmp/000006-" + UUID.randomUUID().toString() + ".metadata.json");
 
-    TableMetadata base = new TableMetadata(localInput(latestPreviousMetadata.file()), 1, UUID.randomUUID().toString(),
+    TableMetadata base = new TableMetadata(latestPreviousMetadata.file(), 1, UUID.randomUUID().toString(),
         TEST_LOCATION, 0, currentTimestamp - 50, 3,
         7, ImmutableList.of(TEST_SCHEMA), 5,
         ImmutableList.of(SPEC_5), SPEC_5.lastAssignedFieldId(), 3, ImmutableList.of(SORT_ORDER_3),
@@ -434,7 +431,7 @@ public class TestTableMetadata {
     MetadataLogEntry latestPreviousMetadata = new MetadataLogEntry(currentTimestamp - 50,
         "/tmp/000006-" + UUID.randomUUID().toString() + ".metadata.json");
 
-    TableMetadata base = new TableMetadata(localInput(latestPreviousMetadata.file()), 1, UUID.randomUUID().toString(),
+    TableMetadata base = new TableMetadata(latestPreviousMetadata.file(), 1, UUID.randomUUID().toString(),
         TEST_LOCATION, 0, currentTimestamp - 50, 3, 7, ImmutableList.of(TEST_SCHEMA), 2,
         ImmutableList.of(SPEC_5), SPEC_5.lastAssignedFieldId(),
         TableMetadata.INITIAL_SORT_ORDER_ID, ImmutableList.of(SortOrder.unsorted()),
@@ -486,20 +483,17 @@ public class TestTableMetadata {
   @Test
   public void testParserVersionValidation() throws Exception {
     String supportedVersion1 = readTableMetadataInputFile("TableMetadataV1Valid.json");
-    TableMetadata parsed1 = TableMetadataParser.fromJson(
-        ops.io(), null, JsonUtil.mapper().readValue(supportedVersion1, JsonNode.class));
+    TableMetadata parsed1 = TableMetadataParser.fromJson(ops.io(), supportedVersion1);
     Assert.assertNotNull("Should successfully read supported metadata version", parsed1);
 
     String supportedVersion2 = readTableMetadataInputFile("TableMetadataV2Valid.json");
-    TableMetadata parsed2 = TableMetadataParser.fromJson(
-        ops.io(), null, JsonUtil.mapper().readValue(supportedVersion2, JsonNode.class));
+    TableMetadata parsed2 = TableMetadataParser.fromJson(ops.io(), supportedVersion2);
     Assert.assertNotNull("Should successfully read supported metadata version", parsed2);
 
     String unsupportedVersion = readTableMetadataInputFile("TableMetadataUnsupportedVersion.json");
     AssertHelpers.assertThrows("Should not read unsupported metadata",
         IllegalArgumentException.class, "Cannot read unsupported version",
-        () -> TableMetadataParser.fromJson(
-            ops.io(), null, JsonUtil.mapper().readValue(unsupportedVersion, JsonNode.class))
+        () -> TableMetadataParser.fromJson(ops.io(), unsupportedVersion)
     );
   }
 
@@ -509,8 +503,7 @@ public class TestTableMetadata {
     String unsupportedVersion = readTableMetadataInputFile("TableMetadataV2MissingPartitionSpecs.json");
     AssertHelpers.assertThrows("Should reject v2 metadata without partition specs",
         IllegalArgumentException.class, "partition-specs must exist in format v2",
-        () -> TableMetadataParser.fromJson(
-            ops.io(), null, JsonUtil.mapper().readValue(unsupportedVersion, JsonNode.class))
+        () -> TableMetadataParser.fromJson(ops.io(), unsupportedVersion)
     );
   }
 
@@ -519,8 +512,7 @@ public class TestTableMetadata {
     String unsupportedVersion = readTableMetadataInputFile("TableMetadataV2MissingLastPartitionId.json");
     AssertHelpers.assertThrows("Should reject v2 metadata without last assigned partition field id",
         IllegalArgumentException.class, "last-partition-id must exist in format v2",
-        () -> TableMetadataParser.fromJson(
-            ops.io(), null, JsonUtil.mapper().readValue(unsupportedVersion, JsonNode.class))
+        () -> TableMetadataParser.fromJson(ops.io(), unsupportedVersion)
     );
   }
 
@@ -529,8 +521,7 @@ public class TestTableMetadata {
     String unsupportedVersion = readTableMetadataInputFile("TableMetadataV2MissingSortOrder.json");
     AssertHelpers.assertThrows("Should reject v2 metadata without sort order",
         IllegalArgumentException.class, "sort-orders must exist in format v2",
-        () -> TableMetadataParser.fromJson(
-            ops.io(), null, JsonUtil.mapper().readValue(unsupportedVersion, JsonNode.class))
+        () -> TableMetadataParser.fromJson(ops.io(), unsupportedVersion)
     );
   }
 
@@ -539,8 +530,7 @@ public class TestTableMetadata {
     String unsupported = readTableMetadataInputFile("TableMetadataV2CurrentSchemaNotFound.json");
     AssertHelpers.assertThrows("Should reject v2 metadata without valid schema id",
         IllegalArgumentException.class, "Cannot find schema with current-schema-id=2 from schemas",
-        () -> TableMetadataParser.fromJson(
-            ops.io(), null, JsonUtil.mapper().readValue(unsupported, JsonNode.class))
+        () -> TableMetadataParser.fromJson(ops.io(), unsupported)
     );
   }
 
@@ -549,8 +539,7 @@ public class TestTableMetadata {
     String unsupported = readTableMetadataInputFile("TableMetadataV2MissingSchemas.json");
     AssertHelpers.assertThrows("Should reject v2 metadata without schemas",
         IllegalArgumentException.class, "schemas must exist in format v2",
-        () -> TableMetadataParser.fromJson(
-            ops.io(), null, JsonUtil.mapper().readValue(unsupported, JsonNode.class))
+        () -> TableMetadataParser.fromJson(ops.io(), unsupported)
     );
   }
 
@@ -726,8 +715,7 @@ public class TestTableMetadata {
   @Test
   public void testParseSchemaIdentifierFields() throws Exception {
     String data = readTableMetadataInputFile("TableMetadataV2Valid.json");
-    TableMetadata parsed = TableMetadataParser.fromJson(
-        ops.io(), null, JsonUtil.mapper().readValue(data, JsonNode.class));
+    TableMetadata parsed = TableMetadataParser.fromJson(ops.io(), data);
     Assert.assertEquals(Sets.newHashSet(), parsed.schemasById().get(0).identifierFieldIds());
     Assert.assertEquals(Sets.newHashSet(1, 2), parsed.schemasById().get(1).identifierFieldIds());
   }

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.UncheckedIOException;


### PR DESCRIPTION
This adds methods to parse `TableMetadata` from JSON strings, not just from `InputFile`. This is in support of the REST catalog.