### PR TITLE
Core: ensure Kryo serializability of MetricsConfig

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetricsConfig.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsConfig.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.SerializableMap;
 import org.apache.iceberg.util.SortOrderUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,13 +45,13 @@ public final class MetricsConfig implements Serializable {
   private static final Joiner DOT = Joiner.on('.');
 
   private static final MetricsConfig DEFAULT = new MetricsConfig(ImmutableMap.of(),
-          MetricsModes.fromString(DEFAULT_WRITE_METRICS_MODE_DEFAULT));
+      MetricsModes.fromString(DEFAULT_WRITE_METRICS_MODE_DEFAULT));
 
   private final Map<String, MetricsMode> columnModes;
   private final MetricsMode defaultMode;
 
   private MetricsConfig(Map<String, MetricsMode> columnModes, MetricsMode defaultMode) {
-    this.columnModes = ImmutableMap.copyOf(columnModes);
+    this.columnModes = SerializableMap.copyOf(columnModes).immutableMap();
     this.defaultMode = defaultMode;
   }
 


### PR DESCRIPTION
In #3638 , we improved `MetricsConfig` construction and marked it as immutable. As @aokolnychyi pointed out the class was used for serialization before we introduced `SerializableTable`. Although it is not likely that people are still serializing the metrics config, because it implements the `Serializable` interface, it's still safer to use `SerializableMap` instead of `ImmutableMap` for this to avoid any potential trouble.