### PR TITLE
Spark: support delete_reachable_files procedure

### DIFF
--- a/site/docs/spark-procedures.md
+++ b/site/docs/spark-procedures.md
@@ -240,6 +240,34 @@ Remove any files in the `tablelocation/data` folder which are not known to the t
 CALL catalog_name.system.remove_orphan_files(table => 'db.sample', location => 'tablelocation/data')
 ```
 
+### `delete_reachable_files`
+
+Used to delete all files referenced by a table metadata file. 
+This procedure will irreversibly delete all reachable files such as data files, manifests, manifest lists 
+and should be used to clean up the underlying storage once a table is dropped and no longer needed.
+
+#### Usage
+
+| Argument Name | Required? | Type | Description |
+|---------------|-----------|------|-------------|
+| `metadataFileLocation`       | ✔️  | string | Location of metadata file of dropped table (with purge = false) or the table which is no longer needed|
+
+#### Output
+
+| Output Name | Type | Description |
+| ------------|------|-------------|
+| `deleted_data_files_count` | long | Number of data files deleted by this operation |
+| `deleted_manifest_files_count` | long | Number of manifest files deleted by this operation |
+| `deleted_manifest_lists_count` | long | Number of manifest List files deleted by this operation |
+| `deleted_other_files_count` | long | Number of other files (metadata.json, version_hint.txt, etc..) deleted by this operation |
+
+#### Examples
+
+Delete all the reachable files for given metadata path:
+```sql
+CALL catalog_name.system.delete_reachable_files(metadataFileLocation => 'path-to-metadata-file')
+```
+
 ### `rewrite_data_files`
 
 Iceberg tracks each data file in a table. More data files leads to more metadata stored in manifest files, and small data files causes an unnecessary amount of metadata and less efficient queries from file open costs.

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDeleteReachableFilesProcedure.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDeleteReachableFilesProcedure.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.extensions;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.apache.iceberg.TableProperties.GC_ENABLED;
+
+public class TestDeleteReachableFilesProcedure extends SparkExtensionsTestBase {
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  public TestDeleteReachableFilesProcedure(String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
+  }
+
+  @Test
+  public void testDeleteReachableFilesInEmptyTable() throws IOException {
+    if (!createTable()) {
+      return;
+    }
+    Table table = catalog.loadTable(tableIdent);
+    String metadataFileLocation = metadataFileLocation(table);
+
+    catalog.dropTable(tableIdent, false);
+
+    List<Object[]> output = sql(
+        "CALL %s.system.delete_reachable_files('%s')",
+        catalogName, metadataFileLocation);
+    assertEquals("Should delete only other files (metadata json and version_hint file)",
+        ImmutableList.of(row(0L, 0L, 0L, 2L)), output);
+  }
+
+  @Test
+  public void testDeleteReachableFilesInDataFolder() throws IOException {
+    if (!createTable()) {
+      return;
+    }
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+
+    Table table = catalog.loadTable(tableIdent);
+    String metadataFileLocation = metadataFileLocation(table);
+
+    catalog.dropTable(tableIdent, false);
+
+    List<Object[]> output = sql(
+        "CALL %s.system.delete_reachable_files('%s')",
+        catalogName, metadataFileLocation);
+    assertEquals("Should delete expected number of files",
+        ImmutableList.of(row(2L, 2L, 2L, 4L)), output);
+  }
+
+  @Test
+  public void testDeleteReachableFilesGCDisabled() throws IOException {
+    if (!createTable()) {
+      return;
+    }
+    sql("ALTER TABLE %s SET TBLPROPERTIES ('%s' 'false')", tableName, GC_ENABLED);
+
+    Table table = catalog.loadTable(tableIdent);
+    String metadataFileLocation = metadataFileLocation(table);
+
+    catalog.dropTable(tableIdent, false);
+    AssertHelpers.assertThrows("Should reject call",
+        ValidationException.class, "Cannot remove files: GC is disabled",
+        () -> sql("CALL %s.system.delete_reachable_files('%s')", catalogName, metadataFileLocation));
+  }
+
+  private String metadataFileLocation(Table tbl) {
+    return ((HasTableOperations) tbl).operations().current().metadataFileLocation();
+  }
+
+  private boolean createTable() throws IOException {
+    if (catalogName.equals("testhadoop") || catalogName.equals("testhive")) {
+      // This procedure cannot work for hadoop catalog,
+      // as after drop table metadata file will be deleted (even with purge=false)
+      // For hive catalog, drop table with purge = true is not cleaning the table in metastore.
+      // Hence, table creation failing for second test case
+      return false;
+    }
+    // give a fresh location to Hive tables as Spark will not clean up the table location
+    // correctly while dropping tables through spark_catalog
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg LOCATION '%s'",
+            tableName, temp.newFolder());
+    return true;
+  }
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/DeleteReachableFilesProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/DeleteReachableFilesProcedure.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.procedures;
+
+import org.apache.iceberg.actions.DeleteReachableFiles;
+import org.apache.iceberg.spark.actions.SparkActions;
+import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * A procedure that deletes all reachable files for given metadata location.
+ *
+ * @see SparkActions#deleteReachableFiles(String)
+ */
+public class DeleteReachableFilesProcedure extends BaseProcedure {
+
+  private static final ProcedureParameter[] PARAMETERS = new ProcedureParameter[] {
+      ProcedureParameter.required("metadataFileLocation", DataTypes.StringType)
+  };
+
+  private static final StructType OUTPUT_TYPE = new StructType(new StructField[]{
+      new StructField("deleted_data_files_count", DataTypes.LongType, true, Metadata.empty()),
+      new StructField("deleted_manifest_files_count", DataTypes.LongType, true, Metadata.empty()),
+      new StructField("deleted_manifest_lists_count", DataTypes.LongType, true, Metadata.empty()),
+      new StructField("deleted_other_files_count", DataTypes.LongType, true, Metadata.empty())
+  });
+
+  public static ProcedureBuilder builder() {
+    return new Builder<DeleteReachableFilesProcedure>() {
+      @Override
+      protected DeleteReachableFilesProcedure doBuild() {
+        return new DeleteReachableFilesProcedure(tableCatalog());
+      }
+    };
+  }
+
+  private DeleteReachableFilesProcedure(TableCatalog catalog) {
+    super(catalog);
+  }
+
+  @Override
+  public ProcedureParameter[] parameters() {
+    return PARAMETERS;
+  }
+
+  @Override
+  public StructType outputType() {
+    return OUTPUT_TYPE;
+  }
+
+  @Override
+  public InternalRow[] call(InternalRow args) {
+    return toOutputRows(actions().deleteReachableFiles(args.getString(0)).execute());
+  }
+
+  private InternalRow[] toOutputRows(DeleteReachableFiles.Result result) {
+    InternalRow row = newInternalRow(
+        result.deletedDataFilesCount(),
+        result.deletedManifestsCount(),
+        result.deletedManifestListsCount(),
+        result.deletedOtherFilesCount()
+    );
+    return new InternalRow[]{row};
+  }
+
+  @Override
+  public String description() {
+    return "DeleteReachableFilesProcedure";
+  }
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
@@ -48,6 +48,7 @@ public class SparkProcedures {
     mapBuilder.put("rewrite_data_files", RewriteDataFilesProcedure::builder);
     mapBuilder.put("rewrite_manifests", RewriteManifestsProcedure::builder);
     mapBuilder.put("remove_orphan_files", RemoveOrphanFilesProcedure::builder);
+    mapBuilder.put("delete_reachable_files", DeleteReachableFilesProcedure::builder);
     mapBuilder.put("expire_snapshots", ExpireSnapshotsProcedure::builder);
     mapBuilder.put("migrate", MigrateTableProcedure::builder);
     mapBuilder.put("snapshot", SnapshotTableProcedure::builder);


### PR DESCRIPTION
All the spark actions should have call procedures for easy SQL access. We don't have the call procedure for delete_reachable_files. Hence the PR.