### PR TITLE
Build: Append _2.12 (scala version) to Spark 3.1 and 3.2 module names

### DIFF
--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -123,7 +123,7 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
       - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-      - run: ./gradlew -DsparkVersions=${{ matrix.spark }} -DhiveVersions= -DflinkVersions= :iceberg-spark:iceberg-spark-${{ matrix.spark }}:check :iceberg-spark:iceberg-spark-${{ matrix.spark }}-extensions:check :iceberg-spark:iceberg-spark-${{ matrix.spark }}-runtime:check -Pquick=true -x javadoc
+      - run: ./gradlew -DsparkVersions=${{ matrix.spark }} -DhiveVersions= -DflinkVersions= :iceberg-spark:iceberg-spark-${{ matrix.spark }}_2.12:check :iceberg-spark:iceberg-spark-${{ matrix.spark }}-extensions_2.12:check :iceberg-spark:iceberg-spark-${{ matrix.spark }}-runtime_2.12:check -Pquick=true -x javadoc
       - uses: actions/upload-artifact@v2
         if: failure()
         with:

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -109,7 +109,6 @@ jobs:
     strategy:
       matrix:
         jvm: [8, 11]
-        scala: ['2.12']
         spark: ['3.1', '3.2']
     env:
       SPARK_LOCAL_IP: localhost
@@ -124,7 +123,7 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
       - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-      - run: ./gradlew -DsparkVersions=${{ matrix.spark }} -DhiveVersions= -DflinkVersions= :iceberg-spark:iceberg-spark-${{ matrix.spark }}_${{ matrix.scala }}:check :iceberg-spark:iceberg-spark-${{ matrix.spark }}-extensions_${{ matrix.scala }}:check :iceberg-spark:iceberg-spark-${{ matrix.spark }}-runtime_${{ matrix.scala }}:check -Pquick=true -x javadoc
+      - run: ./gradlew -DsparkVersions=${{ matrix.spark }} -DhiveVersions= -DflinkVersions= :iceberg-spark:iceberg-spark-${{ matrix.spark }}_2.12:check :iceberg-spark:iceberg-spark-${{ matrix.spark }}-extensions_2.12:check :iceberg-spark:iceberg-spark-${{ matrix.spark }}-runtime_2.12:check -Pquick=true -x javadoc
       - uses: actions/upload-artifact@v2
         if: failure()
         with:

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -109,6 +109,7 @@ jobs:
     strategy:
       matrix:
         jvm: [8, 11]
+        scala: ['2.12']
         spark: ['3.1', '3.2']
     env:
       SPARK_LOCAL_IP: localhost
@@ -123,7 +124,7 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
       - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-      - run: ./gradlew -DsparkVersions=${{ matrix.spark }} -DhiveVersions= -DflinkVersions= :iceberg-spark:iceberg-spark-${{ matrix.spark }}_2.12:check :iceberg-spark:iceberg-spark-${{ matrix.spark }}-extensions_2.12:check :iceberg-spark:iceberg-spark-${{ matrix.spark }}-runtime_2.12:check -Pquick=true -x javadoc
+      - run: ./gradlew -DsparkVersions=${{ matrix.spark }} -DhiveVersions= -DflinkVersions= :iceberg-spark:iceberg-spark-${{ matrix.spark }}_${{ matrix.scala }}:check :iceberg-spark:iceberg-spark-${{ matrix.spark }}-extensions_${{ matrix.scala }}:check :iceberg-spark:iceberg-spark-${{ matrix.spark }}-runtime_${{ matrix.scala }}:check -Pquick=true -x javadoc
       - uses: actions/upload-artifact@v2
         if: failure()
         with:

