### PR TITLE
Hive: HiveCatalog should remove HMS stats for certain engines based on config

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/ConfigProperties.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/ConfigProperties.java
@@ -25,4 +25,5 @@ public class ConfigProperties {
   }
 
   public static final String ENGINE_HIVE_ENABLED = "iceberg.engine.hive.enabled";
+  public static final String KEEP_HIVE_STATS = "iceberg.hive.keep.stats";
 }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -264,8 +264,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
       setHmsTableParameters(newMetadataLocation, tbl, metadata.properties(), removedProps, hiveEngineEnabled, summary);
 
       if (!keepHiveStats) {
-        StatsSetupConst.setBasicStatsState(tbl.getParameters(), StatsSetupConst.FALSE);
-        StatsSetupConst.clearColumnStatsState(tbl.getParameters());
+        tbl.getParameters().remove(StatsSetupConst.COLUMN_STATS_ACCURATE);
       }
 
       try {

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -212,6 +212,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
   protected void doCommit(TableMetadata base, TableMetadata metadata) {
     String newMetadataLocation = writeNewMetadata(metadata, currentVersion() + 1);
     boolean hiveEngineEnabled = hiveEngineEnabled(metadata, conf);
+    boolean keepHiveStats = conf.getBoolean(ConfigProperties.KEEP_HIVE_STATS, false);
 
     CommitStatus commitStatus = CommitStatus.FAILURE;
     boolean updateHiveTable = false;
@@ -261,6 +262,11 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
           .map(Snapshot::summary)
           .orElseGet(ImmutableMap::of);
       setHmsTableParameters(newMetadataLocation, tbl, metadata.properties(), removedProps, hiveEngineEnabled, summary);
+
+      if (!keepHiveStats) {
+        StatsSetupConst.setBasicStatsState(tbl.getParameters(), StatsSetupConst.FALSE);
+        StatsSetupConst.clearColumnStatsState(tbl.getParameters());
+      }
 
       try {
         persistTable(tbl, updateHiveTable);

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -758,7 +758,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     String insert = testTables.getInsertQuery(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, identifier, false);
     shell.executeStatement(insert);
     String stats = shell.metastore().getTable(identifier).getParameters().get(StatsSetupConst.COLUMN_STATS_ACCURATE);
-    Assert.assertEquals("{\"BASIC_STATS\":\"true\"}", stats);
+    Assert.assertTrue(stats.startsWith("{\"BASIC_STATS\":\"true\"")); // it's followed by column stats in Hive3
 
     // Create a Catalog where the KEEP_HIVE_STATS is false
     shell.metastore().hiveConf().set(ConfigProperties.KEEP_HIVE_STATS, StatsSetupConst.FALSE);
@@ -774,7 +774,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     // insert some data again using Hive catalog, and check the stats are back
     shell.executeStatement(insert);
     stats = shell.metastore().getTable(identifier).getParameters().get(StatsSetupConst.COLUMN_STATS_ACCURATE);
-    Assert.assertEquals("{\"BASIC_STATS\":\"true\"}", stats);
+    Assert.assertTrue(stats.startsWith("{\"BASIC_STATS\":\"true\"")); // it's followed by column stats in Hive3
   }
 
   private void testComplexTypeWrite(Schema schema, List<Record> records) throws IOException {

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -769,7 +769,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     nonHiveTestTables.appendIcebergTable(shell.getHiveConf(), nonHiveTable, fileFormat, null,
         HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
     stats = shell.metastore().getTable(identifier).getParameters().get(StatsSetupConst.COLUMN_STATS_ACCURATE);
-    Assert.assertEquals("{}", stats);
+    Assert.assertNull(stats);
 
     // insert some data again using Hive catalog, and check the stats are back
     shell.executeStatement(insert);

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.mr.ExecMapper;
 import org.apache.iceberg.FileFormat;
@@ -35,6 +36,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.hadoop.ConfigProperties;
 import org.apache.iceberg.hive.HiveSchemaUtil;
 import org.apache.iceberg.hive.MetastoreUtil;
 import org.apache.iceberg.mr.TestHelper;
@@ -737,6 +739,42 @@ public class TestHiveIcebergStorageHandlerWithEngine {
             HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
     shell.executeStatement("INSERT INTO target SELECT * FROM source WHERE first_name = 'Nobody'");
     HiveIcebergTestUtils.validateData(target, ImmutableList.of(), 0);
+  }
+
+  @Test
+  public void testStatsPopulation() throws Exception {
+    Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
+    Assume.assumeTrue("Only HiveCatalog can remove stats which become obsolete",
+        testTableType == TestTables.TestTableType.HIVE_CATALOG);
+    shell.setHiveSessionValue(HiveConf.ConfVars.HIVESTATSAUTOGATHER.varname, true);
+
+    // create the table using a catalog which supports updating Hive stats (KEEP_HIVE_STATS is true)
+    shell.setHiveSessionValue(ConfigProperties.KEEP_HIVE_STATS, true);
+    TableIdentifier identifier = TableIdentifier.of("default", "customers");
+    testTables.createTable(shell, identifier.name(), HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        PartitionSpec.unpartitioned(), fileFormat, ImmutableList.of());
+
+    // insert some data and check the stats are up-to-date
+    String insert = testTables.getInsertQuery(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, identifier, false);
+    shell.executeStatement(insert);
+    String stats = shell.metastore().getTable(identifier).getParameters().get(StatsSetupConst.COLUMN_STATS_ACCURATE);
+    Assert.assertEquals("{\"BASIC_STATS\":\"true\"}", stats);
+
+    // Create a Catalog where the KEEP_HIVE_STATS is false
+    shell.metastore().hiveConf().set(ConfigProperties.KEEP_HIVE_STATS, StatsSetupConst.FALSE);
+    TestTables nonHiveTestTables = HiveIcebergStorageHandlerTestUtils.testTables(shell, testTableType, temp);
+    Table nonHiveTable = nonHiveTestTables.loadTable(identifier);
+
+    // Append data to the table through a non-Hive engine (in this case, via the java API) -> should remove stats
+    nonHiveTestTables.appendIcebergTable(shell.getHiveConf(), nonHiveTable, fileFormat, null,
+        HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+    stats = shell.metastore().getTable(identifier).getParameters().get(StatsSetupConst.COLUMN_STATS_ACCURATE);
+    Assert.assertEquals("{}", stats);
+
+    // insert some data again using Hive catalog, and check the stats are back
+    shell.executeStatement(insert);
+    stats = shell.metastore().getTable(identifier).getParameters().get(StatsSetupConst.COLUMN_STATS_ACCURATE);
+    Assert.assertEquals("{\"BASIC_STATS\":\"true\"}", stats);
   }
 
   private void testComplexTypeWrite(Schema schema, List<Record> records) throws IOException {

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
@@ -218,6 +218,21 @@ abstract class TestTables {
     return loadTable(identifier);
   }
 
+  public String getInsertQuery(List<Record> records, TableIdentifier identifier, boolean isOverwrite) {
+    StringBuilder query = new StringBuilder(String.format("INSERT %s %s VALUES ",
+            isOverwrite ? "OVERWRITE TABLE" : "INTO", identifier));
+
+    records.forEach(record -> {
+      query.append("(");
+      query.append(record.struct().fields().stream()
+              .map(field -> getStringValueForInsert(record.getField(field.name()), field.type()))
+              .collect(Collectors.joining(",")));
+      query.append("),");
+    });
+    query.setLength(query.length() - 1);
+    return query.toString();
+  }
+
   /**
    * Creates a Hive test table. Creates the Iceberg table/data and creates the corresponding Hive table as well when
    * needed. The table will be in the 'default' database. The table will be populated with the provided with randomly


### PR DESCRIPTION
The Hive engine keeps the HMS stats updated after each write to a table, provided that hive.stats.autogather is turned on. If other engines are interacting with the same table however, e.g. Spark writing to the same table, they might not update the HMS stats but also not invalidate the stats within HMS either, leaving it stale but HMS believing that it's up-to-date. This PR introduces a config which can enable/disable HMS stats invalidation in HiveCatalog for each engine.

cc @pvary 