### PR TITLE
retain flinkCheckpointInfo when rewrite datafiles to ensure restore flink job from checkpoint success

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -232,6 +232,9 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
 
     ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
 
+    // merge flinkCheckpointInfo from previousSummary into currentSummary when rewrite datafiles
+    mergeFlinkCheckpointInfo(builder, previousSummary, summary);
+
     // copy all summary properties from the implementation
     builder.putAll(summary);
 
@@ -445,6 +448,20 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
 
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to read manifest: %s", manifest.path());
+    }
+  }
+
+  private static void mergeFlinkCheckpointInfo(ImmutableMap.Builder<String, String> summaryBuilder,
+                                               Map<String, String> previousSummary,
+                                               Map<String, String> currentSummary) {
+    if (!currentSummary.containsKey(SnapshotSummary.FLINK_JOB_ID) &&
+            previousSummary.containsKey(SnapshotSummary.FLINK_JOB_ID)) {
+      summaryBuilder.put(SnapshotSummary.FLINK_JOB_ID, previousSummary.get(SnapshotSummary.FLINK_JOB_ID));
+    }
+    if (!currentSummary.containsKey(SnapshotSummary.FLINK_MAX_COMMITTED_CHECKPOINT_ID) &&
+            previousSummary.containsKey(SnapshotSummary.FLINK_MAX_COMMITTED_CHECKPOINT_ID)) {
+      summaryBuilder.put(SnapshotSummary.FLINK_MAX_COMMITTED_CHECKPOINT_ID,
+              previousSummary.get(SnapshotSummary.FLINK_MAX_COMMITTED_CHECKPOINT_ID));
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
@@ -54,6 +54,8 @@ public class SnapshotSummary {
   public static final String SOURCE_SNAPSHOT_ID_PROP = "source-snapshot-id";
   public static final String REPLACE_PARTITIONS_PROP = "replace-partitions";
   public static final String EXTRA_METADATA_PREFIX = "snapshot-property.";
+  public static final String FLINK_JOB_ID = "flink.job-id";
+  public static final String FLINK_MAX_COMMITTED_CHECKPOINT_ID = "flink.max-committed-checkpoint-id";
 
   public static final MapJoiner MAP_JOINER = Joiner.on(",").withKeyValueSeparator("=");
 

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
@@ -396,8 +396,8 @@ public class TestRewriteDataFilesAction extends FlinkCatalogTestBase {
     String flinkMaxCommitedCheckpointIDBeforeRewrite = summary.get(SnapshotSummary.FLINK_MAX_COMMITTED_CHECKPOINT_ID);
 
     Actions.forTable(icebergTableUnPartitioned)
-            .rewriteDataFiles()
-            .execute();
+        .rewriteDataFiles()
+        .execute();
 
     icebergTableUnPartitioned.refresh();
 
@@ -405,9 +405,9 @@ public class TestRewriteDataFilesAction extends FlinkCatalogTestBase {
 
     // Assert the flink job info retain after rewrite.
     Assert.assertEquals("Should retain flinkJobId after rewrite",
-            flinkJobIdBeforeRewrite, summaryAfterRewrite.get(SnapshotSummary.FLINK_JOB_ID));
+        flinkJobIdBeforeRewrite, summaryAfterRewrite.get(SnapshotSummary.FLINK_JOB_ID));
     Assert.assertEquals("Should retain flinkMaxCommitedCheckpointID after rewrite",
-            flinkMaxCommitedCheckpointIDBeforeRewrite,
-            summaryAfterRewrite.get(SnapshotSummary.FLINK_MAX_COMMITTED_CHECKPOINT_ID));
+        flinkMaxCommitedCheckpointIDBeforeRewrite,
+        summaryAfterRewrite.get(SnapshotSummary.FLINK_MAX_COMMITTED_CHECKPOINT_ID));
   }
 }

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
@@ -23,6 +23,7 @@ package org.apache.iceberg.flink.actions;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.configuration.CoreOptions;
@@ -34,6 +35,7 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.RewriteDataFilesActionResult;
 import org.apache.iceberg.catalog.Namespace;
@@ -380,5 +382,32 @@ public class TestRewriteDataFilesAction extends FlinkCatalogTestBase {
     expected.add(SimpleDataUtil.createRecord(1, "a"));
     expected.add(SimpleDataUtil.createRecord(2, "b"));
     SimpleDataUtil.assertTableRecords(icebergTableUnPartitioned, expected);
+  }
+
+  @Test
+  public void testRewriteDataFilesMergeCheckpointInfo() throws Exception {
+    sql("INSERT INTO %s SELECT 1, 'hello'", TABLE_NAME_UNPARTITIONED);
+    sql("INSERT INTO %s SELECT 2, 'world'", TABLE_NAME_UNPARTITIONED);
+
+    icebergTableUnPartitioned.refresh();
+
+    Map<String, String> summary = icebergTableUnPartitioned.currentSnapshot().summary();
+    String flinkJobIdBeforeRewrite = summary.get(SnapshotSummary.FLINK_JOB_ID);
+    String flinkMaxCommitedCheckpointIDBeforeRewrite = summary.get(SnapshotSummary.FLINK_MAX_COMMITTED_CHECKPOINT_ID);
+
+    Actions.forTable(icebergTableUnPartitioned)
+            .rewriteDataFiles()
+            .execute();
+
+    icebergTableUnPartitioned.refresh();
+
+    Map<String, String> summaryAfterRewrite = icebergTableUnPartitioned.currentSnapshot().summary();
+
+    // Assert the flink job info retain after rewrite.
+    Assert.assertEquals("Should retain flinkJobId after rewrite",
+            flinkJobIdBeforeRewrite, summaryAfterRewrite.get(SnapshotSummary.FLINK_JOB_ID));
+    Assert.assertEquals("Should retain flinkMaxCommitedCheckpointID after rewrite",
+            flinkMaxCommitedCheckpointIDBeforeRewrite,
+            summaryAfterRewrite.get(SnapshotSummary.FLINK_MAX_COMMITTED_CHECKPOINT_ID));
   }
 }


