### PR TITLE
Add FileIO, InputFile, and OutputFile abstract base classes

### DIFF
--- a/python/src/iceberg/io/base.py
+++ b/python/src/iceberg/io/base.py
@@ -56,16 +56,9 @@ class InputFile(ABC):
 class OutputFile(ABC):
     """A base class for OutputFile implementations"""
 
-    def __init__(self, location: str):
+    def __init__(self, location: str, overwrite: bool = False):
         self._location = location
-
-    @abstractmethod
-    def __call__(self, overwrite: bool = False, **kwargs):
-        """Set an overwrite flag, and any other kwargs before opening the
-        context manager. Exiting the context manager should remove these where
-        applicable (such as a closed connection)."""
         self._overwrite = overwrite
-        return self
 
     @abstractmethod
     def __len__(self) -> int:
@@ -75,6 +68,11 @@ class OutputFile(ABC):
     def location(self) -> str:
         """The fully-qualified location of the output file"""
         return self._location
+
+    @property
+    def overwrite(self) -> bool:
+        """Whether or not to overwrite the file if it exists"""
+        return self._overwrite
 
     @property
     @abstractmethod
@@ -90,8 +88,8 @@ class OutputFile(ABC):
         """Enter context for OutputFile
 
         This method should return a file-like object. If the file already exists
-        at `self.location` and `self._overwrite` is False (set by the `__call__`
-        method), a FileExistsError should be raised.
+        at `self.location` and `self.overwrite` is False a FileExistsError should
+        be raised.
 
         Example:
             >>> with OutputFile(overwrite=True) as f:

--- a/python/src/iceberg/io/base.py
+++ b/python/src/iceberg/io/base.py
@@ -14,6 +14,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""Base FileIO classes for implementing reading and writing table files
+
+The FileIO abstraction includes a subset of full filesystem implementations. Specifically,
+Iceberg needs to read or write a file at a given location (as a seekable stream), as well
+as check if a file exists. An implementation of the FileIO abstract base class is responsible
+for returning an InputFile instance, an OutputFile instance, and deleting a file given
+its location.
+"""
 
 from abc import ABC, abstractmethod
 

--- a/python/src/iceberg/io/base.py
+++ b/python/src/iceberg/io/base.py
@@ -24,6 +24,7 @@ its location.
 """
 
 from abc import ABC, abstractmethod
+from typing import Union
 
 
 class InputFile(ABC):
@@ -95,5 +96,5 @@ class FileIO(ABC):
         """Get an OutputFile instance to write bytes to the file at the given location"""
 
     @abstractmethod
-    def delete(self, location: str) -> None:
+    def delete(self, location: Union[str, InputFile, OutputFile]) -> None:
         """Delete the file at the given path"""

--- a/python/src/iceberg/io/base.py
+++ b/python/src/iceberg/io/base.py
@@ -47,26 +47,15 @@ class InputFile(ABC):
         """Checks whether the file exists"""
 
     @abstractmethod
-    def __enter__(self):
-        """Enter context for InputFile
-
-        This method should assign a seekable stream to `self.input_stream` and
-        return `self`. If the file does not exist, a FileNotFoundError should
-        be raised."""
-
-    @abstractmethod
-    def __exit__(self, exc_type, exc_value, exc_traceback):
-        """Exit context for InputFile
-
-        This method should perform any necessary teardown."""
+    def open(self):
+        """This method should return an instance of an seekable input stream."""
 
 
 class OutputFile(ABC):
     """A base class for OutputFile implementations"""
 
-    def __init__(self, location: str, overwrite: bool = False):
+    def __init__(self, location: str):
         self._location = location
-        self._overwrite = overwrite
 
     @abstractmethod
     def __len__(self) -> int:
@@ -78,11 +67,6 @@ class OutputFile(ABC):
         return self._location
 
     @property
-    def overwrite(self) -> bool:
-        """Whether or not to overwrite the file if it exists"""
-        return self._overwrite
-
-    @property
     @abstractmethod
     def exists(self) -> bool:
         """Checks whether the file exists"""
@@ -92,28 +76,12 @@ class OutputFile(ABC):
         """Returns an InputFile for the location of this output file"""
 
     @abstractmethod
-    def __enter__(self):
-        """Enter context for OutputFile
+    def create(self, overwrite: bool = False):
+        """This method should return a file-like object.
 
-        This method should return a file-like object. If the file already exists
-        at `self.location` and `self.overwrite` is False a FileExistsError should
-        be raised.
-
-        Example:
-            >>> with OutputFile(overwrite=True) as f:
-                    content = f.read()
-        """
-
-    @abstractmethod
-    def __exit__(self, exc_type, exc_value, exc_traceback):
-        """Exit context for OutputFile
-
-        This method should perform any necessary teardown.
-
-        Example:
-            >>> with OutputFile(connection=connection):
-                    content = f.read()
-                    connection.close()  # `__exit__` method would contain `del self._connection`
+        Args:
+            overwrite(bool): If the file already exists at `self.location`
+            and `overwrite` is False a FileExistsError should be raised.
         """
 
 
