### PR TITLE
Spark: Add connector APIs for row-level commands

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/spark/sql/connector/iceberg/write/DeltaBatchWrite.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/spark/sql/connector/iceberg/write/DeltaBatchWrite.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.connector.iceberg.write;
+
+import org.apache.spark.sql.connector.write.BatchWrite;
+import org.apache.spark.sql.connector.write.PhysicalWriteInfo;
+
+/**
+ * An interface that defines how to write a delta of rows during batch processing.
+ */
+public interface DeltaBatchWrite extends BatchWrite {
+  @Override
+  DeltaWriterFactory createBatchWriterFactory(PhysicalWriteInfo info);
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/spark/sql/connector/iceberg/write/DeltaWrite.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/spark/sql/connector/iceberg/write/DeltaWrite.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.connector.iceberg.write;
+
+import org.apache.spark.sql.connector.write.Write;
+
+/**
+ * A logical representation of a data source write that handles a delta of rows.
+ */
+public interface DeltaWrite extends Write {
+  @Override
+  DeltaBatchWrite toBatch();
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/spark/sql/connector/iceberg/write/DeltaWrite.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/spark/sql/connector/iceberg/write/DeltaWrite.java
@@ -23,6 +23,9 @@ import org.apache.spark.sql.connector.write.Write;
 
 /**
  * A logical representation of a data source write that handles a delta of rows.
+ * A delta of rows is a set of instructions that indicate which records need to be deleted,
+ * updated, or inserted. Data sources that support deltas allow Spark to discard unchanged rows
+ * and pass only the information about what rows have changed during a row-level operation.
  */
 public interface DeltaWrite extends Write {
   @Override

--- a/spark/v3.2/spark/src/main/java/org/apache/spark/sql/connector/iceberg/write/DeltaWriteBuilder.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/spark/sql/connector/iceberg/write/DeltaWriteBuilder.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.connector.iceberg.write;
+
+import org.apache.spark.sql.connector.write.WriteBuilder;
+
+/**
+ * An interface for building delta writes.
+ */
+public interface DeltaWriteBuilder extends WriteBuilder {
+  /**
+   * Returns a logical delta write.
+   */
+  @Override
+  default DeltaWrite build() {
+    throw new UnsupportedOperationException("Not implemented: build");
+  }
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/spark/sql/connector/iceberg/write/DeltaWriter.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/spark/sql/connector/iceberg/write/DeltaWriter.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.connector.iceberg.write;
+
+import java.io.IOException;
+import org.apache.spark.sql.connector.write.DataWriter;
+
+/**
+ * A data writer responsible for writing a delta of rows.
+ */
+public interface DeltaWriter<T> extends DataWriter<T> {
+  /**
+   * Passes information for a row that must be deleted.
+   *
+   * @param metadata values for metadata columns that were projected but are not part of the row ID
+   * @param id a row ID to delete
+   * @throws IOException if the write process encounters an error
+   */
+  void delete(T metadata, T id) throws IOException;
+
+  /**
+   * Passes information for a row that must be updated together with the updated row.
+   *
+   * @param metadata values for metadata columns that were projected but are not part of the row ID
+   * @param id a row ID to update
+   * @param row a row with updated values
+   * @throws IOException if the write process encounters an error
+   */
+  void update(T metadata, T id, T row) throws IOException;
+
+  /**
+   * Passes a row to insert.
+   *
+   * @param row a row to insert
+   * @throws IOException if the write process encounters an error
+   */
+  void insert(T row) throws IOException;
+
+  @Override
+  default void write(T row) throws IOException {
+    insert(row);
+  }
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/spark/sql/connector/iceberg/write/DeltaWriterFactory.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/spark/sql/connector/iceberg/write/DeltaWriterFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.connector.iceberg.write;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.write.DataWriterFactory;
+
+/**
+ * A factory for creating and initializing delta writers at the executor side.
+ */
+public interface DeltaWriterFactory extends DataWriterFactory {
+  @Override
+  DeltaWriter<InternalRow> createWriter(int partitionId, long taskId);
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/spark/sql/connector/iceberg/write/ExtendedLogicalWriteInfo.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/spark/sql/connector/iceberg/write/ExtendedLogicalWriteInfo.java
@@ -27,12 +27,12 @@ import org.apache.spark.sql.types.StructType;
  */
 public interface ExtendedLogicalWriteInfo extends LogicalWriteInfo {
   /**
-   * the schema of the input metadata from Spark to data source.
+   * The schema of the input metadata from Spark to data source.
    */
   StructType metadataSchema();
 
   /**
-   * the schema of the ID columns from Spark to data source.
+   * The schema of the ID columns from Spark to data source.
    */
   StructType rowIdSchema();
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/spark/sql/connector/iceberg/write/ExtendedLogicalWriteInfo.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/spark/sql/connector/iceberg/write/ExtendedLogicalWriteInfo.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.connector.iceberg.write;
+
+import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * A class that holds logical write information not covered by LogicalWriteInfo in Spark.
+ */
+public interface ExtendedLogicalWriteInfo extends LogicalWriteInfo {
+  /**
+   * the schema of the input metadata from Spark to data source.
+   */
+  StructType metadataSchema();
+
+  /**
+   * the schema of the ID columns from Spark to data source.
+   */
+  StructType rowIdSchema();
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/spark/sql/connector/iceberg/write/RowLevelOperation.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/spark/sql/connector/iceberg/write/RowLevelOperation.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.connector.iceberg.write;
+
+import org.apache.spark.sql.connector.expressions.NamedReference;
+import org.apache.spark.sql.connector.read.ScanBuilder;
+import org.apache.spark.sql.connector.write.WriteBuilder;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+/**
+ * A logical representation of a data source DELETE, UPDATE, or MERGE operation that requires
+ * rewriting data.
+ */
+public interface RowLevelOperation {
+
+  /**
+   * The SQL operation being performed.
+   */
+  enum Command {
+    DELETE, UPDATE, MERGE
+  }
+
+  /**
+   * Returns the description associated with this row-level operation.
+   */
+  default String description() {
+    return this.getClass().toString();
+  }
+
+  /**
+   * Returns the actual SQL operation being performed.
+   */
+  Command command();
+
+  /**
+   * Returns a scan builder to configure a scan for this row-level operation.
+   * <p>
+   * Sources fall into two categories: those that can handle a delta of rows and those that need
+   * to replace groups (e.g. partitions, files). Sources that handle deltas allow Spark to quickly
+   * discard unchanged rows and have no requirements for input scans. Sources that replace groups
+   * of rows can discard deleted rows but need to keep unchanged rows to be passed back into
+   * the source. This means that scans for such data sources must produce all rows in a group
+   * if any are returned. Some sources will avoid pushing filters into files (file granularity),
+   * while others will avoid pruning files within a partition (partition granularity).
+   * <p>
+   * For example, if a source can only replace partitions, all rows from a partition must
+   * be returned by the scan, even if a filter can narrow the set of changes to a single file
+   * in the partition. Similarly, a source that can swap individual files must produce all rows
+   * of files where at least one record must be changed, not just the rows that must be changed.
+   */
+  ScanBuilder newScanBuilder(CaseInsensitiveStringMap options);
+
+  /**
+   * Returns a write builder to configure a write for this row-level operation.
+   * <p>
+   * Note that Spark will first configure the scan and then the write, allowing data sources
+   * to pass information from the scan to the write. For example, the scan can report
+   * which condition was used to read the data that may be needed by the write under certain
+   * isolation levels.
+   */
+  WriteBuilder newWriteBuilder(ExtendedLogicalWriteInfo info);
+
+  /**
+   * Returns metadata attributes that are required to perform this row-level operation.
+   * <p>
+   * Data sources that can use this method to project metadata columns needed for writing
+   * the data back (e.g. metadata columns for grouping data).
+   */
+  default NamedReference[] requiredMetadataAttributes() {
+    return new NamedReference[0];
+  }
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/spark/sql/connector/iceberg/write/RowLevelOperationBuilder.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/spark/sql/connector/iceberg/write/RowLevelOperationBuilder.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.connector.iceberg.write;
+
+/**
+ * An interface for building a row-level operation.
+ */
+public interface RowLevelOperationBuilder {
+  /**
+   * Returns a row-level operation that controls how Spark rewrites data for DELETE, UPDATE, MERGE commands.
+   */
+  RowLevelOperation build();
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/spark/sql/connector/iceberg/write/RowLevelOperationInfo.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/spark/sql/connector/iceberg/write/RowLevelOperationInfo.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.connector.iceberg.write;
+
+import org.apache.spark.sql.connector.iceberg.write.RowLevelOperation.Command;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+/**
+ * An interface with logical information for a row-level operation such as DELETE or MERGE.
+ */
+public interface RowLevelOperationInfo {
+  /**
+   * Returns options that the user specified when performing the row-level operation.
+   */
+  CaseInsensitiveStringMap options();
+
+  /**
+   * Returns the SQL command (e.g. DELETE, UPDATE, MERGE) for this row-level operation.
+   */
+  Command command();
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/spark/sql/connector/iceberg/write/SupportsDelta.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/spark/sql/connector/iceberg/write/SupportsDelta.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.spark.sql.connector.iceberg.write;
+
+import org.apache.spark.sql.connector.expressions.NamedReference;
+
+/**
+ * A mix-in interface for RowLevelOperation. Data sources can implement this interface
+ * to indicate they support handling deltas of rows.
+ */
+public interface SupportsDelta extends RowLevelOperation {
+  @Override
+  DeltaWriteBuilder newWriteBuilder(ExtendedLogicalWriteInfo info);
+
+  /**
+   * Returns the row ID column references that should be used for row equality.
+   */
+  NamedReference[] rowId();
+}


### PR DESCRIPTION
This PR adds new connector APIs for row-level commands in Spark 3.2 based on the voted [Spark SPIP](https://docs.google.com/document/d/12Ywmc47j3l2WF4anG5vL4qlrhT2OKigb7_EbIKhxg60).

Resolves #3628.