### PR TITLE
Hive: initialize serde parameters when committing table in HiveCatalog

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -69,6 +69,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.BiMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableBiMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.Tasks;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
@@ -397,6 +398,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     storageDescriptor.setCols(HiveSchemaUtil.convert(metadata.schema()));
     storageDescriptor.setLocation(metadata.location());
     SerDeInfo serDeInfo = new SerDeInfo();
+    serDeInfo.setParameters(Maps.newHashMap());
     if (hiveEngineEnabled) {
       storageDescriptor.setInputFormat("org.apache.iceberg.mr.hive.HiveIcebergInputFormat");
       storageDescriptor.setOutputFormat("org.apache.iceberg.mr.hive.HiveIcebergOutputFormat");


### PR DESCRIPTION
Leaving the serdeInfo.parameters as null can lead to NPE for consumers. We have encountered such an [error](https://github.com/apache/hive/commit/2431fd16aedbb857356cef3e15f20e91185e4039#diff-b1bce663288d98098d8aaa474ad0694d43484b0cd1977a788dc9f6c6f7fae4d0R206) in Hive before - this should guard against such scenarios.