### PR TITLE
API: add methods that operate on meta files

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Table.java
+++ b/api/src/main/java/org/apache/iceberg/Table.java
@@ -273,9 +273,14 @@ public interface Table {
   Transaction newTransaction();
 
   /**
-   * Returns a {@link FileIO} to read and write table data and metadata files.
+   * Returns a {@link FileIO} to read and write table data files.
    */
   FileIO io();
+
+  /**
+   * Returns a {@link FileIO} to read and write table metadata files.
+   */
+  default FileIO metaIO() { return io(); }
 
   /**
    * Returns an {@link org.apache.iceberg.encryption.EncryptionManager} to encrypt and decrypt data files.

--- a/core/src/main/java/org/apache/iceberg/TableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/TableOperations.java
@@ -66,9 +66,14 @@ public interface TableOperations {
   void commit(TableMetadata base, TableMetadata metadata);
 
   /**
-   * Returns a {@link FileIO} to read and write table data and metadata files.
+   * Returns a {@link FileIO} to read and write table data files.
    */
   FileIO io();
+
+  /**
+   * Returns a {@link FileIO} to read and write table metadata files.
+   */
+  default FileIO metaIO() { return io(); }
 
   /**
    * Returns a {@link org.apache.iceberg.encryption.EncryptionManager} to encrypt and decrypt data files.


### PR DESCRIPTION
The purpose of this PR is to split the io() methods that operate on data files and meta files. 

The reason is that when I implemented the custom catalog, I found that the API can only customize the read/write logic of meta.json files, but had no control over the manifest files that also belong to metadata. Since the data file and manifest file are basically operated by the FileIO object obtained by [Table.io() ](https://github.com/apache/iceberg/blob/master/api/src/main/java/org/apache/iceberg/Table.java)or [TableOperations.io() ](https://github.com/apache/iceberg/blob/master/core/src/main/java/org/apache/iceberg/TableOperations.java)method, the read/write logic of the two files cannot be split. Separating the FileIO of the meta file may be more conducive to custom catalog.

Of course there is still a lot of code involved to fully implement the splitting of data files and manifest files, so if this solution is feasible, there is still a lot of work to follow.