### PR TITLE
Site Docs - Fix Flink batch job incorrectly labeled as streaming

### DIFF
--- a/site/docs/flink.md
+++ b/site/docs/flink.md
@@ -473,7 +473,7 @@ DataStream<RowData> stream = FlinkSource.forRowData()
 stream.print();
 
 // Submit and execute this streaming read job.
-env.execute("Test Iceberg Batch Read");
+env.execute("Test Iceberg Streaming Read");
 ```
 
 There are other options that we could set by Java API, please see the [FlinkSource#Builder](./javadoc/{{ versions.iceberg }}/org/apache/iceberg/flink/source/FlinkSource.html).


### PR DESCRIPTION
modify description for flink streaming job