### PR TITLE
Build: Rename Spark 3.1 and 3.2 module names

### DIFF
--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -123,7 +123,7 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
       - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-      - run: ./gradlew -DsparkVersions=${{ matrix.spark }} -DhiveVersions= -DflinkVersions= :iceberg-spark:iceberg-spark-${{ matrix.spark }}_2.12:check :iceberg-spark:iceberg-spark-${{ matrix.spark }}-extensions_2.12:check :iceberg-spark:iceberg-spark-${{ matrix.spark }}-runtime_2.12:check -Pquick=true -x javadoc
+      - run: ./gradlew -DsparkVersions=${{ matrix.spark }} -DhiveVersions= -DflinkVersions= :iceberg-spark:iceberg-spark-${{ matrix.spark }}_2.12:check :iceberg-spark:iceberg-spark-extensions-${{ matrix.spark }}_2.12:check :iceberg-spark:iceberg-spark-runtime-${{ matrix.spark }}_2.12:check -Pquick=true -x javadoc
       - uses: actions/upload-artifact@v2
         if: failure()
         with:

--- a/settings.gradle
+++ b/settings.gradle
@@ -109,26 +109,26 @@ if (sparkVersions.contains("3.0")) {
 
 if (sparkVersions.contains("3.1")) {
   include ':iceberg-spark:spark-3.1_2.12'
-  include ':iceberg-spark:spark-3.1-extensions_2.12'
-  include ':iceberg-spark:spark-3.1-runtime_2.12'
+  include ':iceberg-spark:spark-extensions-3.1_2.12'
+  include ':iceberg-spark:spark-runtime-3.1_2.12'
   project(':iceberg-spark:spark-3.1_2.12').projectDir = file('spark/v3.1/spark')
   project(':iceberg-spark:spark-3.1_2.12').name = 'iceberg-spark-3.1_2.12'
-  project(':iceberg-spark:spark-3.1-extensions_2.12').projectDir = file('spark/v3.1/spark-extensions')
-  project(':iceberg-spark:spark-3.1-extensions_2.12').name = 'iceberg-spark-3.1-extensions_2.12'
-  project(':iceberg-spark:spark-3.1-runtime_2.12').projectDir = file('spark/v3.1/spark-runtime')
-  project(':iceberg-spark:spark-3.1-runtime_2.12').name = 'iceberg-spark-3.1-runtime_2.12'
+  project(':iceberg-spark:spark-extensions-3.1_2.12').projectDir = file('spark/v3.1/spark-extensions')
+  project(':iceberg-spark:spark-extensions-3.1_2.12').name = 'iceberg-spark-extensions-3.1_2.12'
+  project(':iceberg-spark:spark-runtime-3.1_2.12').projectDir = file('spark/v3.1/spark-runtime')
+  project(':iceberg-spark:spark-runtime-3.1_2.12').name = 'iceberg-spark-runtime-3.1_2.12'
 }
 
 if (sparkVersions.contains("3.2")) {
   include ':iceberg-spark:spark-3.2_2.12'
-  include ':iceberg-spark:spark-3.2-extensions_2.12'
-  include ':iceberg-spark:spark-3.2-runtime_2.12'
+  include ':iceberg-spark:spark-extensions-3.2_2.12'
+  include ':iceberg-spark:spark-runtime-3.2_2.12'
   project(':iceberg-spark:spark-3.2_2.12').projectDir = file('spark/v3.2/spark')
   project(':iceberg-spark:spark-3.2_2.12').name = 'iceberg-spark-3.2_2.12'
-  project(':iceberg-spark:spark-3.2-extensions_2.12').projectDir = file('spark/v3.2/spark-extensions')
-  project(':iceberg-spark:spark-3.2-extensions_2.12').name = 'iceberg-spark-3.2-extensions_2.12'
-  project(':iceberg-spark:spark-3.2-runtime_2.12').projectDir = file('spark/v3.2/spark-runtime')
-  project(':iceberg-spark:spark-3.2-runtime_2.12').name = 'iceberg-spark-3.2-runtime_2.12'
+  project(':iceberg-spark:spark-extensions-3.2_2.12').projectDir = file('spark/v3.2/spark-extensions')
+  project(':iceberg-spark:spark-extensions-3.2_2.12').name = 'iceberg-spark-extensions-3.2_2.12'
+  project(':iceberg-spark:spark-runtime-3.2_2.12').projectDir = file('spark/v3.2/spark-runtime')
+  project(':iceberg-spark:spark-runtime-3.2_2.12').name = 'iceberg-spark-runtime-3.2_2.12'
 }
 
 // hive 3 depends on hive 2, so always add hive 2 if hive3 is enabled

--- a/spark/v3.1/build.gradle
+++ b/spark/v3.1/build.gradle
@@ -19,8 +19,8 @@
 
 def sparkProjects = [
     project(':iceberg-spark:iceberg-spark-3.1_2.12'),
-    project(":iceberg-spark:iceberg-spark-3.1-extensions_2.12"),
-    project(':iceberg-spark:iceberg-spark-3.1-runtime_2.12')
+    project(":iceberg-spark:iceberg-spark-extensions-3.1_2.12"),
+    project(':iceberg-spark:iceberg-spark-runtime-3.1_2.12')
 ]
 
 configure(sparkProjects) {
@@ -104,7 +104,7 @@ project(':iceberg-spark:iceberg-spark-3.1_2.12') {
   }
 }
 
-project(":iceberg-spark:iceberg-spark-3.1-extensions_2.12") {
+project(":iceberg-spark:iceberg-spark-extensions-3.1_2.12") {
   apply plugin: 'java-library'
   apply plugin: 'scala'
   apply plugin: 'antlr'
@@ -160,7 +160,7 @@ project(":iceberg-spark:iceberg-spark-3.1-extensions_2.12") {
   }
 }
 
-project(':iceberg-spark:iceberg-spark-3.1-runtime_2.12') {
+project(':iceberg-spark:iceberg-spark-runtime-3.1_2.12') {
   apply plugin: 'com.github.johnrengelman.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
@@ -195,7 +195,7 @@ project(':iceberg-spark:iceberg-spark-3.1-runtime_2.12') {
   dependencies {
     api project(':iceberg-api')
     implementation project(':iceberg-spark:iceberg-spark-3.1_2.12')
-    implementation project(':iceberg-spark:iceberg-spark-3.1-extensions_2.12')
+    implementation project(':iceberg-spark:iceberg-spark-extensions-3.1_2.12')
     implementation project(':iceberg-aws')
     implementation(project(':iceberg-nessie')) {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
@@ -207,9 +207,9 @@ project(':iceberg-spark:iceberg-spark-3.1-runtime_2.12') {
     integrationImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
     integrationImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
     integrationImplementation project(path: ':iceberg-spark:iceberg-spark-3.1_2.12', configuration: 'testArtifacts')
-    integrationImplementation project(path: ':iceberg-spark:iceberg-spark-3.1-extensions_2.12', configuration: 'testArtifacts')
+    integrationImplementation project(path: ':iceberg-spark:iceberg-spark-extensions-3.1_2.12', configuration: 'testArtifacts')
     // Not allowed on our classpath, only the runtime jar is allowed
-    integrationCompileOnly project(':iceberg-spark:iceberg-spark-3.1-extensions_2.12')
+    integrationCompileOnly project(':iceberg-spark:iceberg-spark-extensions-3.1_2.12')
     integrationCompileOnly project(':iceberg-spark:iceberg-spark-3.1_2.12')
     integrationCompileOnly project(':iceberg-api')
   }

--- a/spark/v3.2/build.gradle
+++ b/spark/v3.2/build.gradle
@@ -19,8 +19,8 @@
 
 def sparkProjects = [
     project(':iceberg-spark:iceberg-spark-3.2_2.12'),
-    project(":iceberg-spark:iceberg-spark-3.2-extensions_2.12"),
-    project(':iceberg-spark:iceberg-spark-3.2-runtime_2.12')
+    project(":iceberg-spark:iceberg-spark-extensions-3.2_2.12"),
+    project(':iceberg-spark:iceberg-spark-runtime-3.2_2.12')
 ]
 
 configure(sparkProjects) {
@@ -108,7 +108,7 @@ project(':iceberg-spark:iceberg-spark-3.2_2.12') {
   }
 }
 
-project(":iceberg-spark:iceberg-spark-3.2-extensions_2.12") {
+project(":iceberg-spark:iceberg-spark-extensions-3.2_2.12") {
   apply plugin: 'java-library'
   apply plugin: 'scala'
   apply plugin: 'antlr'
@@ -162,7 +162,7 @@ project(":iceberg-spark:iceberg-spark-3.2-extensions_2.12") {
   }
 }
 
-project(':iceberg-spark:iceberg-spark-3.2-runtime_2.12') {
+project(':iceberg-spark:iceberg-spark-runtime-3.2_2.12') {
   apply plugin: 'com.github.johnrengelman.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
@@ -197,7 +197,7 @@ project(':iceberg-spark:iceberg-spark-3.2-runtime_2.12') {
   dependencies {
     api project(':iceberg-api')
     implementation project(':iceberg-spark:iceberg-spark-3.2_2.12')
-    implementation project(':iceberg-spark:iceberg-spark-3.2-extensions_2.12')
+    implementation project(':iceberg-spark:iceberg-spark-extensions-3.2_2.12')
     implementation project(':iceberg-aws')
     implementation(project(':iceberg-nessie')) {
       exclude group: 'com.google.code.findbugs', module: 'jsr305'
@@ -209,9 +209,9 @@ project(':iceberg-spark:iceberg-spark-3.2-runtime_2.12') {
     integrationImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
     integrationImplementation project(path: ':iceberg-hive-metastore', configuration: 'testArtifacts')
     integrationImplementation project(path: ':iceberg-spark:iceberg-spark-3.2_2.12', configuration: 'testArtifacts')
-    integrationImplementation project(path: ':iceberg-spark:iceberg-spark-3.2-extensions_2.12', configuration: 'testArtifacts')
+    integrationImplementation project(path: ':iceberg-spark:iceberg-spark-extensions-3.2_2.12', configuration: 'testArtifacts')
     // Not allowed on our classpath, only the runtime jar is allowed
-    integrationCompileOnly project(':iceberg-spark:iceberg-spark-3.2-extensions_2.12')
+    integrationCompileOnly project(':iceberg-spark:iceberg-spark-extensions-3.2_2.12')
     integrationCompileOnly project(':iceberg-spark:iceberg-spark-3.2_2.12')
     integrationCompileOnly project(':iceberg-api')
   }


### PR DESCRIPTION
With this rename, the modules for Spark 3.1 and 3.2 will be:

iceberg-spark-3.1_2.12
iceberg-spark-extensions-3.1_2.12
iceberg-spark-runtime-3.1_2.12
iceberg-spark-3.2_2.12
iceberg-spark-extensions-3.2_2.12
iceberg-spark-runtime-3.2_2.12

The 1st and 4th are current names as a result of #3624. Here we are renaming the rest. The new names are, in my opinion, more rational and still conform to sbt convention.