### PR TITLE
Docs: Add ververica blog - Using Flink CDC to synchronize data from MySQL sharding tables and build real-time data lake

### DIFF
--- a/site/docs/blogs.md
+++ b/site/docs/blogs.md
@@ -19,6 +19,10 @@
 
 Here is a list of company blogs that talk about Iceberg. The blogs are ordered from most recent to oldest.
 
+### [Using Flink CDC to synchronize data from MySQL sharding tables and build real-time data lake](https://ververica.github.io/flink-cdc-connectors/master/content/quickstart/build-real-time-data-lake-tutorial.html)
+**Date**: 11 November 2021, **Company**: Ververica, Alibaba Could
+**Author**: [Yuxia Luo](https://github.com/luoyuxia), [Jark Wu](https://github.com/wuchong), [Zheng Hu](https://www.linkedin.com/in/zheng-hu-37017683/)
+
 ### [Metadata Indexing in Iceberg](https://tabular.io/blog/iceberg-metadata-indexing/)
 **Date**: 10 October 2021, **Company**: Tabular
 **Author**: [Ryan Blue](https://www.linkedin.com/in/rdblue/)


### PR DESCRIPTION
There is a blog written by ververica.com's  flink-cdc-connector authors.  I think it's good to add this to apache iceberg blog list.

https://ververica.github.io/flink-cdc-connectors/master/content/quickstart/build-real-time-data-lake-tutorial.html