### PR TITLE
Spark: Remove ImmutableMap from SparkPartition for Kryo SerDe

### DIFF
--- a/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -55,8 +55,8 @@ import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 import org.apache.spark.TaskContext;
@@ -645,7 +645,7 @@ public class SparkTableUtil {
     private final String format;
 
     public SparkPartition(Map<String, String> values, String uri, String format) {
-      this.values = ImmutableMap.copyOf(values);
+      this.values = Maps.newHashMap(values);
       this.uri = uri;
       this.format = format;
     }

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -55,8 +55,8 @@ import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 import org.apache.spark.TaskContext;
@@ -647,7 +647,7 @@ public class SparkTableUtil {
     private final String format;
 
     public SparkPartition(Map<String, String> values, String uri, String format) {
-      this.values = ImmutableMap.copyOf(values);
+      this.values = Maps.newHashMap(values);
       this.uri = uri;
       this.format = format;
     }

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkTableUtil.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkTableUtil.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark;
+
+import java.io.IOException;
+import java.util.Map;
+import org.apache.iceberg.KryoHelpers;
+import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.spark.SparkTableUtil.SparkPartition;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class TestSparkTableUtil {
+  @Test
+  public void testSparkPartitionOKryoSerialization() throws IOException {
+    Map<String, String> values = ImmutableMap.of("id", "2");
+    String uri = "s3://bucket/table/data/id=2";
+    String format = "parquet";
+    SparkPartition sparkPartition = new SparkPartition(values, uri, format);
+
+    SparkPartition deserialized = KryoHelpers.roundTripSerialize(sparkPartition);
+    Assertions.assertThat(sparkPartition).isEqualTo(deserialized);
+  }
+
+  @Test
+  public void testSparkPartitionJavaSerialization() throws IOException, ClassNotFoundException {
+    Map<String, String> values = ImmutableMap.of("id", "2");
+    String uri = "s3://bucket/table/data/id=2";
+    String format = "parquet";
+    SparkPartition sparkPartition = new SparkPartition(values, uri, format);
+
+    SparkPartition deserialized = TestHelpers.roundTripSerialize(sparkPartition);
+    Assertions.assertThat(sparkPartition).isEqualTo(deserialized);
+  }
+}

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -55,8 +55,8 @@ import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 import org.apache.spark.TaskContext;
@@ -647,7 +647,7 @@ public class SparkTableUtil {
     private final String format;
 
     public SparkPartition(Map<String, String> values, String uri, String format) {
-      this.values = ImmutableMap.copyOf(values);
+      this.values = Map.newHashMap(values);
       this.uri = uri;
       this.format = format;
     }

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -647,7 +647,7 @@ public class SparkTableUtil {
     private final String format;
 
     public SparkPartition(Map<String, String> values, String uri, String format) {
-      this.values = Map.newHashMap(values);
+      this.values = Maps.newHashMap(values);
       this.uri = uri;
       this.format = format;
     }

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkTableUtil.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkTableUtil.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark;
+
+import java.io.IOException;
+import java.util.Map;
+import org.apache.iceberg.KryoHelpers;
+import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.spark.SparkTableUtil.SparkPartition;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class TestSparkTableUtil {
+  @Test
+  public void testSparkPartitionOKryoSerialization() throws IOException {
+    Map<String, String> values = ImmutableMap.of("id", "2");
+    String uri = "s3://bucket/table/data/id=2";
+    String format = "parquet";
+    SparkPartition sparkPartition = new SparkPartition(values, uri, format);
+
+    SparkPartition deserialized = KryoHelpers.roundTripSerialize(sparkPartition);
+    Assertions.assertThat(sparkPartition).isEqualTo(deserialized);
+  }
+
+  @Test
+  public void testSparkPartitionJavaSerialization() throws IOException, ClassNotFoundException {
+    Map<String, String> values = ImmutableMap.of("id", "2");
+    String uri = "s3://bucket/table/data/id=2";
+    String format = "parquet";
+    SparkPartition sparkPartition = new SparkPartition(values, uri, format);
+
+    SparkPartition deserialized = TestHelpers.roundTripSerialize(sparkPartition);
+    Assertions.assertThat(sparkPartition).isEqualTo(deserialized);
+  }
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -55,8 +55,8 @@ import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 import org.apache.spark.TaskContext;
@@ -647,7 +647,7 @@ public class SparkTableUtil {
     private final String format;
 
     public SparkPartition(Map<String, String> values, String uri, String format) {
-      this.values = ImmutableMap.copyOf(values);
+      this.values = Maps.newHashMap(values);
       this.uri = uri;
       this.format = format;
     }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkPartitionSerialization.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkPartitionSerialization.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark;
+
+import java.io.IOException;
+import java.util.Map;
+import org.apache.iceberg.KryoHelpers;
+import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.spark.SparkTableUtil.SparkPartition;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class TestSparkPartitionSerialization {
+
+  @Test
+  public void testSparkPartitionOKryoSerialization() throws IOException {
+    Map<String, String> values = ImmutableMap.of("id", "2");
+    String uri = "s3://bucket/table/data/id=2";
+    String format = "parquet";
+    SparkPartition sparkPartition = new SparkPartition(values, uri, format);
+
+    SparkPartition deserialized = KryoHelpers.roundTripSerialize(sparkPartition);
+
+    Assertions.assertThat(sparkPartition).isEqualTo(deserialized);
+  }
+
+  @Test
+  public void testSparkPartitionJavaSerialization() throws IOException, ClassNotFoundException {
+    Map<String, String> values = ImmutableMap.of("id", "2");
+    String uri = "s3://bucket/table/data/id=2";
+    String format = "parquet";
+    SparkPartition sparkPartition = new SparkPartition(values, uri, format);
+
+    SparkPartition deserialized = TestHelpers.roundTripSerialize(sparkPartition);
+    Assertions.assertThat(sparkPartition).isEqualTo(deserialized);
+  }
+}

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkTableUtil.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkTableUtil.java
@@ -28,8 +28,7 @@ import org.apache.iceberg.spark.SparkTableUtil.SparkPartition;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
-public class TestSparkPartitionSerialization {
-
+public class TestSparkTableUtil {
   @Test
   public void testSparkPartitionOKryoSerialization() throws IOException {
     Map<String, String> values = ImmutableMap.of("id", "2");
@@ -38,7 +37,6 @@ public class TestSparkPartitionSerialization {
     SparkPartition sparkPartition = new SparkPartition(values, uri, format);
 
     SparkPartition deserialized = KryoHelpers.roundTripSerialize(sparkPartition);
-
     Assertions.assertThat(sparkPartition).isEqualTo(deserialized);
   }
 


### PR DESCRIPTION
This PR replaces https://github.com/apache/iceberg/pull/3597, as @dubeme has not responded about some minor changes and we need this patch prior to the upcoming 0.13.0 release.

I have added them as a co-author on this PR so that they still get credit for their contribution 😄 

Issue #3586 shows situation where Kyro is unable to serialize the SparkPartition object (@rdblue points it out from the stack trace). This commit replaces the ImmutableMap with HashMap and adds a test for round trip Kryo serialization and Java serialization for `SparkPartition` objects.

I also tested this by running the `add_files` test suite with Kryo serialization enabled. The tests failed until this patch was applied. Unfortunately, I couldn't add a test there as the usual `withSQLConf` method did not pick up the change in `spark.serializer`.

Co-authored-by: Dubem Enyekwe <dubem@dubemenyekwe.com>

cc @rdblue @jackye1995 @dubeme