### PR DESCRIPTION
when flink job restore from checkpoint，IcebergFilesCommitter read the maxCommittedCheckpointId from summary in metadata file， and only commit the uncommitted DataFiles from maxCommittedCheckpointId +1，get maxCommittedCheckpointId will traverse iceberg table's snapshots until get the maxCommittedCheckpointId which is not null，but if after rewrite data files ,expire snapshots and only retain the latest snapshot after rewrite data files, will lost the maxCommittedCheckpointId info and the flink job restore operation will repeatedly commit the datafile that has committed，then an error will be reported like this because manifest file has been deleted:

> org.apache.iceberg.exceptions.NotFoundException: Failed to open input stream for file: file:/tmp/iceberg10/metadata/41b2614f36cb4fff57efbecd063827ba-00000-0-3-00003.avro
	at org.apache.iceberg.hadoop.HadoopInputFile.newStream(HadoopInputFile.java:177)
	at org.apache.iceberg.avro.AvroIterable.newFileReader(AvroIterable.java:101)
	at org.apache.iceberg.avro.AvroIterable.getMetadata(AvroIterable.java:66)
	at org.apache.iceberg.ManifestReader.<init>(ManifestReader.java:103)
	at org.apache.iceberg.ManifestFiles.read(ManifestFiles.java:87)
	at org.apache.iceberg.ManifestFiles.read(ManifestFiles.java:71)
	at org.apache.iceberg.flink.sink.FlinkManifestUtil.readDataFiles(FlinkManifestUtil.java:59)
	at org.apache.iceberg.flink.sink.FlinkManifestUtil.readCompletedFiles(FlinkManifestUtil.java:105)
	at org.apache.iceberg.flink.sink.IcebergFilesCommitter.commitUpToCheckpoint(IcebergFilesCommitter.java:207)
	at org.apache.iceberg.flink.sink.IcebergFilesCommitter.initializeState(IcebergFilesCommitter.java:153)
	at org.apache.flink.streaming.api.operators.StreamOperatorStateHandler.initializeOperatorState(StreamOperatorStateHandler.java:111)
	at org.apache.flink.streaming.api.operators.AbstractStreamOperator.initializeState(AbstractStreamOperator.java:290)
	at org.apache.flink.streaming.runtime.tasks.OperatorChain.initializeStateAndOpenOperators(OperatorChain.java:432)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.lambda$beforeInvoke$2(StreamTask.java:545)
	at org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor$1.runThrowing(StreamTaskActionExecutor.java:50)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.beforeInvoke(StreamTask.java:535)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.invoke(StreamTask.java:575)
	at org.apache.flink.runtime.taskmanager.Task.doRun(Task.java:758)
	at org.apache.flink.runtime.taskmanager.Task.run(Task.java:573)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.io.FileNotFoundException: File file:/tmp/iceberg10/metadata/41b2614f36cb4fff57efbecd063827ba-00000-0-3-00003.avro does not exist
	at org.apache.hadoop.fs.RawLocalFileSystem.deprecatedGetFileStatus(RawLocalFileSystem.java:611)
	at org.apache.hadoop.fs.RawLocalFileSystem.getFileLinkStatusInternal(RawLocalFileSystem.java:824)
	at org.apache.hadoop.fs.RawLocalFileSystem.getFileStatus(RawLocalFileSystem.java:601)
	at org.apache.hadoop.fs.FilterFileSystem.getFileStatus(FilterFileSystem.java:421)
	at org.apache.hadoop.fs.ChecksumFileSystem$ChecksumFSInputChecker.<init>(ChecksumFileSystem.java:142)
	at org.apache.hadoop.fs.ChecksumFileSystem.open(ChecksumFileSystem.java:346)
	at org.apache.hadoop.fs.FileSystem.open(FileSystem.java:769)
	at org.apache.iceberg.hadoop.HadoopInputFile.newStream(HadoopInputFile.java:175)
	... 19 more

i think a way to ensure restore flink job from checkpoint success is to retain flinkCheckpointInfo when rewrite datafiles.
