### PR TITLE
[SPARK] Make drop namespaces call respect CASCADE and IF EXISTS

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -393,10 +393,11 @@ public class SparkCatalog extends BaseCatalog {
         return false;
       }
 
-      // Recursively drop namespaces under the requested `namespace`
-      // so that the base case will delete the tables and then the namespace of those tables
-      // if the user used CASCADE. If the user did not use CASCADE, Spark will return false
-      // as soon as it encounters a non-empty namespace.
+      // Recursively drop namespaces under the requested `namespace so that:
+      //   1) query has CASCADE in it and thus the base case will delete the tables
+      //      and then the namespace of those tables
+      //   2) query does not have CASCADE in it, so Spark will throw
+      //      as soon as it encounters a non-empty namespace.
       for (String[] ns : subNamespaces) {
         try {
           boolean didDrop = dropNamespace(ns);

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -395,7 +395,7 @@ public class SparkCatalog extends BaseCatalog {
         throw new NoSuchNamespaceException(namespace);
       }
 
-      if (!exists && (subNamespaces == null || subNamespaces.length == 0)){
+      if (!exists && (subNamespaces == null || subNamespaces.length == 0)) {
         return false;
       }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.spark;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -369,15 +370,53 @@ public class SparkCatalog extends BaseCatalog {
   }
 
   @Override
+  // Spark assumes that catalogs CASCADE by default. So we have to eagerly
+  // attempt to drop namespaces and tables, but the CASCADE keyword is still
+  // required to actually drop tables and namespaces as Spark will error out
+  // if any of the recursive deletes are non-empty and the user didn't specify
+  // cascades in their query.
   public boolean dropNamespace(String[] namespace) throws NoSuchNamespaceException {
     if (asNamespaceCatalog != null) {
+      Namespace asNamespace = Namespace.of(namespace);
+      boolean exists = namespaceExists(namespace);
+
+      // Spark only throws the catalyst version of `NoSuchNamespaceException` if the namespace
+      // does not exist AND the user did not specify `IF EXISTS` in their query.
+      //
+      // If the namespace does not exist, but listNamespaces didn't throw an exception,
+      // we know the user used IF EXISTS and can return false early.
+      List<Namespace> subNamespaces;
       try {
-        return asNamespaceCatalog.dropNamespace(Namespace.of(namespace));
+        subNamespaces = asNamespaceCatalog.listNamespaces(asNamespace);
       } catch (org.apache.iceberg.exceptions.NoSuchNamespaceException e) {
         throw new NoSuchNamespaceException(namespace);
       }
-    }
 
+      if (!exists && subNamespaces.size() == 0) {
+        return false;
+      }
+
+      // Recursively drop namespaces under the requested `namespace`
+      // so that the base case will delete the tables and then the namespace of those tables
+      // if the user used CASCADE. If the user did not use CASCADE, Spark will return false
+      // as soon as it encounters a non-empty namespace.
+      for (Namespace ns : subNamespaces) {
+        try {
+          boolean didDrop = dropNamespace(ns.levels());
+          if (!didDrop) {
+            return false;
+          }
+        } catch (NoSuchNamespaceException e) {
+          // Spark says this sub-namespace doesn't exist. This is unlikely to happen as we just
+          // got it from a listing, but it could have been concurrently removed.
+          // In either case, the result is the same.
+        }
+      }
+
+      // Base case
+      Arrays.stream(listTables(namespace)).forEach(this::dropTable);
+      return asNamespaceCatalog.dropNamespace(asNamespace);
+    }
     return false;
   }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -377,6 +377,12 @@ public class SparkCatalog extends BaseCatalog {
       Namespace asNamespace = Namespace.of(namespace);
       boolean exists = namespaceExists(namespace);
 
+      // TODO - Follow up
+      //
+      // If not exists, we can eagerly try to drop the namespace.
+      // If it throws, then that means that the user did not use IF EXISTS.
+      // If it does not throw, we can return false early as the user must have used IF EXISTS.
+
       // Spark only throws the catalyst version of `NoSuchNamespaceException` if the namespace
       // does not exist AND the user did not specify `IF EXISTS` in their query.
       //

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
@@ -108,9 +108,9 @@ public class SparkSessionCatalog<T extends TableCatalog & SupportsNamespaces>
     // and Spark will handle things based on whether the query used IF EXISTS or CASCADE
     //
     // First check if the namespace exists.
-    //   - If it doesn't, we can try dropping it, with two possible outcomes:
-    //      1) throw a NoSuchNamespace exception, e.g. user did not use `IF EXISTS` when dropping
-    //      2) return false because the user used "IF EXISTS" in their drop statement.
+    //  - If it doesn't, we can try dropping it, with two possible outcomes:
+    //     1) throw a NoSuchNamespaceException - query did not use `IF EXISTS` when dropping
+    //     2) return false because the user used "IF EXISTS" in their drop statement.
     boolean doesNamespaceExist = namespaceExists(namespace);
     if (!doesNamespaceExist) {
       return getSessionCatalog().dropNamespace(namespace);

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
@@ -110,7 +110,7 @@ public class SparkSessionCatalog<T extends TableCatalog & SupportsNamespaces>
     // First check if the namespace exists.
     //  - If it doesn't, we can try dropping it, with two possible outcomes:
     //     1) throw a NoSuchNamespaceException - query did not use `IF EXISTS` when dropping
-    //     2) return false because the user used "IF EXISTS" in their drop statement.
+    //     2) return false - query did use `IF EXISTS` when dropping.
     boolean doesNamespaceExist = namespaceExists(namespace);
     if (!doesNamespaceExist) {
       return getSessionCatalog().dropNamespace(namespace);

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestNamespaceSQL.java
@@ -227,6 +227,12 @@ public class TestNamespaceSQL extends SparkCatalogTestBase {
         "Attempting to drop a non-existing namespace without IF EXISTS should throw",
         NoSuchNamespaceException.class, "not found",
         () -> sql("DROP NAMESPACE %s", NS));
+
+    sql("CREATE NAMESPACE %s", fullNamespace);
+    Assert.assertTrue("Namespace should exist", validationNamespaceCatalog.namespaceExists(NS));
+
+    sql("DROP NAMESPACE IF EXISTS %s", fullNamespace);
+    Assert.assertFalse("Namespace should no longer exist", validationNamespaceCatalog.namespaceExists(NS));
   }
 
   @Test


### PR DESCRIPTION
This closes issue https://github.com/apache/iceberg/issues/3541

Currently, `DROP NAMESPACE [IF EXISTS] {ns} [CASCADE]` does not work with Iceberg on Spark.

The Spark Catalog assumes that implementations will cascade by default. Currently, we don't do that, and so if users attempt to drop a namespace, they get a rather unhelpful error message.

```scala
scala> spark.sql("drop namespace iceberg.accounting cascade").show
org.apache.iceberg.exceptions.NamespaceNotEmptyException: Namespace accounting is not empty. One or more tables exist.
```

Relevant code in Spark can be seen here:
- The original PR that made this design shows that it's for performance - https://github.com/apache/spark/pull/26476.
- The actual Exec that is called: https://github.com/apache/spark/blob/06c09a79b371c5ac3e4ebad1118ed94b460f48d1/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/v2/DropNamespaceExec.scala
- Sample catalog source that is used in all of the tests in Spark that does have `cascade` in them (link to the `dropNamespace` function there) - https://github.com/apache/spark/blob/e99fdf9654481dd9b691a3c10e52f3f3db6ed2ba/sql/catalyst/src/test/scala/org/apache/spark/sql/connector/catalog/InMemoryTableCatalog.scala#L216-L224

I've added support for `CASCADE` and `IF EXISTS`, as well as tested `RESTRICT` (the default behavior).

There are unit tests to verify all of the new behavior.

I was also able to make the session catalog included in more unit tests with this change (as we're adhering more to the interface for the session catalog).


