### PR TITLE
HiveTableOperations: update HMS transient_lastDdlTime param on snapshot writes

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -362,6 +362,9 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     // remove any props from HMS that are no longer present in Iceberg table props
     obsoleteProps.forEach(parameters::remove);
 
+    // remove the DDL_TIME so it gets refreshed
+    parameters.remove(hive_metastoreConstants.DDL_TIME);
+
     parameters.put(TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE.toUpperCase(Locale.ENGLISH));
     parameters.put(METADATA_LOCATION_PROP, newMetadataLocation);
 

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -362,7 +362,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     // remove any props from HMS that are no longer present in Iceberg table props
     obsoleteProps.forEach(parameters::remove);
 
-    // remove the DDL_TIME so it gets refreshed
+    // remove any props that are controlled by HMS so it can handle them
     parameters.remove(hive_metastoreConstants.DDL_TIME);
 
     parameters.put(TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE.toUpperCase(Locale.ENGLISH));

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -647,6 +647,8 @@ public class TestHiveIcebergStorageHandlerNoScan {
     Assert.assertEquals(HiveIcebergInputFormat.class.getName(), hmsTable.getSd().getInputFormat());
     Assert.assertEquals(HiveIcebergOutputFormat.class.getName(), hmsTable.getSd().getOutputFormat());
     Assert.assertEquals(HiveIcebergSerDe.class.getName(), hmsTable.getSd().getSerdeInfo().getSerializationLib());
+    // Add 1 second delay to reflect DDL_TIME change in HMS
+    Thread.sleep(1000);
 
     // Add two new properties to the Iceberg table and update an existing one
     icebergTable.updateProperties()
@@ -671,6 +673,10 @@ public class TestHiveIcebergStorageHandlerNoScan {
       String newSnapshot = getCurrentSnapshotForHiveCatalogTable(icebergTable);
       Assert.assertEquals(hmsParams.get(BaseMetastoreTableOperations.PREVIOUS_METADATA_LOCATION_PROP), prevSnapshot);
       Assert.assertEquals(hmsParams.get(BaseMetastoreTableOperations.METADATA_LOCATION_PROP), newSnapshot);
+      // tableProperties contains fields from initial table creation
+      String createdAtTime = tableProperties.getProperty(hive_metastoreConstants.DDL_TIME);
+      String updatedTime = hmsParams.get(hive_metastoreConstants.DDL_TIME);
+      Assert.assertTrue(Long.parseLong(createdAtTime) < Long.parseLong(updatedTime));
     } else {
       Assert.assertEquals(8, hmsParams.size());
     }


### PR DESCRIPTION
`HiveTableOperations` does not update HMS `transient_lastDdlTime` parameter on snapshot write. The param is updated once only on table creation.

For context, we currently query the `transient_lastDdlTime` param directly from HMS to determine the freshness of tables. This is faster than reading all the metadata files and get the timestamp for each iceberg table's most recent snapshot.

This PR removes the `transient_lastDdlTime`/`hive_metastoreConstants.DDL_TIME` param when setting HMS table parameters in `HiveTableOperations`. By doing so, the [HMS client will update the field in its alter table function](https://github.com/apache/hive/blob/cceee0a61a75274520178cd31cad26e3b1a25b12/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java#L6081-L6086). This is what the [Hive Engine is doing for alter table](https://github.com/apache/hive/blob/a8e50734e0460e506f1762fbe0f628bcb444b8f5/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java#L841-L845).

Alternatively, we can explicitly set the timestamp in `HiveTableOperations` instead of relying on HMS client implementation. 

Also added checks in the integration test to reflect the `transient_lastDdlTime` change in value in subsequent snapshot writes.