### PR TITLE
Docs: add spark create clause CTAS/RTAS example

### DIFF
--- a/site/docs/spark-ddl.md
+++ b/site/docs/spark-ddl.md
@@ -104,6 +104,13 @@ USING iceberg
 AS SELECT ...
 ```
 ```sql
+REPLACE TABLE prod.db.sample
+USING iceberg
+PARTITIONED BY (part)
+TBLPROPERTIES ('key'='value')
+AS SELECT ...
+```
+```sql
 CREATE OR REPLACE TABLE prod.db.sample
 USING iceberg
 AS SELECT ...


### PR DESCRIPTION
Adds an example for specifying create clauses in a spark CTAS/RTAS DDL