### PR TITLE
Core: Request Split_Offsets when Planning Scans

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
@@ -118,11 +118,13 @@ class BaseFileScanTask implements FileScanTask {
       this.parentScanTask = parentScanTask;
       this.targetSplitSize = targetSplitSize;
       this.splitSizes = new ArrayList<>(offsets.size());
-      int lastIndex = offsets.size() - 1;
-      for (int index = 0; index < lastIndex; index++) {
-        splitSizes.add(offsets.get(index + 1) - offsets.get(index));
+      if (offsets.size() > 0) {
+        int lastIndex = offsets.size() - 1;
+        for (int index = 0; index < lastIndex; index++) {
+          splitSizes.add(offsets.get(index + 1) - offsets.get(index));
+        }
+        splitSizes.add(parentScanTask.length() - offsets.get(lastIndex));
       }
-      splitSizes.add(parentScanTask.length() - offsets.get(lastIndex));
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -30,7 +30,7 @@ import org.apache.iceberg.util.ThreadPools;
 public class DataTableScan extends BaseTableScan {
   static final ImmutableList<String> SCAN_COLUMNS = ImmutableList.of(
       "snapshot_id", "file_path", "file_ordinal", "file_format", "block_size_in_bytes",
-      "file_size_in_bytes", "record_count", "partition", "key_metadata"
+      "file_size_in_bytes", "record_count", "partition", "key_metadata", "split_offsets"
   );
   static final ImmutableList<String> SCAN_WITH_STATS_COLUMNS = ImmutableList.<String>builder()
       .addAll(SCAN_COLUMNS)

--- a/core/src/test/java/org/apache/iceberg/TestSplitPlanning.java
+++ b/core/src/test/java/org/apache/iceberg/TestSplitPlanning.java
@@ -23,7 +23,10 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.DataFiles.Builder;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -207,6 +210,30 @@ public class TestSplitPlanning extends TableTestBase {
         });
   }
 
+  @Test
+  public void testSplitPlanningWithOffsets() {
+    List<DataFile> files16Mb = newFiles(16, 16 * 1024 * 1024, 2);
+    appendFiles(files16Mb);
+
+    // Split Size is slightly larger than rowGroup Size, but we should still end up with
+    // 1 split per row group
+    TableScan scan = table.newScan()
+        .option(TableProperties.SPLIT_SIZE, String.valueOf(10L * 1024 * 1024));
+    Assert.assertEquals("We should get one task per row group", 32, Iterables.size(scan.planTasks()));
+  }
+
+  @Test
+  public void testSplitPlanningWithOffsetsUnableToSplit() {
+    List<DataFile> files16Mb = newFiles(16, 16 * 1024 * 1024, 2);
+    appendFiles(files16Mb);
+
+    // Split Size does not match up with offsets, so even though we want 4 cuts per file we still only get 2
+    TableScan scan = table.newScan()
+        .option(TableProperties.SPLIT_OPEN_FILE_COST, String.valueOf(0))
+        .option(TableProperties.SPLIT_SIZE, String.valueOf(4L * 1024 * 1024));
+    Assert.assertEquals("We should still only get 2 tasks per file", 32, Iterables.size(scan.planTasks()));
+  }
+
   private void appendFiles(Iterable<DataFile> files) {
     AppendFiles appendFiles = table.newAppend();
     files.forEach(appendFiles::appendFile);
@@ -214,23 +241,38 @@ public class TestSplitPlanning extends TableTestBase {
   }
 
   private List<DataFile> newFiles(int numFiles, long sizeInBytes) {
-    return newFiles(numFiles, sizeInBytes, FileFormat.PARQUET);
+    return newFiles(numFiles, sizeInBytes, FileFormat.PARQUET, 1);
+  }
+
+  private List<DataFile> newFiles(int numFiles, long sizeInBytes, int numOffset) {
+    return newFiles(numFiles, sizeInBytes, FileFormat.PARQUET, numOffset);
   }
 
   private List<DataFile> newFiles(int numFiles, long sizeInBytes, FileFormat fileFormat) {
+    return newFiles(numFiles, sizeInBytes, fileFormat, 1);
+  }
+
+  private List<DataFile> newFiles(int numFiles, long sizeInBytes, FileFormat fileFormat, int numOffset) {
     List<DataFile> files = Lists.newArrayList();
     for (int fileNum = 0; fileNum < numFiles; fileNum++) {
-      files.add(newFile(sizeInBytes, fileFormat));
+      files.add(newFile(sizeInBytes, fileFormat, numOffset));
     }
     return files;
   }
 
-  private DataFile newFile(long sizeInBytes, FileFormat fileFormat) {
+  private DataFile newFile(long sizeInBytes, FileFormat fileFormat, int numOffsets) {
     String fileName = UUID.randomUUID().toString();
-    return DataFiles.builder(PartitionSpec.unpartitioned())
+    Builder builder = DataFiles.builder(PartitionSpec.unpartitioned())
         .withPath(fileFormat.addExtension(fileName))
         .withFileSizeInBytes(sizeInBytes)
-        .withRecordCount(2)
-        .build();
+        .withRecordCount(2);
+
+    if (numOffsets > 1) {
+      long stepSize = sizeInBytes / numOffsets;
+      List<Long> offsets = LongStream.range(0, numOffsets).map(i -> i * stepSize).boxed().collect(Collectors.toList());
+      builder.withSplitOffsets(offsets);
+    }
+
+    return builder.build();
   }
 }

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -188,6 +188,7 @@ public class TestDataSourceOptions {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     Map<String, String> options = Maps.newHashMap();
     options.put(TableProperties.SPLIT_SIZE, String.valueOf(128L * 1024 * 1024)); // 128Mb
+    options.put(TableProperties.DEFAULT_FILE_FORMAT, String.valueOf(FileFormat.AVRO)); // Arbitrarily splittable
     Table icebergTable = tables.create(SCHEMA, spec, options, tableLocation);
 
     List<SimpleRecord> expectedRecords = Lists.newArrayList(

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -230,9 +230,9 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
         .execute();
 
     Assert.assertEquals("Action should delete 1 data files", 1, result.rewrittenDataFilesCount());
-    Assert.assertEquals("Action should add 2 data files", 2, result.addedDataFilesCount());
+    Assert.assertEquals("Action should add 3 data files", 3, result.addedDataFilesCount());
 
-    shouldHaveFiles(table, 2);
+    shouldHaveFiles(table, 3);
 
     List<Object[]> actualRecords = currentData();
     assertEquals("Rows must match", expectedRecords, actualRecords);

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -188,6 +188,7 @@ public class TestDataSourceOptions {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     Map<String, String> options = Maps.newHashMap();
     options.put(TableProperties.SPLIT_SIZE, String.valueOf(128L * 1024 * 1024)); // 128Mb
+    options.put(TableProperties.DEFAULT_FILE_FORMAT, String.valueOf(FileFormat.AVRO)); // Arbitrarily splittable
     Table icebergTable = tables.create(SCHEMA, spec, options, tableLocation);
 
     List<SimpleRecord> expectedRecords = Lists.newArrayList(

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -230,9 +230,9 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
         .execute();
 
     Assert.assertEquals("Action should delete 1 data files", 1, result.rewrittenDataFilesCount());
-    Assert.assertEquals("Action should add 2 data files", 2, result.addedDataFilesCount());
+    Assert.assertEquals("Action should add 3 data files", 3, result.addedDataFilesCount());
 
-    shouldHaveFiles(table, 2);
+    shouldHaveFiles(table, 3);
 
     List<Object[]> actualRecords = currentData();
     assertEquals("Rows must match", expectedRecords, actualRecords);

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -188,6 +188,7 @@ public class TestDataSourceOptions {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     Map<String, String> options = Maps.newHashMap();
     options.put(TableProperties.SPLIT_SIZE, String.valueOf(128L * 1024 * 1024)); // 128Mb
+    options.put(TableProperties.DEFAULT_FILE_FORMAT, String.valueOf(FileFormat.AVRO)); // Arbitrarily splittable
     Table icebergTable = tables.create(SCHEMA, spec, options, tableLocation);
 
     List<SimpleRecord> expectedRecords = Lists.newArrayList(

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -348,9 +348,9 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
         .execute();
 
     Assert.assertEquals("Action should delete 1 data files", 1, result.rewrittenDataFilesCount());
-    Assert.assertEquals("Action should add 2 data files", 2, result.addedDataFilesCount());
+    Assert.assertEquals("Action should add 3 data files", 3, result.addedDataFilesCount());
 
-    shouldHaveFiles(table, 2);
+    shouldHaveFiles(table, 3);
 
     List<Object[]> actualRecords = currentData();
     assertEquals("Rows must match", expectedRecords, actualRecords);

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestDataSourceOptions.java
@@ -188,6 +188,7 @@ public class TestDataSourceOptions {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     Map<String, String> options = Maps.newHashMap();
     options.put(TableProperties.SPLIT_SIZE, String.valueOf(128L * 1024 * 1024)); // 128Mb
+    options.put(TableProperties.DEFAULT_FILE_FORMAT, String.valueOf(FileFormat.AVRO)); // Arbitrarily splittable
     Table icebergTable = tables.create(SCHEMA, spec, options, tableLocation);
 
     List<SimpleRecord> expectedRecords = Lists.newArrayList(


### PR DESCRIPTION
Previously we didn't explicitly request the split_offsets column from
manifest files when planning Scan Tasks. This meant that the datafiles
would be split aware when they were divided. To fix this we request the
split_offset information when we do the Manifest read. In addition tests
are added to make sure this isn't missed again in the future.

Closes #3662