### PR TITLE
API: Use Immutables for TableIdentifier/Namespace

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -3,6 +3,41 @@ versionOverrides:
 acceptedBreaks:
   apache-iceberg-0.14.0:
     org.apache.iceberg:iceberg-api:
+    - code: "java.annotation.added"
+      old: "class org.apache.iceberg.catalog.Namespace"
+      new: "class org.apache.iceberg.catalog.Namespace"
+      justification: "false positive - converting to an Immutable class doesn't break\
+        \ the API"
+    - code: "java.annotation.added"
+      old: "class org.apache.iceberg.catalog.TableIdentifier"
+      new: "class org.apache.iceberg.catalog.TableIdentifier"
+      justification: "false positive - converting to an Immutable class doesn't break\
+        \ the API"
+    - code: "java.class.nowAbstract"
+      old: "class org.apache.iceberg.catalog.Namespace"
+      new: "class org.apache.iceberg.catalog.Namespace"
+      justification: "false positive - converting to an Immutable class doesn't break\
+        \ the API"
+    - code: "java.class.nowAbstract"
+      old: "class org.apache.iceberg.catalog.TableIdentifier"
+      new: "class org.apache.iceberg.catalog.TableIdentifier"
+      justification: "false positive - converting to an Immutable class doesn't break\
+        \ the API"
+    - code: "java.method.nowAbstract"
+      old: "method java.lang.String org.apache.iceberg.catalog.TableIdentifier::name()"
+      new: "method java.lang.String org.apache.iceberg.catalog.TableIdentifier::name()"
+      justification: "false positive - converting to an Immutable class doesn't break\
+        \ the API"
+    - code: "java.method.nowAbstract"
+      old: "method java.lang.String[] org.apache.iceberg.catalog.Namespace::levels()"
+      new: "method java.lang.String[] org.apache.iceberg.catalog.Namespace::levels()"
+      justification: "false positive - converting to an Immutable class doesn't break\
+        \ the API"
+    - code: "java.method.nowAbstract"
+      old: "method org.apache.iceberg.catalog.Namespace org.apache.iceberg.catalog.TableIdentifier::namespace()"
+      new: "method org.apache.iceberg.catalog.Namespace org.apache.iceberg.catalog.TableIdentifier::namespace()"
+      justification: "false positive - converting to an Immutable class doesn't break\
+        \ the API"
     - code: "java.class.defaultSerializationChanged"
       old: "class org.apache.iceberg.PartitionKey"
       new: "class org.apache.iceberg.PartitionKey"

--- a/api/src/main/java/org/apache/iceberg/catalog/Namespace.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Namespace.java
@@ -18,21 +18,21 @@
  */
 package org.apache.iceberg.catalog;
 
-import java.util.Arrays;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.immutables.value.Value;
 
 /** A namespace in a {@link Catalog}. */
-public class Namespace {
-  private static final Namespace EMPTY_NAMESPACE = new Namespace(new String[] {});
+@Value.Immutable
+public abstract class Namespace {
   private static final Joiner DOT = Joiner.on('.');
   private static final Predicate<String> CONTAINS_NULL_CHARACTER =
       Pattern.compile("\u0000", Pattern.UNICODE_CHARACTER_CLASS).asPredicate();
 
   public static Namespace empty() {
-    return EMPTY_NAMESPACE;
+    return ImmutableNamespace.builder().levels(new String[] {}).build();
   }
 
   public static Namespace of(String... levels) {
@@ -48,52 +48,25 @@ public class Namespace {
           "Cannot create a namespace with the null-byte character");
     }
 
-    return new Namespace(levels);
+    return ImmutableNamespace.builder().levels(levels).build();
   }
 
-  private final String[] levels;
-
-  private Namespace(String[] levels) {
-    this.levels = levels;
-  }
-
-  public String[] levels() {
-    return levels;
-  }
+  public abstract String[] levels();
 
   public String level(int pos) {
-    return levels[pos];
+    return levels()[pos];
   }
 
   public boolean isEmpty() {
-    return levels.length == 0;
+    return levels().length == 0;
   }
 
   public int length() {
-    return levels.length;
-  }
-
-  @Override
-  public boolean equals(Object other) {
-    if (this == other) {
-      return true;
-    }
-
-    if (other == null || getClass() != other.getClass()) {
-      return false;
-    }
-
-    Namespace namespace = (Namespace) other;
-    return Arrays.equals(levels, namespace.levels);
-  }
-
-  @Override
-  public int hashCode() {
-    return Arrays.hashCode(levels);
+    return levels().length;
   }
 
   @Override
   public String toString() {
-    return DOT.join(levels);
+    return DOT.join(levels());
   }
 }

--- a/api/src/test/java/org/apache/iceberg/catalog/TestTableIdentifier.java
+++ b/api/src/test/java/org/apache/iceberg/catalog/TestTableIdentifier.java
@@ -56,11 +56,11 @@ public class TestTableIdentifier {
   public void testInvalidTableName() {
     Assertions.assertThatThrownBy(() -> TableIdentifier.of(Namespace.empty(), ""))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid table name: null or empty");
+        .hasMessage("Invalid table name: empty");
 
     Assertions.assertThatThrownBy(() -> TableIdentifier.of(Namespace.empty(), null))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid table name: null or empty");
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("name");
   }
 
   @Test
@@ -74,7 +74,7 @@ public class TestTableIdentifier {
         .hasMessage("Cannot parse table identifier: null");
 
     Assertions.assertThatThrownBy(() -> TableIdentifier.of(null, "name"))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid Namespace: null");
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("namespace");
   }
 }


### PR DESCRIPTION
## Motivation
* Use true immutable objects that are type-safe, thread-safe, null-safe
* Get builder classes for free
* Get JSON serialization/deserialization for free (this will also be helpful for the REST-based Catalog #3561)

This is relying on https://immutables.github.io/ (Apache License 2.0), which allows generating immutable objects and builders via annotation processing.
* Immutable objects are serialization ready (including JSON and its binary forms)
* Supports lazy, derived and optional attributes
* Immutable objects are constructed once, in a consistent state, and can be safely shared
  * Will fail if mandatory attributes are missing
  * Cannot be sneakily modified when passed to other code
* Immutable objects are naturally thread-safe and can therefore be safely shared among threads
  * No excessive copying
  * No excessive synchronization
* Object definitions are pleasant to write and read
  * No boilerplate setter and getters
  * No ugly IDE-generated hashCode, equals and toString methods that end up being stored in source control.