### PR TITLE
Flink: Fix ALTER for tables with primary key fields

### DIFF
--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -400,6 +400,24 @@ public class FlinkCatalog extends AbstractCatalog {
     }
   }
 
+  // skip the AbstractConstraint comparison
+  public boolean schemaCompare(org.apache.flink.table.api.Schema rawSchema,
+                               org.apache.flink.table.api.Schema newSchema) {
+
+    org.apache.flink.table.api.Schema.UnresolvedPrimaryKey rawPK = rawSchema.getPrimaryKey().orElse(null);
+
+    org.apache.flink.table.api.Schema.UnresolvedPrimaryKey newPK = newSchema.getPrimaryKey().orElse(null);
+    if ((rawPK == null && newPK != null) || (rawPK != null && newPK == null)) {
+      return false;
+    }
+    boolean exp = rawSchema.getColumns().equals(newSchema.getColumns()) &&
+            rawSchema.getWatermarkSpecs().equals(newSchema.getWatermarkSpecs());
+    boolean exp2 = rawPK != null && newPK != null ?
+            rawPK.getColumnNames().equals(newPK.getColumnNames())
+            : true;
+    return exp && exp2;
+  }
+
   @Override
   public void alterTable(ObjectPath tablePath, CatalogBaseTable newTable, boolean ignoreIfNotExists)
       throws CatalogException, TableNotExistException {
@@ -422,7 +440,7 @@ public class FlinkCatalog extends AbstractCatalog {
 
     // For current Flink Catalog API, support for adding/removing/renaming columns cannot be done by comparing
     // CatalogTable instances, unless the Flink schema contains Iceberg column IDs.
-    if (!table.getSchema().equals(newTable.getSchema())) {
+    if (!schemaCompare(table.getUnresolvedSchema(), newTable.getUnresolvedSchema())) {
       throw new UnsupportedOperationException("Altering schema is not supported yet.");
     }
 

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -319,6 +319,30 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
   }
 
   @Test
+  public void testAlterPrimaryKeyTable() throws TableNotExistException {
+    sql("CREATE TABLE tl(id BIGINT, key STRING PRIMARY KEY NOT ENFORCED) WITH ('oldK'='oldV')");
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("oldK", "oldV");
+
+    // new
+    sql("ALTER TABLE tl SET('newK'='newV')");
+    properties.put("newK", "newV");
+    Assert.assertEquals(properties, table("tl").properties());
+
+    // update old
+    sql("ALTER TABLE tl SET('oldK'='oldV2')");
+    properties.put("oldK", "oldV2");
+    Assert.assertEquals(properties, table("tl").properties());
+
+    // remove property
+    CatalogTable catalogTable = catalogTable("tl");
+    properties.remove("oldK");
+    getTableEnv().getCatalog(getTableEnv().getCurrentCatalog()).get().alterTable(
+            new ObjectPath(DATABASE, "tl"), catalogTable.copy(properties), false);
+    Assert.assertEquals(properties, table("tl").properties());
+  }
+
+  @Test
   public void testRelocateTable() {
     Assume.assumeFalse("HadoopCatalog does not support relocate table", isHadoopCatalog);
 


### PR DESCRIPTION
fix #3521 

it makes flink table changes its properties via not comparing PK's name because its random name
using new schema api because old schema method is Deprecated