### PR TITLE
Core: Allow deleting and adding the same column

### DIFF
--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -471,9 +471,8 @@ public class PartitionSpec implements Serializable {
 
     public Builder alwaysNull(String sourceName, String targetName) {
       Types.NestedField sourceColumn = findSourceColumn(sourceName);
-      Transform<?, Void> transform = Transforms.alwaysNull();
       checkAndAddPartitionName(targetName, sourceColumn.fieldId()); // can duplicate a source column name
-      fields.add(new PartitionField(sourceColumn.fieldId(), nextFieldId(), targetName, transform));
+      fields.add(new PartitionField(sourceColumn.fieldId(), nextFieldId(), targetName, Transforms.alwaysNull()));
       return this;
     }
 

--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -319,7 +319,7 @@ public class PartitionSpec implements Serializable {
   public static class Builder {
     private final Schema schema;
     private final List<PartitionField> fields = Lists.newArrayList();
-    private final Set<String> partitionNames = Sets.newHashSet();
+    private final Map<String, Integer> partitionNamesToFieldId = Maps.newHashMap();
     private Map<Map.Entry<Integer, String>, PartitionField> dedupFields = Maps.newHashMap();
     private int specId = 0;
     private final AtomicInteger lastAssignedFieldId = new AtomicInteger(PARTITION_DATA_ID_START - 1);
@@ -350,9 +350,10 @@ public class PartitionSpec implements Serializable {
       }
       Preconditions.checkArgument(name != null && !name.isEmpty(),
           "Cannot use empty or null partition name: %s", name);
-      Preconditions.checkArgument(!partitionNames.contains(name),
+      Preconditions.checkArgument(!partitionNamesToFieldId.containsKey(name) ||
+                      partitionNamesToFieldId.get(name).equals(sourceColumnId),
           "Cannot use partition name more than once: %s", name);
-      partitionNames.add(name);
+      partitionNamesToFieldId.put(name, sourceColumnId);
     }
 
     private void checkForRedundantPartitions(PartitionField field) {

--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -22,7 +22,11 @@ package org.apache.iceberg;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.util.*;
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -315,7 +319,7 @@ public class PartitionSpec implements Serializable {
   public static class Builder {
     private final Schema schema;
     private final List<PartitionField> fields = Lists.newArrayList();
-    private final Set<String> partitionNamesAndTransform = new HashSet<>();
+    private final Set<String> partitionNameAndTransform = Sets.newHashSet();
     private Map<Map.Entry<Integer, String>, PartitionField> dedupFields = Maps.newHashMap();
     private int specId = 0;
     private final AtomicInteger lastAssignedFieldId = new AtomicInteger(PARTITION_DATA_ID_START - 1);
@@ -347,9 +351,9 @@ public class PartitionSpec implements Serializable {
       Preconditions.checkArgument(name != null && !name.isEmpty(),
           "Cannot use empty or null partition name: %s", name);
       String nameAndTransform = name + "_" + transformName;
-      Preconditions.checkArgument(!partitionNamesAndTransform.contains(nameAndTransform),
+      Preconditions.checkArgument(!partitionNameAndTransform.contains(nameAndTransform),
           "Cannot use partition name more than once: %s", name);
-      partitionNamesAndTransform.add(nameAndTransform);
+      partitionNameAndTransform.add(nameAndTransform);
     }
 
     private void checkForRedundantPartitions(PartitionField field) {

--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -473,7 +473,8 @@ public class PartitionSpec implements Serializable {
     public Builder alwaysNull(String sourceName, String targetName) {
       Types.NestedField sourceColumn = findSourceColumn(sourceName);
       Transform<?, Void> transform = Transforms.alwaysNull();
-      checkAndAddPartitionName(targetName, sourceColumn.fieldId(), transform.dedupName()); // can duplicate a source column name
+      checkAndAddPartitionName(targetName, sourceColumn.fieldId(),
+              transform.dedupName()); // can duplicate a source column name
       fields.add(new PartitionField(sourceColumn.fieldId(), nextFieldId(), targetName, transform));
       return this;
     }

--- a/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
@@ -135,7 +135,7 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
     PartitionField existing = transformToField.get(validationKey);
     Preconditions.checkArgument(existing == null ||
         (deletes.contains(existing.fieldId()) &&
-            !existing.transform().dedupName().equals(sourceTransform.second().dedupName())),
+            !existing.transform().toString().equals(sourceTransform.second().toString())),
         "Cannot add duplicate partition field %s=%s, conflicts with %s", name, term, existing);
 
     PartitionField added = transformToAddedField.get(validationKey);

--- a/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
@@ -133,7 +133,9 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
     Pair<Integer, String> validationKey = Pair.of(sourceTransform.first(), sourceTransform.second().toString());
 
     PartitionField existing = transformToField.get(validationKey);
-    Preconditions.checkArgument(existing == null || deletes.contains(existing.fieldId()),
+    Preconditions.checkArgument(existing == null ||
+        (deletes.contains(existing.fieldId()) &&
+            !existing.transform().dedupName().equals(sourceTransform.second().dedupName())),
         "Cannot add duplicate partition field %s=%s, conflicts with %s", name, term, existing);
 
     PartitionField added = transformToAddedField.get(validationKey);

--- a/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
@@ -151,7 +151,6 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
     transformToAddedField.put(validationKey, newField);
 
     PartitionField existingField = nameToField.get(newField.name());
-
     if (existingField != null && !deletes.contains(existingField.fieldId())) {
       if (isVoidTransform(existingField)) {
         // rename the old deleted field that is being replaced by the new field
@@ -160,8 +159,7 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
         throw new IllegalArgumentException(String.format("Cannot add duplicate partition field name: %s", name));
       }
     } else if (existingField != null && deletes.contains(existingField.fieldId())) {
-      renameFieldInternal(existingField.name(), existingField.name() + "_" + existingField.fieldId(),
-              true);
+      renames.put(existingField.name(), existingField.name() + "_" + existingField.fieldId());
     }
 
     nameToAddedField.put(newField.name(), newField);
@@ -209,10 +207,6 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
 
   @Override
   public BaseUpdatePartitionSpec renameField(String name, String newName) {
-    return renameFieldInternal(name, newName, false);
-  }
-
-  private BaseUpdatePartitionSpec renameFieldInternal(String name, String newName, boolean allowDeleteFirst) {
     PartitionField existingField = nameToField.get(newName);
     if (existingField != null && isVoidTransform(existingField)) {
       // rename the old deleted field that is being replaced by the new field
@@ -226,10 +220,8 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
     PartitionField field = nameToField.get(name);
     Preconditions.checkArgument(field != null,
         "Cannot find partition field to rename: %s", name);
-    if (!allowDeleteFirst) {
-      Preconditions.checkArgument(!deletes.contains(field.fieldId()),
-          "Cannot delete and rename partition field: %s", name);
-    }
+    Preconditions.checkArgument(!deletes.contains(field.fieldId()),
+        "Cannot delete and rename partition field: %s", name);
 
     renames.put(name, newName);
 

--- a/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
@@ -235,23 +235,19 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
       if (!deletes.contains(field.fieldId())) {
         String newName = renames.get(field.name());
         if (newName != null) {
-          System.out.println("adding(1) " + field.name());
           builder.add(field.sourceId(), field.fieldId(), newName, field.transform());
         } else {
-          System.out.println("adding(2) " + field.name());
           builder.add(field.sourceId(), field.fieldId(), field.name(), field.transform());
         }
       } else if (formatVersion < 2) {
         // field IDs were not required for v1 and were assigned sequentially in each partition spec starting at 1,000.
         // to maintain consistent field ids across partition specs in v1 tables, any partition field that is removed
         // must be replaced with a null transform. null values are always allowed in partition data.
-        System.out.println("adding(3) " + field.name() + " with id " + field.fieldId());
         builder.add(field.sourceId(), field.fieldId(), field.name(), Transforms.alwaysNull());
       }
     }
 
     for (PartitionField newField : adds) {
-      System.out.println("adding field " + newField.name() + " with id " + newField.fieldId());
       builder.add(newField.sourceId(), newField.fieldId(), newField.name(), newField.transform());
     }
 

--- a/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
@@ -173,7 +173,6 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
 
   @Override
   public BaseUpdatePartitionSpec removeField(String name) {
-    System.out.println("calling removeField");
     PartitionField alreadyAdded = nameToAddedField.get(name);
     Preconditions.checkArgument(alreadyAdded == null, "Cannot delete newly added field: %s", alreadyAdded);
 

--- a/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
+++ b/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
@@ -618,19 +618,19 @@ public class TestUpdatePartitionSpec extends TableTestBase {
     if (formatVersion == 1) {
       Assert.assertEquals("Should match expected spec field size", 2, updated.fields().size());
       Assert.assertEquals("Should match expected field name", "ts_1000",
-              updated.fields().get(0).name());
+          updated.fields().get(0).name());
       Assert.assertEquals("Should match expected field name", "ts",
-              updated.fields().get(1).name());
+          updated.fields().get(1).name());
       Assert.assertEquals("Should match expected field transform", "void",
-              updated.fields().get(0).transform().toString());
+          updated.fields().get(0).transform().toString());
       Assert.assertEquals("Should match expected field transform", "identity",
-              updated.fields().get(1).transform().toString());
+          updated.fields().get(1).transform().toString());
     } else {
       Assert.assertEquals("Should match expected spec field size", 1, updated.fields().size());
       Assert.assertEquals("Should match expected field name", "ts",
-              updated.fields().get(0).name());
+          updated.fields().get(0).name());
       Assert.assertEquals("Should match expected field transform", "identity",
-              updated.fields().get(0).transform().toString());
+          updated.fields().get(0).transform().toString());
     }
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
+++ b/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
@@ -477,6 +477,15 @@ public class TestUpdatePartitionSpec extends TableTestBase {
   }
 
   @Test
+  public void testAddDeletedField() {
+    AssertHelpers.assertThrows("Should fail adding a duplicate field",
+        IllegalArgumentException.class, "Cannot add duplicate partition field",
+        () -> new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
+            .removeField("shard")
+            .addField(bucket("id", 16))); // duplicates shard
+  }
+
+  @Test
   public void testAddDuplicateByName() {
     AssertHelpers.assertThrows("Should fail adding a duplicate field",
         IllegalArgumentException.class, "Cannot add duplicate partition field",
@@ -603,35 +612,6 @@ public class TestUpdatePartitionSpec extends TableTestBase {
             .build();
 
     V2Assert.assertEquals("Should match expected spec", v2Expected, updated);
-  }
-
-  @Test
-  public void testRemoveAndUpdateWithIdentity() {
-    PartitionSpec expected = PartitionSpec.builderFor(SCHEMA)
-         .identity("ts")
-         .build();
-    PartitionSpec updated = new BaseUpdatePartitionSpec(formatVersion, expected)
-         .removeField("ts")
-         .addField("ts")
-         .apply();
-
-    if (formatVersion == 1) {
-      Assert.assertEquals("Should match expected spec field size", 2, updated.fields().size());
-      Assert.assertEquals("Should match expected field name", "ts_1000",
-          updated.fields().get(0).name());
-      Assert.assertEquals("Should match expected field name", "ts",
-          updated.fields().get(1).name());
-      Assert.assertEquals("Should match expected field transform", "void",
-          updated.fields().get(0).transform().toString());
-      Assert.assertEquals("Should match expected field transform", "identity",
-          updated.fields().get(1).transform().toString());
-    } else {
-      Assert.assertEquals("Should match expected spec field size", 1, updated.fields().size());
-      Assert.assertEquals("Should match expected field name", "ts",
-          updated.fields().get(0).name());
-      Assert.assertEquals("Should match expected field transform", "identity",
-          updated.fields().get(0).transform().toString());
-    }
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
+++ b/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
@@ -608,18 +608,61 @@ public class TestUpdatePartitionSpec extends TableTestBase {
   @Test
   public void testRemoveAndUpdate() {
     PartitionSpec expected = PartitionSpec.builderFor(SCHEMA)
-            .identity("category")
             .identity("ts")
+            .identity("category")
             .identity("id")
             .build();
-    new BaseUpdatePartitionSpec(formatVersion, expected)
+    PartitionSpec updated = new BaseUpdatePartitionSpec(formatVersion, expected)
             .removeField("ts")
             .removeField("category")
             .removeField("id")
             .addField("ts")
-            .addField("id")
             .addField("category")
+            .addField("id")
             .apply();
+
+    if (formatVersion == 1) {
+      Assert.assertEquals("Should match expected spec field size", 6, updated.fields().size());
+      Assert.assertEquals("Should match expected field name", "ts",
+              updated.fields().get(0).name());
+      Assert.assertEquals("Should match expected field name", "category",
+              updated.fields().get(1).name());
+      Assert.assertEquals("Should match expected field name", "id",
+              updated.fields().get(2).name());
+      Assert.assertEquals("Should match expected field name", "ts",
+              updated.fields().get(3).name());
+      Assert.assertEquals("Should match expected field name", "category",
+              updated.fields().get(4).name());
+      Assert.assertEquals("Should match expected field name", "id",
+              updated.fields().get(5).name());
+
+      Assert.assertEquals("Should match expected field transform", "void",
+              updated.fields().get(0).transform().toString());
+      Assert.assertEquals("Should match expected field transform", "void",
+              updated.fields().get(1).transform().toString());
+      Assert.assertEquals("Should match expected field transform", "void",
+              updated.fields().get(2).transform().toString());
+      Assert.assertEquals("Should match expected field transform", "identity",
+              updated.fields().get(3).transform().toString());
+      Assert.assertEquals("Should match expected field transform", "identity",
+              updated.fields().get(4).transform().toString());
+      Assert.assertEquals("Should match expected field transform", "identity",
+              updated.fields().get(5).transform().toString());
+    } else {
+      Assert.assertEquals("Should match expected spec field size", 3, updated.fields().size());
+      Assert.assertEquals("Should match expected field name", "ts",
+              updated.fields().get(0).name());
+      Assert.assertEquals("Should match expected field name", "category",
+              updated.fields().get(1).name());
+      Assert.assertEquals("Should match expected field name", "id",
+              updated.fields().get(2).name());
+      Assert.assertEquals("Should match expected field transform", "identity",
+              updated.fields().get(0).transform().toString());
+      Assert.assertEquals("Should match expected field transform", "identity",
+              updated.fields().get(1).transform().toString());
+      Assert.assertEquals("Should match expected field transform", "identity",
+              updated.fields().get(2).transform().toString());
+    }
   }
 
   private static int id(String name) {

--- a/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
+++ b/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
@@ -477,15 +477,6 @@ public class TestUpdatePartitionSpec extends TableTestBase {
   }
 
   @Test
-  public void testAddDeletedField() {
-    AssertHelpers.assertThrows("Should fail adding a duplicate field",
-        IllegalArgumentException.class, "Cannot add duplicate partition field",
-        () -> new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
-            .removeField("shard")
-            .addField(bucket("id", 16))); // duplicates shard
-  }
-
-  @Test
   public void testAddDuplicateByName() {
     AssertHelpers.assertThrows("Should fail adding a duplicate field",
         IllegalArgumentException.class, "Cannot add duplicate partition field",
@@ -612,6 +603,23 @@ public class TestUpdatePartitionSpec extends TableTestBase {
             .build();
 
     V2Assert.assertEquals("Should match expected spec", v2Expected, updated);
+  }
+
+  @Test
+  public void testRemoveAndUpdate() {
+    PartitionSpec expected = PartitionSpec.builderFor(SCHEMA)
+            .identity("category")
+            .identity("ts")
+            .identity("id")
+            .build();
+    new BaseUpdatePartitionSpec(formatVersion, expected)
+            .removeField("ts")
+            .removeField("category")
+            .removeField("id")
+            .addField("ts")
+            .addField("id")
+            .addField("category")
+            .apply();
   }
 
   private static int id(String name) {

--- a/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
+++ b/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
@@ -599,8 +599,8 @@ public class TestUpdatePartitionSpec extends TableTestBase {
     }
 
     PartitionSpec v2Expected = PartitionSpec.builderFor(SCHEMA)
-        .month("ts", "ts_date")
-        .build();
+            .month("ts", "ts_date")
+            .build();
 
     V2Assert.assertEquals("Should match expected spec", v2Expected, updated);
   }

--- a/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
+++ b/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
@@ -606,7 +606,7 @@ public class TestUpdatePartitionSpec extends TableTestBase {
   }
 
   @Test
-  public void testRemoveAndUpdate() {
+  public void testRemoveAndUpdateWithIdentity() {
     PartitionSpec expected = PartitionSpec.builderFor(SCHEMA)
             .identity("ts")
             .identity("category")
@@ -662,6 +662,36 @@ public class TestUpdatePartitionSpec extends TableTestBase {
               updated.fields().get(1).transform().toString());
       Assert.assertEquals("Should match expected field transform", "identity",
               updated.fields().get(2).transform().toString());
+    }
+  }
+
+  @Test
+  public void testRemoveAndUpdateWithDifferentTransformation() {
+    PartitionSpec expected = PartitionSpec.builderFor(SCHEMA)
+            .month("ts", "ts_transformed")
+            .build();
+    PartitionSpec updated = new BaseUpdatePartitionSpec(formatVersion, expected)
+            .removeField("ts_transformed")
+            .addField("ts_transformed", day("ts"))
+            .apply();
+
+    if (formatVersion == 1) {
+      Assert.assertEquals("Should match expected spec field size", 2, updated.fields().size());
+      Assert.assertEquals("Should match expected field name", "ts_transformed",
+              updated.fields().get(0).name());
+      Assert.assertEquals("Should match expected field name", "ts_transformed",
+              updated.fields().get(1).name());
+
+      Assert.assertEquals("Should match expected field transform", "void",
+              updated.fields().get(0).transform().toString());
+      Assert.assertEquals("Should match expected field transform", "day",
+              updated.fields().get(1).transform().toString());
+    } else {
+      Assert.assertEquals("Should match expected spec field size", 1, updated.fields().size());
+      Assert.assertEquals("Should match expected field name", "ts_transformed",
+              updated.fields().get(0).name());
+      Assert.assertEquals("Should match expected field transform", "day",
+              updated.fields().get(0).transform().toString());
     }
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
+++ b/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
@@ -609,59 +609,28 @@ public class TestUpdatePartitionSpec extends TableTestBase {
   public void testRemoveAndUpdateWithIdentity() {
     PartitionSpec expected = PartitionSpec.builderFor(SCHEMA)
             .identity("ts")
-            .identity("category")
-            .identity("id")
             .build();
     PartitionSpec updated = new BaseUpdatePartitionSpec(formatVersion, expected)
             .removeField("ts")
-            .removeField("category")
-            .removeField("id")
             .addField("ts")
-            .addField("category")
-            .addField("id")
             .apply();
 
     if (formatVersion == 1) {
-      Assert.assertEquals("Should match expected spec field size", 6, updated.fields().size());
+      Assert.assertEquals("Should match expected spec field size", 2, updated.fields().size());
       Assert.assertEquals("Should match expected field name", "ts",
               updated.fields().get(0).name());
-      Assert.assertEquals("Should match expected field name", "category",
-              updated.fields().get(1).name());
-      Assert.assertEquals("Should match expected field name", "id",
-              updated.fields().get(2).name());
       Assert.assertEquals("Should match expected field name", "ts",
-              updated.fields().get(3).name());
-      Assert.assertEquals("Should match expected field name", "category",
-              updated.fields().get(4).name());
-      Assert.assertEquals("Should match expected field name", "id",
-              updated.fields().get(5).name());
-
+              updated.fields().get(1).name());
       Assert.assertEquals("Should match expected field transform", "void",
               updated.fields().get(0).transform().toString());
-      Assert.assertEquals("Should match expected field transform", "void",
+      Assert.assertEquals("Should match expected field transform", "identity",
               updated.fields().get(1).transform().toString());
-      Assert.assertEquals("Should match expected field transform", "void",
-              updated.fields().get(2).transform().toString());
-      Assert.assertEquals("Should match expected field transform", "identity",
-              updated.fields().get(3).transform().toString());
-      Assert.assertEquals("Should match expected field transform", "identity",
-              updated.fields().get(4).transform().toString());
-      Assert.assertEquals("Should match expected field transform", "identity",
-              updated.fields().get(5).transform().toString());
     } else {
-      Assert.assertEquals("Should match expected spec field size", 3, updated.fields().size());
+      Assert.assertEquals("Should match expected spec field size", 1, updated.fields().size());
       Assert.assertEquals("Should match expected field name", "ts",
               updated.fields().get(0).name());
-      Assert.assertEquals("Should match expected field name", "category",
-              updated.fields().get(1).name());
-      Assert.assertEquals("Should match expected field name", "id",
-              updated.fields().get(2).name());
       Assert.assertEquals("Should match expected field transform", "identity",
               updated.fields().get(0).transform().toString());
-      Assert.assertEquals("Should match expected field transform", "identity",
-              updated.fields().get(1).transform().toString());
-      Assert.assertEquals("Should match expected field transform", "identity",
-              updated.fields().get(2).transform().toString());
     }
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
+++ b/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
@@ -599,8 +599,8 @@ public class TestUpdatePartitionSpec extends TableTestBase {
     }
 
     PartitionSpec v2Expected = PartitionSpec.builderFor(SCHEMA)
-            .month("ts", "ts_date")
-            .build();
+        .month("ts", "ts_date")
+        .build();
 
     V2Assert.assertEquals("Should match expected spec", v2Expected, updated);
   }
@@ -608,16 +608,16 @@ public class TestUpdatePartitionSpec extends TableTestBase {
   @Test
   public void testRemoveAndUpdateWithIdentity() {
     PartitionSpec expected = PartitionSpec.builderFor(SCHEMA)
-            .identity("ts")
-            .build();
+         .identity("ts")
+         .build();
     PartitionSpec updated = new BaseUpdatePartitionSpec(formatVersion, expected)
-            .removeField("ts")
-            .addField("ts")
-            .apply();
+         .removeField("ts")
+         .addField("ts")
+         .apply();
 
     if (formatVersion == 1) {
       Assert.assertEquals("Should match expected spec field size", 2, updated.fields().size());
-      Assert.assertEquals("Should match expected field name", "ts",
+      Assert.assertEquals("Should match expected field name", "ts_1000",
               updated.fields().get(0).name());
       Assert.assertEquals("Should match expected field name", "ts",
               updated.fields().get(1).name());
@@ -637,16 +637,16 @@ public class TestUpdatePartitionSpec extends TableTestBase {
   @Test
   public void testRemoveAndUpdateWithDifferentTransformation() {
     PartitionSpec expected = PartitionSpec.builderFor(SCHEMA)
-            .month("ts", "ts_transformed")
-            .build();
+        .month("ts", "ts_transformed")
+        .build();
     PartitionSpec updated = new BaseUpdatePartitionSpec(formatVersion, expected)
-            .removeField("ts_transformed")
-            .addField("ts_transformed", day("ts"))
-            .apply();
+        .removeField("ts_transformed")
+        .addField("ts_transformed", day("ts"))
+        .apply();
 
     if (formatVersion == 1) {
       Assert.assertEquals("Should match expected spec field size", 2, updated.fields().size());
-      Assert.assertEquals("Should match expected field name", "ts_transformed",
+      Assert.assertEquals("Should match expected field name", "ts_transformed_1000",
               updated.fields().get(0).name());
       Assert.assertEquals("Should match expected field name", "ts_transformed",
               updated.fields().get(1).name());


### PR DESCRIPTION
this would be convenient for the users to have various (can be same) transformations with the same target column name after deleting the original one