### PR TITLE
Core: Commit state should be unknown even when new location is not in history

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -306,8 +306,8 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
             LOG.info("Commit status check: Commit to {} of {} succeeded", tableName(), newMetadataLocation);
             status.set(CommitStatus.SUCCESS);
           } else {
-            LOG.info("Commit status check: Commit to {} of {} failed", tableName(), newMetadataLocation);
-            status.set(CommitStatus.FAILURE);
+            LOG.warn("Commit status check: Commit to {} of {} unknown, new metadata location is not current " +
+                    "or in history", tableName(), newMetadataLocation);
           }
         });
 


### PR DESCRIPTION
This PR fixes an issue where a commit succeeds but its metadata file is deleted and table is corrupted.

Currently when there's an exception during commit, we refresh table and check commit state by looking at if the new metadata location matches current or in history, and commit state is Failure if not, and the current metadata file is deleted.
There's a possibility that when the check happens, the metadata remote server (e.g. Hive metastore) is still processing the commit and eventually succeed later, in this case, the commit(atomic location swap) succeeds but metadata file is deleted, and the table is in bad state.
The commit state should be considered as unknown to avoid metadata being deleted, also the error propagated to user is more accurate.