### PR TITLE
AWS: support S3FileIO alternative endpoint and credentials

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/TestDefaultAwsClientFactory.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/TestDefaultAwsClientFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.aws;
+
+import java.util.Map;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.Test;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+public class TestDefaultAwsClientFactory {
+
+  @Test
+  public void testS3FileIoEndpointOverride() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(AwsProperties.S3FILEIO_ENDPOINT, "https://unknown:1234");
+    AwsClientFactory factory = AwsClientFactories.from(properties);
+    S3Client s3Client = factory.s3();
+    AssertHelpers.assertThrowsCause("Should refuse connection to unknown endpoint",
+        SdkClientException.class,
+        "Unable to execute HTTP request: unknown",
+        () -> s3Client.getObject(GetObjectRequest.builder().bucket("bucket").key("key").build()));
+  }
+
+  @Test
+  public void testS3FileIoCredentialsOverride() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(AwsProperties.S3FILEIO_ACCESS_KEY_ID, "unknown");
+    properties.put(AwsProperties.S3FILEIO_SECRET_ACCESS_KEY, "unknown");
+    AwsClientFactory factory = AwsClientFactories.from(properties);
+    S3Client s3Client = factory.s3();
+    AssertHelpers.assertThrows("Should fail request because of bad access key",
+        S3Exception.class,
+        "The AWS Access Key Id you provided does not exist in our records",
+        () -> s3Client.getObject(GetObjectRequest.builder().bucket("bucket").key("key").build()));
+  }
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
@@ -44,10 +44,14 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
   private String externalId;
   private int timeout;
   private String region;
+  private String s3Endpoint;
 
   @Override
   public S3Client s3() {
-    return S3Client.builder().applyMutation(this::configure).build();
+    return S3Client.builder()
+        .applyMutation(this::configure)
+        .applyMutation(builder -> AwsClientFactories.configureEndpoint(builder, s3Endpoint))
+        .build();
   }
 
   @Override
@@ -76,6 +80,8 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
 
     region = properties.get(AwsProperties.CLIENT_ASSUME_ROLE_REGION);
     Preconditions.checkNotNull(region, "Cannot initialize AssumeRoleClientConfigFactory with null region");
+
+    this.s3Endpoint = properties.get(AwsProperties.S3FILEIO_ENDPOINT);
   }
 
   private <T extends AwsClientBuilder & AwsSyncClientBuilder> T configure(T clientBuilder) {

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -132,6 +132,40 @@ public class AwsProperties implements Serializable {
   public static final String S3FILEIO_ACL = "s3.acl";
 
   /**
+   * Configure an alternative endpoint of the S3 service for S3FileIO to access.
+   * <p>
+   * This could be used to use S3FileIO with any s3-compatible object storage service that has a different endpoint,
+   * or access a private S3 endpoint in a virtual private cloud.
+   */
+  public static final String S3FILEIO_ENDPOINT = "s3.endpoint";
+
+  /**
+   * Configure the static access key ID used to access S3FileIO.
+   * <p>
+   * When set, the default client factory will use the basic or session credentials provided instead of
+   * reading the default credential chain to create S3 access credentials.
+   * If {@link #S3FILEIO_SESSION_TOKEN} is set, session credential is used, otherwise basic credential is used.
+   */
+  public static final String S3FILEIO_ACCESS_KEY_ID = "s3.access-key-id";
+
+  /**
+   * Configure the static secret access key used to access S3FileIO.
+   * <p>
+   * When set, the default client factory will use the basic or session credentials provided instead of
+   * reading the default credential chain to create S3 access credentials.
+   * If {@link #S3FILEIO_SESSION_TOKEN} is set, session credential is used, otherwise basic credential is used.
+   */
+  public static final String S3FILEIO_SECRET_ACCESS_KEY = "s3.secret-access-key";
+
+  /**
+   * Configure the static session token used to access S3FileIO.
+   * <p>
+   * When set, the default client factory will use the session credentials provided instead of
+   * reading the default credential chain to create S3 access credentials.
+   */
+  public static final String S3FILEIO_SESSION_TOKEN = "s3.session-token";
+
+  /**
    * DynamoDB table name for {@link DynamoDbCatalog}
    */
   public static final String DYNAMODB_TABLE_NAME = "dynamodb.table-name";

--- a/aws/src/test/java/org/apache/iceberg/aws/TestAwsClientFactories.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestAwsClientFactories.java
@@ -20,9 +20,15 @@
 package org.apache.iceberg.aws;
 
 import java.util.Map;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.Assert;
 import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.glue.GlueClient;
 import software.amazon.awssdk.services.kms.KmsClient;
@@ -46,6 +52,35 @@ public class TestAwsClientFactories {
     properties.put(AwsProperties.CLIENT_FACTORY, CustomFactory.class.getName());
     Assert.assertTrue("should load custom class",
         AwsClientFactories.from(properties) instanceof CustomFactory);
+  }
+
+  @Test
+  public void testS3FileIoCredentialsProviders() {
+    AwsCredentialsProvider basicCredentials = AwsClientFactories.credentialsProvider("key", "secret", null);
+    Assert.assertTrue("Should use basic credentials if access key ID and secret access key are set",
+         basicCredentials.resolveCredentials() instanceof AwsBasicCredentials);
+    AwsCredentialsProvider sessionCredentials = AwsClientFactories.credentialsProvider("key", "secret", "token");
+    Assert.assertTrue("Should use session credentials if session token is set",
+         sessionCredentials.resolveCredentials() instanceof AwsSessionCredentials);
+    Assert.assertTrue("Should use default credentials if nothing is set",
+        AwsClientFactories.credentialsProvider(null, null, null) instanceof DefaultCredentialsProvider);
+  }
+
+  @Test
+  public void testS3FileIoCredentialsVerification() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(AwsProperties.S3FILEIO_ACCESS_KEY_ID, "key");
+    AssertHelpers.assertThrows("Should fail if only access key ID is set",
+        ValidationException.class,
+        "S3 client access key ID and secret access key must be set at the same time",
+        () -> AwsClientFactories.from(properties));
+
+    properties.remove(AwsProperties.S3FILEIO_ACCESS_KEY_ID);
+    properties.put(AwsProperties.S3FILEIO_SECRET_ACCESS_KEY, "secret");
+    AssertHelpers.assertThrows("Should fail if only secret access key is set",
+        ValidationException.class,
+        "S3 client access key ID and secret access key must be set at the same time",
+        () -> AwsClientFactories.from(properties));
   }
 
   public static class CustomFactory implements AwsClientFactory {


### PR DESCRIPTION
As discussed in the mailing list: https://mail-archives.apache.org/mod_mbox/iceberg-dev/202112.mbox/%3CCAMwmD1_P2PCMpzUai5RV%2B4a9Bv62ZFqrrDdxCtLcTSvPnUxk6g%40mail.gmail.com%3E

For `DefaultClientFactory`, we allow configuration of S3 static credentials and endpoint.
For `AssumeRoleClientFactory`, we only allow configuration of S3 endpoint, because credential is always assume role credential.

@rdblue @danielcweeks @findepi @mayursrivastava