### PR TITLE
build: remove slf4j-api from spark runtime projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,9 @@ subprojects {
   targetCompatibility = '1.8'
 
   dependencies {
-    implementation 'org.slf4j:slf4j-api'
+    if (!(project.name.contains("spark") && project.name.contains("runtime"))) {
+      implementation 'org.slf4j:slf4j-api'
+    }
     implementation 'com.github.stephenc.findbugs:findbugs-annotations'
 
     testImplementation 'org.junit.vintage:junit-vintage-engine'


### PR DESCRIPTION
Spark already includes sl4fj-api, so runtime projects should not declare slf4j-api as a dependency

Fixes #3620
