### PR TITLE
Parquet: fix the `limit` setting of ParquetValueReaders#BytesReader

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
@@ -330,7 +330,7 @@ public class ParquetValueReaders {
       if (reuse != null && reuse.hasArray() && reuse.capacity() >= data.remaining()) {
         data.get(reuse.array(), reuse.arrayOffset(), data.remaining());
         reuse.position(0);
-        reuse.limit(data.remaining());
+        reuse.limit(binary.length());
         return reuse;
       } else {
         byte[] array = new byte[data.remaining()];


### PR DESCRIPTION
This is trying to address issue: [#3575](https://github.com/apache/iceberg/issues/3575)