### PR TITLE
Ensure MetricsConfig is immutable

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetricsConfig.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsConfig.java
@@ -23,9 +23,11 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.concurrent.Immutable;
 import org.apache.iceberg.MetricsModes.MetricsMode;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.SortOrderUtil;
 import org.slf4j.Logger;
@@ -35,21 +37,22 @@ import static org.apache.iceberg.TableProperties.DEFAULT_WRITE_METRICS_MODE;
 import static org.apache.iceberg.TableProperties.DEFAULT_WRITE_METRICS_MODE_DEFAULT;
 import static org.apache.iceberg.TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX;
 
-public class MetricsConfig implements Serializable {
+@Immutable
+public final class MetricsConfig implements Serializable {
 
   private static final Logger LOG = LoggerFactory.getLogger(MetricsConfig.class);
   private static final Joiner DOT = Joiner.on('.');
 
-  private Map<String, MetricsMode> columnModes = Maps.newHashMap();
-  private MetricsMode defaultMode;
+  private final Map<String, MetricsMode> columnModes;
+  private final MetricsMode defaultMode;
 
-  private MetricsConfig() {
+  private MetricsConfig(Map<String, MetricsMode> columnModes, MetricsMode defaultMode) {
+    this.columnModes = ImmutableMap.copyOf(columnModes);
+    this.defaultMode = defaultMode;
   }
 
   public static MetricsConfig getDefault() {
-    MetricsConfig spec = new MetricsConfig();
-    spec.defaultMode = MetricsModes.fromString(DEFAULT_WRITE_METRICS_MODE_DEFAULT);
-    return spec;
+    return new MetricsConfig(ImmutableMap.of(), MetricsModes.fromString(DEFAULT_WRITE_METRICS_MODE_DEFAULT));
   }
 
   static Map<String, String> updateProperties(Map<String, String> props, List<String> deletedColumns,
@@ -104,38 +107,40 @@ public class MetricsConfig implements Serializable {
    * @param table an Iceberg table
    */
   public static MetricsConfig forPositionDelete(Table table) {
-    MetricsConfig config = new MetricsConfig();
+    ImmutableMap.Builder<String, MetricsMode> columnModes = ImmutableMap.builder();
 
-    config.columnModes.put(MetadataColumns.DELETE_FILE_PATH.name(), MetricsModes.Full.get());
-    config.columnModes.put(MetadataColumns.DELETE_FILE_POS.name(), MetricsModes.Full.get());
+    columnModes.put(MetadataColumns.DELETE_FILE_PATH.name(), MetricsModes.Full.get());
+    columnModes.put(MetadataColumns.DELETE_FILE_POS.name(), MetricsModes.Full.get());
 
     MetricsConfig tableConfig = forTable(table);
 
-    config.defaultMode = tableConfig.defaultMode;
+    MetricsMode defaultMode = tableConfig.defaultMode;
     tableConfig.columnModes.forEach((columnAlias, mode) -> {
       String positionDeleteColumnAlias = DOT.join(MetadataColumns.DELETE_FILE_ROW_FIELD_NAME, columnAlias);
-      config.columnModes.put(positionDeleteColumnAlias, mode);
+      columnModes.put(positionDeleteColumnAlias, mode);
     });
 
-    return config;
+    return new MetricsConfig(columnModes.build(), defaultMode);
   }
 
   private static MetricsConfig from(Map<String, String> props, SortOrder order) {
-    MetricsConfig spec = new MetricsConfig();
+    Map<String, MetricsMode> columnModes = Maps.newHashMap();
+    MetricsMode defaultMode;
     String defaultModeAsString = props.getOrDefault(DEFAULT_WRITE_METRICS_MODE, DEFAULT_WRITE_METRICS_MODE_DEFAULT);
     try {
-      spec.defaultMode = MetricsModes.fromString(defaultModeAsString);
+      defaultMode = MetricsModes.fromString(defaultModeAsString);
     } catch (IllegalArgumentException err) {
       // Mode was invalid, log the error and use the default
       LOG.warn("Ignoring invalid default metrics mode: {}", defaultModeAsString, err);
-      spec.defaultMode = MetricsModes.fromString(DEFAULT_WRITE_METRICS_MODE_DEFAULT);
+      defaultMode = MetricsModes.fromString(DEFAULT_WRITE_METRICS_MODE_DEFAULT);
     }
 
     // First set sorted column with sorted column default (can be overridden by user)
-    MetricsMode sortedColDefaultMode = sortedColumnDefaultMode(spec.defaultMode);
+    MetricsMode sortedColDefaultMode = sortedColumnDefaultMode(defaultMode);
     Set<String> sortedCols = SortOrderUtil.orderPreservingSortedColumns(order);
-    sortedCols.forEach(sc -> spec.columnModes.put(sc, sortedColDefaultMode));
+    sortedCols.forEach(sc -> columnModes.put(sc, sortedColDefaultMode));
 
+    MetricsMode defaultModeFinal = defaultMode;
     props.keySet().stream()
         .filter(key -> key.startsWith(METRICS_MODE_COLUMN_CONF_PREFIX))
         .forEach(key -> {
@@ -146,12 +151,12 @@ public class MetricsConfig implements Serializable {
           } catch (IllegalArgumentException err) {
             // Mode was invalid, log the error and use the default
             LOG.warn("Ignoring invalid metrics mode for column {}: {}", columnAlias, props.get(key), err);
-            mode = spec.defaultMode;
+            mode = defaultModeFinal;
           }
-          spec.columnModes.put(columnAlias, mode);
+          columnModes.put(columnAlias, mode);
         });
 
-    return spec;
+    return new MetricsConfig(columnModes, defaultMode);
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/MetricsConfig.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsConfig.java
@@ -43,6 +43,9 @@ public final class MetricsConfig implements Serializable {
   private static final Logger LOG = LoggerFactory.getLogger(MetricsConfig.class);
   private static final Joiner DOT = Joiner.on('.');
 
+  private static final MetricsConfig DEFAULT = new MetricsConfig(ImmutableMap.of(),
+          MetricsModes.fromString(DEFAULT_WRITE_METRICS_MODE_DEFAULT));
+
   private final Map<String, MetricsMode> columnModes;
   private final MetricsMode defaultMode;
 
@@ -52,7 +55,7 @@ public final class MetricsConfig implements Serializable {
   }
 
   public static MetricsConfig getDefault() {
-    return new MetricsConfig(ImmutableMap.of(), MetricsModes.fromString(DEFAULT_WRITE_METRICS_MODE_DEFAULT));
+    return DEFAULT;
   }
 
   static Map<String, String> updateProperties(Map<String, String> props, List<String> deletedColumns,

--- a/core/src/main/java/org/apache/iceberg/MetricsModes.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsModes.java
@@ -56,6 +56,11 @@ public class MetricsModes {
     throw new IllegalArgumentException("Invalid metrics mode: " + mode);
   }
 
+  /**
+   * A metrics calculation mode.
+   * <p>
+   * Implementations must be immutable.
+   */
   public interface MetricsMode extends Serializable {
   }
 


### PR DESCRIPTION
`MetricsConfig` was effectively immutable from user perspective, because
all mutations were done in factory methods. Still, making the class
declare & enforce immutability helps the class users determine whether
it can be safety kept.