### PR TITLE
AWS: Make the error message of GlueCatalog's isValidIdentifier more detailed

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -425,8 +425,9 @@ public class GlueCatalog extends BaseMetastoreCatalog
 
   @Override
   protected boolean isValidIdentifier(TableIdentifier tableIdentifier) {
-    return IcebergToGlueConverter.isValidNamespace(tableIdentifier.namespace()) &&
-        IcebergToGlueConverter.isValidTableName(tableIdentifier.name());
+    IcebergToGlueConverter.validateNamespace(tableIdentifier.namespace());
+    IcebergToGlueConverter.validateTableName(tableIdentifier.name());
+    return true;
   }
 
   @Override


### PR DESCRIPTION
There seems to be an inconsistency in the public documentation: https://docs.aws.amazon.com/athena/latest/ug/glue-best-practices.html#schema-names. As per the doc, the database name has the following constraints:

- A database name cannot be longer than 255 characters.
- The only acceptable characters for database names, table names, and column names are lowercase letters, numbers, and the underscore character.

However, I was able to create the following databases (in `us-east-1` region using console UI and CLI):

```
aws glue create-database --database-input "{\"Name\":\"iceberg-test\"}"
aws glue create-database --database-input "{\"Name\":\"tempdb-test\"}"
aws glue create-database --database-input "{\"Name\":\"tempdb-test$21.asdj123\"}"
aws glue create-database --database-input "{\"Name\":\"tempdb-test$21.asdj123||\"}"
aws glue create-database --database-input "{\"Name\":\"tempdb-test$21.asdj123||#^@#^$@$$!@#@!#\"}"
```

If database is not created using Iceberg library and doesn't adheres to the validation present in Iceberg, then we get the following exception:
```
Caused by: java.lang.IllegalArgumentException: Invalid table identifier: iceberg-test.iceberg_table
	at org.apache.iceberg.relocated.com.google.common.base.Preconditions.checkArgument(Preconditions.java:217)
	at org.apache.iceberg.BaseMetastoreCatalog$BaseMetastoreCatalogTableBuilder.(BaseMetastoreCatalog.java:115)
	at org.apache.iceberg.BaseMetastoreCatalog.buildTable(BaseMetastoreCatalog.java:68)
	at org.apache.iceberg.catalog.Catalog.createTable(Catalog.java:74)
```
----
Proposals:
1. Make the error message more detailed highlighting which part (database or table name) failed the validation. Also throw a better exception like `ValidationException` instead of `IllegalArgumentException` since it’s too general.
2. Remove the namespace validation from `GlueCatalog#isValidIdentifier(TableIdentifier tableIdentifier)` since at that time the database likely already existed (if not created using Iceberg library). 

Note: I have reached out to Glue Team for clarification on the public documentation (awaiting reply).