### PR TITLE
Add watermark in flink table

### DIFF
--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -382,18 +382,23 @@ public class FlinkCatalog extends AbstractCatalog {
 
     List<WatermarkSpec> watermarkSpecs = table.getSchema().getWatermarkSpecs();
     if (watermarkSpecs != null) {
+      if (watermarkSpecs.size() > 1) {
+        throw new IllegalStateException(
+            "Multiple watermark definition is not supported yet.");
+      }
+
       for (int i = 0; i < watermarkSpecs.size(); i++) {
         WatermarkSpec watermarkSpec = watermarkSpecs.get(i);
         properties.put(
-            FlinkSchemaUtil.flinkPrefix + DescriptorProperties.WATERMARK + '.' + i + '.' +
+            FlinkSchemaUtil.FLINK_PREFIX + DescriptorProperties.WATERMARK + '.' + i + '.' +
                 DescriptorProperties.WATERMARK_ROWTIME,
             watermarkSpec.getRowtimeAttribute());
         properties.put(
-            FlinkSchemaUtil.flinkPrefix + DescriptorProperties.WATERMARK + '.' + i + '.' +
+            FlinkSchemaUtil.FLINK_PREFIX + DescriptorProperties.WATERMARK + '.' + i + '.' +
                 DescriptorProperties.WATERMARK_STRATEGY_EXPR,
             watermarkSpec.getWatermarkExpr());
         properties.put(
-            FlinkSchemaUtil.flinkPrefix + DescriptorProperties.WATERMARK + '.' + i + '.' +
+            FlinkSchemaUtil.FLINK_PREFIX + DescriptorProperties.WATERMARK + '.' + i + '.' +
                 DescriptorProperties.WATERMARK_STRATEGY_DATA_TYPE,
             watermarkSpec.getWatermarkExprOutputType().toString());
       }

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -279,6 +279,7 @@ public class FlinkCatalog extends AbstractCatalog {
         if (!removals.isEmpty()) {
           asNamespaceCatalog.removeProperties(namespace, removals);
         }
+
       } catch (NoSuchNamespaceException e) {
         if (!ignoreIfNotExists) {
           throw new DatabaseNotExistException(getName(), name, e);
@@ -384,13 +385,16 @@ public class FlinkCatalog extends AbstractCatalog {
       for (int i = 0; i < watermarkSpecs.size(); i++) {
         WatermarkSpec watermarkSpec = watermarkSpecs.get(i);
         properties.put(
-            DescriptorProperties.WATERMARK + '.' + i + '.' + DescriptorProperties.WATERMARK_ROWTIME,
+            FlinkSchemaUtil.flinkPrefix + DescriptorProperties.WATERMARK + '.' + i + '.' +
+                DescriptorProperties.WATERMARK_ROWTIME,
             watermarkSpec.getRowtimeAttribute());
         properties.put(
-            DescriptorProperties.WATERMARK + '.' + i + '.' + DescriptorProperties.WATERMARK_STRATEGY_EXPR,
+            FlinkSchemaUtil.flinkPrefix + DescriptorProperties.WATERMARK + '.' + i + '.' +
+                DescriptorProperties.WATERMARK_STRATEGY_EXPR,
             watermarkSpec.getWatermarkExpr());
         properties.put(
-            DescriptorProperties.WATERMARK + '.' + i + '.' + DescriptorProperties.WATERMARK_STRATEGY_DATA_TYPE,
+            FlinkSchemaUtil.flinkPrefix + DescriptorProperties.WATERMARK + '.' + i + '.' +
+                DescriptorProperties.WATERMARK_STRATEGY_DATA_TYPE,
             watermarkSpec.getWatermarkExprOutputType().toString());
       }
     }

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -50,9 +50,9 @@ import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotPartitionedException;
 import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;
 import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
+import org.apache.flink.table.descriptors.DescriptorProperties;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.factories.Factory;
-import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.StringUtils;
 import org.apache.iceberg.CachingCatalog;
 import org.apache.iceberg.DataFile;
@@ -78,11 +78,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-
-import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK;
-import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_ROWTIME;
-import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_STRATEGY_DATA_TYPE;
-import static org.apache.flink.table.descriptors.DescriptorProperties.WATERMARK_STRATEGY_EXPR;
 
 /**
  * A Flink Catalog implementation that wraps an Iceberg {@link Catalog}.
@@ -284,7 +279,6 @@ public class FlinkCatalog extends AbstractCatalog {
         if (!removals.isEmpty()) {
           asNamespaceCatalog.removeProperties(namespace, removals);
         }
-
       } catch (NoSuchNamespaceException e) {
         if (!ignoreIfNotExists) {
           throw new DatabaseNotExistException(getName(), name, e);
@@ -386,12 +380,18 @@ public class FlinkCatalog extends AbstractCatalog {
     ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
 
     List<WatermarkSpec> watermarkSpecs = table.getSchema().getWatermarkSpecs();
-    if (watermarkSpecs!=null){
+    if (watermarkSpecs != null) {
       for (int i = 0; i < watermarkSpecs.size(); i++) {
         WatermarkSpec watermarkSpec = watermarkSpecs.get(i);
-        properties.put(WATERMARK + '.' + i + '.' + WATERMARK_ROWTIME, watermarkSpec.getRowtimeAttribute());
-        properties.put(WATERMARK + '.' + i + '.' + WATERMARK_STRATEGY_EXPR, watermarkSpec.getWatermarkExpr());
-        properties.put(WATERMARK + '.' + i + '.' + WATERMARK_STRATEGY_DATA_TYPE, watermarkSpec.getWatermarkExprOutputType().toString());
+        properties.put(
+            DescriptorProperties.WATERMARK + '.' + i + '.' + DescriptorProperties.WATERMARK_ROWTIME,
+            watermarkSpec.getRowtimeAttribute());
+        properties.put(
+            DescriptorProperties.WATERMARK + '.' + i + '.' + DescriptorProperties.WATERMARK_STRATEGY_EXPR,
+            watermarkSpec.getWatermarkExpr());
+        properties.put(
+            DescriptorProperties.WATERMARK + '.' + i + '.' + DescriptorProperties.WATERMARK_STRATEGY_DATA_TYPE,
+            watermarkSpec.getWatermarkExprOutputType().toString());
       }
     }
 

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/FlinkSchemaUtil.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/FlinkSchemaUtil.java
@@ -59,7 +59,7 @@ import org.apache.iceberg.types.Types;
  */
 public class FlinkSchemaUtil {
 
-  public static final String flinkPrefix = "flink.";
+  public static final String FLINK_PREFIX = "flink.";
 
   private FlinkSchemaUtil() {
   }
@@ -171,18 +171,18 @@ public class FlinkSchemaUtil {
         properties.keySet().stream()
             .filter(
                 (k) ->
-                    k.startsWith(flinkPrefix + DescriptorProperties.WATERMARK) &&
+                    k.startsWith(FLINK_PREFIX + DescriptorProperties.WATERMARK) &&
                         k.endsWith('.' + DescriptorProperties.WATERMARK_ROWTIME))
             .mapToInt((k) -> 1)
             .sum();
     if (watermarkCount > 0) {
       for (int i = 0; i < watermarkCount; i++) {
         final String rowtimeKey =
-            flinkPrefix + DescriptorProperties.WATERMARK + '.' + i + '.' + DescriptorProperties.WATERMARK_ROWTIME;
+            FLINK_PREFIX + DescriptorProperties.WATERMARK + '.' + i + '.' + DescriptorProperties.WATERMARK_ROWTIME;
         final String exprKey =
-            flinkPrefix + DescriptorProperties.WATERMARK + '.' + i + '.' + DescriptorProperties.WATERMARK_STRATEGY_EXPR;
+            FLINK_PREFIX + DescriptorProperties.WATERMARK + '.' + i + '.' + DescriptorProperties.WATERMARK_STRATEGY_EXPR;
         final String typeKey =
-            flinkPrefix + DescriptorProperties.WATERMARK + '.' + i + '.' +
+            FLINK_PREFIX + DescriptorProperties.WATERMARK + '.' + i + '.' +
                 DescriptorProperties.WATERMARK_STRATEGY_DATA_TYPE;
         final String rowtime =
             optionalGet(rowtimeKey, properties).orElseThrow(exceptionSupplier(rowtimeKey));

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/FlinkSchemaUtil.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/FlinkSchemaUtil.java
@@ -59,6 +59,8 @@ import org.apache.iceberg.types.Types;
  */
 public class FlinkSchemaUtil {
 
+  public static final String flinkPrefix = "flink.";
+
   private FlinkSchemaUtil() {
   }
 
@@ -169,18 +171,19 @@ public class FlinkSchemaUtil {
         properties.keySet().stream()
             .filter(
                 (k) ->
-                    k.startsWith(DescriptorProperties.WATERMARK) &&
+                    k.startsWith(flinkPrefix + DescriptorProperties.WATERMARK) &&
                         k.endsWith('.' + DescriptorProperties.WATERMARK_ROWTIME))
             .mapToInt((k) -> 1)
             .sum();
     if (watermarkCount > 0) {
       for (int i = 0; i < watermarkCount; i++) {
         final String rowtimeKey =
-            DescriptorProperties.WATERMARK + '.' + i + '.' + DescriptorProperties.WATERMARK_ROWTIME;
+            flinkPrefix + DescriptorProperties.WATERMARK + '.' + i + '.' + DescriptorProperties.WATERMARK_ROWTIME;
         final String exprKey =
-            DescriptorProperties.WATERMARK + '.' + i + '.' + DescriptorProperties.WATERMARK_STRATEGY_EXPR;
+            flinkPrefix + DescriptorProperties.WATERMARK + '.' + i + '.' + DescriptorProperties.WATERMARK_STRATEGY_EXPR;
         final String typeKey =
-            DescriptorProperties.WATERMARK + '.' + i + '.' + DescriptorProperties.WATERMARK_STRATEGY_DATA_TYPE;
+            flinkPrefix + DescriptorProperties.WATERMARK + '.' + i + '.' +
+                DescriptorProperties.WATERMARK_STRATEGY_DATA_TYPE;
         final String rowtime =
             optionalGet(rowtimeKey, properties).orElseThrow(exceptionSupplier(rowtimeKey));
         final String exprString =
@@ -216,7 +219,7 @@ public class FlinkSchemaUtil {
   private static Supplier<TableException> exceptionSupplier(String key) {
     return () -> {
       throw new TableException(
-          "Property with key '" + key + "' could not be found. " +
+          "Required property with key '" + key + "' could not be found. " +
               "This is a bug because the validation logic should have checked that before.");
     };
   }

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/TypeToFlinkType.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/TypeToFlinkType.java
@@ -108,10 +108,10 @@ class TypeToFlinkType extends TypeUtil.SchemaVisitor<LogicalType> {
         Types.TimestampType timestamp = (Types.TimestampType) primitive;
         if (timestamp.shouldAdjustToUTC()) {
           // MICROS
-          return new LocalZonedTimestampType(6);
+          return new LocalZonedTimestampType(3);
         } else {
           // MICROS
-          return new TimestampType(6);
+          return new TimestampType(3);
         }
       case STRING:
         return new VarCharType(VarCharType.MAX_LENGTH);

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/StreamingReaderOperator.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/StreamingReaderOperator.java
@@ -166,6 +166,7 @@ public class StreamingReaderOperator extends AbstractStreamOperator<RowData>
   @Override
   public void processWatermark(Watermark mark) {
     // we do nothing because we emit our own watermarks if needed.
+    output.emitWatermark(mark);
   }
 
   @Override

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/StreamingReaderOperator.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/StreamingReaderOperator.java
@@ -166,7 +166,6 @@ public class StreamingReaderOperator extends AbstractStreamOperator<RowData>
   @Override
   public void processWatermark(Watermark mark) {
     // we do nothing because we emit our own watermarks if needed.
-    output.emitWatermark(mark);
   }
 
   @Override

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -175,15 +175,15 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
     Table table = table("tl");
     Assert.assertEquals(
         "Should have the expected watermark properties.",
-        table.properties().get(FlinkSchemaUtil.flinkPrefix + WATERMARK + '.' + 0 + '.' + WATERMARK_ROWTIME),
+        table.properties().get(FlinkSchemaUtil.FLINK_PREFIX + WATERMARK + '.' + 0 + '.' + WATERMARK_ROWTIME),
         "testTime");
     Assert.assertEquals(
         "Should have the expected watermark properties.",
-        table.properties().get(FlinkSchemaUtil.flinkPrefix + WATERMARK + '.' + 0 + '.' + WATERMARK_STRATEGY_DATA_TYPE),
+        table.properties().get(FlinkSchemaUtil.FLINK_PREFIX + WATERMARK + '.' + 0 + '.' + WATERMARK_STRATEGY_DATA_TYPE),
         "TIMESTAMP(3)");
     Assert.assertEquals(
         "Should have the expected watermark properties.",
-        table.properties().get(FlinkSchemaUtil.flinkPrefix + WATERMARK + '.' + 0 + '.' + WATERMARK_STRATEGY_EXPR),
+        table.properties().get(FlinkSchemaUtil.FLINK_PREFIX + WATERMARK + '.' + 0 + '.' + WATERMARK_STRATEGY_EXPR),
         "`testTime` - INTERVAL '5' SECOND");
   }
 

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -175,15 +175,15 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
     Table table = table("tl");
     Assert.assertEquals(
         "Should have the expected watermark properties.",
-        table.properties().get(WATERMARK + '.' + 0 + '.' + WATERMARK_ROWTIME),
+        table.properties().get(FlinkSchemaUtil.flinkPrefix + WATERMARK + '.' + 0 + '.' + WATERMARK_ROWTIME),
         "testTime");
     Assert.assertEquals(
         "Should have the expected watermark properties.",
-        table.properties().get(WATERMARK + '.' + 0 + '.' + WATERMARK_STRATEGY_DATA_TYPE),
+        table.properties().get(FlinkSchemaUtil.flinkPrefix + WATERMARK + '.' + 0 + '.' + WATERMARK_STRATEGY_DATA_TYPE),
         "TIMESTAMP(3)");
     Assert.assertEquals(
         "Should have the expected watermark properties.",
-        table.properties().get(WATERMARK + '.' + 0 + '.' + WATERMARK_STRATEGY_EXPR),
+        table.properties().get(FlinkSchemaUtil.flinkPrefix + WATERMARK + '.' + 0 + '.' + WATERMARK_STRATEGY_EXPR),
         "`testTime` - INTERVAL '5' SECOND");
   }
 

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -169,18 +169,22 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
 
   @Test
   public void testCreateTableWithWatermark() {
-    sql("CREATE TABLE tl(id BIGINT, data STRING, testTime TIMESTAMP(3), WATERMARK FOR testTime AS testTime - INTERVAL '5' SECOND)");
+    sql("CREATE TABLE tl(id BIGINT, data STRING, testTime TIMESTAMP(3), WATERMARK FOR testTime AS testTime - " +
+        "INTERVAL '5' SECOND)");
 
     Table table = table("tl");
-    Assert.assertEquals("Should have the expected watermark properties.",
-            table.properties().get(WATERMARK + '.' + 0 + '.' + WATERMARK_ROWTIME),
-            "testTime");
-    Assert.assertEquals("Should have the expected watermark properties.",
-            table.properties().get(WATERMARK + '.' + 0 + '.' + WATERMARK_STRATEGY_EXPR),
-            "TIMESTAMP(3)");
-    Assert.assertEquals("Should have the expected watermark properties.",
-            table.properties().get(WATERMARK + '.' + 0 + '.' + WATERMARK_STRATEGY_DATA_TYPE),
-            "testTime - INTERVAL '5' SECOND");
+    Assert.assertEquals(
+        "Should have the expected watermark properties.",
+        table.properties().get(WATERMARK + '.' + 0 + '.' + WATERMARK_ROWTIME),
+        "testTime");
+    Assert.assertEquals(
+        "Should have the expected watermark properties.",
+        table.properties().get(WATERMARK + '.' + 0 + '.' + WATERMARK_STRATEGY_DATA_TYPE),
+        "TIMESTAMP(3)");
+    Assert.assertEquals(
+        "Should have the expected watermark properties.",
+        table.properties().get(WATERMARK + '.' + 0 + '.' + WATERMARK_STRATEGY_EXPR),
+        "`testTime` - INTERVAL '5' SECOND");
   }
 
   @Test

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.flink;
 
-import com.google.common.collect.Maps;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
@@ -36,6 +35,7 @@ import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.flink;
 
+import com.google.common.collect.Maps;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
@@ -306,7 +307,7 @@ public class TestFlinkSchemaUtil {
         Sets.newHashSet(1, 2)
     );
 
-    TableSchema tableSchema = FlinkSchemaUtil.toSchema(icebergSchema);
+    TableSchema tableSchema = FlinkSchemaUtil.toSchema(icebergSchema, Maps.newHashMap());
     Assert.assertTrue(tableSchema.getPrimaryKey().isPresent());
     Assert.assertEquals(ImmutableSet.of("int", "string"),
         ImmutableSet.copyOf(tableSchema.getPrimaryKey().get().getColumns()));
@@ -323,6 +324,6 @@ public class TestFlinkSchemaUtil {
     AssertHelpers.assertThrows("Does not support the nested columns in flink schema's primary keys",
         ValidationException.class,
         "Column 'struct.inner' does not exist",
-        () -> FlinkSchemaUtil.toSchema(icebergSchema));
+        () -> FlinkSchemaUtil.toSchema(icebergSchema, Maps.newHashMap()));
   }
 }


### PR DESCRIPTION
If we add watermark in table we can deal data by flink with eventtime, and then we can count stream window with watermark and join with 'version table'(can works in combination https://github.com/apache/iceberg/pull/3095) what flink define.
In this PR the information of watermark is stored in table properties so that it will not affect original scheam of iceberg.
Below properties will be added in watermark table:
'watermark.0.rowtime'='testTime', 
'watermark.0.strategy.data-type'='TIMESTAMP(3)', 
'watermark.0.strategy.expr'='`testTime` - INTERVAL \'5\' SECOND'

After this PR we can create table set watermark like below sql:
 CREATE TABLE catalog.database.table(
    id BIGINT COMMENT 'unique id',
    data STRING, 
    testTime TIMESTAMP(3),
    PRIMARY KEY(id) NOT ENFORCED,
    WATERMARK FOR testTime AS testTime - INTERVAL '5' SECOND
) 
with ('format-version' = '2'
);