--- a/jmh.gradle
+++ b/jmh.gradle
@@ -33,7 +33,7 @@ if (sparkVersions.contains("3.0")) {
 }
 
 if (sparkVersions.contains("3.2")) {
-  jmhProjects.add(project(":iceberg-spark:iceberg-spark-3.2"))
+  jmhProjects.add(project(":iceberg-spark:iceberg-spark-3.2_2.12"))
 }
 
 configure(jmhProjects) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -112,11 +112,11 @@ if (sparkVersions.contains("3.1")) {
   include ':iceberg-spark:spark-3.1-extensions'
   include ':iceberg-spark:spark-3.1-runtime'
   project(':iceberg-spark:spark-3.1').projectDir = file('spark/v3.1/spark')
-  project(':iceberg-spark:spark-3.1').name = 'iceberg-spark-3.1'
+  project(':iceberg-spark:spark-3.1').name = 'iceberg-spark-3.1_2.12'
   project(':iceberg-spark:spark-3.1-extensions').projectDir = file('spark/v3.1/spark-extensions')
-  project(':iceberg-spark:spark-3.1-extensions').name = 'iceberg-spark-3.1-extensions'
+  project(':iceberg-spark:spark-3.1-extensions').name = 'iceberg-spark-3.1-extensions_2.12'
   project(':iceberg-spark:spark-3.1-runtime').projectDir = file('spark/v3.1/spark-runtime')
-  project(':iceberg-spark:spark-3.1-runtime').name = 'iceberg-spark-3.1-runtime'
+  project(':iceberg-spark:spark-3.1-runtime').name = 'iceberg-spark-3.1-runtime_2.12'
 }
 
 if (sparkVersions.contains("3.2")) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -108,15 +108,15 @@ if (sparkVersions.contains("3.0")) {
 }
 
 if (sparkVersions.contains("3.1")) {
-  include ':iceberg-spark:spark-3.1'
-  include ':iceberg-spark:spark-3.1-extensions'
-  include ':iceberg-spark:spark-3.1-runtime'
-  project(':iceberg-spark:spark-3.1').projectDir = file('spark/v3.1/spark')
-  project(':iceberg-spark:spark-3.1').name = 'iceberg-spark-3.1_2.12'
-  project(':iceberg-spark:spark-3.1-extensions').projectDir = file('spark/v3.1/spark-extensions')
-  project(':iceberg-spark:spark-3.1-extensions').name = 'iceberg-spark-3.1-extensions_2.12'
-  project(':iceberg-spark:spark-3.1-runtime').projectDir = file('spark/v3.1/spark-runtime')
-  project(':iceberg-spark:spark-3.1-runtime').name = 'iceberg-spark-3.1-runtime_2.12'
+  include ':iceberg-spark:spark-3.1_2.12'
+  include ':iceberg-spark:spark-3.1-extensions_2.12'
+  include ':iceberg-spark:spark-3.1-runtime_2.12'
+  project(':iceberg-spark:spark-3.1_2.12').projectDir = file('spark/v3.1/spark')
+  project(':iceberg-spark:spark-3.1_2.12').name = 'iceberg-spark-3.1_2.12'
+  project(':iceberg-spark:spark-3.1-extensions_2.12').projectDir = file('spark/v3.1/spark-extensions')
+  project(':iceberg-spark:spark-3.1-extensions_2.12').name = 'iceberg-spark-3.1-extensions_2.12'
+  project(':iceberg-spark:spark-3.1-runtime_2.12').projectDir = file('spark/v3.1/spark-runtime')
+  project(':iceberg-spark:spark-3.1-runtime_2.12').name = 'iceberg-spark-3.1-runtime_2.12'
 }
 
 if (sparkVersions.contains("3.2")) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -120,15 +120,15 @@ if (sparkVersions.contains("3.1")) {
 }
 
 if (sparkVersions.contains("3.2")) {
-  include ':iceberg-spark:spark-3.2'
-  include ':iceberg-spark:spark-3.2-extensions'
-  include ':iceberg-spark:spark-3.2-runtime'
-  project(':iceberg-spark:spark-3.2').projectDir = file('spark/v3.2/spark')
-  project(':iceberg-spark:spark-3.2').name = 'iceberg-spark-3.2'
-  project(':iceberg-spark:spark-3.2-extensions').projectDir = file('spark/v3.2/spark-extensions')
-  project(':iceberg-spark:spark-3.2-extensions').name = 'iceberg-spark-3.2-extensions'
-  project(':iceberg-spark:spark-3.2-runtime').projectDir = file('spark/v3.2/spark-runtime')
-  project(':iceberg-spark:spark-3.2-runtime').name = 'iceberg-spark-3.2-runtime'
+  include ':iceberg-spark:spark-3.2_2.12'
+  include ':iceberg-spark:spark-3.2-extensions_2.12'
+  include ':iceberg-spark:spark-3.2-runtime_2.12'
+  project(':iceberg-spark:spark-3.2_2.12').projectDir = file('spark/v3.2/spark')
+  project(':iceberg-spark:spark-3.2_2.12').name = 'iceberg-spark-3.2_2.12'
+  project(':iceberg-spark:spark-3.2-extensions_2.12').projectDir = file('spark/v3.2/spark-extensions')
+  project(':iceberg-spark:spark-3.2-extensions_2.12').name = 'iceberg-spark-3.2-extensions_2.12'
+  project(':iceberg-spark:spark-3.2-runtime_2.12').projectDir = file('spark/v3.2/spark-runtime')
+  project(':iceberg-spark:spark-3.2-runtime_2.12').name = 'iceberg-spark-3.2-runtime_2.12'
 }
 
 // hive 3 depends on hive 2, so always add hive 2 if hive3 is enabled

