### PR TITLE
Aliyun: align property names with AWS module

### DIFF
--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/AliyunClientFactories.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/AliyunClientFactories.java
@@ -24,6 +24,7 @@ import com.aliyun.oss.OSSClientBuilder;
 import java.util.Map;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.PropertyUtil;
 
 public class AliyunClientFactories {
 
@@ -36,12 +37,10 @@ public class AliyunClientFactories {
     return ALIYUN_CLIENT_FACTORY_DEFAULT;
   }
 
-  public static AliyunClientFactory load(Map<String, String> properties) {
-    if (properties.containsKey(AliyunProperties.CLIENT_FACTORY)) {
-      return load(properties.get(AliyunProperties.CLIENT_FACTORY), properties);
-    } else {
-      return defaultFactory();
-    }
+  public static AliyunClientFactory from(Map<String, String> properties) {
+    String factoryImpl = PropertyUtil.propertyAsString(
+        properties, AliyunProperties.CLIENT_FACTORY, DefaultAliyunClientFactory.class.getName());
+    return loadClientFactory(factoryImpl, properties);
   }
 
   /**
@@ -51,10 +50,10 @@ public class AliyunClientFactories {
    * @param properties to initialize the factory.
    * @return an initialized {@link AliyunClientFactory}.
    */
-  private static AliyunClientFactory load(String impl, Map<String, String> properties) {
+  private static AliyunClientFactory loadClientFactory(String impl, Map<String, String> properties) {
     DynConstructors.Ctor<AliyunClientFactory> ctor;
     try {
-      ctor = DynConstructors.builder(AliyunClientFactory.class).impl(impl).buildChecked();
+      ctor = DynConstructors.builder(AliyunClientFactory.class).hiddenImpl(impl).buildChecked();
     } catch (NoSuchMethodException e) {
       throw new IllegalArgumentException(String.format(
           "Cannot initialize AliyunClientFactory, missing no-arg constructor: %s", impl), e);
@@ -84,7 +83,7 @@ public class AliyunClientFactories {
           aliyunProperties, "Cannot create aliyun oss client before initializing the AliyunClientFactory.");
 
       return new OSSClientBuilder().build(
-          aliyunProperties.ossEndpoint(), aliyunProperties.accessKeyId(), aliyunProperties.accessKeySecret());
+          aliyunProperties.ossEndpoint(), aliyunProperties.accessKeyId(), aliyunProperties.secretAccessKey());
     }
 
     @Override

--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/AliyunClientFactories.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/AliyunClientFactories.java
@@ -83,7 +83,7 @@ public class AliyunClientFactories {
           aliyunProperties, "Cannot create aliyun oss client before initializing the AliyunClientFactory.");
 
       return new OSSClientBuilder().build(
-          aliyunProperties.ossEndpoint(), aliyunProperties.accessKeyId(), aliyunProperties.secretAccessKey());
+          aliyunProperties.ossEndpoint(), aliyunProperties.accessKeyId(), aliyunProperties.accessKeySecret());
     }
 
     @Override

--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/AliyunProperties.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/AliyunProperties.java
@@ -40,7 +40,7 @@ public class AliyunProperties implements Serializable {
    * For more information about how to obtain an AccessKey pair, see:
    * https://www.alibabacloud.com/help/doc-detail/53045.htm
    */
-  public static final String ACCESS_KEY_ID = "access.key.id";
+  public static final String CLIENT_ACCESS_KEY_ID = "client.access-key-id";
 
   /**
    * Aliyun uses an AccessKey pair, which includes an AccessKey ID and an AccessKey secret to implement symmetric
@@ -50,7 +50,7 @@ public class AliyunProperties implements Serializable {
    * For more information about how to obtain an AccessKey pair, see:
    * https://www.alibabacloud.com/help/doc-detail/53045.htm
    */
-  public static final String ACCESS_KEY_SECRET = "access.key.secret";
+  public static final String CLIENT_SECRET_ACCESS_KEY = "client.secret-access-key";
 
   /**
    * The implementation class of {@link AliyunClientFactory} to customize Aliyun client configurations.
@@ -66,7 +66,7 @@ public class AliyunProperties implements Serializable {
 
   private final String ossEndpoint;
   private final String accessKeyId;
-  private final String accessKeySecret;
+  private final String secretAccessKey;
   private final String ossStagingDirectory;
 
   public AliyunProperties() {
@@ -76,8 +76,8 @@ public class AliyunProperties implements Serializable {
   public AliyunProperties(Map<String, String> properties) {
     // OSS endpoint, accessKeyId, accessKeySecret.
     this.ossEndpoint = properties.get(OSS_ENDPOINT);
-    this.accessKeyId = properties.get(ACCESS_KEY_ID);
-    this.accessKeySecret = properties.get(ACCESS_KEY_SECRET);
+    this.accessKeyId = properties.get(CLIENT_ACCESS_KEY_ID);
+    this.secretAccessKey = properties.get(CLIENT_SECRET_ACCESS_KEY);
 
     this.ossStagingDirectory = PropertyUtil.propertyAsString(properties, OSS_STAGING_DIRECTORY,
         System.getProperty("java.io.tmpdir"));
@@ -91,8 +91,8 @@ public class AliyunProperties implements Serializable {
     return accessKeyId;
   }
 
-  public String accessKeySecret() {
-    return accessKeySecret;
+  public String secretAccessKey() {
+    return secretAccessKey;
   }
 
   public String ossStagingDirectory() {

--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/AliyunProperties.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/AliyunProperties.java
@@ -44,13 +44,13 @@ public class AliyunProperties implements Serializable {
 
   /**
    * Aliyun uses an AccessKey pair, which includes an AccessKey ID and an AccessKey secret to implement symmetric
-   * encryption and verify the identity of a requester.  The AccessKey secret is used to encrypt and verify the
+   * encryption and verify the identity of a requester. The AccessKey secret is used to encrypt and verify the
    * signature string.
    * <p>
    * For more information about how to obtain an AccessKey pair, see:
    * https://www.alibabacloud.com/help/doc-detail/53045.htm
    */
-  public static final String CLIENT_SECRET_ACCESS_KEY = "client.secret-access-key";
+  public static final String CLIENT_ACCESS_KEY_SECRET = "client.access-key-secret";
 
   /**
    * The implementation class of {@link AliyunClientFactory} to customize Aliyun client configurations.
@@ -66,7 +66,7 @@ public class AliyunProperties implements Serializable {
 
   private final String ossEndpoint;
   private final String accessKeyId;
-  private final String secretAccessKey;
+  private final String accessKeySecret;
   private final String ossStagingDirectory;
 
   public AliyunProperties() {
@@ -77,7 +77,7 @@ public class AliyunProperties implements Serializable {
     // OSS endpoint, accessKeyId, accessKeySecret.
     this.ossEndpoint = properties.get(OSS_ENDPOINT);
     this.accessKeyId = properties.get(CLIENT_ACCESS_KEY_ID);
-    this.secretAccessKey = properties.get(CLIENT_SECRET_ACCESS_KEY);
+    this.accessKeySecret = properties.get(CLIENT_ACCESS_KEY_SECRET);
 
     this.ossStagingDirectory = PropertyUtil.propertyAsString(properties, OSS_STAGING_DIRECTORY,
         System.getProperty("java.io.tmpdir"));
@@ -91,8 +91,8 @@ public class AliyunProperties implements Serializable {
     return accessKeyId;
   }
 
-  public String secretAccessKey() {
-    return secretAccessKey;
+  public String accessKeySecret() {
+    return accessKeySecret;
   }
 
   public String ossStagingDirectory() {

--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSFileIO.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSFileIO.java
@@ -89,7 +89,7 @@ public class OSSFileIO implements FileIO {
 
   @Override
   public void initialize(Map<String, String> properties) {
-    AliyunClientFactory factory = AliyunClientFactories.load(properties);
+    AliyunClientFactory factory = AliyunClientFactories.from(properties);
     this.aliyunProperties = factory.aliyunProperties();
     this.oss = factory::newOSSClient;
   }

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/TestAliyunClientFactories.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/TestAliyunClientFactories.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.aliyun;
 
 import com.aliyun.oss.OSS;
 import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.Assert;
 import org.junit.Test;
@@ -32,9 +33,20 @@ public class TestAliyunClientFactories {
     Assert.assertEquals("Default client should be singleton",
         AliyunClientFactories.defaultFactory(), AliyunClientFactories.defaultFactory());
 
+    AliyunClientFactory defaultFactory = AliyunClientFactories.from(Maps.newHashMap());
     Assert.assertTrue(
-        "Should load default when not configured",
-        AliyunClientFactories.load(Maps.newHashMap()) instanceof AliyunClientFactories.DefaultAliyunClientFactory);
+        "Should load default when factory impl not configured",
+         defaultFactory instanceof AliyunClientFactories.DefaultAliyunClientFactory);
+    Assert.assertNull("Should have no Aliyun properties set",
+        defaultFactory.aliyunProperties().accessKeyId());
+
+    AliyunClientFactory defaultFactoryWithConfig = AliyunClientFactories.from(
+        ImmutableMap.of(AliyunProperties.CLIENT_ACCESS_KEY_ID, "key"));
+    Assert.assertTrue(
+        "Should load default when factory impl not configured",
+        defaultFactoryWithConfig instanceof AliyunClientFactories.DefaultAliyunClientFactory);
+    Assert.assertEquals("Should have access key set",
+        "key", defaultFactoryWithConfig.aliyunProperties().accessKeyId());
   }
 
   @Test
@@ -43,7 +55,7 @@ public class TestAliyunClientFactories {
     properties.put(AliyunProperties.CLIENT_FACTORY, CustomFactory.class.getName());
     Assert.assertTrue(
         "Should load custom class",
-        AliyunClientFactories.load(properties) instanceof CustomFactory);
+        AliyunClientFactories.from(properties) instanceof CustomFactory);
   }
 
   public static class CustomFactory implements AliyunClientFactory {


### PR DESCRIPTION
@openinx @xingbowu

I was writing #3658 and I noticed that there is some inconsistency between Aliyun and AWS module. I suggest making the following changes:

1. use `client.access-key-id` and `client.secret-access-key` as property names, 

`.` is used to build hierarchy to config names, but `access.key.id` does not have any hierarchy in it. Also I checked Aliyun doc, the name is secret access key, not access key secret, as shown in the builder method:

```
public class OSSClientBuilder implements OSSBuilder {

    @Override
    public OSS build(String endpoint, String accessKeyId, String secretAccessKey) {
        return new OSSClient(endpoint, getDefaultCredentialProvider(accessKeyId, secretAccessKey),
                getClientConfiguration());
    }
```

I made `client` as the prefix because it seems like your credentials config will affect all the clients. In AWS module, I made the config `s3.access-key-id` because it would only affect `s3`.

2. I renamed `AliyunClientFactories.load` to `AliyunClientFactories.from` to be consistent with `AwsClientFactories.from`. It also seems to me that the default client did not initialize and load the properties, so I also fixed the method and added tests.