### PR TITLE
types and literals in one w/ generics

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -19,7 +19,7 @@ from setuptools import setup
 
 setup(
     name="py-iceberg",
-    install_requires=[],
+    install_requires=["mmh3", "numpy"],
     extras_require={
         "dev": [
             "tox-travis==0.12",

--- a/python/src/iceberg/types.py
+++ b/python/src/iceberg/types.py
@@ -15,157 +15,1195 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Optional
+from base64 import b64encode
+from datetime import date, datetime, time
+import decimal
+from decimal import Decimal as PythonDecimal
+import math
+import mmh3
+from numpy import float32, float64, isnan, isinf
+import struct
+from typing import Any, Dict
+from typing import List as PythonList
+from typing import Optional, Tuple, Type, Union
+from uuid import UUID as PythonUUID
+
+# intended for use inside this module only
+class IcebergMetaType(type):
+    """
+    MetaClass to:
+        Generate a str for an `IcebergType`
+        Generate a repr for an `IcebergType`
+        Freeze attributes that define a generic `IcebergType`
+
+    Note: for internal iceberg use only
+    """
+
+    _always_frozen = {"_strname", "_frozen_attrs", "_always_frozen"}
+    # freeze setting of generic attributes
+    def __setattr__(cls, key, value):
+        if key in getattr(cls, "_frozen_attrs", set()) or key in cls._always_frozen:
+            raise AttributeError(f"{key} may not be altered on type {cls}")
+        type.__setattr__(cls, key, value)
+
+    # freeze deleting of generic attributes
+    def __delattr__(cls, key):
+        if key in getattr(cls, "_frozen_attrs", set()) or key in cls._always_frozen:
+            raise AttributeError(f"{key} may not be deleted on type {cls}")
+        type.__delattr__(cls, key)
+
+    def __getitem__(cls, key):
+        return cls._get_generic(cls, key)
+
+    def __subclasscheck__(cls, other):
+        """custom subclass check for when checking `issubclass` on an IcebergType to ensure covariance on generics"""
+        if cls == other:
+            return True
+        if generic_class.is_generic_type(
+            cls, True, True
+        ) and generic_class.is_generic_type(other, True, True):
+
+            unspecified_generic = generic_class.get_unspecified_generic_type(cls)
+            generic_names = [
+                g[1]
+                for g in generic_class.generics.values()
+                if g[0] == unspecified_generic
+            ][0]
+            return all(
+                issubclass(sv, tv)
+                for sv, tv in [
+                    (type.__getattribute__(other, a), type.__getattribute__(cls, a))
+                    for a in generic_names
+                ]
+            )
+        try:
+            return _is_subclass(other, cls)
+        except AttributeError:
+            return False
+
+    # basic repr
+    def __repr__(cls):
+        return cls.__name__
+
+    def __str__(cls):
+        return getattr(cls, "_strname", cls.__name__)
 
 
-class Type(object):
-    def __init__(self, type_string: str, repr_string: str, is_primitive=False):
-        self._type_string = type_string
-        self._repr_string = repr_string
-        self._is_primitive = is_primitive
+class IcebergType(metaclass=IcebergMetaType):
+    """Base type for all Iceberg Types"""
 
-    def __repr__(self):
-        return self._repr_string
+    def __setattr__(self, key, value):
+        if key in getattr(self, "_frozen_attrs", set()) or key in getattr(
+            type(self), "_always_frozen", set()
+        ):
+            raise AttributeError(f"{key} may not be altered on isntance {self}")
+        object.__setattr__(self, key, value)
 
-    def __str__(self):
-        return self._type_string
+    # freeze deleting of generic attributes
+    def __delattr__(self, key):
+        if key in getattr(self, "_frozen_attrs", set()) or key in getattr(
+            type(self), "_always_frozen", set()
+        ):
+            raise AttributeError(f"{key} may not be deleted on instance {self}")
+        object.__delattr__(self, key)
 
-    @property
-    def is_primitive(self) -> bool:
-        return self._is_primitive
+    @classmethod
+    def can_cast(cls, _type: Type["IcebergType"]):
+        return cls == _type
 
 
-class FixedType(Type):
-    def __init__(self, length: int):
-        super().__init__(
-            f"fixed[{length}]", f"FixedType(length={length})", is_primitive=True
+class PrimitiveType(IcebergType):
+    """
+    base type for primitives `IcebergType`s
+    Primitives include an instance attribute `value` which is used as the underlying value to work with the type
+    a `PrimitiveType` should type the instance `value` most specific to that type
+    """
+
+    value: Union[bytes, bool, int, float32, float64, PythonDecimal, str, dict]
+
+    def __init__(self, value):
+
+        if issubclass(type(value), PrimitiveType):
+            try:
+                self.value = value.to(type(self)).value
+            except AttributeError:
+                raise TypeError(f"Cannot convert {value} to type {type(self)}")
+        else:
+            self.value = value
+
+    def __repr__(self) -> str:
+        return f"{repr(type(self))}(value={self.value})"
+
+    def __str__(self) -> str:
+        return f"{str(type(self))}({self.value})"
+
+    def __bool__(self) -> bool:
+        return bool(self.value)
+
+    def __eq__(self, other) -> bool:
+        return type(other) == type(self) and self.value == other.value
+
+    def __bytes__(self) -> bytes:
+        return bytes(self.value)
+
+    def __hash__(self) -> int:
+        """https://iceberg.apache.org/#spec/#appendix-b-32-bit-hash-requirements"""
+        return mmh3.hash(bytes(self))
+
+    def to(self, _type: Type["PrimitiveType"], coerce: bool = False):
+        if type(self).can_cast(_type) or coerce:
+            return _type(self.value)
+        raise TypeError(f"Cannot cast {type(self)} to {_type}.")
+
+
+class Number(PrimitiveType):
+    """
+    base `PrimitiveType` for `IcebergType`s for numeric types
+    per https://iceberg.apache.org/#spec/#primitive-types these include int, long, float, double, decimal
+    """
+
+    value: Union[int, float32, float64, PythonDecimal]
+
+    def __float__(self) -> int:
+        return float(self.value)
+
+    def __int__(self) -> float:
+        return int(self.value)
+
+    def __math(self, op, other=None):
+        with decimal.localcontext() as ctx:
+            if isinstance(self, Decimal):
+                ctx.prec = self.precision
+            op_f = getattr(self.value, op)
+            try:
+                if op in ("__add__", "__sub__", "__div__", "__mul__",):
+                    other = other.to(type(self))
+                    return type(self)(op_f(other.value))
+                if op in ("__pow__", "__mod__",):
+                    other = type(self)(other)
+                    return type(self)(op_f(other.value))
+                if op in ("__lt__", "__eq__"):
+                    other = other.to(type(self))
+                    return op_f(other.value)
+            except TypeError:
+                raise TypeError(
+                    f"Cannot compare {self} with {other}. Perhaps try coercing to the appropriate type as {other}.to({type(self)}, coerce=True)."
+                )
+            except AttributeError:
+                raise TypeError(
+                    f"Cannot compare {self} with {other}. Ensure try creating an appropriate type {type(self)}({other})."
+                )
+
+            if op in ("__neg__", "__abs__"):
+                return type(self)(op_f())
+
+    def __add__(self, other: "Number") -> "Number":
+        return self.__math("__add__", other)
+
+    def __sub__(self, other: "Number") -> "Number":
+        return self.__math("__sub__", other)
+
+    def __mul__(self, other: "Number") -> "Number":
+        return self.__math("__mul__", other)
+
+    def __div__(self, other: "Number") -> "Number":
+        return self.__math("__div__", other)
+
+    def __neg__(self) -> "Number":
+        return self.__math("__neg__")
+
+    def __abs__(self) -> "Number":
+        return self.__math("__abs__")
+
+    def __pow__(self, other: "Number", mod: Optional["Number"] = None) -> "Number":
+        return self.__math("__pow__", other)
+
+    def __mod__(self, other: "Number") -> "Number":
+        return self.__math("__mod__", other)
+
+    def __lt__(self, other) -> bool:
+        return self.__math("__lt__", other)
+
+    def __eq__(self, other) -> bool:
+        return self.__math("__eq__", other) and self._neg == other._neg
+
+    def __gt__(self, other) -> bool:
+        return not self.__le__(other)
+
+    def __le__(self, other) -> bool:
+        return self.__lt__(other) or self.__eq__(other)
+
+    def __ge__(self, other) -> bool:
+        return self.__gt__(other) or self.__eq__(other)
+
+    def __hash__(self) -> int:
+        return super().__hash__()
+
+
+class Integral(Number):
+    """
+    base class for integral types Integer, Long
+
+    Note:
+       for internal iceberg use only
+
+    Examples:
+        Can be used in place of typing for Integer and Long
+    """
+
+    value: int
+    _neg: bool
+    _frozen_attrs = {"min", "max", "_neg"}
+
+    def __init__(self, value: Union[str, float, int]):
+        super().__init__(value)
+
+        if isinstance(self.value, Number):
+            self.value = int(self.value.value)
+        else:
+            self.value = int(self.value)
+        self._check()
+        object.__setattr__(self, "_neg", self.value < 0)
+
+    def _check(self) -> "Integral":
+        """
+        helper method for `Integal` specific `_check` to ensure value is within spec
+        """
+        if self.value > self.max:
+            raise ValueError(f"{type(self)} must be less than or equal to {self.max}")
+
+        if self.value < self.min:
+            raise ValueError(
+                f"{type(self)} must be greater than or equal to {self.min}"
+            )
+
+        return self
+
+    def __bytes__(self) -> bytes:
+        return struct.pack("q", self.value)
+
+
+class Floating(Number):
+    """
+    base class for floating types Float, Double
+
+    Note:
+       for internal iceberg use only
+
+    Examples:
+        Can be used in place of typing for Float and Double
+    """
+
+    _neg: bool
+    _frozen_attrs = {"_neg"}
+
+    def __init__(self, float_t, value: Union[float, str, int]):
+        super().__init__(value)
+        object.__setattr__(self, "_neg", str(self.value).strip().startswith("-"))
+        if isinstance(self.value, Number):
+            self.value = float_t(self.value.value)
+        else:
+            self.value = float_t(self.value)
+
+    def __bytes__(self) -> bytes:
+        return struct.pack("d", self.value)
+
+    def __repr__(self) -> str:
+        ret = super().__repr__()
+        if self._neg and isnan(self.value):
+            return ret.replace("nan", "-nan")
+        return ret
+
+    def is_nan(self) -> bool:
+        return isnan(self.value)
+
+    def is_inf(self) -> bool:
+        return isinf(self.value)
+
+    def __str__(self) -> str:
+        ret = super().__str__()
+        if self._neg and isnan(self.value):
+            return ret.replace("nan", "-nan")
+        if self._neg and self.value == 0.0:
+            return ret.replace("0.0", "-0.0")
+        return ret
+
+    def __lt__(self, other: "Floating") -> bool:
+        try:
+            other = other.to(type(self))
+        except TypeError:
+            raise TypeError(
+                f"Cannot compare {self} with {other}. Perhaps try coercing to the appropriate type as {other}.to({type(self)}, coerce=True)."
+            )
+        except AttributeError:
+            raise TypeError(
+                f"Cannot compare {self} with {other}. Ensure try creating an appropriate type {type(self)}({other})."
+            )
+
+        def get_key(x):
+            if x.is_nan():
+                ret = "nan"
+            elif x.is_inf():
+                ret = "inf"
+            else:
+                return "value"
+            return ("-" if x._neg else "") + ret
+
+        return {
+            ("inf", "value"): False,
+            ("nan", "nan"): False,
+            ("-inf", "-inf"): False,
+            ("value", "inf"): True,
+            ("-inf", "-nan"): True,
+            ("-nan", "-nan"): False,
+            ("value", "-nan"): False,
+            ("-nan", "-inf"): False,
+            ("-inf", "inf"): True,
+            ("-nan", "nan"): True,
+            ("nan", "value"): False,
+            ("nan", "-nan"): False,
+            ("inf", "nan"): False,
+            ("-nan", "inf"): True,
+            ("inf", "inf"): False,
+            ("nan", "-inf"): False,
+            ("value", "value"): (self._neg and not other._neg)
+            or (self.value < other.value),
+            ("-nan", "value"): True,
+            ("value", "nan"): True,
+            ("-inf", "value"): True,
+            ("-inf", "nan"): True,
+            ("inf", "-inf"): False,
+            ("nan", "inf"): True,
+            ("value", "-inf"): False,
+            ("inf", "-nan"): False,
+        }[(get_key(self), get_key(other))]
+
+
+class Integer(Integral):
+    """
+    32-bit signed integers: `int` from https://iceberg.apache.org/#spec/#primitive-types
+
+
+    Args:
+        value: value for which the integer will represent
+
+    Attributes:
+        value (int): the literal value contained by the `Integer`
+        max (int): the maximum value `Integer` may take on
+        min (int): the minimum value `Integer` may take on
+
+    Examples:
+        >>> Integer(5)
+        Integer(value=5)
+
+        >>> Integer('3.14')
+        Integer(value=3)
+
+        >>> Integer(3.14)
+        Integer(value=3)
+
+    """
+
+    max: int = 2147483647
+    min: int = -2147483648
+
+    @classmethod
+    def can_cast(cls, _type):
+        return _type in (cls, Long)
+
+
+class Long(Integral):
+    """
+    64-bit signed integers: `long` from https://iceberg.apache.org/#spec/#primitive-types
+
+
+    Args:
+        value: value for which the long will represent
+
+    Attributes:
+        value (int): the literal value contained by the `Long`
+        max (int): the maximum value `Long` may take on
+        min (int): the minimum value `Long` may take on
+
+    Examples:
+        >>> Long(5)
+        Long(value=5)
+
+        >>> Long('3.14')
+        Long(value=3)
+
+        >>> Long(3.14)
+        Long(value=3)
+    """
+
+    max: int = 9223372036854775807
+    min: int = -9223372036854775808
+
+
+class Float(Floating):
+    """
+    32-bit IEEE 754 floating point: `float` from https://iceberg.apache.org/#spec/#primitive-types
+
+    Args:
+        value: value for which the float will represent
+
+     Examples:
+        >>> Float(5)
+        Float(value=5.0)
+
+        >>> Float(3.14)
+        Float(value=3)
+    """
+
+    # float32 ensures spec
+    value: float32
+
+    def __init__(self, value):
+        super().__init__(float32, value)
+
+    @classmethod
+    def can_cast(cls, _type):
+        return _type in (cls, Double)
+
+
+class Double(Floating):
+    """
+    64-bit IEEE 754 floating point: `double` from https://iceberg.apache.org/#spec/#primitive-types
+
+    Args:
+        value: value for which the double will represent
+
+    Examples:
+        >>> Double(5)
+        Double(value=5.0)
+
+        >>> Double(3.14)
+        Double(value=3)
+
+    """
+
+    # float64 ensures spec
+    value: float64
+
+    def __init__(self, value):
+        super().__init__(float64, value)
+
+
+class Boolean(PrimitiveType):
+    """
+    `boolean` from https://iceberg.apache.org/#spec/#primitive-types
+
+    Args:
+        value (bool): value the boolean will represent
+
+Examples:
+        >>>Boolean(True)
+        Boolean(value=True)
+    """
+
+    value: bool
+
+    def __bool__(self):
+        return self.value
+
+    def __bytes__(self) -> bytes:
+        return bytes(Integer(True))
+
+    def __hash__(self) -> int:
+        return super().__hash__()
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, Boolean) and self.value == other.value
+
+
+class String(PrimitiveType):
+    """
+    Arbitrary-length character sequences Encoded with UTF-8: `string` from https://iceberg.apache.org/#spec/#primitive-types
+
+    Args:
+        value (str): value the string will represent
+
+    Attributes:
+        value (str): the literal value contained by the `String`
+
+    Examples:
+        >>> String("Hello")
+        String(value='Hello')
+    """
+
+    value: str
+
+    def __hash__(self) -> int:
+        return mmh3.hash(self.value)
+
+
+class UUID(PrimitiveType):
+    """
+    Universally unique identifiers: `uuid` from https://iceberg.apache.org/#spec/#primitive-types
+
+    Args:
+        value: value the uuid will represent
+
+    Attributes:
+        value (uuid.UUID): literal value contained by the `UUID`
+
+    Examples:
+        >>> UUID("f79c3e09-677c-4bbd-a479-3f349cb785e7")
+        UUID(value=f79c3e09-677c-4bbd-a479-3f349cb785e7)
+    """
+
+    value: PythonUUID
+
+    def __init__(self, value: Union[str, PythonUUID]):
+        super().__init__(value)
+        if not isinstance(self.value, PythonUUID):
+            self.value = PythonUUID(self.value)
+
+    def __int__(self) -> int:
+        return self.value.int
+
+    def __bytes__(self) -> bytes:
+        v = int(self)
+        return struct.pack(
+            ">QQ", (v >> 64) & 0xFFFFFFFFFFFFFFFF, v & 0xFFFFFFFFFFFFFFFF,
         )
-        self._length = length
-
-    @property
-    def length(self) -> int:
-        return self._length
 
 
-class DecimalType(Type):
-    def __init__(self, precision: int, scale: int):
-        super().__init__(
-            f"decimal({precision}, {scale})",
-            f"DecimalType(precision={precision}, scale={scale})",
-            is_primitive=True,
-        )
-        self._precision = precision
-        self._scale = scale
+class Binary(PrimitiveType):
+    """
+    Arbitrary-length byte array from  https://iceberg.apache.org/#spec/#primitive-types
 
-    @property
-    def precision(self) -> int:
-        return self._precision
+    Args:
+        value (bytes): bytes to hold in binary buffer
 
-    @property
-    def scale(self) -> int:
-        return self._scale
+    Attributes:
+        value (bytes): bytes to hold in binary buffer
+
+    Examples:
+        >>> Binary(b"\x00\x01\x02\x03")
+        Binary(value=b'\x00\x01\x02\x03')
+    """
+
+    value: bytes
+
+    def to_base64(self) -> str:
+        return b64encode(self.value).decode("ISO-8859-1")
 
 
-class NestedField(object):
-    def __init__(
-        self,
-        is_optional: bool,
-        field_id: int,
+class Datetime(PrimitiveType):
+    """
+    base class for Date, Time, Timestamp, Timestamptz
+    Note:
+       for internal iceberg use only
+
+    Examples:
+        Can be used in place of typing for all of Date, Time, Timestamp, Timestamptz
+    """
+
+    epoch: datetime = datetime.utcfromtimestamp(0)
+    _frozen_attrs = {"epoch"}
+    value: Union[date, time, datetime]
+
+    def __init__(self, dt_t, *args, **kwargs):
+        try:
+            self.value = dt_t.fromisoformat(*args, **kwargs)
+        except TypeError:
+            self.value = dt_t(*args, **kwargs)
+
+    def __getattr__(self, attr):
+        """
+        pass attribute to `value` when the `Datetime` does not have it
+        very convenient for datetime types
+        """
+        return getattr(self.value, attr)
+
+    def __bytes__(self) -> bytes:
+        return struct.pack("q", int(self))
+
+
+class Date(Datetime):
+    """
+    `date` type from https://iceberg.apache.org/#spec/#primitive-types
+
+    Args:
+        *args: can pass a string formatted in the isoformat or several `int` for year, month, day
+        **kwargs: can pass kwargs for named year, month, day
+
+    Attributes:
+        value (datetime.date): literal date value Date holds
+
+    Examples:
+        >>> Date("2017-11-16")
+        Date(value=2017-11-16)
+    """
+
+    value: date
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(date, *args, **kwargs)
+
+    def __int__(self) -> int:
+        """days from unix epoch"""
+        return (self.value - Datetime.epoch.date()).days
+
+
+class Time(Datetime):
+    """
+    `time` type from https://iceberg.apache.org/#spec/#primitive-types
+
+    Args:
+        *args: can pass a string formatted in the isoformat or several `int` for hour[, minute[, second[, microsecond]
+        **kwargs: can pass kwargs for named hour[, minute[, second[, microsecond]
+
+    Attributes:
+        value (datetime.time): literal time value Time holds
+
+    Examples:
+        >>> Time(22, 31, 8)
+        Time(value=22:31:08)
+    """
+
+    value: time
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(time, *args, **kwargs)
+
+    def __int__(self) -> int:
+        """microseconds from midnight"""
+        return (
+            (((self.value.hour * 60 + self.value.minute) * 60 + self.value.second))
+        ) * 1000000 + self.value.microsecond
+
+
+class Timestamp(Datetime):
+    """
+    `timestamp` type from https://iceberg.apache.org/#spec/#primitive-types
+
+    Args:
+        *args: can pass a string formatted in the isoformat or several `int` for year, month, day[, hour[, minute[, second[, microsecond]]]]
+        **kwargs: can pass kwargs for named year, month, day[, hour[, minute[, second[, microsecond]]]]
+
+    Attributes:
+        value (datetime.datetime): literal timestamp value Timestamp holds
+
+    Examples:
+        >>> Timestamp("2017-11-16T14:31:08-08:00")
+       Timestamp(value=2017-11-16 14:31:08-08:00)
+    """
+
+    value: datetime
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(datetime, *args, **kwargs)
+
+    def __int__(self) -> int:
+        """microseconds from epoch"""
+        return int(self.timestamp()) * 1000000
+
+
+class Timestamptz(Timestamp):
+    """
+    `timestamptz` type from https://iceberg.apache.org/#spec/#primitive-types
+
+    Args:
+        *args: can pass a string formatted in the isoformat or several `int` for year, month, day[, hour[, minute[, second[, microsecond[,tzinfo]]]]]
+        **kwargs: can pass kwargs for named year, month, day[, hour[, minute[, second[, microsecond[,tzinfo]]]]]
+
+    Attributes:
+        value (datetime.datetime): literal timestamp value Timestamp holds
+
+    Examples:
+        >>> Timestamptz("2017-11-16T14:31:08-08:00")
+       Timestamptz(value=2017-11-16 14:31:08-08:00)
+    """
+
+
+# helper for checking subclass in some generic methods
+# should not be used outside of this module
+def _is_subclass(cls, other):  # pragma: no cover
+    try:
+        return other in cls.__mro__
+    except AttributeError:
+        return False
+
+
+class generic_class(type):
+    generics: Dict[str, Tuple[Type[IcebergType], PythonList[str]]] = dict()
+
+    def __new__(
+        cls,
         name: str,
-        field_type: Type,
-        doc: Optional[str] = None,
+        attributes: PythonList[
+            Tuple[
+                str,
+                Type[Union[IcebergType, "Instance"]],
+                Tuple[str, Type[Union[IcebergType, "Instance"]], Any],
+            ]
+        ],
+        base_type: type = IcebergType,
+        doc: str = "",
+        meta_doc: str = "",
     ):
-        self._is_optional = is_optional
-        self._id = field_id
-        self._name = name
-        self._type = field_type
-        self._doc = doc
+        """
+        facilitates generating generic type factories such as `List` e.g. `List[Integer]`
+        in the spirit of builtin `type` e.g.:
+            def Robot_init(self, name):
+                self.name = name
 
-    @property
-    def is_optional(self) -> bool:
-        return self._is_optional
+            Robot2 = type("Robot2",
+                          (),
+                          {"counter":0,
+                           "__init__": Robot_init,})
 
-    @property
-    def is_required(self) -> bool:
-        return not self._is_optional
+        Args:
+            name: the name of the generic type used in repr and str
+            attributes: list of generic attribute names and types - must provide at least a name type or both for each attribute
+            base_type: class for generic to inherit from
+            doc: docstring of specfied generic e.g. List[Integer]
+            meta_doc: docstring of unspecified generic e.g. List
 
-    @property
-    def field_id(self) -> int:
-        return self._id
+        Examples:
+            >>>List = generic_class("List", [("type", IcebergType)], PrimitiveType)
+            >>>List[Integer]
+            List[type=Integer]
+        """
+        attributes = [a if len(a) == 3 else (*a, None) for a in attributes]
+        attribute_names = [a[0] for a in attributes]
+        attribute_types = [a[1] for a in attributes]
+        attribute_defaults = dict(zip(attribute_names, [a[2] for a in attributes]))
 
-    @property
-    def name(self) -> str:
-        return self._name
+        def get_generic(cls, attrs):
+            attrs = attrs if isinstance(attrs, tuple) else (attrs,)
 
-    @property
-    def type(self) -> Type:
-        return self._type
+            if len(attrs) > len(attributes):
+                raise TypeError(
+                    f'Too many generic parameters provided. Expected {len(attribute_names)} parameter(s) of subtypes of ({",".join(repr(i) for i in attribute_types)}). Provided {attrs}'
+                )
 
-    def __repr__(self):
+            kwargs = dict(zip(attribute_names, attrs))
+            for k, v in attribute_defaults.items():
+                if kwargs.get(k) is None:
+                    if v is None:
+                        raise TypeError(
+                            f"Generic attribute `{str(k)}` on {name} requires a value and has no default."
+                        )
+                    else:
+                        kwargs[k] = v
+            for given_attribute, defined_attribute in zip(attrs, attribute_types):
+                try:
+                    is_instance = issubclass(defined_attribute, Instance)
+                except TypeError:
+                    is_instance = False
+                if not is_instance:
+                    defined_attribute = getattr(
+                        defined_attribute, "__args__", (defined_attribute,)
+                    )
+
+                if is_instance:
+                    if not issubclass(type(given_attribute), defined_attribute.type):
+                        raise TypeError(
+                            f"Improper types of {cls}. Given {repr(given_attribute)} instance of {type(given_attribute)}, expected instance of type {defined_attribute.type}."
+                        )
+                else:
+
+                    if not any(
+                        issubclass(given_attribute, t) for t in defined_attribute
+                    ):
+                        raise TypeError(
+                            f"Improper types of {cls}. Given type {repr(given_attribute)}, expected one of {repr(defined_attribute)}."
+                        )
+            if attrs in cls._implemented:
+                return cls._implemented[attrs]
+            else:
+
+                class _Type(
+                    *(
+                        (base_type, _Factory)
+                        if not issubclass(_Factory, base_type)
+                        else (_Factory,)
+                    )
+                ):
+                    __doc__ = f"""
+                    Generic instance of {name} with generic attributes {kwargs}
+
+                    {doc}
+                    """
+
+                for k, v in kwargs.items():
+                    setattr(_Type, k, v)
+                setattr(
+                    _Type,
+                    "__name__",
+                    f"{name}[{', '.join(f'{k}={repr(v)}' for k,v in kwargs.items())}]",
+                )
+                setattr(
+                    _Type, "__args__", attrs,
+                )
+                type.__setattr__(
+                    _Type,
+                    "_strname",
+                    f"{name}[{', '.join(f'{str(v)}' for _, v in kwargs.items())}]",
+                )
+                type.__setattr__(
+                    _Type,
+                    "_frozen_attrs",
+                    getattr(base_type, "_frozen_attrs", set()) | set(attribute_names),
+                )
+                setattr(
+                    _Type,
+                    "__annotations__",
+                    dict(zip(attribute_names, attribute_types)),
+                )
+
+            cls._implemented[attrs] = _Type
+            return _Type
+
+        class _Factory(IcebergType):
+            __doc__ = f"{meta_doc if meta_doc else name}"
+            _implemented = dict()
+
+        setattr(
+            _Factory, "_get_generic", get_generic,
+        )
+
+        setattr(
+            _Factory, "__name__", name,
+        )
+        type.__setattr__(_Factory, "_frozen_attrs", {"_get_generic", "_implemented"})
+        cls.generics[name] = (_Factory, attribute_names)
+        return _Factory
+
+    def get_unspecified_generic_type(cls):
+        """
+        get the unspecified generic type of `cls` e.g. List for List[Integer]
+
+        Args:
+            cls: type to test
+        """
+        try:
+            ret = [
+                g[0] for g in generic_class.generics.values() if _is_subclass(cls, g[0])
+            ]
+            return ret[0]
+        except (TypeError, IndexError):
+            raise TypeError(f"{cls} is not a generic nor specified generic IcebergType")
+
+    def is_generic_type(cls, subtype: bool = False, subtype_only: bool = False):
+        """
+        Tell if `cls` is a generic IcebergType
+
+        Args:
+            cls: type to test
+            subtype: test if cls is a subtype e.g. List[Integer] is a subtype of List
+                subtype_only: return True only if type is not fully defined e.g. List and not List[Integer]
+        """
+        if subtype:
+            return any(
+                _is_subclass(cls, g[0]) and (cls != g[0] if subtype_only else True)
+                for g in generic_class.generics.values()
+            )
+
+        return cls in [g[0] for g in generic_class.generics.values()]
+
+
+Instance = generic_class(
+    "Instance",
+    [("type", Union[int, float, str, bool])],
+    meta_doc="""
+    Instance used to represent that a generic parameter requires an instance of a primitive python type
+    intended for usage with `generic_class` only
+
+    Examples:
+        >>> Fixed = generic_class("Fixed", [("length", Instance[int])], Binary)
+        >>> Fixed[5]
+        Fixed[length=5]
+        >>> Fixed['hello']
+        TypeError: Improper types of Fixed. Given 'hello' instance of <class 'str'>, expected instance of type <class 'int'>.
+
+""",
+)
+
+
+class _ListBase(PrimitiveType):
+    """base type for behavior of a List"""
+
+    @classmethod
+    def can_cast(cls, _type):
+
         return (
-            f"NestedField(is_optional={self._is_optional}, field_id={self._id}, "
-            f"name={repr(self._name)}, field_type={repr(self._type)}, doc={repr(self._doc)})"
+            issubclass(_type, List)
+            and hasattr(_type, "type")
+            and cls.type.can_cast(_type.type)
         )
 
-    def __str__(self):
+
+List = generic_class(
+    "List",
+    [("type", IcebergType)],
+    _ListBase,
+    doc="""
+Note: see `List` for more details
+
+Args:
+    value (list): list of values of type of List e.g. Integers if List.type==Integer
+
+""",
+    meta_doc="""
+A list with elements of any data type: `list<E>` from https://iceberg.apache.org/#spec/#primitive-types
+
+Args:
+    type: type of elements contained in list
+
+Attributes:
+        type: type of elements contained in list
+
+Examples:
+    >>> List[Integer]
+    List[type=Integer]
+""",
+)
+
+
+class _MapBase(PrimitiveType):
+    """base type for behavior of a Map"""
+
+    @classmethod
+    def can_cast(cls, _type):
+
         return (
-            f"{self._id}: {self._name}: {'optional' if self._is_optional else 'required'} {self._type}"
-            ""
-            if self._doc is None
-            else f" ({self._doc})"
+            issubclass(_type, Map)
+            and hasattr(_type, "key_type")
+            and cls.key_type.can_cast(_type.key_type)
+            and cls.value_type.can_cast(_type.value_type)
         )
 
 
-class StructType(Type):
-    def __init__(self, fields: list):
-        super().__init__(
-            f"struct<{', '.join(map(str, fields))}>",
-            f"StructType(fields={repr(fields)})",
+Map = generic_class(
+    "Map",
+    [("key_type", IcebergType), ("value_type", IcebergType)],
+    _MapBase,
+    doc="""
+Note: see `Map` for more details
+
+Args:
+    value (dict): dictionary of key, value pairs matching (key_type, value_type)
+
+""",
+    meta_doc="""
+A map with keys and values of any data type: `Map<K, V>` from https://iceberg.apache.org/#spec/#primitive-types
+
+Args:
+    key_type: the type of the keys of the map
+    value_type: the type of the values of the map
+
+Attributes:
+    key_type: the type of the keys of the map
+    value_type: the type of the values of the map
+
+Examples:
+    >>> Map[String, Integer]
+    Map[key_type=String, value_type=Integer]
+""",
+)
+
+
+Fixed = generic_class(
+    "Fixed",
+    [("length", Instance[int])],
+    Binary,
+    doc="""
+Note: see `Fixed` for more details
+
+Args:
+    value: the value the fixed will represent
+
+""",
+    meta_doc="""
+Fixed-length byte array of length L: `Fixed(L)` from https://iceberg.apache.org/#spec/#primitive-types
+
+Args:
+    length (int): fixed length of the byte buffer
+
+Attributes:
+    length (int): fixed length of the byte buffer
+
+Examples:
+    >>> Fixed[8]
+    Fixed[length=8]
+""",
+)
+
+
+class _DecimalBase(Number):
+    """base type for behavior of a decimal type e.g. Decimal[precision=28, scale=3]"""
+
+    _neg: bool
+    _frozen_attrs = {"_neg"}
+
+    def __init__(self, value: Union[float, str, int]):
+        with decimal.localcontext() as ctx:
+            ctx.prec = self.precision
+            super().__init__(value)
+
+            if isinstance(self.value, Number):
+                self.value = PythonDecimal(str(self.value.value))
+            else:
+                self.value = PythonDecimal(str(self.value))
+            self._scale = PythonDecimal(10) ** -self.scale
+            self.value = self.value.quantize(self._scale)
+            object.__setattr__(self, "_neg", self.value < 0)
+
+    def unscale(self) -> int:
+        value_tuple = self.value.as_tuple()
+        return int(
+            ("-" if value_tuple.sign else "")
+            + "".join([str(d) for d in value_tuple.digits])
         )
-        self._fields = fields
 
-    @property
-    def fields(self) -> list:
-        return self._fields
+    def __bytes__(self) -> bytes:
+        unscaled_value = self.unscale()
+        number_of_bytes = int(math.ceil(unscaled_value.bit_length() / 8))
+        return unscaled_value.to_bytes(length=number_of_bytes, byteorder="big")
 
-
-class ListType(Type):
-    def __init__(self, element: NestedField):
-        super().__init__(f"list<{element.type}>", f"ListType(element={repr(element)})")
-        self._element_field = element
-
-    @property
-    def element(self) -> NestedField:
-        return self._element_field
-
-
-class MapType(Type):
-    def __init__(self, key: NestedField, value: NestedField):
-        super().__init__(
-            f"map<{key.type}, {value.type}>",
-            f"MapType(key={repr(key)}, value={repr(value)})",
+    @classmethod
+    def can_cast(cls, _type):
+        return (
+            issubclass(_type, Decimal)
+            and hasattr(_type, "precision")
+            and _type.precision >= cls.precision
+            and _type.scale == cls.scale
         )
-        self._key_field = key
-        self._value_field = value
-
-    @property
-    def key(self) -> NestedField:
-        return self._key_field
-
-    @property
-    def value(self) -> NestedField:
-        return self._value_field
 
 
-BooleanType = Type("boolean", "BooleanType", is_primitive=True)
-IntegerType = Type("int", "IntegerType", is_primitive=True)
-LongType = Type("long", "LongType", is_primitive=True)
-FloatType = Type("float", "FloatType", is_primitive=True)
-DoubleType = Type("double", "DoubleType", is_primitive=True)
-DateType = Type("date", "DateType", is_primitive=True)
-TimeType = Type("time", "TimeType", is_primitive=True)
-TimestampType = Type("timestamp", "TimestampType", is_primitive=True)
-TimestamptzType = Type("timestamptz", "TimestamptzType", is_primitive=True)
-StringType = Type("string", "StringType", is_primitive=True)
-UUIDType = Type("uuid", "UUIDType", is_primitive=True)
-BinaryType = Type("binary", "BinaryType", is_primitive=True)
+Decimal = generic_class(
+    "Decimal",
+    [("precision", Instance[int]), ("scale", Instance[int])],
+    _DecimalBase,
+    doc="""
+Note: see `Decimal` for more details
+
+Args:
+    value: the value the decimal will represent
+
+    """,
+    meta_doc="""
+Fixed-point decimal; precision P, scale S: `decimal(P,S)` from https://iceberg.apache.org/#spec/#primitive-types
+
+Args:
+    precision (int): the number of digits in value
+    scale (int): the number of digits to the right of the decimal point in value
+
+Attributes:
+    precision (int): the number of digits in value
+    scale (int): the number of digits to the right of the decimal point in value
+
+Examples:
+    >>> Decimal[32, 3]
+    Decimal[precision=32, scale=3]
+""",
+)
+
+
+NestedField = generic_class(
+    "NestedField",
+    [
+        ("type", IcebergType),
+        ("optional", Instance[bool]),
+        ("field_id", Instance[int]),
+        ("name", Instance[str]),
+        ("doc", Instance[str], ""),
+    ],
+    IcebergType,
+    meta_doc="""
+equivalent of `NestedField` type from Java implementation
+""",
+)
+
+
+def _struct():  # pragma: no cover
+    """
+    this function serves only to encapsulate
+    logic for creating a struct factory
+    and is not meant to serve as a factory itself
+    """
+
+    class _StructBase(IcebergType):
+        fields: tuple
+
+        def __init__(self, *fields):
+            if not len(fields) == len(self._types) or not all(
+                isinstance(f, t) for f, t in zip(fields, self._types)
+            ):
+                raise TypeError(
+                    f"Must provide all generic parameters of matching types. Provided {self._types}. Provided {fields}"
+                )
+            self.fields = fields
+
+    def get_generic(cls, types):
+        types = types if isinstance(types, tuple) else (types,)
+        if types in cls._implemented:
+            return cls._implemented[types]
+        else:
+
+            class _StructType(_StructBase, Struct):
+                """
+                A generic instance of Struct
+                """
+
+                _types = types
+
+                def __new__(cls, *_):
+                    return object.__new__(cls)
+
+                def __repr__(self):
+                    return f"{type(self)}({', '.join(repr(f) for f in self.fields)})"
+
+            setattr(_StructType, "__annotations__", types)
+            setattr(
+                _StructType, "__name__", f"Struct{list(types)}",
+            )
+            cls._implemented[types] = _StructType
+            return _StructType
+
+    class Struct(IcebergType):
+        """
+        A record with named fields of any data type: `struct` from https://iceberg.apache.org/#schemas/
+
+        Note: this type can infer it's own generics for convenience e.g. Struct(Integer(5), Long(6)) -> Struct[Integer, Long](Integer(value=5), Long(value=6))
+
+        Examples:
+            >>>Struct(Integer(5), Long(6))
+            Struct[Integer, Long](Integer(value=5), Long(value=6))
+
+            >>>Struct[
+                NestedField[Decimal[32, 3], True, 0, "c1"],
+                NestedField[Float, False, 1, "c2"],
+            ]
+            Struct[NestedField[type=Decimal[precision=32, scale=3], optional=True, field_id=0, name='c1', doc=''], NestedField[type=Float, optional=False, field_id=1, name='c2', doc='']]
+        """
+
+        _implemented = dict()
+
+        def __new__(cls, *fields: IcebergType):
+            """
+            calling Struct will give you an instance of the generic of the appropriate type by inference
+            """
+            cls = cls[tuple(type(f) for f in fields)]
+            return cls(*fields)
+
+    setattr(
+        Struct, "_get_generic", get_generic,
+    )
+    setattr(
+        Struct, "__name__", "Struct",
+    )
+    type.__setattr__(
+        Struct, "_frozen_attrs", {"_get_generic", "_implemented", "_types"}
+    )
+
+    return Struct
+
+
+Struct = _struct()
+
+generic_class.generics["Struct"] = (Struct,)

--- a/python/src/iceberg/types.py
+++ b/python/src/iceberg/types.py
@@ -15,18 +15,20 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import decimal
+import math
+import struct
 from base64 import b64encode
 from datetime import date, datetime, time
-import decimal
 from decimal import Decimal as PythonDecimal
-import math
-import mmh3
-from numpy import float32, float64, isnan, isinf
-import struct
 from typing import Any, Dict
 from typing import List as PythonList
 from typing import Optional, Tuple, Type, Union
 from uuid import UUID as PythonUUID
+
+import mmh3
+from numpy import float32, float64, isinf, isnan
+
 
 # intended for use inside this module only
 class IcebergMetaType(type):
@@ -176,10 +178,18 @@ class Number(PrimitiveType):
                 ctx.prec = self.precision
             op_f = getattr(self.value, op)
             try:
-                if op in ("__add__", "__sub__", "__div__", "__mul__",):
+                if op in (
+                    "__add__",
+                    "__sub__",
+                    "__div__",
+                    "__mul__",
+                ):
                     other = other.to(type(self))
                     return type(self)(op_f(other.value))
-                if op in ("__pow__", "__mod__",):
+                if op in (
+                    "__pow__",
+                    "__mod__",
+                ):
                     other = type(self)(other)
                     return type(self)(op_f(other.value))
                 if op in ("__lt__", "__eq__"):
@@ -491,14 +501,14 @@ class Double(Floating):
 
 class Boolean(PrimitiveType):
     """
-    `boolean` from https://iceberg.apache.org/#spec/#primitive-types
+        `boolean` from https://iceberg.apache.org/#spec/#primitive-types
 
-    Args:
-        value (bool): value the boolean will represent
+        Args:
+            value (bool): value the boolean will represent
 
-Examples:
-        >>>Boolean(True)
-        Boolean(value=True)
+    Examples:
+            >>>Boolean(True)
+            Boolean(value=True)
     """
 
     value: bool
@@ -565,7 +575,9 @@ class UUID(PrimitiveType):
     def __bytes__(self) -> bytes:
         v = int(self)
         return struct.pack(
-            ">QQ", (v >> 64) & 0xFFFFFFFFFFFFFFFF, v & 0xFFFFFFFFFFFFFFFF,
+            ">QQ",
+            (v >> 64) & 0xFFFFFFFFFFFFFFFF,
+            v & 0xFFFFFFFFFFFFFFFF,
         )
 
 
@@ -837,7 +849,9 @@ class generic_class(type):
                     f"{name}[{', '.join(f'{k}={repr(v)}' for k,v in kwargs.items())}]",
                 )
                 setattr(
-                    _Type, "__args__", attrs,
+                    _Type,
+                    "__args__",
+                    attrs,
                 )
                 type.__setattr__(
                     _Type,
@@ -863,11 +877,15 @@ class generic_class(type):
             _implemented = dict()
 
         setattr(
-            _Factory, "_get_generic", get_generic,
+            _Factory,
+            "_get_generic",
+            get_generic,
         )
 
         setattr(
-            _Factory, "__name__", name,
+            _Factory,
+            "__name__",
+            name,
         )
         type.__setattr__(_Factory, "_frozen_attrs", {"_get_generic", "_implemented"})
         cls.generics[name] = (_Factory, attribute_names)
@@ -1160,7 +1178,9 @@ def _struct():  # pragma: no cover
 
             setattr(_StructType, "__annotations__", types)
             setattr(
-                _StructType, "__name__", f"Struct{list(types)}",
+                _StructType,
+                "__name__",
+                f"Struct{list(types)}",
             )
             cls._implemented[types] = _StructType
             return _StructType
@@ -1192,10 +1212,14 @@ def _struct():  # pragma: no cover
             return cls(*fields)
 
     setattr(
-        Struct, "_get_generic", get_generic,
+        Struct,
+        "_get_generic",
+        get_generic,
     )
     setattr(
-        Struct, "__name__", "Struct",
+        Struct,
+        "__name__",
+        "Struct",
     )
     type.__setattr__(
         Struct, "_frozen_attrs", {"_get_generic", "_implemented", "_types"}

--- a/python/src/iceberg/types.py
+++ b/python/src/iceberg/types.py
@@ -186,10 +186,18 @@ class Number(PrimitiveType):
                 ctx.prec = self.precision
             op_f = getattr(self.value, op)
             try:
-                if op in ("__add__", "__sub__", "__div__", "__mul__",):
+                if op in (
+                    "__add__",
+                    "__sub__",
+                    "__div__",
+                    "__mul__",
+                ):
                     other = other.to(type(self))
                     return type(self)(op_f(other.value))
-                if op in ("__pow__", "__mod__",):
+                if op in (
+                    "__pow__",
+                    "__mod__",
+                ):
                     other = type(self)(other)
                     return type(self)(op_f(other.value))
                 if op in ("__lt__", "__eq__"):
@@ -251,8 +259,7 @@ class Number(PrimitiveType):
 
 
 class Integral(Number):
-    """
-    base class for integral types Integer, Long
+    """base class for integral types Integer, Long
 
     Note:
        for internal iceberg use only
@@ -295,8 +302,7 @@ class Integral(Number):
 
 
 class Floating(Number):
-    """
-    base class for floating types Float, Double
+    """base class for floating types Float, Double
 
     Note:
        for internal iceberg use only
@@ -366,10 +372,10 @@ class Floating(Number):
             ("nan", "nan"): False,
             ("-inf", "-inf"): False,
             ("value", "inf"): True,
-            ("-inf", "-nan"): True,
+            ("-inf", "-nan"): False,
             ("-nan", "-nan"): False,
             ("value", "-nan"): False,
-            ("-nan", "-inf"): False,
+            ("-nan", "-inf"): True,
             ("-inf", "inf"): True,
             ("-nan", "nan"): True,
             ("nan", "value"): False,
@@ -392,8 +398,7 @@ class Floating(Number):
 
 
 class Integer(Integral):
-    """
-    32-bit signed integers: `int` from https://iceberg.apache.org/#spec/#primitive-types
+    """32-bit signed integers: `int` from https://iceberg.apache.org/#spec/#primitive-types
 
 
     Args:
@@ -425,8 +430,7 @@ class Integer(Integral):
 
 
 class Long(Integral):
-    """
-    64-bit signed integers: `long` from https://iceberg.apache.org/#spec/#primitive-types
+    """64-bit signed integers: `long` from https://iceberg.apache.org/#spec/#primitive-types
 
 
     Args:
@@ -453,8 +457,7 @@ class Long(Integral):
 
 
 class Float(Floating):
-    """
-    32-bit IEEE 754 floating point: `float` from https://iceberg.apache.org/#spec/#primitive-types
+    """32-bit IEEE 754 floating point: `float` from https://iceberg.apache.org/#spec/#primitive-types
 
     Args:
         value: value for which the float will represent
@@ -479,8 +482,7 @@ class Float(Floating):
 
 
 class Double(Floating):
-    """
-    64-bit IEEE 754 floating point: `double` from https://iceberg.apache.org/#spec/#primitive-types
+    """64-bit IEEE 754 floating point: `double` from https://iceberg.apache.org/#spec/#primitive-types
 
     Args:
         value: value for which the double will represent
@@ -502,10 +504,9 @@ class Double(Floating):
 
 
 class Boolean(PrimitiveType):
-    """
-        `boolean` from https://iceberg.apache.org/#spec/#primitive-types
+    """`boolean` from https://iceberg.apache.org/#spec/#primitive-types
 
-        Args:
+    Args:
             value (bool): value the boolean will represent
 
     Examples:
@@ -530,8 +531,7 @@ class Boolean(PrimitiveType):
 
 
 class String(PrimitiveType):
-    """
-    Arbitrary-length character sequences Encoded with UTF-8: `string` from https://iceberg.apache.org/#spec/#primitive-types
+    """Arbitrary-length character sequences Encoded with UTF-8: `string` from https://iceberg.apache.org/#spec/#primitive-types
 
     Args:
         value (str): value the string will represent
@@ -552,8 +552,7 @@ class String(PrimitiveType):
 
 
 class UUID(PrimitiveType):
-    """
-    Universally unique identifiers: `uuid` from https://iceberg.apache.org/#spec/#primitive-types
+    """Universally unique identifiers: `uuid` from https://iceberg.apache.org/#spec/#primitive-types
 
     Args:
         value: value the uuid will represent
@@ -580,13 +579,14 @@ class UUID(PrimitiveType):
     def to_bytes(cls, value) -> bytes:
         v = int(value.int)
         return struct.pack(
-            ">QQ", (v >> 64) & 0xFFFFFFFFFFFFFFFF, v & 0xFFFFFFFFFFFFFFFF,
+            ">QQ",
+            (v >> 64) & 0xFFFFFFFFFFFFFFFF,
+            v & 0xFFFFFFFFFFFFFFFF,
         )
 
 
 class Binary(PrimitiveType):
-    """
-    Arbitrary-length byte array from  https://iceberg.apache.org/#spec/#primitive-types
+    """Arbitrary-length byte array from  https://iceberg.apache.org/#spec/#primitive-types
 
     Args:
         value (bytes): bytes to hold in binary buffer
@@ -606,13 +606,11 @@ class Binary(PrimitiveType):
 
 
 class Datetime(PrimitiveType):
-    """
-    base class for Date, Time, Timestamp, Timestamptz
+    """base class for Date, Time, Timestamp, Timestamptz
+
     Note:
        for internal iceberg use only
 
-    Examples:
-        Can be used in place of typing for all of Date, Time, Timestamp, Timestamptz
     """
 
     epoch: datetime = datetime.utcfromtimestamp(0)
@@ -644,8 +642,7 @@ class Datetime(PrimitiveType):
 
 
 class Date(Datetime):
-    """
-    `date` type from https://iceberg.apache.org/#spec/#primitive-types
+    """`date` type from https://iceberg.apache.org/#spec/#primitive-types
 
     Args:
         *args: can pass a string formatted in the isoformat or several `int` for year, month, day
@@ -670,8 +667,7 @@ class Date(Datetime):
 
 
 class Time(Datetime):
-    """
-    `time` type from https://iceberg.apache.org/#spec/#primitive-types
+    """`time` type from https://iceberg.apache.org/#spec/#primitive-types
 
     Args:
         *args: can pass a string formatted in the isoformat or several `int` for hour[, minute[, second[, microsecond]
@@ -698,8 +694,7 @@ class Time(Datetime):
 
 
 class Timestamp(Datetime):
-    """
-    `timestamp` type from https://iceberg.apache.org/#spec/#primitive-types
+    """`timestamp` type from https://iceberg.apache.org/#spec/#primitive-types
 
     Args:
         *args: can pass a string formatted in the isoformat or several `int` for year, month, day[, hour[, minute[, second[, microsecond]]]]
@@ -724,8 +719,7 @@ class Timestamp(Datetime):
 
 
 class Timestamptz(Timestamp):
-    """
-    `timestamptz` type from https://iceberg.apache.org/#spec/#primitive-types
+    """`timestamptz` type from https://iceberg.apache.org/#spec/#primitive-types
 
     Args:
         *args: can pass a string formatted in the isoformat or several `int` for year, month, day[, hour[, minute[, second[, microsecond[,tzinfo]]]]]
@@ -766,8 +760,7 @@ class generic_class(type):
         doc: str = "",
         meta_doc: str = "",
     ):
-        """
-        facilitates generating generic type factories such as `List` e.g. `List[Integer]`
+        """facilitates generating generic type factories such as `List` e.g. `List[Integer]`
         in the spirit of builtin `type` e.g.:
             def Robot_init(self, name):
                 self.name = name
@@ -799,7 +792,9 @@ class generic_class(type):
 
             if len(attrs) > len(attributes):
                 raise TypeError(
-                    f'Too many generic parameters provided. Expected {len(attribute_names)} parameter(s) of subtypes of ({",".join(repr(i) for i in attribute_types)}). Provided {attrs}'
+                    f"""Too many generic parameters provided. Expected {len(attribute_names)} 
+                    parameter(s) of subtypes of ({",".join(repr(i) for i in attribute_types)}). 
+                    Provided {attrs}"""
                 )
 
             kwargs = dict(zip(attribute_names, attrs))
@@ -845,8 +840,7 @@ class generic_class(type):
                         else (_Factory,)
                     )
                 ):
-                    __doc__ = f"""
-                    Generic instance of {name} with generic attributes {kwargs}
+                    __doc__ = f"""Generic instance of {name} with generic attributes {kwargs}
 
                     {doc}
                     """
@@ -859,7 +853,9 @@ class generic_class(type):
                     f"{name}[{', '.join(f'{k}={repr(v)}' for k,v in kwargs.items())}]",
                 )
                 setattr(
-                    _Type, "__args__", attrs,
+                    _Type,
+                    "__args__",
+                    attrs,
                 )
                 type.__setattr__(
                     _Type,
@@ -885,47 +881,52 @@ class generic_class(type):
             _implemented = dict()
 
         setattr(
-            _Factory, "_get_generic", get_generic,
+            _Factory,
+            "_get_generic",
+            get_generic,
         )
 
         setattr(
-            _Factory, "__name__", name,
+            _Factory,
+            "__name__",
+            name,
         )
         type.__setattr__(_Factory, "_frozen_attrs", {"_get_generic", "_implemented"})
         cls.generics[name] = (_Factory, attribute_names)
         return _Factory
 
     def get_unspecified_generic_type(cls):
-        """
-        get the unspecified generic type of `cls` e.g. List for List[Integer]
+        """get the unspecified generic type of `cls` e.g. List for List[Integer]
 
         Args:
             cls: type to test
         """
         try:
             ret = [
-                g[0] for g in generic_class.generics.values() if _is_subclass(cls, g[0])
+                generic[0]
+                for generic in generic_class.generics.values()
+                if _is_subclass(cls, generic[0])
             ]
             return ret[0]
         except (TypeError, IndexError):
             raise TypeError(f"{cls} is not a generic nor specified generic IcebergType")
 
     def is_generic_type(cls, subtype: bool = False, subtype_only: bool = False):
-        """
-        Tell if `cls` is a generic IcebergType
+        """Tell if `cls` is a generic IcebergType
 
         Args:
             cls: type to test
             subtype: test if cls is a subtype e.g. List[Integer] is a subtype of List
-                subtype_only: return True only if type is not fully defined e.g. List and not List[Integer]
+            subtype_only(optional): return True only if type is not fully defined e.g. List and not List[Integer]
         """
         if subtype:
             return any(
-                _is_subclass(cls, g[0]) and (cls != g[0] if subtype_only else True)
-                for g in generic_class.generics.values()
+                _is_subclass(cls, generic[0])
+                and (cls != generic[0] if subtype_only else True)
+                for generic in generic_class.generics.values()
             )
 
-        return cls in [g[0] for g in generic_class.generics.values()]
+        return cls in [generic[0] for generic in generic_class.generics.values()]
 
 
 Instance = generic_class(
@@ -963,15 +964,13 @@ List = generic_class(
     "List",
     [("type", IcebergType)],
     _ListBase,
-    doc="""
-Note: see `List` for more details
+    doc="""Note: see `List` for more details
 
 Args:
     value (list): list of values of type of List e.g. Integers if List.type==Integer
 
 """,
-    meta_doc="""
-A list with elements of any data type: `list<E>` from https://iceberg.apache.org/#spec/#primitive-types
+    meta_doc="""A list with elements of any data type: `list<E>` from https://iceberg.apache.org/#spec/#primitive-types
 
 Args:
     type: type of elements contained in list
@@ -1004,15 +1003,13 @@ Map = generic_class(
     "Map",
     [("key_type", IcebergType), ("value_type", IcebergType)],
     _MapBase,
-    doc="""
-Note: see `Map` for more details
+    doc="""Note: see `Map` for more details
 
 Args:
     value (dict): dictionary of key, value pairs matching (key_type, value_type)
 
 """,
-    meta_doc="""
-A map with keys and values of any data type: `Map<K, V>` from https://iceberg.apache.org/#spec/#primitive-types
+    meta_doc="""A map with keys and values of any data type: `Map<K, V>` from https://iceberg.apache.org/#spec/#primitive-types
 
 Args:
     key_type: the type of the keys of the map
@@ -1033,15 +1030,13 @@ Fixed = generic_class(
     "Fixed",
     [("length", Instance[int])],
     Binary,
-    doc="""
-Note: see `Fixed` for more details
+    doc="""Note: see `Fixed` for more details
 
 Args:
     value: the value the fixed will represent
 
 """,
-    meta_doc="""
-Fixed-length byte array of length L: `Fixed(L)` from https://iceberg.apache.org/#spec/#primitive-types
+    meta_doc="""Fixed-length byte array of length L: `Fixed(L)` from https://iceberg.apache.org/#spec/#primitive-types
 
 Args:
     length (int): fixed length of the byte buffer
@@ -1103,15 +1098,13 @@ Decimal = generic_class(
     "Decimal",
     [("precision", Instance[int]), ("scale", Instance[int])],
     _DecimalBase,
-    doc="""
-Note: see `Decimal` for more details
+    doc="""Note: see `Decimal` for more details
 
 Args:
     value: the value the decimal will represent
 
     """,
-    meta_doc="""
-Fixed-point decimal; precision P, scale S: `decimal(P,S)` from https://iceberg.apache.org/#spec/#primitive-types
+    meta_doc="""Fixed-point decimal; precision P, scale S: `decimal(P,S)` from https://iceberg.apache.org/#spec/#primitive-types
 
 Args:
     precision (int): the number of digits in value
@@ -1138,9 +1131,7 @@ NestedField = generic_class(
         ("doc", Instance[str], ""),
     ],
     IcebergType,
-    meta_doc="""
-equivalent of `NestedField` type from Java implementation
-""",
+    meta_doc="""equivalent of `NestedField` type from Java implementation""",
 )
 
 
@@ -1156,7 +1147,7 @@ def _struct():  # pragma: no cover
 
         def __init__(self, *fields):
             if not len(fields) == len(self._types) or not all(
-                isinstance(f, t) for f, t in zip(fields, self._types)
+                isinstance(field, _type) for field, _type in zip(fields, self._types)
             ):
                 raise TypeError(
                     f"Must provide all generic parameters of matching types. Provided {self._types}. Provided {fields}"
@@ -1184,14 +1175,15 @@ def _struct():  # pragma: no cover
 
             setattr(_StructType, "__annotations__", types)
             setattr(
-                _StructType, "__name__", f"Struct{list(types)}",
+                _StructType,
+                "__name__",
+                f"Struct{list(types)}",
             )
             cls._implemented[types] = _StructType
             return _StructType
 
     class Struct(IcebergType):
-        """
-        A record with named fields of any data type: `struct` from https://iceberg.apache.org/#schemas/
+        """A record with named fields of any data type: `struct` from https://iceberg.apache.org/#schemas/
 
         Note: this type can infer it's own generics for convenience e.g. Struct(Integer(5), Long(6)) -> Struct[Integer, Long](Integer(value=5), Long(value=6))
 
@@ -1216,10 +1208,14 @@ def _struct():  # pragma: no cover
             return cls(*fields)
 
     setattr(
-        Struct, "_get_generic", get_generic,
+        Struct,
+        "_get_generic",
+        get_generic,
     )
     setattr(
-        Struct, "__name__", "Struct",
+        Struct,
+        "__name__",
+        "Struct",
     )
     type.__setattr__(
         Struct, "_frozen_attrs", {"_get_generic", "_implemented", "_types"}

--- a/python/tests/test_types.py
+++ b/python/tests/test_types.py
@@ -469,8 +469,8 @@ def test_is_generic_type(type_, r1, r2, r3):
 @pytest.mark.parametrize(
     "order",
     [
-        Float("-inf")
-        < Float("-nan")
+        Float("-nan")
+        < Float("-inf")
         < Float(-4e10)
         < Float(-24)
         < Float("-0")
@@ -479,8 +479,8 @@ def test_is_generic_type(type_, r1, r2, r3):
         < Float(4e10)
         < Float("nan")
         < Float("inf"),
-        Float("-inf")
-        <= Float("-nan")
+        Float("-nan")
+        <= Float("-inf")
         <= Float(-4e10)
         <= Float(-24)
         <= Float("-0")
@@ -489,8 +489,8 @@ def test_is_generic_type(type_, r1, r2, r3):
         <= Float(4e10)
         <= Float("nan")
         <= Float("inf"),
-        Double("-inf")
-        < Double("-nan")
+        Double("-nan")
+        < Double("-inf")
         < Double(-4e10)
         < Double(-24)
         < Double("-0")
@@ -499,8 +499,8 @@ def test_is_generic_type(type_, r1, r2, r3):
         < Double(4e10)
         < Double("nan")
         < Double("inf"),
-        Double("-inf")
-        <= Double("-nan")
+        Double("-nan")
+        <= Double("-inf")
         <= Double(-4e10)
         <= Double(-24)
         <= Double("-0")
@@ -509,8 +509,8 @@ def test_is_generic_type(type_, r1, r2, r3):
         <= Double(4e10)
         <= Double("nan")
         <= Double("inf"),
-        not Float("-inf")
-        > Float("-nan")
+        not Float("-nan")
+        > Float("-inf")
         > Float(-4e10)
         > Float(-24)
         > Float("-0")
@@ -519,8 +519,8 @@ def test_is_generic_type(type_, r1, r2, r3):
         > Float(4e10)
         > Float("nan")
         > Float("inf"),
-        not Float("-inf")
-        >= Float("-nan")
+        not Float("-nan")
+        >= Float("-inf")
         >= Float(-4e10)
         >= Float(-24)
         >= Float("-0")
@@ -529,8 +529,8 @@ def test_is_generic_type(type_, r1, r2, r3):
         >= Float(4e10)
         >= Float("nan")
         >= Float("inf"),
-        not Double("-inf")
-        > Double("-nan")
+        not Double("-nan")
+        > Double("-inf")
         > Double(-4e10)
         > Double(-24)
         > Double("-0")
@@ -539,8 +539,8 @@ def test_is_generic_type(type_, r1, r2, r3):
         > Double(4e10)
         > Double("nan")
         > Double("inf"),
-        not Double("-inf")
-        >= Double("-nan")
+        not Double("-nan")
+        >= Double("-inf")
         >= Double(-4e10)
         >= Double(-24)
         >= Double("-0")
@@ -553,3 +553,10 @@ def test_is_generic_type(type_, r1, r2, r3):
 )
 def test_floating_sort_order(order):
     assert order
+
+
+def test_sort_order_fails():
+    with pytest.raises(TypeError):
+        Float(5) < Integer(6)
+    with pytest.raises(TypeError):
+        Float(5) < int

--- a/python/tests/test_types.py
+++ b/python/tests/test_types.py
@@ -15,149 +15,541 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import decimal
+import math
+
 import pytest
 
 from iceberg.types import (
-    BinaryType,
-    BooleanType,
-    DateType,
-    DecimalType,
-    DoubleType,
-    FixedType,
-    FloatType,
-    IntegerType,
-    ListType,
-    LongType,
-    MapType,
+    UUID,
+    Binary,
+    Boolean,
+    Date,
+    Decimal,
+    Double,
+    Fixed,
+    Float,
+    IcebergType,
+    Integer,
+    List,
+    Long,
+    Map,
     NestedField,
-    StringType,
-    StructType,
-    TimestampType,
-    TimestamptzType,
-    TimeType,
-    UUIDType,
+    Number,
+    PrimitiveType,
+    String,
+    Struct,
+    Time,
+    Timestamp,
+    Timestamptz,
+    generic_class,
 )
 
 
 @pytest.mark.parametrize(
-    "input_type",
+    "type, expected_result",
     [
-        BooleanType,
-        IntegerType,
-        LongType,
-        FloatType,
-        DoubleType,
-        DateType,
-        TimeType,
-        TimestampType,
-        TimestamptzType,
-        StringType,
-        UUIDType,
-        BinaryType,
+        (UUID, True),
+        (Number, True),
+        (String, True),
+        (Fixed, True),
+        (Decimal, True),
+        (Map, True),
+        (List, True),
+        (Float, True),
+        (Boolean, True),
+        (Double, True),
+        (Long, True),
+        (PrimitiveType, True),
+        (IcebergType, True),
+        (Integer, True),
+        (Struct, True),
+        (NestedField, True),
+        (NestedField[Decimal[32, 3], True, 0, "c1"], True),
+        (Map[String, Boolean], True),
+        (Map[Integer, Float], True),
+        (Map[Long, Boolean], True),
+        (List[Integer], True),
+        (List[String], True),
+        (List[Map[Long, Boolean]], True),
+        (Decimal[32, 3], True),
+        (
+            Struct[
+                NestedField[Decimal[32, 3], True, 0, "c1"],
+                NestedField[Float, False, 1, "c2"],
+            ],
+            True,
+        ),
+        (type, False),
+        (object, False),
+        (int, False),
+        (float, False),
+        (decimal.Decimal, False),
+        (str, False),
+        (bool, False),
     ],
 )
-def test_repr_primitive_types(input_type):
-    assert input_type == eval(repr(input_type))
+def test_is_icebergtype(type, expected_result):
+    assert issubclass(type, IcebergType) == expected_result
 
 
-def test_fixed_type():
-    type_var = FixedType(length=5)
-    assert type_var.length == 5
-    assert str(type_var) == "fixed[5]"
-    assert repr(type_var) == "FixedType(length=5)"
-    assert str(type_var) == str(eval(repr(type_var)))
+# https://iceberg.apache.org/#spec/#appendix-b-32-bit-hash-requirements
+@pytest.mark.parametrize(
+    "instance,expected",
+    [
+        (UUID("f79c3e09-677c-4bbd-a479-3f349cb785e7"), 1488055340),
+        (Boolean(True), 1392991556),
+        (Integer(34), 2017239379),
+        (Long(34), 2017239379),
+        (Float(1), -142385009),
+        (Double(1), -142385009),
+        (Decimal[9, 2]("14.20"), -500754589),
+        (String("iceberg"), 1210000089),
+        (Binary(b"\x00\x01\x02\x03"), -188683207),
+        (Fixed[8](b"\x00\x01\x02\x03"), -188683207),
+        (Date("2017-11-16"), -653330422),
+        (Time(22, 31, 8), -662762989),
+        (Timestamp("2017-11-16T14:31:08-08:00"), -2047944441),
+        (Timestamptz("2017-11-16T14:31:08-08:00"), -2047944441),
+    ],
+)
+def test_hashing(instance, expected):
+    assert hash(instance) == expected
 
 
-def test_decimal_type():
-    type_var = DecimalType(precision=9, scale=2)
-    assert type_var.precision == 9
-    assert type_var.scale == 2
-    assert str(type_var) == "decimal(9, 2)"
-    assert repr(type_var) == "DecimalType(precision=9, scale=2)"
-    assert str(type_var) == str(eval(repr(type_var)))
+@pytest.mark.parametrize(
+    "type, expected_result",
+    [
+        (UUID, "UUID"),
+        (Boolean, "Boolean"),
+        (Long, "Long"),
+        (Double, "Double"),
+        (Decimal, "Decimal"),
+        (Integer, "Integer"),
+        (Float, "Float"),
+        (Fixed, "Fixed"),
+        (Number, "Number"),
+        (String, "String"),
+        (Map, "Map"),
+        (PrimitiveType, "PrimitiveType"),
+        (List, "List"),
+        (IcebergType, "IcebergType"),
+    ],
+)
+def test_type_repr(type, expected_result):
+    assert repr(type) == expected_result == str(type)
 
 
-def test_struct_type():
-    type_var = StructType(
-        [
-            NestedField(True, 1, "optional_field", IntegerType),
-            NestedField(False, 2, "required_field", FixedType(5)),
-            NestedField(
-                False,
-                3,
-                "required_field",
-                StructType(
-                    [
-                        NestedField(True, 4, "optional_field", DecimalType(8, 2)),
-                        NestedField(False, 5, "required_field", LongType),
-                    ]
-                ),
+@pytest.mark.parametrize(
+    "instance, expected_result",
+    [
+        (
+            UUID("f79c3e09-677c-4bbd-a479-3f349cb785e7"),
+            "UUID(value=f79c3e09-677c-4bbd-a479-3f349cb785e7)",
+        ),
+        (String("hello"), "String(value=hello)"),
+        (Boolean(True), "Boolean(value=True)"),
+        (Boolean(False), "Boolean(value=False)"),
+        (Integer(math.pi), "Integer(value=3)"),
+        (Integer(1), "Integer(value=1)"),
+        (Integer(1.0), "Integer(value=1)"),
+        (Integer("1"), "Integer(value=1)"),
+        (Long(math.pi), "Long(value=3)"),
+        (Long(1), "Long(value=1)"),
+        (Long(1.0), "Long(value=1)"),
+        (Long("1"), "Long(value=1)"),
+        (Float(math.pi), "Float(value=3.1415927410125732)"),
+        (Float(1), "Float(value=1.0)"),
+        (Float(1.0), "Float(value=1.0)"),
+        (Float("1"), "Float(value=1.0)"),
+        (Float("1.0"), "Float(value=1.0)"),
+        (Double(math.pi), "Double(value=3.141592653589793)"),
+        (Double(1), "Double(value=1.0)"),
+        (Double(1.0), "Double(value=1.0)"),
+        (Double("1"), "Double(value=1.0)"),
+        (Double("1.0"), "Double(value=1.0)"),
+        (Fixed[16], "Fixed[length=16]"),
+        (Fixed[8], "Fixed[length=8]"),
+        (
+            Binary(bytes(16)),
+            r"Binary(value=b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00')",
+        ),
+        (Decimal[32, 1], "Decimal[precision=32, scale=1]"),
+        (Decimal[32, 3](math.pi), "Decimal[precision=32, scale=3](value=3.142)"),
+        (Decimal[32, 5](math.pi), "Decimal[precision=32, scale=5](value=3.14159)"),
+        (
+            Fixed[8](bytes(8)),
+            r"Fixed[length=8](value=b'\x00\x00\x00\x00\x00\x00\x00\x00')",
+        ),
+        (Struct(Integer(5)), "Struct[Integer](Integer(value=5))"),
+        (
+            Struct(Integer(5), Decimal[32, 3](math.pi)),
+            "Struct[Integer, Decimal[precision=32, scale=3]](Integer(value=5), Decimal[precision=32, scale=3](value=3.142))",
+        ),
+        (
+            Struct[Integer, Decimal[32, 3]](Integer(5), Decimal[32, 3](math.pi)),
+            "Struct[Integer, Decimal[precision=32, scale=3]](Integer(value=5), Decimal[precision=32, scale=3](value=3.142))",
+        ),
+        (
+            Struct[NestedField[Decimal[32, 3], True, 0, "c1"]],
+            """Struct[NestedField[type=Decimal[precision=32, scale=3], optional=True, field_id=0, name='c1', doc='']]""",
+        ),
+        (
+            Struct[
+                NestedField[Decimal[32, 3], True, 0, "c1"],
+                NestedField[Float, False, 1, "c2"],
+            ],
+            """Struct[NestedField[type=Decimal[precision=32, scale=3], optional=True, field_id=0, name='c1', doc=''], NestedField[type=Float, optional=False, field_id=1, name='c2', doc='']]""",
+        ),
+        (
+            NestedField[Decimal[32, 3], True, 0, "c1"],
+            "NestedField[type=Decimal[precision=32, scale=3], optional=True, field_id=0, name='c1', doc='']",
+        ),
+        (
+            Map[String, Boolean](
+                {
+                    String("a"): Boolean(True),
+                    String("b"): Boolean(False),
+                    String("c"): Boolean(True),
+                    String("d"): Boolean(False),
+                }
             ),
-        ]
-    )
-    assert len(type_var.fields) == 3
-    assert str(type_var) == str(eval(repr(type_var)))
+            "Map[key_type=String, value_type=Boolean](value={String(value=a): Boolean(value=True), String(value=b): Boolean(value=False), String(value=c): Boolean(value=True), String(value=d): Boolean(value=False)})",
+        ),
+        (
+            List[Integer]([Integer(5), Integer(1), Integer(12), Integer(3.14)]),
+            "List[type=Integer](value=[Integer(value=5), Integer(value=1), Integer(value=12), Integer(value=3)])",
+        ),
+    ],
+)
+def test_instance_repr(instance, expected_result):
+    assert repr(instance) == expected_result
 
 
-def test_list_type():
-    type_var = ListType(
-        NestedField(
+@pytest.mark.parametrize(
+    "specific, unspecific",
+    [
+        (Decimal[32, 1], Decimal),
+        (Map[String, Boolean], Map),
+        (List[Integer], List),
+        (Fixed[16], Fixed),
+        (
+            Struct[
+                NestedField[Decimal[32, 3], True, 0, "c1"],
+                NestedField[Float, False, 1, "c2"],
+            ],
+            Struct,
+        ),
+    ],
+)
+def test_specific_generic_subclass_unspecific(specific, unspecific):
+    assert issubclass(specific, unspecific)
+
+
+def test_integer_under_overflows():
+    with pytest.raises(ValueError):
+        Integer(2 ** 31)
+    with pytest.raises(ValueError):
+        Integer(-(2 ** 31) - 1)
+
+
+def test_cannot_alter_integer_bounds():
+    with pytest.raises(AttributeError):
+        del Integer.max
+    with pytest.raises(AttributeError):
+        del Integer.min
+    with pytest.raises(AttributeError):
+        Integer.min = 0
+    with pytest.raises(AttributeError):
+        Integer.max = 0
+
+
+def test_cannot_alter_long_bounds():
+    with pytest.raises(AttributeError):
+        del Long.max
+    with pytest.raises(AttributeError):
+        del Long.min
+    with pytest.raises(AttributeError):
+        Long.min = 0
+    with pytest.raises(AttributeError):
+        Long.max = 0
+
+
+def test_long_not_under_overflows():
+    Long(2 ** 63 - 1)
+    Long(-(2 ** 63))
+
+
+def test_long_under_overflows():
+    with pytest.raises(ValueError):
+        Long(2 ** 63)
+    with pytest.raises(ValueError):
+        Long(-(2 ** 63) - 1)
+
+
+def test_cannot_alter_floating_neg():
+    with pytest.raises(AttributeError):
+        del Float(3.14)._neg
+    with pytest.raises(AttributeError):
+        Float(3.14)._neg = 0
+    with pytest.raises(AttributeError):
+        del Double(3.14)._neg
+    with pytest.raises(AttributeError):
+        Double(3.14)._neg = 0
+
+
+@pytest.mark.parametrize(
+    "_from, to, coerce",
+    [
+        (Integer(5), Long, False),
+        (Integer(5), Double, True),
+        (Integer(5), Float, True),
+        (Float(3.14), Double, True),
+        (Decimal[32, 3](math.pi), Decimal[33, 3], False),
+    ],
+)
+def test_number_casting_succeeds(_from, to, coerce):
+    assert _from.to(to, coerce)
+
+
+@pytest.mark.parametrize(
+    "_from, to",
+    [
+        (Integer(5), Double),
+        (Integer(5), Float),
+        (Long(9), Decimal[9, 2]),
+        (Long(5), Double),
+        (Long(5), Float),
+        (Decimal[32, 3](math.pi), Decimal[31, 3]),
+        (Decimal[32, 3](math.pi), Decimal[32, 2]),
+    ],
+)
+def test_number_casting_fails(_from, to):
+    with pytest.raises(TypeError):
+        _from.to(to)
+
+
+@pytest.mark.parametrize(
+    "operation, result",
+    [
+        (Integer(5) <= Integer(5), True),
+        (Long(5) <= Long(5), True),
+        (Integer(5) < Integer(5), False),
+        (Long(5) < Long(5), False),
+        (Long(5) < Integer(5), False),
+        (Double(5) < Float(5), False),
+        (Decimal[32, 3](5) <= Decimal[32, 3](5), True),
+        (Decimal[32, 3](5) < Decimal[32, 3](5), False),
+        (Long(2) - Long(1), Long(1)),
+        (
+            Double(math.pi) == Float(math.pi),
             False,
-            1,
-            "required_field",
-            StructType(
-                [
-                    NestedField(True, 2, "optional_field", DecimalType(8, 2)),
-                    NestedField(False, 3, "required_field", LongType),
-                ]
-            ),
-        )
-    )
-    assert isinstance(type_var.element.type, StructType)
-    assert len(type_var.element.type.fields) == 2
-    assert type_var.element.field_id == 1
-    assert str(type_var) == str(eval(repr(type_var)))
-
-
-def test_map_type():
-    type_var = MapType(
-        NestedField(True, 1, "optional_field", DoubleType),
-        NestedField(False, 2, "required_field", UUIDType),
-    )
-    assert type_var.key.type == DoubleType
-    assert type_var.key.field_id == 1
-    assert type_var.value.type == UUIDType
-    assert type_var.value.field_id == 2
-    assert str(type_var) == str(eval(repr(type_var)))
+        ),  # False is the correct value based on ieee754 representation going from 32 to 64 bits
+        (Double(math.pi) ** 2, Double(math.pi ** 2)),
+        (abs(Float(-6) ** Float(2)), Float(36)),
+        ((Float(5) ** 4) % Float(4), Float(1)),
+        (Decimal[32, 3](math.pi).to(Integer, True), Integer(3)),
+    ],
+)
+def test_number_arithmetic(operation, result):
+    assert operation == result
 
 
 def test_nested_field():
-    field_var = NestedField(
-        True,
-        1,
-        "optional_field1",
-        StructType(
-            [
-                NestedField(
-                    True,
-                    2,
-                    "optional_field2",
-                    ListType(NestedField(False, 3, "required_field3", DoubleType)),
-                ),
-                NestedField(
-                    False,
-                    4,
-                    "required_field4",
-                    MapType(
-                        NestedField(True, 5, "optional_field5", TimeType),
-                        NestedField(False, 6, "required_field6", UUIDType),
-                    ),
-                ),
-            ]
-        ),
-    )
-    assert field_var.is_optional
-    assert not field_var.is_required
+    field_var = NestedField[
+        List[NestedField[Double, False, 2, "required_field"]], True, 1, "optional_field"
+    ]
+    assert field_var.optional
+    assert not field_var.type.type.optional
     assert field_var.field_id == 1
-    assert isinstance(field_var.type, StructType)
-    assert str(field_var) == str(eval(repr(field_var)))
+    assert field_var.type == List[NestedField[Double, False, 2, "required_field"]]
+
+
+@pytest.mark.parametrize(
+    "struct, struct_type",
+    [
+        (Struct(Double(math.pi)), Struct[Double]),
+        (Struct(Decimal[32, 3](math.pi)), Struct[Decimal[32, 3]]),
+        (
+            Struct(
+                Map[String, Boolean](
+                    {
+                        String("a"): Boolean(True),
+                        String("b"): Boolean(False),
+                        String("c"): Boolean(True),
+                        String("d"): Boolean(False),
+                    }
+                ),
+                Float(1.9),
+            ),
+            Struct[Map[String, Boolean], Float],
+        ),
+        (
+            Struct(List[Boolean]([Boolean(True), Boolean(True), Boolean(False)])),
+            Struct[List[Boolean]],
+        ),
+    ],
+)
+def test_struct_infer_type(struct, struct_type):
+    assert type(struct) == struct_type
+
+
+@pytest.mark.parametrize(
+    "type1, type2, result",
+    [
+        (List[Integer], List[Number], True),
+        (List[Integer], List, True),
+        (Map[String, Integer], Map[IcebergType, IcebergType], True),
+        (List[Integer], List[String], False),
+        (List[Map[String, Integer]], List[IcebergType], True),
+        (List[Map[String, Integer]], List[Map], True),
+        (List[Map[String, Integer]], List[Map[String, Number]], True),
+        (List[Map[String, Integer]], List[Map[Float, Number]], False),
+        (List[Map[String, Decimal[32, 3]]], List[Map[String, Number]], True),
+        (List, Map, False),
+        (Double, IcebergType, True),
+        (Float, Number, True),
+        (Long, Fixed, False),
+    ],
+)
+def test_issubclass(type1, type2, result):
+    assert issubclass(type1, type2) == result
+
+
+@pytest.mark.parametrize(
+    "type, result",
+    [
+        (List[Integer], List),
+        (Map[String, Integer], Map),
+        (List[Integer], List),
+        (List[Map[String, Integer]], List),
+        (List[Map[String, Decimal[32, 3]]], List),
+        (NestedField[Double, False, 2, "required_field"], NestedField),
+        (List, List),
+        (Decimal, Decimal),
+        (Fixed[8], Fixed),
+        (Decimal[16, 3], Decimal),
+        (Double, None),
+        (Float, None),
+        (Long, None),
+    ],
+)
+def test_get_unspecified_generic_type(type, result):
+    if result is None:
+        with pytest.raises(TypeError):
+            generic_class.get_unspecified_generic_type(type)
+    else:
+        assert generic_class.get_unspecified_generic_type(type) == result
+
+
+@pytest.mark.parametrize(
+    "type_, r1, r2, r3",
+    [
+        (List[Integer], False, True, True),
+        (Map[String, Integer], False, True, True),
+        (List[Integer], False, True, True),
+        (List[Map[String, Integer]], False, True, True),
+        (List[Map[String, Decimal[32, 3]]], False, True, True),
+        (NestedField[String, False, 2, "required_field"], False, True, True),
+        (List, True, True, False),
+        (Decimal, True, True, False),
+        (Fixed[8], False, True, True),
+        (Decimal[16, 3], False, True, True),
+        (Double, False, False, False),
+        (Float, False, False, False),
+        (Long, False, False, False),
+    ],
+)
+def test_is_generic_type(type_, r1, r2, r3):
+    assert generic_class.is_generic_type(type_) == r1
+    assert generic_class.is_generic_type(type_, True) == r2
+    assert generic_class.is_generic_type(type_, True, True) == r3
+
+
+@pytest.mark.parametrize(
+    "order",
+    [
+        Float("-inf")
+        < Float("-nan")
+        < Float(-4e10)
+        < Float(-24)
+        < Float("-0")
+        < Float(0)
+        < Float(24)
+        < Float(4e10)
+        < Float("nan")
+        < Float("inf"),
+        Float("-inf")
+        <= Float("-nan")
+        <= Float(-4e10)
+        <= Float(-24)
+        <= Float("-0")
+        <= Float(0)
+        <= Float(24)
+        <= Float(4e10)
+        <= Float("nan")
+        <= Float("inf"),
+        Double("-inf")
+        < Double("-nan")
+        < Double(-4e10)
+        < Double(-24)
+        < Double("-0")
+        < Double(0)
+        < Double(24)
+        < Double(4e10)
+        < Double("nan")
+        < Double("inf"),
+        Double("-inf")
+        <= Double("-nan")
+        <= Double(-4e10)
+        <= Double(-24)
+        <= Double("-0")
+        <= Double(0)
+        <= Double(24)
+        <= Double(4e10)
+        <= Double("nan")
+        <= Double("inf"),
+        not Float("-inf")
+        > Float("-nan")
+        > Float(-4e10)
+        > Float(-24)
+        > Float("-0")
+        > Float(0)
+        > Float(24)
+        > Float(4e10)
+        > Float("nan")
+        > Float("inf"),
+        not Float("-inf")
+        >= Float("-nan")
+        >= Float(-4e10)
+        >= Float(-24)
+        >= Float("-0")
+        >= Float(0)
+        >= Float(24)
+        >= Float(4e10)
+        >= Float("nan")
+        >= Float("inf"),
+        not Double("-inf")
+        > Double("-nan")
+        > Double(-4e10)
+        > Double(-24)
+        > Double("-0")
+        > Double(0)
+        > Double(24)
+        > Double(4e10)
+        > Double("nan")
+        > Double("inf"),
+        not Double("-inf")
+        >= Double("-nan")
+        >= Double(-4e10)
+        >= Double(-24)
+        >= Double("-0")
+        >= Double(0)
+        >= Double(24)
+        >= Double(4e10)
+        >= Double("nan")
+        >= Double("inf"),
+    ],
+)
+def test_floating_sort_order(order):
+    assert order

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -23,7 +23,10 @@ usedevelop = true
 deps =
     coverage
     mock
+    numpy
     pytest
+    mmh3
+extras = dev
 setenv =
     COVERAGE_FILE = test-reports/{envname}/.coverage
     PYTEST_ADDOPTS = --junitxml=test-reports/{envname}/junit.xml -vv
@@ -65,7 +68,7 @@ commands =
 deps =
     mypy
 commands =
-    mypy --no-implicit-optional src
+    mypy --install-types --non-interactive --no-implicit-optional --ignore-missing-imports src
 
 [testenv:docs]
 basepython = python3


### PR DESCRIPTION
Based off initial commentary in Issue #3464

This pr looks to create a unified way of accessing types and interacting with literals.

I think this will serve for better developer experience inside the library and outside. For example, see [transforms implemented very concisely using this type system](https://github.com/CircArgs/iceberg/blob/typed-transforms/python/src/iceberg/transforms.py) (and accompanying [PR into existing transforms pr](https://github.com/jun-he/incubator-iceberg/pull/4))

- It includes a simple and intuitive api for describing even generic types as you would expect in the standard typing library such as `Decimal` where `Decimal[32, 3]` specifies a `Decimal` type with precision `32` and scale `3` or `List[Integer]` which specifies an Icerberg `List` type containing `Integer`s

- It makes consistent the logic for checking if things are particular types whereas currently, `Decimal` and `Fixed` are actually instances. Now, `issubclass` and `==` can be used as intended throughout such as `assert Fixed[8]==Fixed[8]`

- Types are implemented according to the spec including min, max for Integral types, IEEE-754 based floating types with the [correct sorting behavior](https://github.com/CircArgs/iceberg/blob/7c29ee28ade88c6f45954b2c547a02330c2df806/python/tests/test_types.py#L469) and [hashing](https://github.com/CircArgs/iceberg/blob/7c29ee28ade88c6f45954b2c547a02330c2df806/python/tests/test_types.py#L97)

- Casting semantics are also fully implemented, so for example, `Decimal[32, 3]('3.14').to(Decimal[33, 3])` and `Decimal[33, 3](Decimal[32, 3]('3.14'))` succeed while `Decimal[32, 3]('3.14').to(Decimal[31, 3])`  `Decimal[32, 3]('3.14').to(Decimal[32, 2])`  `Decimal[32, 3]('3.14').to(Decimal[31, 3])` all fail 

- Types are fully covariant. Besides `issubclass(Decimal[32, 3], Decimal)==True` we have `issubclass(List[Decimal[32, 3]], List[Decimal])==True` and `issubclass(List[Map[String, Decimal[32, 3]]], List[Map[IcebergType, Decimal[32, 3]]])==True`