### PR TITLE
Checkstyle:Add checkstyle rule to prevent using raw HashMap, HashSet, ArrayList

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -51,6 +51,21 @@
         <property name="format" value="new JavaSparkContext\(.*\)"/>
         <property name="message" value="Prefer using JavaSparkContext.fromSparkContext() instead of calling a constructor directly."/>
     </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="new HashMap&lt;&gt;\(.*\)"/>
+        <property name="message"
+                  value="Prefer using Maps.newHashMap instead."/>
+    </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="new ArrayList&lt;&gt;\(.*\)"/>
+        <property name="message"
+                  value="Prefer using Lists.newArrayList() instead."/>
+    </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="new HashSet&lt;&gt;\(.*\)"/>
+        <property name="message"
+                  value="Prefer using Sets.newHashSet() instead."/>
+    </module>
     <module name="SuppressionFilter"> <!-- baseline-gradle: README.md -->
         <property name="file" value="${config_loc}/checkstyle-suppressions.xml"/>
     </module>

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/ArrowReaderTest.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/ArrowReaderTest.java
@@ -30,7 +30,6 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -77,6 +76,7 @@ import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.UUIDUtil;
@@ -604,7 +604,7 @@ public class ArrowReaderTest {
   }
 
   private void writeTable(boolean constantRecords) throws Exception {
-    rowsWritten = new ArrayList<>();
+    rowsWritten = Lists.newArrayList();
     tables = new HadoopTables();
     tableLocation = temp.newFolder("test").toString();
 
@@ -728,7 +728,7 @@ public class ArrowReaderTest {
   }
 
   private List<GenericRecord> createIncrementalRecordsForDate(Schema schema, LocalDateTime datetime) {
-    List<GenericRecord> records = new ArrayList<>();
+    List<GenericRecord> records = Lists.newArrayList();
     for (int i = 0; i < NUM_ROWS_PER_MONTH; i++) {
       GenericRecord rec = GenericRecord.create(schema);
       rec.setField("timestamp", datetime.plus(i, ChronoUnit.DAYS));
@@ -764,7 +764,7 @@ public class ArrowReaderTest {
   }
 
   private List<GenericRecord> createConstantRecordsForDate(Schema schema, LocalDateTime datetime) {
-    List<GenericRecord> records = new ArrayList<>();
+    List<GenericRecord> records = Lists.newArrayList();
     for (int i = 0; i < NUM_ROWS_PER_MONTH; i++) {
       GenericRecord rec = GenericRecord.create(schema);
       rec.setField("timestamp", datetime);

--- a/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg;
 
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -28,6 +27,7 @@ import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
 class BaseFileScanTask implements FileScanTask {
   private final DataFile file;
@@ -117,7 +117,7 @@ class BaseFileScanTask implements FileScanTask {
       this.offsets = ImmutableList.copyOf(offsetList);
       this.parentScanTask = parentScanTask;
       this.targetSplitSize = targetSplitSize;
-      this.splitSizes = new ArrayList<>(offsets.size());
+      this.splitSizes = Lists.newArrayListWithCapacity(offsets.size());
       if (offsets.size() > 0) {
         int lastIndex = offsets.size() - 1;
         for (int index = 0; index < lastIndex; index++) {

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -24,7 +24,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.AccessDeniedException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -287,7 +286,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog implements Closeable, Su
     try {
       // using the iterator listing allows for paged downloads
       // from HDFS and prefetching from object storage.
-      List<Namespace> namespaces = new ArrayList<>();
+      List<Namespace> namespaces = Lists.newArrayList();
       RemoteIterator<FileStatus> it = fs.listStatusIterator(nsPath);
       while (it.hasNext()) {
         Path path = it.next().getPath();

--- a/core/src/main/java/org/apache/iceberg/util/Tasks.java
+++ b/core/src/main/java/org/apache/iceberg/util/Tasks.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.util;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -471,7 +470,7 @@ public class Tasks {
       }
 
       if (numFinished == futures.size()) {
-        List<Throwable> uncaught = new ArrayList<>();
+        List<Throwable> uncaught = Lists.newArrayList();
         // all of the futures are done, get any uncaught exceptions
         for (Future<?> future : futures) {
           try {

--- a/core/src/test/java/org/apache/iceberg/TestMetrics.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetrics.java
@@ -432,7 +432,7 @@ public abstract class TestMetrics {
     Assume.assumeTrue("Skip test for formats that do not support small row groups", supportsSmallRowGroups());
 
     int recordCount = 201;
-    List<Record> records = Lists.newArrayListWithCapacity(recordCount);
+    List<Record> records = Lists.newArrayListWithExpectedSize(recordCount);
 
     for (int i = 0; i < recordCount; i++) {
       Record newRecord = GenericRecord.create(SIMPLE_SCHEMA);

--- a/core/src/test/java/org/apache/iceberg/TestMetrics.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetrics.java
@@ -25,7 +25,6 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -433,7 +432,7 @@ public abstract class TestMetrics {
     Assume.assumeTrue("Skip test for formats that do not support small row groups", supportsSmallRowGroups());
 
     int recordCount = 201;
-    List<Record> records = new ArrayList<>(recordCount);
+    List<Record> records = Lists.newArrayListWithCapacity(recordCount);
 
     for (int i = 0; i < recordCount; i++) {
       Record newRecord = GenericRecord.create(SIMPLE_SCHEMA);

--- a/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
+++ b/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
@@ -20,8 +20,6 @@
 package org.apache.iceberg;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -887,7 +885,7 @@ public class TestRemoveSnapshots extends TableTestBase {
         .appendFile(FILE_C)
         .commit();
 
-    Set<String> deletedFiles = new HashSet<>();
+    Set<String> deletedFiles = Sets.newHashSet();
 
     // Expire all commits including dangling staged snapshot.
     table.expireSnapshots()
@@ -895,7 +893,7 @@ public class TestRemoveSnapshots extends TableTestBase {
         .expireOlderThan(snapshotB.timestampMillis() + 1)
         .commit();
 
-    Set<String> expectedDeletes = new HashSet<>();
+    Set<String> expectedDeletes = Sets.newHashSet();
     expectedDeletes.add(snapshotA.manifestListLocation());
 
     // Files should be deleted of dangling staged snapshot
@@ -932,7 +930,7 @@ public class TestRemoveSnapshots extends TableTestBase {
     Snapshot snapshotA = table.currentSnapshot();
 
     // `B` commit
-    Set<String> deletedAFiles = new HashSet<>();
+    Set<String> deletedAFiles = Sets.newHashSet();
     table.newOverwrite()
         .addFile(FILE_B)
         .deleteFile(FILE_A)
@@ -964,7 +962,7 @@ public class TestRemoveSnapshots extends TableTestBase {
     table.manageSnapshots()
         .setCurrentSnapshot(snapshotC.snapshotId())
         .commit();
-    List<String> deletedFiles = new ArrayList<>();
+    List<String> deletedFiles = Lists.newArrayList();
 
     // Expire `C`
     table.expireSnapshots()
@@ -1017,7 +1015,7 @@ public class TestRemoveSnapshots extends TableTestBase {
     base = readMetadata();
     Snapshot snapshotD = base.snapshots().get(3);
 
-    List<String> deletedFiles = new ArrayList<>();
+    List<String> deletedFiles = Lists.newArrayList();
 
     // Expire `B` commit.
     table.expireSnapshots()

--- a/core/src/test/java/org/apache/iceberg/TestSequenceNumberForV2Table.java
+++ b/core/src/test/java/org/apache/iceberg/TestSequenceNumberForV2Table.java
@@ -19,11 +19,11 @@
 
 package org.apache.iceberg;
 
-import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.iceberg.ManifestEntry.Status;
 import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.junit.Test;
 
 public class TestSequenceNumberForV2Table extends TableTestBase {
@@ -236,8 +236,8 @@ public class TestSequenceNumberForV2Table extends TableTestBase {
     V2Assert.assertEquals("Snapshot sequence number should be 1", 1, snap1.sequenceNumber());
     V2Assert.assertEquals("Last sequence number should be 0", 0, readMetadata().lastSequenceNumber());
 
-    Set<DataFile> toAddFiles = new HashSet<>();
-    Set<DataFile> toDeleteFiles = new HashSet<>();
+    Set<DataFile> toAddFiles = Sets.newHashSet();
+    Set<DataFile> toDeleteFiles = Sets.newHashSet();
     toAddFiles.add(FILE_B);
     toDeleteFiles.add(FILE_A);
     txn.newRewrite().rewriteFiles(toDeleteFiles, toAddFiles).commit();

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopTables.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopTables.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
@@ -34,6 +33,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.transforms.Transforms;
@@ -168,7 +168,7 @@ public class TestHadoopTables {
     Table table = TABLES.create(SCHEMA, tableDir.toURI().toString());
     AppendFiles append = table.newAppend();
     String data = dataDir.getPath() + "/data.parquet";
-    Files.write(Paths.get(data), new ArrayList<>(), StandardCharsets.UTF_8);
+    Files.write(Paths.get(data), Lists.newArrayList(), StandardCharsets.UTF_8);
     DataFile dataFile = DataFiles.builder(PartitionSpec.unpartitioned())
         .withPath(data)
         .withFileSizeInBytes(10)

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -284,7 +283,7 @@ public class TestJdbcCatalog {
     Table table = catalog.createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
     // append file and commit!
     String data = temp.newFile("data.parquet").getPath();
-    Files.write(Paths.get(data), new ArrayList<>(), StandardCharsets.UTF_8);
+    Files.write(Paths.get(data), Lists.newArrayList(), StandardCharsets.UTF_8);
     DataFile dataFile = DataFiles.builder(PartitionSpec.unpartitioned())
         .withPath(data)
         .withFileSizeInBytes(10)
@@ -294,7 +293,7 @@ public class TestJdbcCatalog {
     Assert.assertEquals(1, table.history().size());
     catalog.dropTable(tableIdentifier);
     data = temp.newFile("data2.parquet").getPath();
-    Files.write(Paths.get(data), new ArrayList<>(), StandardCharsets.UTF_8);
+    Files.write(Paths.get(data), Lists.newArrayList(), StandardCharsets.UTF_8);
     DataFile dataFile2 = DataFiles.builder(PartitionSpec.unpartitioned())
         .withPath(data)
         .withFileSizeInBytes(10)
@@ -313,7 +312,7 @@ public class TestJdbcCatalog {
     Table table = catalog.loadTable(testTable);
 
     String data = temp.newFile("data.parquet").getPath();
-    Files.write(Paths.get(data), new ArrayList<>(), StandardCharsets.UTF_8);
+    Files.write(Paths.get(data), Lists.newArrayList(), StandardCharsets.UTF_8);
     DataFile dataFile = DataFiles.builder(PartitionSpec.unpartitioned())
         .withPath(data)
         .withFileSizeInBytes(10)
@@ -323,7 +322,7 @@ public class TestJdbcCatalog {
     Assert.assertEquals(1, table.history().size());
 
     data = temp.newFile("data2.parquet").getPath();
-    Files.write(Paths.get(data), new ArrayList<>(), StandardCharsets.UTF_8);
+    Files.write(Paths.get(data), Lists.newArrayList(), StandardCharsets.UTF_8);
     dataFile = DataFiles.builder(PartitionSpec.unpartitioned())
         .withPath(data)
         .withFileSizeInBytes(10)
@@ -333,7 +332,7 @@ public class TestJdbcCatalog {
     Assert.assertEquals(2, table.history().size());
 
     data = temp.newFile("data3.parquet").getPath();
-    Files.write(Paths.get(data), new ArrayList<>(), StandardCharsets.UTF_8);
+    Files.write(Paths.get(data), Lists.newArrayList(), StandardCharsets.UTF_8);
     dataFile = DataFiles.builder(PartitionSpec.unpartitioned())
         .withPath(data)
         .withFileSizeInBytes(10)

--- a/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilterTypes.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilterTypes.java
@@ -30,7 +30,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
@@ -137,7 +136,7 @@ public class TestMetricsRowGroupFilterTypes {
 
   @Before
   public void createInputFile() throws IOException {
-    List<Record> records = new ArrayList<>();
+    List<Record> records = Lists.newArrayList();
     // create 50 records
     for (int i = 0; i < 50; i += 1) {
       Record record = GenericRecord.create(FILE_SCHEMA);

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,11 +15,11 @@
 
 jmhOutputPath=build/reports/jmh/human-readable-output.txt
 jmhIncludeRegex=.*
-systemProp.defaultFlinkVersions=1.14
+systemProp.defaultFlinkVersions=1.12
 systemProp.knownFlinkVersions=1.12,1.13,1.14
-systemProp.defaultHiveVersions=2
+systemProp.defaultHiveVersions=3
 systemProp.knownHiveVersions=2,3
-systemProp.defaultSparkVersions=3.2
+systemProp.defaultSparkVersions=2.4
 systemProp.knownSparkVersions=2.4,3.0,3.1,3.2
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx768m

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,11 +15,11 @@
 
 jmhOutputPath=build/reports/jmh/human-readable-output.txt
 jmhIncludeRegex=.*
-systemProp.defaultFlinkVersions=1.12
+systemProp.defaultFlinkVersions=1.14
 systemProp.knownFlinkVersions=1.12,1.13,1.14
-systemProp.defaultHiveVersions=3
+systemProp.defaultHiveVersions=2
 systemProp.knownHiveVersions=2,3
-systemProp.defaultSparkVersions=2.4
+systemProp.defaultSparkVersions=3.2
 systemProp.knownSparkVersions=2.4,3.0,3.1,3.2
 org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx768m

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaConverter.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaConverter.java
@@ -61,7 +61,7 @@ class HiveSchemaConverter {
   }
 
   List<Types.NestedField> convertInternal(List<String> names, List<TypeInfo> typeInfos, List<String> comments) {
-    List<Types.NestedField> result = Lists.newArrayListWithCapacity(names.size());
+    List<Types.NestedField> result = Lists.newArrayListWithExpectedSize(names.size());
     for (int i = 0; i < names.size(); ++i) {
       result.add(Types.NestedField.optional(id++, names.get(i), convertType(typeInfos.get(i)),
           (comments.isEmpty() || i >= comments.size()) ? null : comments.get(i)));

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaConverter.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaConverter.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.hive;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
@@ -30,6 +29,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.slf4j.Logger;
@@ -61,7 +61,7 @@ class HiveSchemaConverter {
   }
 
   List<Types.NestedField> convertInternal(List<String> names, List<TypeInfo> typeInfos, List<String> comments) {
-    List<Types.NestedField> result = new ArrayList<>(names.size());
+    List<Types.NestedField> result = Lists.newArrayListWithCapacity(names.size());
     for (int i = 0; i < names.size(); ++i) {
       result.add(Types.NestedField.optional(id++, names.get(i), convertType(typeInfos.get(i)),
           (comments.isEmpty() || i >= comments.size()) ? null : comments.get(i)));

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaUtil.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaUtil.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.hive;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
@@ -27,6 +26,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 
@@ -66,9 +66,9 @@ public final class HiveSchemaUtil {
    * @return An equivalent Iceberg Schema
    */
   public static Schema convert(List<FieldSchema> fieldSchemas, boolean autoConvert) {
-    List<String> names = new ArrayList<>(fieldSchemas.size());
-    List<TypeInfo> typeInfos = new ArrayList<>(fieldSchemas.size());
-    List<String> comments = new ArrayList<>(fieldSchemas.size());
+    List<String> names = Lists.newArrayListWithCapacity(fieldSchemas.size());
+    List<TypeInfo> typeInfos = Lists.newArrayListWithCapacity(fieldSchemas.size());
+    List<String> comments = Lists.newArrayListWithCapacity(fieldSchemas.size());
 
     for (FieldSchema col : fieldSchemas) {
       names.add(col.getName());

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaUtil.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaUtil.java
@@ -66,9 +66,9 @@ public final class HiveSchemaUtil {
    * @return An equivalent Iceberg Schema
    */
   public static Schema convert(List<FieldSchema> fieldSchemas, boolean autoConvert) {
-    List<String> names = Lists.newArrayListWithCapacity(fieldSchemas.size());
-    List<TypeInfo> typeInfos = Lists.newArrayListWithCapacity(fieldSchemas.size());
-    List<String> comments = Lists.newArrayListWithCapacity(fieldSchemas.size());
+    List<String> names = Lists.newArrayListWithExpectedSize(fieldSchemas.size());
+    List<TypeInfo> typeInfos = Lists.newArrayListWithExpectedSize(fieldSchemas.size());
+    List<String> comments = Lists.newArrayListWithExpectedSize(fieldSchemas.size());
 
     for (FieldSchema col : fieldSchemas) {
       names.add(col.getName());

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveSchemaUtil.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveSchemaUtil.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.hive;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -30,6 +29,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
@@ -120,7 +120,7 @@ public class TestHiveSchemaUtil {
     for (FieldSchema notSupportedField : getNotSupportedFieldSchemas()) {
       AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
           "Unsupported Hive type", () -> {
-            HiveSchemaUtil.convert(new ArrayList<>(Arrays.asList(notSupportedField)));
+            HiveSchemaUtil.convert(Lists.newArrayList(Arrays.asList(notSupportedField)));
           }
       );
     }
@@ -171,7 +171,7 @@ public class TestHiveSchemaUtil {
   }
 
   protected List<FieldSchema> getSupportedFieldSchemas() {
-    List<FieldSchema> fields = new ArrayList<>();
+    List<FieldSchema> fields = Lists.newArrayList();
     fields.add(new FieldSchema("c_float", serdeConstants.FLOAT_TYPE_NAME, "float comment"));
     fields.add(new FieldSchema("c_double", serdeConstants.DOUBLE_TYPE_NAME, "double comment"));
     fields.add(new FieldSchema("c_boolean", serdeConstants.BOOLEAN_TYPE_NAME, "boolean comment"));
@@ -186,7 +186,7 @@ public class TestHiveSchemaUtil {
   }
 
   protected List<FieldSchema> getNotSupportedFieldSchemas() {
-    List<FieldSchema> fields = new ArrayList<>();
+    List<FieldSchema> fields = Lists.newArrayList();
     fields.add(new FieldSchema("c_byte", serdeConstants.TINYINT_TYPE_NAME, ""));
     fields.add(new FieldSchema("c_short", serdeConstants.SMALLINT_TYPE_NAME, ""));
     fields.add(new FieldSchema("c_char", serdeConstants.CHAR_TYPE_NAME + "(5)", ""));

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveSchemaUtil.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveSchemaUtil.java
@@ -171,7 +171,7 @@ public class TestHiveSchemaUtil {
   }
 
   protected List<FieldSchema> getSupportedFieldSchemas() {
-    List<FieldSchema> fields = Lists.newArrayList();
+    List<FieldSchema> fields = Lists.newArrayListWithCapacity(10);
     fields.add(new FieldSchema("c_float", serdeConstants.FLOAT_TYPE_NAME, "float comment"));
     fields.add(new FieldSchema("c_double", serdeConstants.DOUBLE_TYPE_NAME, "double comment"));
     fields.add(new FieldSchema("c_boolean", serdeConstants.BOOLEAN_TYPE_NAME, "boolean comment"));
@@ -186,7 +186,7 @@ public class TestHiveSchemaUtil {
   }
 
   protected List<FieldSchema> getNotSupportedFieldSchemas() {
-    List<FieldSchema> fields = Lists.newArrayList();
+    List<FieldSchema> fields = Lists.newArrayListWithCapacity(6);
     fields.add(new FieldSchema("c_byte", serdeConstants.TINYINT_TYPE_NAME, ""));
     fields.add(new FieldSchema("c_short", serdeConstants.SMALLINT_TYPE_NAME, ""));
     fields.add(new FieldSchema("c_char", serdeConstants.CHAR_TYPE_NAME + "(5)", ""));

--- a/hive3/src/main/java/org/apache/hadoop/hive/ql/io/orc/OrcSplit.java
+++ b/hive3/src/main/java/org/apache/hadoop/hive/ql/io/orc/OrcSplit.java
@@ -23,7 +23,6 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -37,11 +36,11 @@ import org.apache.hadoop.hive.ql.io.SyntheticFileId;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.WritableUtils;
 import org.apache.hadoop.mapred.FileSplit;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.orc.OrcProto;
 import org.apache.orc.impl.OrcTail;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 
 /**
  * In order to fix some compatibility issues with ORC support with Hive 3.x and the shaded ORC libraries,
@@ -59,7 +58,7 @@ public class OrcSplit extends FileSplit implements ColumnarSplit, LlapAwareSplit
   private boolean hasBase;
   // partition root
   private Path rootDir;
-  private final List<AcidInputFormat.DeltaMetaData> deltas = new ArrayList<>();
+  private final List<AcidInputFormat.DeltaMetaData> deltas = Lists.newArrayList();
   private long projColsUncompressedSize;
   private transient Object fileKey;
   private long fileLen;

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/Deserializer.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/Deserializer.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.mr.hive;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
@@ -32,6 +31,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.mr.hive.serde.objectinspector.WriteObjectInspector;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.schema.SchemaWithPartnerVisitor;
 import org.apache.iceberg.types.Type.PrimitiveType;
@@ -153,7 +153,7 @@ class Deserializer {
           return null;
         }
 
-        List<Object> result = new ArrayList<>();
+        List<Object> result = Lists.newArrayList();
         ListObjectInspector listInspector = (ListObjectInspector) pair.sourceInspector();
 
         for (Object val : listInspector.getList(o)) {

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.mr.hive;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -45,6 +44,7 @@ import org.apache.iceberg.mr.Catalogs;
 import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.iceberg.mr.hive.serde.objectinspector.IcebergObjectInspector;
 import org.apache.iceberg.mr.mapred.Container;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -170,9 +170,9 @@ public class HiveIcebergSerDe extends AbstractSerDe {
     if (columnNames != null && columnTypes != null && columnNameDelimiter != null &&
         !columnNames.isEmpty() && !columnTypes.isEmpty() && !columnNameDelimiter.isEmpty()) {
       // Parse the configuration parameters
-      List<String> names = new ArrayList<>();
+      List<String> names = Lists.newArrayList();
       Collections.addAll(names, columnNames.split(columnNameDelimiter));
-      List<String> comments = new ArrayList<>();
+      List<String> comments = Lists.newArrayList();
       if (columnComments != null) {
         Collections.addAll(comments, columnComments.split(Character.toString(Character.MIN_VALUE)));
       }

--- a/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
@@ -22,7 +22,6 @@ package org.apache.iceberg.mr;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -58,6 +57,7 @@ import org.apache.iceberg.mr.mapreduce.IcebergInputFormat;
 import org.apache.iceberg.mr.mapreduce.IcebergSplit;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
@@ -180,7 +180,7 @@ public class TestIcebergInputFormats {
     writeRecords.get(1).set(1, 456L);
     writeRecords.get(1).set(2, "2020-03-20");
 
-    List<Record> expectedRecords = new ArrayList<>();
+    List<Record> expectedRecords = Lists.newArrayList();
     expectedRecords.add(writeRecords.get(0));
 
     DataFile dataFile1 = helper.writeFile(Row.of("2020-03-20", 0), writeRecords);
@@ -432,8 +432,8 @@ public class TestIcebergInputFormats {
       try {
         org.apache.hadoop.mapred.InputSplit[] splits = inputFormat.getSplits(job, 1);
 
-        List<IcebergSplit> iceSplits = new ArrayList<>(splits.length);
-        List<T> records = new ArrayList<>();
+        List<IcebergSplit> iceSplits = Lists.newArrayListWithCapacity(splits.length);
+        List<T> records = Lists.newArrayList();
 
         for (org.apache.hadoop.mapred.InputSplit split : splits) {
           iceSplits.add((IcebergSplit) split);
@@ -469,8 +469,8 @@ public class TestIcebergInputFormats {
       IcebergInputFormat<T> inputFormat = new IcebergInputFormat<>();
       List<InputSplit> splits = inputFormat.getSplits(context);
 
-      List<IcebergSplit> iceSplits = new ArrayList<>(splits.size());
-      List<T> records = new ArrayList<>();
+      List<IcebergSplit> iceSplits = Lists.newArrayListWithCapacity(splits.size());
+      List<T> records = Lists.newArrayList();
 
       for (InputSplit split : splits) {
         iceSplits.add((IcebergSplit) split);

--- a/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestIcebergInputFormats.java
@@ -432,7 +432,7 @@ public class TestIcebergInputFormats {
       try {
         org.apache.hadoop.mapred.InputSplit[] splits = inputFormat.getSplits(job, 1);
 
-        List<IcebergSplit> iceSplits = Lists.newArrayListWithCapacity(splits.length);
+        List<IcebergSplit> iceSplits = Lists.newArrayListWithExpectedSize(splits.length);
         List<T> records = Lists.newArrayList();
 
         for (org.apache.hadoop.mapred.InputSplit split : splits) {
@@ -469,7 +469,7 @@ public class TestIcebergInputFormats {
       IcebergInputFormat<T> inputFormat = new IcebergInputFormat<>();
       List<InputSplit> splits = inputFormat.getSplits(context);
 
-      List<IcebergSplit> iceSplits = Lists.newArrayListWithCapacity(splits.size());
+      List<IcebergSplit> iceSplits = Lists.newArrayListWithExpectedSize(splits.size());
       List<T> records = Lists.newArrayList();
 
       for (InputSplit split : splits) {

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
@@ -32,7 +32,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -60,6 +59,7 @@ import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.IcebergGenerics;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ByteBuffers;
 import org.junit.Assert;
@@ -220,7 +220,7 @@ public class HiveIcebergTestUtils {
   public static void validateData(Table table, List<Record> expected, int sortBy) throws IOException {
     // Refresh the table, so we get the new data as well
     table.refresh();
-    List<Record> records = new ArrayList<>(expected.size());
+    List<Record> records = Lists.newArrayListWithExpectedSize(expected.size());
     try (CloseableIterable<Record> iterable = IcebergGenerics.read(table).build()) {
       iterable.forEach(records::add);
     }
@@ -236,8 +236,8 @@ public class HiveIcebergTestUtils {
    * @param sortBy The column position by which we will sort
    */
   public static void validateData(List<Record> expected, List<Record> actual, int sortBy) {
-    List<Record> sortedExpected = new ArrayList<>(expected);
-    List<Record> sortedActual = new ArrayList<>(actual);
+    List<Record> sortedExpected = Lists.newArrayList(expected);
+    List<Record> sortedActual = Lists.newArrayList(actual);
     // Sort based on the specified column
     sortedExpected.sort(Comparator.comparingLong(record -> (Long) record.get(sortBy)));
     sortedActual.sort(Comparator.comparingLong(record -> (Long) record.get(sortBy)));

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergOutputCommitter.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergOutputCommitter.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.mr.hive;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -49,6 +48,7 @@ import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.iceberg.mr.TestHelper;
 import org.apache.iceberg.mr.mapred.Container;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.SerializationUtil;
@@ -260,7 +260,7 @@ public class TestHiveIcebergOutputCommitter {
    */
   private List<Record> writeRecords(String name, int taskNum, int attemptNum, boolean commitTasks, boolean abortTasks,
                                     JobConf conf, OutputCommitter committer) throws IOException {
-    List<Record> expected = new ArrayList<>(RECORD_NUM * taskNum);
+    List<Record> expected = Lists.newArrayListWithCapacity(RECORD_NUM * taskNum);
 
     Table table = HiveIcebergStorageHandler.table(conf, name);
     FileIO io = table.io();

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergOutputCommitter.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergOutputCommitter.java
@@ -260,7 +260,7 @@ public class TestHiveIcebergOutputCommitter {
    */
   private List<Record> writeRecords(String name, int taskNum, int attemptNum, boolean commitTasks, boolean abortTasks,
                                     JobConf conf, OutputCommitter committer) throws IOException {
-    List<Record> expected = Lists.newArrayListWithCapacity(RECORD_NUM * taskNum);
+    List<Record> expected = Lists.newArrayListWithExpectedSize(RECORD_NUM * taskNum);
 
     Table table = HiveIcebergStorageHandler.table(conf, name);
     FileIO io = table.io();

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerLocalScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerLocalScan.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.mr.hive;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -63,7 +62,7 @@ public class TestHiveIcebergStorageHandlerLocalScan {
 
   @Parameters(name = "fileFormat={0}, catalog={1}")
   public static Collection<Object[]> parameters() {
-    Collection<Object[]> testParams = new ArrayList<>();
+    Collection<Object[]> testParams = Lists.newArrayList();
 
     // Run tests with every FileFormat for a single Catalog (HiveCatalog)
     for (FileFormat fileFormat : HiveIcebergStorageHandlerTestUtils.FILE_FORMATS) {

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.mr.hive;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -54,6 +53,7 @@ import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
@@ -114,7 +114,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
   @Parameters(name = "catalog={0}")
   public static Collection<Object[]> parameters() {
-    Collection<Object[]> testParams = new ArrayList<>();
+    Collection<Object[]> testParams = Lists.newArrayList();
     for (TestTables.TestTableType testTableType : TestTables.ALL_TABLE_TYPES) {
       testParams.add(new Object[] {testTableType});
     }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.mr.hive;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -101,7 +100,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
 
   @Parameters(name = "fileFormat={0}, engine={1}, catalog={2}, isVectorized={3}")
   public static Collection<Object[]> parameters() {
-    Collection<Object[]> testParams = new ArrayList<>();
+    Collection<Object[]> testParams = Lists.newArrayList();
     String javaVersion = System.getProperty("java.specification.version");
 
     // Run tests with every FileFormat for a single Catalog (HiveCatalog)
@@ -374,7 +373,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     shell.executeStatement("INSERT INTO customers SELECT * FROM customers");
 
     // Check that everything is duplicated as expected
-    List<Record> records = new ArrayList<>(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+    List<Record> records = Lists.newArrayList(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
     records.addAll(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
     HiveIcebergTestUtils.validateData(table, records, 0);
   }
@@ -394,7 +393,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     shell.executeStatement("INSERT INTO customers SELECT * FROM customers ORDER BY customer_id");
 
     // Check that everything is duplicated as expected
-    List<Record> records = new ArrayList<>(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+    List<Record> records = Lists.newArrayList(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
     records.addAll(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
     HiveIcebergTestUtils.validateData(table, records, 0);
   }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithMultipleCatalogs.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithMultipleCatalogs.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.mr.hive;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import org.apache.iceberg.FileFormat;
@@ -28,6 +27,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.mr.InputFormatConfig;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -70,7 +70,7 @@ public class TestHiveIcebergStorageHandlerWithMultipleCatalogs {
   @Parameterized.Parameters(name = "fileFormat1={0}, fileFormat2={1}, engine={2}, tableType1={3}, catalogName1={4}, " +
           "tableType2={5}, catalogName2={6}")
   public static Collection<Object[]> parameters() {
-    Collection<Object[]> testParams = new ArrayList<>();
+    Collection<Object[]> testParams = Lists.newArrayList();
     String javaVersion = System.getProperty("java.specification.version");
 
     // Run tests with PARQUET and ORC file formats for a two Catalogs
@@ -124,7 +124,7 @@ public class TestHiveIcebergStorageHandlerWithMultipleCatalogs {
             "FROM default.customers2 c2 JOIN default.customers1 c1 ON c2.customer_id = c1.customer_id " +
             "ORDER BY c2.customer_id");
     Assert.assertEquals(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS.size(), rows.size());
-    HiveIcebergTestUtils.validateData(new ArrayList<>(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS),
+    HiveIcebergTestUtils.validateData(Lists.newArrayList(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS),
             HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, rows), 0);
   }
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveShell.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveShell.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.mr.hive;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
@@ -34,6 +33,7 @@ import org.apache.hive.service.cli.session.HiveSession;
 import org.apache.hive.service.server.HiveServer2;
 import org.apache.iceberg.hive.TestHiveMetastore;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
 /**
  * Test class for running HiveQL queries, essentially acting like a Beeline shell in tests.
@@ -136,7 +136,7 @@ public class TestHiveShell {
             "You have to start TestHiveShell and open a session first, before running a query.");
     try {
       OperationHandle handle = client.executeStatement(session.getSessionHandle(), statement, Collections.emptyMap());
-      List<Object[]> resultSet = new ArrayList<>();
+      List<Object[]> resultSet = Lists.newArrayList();
       if (handle.hasResultSet()) {
         RowSet rowSet;
         // keep fetching results until we can

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.nessie;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +29,7 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.ContentKey;
 import org.projectnessie.model.EntriesResponse;
@@ -81,7 +81,7 @@ public final class NessieUtil {
   }
 
   static ContentKey toKey(TableIdentifier tableIdentifier) {
-    List<String> identifiers = new ArrayList<>();
+    List<String> identifiers = Lists.newArrayList();
     if (tableIdentifier.hasNamespace()) {
       identifiers.addAll(Arrays.asList(tableIdentifier.namespace().levels()));
     }

--- a/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.nessie;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.hadoop.conf.Configuration;
@@ -37,6 +36,7 @@ import org.apache.iceberg.avro.Avro;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.LongType;
 import org.apache.iceberg.types.Types.StructType;
@@ -144,7 +144,7 @@ public abstract class BaseTestIceberg {
   }
 
   protected static Schema schema(int count) {
-    List<Types.NestedField> fields = new ArrayList<>();
+    List<Types.NestedField> fields = Lists.newArrayList();
     for (int i = 0; i < count; i++) {
       fields.add(required(i, "id" + i, Types.LongType.get()));
     }

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
@@ -394,7 +394,7 @@ public class TestNessieTable extends BaseTestIceberg {
   private static String addRecordsToFile(Table table, String filename) throws IOException {
     GenericRecordBuilder recordBuilder =
         new GenericRecordBuilder(AvroSchemaUtil.convert(schema, "test"));
-    List<GenericData.Record> records = Lists.newArrayList();
+    List<GenericData.Record> records = Lists.newArrayListWithCapacity(3);
     records.add(recordBuilder.set("id", 1L).build());
     records.add(recordBuilder.set("id", 2L).build());
     records.add(recordBuilder.set("id", 3L).build());

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
@@ -22,7 +22,6 @@ package org.apache.iceberg.nessie;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -39,6 +38,7 @@ import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
@@ -394,7 +394,7 @@ public class TestNessieTable extends BaseTestIceberg {
   private static String addRecordsToFile(Table table, String filename) throws IOException {
     GenericRecordBuilder recordBuilder =
         new GenericRecordBuilder(AvroSchemaUtil.convert(schema, "test"));
-    List<GenericData.Record> records = new ArrayList<>();
+    List<GenericData.Record> records = Lists.newArrayList();
     records.add(recordBuilder.set("id", 1L).build());
     records.add(recordBuilder.set("id", 2L).build());
     records.add(recordBuilder.set("id", 3L).build());

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
@@ -21,9 +21,7 @@ package org.apache.iceberg.parquet;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +41,7 @@ import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Conversions;
@@ -210,7 +209,7 @@ public class ParquetUtil {
    * Returns a list of offsets in ascending order determined by the starting position of the row groups.
    */
   public static List<Long> getSplitOffsets(ParquetMetadata md) {
-    List<Long> splitOffsets = new ArrayList<>(md.getBlocks().size());
+    List<Long> splitOffsets = Lists.newArrayListWithCapacity(md.getBlocks().size());
     for (BlockMetaData blockMetaData : md.getBlocks()) {
       splitOffsets.add(blockMetaData.getStartingPos());
     }
@@ -317,7 +316,7 @@ public class ParquetUtil {
     }
 
     // without EncodingStats, fall back to testing the encoding list
-    Set<Encoding> encodings = new HashSet<>(meta.getEncodings());
+    Set<Encoding> encodings = Sets.newHashSet(meta.getEncodings());
     if (encodings.remove(Encoding.PLAIN_DICTIONARY)) {
       // if remove returned true, PLAIN_DICTIONARY was present, which means at
       // least one page was dictionary encoded and 1.0 encodings are used

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
@@ -209,7 +209,7 @@ public class ParquetUtil {
    * Returns a list of offsets in ascending order determined by the starting position of the row groups.
    */
   public static List<Long> getSplitOffsets(ParquetMetadata md) {
-    List<Long> splitOffsets = Lists.newArrayListWithCapacity(md.getBlocks().size());
+    List<Long> splitOffsets = Lists.newArrayListWithExpectedSize(md.getBlocks().size());
     for (BlockMetaData blockMetaData : md.getBlocks()) {
       splitOffsets.add(blockMetaData.getStartingPos());
     }

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.parquet;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
@@ -29,6 +28,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types.IntegerType;
 import org.apache.iceberg.util.Pair;
 import org.apache.parquet.hadoop.ParquetFileReader;
@@ -82,7 +82,7 @@ public class TestParquet {
     int recordCount = 100099;
     File file = createTempFile(temp);
 
-    List<GenericData.Record> records = new ArrayList<>(recordCount);
+    List<GenericData.Record> records = Lists.newArrayListWithCapacity(recordCount);
     org.apache.avro.Schema avroSchema = AvroSchemaUtil.convert(schema.asStruct());
     for (int i = 1; i <= recordCount; i++) {
       GenericData.Record record = new GenericData.Record(avroSchema);
@@ -106,7 +106,7 @@ public class TestParquet {
     int minimumRowGroupRecordCount = 100;
     int desiredRecordCount = minimumRowGroupRecordCount + 1;
 
-    List<GenericData.Record> records = new ArrayList<>(desiredRecordCount);
+    List<GenericData.Record> records = Lists.newArrayListWithCapacity(desiredRecordCount);
     org.apache.avro.Schema avroSchema = AvroSchemaUtil.convert(schema.asStruct());
     for (int i = 1; i <= desiredRecordCount; i++) {
       GenericData.Record record = new GenericData.Record(avroSchema);

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/examples/ConcurrencyTest.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/examples/ConcurrencyTest.java
@@ -22,7 +22,6 @@ package org.apache.iceberg.examples;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -31,6 +30,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -58,7 +58,7 @@ public class ConcurrencyTest {
   private File tableLocation;
   private Table table;
 
-  private List<SimpleRecord> data = new ArrayList<>();
+  private List<SimpleRecord> data = Lists.newArrayList();
 
   @Before
   public void before() throws IOException {
@@ -84,7 +84,7 @@ public class ConcurrencyTest {
   @Test
   public void writingAndReadingConcurrently() throws InterruptedException {
     ExecutorService threadPool = Executors.newFixedThreadPool(5);
-    List<Callable<Void>> tasks = new ArrayList<>();
+    List<Callable<Void>> tasks = Lists.newArrayList();
 
     Callable<Void> write = () -> writeToTable(data);
     tasks.add(write);

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -21,8 +21,6 @@ package org.apache.iceberg.spark.actions;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -557,7 +555,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
         .appendFile(FILE_C)
         .commit();
 
-    Set<String> deletedFiles = new HashSet<>();
+    Set<String> deletedFiles = Sets.newHashSet();
 
     // Expire all commits including dangling staged snapshot.
     ExpireSnapshots.Result result = SparkActions.get().expireSnapshots(table)
@@ -567,7 +565,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
 
     checkExpirationResults(1L, 1L, 2L, result);
 
-    Set<String> expectedDeletes = new HashSet<>();
+    Set<String> expectedDeletes = Sets.newHashSet();
     expectedDeletes.add(snapshotA.manifestListLocation());
 
     // Files should be deleted of dangling staged snapshot
@@ -604,7 +602,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     Snapshot snapshotA = table.currentSnapshot();
 
     // `B` commit
-    Set<String> deletedAFiles = new HashSet<>();
+    Set<String> deletedAFiles = Sets.newHashSet();
     table.newOverwrite()
         .addFile(FILE_B)
         .deleteFile(FILE_A)
@@ -636,7 +634,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     table.manageSnapshots()
         .setCurrentSnapshot(snapshotC.snapshotId())
         .commit();
-    List<String> deletedFiles = new ArrayList<>();
+    List<String> deletedFiles = Lists.newArrayList();
 
     // Expire `C`
     ExpireSnapshots.Result result = SparkActions.get().expireSnapshots(table)
@@ -691,7 +689,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     base = ((BaseTable) table).operations().current();
     Snapshot snapshotD = base.snapshots().get(3);
 
-    List<String> deletedFiles = new ArrayList<>();
+    List<String> deletedFiles = Lists.newArrayList();
 
     // Expire `B` commit.
     ExpireSnapshots.Result firstResult = SparkActions.get().expireSnapshots(table)

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.spark.data;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.arrow.vector.NullCheckingForGet;
@@ -130,7 +129,7 @@ public class TestSparkParquetReadMetadataColumns {
 
   @Before
   public void writeFile() throws IOException {
-    List<Path> fileSplits = new ArrayList<>();
+    List<Path> fileSplits = Lists.newArrayList();
     StructType struct = SparkSchemaUtil.convert(DATA_SCHEMA);
     Configuration conf = new Configuration();
 

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
@@ -25,7 +25,6 @@ import java.net.URI;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -351,7 +350,7 @@ public class TestPartitionPruning {
   private Set<String> extractFilePathsNotIn(List<Row> files, Set<String> filePaths) {
     Set<String> allFilePaths = files.stream().map(r -> CountOpenLocalFileSystem.stripScheme(r.getString(1)))
         .collect(Collectors.toSet());
-    return new HashSet<>(Sets.symmetricDifference(allFilePaths, filePaths));
+    return Sets.newHashSet(Sets.symmetricDifference(allFilePaths, filePaths));
   }
 
   public static class CountOpenLocalFileSystem extends RawLocalFileSystem {

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.spark.source;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.List;
 import org.apache.avro.generic.GenericData;
 import org.apache.iceberg.DataFiles;
@@ -412,7 +411,7 @@ public class TestPartitionValues {
         )
     };
 
-    List<Row> rows = new ArrayList<>();
+    List<Row> rows = Lists.newArrayList();
     rows.add(RowFactory.create(RowFactory.create("nested_string_value")));
     Dataset<Row> sourceDF = spark.createDataFrame(rows, new StructType(structFields));
 

--- a/spark/v3.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.spark.extensions;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +35,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.spark.SparkException;
 import org.apache.spark.sql.AnalysisException;
@@ -335,7 +335,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     sql("ALTER TABLE %s SET TBLPROPERTIES('%s' '%d')", tableName, PARQUET_ROW_GROUP_SIZE_BYTES, 100);
     sql("ALTER TABLE %s SET TBLPROPERTIES('%s' '%d')", tableName, SPLIT_SIZE, 100);
 
-    List<Integer> ids = new ArrayList<>();
+    List<Integer> ids = Lists.newArrayList();
     for (int id = 1; id <= 200; id++) {
       ids.add(id);
     }

--- a/spark/v3.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.spark.extensions;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -36,6 +35,7 @@ import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.spark.SparkException;
 import org.apache.spark.sql.AnalysisException;
@@ -910,7 +910,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
 
     createOrReplaceView("source", Collections.singletonList(1), Encoders.INT());
 
-    List<Integer> ids = new ArrayList<>();
+    List<Integer> ids = Lists.newArrayList();
     for (int id = 1; id <= 200; id++) {
       ids.add(id);
     }

--- a/spark/v3.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.spark.extensions;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +36,7 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.spark.SparkException;
@@ -285,7 +285,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     sql("ALTER TABLE %s SET TBLPROPERTIES('%s' '%d')", tableName, PARQUET_ROW_GROUP_SIZE_BYTES, 100);
     sql("ALTER TABLE %s SET TBLPROPERTIES('%s' '%d')", tableName, SPLIT_SIZE, 100);
 
-    List<Integer> ids = new ArrayList<>();
+    List<Integer> ids = Lists.newArrayList();
     for (int id = 1; id <= 200; id++) {
       ids.add(id);
     }

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -627,7 +626,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
     CatalogTable sourceTable = loadSessionTable(source);
     List<URI> uris;
     if (sourceTable.partitionColumnNames().size() == 0) {
-      uris = new ArrayList<>();
+      uris = Lists.newArrayList();
       uris.add(sourceTable.location());
     } else {
       Seq<CatalogTablePartition> catalogTablePartitionSeq =

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -21,8 +21,6 @@ package org.apache.iceberg.spark.actions;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -557,7 +555,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
         .appendFile(FILE_C)
         .commit();
 
-    Set<String> deletedFiles = new HashSet<>();
+    Set<String> deletedFiles = Sets.newHashSet();
 
     // Expire all commits including dangling staged snapshot.
     ExpireSnapshots.Result result = SparkActions.get().expireSnapshots(table)
@@ -567,7 +565,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
 
     checkExpirationResults(1L, 1L, 2L, result);
 
-    Set<String> expectedDeletes = new HashSet<>();
+    Set<String> expectedDeletes = Sets.newHashSet();
     expectedDeletes.add(snapshotA.manifestListLocation());
 
     // Files should be deleted of dangling staged snapshot
@@ -604,7 +602,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     Snapshot snapshotA = table.currentSnapshot();
 
     // `B` commit
-    Set<String> deletedAFiles = new HashSet<>();
+    Set<String> deletedAFiles = Sets.newHashSet();
     table.newOverwrite()
         .addFile(FILE_B)
         .deleteFile(FILE_A)
@@ -636,7 +634,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     table.manageSnapshots()
         .setCurrentSnapshot(snapshotC.snapshotId())
         .commit();
-    List<String> deletedFiles = new ArrayList<>();
+    List<String> deletedFiles = Lists.newArrayList();
 
     // Expire `C`
     ExpireSnapshots.Result result = SparkActions.get().expireSnapshots(table)
@@ -691,7 +689,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     base = ((BaseTable) table).operations().current();
     Snapshot snapshotD = base.snapshots().get(3);
 
-    List<String> deletedFiles = new ArrayList<>();
+    List<String> deletedFiles = Lists.newArrayList();
 
     // Expire `B` commit.
     ExpireSnapshots.Result firstResult = SparkActions.get().expireSnapshots(table)

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.spark.data;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.arrow.vector.NullCheckingForGet;
@@ -130,7 +129,7 @@ public class TestSparkParquetReadMetadataColumns {
 
   @Before
   public void writeFile() throws IOException {
-    List<Path> fileSplits = new ArrayList<>();
+    List<Path> fileSplits = Lists.newArrayList();
     StructType struct = SparkSchemaUtil.convert(DATA_SCHEMA);
     Configuration conf = new Configuration();
 

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
@@ -25,7 +25,6 @@ import java.net.URI;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -351,7 +350,7 @@ public class TestPartitionPruning {
   private Set<String> extractFilePathsNotIn(List<Row> files, Set<String> filePaths) {
     Set<String> allFilePaths = files.stream().map(r -> CountOpenLocalFileSystem.stripScheme(r.getString(1)))
         .collect(Collectors.toSet());
-    return new HashSet<>(Sets.symmetricDifference(allFilePaths, filePaths));
+    return Sets.newHashSet(Sets.symmetricDifference(allFilePaths, filePaths));
   }
 
   public static class CountOpenLocalFileSystem extends RawLocalFileSystem {

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.spark.source;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.List;
 import org.apache.avro.generic.GenericData;
 import org.apache.iceberg.DataFiles;
@@ -412,7 +411,7 @@ public class TestPartitionValues {
         )
     };
 
-    List<Row> rows = new ArrayList<>();
+    List<Row> rows = Lists.newArrayList();
     rows.add(RowFactory.create(RowFactory.create("nested_string_value")));
     Dataset<Row> sourceDF = spark.createDataFrame(rows, new StructType(structFields));
 

--- a/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.spark.extensions;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +35,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.spark.SparkException;
 import org.apache.spark.sql.AnalysisException;
@@ -335,7 +335,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     sql("ALTER TABLE %s SET TBLPROPERTIES('%s' '%d')", tableName, PARQUET_ROW_GROUP_SIZE_BYTES, 100);
     sql("ALTER TABLE %s SET TBLPROPERTIES('%s' '%d')", tableName, SPLIT_SIZE, 100);
 
-    List<Integer> ids = new ArrayList<>();
+    List<Integer> ids = Lists.newArrayList();
     for (int id = 1; id <= 200; id++) {
       ids.add(id);
     }

--- a/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.spark.extensions;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -36,6 +35,7 @@ import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.spark.SparkException;
 import org.apache.spark.sql.AnalysisException;
@@ -910,7 +910,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
 
     createOrReplaceView("source", Collections.singletonList(1), Encoders.INT());
 
-    List<Integer> ids = new ArrayList<>();
+    List<Integer> ids = Lists.newArrayList();
     for (int id = 1; id <= 200; id++) {
       ids.add(id);
     }

--- a/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -910,7 +910,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
 
     createOrReplaceView("source", Collections.singletonList(1), Encoders.INT());
 
-    List<Integer> ids = Lists.newArrayList();
+    List<Integer> ids = Lists.newArrayListWithCapacity(200);
     for (int id = 1; id <= 200; id++) {
       ids.add(id);
     }

--- a/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.spark.extensions;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +36,7 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.spark.SparkException;
@@ -285,7 +285,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     sql("ALTER TABLE %s SET TBLPROPERTIES('%s' '%d')", tableName, PARQUET_ROW_GROUP_SIZE_BYTES, 100);
     sql("ALTER TABLE %s SET TBLPROPERTIES('%s' '%d')", tableName, SPLIT_SIZE, 100);
 
-    List<Integer> ids = new ArrayList<>();
+    List<Integer> ids = Lists.newArrayList();
     for (int id = 1; id <= 200; id++) {
       ids.add(id);
     }

--- a/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -285,7 +285,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     sql("ALTER TABLE %s SET TBLPROPERTIES('%s' '%d')", tableName, PARQUET_ROW_GROUP_SIZE_BYTES, 100);
     sql("ALTER TABLE %s SET TBLPROPERTIES('%s' '%d')", tableName, SPLIT_SIZE, 100);
 
-    List<Integer> ids = Lists.newArrayList();
+    List<Integer> ids = Lists.newArrayListWithCapacity(200);
     for (int id = 1; id <= 200; id++) {
       ids.add(id);
     }

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -627,7 +626,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
     CatalogTable sourceTable = loadSessionTable(source);
     List<URI> uris;
     if (sourceTable.partitionColumnNames().size() == 0) {
-      uris = new ArrayList<>();
+      uris = Lists.newArrayList();
       uris.add(sourceTable.location());
     } else {
       Seq<CatalogTablePartition> catalogTablePartitionSeq =

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -21,8 +21,6 @@ package org.apache.iceberg.spark.actions;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -557,7 +555,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
         .appendFile(FILE_C)
         .commit();
 
-    Set<String> deletedFiles = new HashSet<>();
+    Set<String> deletedFiles = Sets.newHashSet();
 
     // Expire all commits including dangling staged snapshot.
     ExpireSnapshots.Result result = SparkActions.get().expireSnapshots(table)
@@ -567,7 +565,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
 
     checkExpirationResults(1L, 1L, 2L, result);
 
-    Set<String> expectedDeletes = new HashSet<>();
+    Set<String> expectedDeletes = Sets.newHashSet();
     expectedDeletes.add(snapshotA.manifestListLocation());
 
     // Files should be deleted of dangling staged snapshot
@@ -604,7 +602,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     Snapshot snapshotA = table.currentSnapshot();
 
     // `B` commit
-    Set<String> deletedAFiles = new HashSet<>();
+    Set<String> deletedAFiles = Sets.newHashSet();
     table.newOverwrite()
         .addFile(FILE_B)
         .deleteFile(FILE_A)
@@ -636,7 +634,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     table.manageSnapshots()
         .setCurrentSnapshot(snapshotC.snapshotId())
         .commit();
-    List<String> deletedFiles = new ArrayList<>();
+    List<String> deletedFiles = Lists.newArrayList();
 
     // Expire `C`
     ExpireSnapshots.Result result = SparkActions.get().expireSnapshots(table)
@@ -691,7 +689,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     base = ((BaseTable) table).operations().current();
     Snapshot snapshotD = base.snapshots().get(3);
 
-    List<String> deletedFiles = new ArrayList<>();
+    List<String> deletedFiles = Lists.newArrayList();
 
     // Expire `B` commit.
     ExpireSnapshots.Result firstResult = SparkActions.get().expireSnapshots(table)

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.spark.data;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.arrow.vector.NullCheckingForGet;
@@ -130,7 +129,7 @@ public class TestSparkParquetReadMetadataColumns {
 
   @Before
   public void writeFile() throws IOException {
-    List<Path> fileSplits = new ArrayList<>();
+    List<Path> fileSplits = Lists.newArrayList();
     StructType struct = SparkSchemaUtil.convert(DATA_SCHEMA);
     Configuration conf = new Configuration();
 

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
@@ -25,7 +25,6 @@ import java.net.URI;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -351,7 +350,7 @@ public class TestPartitionPruning {
   private Set<String> extractFilePathsNotIn(List<Row> files, Set<String> filePaths) {
     Set<String> allFilePaths = files.stream().map(r -> CountOpenLocalFileSystem.stripScheme(r.getString(1)))
         .collect(Collectors.toSet());
-    return new HashSet<>(Sets.symmetricDifference(allFilePaths, filePaths));
+    return Sets.newHashSet(Sets.symmetricDifference(allFilePaths, filePaths));
   }
 
   public static class CountOpenLocalFileSystem extends RawLocalFileSystem {

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.spark.source;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.List;
 import org.apache.avro.generic.GenericData;
 import org.apache.iceberg.DataFiles;
@@ -412,7 +411,7 @@ public class TestPartitionValues {
         )
     };
 
-    List<Row> rows = new ArrayList<>();
+    List<Row> rows = Lists.newArrayList();
     rows.add(RowFactory.create(RowFactory.create("nested_string_value")));
     Dataset<Row> sourceDF = spark.createDataFrame(rows, new StructType(structFields));
 

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.spark.extensions;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +35,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.spark.SparkException;
 import org.apache.spark.sql.AnalysisException;
@@ -335,7 +335,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     sql("ALTER TABLE %s SET TBLPROPERTIES('%s' '%d')", tableName, PARQUET_ROW_GROUP_SIZE_BYTES, 100);
     sql("ALTER TABLE %s SET TBLPROPERTIES('%s' '%d')", tableName, SPLIT_SIZE, 100);
 
-    List<Integer> ids = new ArrayList<>();
+    List<Integer> ids = Lists.newArrayList();
     for (int id = 1; id <= 200; id++) {
       ids.add(id);
     }

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -335,7 +335,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     sql("ALTER TABLE %s SET TBLPROPERTIES('%s' '%d')", tableName, PARQUET_ROW_GROUP_SIZE_BYTES, 100);
     sql("ALTER TABLE %s SET TBLPROPERTIES('%s' '%d')", tableName, SPLIT_SIZE, 100);
 
-    List<Integer> ids = Lists.newArrayList();
+    List<Integer> ids = Lists.newArrayListWithCapacity(200);
     for (int id = 1; id <= 200; id++) {
       ids.add(id);
     }

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.spark.extensions;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -36,6 +35,7 @@ import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.spark.SparkException;
 import org.apache.spark.sql.AnalysisException;
@@ -910,7 +910,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
 
     createOrReplaceView("source", Collections.singletonList(1), Encoders.INT());
 
-    List<Integer> ids = new ArrayList<>();
+    List<Integer> ids = Lists.newArrayList();
     for (int id = 1; id <= 200; id++) {
       ids.add(id);
     }

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -910,7 +910,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
 
     createOrReplaceView("source", Collections.singletonList(1), Encoders.INT());
 
-    List<Integer> ids = Lists.newArrayList();
+    List<Integer> ids = Lists.newArrayListWithCapacity(200);
     for (int id = 1; id <= 200; id++) {
       ids.add(id);
     }

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.spark.extensions;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -37,6 +36,7 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.iceberg.spark.SparkSQLProperties;
 import org.apache.spark.SparkException;
@@ -285,7 +285,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     sql("ALTER TABLE %s SET TBLPROPERTIES('%s' '%d')", tableName, PARQUET_ROW_GROUP_SIZE_BYTES, 100);
     sql("ALTER TABLE %s SET TBLPROPERTIES('%s' '%d')", tableName, SPLIT_SIZE, 100);
 
-    List<Integer> ids = new ArrayList<>();
+    List<Integer> ids = Lists.newArrayList();
     for (int id = 1; id <= 200; id++) {
       ids.add(id);
     }

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -285,7 +285,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     sql("ALTER TABLE %s SET TBLPROPERTIES('%s' '%d')", tableName, PARQUET_ROW_GROUP_SIZE_BYTES, 100);
     sql("ALTER TABLE %s SET TBLPROPERTIES('%s' '%d')", tableName, SPLIT_SIZE, 100);
 
-    List<Integer> ids = Lists.newArrayList();
+    List<Integer> ids = Lists.newArrayListWithCapacity(200);
     for (int id = 1; id <= 200; id++) {
       ids.add(id);
     }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -627,7 +626,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
     CatalogTable sourceTable = loadSessionTable(source);
     List<URI> uris;
     if (sourceTable.partitionColumnNames().size() == 0) {
-      uris = new ArrayList<>();
+      uris = Lists.newArrayList();
       uris.add(sourceTable.location());
     } else {
       Seq<CatalogTablePartition> catalogTablePartitionSeq =

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -21,8 +21,6 @@ package org.apache.iceberg.spark.actions;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -557,7 +555,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
         .appendFile(FILE_C)
         .commit();
 
-    Set<String> deletedFiles = new HashSet<>();
+    Set<String> deletedFiles = Sets.newHashSet();
 
     // Expire all commits including dangling staged snapshot.
     ExpireSnapshots.Result result = SparkActions.get().expireSnapshots(table)
@@ -567,7 +565,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
 
     checkExpirationResults(1L, 1L, 2L, result);
 
-    Set<String> expectedDeletes = new HashSet<>();
+    Set<String> expectedDeletes = Sets.newHashSet();
     expectedDeletes.add(snapshotA.manifestListLocation());
 
     // Files should be deleted of dangling staged snapshot
@@ -604,7 +602,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     Snapshot snapshotA = table.currentSnapshot();
 
     // `B` commit
-    Set<String> deletedAFiles = new HashSet<>();
+    Set<String> deletedAFiles = Sets.newHashSet();
     table.newOverwrite()
         .addFile(FILE_B)
         .deleteFile(FILE_A)
@@ -636,7 +634,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     table.manageSnapshots()
         .setCurrentSnapshot(snapshotC.snapshotId())
         .commit();
-    List<String> deletedFiles = new ArrayList<>();
+    List<String> deletedFiles = Lists.newArrayList();
 
     // Expire `C`
     ExpireSnapshots.Result result = SparkActions.get().expireSnapshots(table)
@@ -691,7 +689,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
     base = ((BaseTable) table).operations().current();
     Snapshot snapshotD = base.snapshots().get(3);
 
-    List<String> deletedFiles = new ArrayList<>();
+    List<String> deletedFiles = Lists.newArrayList();
 
     // Expire `B` commit.
     ExpireSnapshots.Result firstResult = SparkActions.get().expireSnapshots(table)

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReadMetadataColumns.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.spark.data;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -137,7 +136,7 @@ public class TestSparkParquetReadMetadataColumns {
 
   @Before
   public void writeFile() throws IOException {
-    List<Path> fileSplits = new ArrayList<>();
+    List<Path> fileSplits = Lists.newArrayList();
     StructType struct = SparkSchemaUtil.convert(DATA_SCHEMA);
     Configuration conf = new Configuration();
 
@@ -175,7 +174,7 @@ public class TestSparkParquetReadMetadataColumns {
   @Test
   public void testReadRowNumbersWithDelete() throws IOException {
     if (vectorized) {
-      List<InternalRow> expectedRowsAfterDelete = new ArrayList<>(EXPECTED_ROWS);
+      List<InternalRow> expectedRowsAfterDelete = Lists.newArrayList(EXPECTED_ROWS);
       // remove row at position 98, 99, 100, 101, 102, this crosses two row groups [0, 100) and [100, 200)
       for (int i = 1; i <= 5; i++) {
         expectedRowsAfterDelete.remove(98);

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionPruning.java
@@ -25,7 +25,6 @@ import java.net.URI;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -351,7 +350,7 @@ public class TestPartitionPruning {
   private Set<String> extractFilePathsNotIn(List<Row> files, Set<String> filePaths) {
     Set<String> allFilePaths = files.stream().map(r -> CountOpenLocalFileSystem.stripScheme(r.getString(1)))
         .collect(Collectors.toSet());
-    return new HashSet<>(Sets.symmetricDifference(allFilePaths, filePaths));
+    return Sets.newHashSet(Sets.symmetricDifference(allFilePaths, filePaths));
   }
 
   public static class CountOpenLocalFileSystem extends RawLocalFileSystem {

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestPartitionValues.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.spark.source;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.List;
 import org.apache.avro.generic.GenericData;
 import org.apache.iceberg.DataFiles;
@@ -414,7 +413,7 @@ public class TestPartitionValues {
         )
     };
 
-    List<Row> rows = new ArrayList<>();
+    List<Row> rows = Lists.newArrayList();
     rows.add(RowFactory.create(RowFactory.create("nested_string_value")));
     Dataset<Row> sourceDF = spark.createDataFrame(rows, new StructType(structFields));
 


### PR DESCRIPTION

For project code consistency, we should add checkstyle rules that prevent the use of raw new HashMap<>, new HashSet<>() and new ArrayList<> in favor of Maps.newHashMap(), Sets.newHashSet() and Lists.newArrayList()

https://github.com/apache/iceberg/issues/3657