### PR TITLE
Spark: Remove iceberg-hive-metastore compile time dependency

### DIFF
--- a/spark/v2.4/build.gradle
+++ b/spark/v2.4/build.gradle
@@ -58,7 +58,6 @@ project(':iceberg-spark:iceberg-spark2') {
     implementation project(':iceberg-orc')
     implementation project(':iceberg-parquet')
     implementation project(':iceberg-arrow')
-    implementation project(':iceberg-hive-metastore')
     implementation "com.github.ben-manes.caffeine:caffeine"
 
     compileOnly "com.google.errorprone:error_prone_annotations"
@@ -85,6 +84,7 @@ project(':iceberg-spark:iceberg-spark2') {
     testImplementation("org.apache.hadoop:hadoop-minicluster") {
       exclude group: 'org.apache.avro', module: 'avro'
     }
+    testImplementation project(path: ':iceberg-hive-metastore')
     testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
@@ -127,6 +127,7 @@ project(':iceberg-spark:iceberg-spark-runtime') {
   dependencies {
     implementation project(':iceberg-spark:iceberg-spark2')
     implementation project(':iceberg-aws')
+    implementation project(':iceberg-hive-metastore')
     implementation(project(':iceberg-nessie')) {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }

--- a/spark/v3.0/build.gradle
+++ b/spark/v3.0/build.gradle
@@ -57,7 +57,6 @@ project(':iceberg-spark:iceberg-spark3') {
     implementation project(':iceberg-orc')
     implementation project(':iceberg-parquet')
     implementation project(':iceberg-arrow')
-    implementation project(':iceberg-hive-metastore')
 
     compileOnly "com.google.errorprone:error_prone_annotations"
     compileOnly "org.apache.avro:avro"
@@ -84,6 +83,7 @@ project(':iceberg-spark:iceberg-spark3') {
     testImplementation("org.apache.hadoop:hadoop-minicluster") {
       exclude group: 'org.apache.avro', module: 'avro'
     }
+    testImplementation project(path: ':iceberg-hive-metastore')
     testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
@@ -131,13 +131,13 @@ project(":iceberg-spark:iceberg-spark3-extensions") {
     compileOnly project(':iceberg-orc')
     compileOnly project(':iceberg-common')
     compileOnly project(':iceberg-spark:iceberg-spark3')
-    compileOnly project(':iceberg-hive-metastore')
     compileOnly("org.apache.spark:spark-hive_2.12:${sparkVersion}") {
       exclude group: 'org.apache.avro', module: 'avro'
       exclude group: 'org.apache.arrow'
       exclude group: 'org.roaringbitmap'
     }
 
+    testImplementation project(path: ':iceberg-hive-metastore')
     testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
 
     testImplementation project(path: ':iceberg-data', configuration: 'testArtifacts')
@@ -197,6 +197,7 @@ project(':iceberg-spark:iceberg-spark3-runtime') {
     implementation project(':iceberg-spark:iceberg-spark3')
     implementation project(':iceberg-spark:iceberg-spark3-extensions')
     implementation project(':iceberg-aws')
+    implementation project(':iceberg-hive-metastore')
     implementation(project(':iceberg-nessie')) {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }

--- a/spark/v3.1/build.gradle
+++ b/spark/v3.1/build.gradle
@@ -57,7 +57,6 @@ project(':iceberg-spark:iceberg-spark-3.1_2.12') {
     implementation project(':iceberg-orc')
     implementation project(':iceberg-parquet')
     implementation project(':iceberg-arrow')
-    implementation project(':iceberg-hive-metastore')
 
     compileOnly "com.google.errorprone:error_prone_annotations"
     compileOnly "org.apache.avro:avro"
@@ -84,6 +83,7 @@ project(':iceberg-spark:iceberg-spark-3.1_2.12') {
     testImplementation("org.apache.hadoop:hadoop-minicluster") {
       exclude group: 'org.apache.avro', module: 'avro'
     }
+    testImplementation project(path: ':iceberg-hive-metastore')
     testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
@@ -131,13 +131,13 @@ project(":iceberg-spark:iceberg-spark-extensions-3.1_2.12") {
     compileOnly project(':iceberg-orc')
     compileOnly project(':iceberg-common')
     compileOnly project(':iceberg-spark:iceberg-spark-3.1_2.12')
-    compileOnly project(':iceberg-hive-metastore')
     compileOnly("org.apache.spark:spark-hive_2.12:${sparkVersion}") {
       exclude group: 'org.apache.avro', module: 'avro'
       exclude group: 'org.apache.arrow'
       exclude group: 'org.roaringbitmap'
     }
 
+    testImplementation project(path: ':iceberg-hive-metastore')
     testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
 
     testImplementation project(path: ':iceberg-data', configuration: 'testArtifacts')
@@ -197,6 +197,7 @@ project(':iceberg-spark:iceberg-spark-runtime-3.1_2.12') {
     implementation project(':iceberg-spark:iceberg-spark-3.1_2.12')
     implementation project(':iceberg-spark:iceberg-spark-extensions-3.1_2.12')
     implementation project(':iceberg-aws')
+    implementation project(':iceberg-hive-metastore')
     implementation(project(':iceberg-nessie')) {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }

--- a/spark/v3.2/build.gradle
+++ b/spark/v3.2/build.gradle
@@ -57,7 +57,6 @@ project(':iceberg-spark:iceberg-spark-3.2_2.12') {
     implementation project(':iceberg-orc')
     implementation project(':iceberg-parquet')
     implementation project(':iceberg-arrow')
-    implementation project(':iceberg-hive-metastore')
 
     compileOnly "com.google.errorprone:error_prone_annotations"
     compileOnly "org.apache.avro:avro"
@@ -88,6 +87,7 @@ project(':iceberg-spark:iceberg-spark-3.2_2.12') {
       // to make sure io.netty.buffer only comes from project(':iceberg-arrow')
       exclude group: 'io.netty', module: 'netty-buffer'
     }
+    testImplementation project(path: ':iceberg-hive-metastore')
     testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
     testImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
@@ -133,7 +133,6 @@ project(":iceberg-spark:iceberg-spark-extensions-3.2_2.12") {
     compileOnly project(':iceberg-core')
     compileOnly project(':iceberg-common')
     compileOnly project(':iceberg-spark:iceberg-spark-3.2_2.12')
-    compileOnly project(':iceberg-hive-metastore')
     compileOnly("org.apache.spark:spark-hive_2.12:${sparkVersion}") {
       exclude group: 'org.apache.avro', module: 'avro'
       exclude group: 'org.apache.arrow'
@@ -142,6 +141,7 @@ project(":iceberg-spark:iceberg-spark-extensions-3.2_2.12") {
       exclude group: 'org.roaringbitmap'
     }
 
+    testImplementation project(path: ':iceberg-hive-metastore')
     testImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
 
     testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
@@ -199,6 +199,7 @@ project(':iceberg-spark:iceberg-spark-runtime-3.2_2.12') {
     implementation project(':iceberg-spark:iceberg-spark-3.2_2.12')
     implementation project(':iceberg-spark:iceberg-spark-extensions-3.2_2.12')
     implementation project(':iceberg-aws')
+    implementation project(':iceberg-hive-metastore')
     implementation(project(':iceberg-nessie')) {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
     }


### PR DESCRIPTION
icebeg-hive-metastore dependency is not needed at compile time (and should not be needed). Spark and spark extension modules should not depend on HiveCatalog being on the classpath.

That said the dependency needed for running the tests, and also needed to be put into the fat runtime jar.

The PR modifies these dependencies accordingly.