### PR TITLE
Core: Change variable name to metadataFile in CatalogUtil's dropTableData

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -118,7 +118,7 @@ public class CatalogUtil {
 
     Tasks.foreach(metadata.metadataFileLocation())
         .noRetry().suppressFailureWhenFinished()
-        .onFailure((list, exc) -> LOG.warn("Delete failed for metadata file: {}", list, exc))
+        .onFailure((metadataFile, exc) -> LOG.warn("Delete failed for metadata file: {}", metadataFile, exc))
         .run(io::deleteFile);
   }
 


### PR DESCRIPTION
Raising a small change to change the variable name from `list` to `metadataFile` as `metadata.metadataFileLocation()` would give the current metadata file (and not a list). 

This change is also consistent with the previous lines where the previous metadata files are deleted: https://github.com/apache/iceberg/blob/master/core/src/main/java/org/apache/iceberg/CatalogUtil.java#L114-L117