@@ -127,5 +95,5 @@ class FileIO(ABC):
         """Get an OutputFile instance to write bytes to the file at the given location"""
 
     @abstractmethod
-    def delete(self, location: str):
+    def delete(self, location: str) -> None:
         """Delete the file at the given path"""

--- a/python/src/iceberg/io/base.py
+++ b/python/src/iceberg/io/base.py
@@ -1,0 +1,125 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from abc import ABC, abstractmethod
+
+
+class InputFile(ABC):
+    """A base class for InputFile implementations"""
+
+    def __init__(self, location: str):
+        self._location = location
+
+    @abstractmethod
+    def __len__(self) -> int:
+        """Returns the total length of the file, in bytes"""
+
+    @property
+    def location(self) -> str:
+        """The fully-qualified location of the input file"""
+        return self._location
+
+    @property
+    @abstractmethod
+    def exists(self) -> bool:
+        """Checks whether the file exists"""
+
+    @abstractmethod
+    def __enter__(self):
+        """Enter context for InputFile
+
+        This method should assign a seekable stream to `self.input_stream` and
+        return `self`. If the file does not exist, a FileNotFoundError should
+        be raised."""
+
+    @abstractmethod
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        """Exit context for InputFile
+
+        This method should perform any necessary teardown."""
+
+
+class OutputFile(ABC):
+    """A base class for OutputFile implementations"""
+
+    def __init__(self, location: str):
+        self._location = location
+
+    @abstractmethod
+    def __call__(self, overwrite: bool = False, **kwargs):
+        """Set an overwrite flag, and any other kwargs before opening the
+        context manager. Exiting the context manager should remove these where
+        applicable (such as a closed connection)."""
+        self._overwrite = overwrite
+        return self
+
+    @abstractmethod
+    def __len__(self) -> int:
+        """Returns the total length of the file, in bytes"""
+
+    @property
+    def location(self) -> str:
+        """The fully-qualified location of the output file"""
+        return self._location
+
+    @property
+    @abstractmethod
+    def exists(self) -> bool:
+        """Checks whether the file exists"""
+
+    @abstractmethod
+    def to_input_file(self) -> InputFile:
+        """Returns an InputFile for the location of this output file"""
+
+    @abstractmethod
+    def __enter__(self):
+        """Enter context for OutputFile
+
+        This method should return a file-like object. If the file already exists
+        at `self.location` and `self._overwrite` is False (set by the `__call__`
+        method), a FileExistsError should be raised.
+
+        Example:
+            >>> with OutputFile(overwrite=True) as f:
+                    content = f.read()
+        """
+
+    @abstractmethod
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        """Exit context for OutputFile
+
+        This method should perform any necessary teardown.
+
+        Example:
+            >>> with OutputFile(connection=connection):
+                    content = f.read()
+                    connection.close()  # `__exit__` method would contain `del self._connection`
+        """
+
+
+class FileIO(ABC):
+    @abstractmethod
+    def new_input(self, location: str) -> InputFile:
+        """Get an InputFile instance to read bytes from the file at the given location"""
+
+    @abstractmethod
+    def new_output(self, location: str) -> OutputFile:
+        """Get an OutputFile instance to write bytes to the file at the given location"""
+
+    @abstractmethod
+    def delete(self, location: str):
+        """Delete the file at the given path"""

--- a/python/tests/io/test_base.py
+++ b/python/tests/io/test_base.py
@@ -89,10 +89,7 @@ class LocalOutputFile(OutputFile):
         return LocalInputFile(location=self.location)
 
     def create(self, overwrite: bool = False) -> None:
-        if not overwrite and self.exists():
-            raise FileExistsError(f"{self.location} already exists")
-
-        return open(self.parsed_location.path, "wb")
+        return open(self.parsed_location.path, "wb" if overwrite else "xb")
 
 
 class LocalFileIO(FileIO):

--- a/python/tests/io/test_base.py
+++ b/python/tests/io/test_base.py
@@ -95,10 +95,11 @@ def test_custom_output_file():
 
 def test_custom_output_file_with_overwrite():
 
-    output_file = FooOutputFile(location="foo/bar.json")
+    output_file = FooOutputFile(location="foo/bar.json", overwrite=True)
     assert output_file.location == "foo/bar.json"
+    assert output_file.overwrite == True
 