--- a/spark/v3.1/build.gradle
+++ b/spark/v3.1/build.gradle
@@ -18,9 +18,9 @@
  */
 
 def sparkProjects = [
-    project(':iceberg-spark:iceberg-spark-3.1'),
-    project(":iceberg-spark:iceberg-spark-3.1-extensions"),
-    project(':iceberg-spark:iceberg-spark-3.1-runtime')
+    project(':iceberg-spark:iceberg-spark-3.1_2.12'),
+    project(":iceberg-spark:iceberg-spark-3.1-extensions_2.12"),
+    project(':iceberg-spark:iceberg-spark-3.1-runtime_2.12')
 ]
 
 configure(sparkProjects) {
@@ -38,7 +38,7 @@ configure(sparkProjects) {
   }
 }
 
-project(':iceberg-spark:iceberg-spark-3.1') {
+project(':iceberg-spark:iceberg-spark-3.1_2.12') {
   apply plugin: 'scala'
 
   sourceSets {
@@ -104,7 +104,7 @@ project(':iceberg-spark:iceberg-spark-3.1') {
   }
 }
 
-project(":iceberg-spark:iceberg-spark-3.1-extensions") {
+project(":iceberg-spark:iceberg-spark-3.1-extensions_2.12") {
   apply plugin: 'java-library'
   apply plugin: 'scala'
   apply plugin: 'antlr'
@@ -130,7 +130,7 @@ project(":iceberg-spark:iceberg-spark-3.1-extensions") {
     compileOnly project(':iceberg-data')
     compileOnly project(':iceberg-orc')
     compileOnly project(':iceberg-common')
-    compileOnly project(':iceberg-spark:iceberg-spark-3.1')
+    compileOnly project(':iceberg-spark:iceberg-spark-3.1_2.12')
     compileOnly project(':iceberg-hive-metastore')
     compileOnly("org.apache.spark:spark-hive_2.12:${sparkVersion}") {
       exclude group: 'org.apache.avro', module: 'avro'
@@ -144,7 +144,7 @@ project(":iceberg-spark:iceberg-spark-3.1-extensions") {
     testImplementation project(path: ':iceberg-orc', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
-    testImplementation project(path: ':iceberg-spark:iceberg-spark-3.1', configuration: 'testArtifacts')
+    testImplementation project(path: ':iceberg-spark:iceberg-spark-3.1_2.12', configuration: 'testArtifacts')
 
     testImplementation "org.apache.avro:avro"
 
@@ -160,7 +160,7 @@ project(":iceberg-spark:iceberg-spark-3.1-extensions") {
   }
 }
 
-project(':iceberg-spark:iceberg-spark-3.1-runtime') {
+project(':iceberg-spark:iceberg-spark-3.1-runtime_2.12') {
   apply plugin: 'com.github.johnrengelman.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
@@ -194,8 +194,8 @@ project(':iceberg-spark:iceberg-spark-3.1-runtime') {
 
   dependencies {
     api project(':iceberg-api')
-    implementation project(':iceberg-spark:iceberg-spark-3.1')
-    implementation project(':iceberg-spark:iceberg-spark-3.1-extensions')
+    implementation project(':iceberg-spark:iceberg-spark-3.1_2.12')
+    implementation project(':iceberg-spark:iceberg-spark-3.1-extensions_2.12')
     implementation project(':iceberg-aws')
     implementation(project(':iceberg-nessie')) {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
@@ -206,11 +206,11 @@ project(':iceberg-spark:iceberg-spark-3.1-runtime') {
     integrationImplementation 'org.slf4j:slf4j-simple'
     integrationImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
     integrationImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
-    integrationImplementation project(path: ':iceberg-spark:iceberg-spark-3.1', configuration: 'testArtifacts')
-    integrationImplementation project(path: ':iceberg-spark:iceberg-spark-3.1-extensions', configuration: 'testArtifacts')
+    integrationImplementation project(path: ':iceberg-spark:iceberg-spark-3.1_2.12', configuration: 'testArtifacts')
+    integrationImplementation project(path: ':iceberg-spark:iceberg-spark-3.1-extensions_2.12', configuration: 'testArtifacts')
     // Not allowed on our classpath, only the runtime jar is allowed
-    integrationCompileOnly project(':iceberg-spark:iceberg-spark-3.1-extensions')
-    integrationCompileOnly project(':iceberg-spark:iceberg-spark-3.1')
+    integrationCompileOnly project(':iceberg-spark:iceberg-spark-3.1-extensions_2.12')
+    integrationCompileOnly project(':iceberg-spark:iceberg-spark-3.1_2.12')
     integrationCompileOnly project(':iceberg-api')
   }
 

--- a/spark/v3.2/build.gradle
+++ b/spark/v3.2/build.gradle
@@ -18,9 +18,9 @@
  */
 
 def sparkProjects = [
-    project(':iceberg-spark:iceberg-spark-3.2'),
-    project(":iceberg-spark:iceberg-spark-3.2-extensions"),
-    project(':iceberg-spark:iceberg-spark-3.2-runtime')
+    project(':iceberg-spark:iceberg-spark-3.2_2.12'),
+    project(":iceberg-spark:iceberg-spark-3.2-extensions_2.12"),
+    project(':iceberg-spark:iceberg-spark-3.2-runtime_2.12')
 ]
 
 configure(sparkProjects) {
@@ -38,7 +38,7 @@ configure(sparkProjects) {
   }
 }
 
-project(':iceberg-spark:iceberg-spark-3.2') {
+project(':iceberg-spark:iceberg-spark-3.2_2.12') {
   apply plugin: 'scala'
 
   sourceSets {
@@ -108,7 +108,7 @@ project(':iceberg-spark:iceberg-spark-3.2') {
   }
 }
 
-project(":iceberg-spark:iceberg-spark-3.2-extensions") {
+project(":iceberg-spark:iceberg-spark-3.2-extensions_2.12") {
   apply plugin: 'java-library'
   apply plugin: 'scala'
   apply plugin: 'antlr'
@@ -132,7 +132,7 @@ project(":iceberg-spark:iceberg-spark-3.2-extensions") {
     compileOnly project(':iceberg-api')
     compileOnly project(':iceberg-core')
     compileOnly project(':iceberg-common')
-    compileOnly project(':iceberg-spark:iceberg-spark-3.2')
+    compileOnly project(':iceberg-spark:iceberg-spark-3.2_2.12')
     compileOnly project(':iceberg-hive-metastore')
     compileOnly("org.apache.spark:spark-hive_2.12:${sparkVersion}") {
       exclude group: 'org.apache.avro', module: 'avro'
@@ -146,7 +146,7 @@ project(":iceberg-spark:iceberg-spark-3.2-extensions") {
 
     testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
-    testImplementation project(path: ':iceberg-spark:iceberg-spark-3.2', configuration: 'testArtifacts')
+    testImplementation project(path: ':iceberg-spark:iceberg-spark-3.2_2.12', configuration: 'testArtifacts')
 
     testImplementation "org.apache.avro:avro"
 
@@ -162,7 +162,7 @@ project(":iceberg-spark:iceberg-spark-3.2-extensions") {
   }
 }
 
-project(':iceberg-spark:iceberg-spark-3.2-runtime') {
+project(':iceberg-spark:iceberg-spark-3.2-runtime_2.12') {
   apply plugin: 'com.github.johnrengelman.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
@@ -196,8 +196,8 @@ project(':iceberg-spark:iceberg-spark-3.2-runtime') {
 
   dependencies {
     api project(':iceberg-api')
-    implementation project(':iceberg-spark:iceberg-spark-3.2')
-    implementation project(':iceberg-spark:iceberg-spark-3.2-extensions')
+    implementation project(':iceberg-spark:iceberg-spark-3.2_2.12')
+    implementation project(':iceberg-spark:iceberg-spark-3.2-extensions_2.12')
     implementation project(':iceberg-aws')
     implementation(project(':iceberg-nessie')) {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
@@ -208,11 +208,11 @@ project(':iceberg-spark:iceberg-spark-3.2-runtime') {
     integrationImplementation 'org.slf4j:slf4j-simple'
     integrationImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
     integrationImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
-    integrationImplementation project(path: ':iceberg-spark:iceberg-spark-3.2', configuration: 'testArtifacts')
-    integrationImplementation project(path: ':iceberg-spark:iceberg-spark-3.2-extensions', configuration: 'testArtifacts')
+    integrationImplementation project(path: ':iceberg-spark:iceberg-spark-3.2_2.12', configuration: 'testArtifacts')
+    integrationImplementation project(path: ':iceberg-spark:iceberg-spark-3.2-extensions_2.12', configuration: 'testArtifacts')
     // Not allowed on our classpath, only the runtime jar is allowed
-    integrationCompileOnly project(':iceberg-spark:iceberg-spark-3.2-extensions')
-    integrationCompileOnly project(':iceberg-spark:iceberg-spark-3.2')
+    integrationCompileOnly project(':iceberg-spark:iceberg-spark-3.2-extensions_2.12')
+    integrationCompileOnly project(':iceberg-spark:iceberg-spark-3.2_2.12')
     integrationCompileOnly project(':iceberg-api')
   }
 


### PR DESCRIPTION
The Spark 3.1 and 3.2 artifacts currently don't have the scala version in them.

As Spark 3.2 adds experimental support for Scala 2.13, we should likely include our scala version in our project names.

I've added `_2.12` to the end of all of the Spark 3.1 and 3.2 projects.

This generates artifacts as follows, which seems a bit off (I'd prefer `3.2_2.12`), but does match sbt builds.
```
:iceberg-spark:iceberg-spark-3.2_2.12
:iceberg-spark:iceberg-spark-3.2-extensions_2.12
:iceberg-spark:iceberg-spark-3.2-runtime_2.12
```

Please feel free to suggest a better way to go about this than manually updating all references if you know one.