### PR TITLE
Spark: Support passing specific list of snapshot id for ExpireSnapshots procedure

### DIFF
--- a/site/docs/spark-procedures.md
+++ b/site/docs/spark-procedures.md
@@ -186,6 +186,8 @@ the `expire_snapshots` procedure will never remove files which are still require
 | `table`       | ✔️  | string | Name of the table to update |
 | `older_than`  | ️   | timestamp | Timestamp before which snapshots will be removed (Default: 5 days ago) |
 | `retain_last` |    | int       | Number of ancestor snapshots to preserve regardless of `older_than` (defaults to 1) |
+| `max_concurrent_deletes` |    | int       | Maximum number of threads in a pool used for delete executor service|
+| `snapshot_ids` |    | string       | Comma separated snapshot IDs to be expired |
 
 #### Output
 
@@ -207,6 +209,12 @@ Erase all snapshots older than the current timestamp but retain the last 5 snaps
 
 ```sql
 CALL hive_prod.system.expire_snapshots(table => 'db.sample', older_than => now(), retain_last => 5)
+```
+
+Remove specific snapshots which are passed as an argument:
+
+```sql
+CALL hive_prod.system.expire_snapshots(table => 'db.sample', snapshot_ids => '123456,234567')
 ```
 
 ### `remove_orphan_files`

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.spark.procedures;
 
+import java.util.Arrays;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -50,7 +51,8 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
       ProcedureParameter.required("table", DataTypes.StringType),
       ProcedureParameter.optional("older_than", DataTypes.TimestampType),
       ProcedureParameter.optional("retain_last", DataTypes.IntegerType),
-      ProcedureParameter.optional("max_concurrent_deletes", DataTypes.IntegerType)
+      ProcedureParameter.optional("max_concurrent_deletes", DataTypes.IntegerType),
+      ProcedureParameter.optional("snapshot_ids", DataTypes.StringType)
   };
 
   private static final StructType OUTPUT_TYPE = new StructType(new StructField[]{
@@ -88,6 +90,7 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
     Long olderThanMillis = args.isNullAt(1) ? null : DateTimeUtil.microsToMillis(args.getLong(1));
     Integer retainLastNum = args.isNullAt(2) ? null : args.getInt(2);
     Integer maxConcurrentDeletes = args.isNullAt(3) ? null : args.getInt(3);
+    String snapshotIds = args.isNullAt(4) ? null : args.getString(4);
 
     Preconditions.checkArgument(maxConcurrentDeletes == null || maxConcurrentDeletes > 0,
         "max_concurrent_deletes should have value > 0,  value: " + maxConcurrentDeletes);
@@ -105,6 +108,10 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
 
       if (maxConcurrentDeletes != null && maxConcurrentDeletes > 0) {
         action.executeDeleteWith(expireService(maxConcurrentDeletes));
+      }
+
+      if (snapshotIds != null &&  !snapshotIds.isEmpty()) {
+        Arrays.stream(snapshotIds.split(",")).forEach(id -> action.expireSnapshotId(Long.parseLong(id)));
       }
 
       ExpireSnapshots.Result result = action.execute();


### PR DESCRIPTION
ExpireSnapshot Action supports setting specific snapshots ids to expire, but it is missing in call procedure. Hence this PR.