-    with output_file(overwrite=True) as f:
+    with output_file as f:
         f.write(b"foo")
 
     output_file._mock_storage.seek(0)

--- a/python/tests/io/test_base.py
+++ b/python/tests/io/test_base.py
@@ -60,10 +60,10 @@ class FooOutputFile(OutputFile):
 
 
 class FooFileIO(FileIO):
-    def new_input(location: str):
+    def new_input(self, location: str):
         return FooInputFile(location=location)
 
-    def new_output(location: str):
+    def new_output(self, location: str):
         return FooOutputFile(location=location)
 
     def delete(self, location: str):
@@ -109,8 +109,8 @@ def test_custom_output_file_with_overwrite():
 def test_custom_file_io():
 
     file_io = FooFileIO()
-    input_file = file_io.new_input()
-    output_file = file_io.new_output()
+    input_file = file_io.new_input(location="foo")
+    output_file = file_io.new_output(location="bar")
 
     assert isinstance(input_file, FooInputFile)
     assert isinstance(output_file, FooOutputFile)

--- a/python/tests/io/test_base.py
+++ b/python/tests/io/test_base.py
@@ -1,0 +1,115 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import io
+
+from iceberg.io.base import FileIO, InputFile, OutputFile
+
+
+class FooInputFile(InputFile):
+    def __len__(self):
+        return io.BytesIO(b"foo").getbuffer().nbytes
+
+    def exists(self):
+        return True
+
+    def __enter__(self):
+        super().__enter__()
+        return io.BytesIO(b"foo")
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        super().__exit__(exc_type, exc_value, exc_traceback)
+        return
+
+
+class FooOutputFile(OutputFile):
+    def __call__(self, overwrite: bool = False, **kwargs):
+        super().__call__(overwrite=True)
+        return self
+
+    def __len__(self):
+        return len(self._file_obj)
+
+    def exists(self):
+        return True
+
+    def to_input_file(self):
+        return FooInputFile(location=self.location)
+
+    def __enter__(self):
+        self._mock_storage = io.BytesIO()
+        return self._mock_storage
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        super().__exit__(exc_type, exc_value, exc_traceback)
+        return
+
+
+class FooFileIO(FileIO):
+    def new_input(location: str):
+        return FooInputFile(location=location)
+
+    def new_output(location: str):
+        return FooOutputFile(location=location)
+
+    def delete(self, location: str):
+        return
+
+
+def test_custom_input_file():
+
+    input_file = FooInputFile(location="foo/bar.json")
+    assert input_file.location == "foo/bar.json"
+
+    with input_file as f:
+        data = f.read()
+
+    assert data == b"foo"
+
+
+def test_custom_output_file():
+
+    output_file = FooOutputFile(location="foo/bar.json")
+    assert output_file.location == "foo/bar.json"
+
+    with output_file as f:
+        f.write(b"foo")
+
+    output_file._mock_storage.seek(0)
+    assert output_file._mock_storage.read() == b"foo"
+
+
+def test_custom_output_file_with_overwrite():
+
+    output_file = FooOutputFile(location="foo/bar.json")
+    assert output_file.location == "foo/bar.json"
+
+    with output_file(overwrite=True) as f:
+        f.write(b"foo")
+
+    output_file._mock_storage.seek(0)
+    assert output_file._mock_storage.read() == b"foo"
+
+
+def test_custom_file_io():
+
+    file_io = FooFileIO()
+    input_file = file_io.new_input()
+    output_file = file_io.new_output()
+
+    assert isinstance(input_file, FooInputFile)
+    assert isinstance(output_file, FooOutputFile)


### PR DESCRIPTION
**UPDATE**: This has been updated to only include the abstract base classes `FileIO`, `InputFile`, and `OutputFile`. The `S3FileIO` implementation can be opened in a follow-up PR.

---
This brings over the `FileIO` abstraction and includes an `S3FileIO` implementation. Implementing `FileIO` requires overriding the `__enter__()` and `__exit__()` methods where the `__enter__()` method sets a byte stream to `self.byte_stream`.

There's been a few discussions lately around file io and hopefully, this PR helps continue that. I think we should aim to maintain the file io abstraction for all file io operations (metadata files, manifest lists, manifest files, and data files) and allow the flexibility to plug in either an implementation that's packaged with the library or a custom implementation of FileIO that a user brings. An example of how we can do this can be found in PR #3677 in the [from_file()](https://github.com/apache/iceberg/pull/3677/files#diff-0a2dcd19c1079e50703f2010f74a47309468503f3ddd753db3aca9951364810fR261) method.

This still leaves an open question on how we manage dependencies for all of the implementations. For example, if a user does not plan on using `S3FileIO` or has their own s3 file io implementation that does not depend on boto3, it should not be forced as a hard dependency.