### PR TITLE
fix startsWith expression NullPointerException error caused by null v…

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
@@ -149,7 +149,8 @@ public class Evaluator implements Serializable {
 
     @Override
     public <T> Boolean startsWith(Bound<T> valueExpr, Literal<T> lit) {
-      return ((String) valueExpr.eval(struct)).startsWith((String) lit.value());
+      T evalRes = valueExpr.eval(struct);
+      return evalRes != null && ((String) evalRes).startsWith((String) lit.value());
     }
 
     @Override

--- a/api/src/test/java/org/apache/iceberg/expressions/TestEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestEvaluator.java
@@ -231,6 +231,8 @@ public class TestEvaluator {
     Assert.assertFalse("Abc startsWith abc should be false", evaluator.eval(TestHelpers.Row.of("Abc")));
     Assert.assertFalse("a startsWith abc should be false", evaluator.eval(TestHelpers.Row.of("a")));
     Assert.assertTrue("abcd startsWith abc should be true", evaluator.eval(TestHelpers.Row.of("abcd")));
+    Assert.assertFalse("null startsWith abc should be false",
+        evaluator.eval(TestHelpers.Row.of((String) null)));
   }
 
   @Test


### PR DESCRIPTION
I got NullPointerException when filtering data with Expressions.startsWith(A,B), because column A contains null value.
But I think its more reasonable to return false then to throw NullPointerException.
This pr will make startsWith Expression return false rather than throw NullPointerException when encounter null in column A.
Please see see, thanks.