### PR TITLE
update slf4j version to 1.7.32

### DIFF
--- a/versions.props
+++ b/versions.props
@@ -1,4 +1,4 @@
-org.slf4j:* = 1.7.25
+org.slf4j:* = 1.7.32
 org.apache.avro:avro = 1.10.1
 org.apache.calcite:* = 1.10.0
 org.apache.flink:* = 1.12.5


### PR DESCRIPTION
update slf4j version  from 1.7.25 to 1.7.32 for CVE-2018-8088