### PR TITLE
Spark: Add register Truncate UDF

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/IcebergSpark.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/IcebergSpark.java
@@ -37,4 +37,12 @@ public class IcebergSpark {
     session.udf().register(funcName,
         value -> bucket.apply(SparkValueConverter.convert(sourceIcebergType, value)), DataTypes.IntegerType);
   }
+
+  public static void registerTruncateUDF(SparkSession session, String funcName, DataType sourceType, int width) {
+    SparkTypeToType typeConverter = new SparkTypeToType();
+    Type sourceIcebergType = typeConverter.atomic(sourceType);
+    Transform<Object, Object> truncate = Transforms.truncate(sourceIcebergType, width);
+    session.udf().register(funcName,
+        value -> truncate.apply(SparkValueConverter.convert(sourceIcebergType, value)), sourceType);
+  }
 }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSpark.java
@@ -185,4 +185,41 @@ public class TestIcebergSpark {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot bucket by type: float");
   }
+
+  @Test
+  public void testRegisterIntegerTruncateUDF() {
+    IcebergSpark.registerTruncateUDF(spark, "iceberg_truncate_int_4", DataTypes.IntegerType, 4);
+    List<Row> results = spark.sql("SELECT iceberg_truncate_int_4(1)").collectAsList();
+    Assert.assertEquals(1, results.size());
+    Assert.assertEquals(Transforms.truncate(Types.IntegerType.get(), 4).apply(1),
+        results.get(0).getInt(0));
+  }
+
+  @Test
+  public void testRegisterLongTruncateUDF() {
+    IcebergSpark.registerTruncateUDF(spark, "iceberg_truncate_long_4", DataTypes.LongType, 4);
+    List<Row> results = spark.sql("SELECT iceberg_truncate_long_4(1L)").collectAsList();
+    Assert.assertEquals(1, results.size());
+    Assert.assertEquals(Transforms.truncate(Types.LongType.get(), 4).apply(1L),
+        results.get(0).getLong(0));
+  }
+
+  @Test
+  public void testRegisterDecimalTruncateUDF() {
+    IcebergSpark.registerTruncateUDF(spark, "iceberg_truncate_decimal_4", new DecimalType(4, 2), 4);
+    List<Row> results =
+        spark.sql("SELECT iceberg_truncate_decimal_4(11.11)").collectAsList();
+    Assert.assertEquals(1, results.size());
+    Assert.assertEquals(Transforms.truncate(Types.DecimalType.of(4, 2), 4)
+        .apply(new BigDecimal("11.11")), results.get(0).getDecimal(0));
+  }
+
+  @Test
+  public void testRegisterStringTruncateUDF() {
+    IcebergSpark.registerTruncateUDF(spark, "iceberg_truncate_string_4", DataTypes.StringType, 4);
+    List<Row> results = spark.sql("SELECT iceberg_truncate_string_4('hello')").collectAsList();
+    Assert.assertEquals(1, results.size());
+    Assert.assertEquals(Transforms.truncate(Types.StringType.get(), 4).apply("hello"),
+        results.get(0).getString(0));
+  }
 }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWritesAsSelect.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestPartitionedWritesAsSelect.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.sql;
+
+import java.util.List;
+import java.util.stream.IntStream;
+import org.apache.iceberg.spark.IcebergSpark;
+import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
+import org.apache.spark.sql.types.DataTypes;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestPartitionedWritesAsSelect extends SparkTestBaseWithCatalog {
+
+  private final String targetTable = tableName("target_table");
+
+  @Before
+  public void createTables() {
+    sql("CREATE TABLE %s (id bigint, data string, category string, ts timestamp) USING iceberg", tableName);
+  }
+
+  @After
+  public void removeTables() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+    sql("DROP TABLE IF EXISTS %s", targetTable);
+  }
+
+  @Test
+  public void testInsertAsSelectAppend() {
+    insertData(3);
+    List<Object[]> expected = currentData();
+
+    sql("CREATE TABLE %s (id bigint, data string, category string, ts timestamp)" +
+        "USING iceberg PARTITIONED BY (days(ts), category)", targetTable);
+
+    sql("INSERT INTO %s SELECT id, data, category, ts FROM %s ORDER BY ts,category", targetTable, tableName);
+    Assert.assertEquals("Should have 15 rows after insert",
+        3 * 5L, scalarSql("SELECT count(*) FROM %s", targetTable));
+
+    assertEquals("Row data should match expected",
+        expected, sql("SELECT * FROM %s ORDER BY id", targetTable));
+  }
+
+  @Test
+  public void testInsertAsSelectWithBucket() {
+    insertData(3);
+    List<Object[]> expected = currentData();
+
+    sql("CREATE TABLE %s (id bigint, data string, category string, ts timestamp)" +
+        "USING iceberg PARTITIONED BY (bucket(8, data))", targetTable);
+
+    IcebergSpark.registerBucketUDF(spark, "iceberg_bucket8", DataTypes.StringType, 8);
+    sql("INSERT INTO %s SELECT id, data, category, ts FROM %s ORDER BY iceberg_bucket8(data)", targetTable, tableName);
+    Assert.assertEquals("Should have 15 rows after insert",
+        3 * 5L, scalarSql("SELECT count(*) FROM %s", targetTable));
+
+    assertEquals("Row data should match expected",
+        expected, sql("SELECT * FROM %s ORDER BY id", targetTable));
+  }
+
+  @Test
+  public void testInsertAsSelectWithTruncate() {
+    insertData(3);
+    List<Object[]> expected = currentData();
+
+    sql("CREATE TABLE %s (id bigint, data string, category string, ts timestamp)" +
+        "USING iceberg PARTITIONED BY (truncate(data, 4), truncate(id, 4))", targetTable);
+
+    IcebergSpark.registerTruncateUDF(spark, "iceberg_truncate_string4", DataTypes.StringType, 4);
+    IcebergSpark.registerTruncateUDF(spark, "iceberg_truncate_long4", DataTypes.LongType, 4);
+    sql("INSERT INTO %s SELECT id, data, category, ts FROM %s " +
+        "ORDER BY iceberg_truncate_string4(data),iceberg_truncate_long4(id)", targetTable, tableName);
+    Assert.assertEquals("Should have 15 rows after insert",
+        3 * 5L, scalarSql("SELECT count(*) FROM %s", targetTable));
+
+    assertEquals("Row data should match expected",
+        expected, sql("SELECT * FROM %s ORDER BY id", targetTable));
+  }
+
+  private void insertData(int repeatCounter) {
+    IntStream.range(0, repeatCounter).forEach(i -> {
+      sql("INSERT INTO %s VALUES (13, '1', 'bgd16', timestamp('2021-11-10 11:20:10'))," +
+          "(21, '2', 'bgd13', timestamp('2021-11-10 11:20:10')), " +
+          "(12, '3', 'bgd14', timestamp('2021-11-10 11:20:10'))," +
+          "(222, '3', 'bgd15', timestamp('2021-11-10 11:20:10'))," +
+          "(45, '4', 'bgd16', timestamp('2021-11-10 11:20:10'))", tableName);
+    });
+  }
+
+  private List<Object[]> currentData() {
+    return rowsToJava(spark.sql("SELECT * FROM " + tableName + " order by id").collectAsList());
+  }
+}


### PR DESCRIPTION
When writing to the partition table, we need to register the truncate transform function in Spark to specify it during sort.

issue: https://github.com/apache/iceberg/issues/3707

cc/ @rdblue @aokolnychyi  