### PR TITLE
[Spark] Add missing Spark 3.1 to JMH configuration

### DIFF
--- a/jmh.gradle
+++ b/jmh.gradle
@@ -32,6 +32,10 @@ if (sparkVersions.contains("3.0")) {
   jmhProjects.add(project(":iceberg-spark:iceberg-spark3"))
 }
 
+if (sparkVersions.contains("3.1")) {
+  jmhProjects.add(project(":iceberg-spark:iceberg-spark-3.1"))
+}
+
 if (sparkVersions.contains("3.2")) {
   jmhProjects.add(project(":iceberg-spark:iceberg-spark-3.2_2.12"))
 }

--- a/jmh.gradle
+++ b/jmh.gradle
@@ -33,7 +33,7 @@ if (sparkVersions.contains("3.0")) {
 }
 
 if (sparkVersions.contains("3.1")) {
-  jmhProjects.add(project(":iceberg-spark:iceberg-spark-3.1"))
+  jmhProjects.add(project(":iceberg-spark:iceberg-spark-3.1_2.12"))
 }
 
 if (sparkVersions.contains("3.2")) {


### PR DESCRIPTION
Noticed we don't have Spark 3.1 as a JMH option.