### PR TITLE
[Flink] Update flink-runtime jar naming with flink version at the end (like we do with Spark)

### DIFF
--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -73,7 +73,7 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: ${{ runner.os }}-gradle
     - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-    - run: ./gradlew -DsparkVersions= -DhiveVersions= -DflinkVersions=${{ matrix.flink }} :iceberg-flink:iceberg-flink-${{ matrix.flink }}:check :iceberg-flink:iceberg-flink-${{ matrix.flink }}-runtime:check -Pquick=true -x javadoc
+    - run: ./gradlew -DsparkVersions= -DhiveVersions= -DflinkVersions=${{ matrix.flink }} :iceberg-flink:iceberg-flink-${{ matrix.flink }}:check :iceberg-flink:iceberg-flink-runtime-{{ matrix.flink }}:check -Pquick=true -x javadoc
     - uses: actions/upload-artifact@v2
       if: failure()
       with:

--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -73,7 +73,7 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
         restore-keys: ${{ runner.os }}-gradle
     - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-    - run: ./gradlew -DsparkVersions= -DhiveVersions= -DflinkVersions=${{ matrix.flink }} :iceberg-flink:iceberg-flink-${{ matrix.flink }}:check :iceberg-flink:iceberg-flink-runtime-{{ matrix.flink }}:check -Pquick=true -x javadoc
+    - run: ./gradlew -DsparkVersions= -DhiveVersions= -DflinkVersions=${{ matrix.flink }} :iceberg-flink:iceberg-flink-${{ matrix.flink }}:check :iceberg-flink:iceberg-flink-runtime-${{ matrix.flink }}:check -Pquick=true -x javadoc
     - uses: actions/upload-artifact@v2
       if: failure()
       with:

--- a/flink/v1.12/build.gradle
+++ b/flink/v1.12/build.gradle
@@ -19,7 +19,7 @@
 
 def flinkProjects = [
     project(':iceberg-flink:iceberg-flink-1.12'),
-    project(':iceberg-flink:iceberg-flink-1.12-runtime')
+    project(':iceberg-flink:iceberg-flink-runtime-1.12')
 ]
 
 configure(flinkProjects) {
@@ -118,7 +118,7 @@ project(':iceberg-flink:iceberg-flink-1.12') {
   }
 }
 
-project(':iceberg-flink:iceberg-flink-1.12-runtime') {
+project(':iceberg-flink:iceberg-flink-runtime-1.12') {
   apply plugin: 'com.github.johnrengelman.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar

--- a/flink/v1.13/build.gradle
+++ b/flink/v1.13/build.gradle
@@ -19,7 +19,7 @@
 
 def flinkProjects = [
   project(':iceberg-flink:iceberg-flink-1.13'),
-  project(':iceberg-flink:iceberg-flink-1.13-runtime')
+  project(':iceberg-flink:iceberg-flink-runtime-1.13')
 ]
 
 configure(flinkProjects) {
@@ -118,7 +118,7 @@ project(':iceberg-flink:iceberg-flink-1.13') {
   }
 }
 
-project(':iceberg-flink:iceberg-flink-1.13-runtime') {
+project(':iceberg-flink:iceberg-flink-runtime-1.13') {
   apply plugin: 'com.github.johnrengelman.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar

--- a/flink/v1.14/build.gradle
+++ b/flink/v1.14/build.gradle
@@ -19,7 +19,7 @@
 
 def flinkProjects = [
   project(':iceberg-flink:iceberg-flink-1.14'),
-  project(':iceberg-flink:iceberg-flink-1.14-runtime')
+  project(':iceberg-flink:iceberg-flink-runtime-1.14')
 ]
 
 configure(flinkProjects) {
@@ -116,7 +116,7 @@ project(':iceberg-flink:iceberg-flink-1.14') {
   }
 }
 
-project(':iceberg-flink:iceberg-flink-1.14-runtime') {
+project(':iceberg-flink:iceberg-flink-runtime-1.14') {
   apply plugin: 'com.github.johnrengelman.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar

--- a/settings.gradle
+++ b/settings.gradle
@@ -79,29 +79,29 @@ if (!flinkVersions.isEmpty()) {
 
 if (flinkVersions.contains("1.12")) {
   include ':iceberg-flink:flink-1.12'
-  include ':iceberg-flink:flink-1.12-runtime'
+  include ':iceberg-flink:flink-runtime-1.12'
   project(':iceberg-flink:flink-1.12').projectDir = file('flink/v1.12/flink')
   project(':iceberg-flink:flink-1.12').name = 'iceberg-flink-1.12'
-  project(':iceberg-flink:flink-1.12-runtime').projectDir = file('flink/v1.12/flink-runtime')
-  project(':iceberg-flink:flink-1.12-runtime').name = 'iceberg-flink-1.12-runtime'
+  project(':iceberg-flink:flink-runtime-1.12').projectDir = file('flink/v1.12/flink-runtime')
+  project(':iceberg-flink:flink-runtime-1.12').name = 'iceberg-flink-runtime-1.12'
 }
 
 if (flinkVersions.contains("1.13")) {
   include ':iceberg-flink:flink-1.13'
-  include ':iceberg-flink:flink-1.13-runtime'
+  include ':iceberg-flink:flink-runtime-1.13'
   project(':iceberg-flink:flink-1.13').projectDir = file('flink/v1.13/flink')
   project(':iceberg-flink:flink-1.13').name = 'iceberg-flink-1.13'
-  project(':iceberg-flink:flink-1.13-runtime').projectDir = file('flink/v1.13/flink-runtime')
-  project(':iceberg-flink:flink-1.13-runtime').name = 'iceberg-flink-1.13-runtime'
+  project(':iceberg-flink:flink-runtime-1.13').projectDir = file('flink/v1.13/flink-runtime')
+  project(':iceberg-flink:flink-runtime-1.13').name = 'iceberg-flink-runtime-1.13'
 }
 
 if (flinkVersions.contains("1.14")) {
   include ':iceberg-flink:flink-1.14'
-  include ':iceberg-flink:flink-1.14-runtime'
+  include ':iceberg-flink:flink-runtime-1.14'
   project(':iceberg-flink:flink-1.14').projectDir = file('flink/v1.14/flink')
   project(':iceberg-flink:flink-1.14').name = 'iceberg-flink-1.14'
-  project(':iceberg-flink:flink-1.14-runtime').projectDir = file('flink/v1.14/flink-runtime')
-  project(':iceberg-flink:flink-1.14-runtime').name = 'iceberg-flink-1.14-runtime'
+  project(':iceberg-flink:flink-runtime-1.14').projectDir = file('flink/v1.14/flink-runtime')
+  project(':iceberg-flink:flink-runtime-1.14').name = 'iceberg-flink-runtime-1.14'
 }
 
 if (sparkVersions.contains("3.0")) {


### PR DESCRIPTION
This PR changes the JAR / task names for different Flink versions, to have the version number at the very end.

This makes the jars alphabetically ordered and also places all words before version numbers.

This also is consistent with how we version our Spark runtime jars as of this PR: https://github.com/apache/iceberg/pull/3655

Current:    `iceberg-1.14-runtime`, `iceberg-1.13-runtime` and `iceberg-1.13`, etc.
Proposed: `iceberg-runtime-1.14`, `iceberg-runtime-1.13` and `iceberg-1.13`, etc.

cc @rdblue @stevenzwu @aokolnychyi @RussellSpitzer @openinx and I believe @wypoon handled the first version change for Spark.