### PR TITLE
Spark 3.1: Backport SparkReadConf.streamingSkipDeleteSnapshots and read from timestamp changes

### DIFF
--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -48,14 +48,20 @@ public class SparkReadConf {
 
   private static final Set<String> LOCALITY_WHITELIST_FS = ImmutableSet.of("hdfs");
 
+  private final SparkSession spark;
   private final Table table;
   private final Map<String, String> readOptions;
   private final SparkConfParser confParser;
 
   public SparkReadConf(SparkSession spark, Table table, Map<String, String> readOptions) {
+    this.spark = spark;
     this.table = table;
     this.readOptions = readOptions;
     this.confParser = new SparkConfParser(spark, table, readOptions);
+  }
+
+  public boolean caseSensitive() {
+    return Boolean.parseBoolean(spark.conf().get("spark.sql.caseSensitive"));
   }
 
   public boolean localityEnabled() {
@@ -95,6 +101,13 @@ public class SparkReadConf {
     return confParser.longConf()
         .option(SparkReadOptions.END_SNAPSHOT_ID)
         .parseOptional();
+  }
+
+  public boolean streamingSkipDeleteSnapshots() {
+    return confParser.booleanConf()
+        .option(SparkReadOptions.STREAMING_SKIP_DELETE_SNAPSHOTS)
+        .defaultValue(SparkReadOptions.STREAMING_SKIP_DELETE_SNAPSHOTS_DEFAULT)
+        .parse();
   }
 
   public boolean parquetVectorizationEnabled() {
@@ -172,6 +185,13 @@ public class SparkReadConf {
         .option(SparkReadOptions.HANDLE_TIMESTAMP_WITHOUT_TIMEZONE)
         .sessionConf(SparkSQLProperties.HANDLE_TIMESTAMP_WITHOUT_TIMEZONE)
         .defaultValue(SparkSQLProperties.HANDLE_TIMESTAMP_WITHOUT_TIMEZONE_DEFAULT)
+        .parse();
+  }
+
+  public Long streamFromTimestamp() {
+    return confParser.longConf()
+        .option(SparkReadOptions.STREAM_FROM_TIMESTAMP)
+        .defaultValue(Long.MIN_VALUE)
         .parse();
   }
 }

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -48,20 +48,14 @@ public class SparkReadConf {
 
   private static final Set<String> LOCALITY_WHITELIST_FS = ImmutableSet.of("hdfs");
 
-  private final SparkSession spark;
   private final Table table;
   private final Map<String, String> readOptions;
   private final SparkConfParser confParser;
 
   public SparkReadConf(SparkSession spark, Table table, Map<String, String> readOptions) {
-    this.spark = spark;
     this.table = table;
     this.readOptions = readOptions;
     this.confParser = new SparkConfParser(spark, table, readOptions);
-  }
-
-  public boolean caseSensitive() {
-    return Boolean.parseBoolean(spark.conf().get("spark.sql.caseSensitive"));
   }
 
   public boolean localityEnabled() {

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java
@@ -59,10 +59,14 @@ public class SparkReadOptions {
 
   // skip snapshots of type delete while reading stream out of iceberg table
   public static final String STREAMING_SKIP_DELETE_SNAPSHOTS = "streaming-skip-delete-snapshots";
+  public static final boolean STREAMING_SKIP_DELETE_SNAPSHOTS_DEFAULT = false;
 
   // Controls whether to allow reading timestamps without zone info
   public static final String HANDLE_TIMESTAMP_WITHOUT_TIMEZONE = "handle-timestamp-without-timezone";
 
   // Controls whether to report locality information to Spark while allocating input partitions
   public static final String LOCALITY = "locality";
+
+  // Timestamp in milliseconds; start a stream from the snapshot that occurs after this timestamp
+  public static final String STREAM_FROM_TIMESTAMP = "stream-from-timestamp";
 }

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchScan.java
@@ -117,7 +117,7 @@ abstract class SparkBatchScan implements Scan, Batch, SupportsReportStatistics {
   @Override
   public MicroBatchStream toMicroBatchStream(String checkpointLocation) {
     return new SparkMicroBatchStream(
-        sparkContext, table, readConf, caseSensitive, expectedSchema, options, checkpointLocation);
+        sparkContext, table, readConf, caseSensitive, expectedSchema, checkpointLocation);
   }
 
   @Override

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -46,9 +46,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkReadConf;
-import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.spark.source.SparkBatchScan.ReadTask;
 import org.apache.iceberg.spark.source.SparkBatchScan.ReaderFactory;
 import org.apache.iceberg.util.SnapshotUtil;
@@ -61,7 +59,6 @@ import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.connector.read.PartitionReaderFactory;
 import org.apache.spark.sql.connector.read.streaming.MicroBatchStream;
 import org.apache.spark.sql.connector.read.streaming.Offset;
-import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,9 +76,10 @@ public class SparkMicroBatchStream implements MicroBatchStream {
   private final boolean localityPreferred;
   private final StreamingOffset initialOffset;
   private final boolean skipDelete;
+  private final Long fromTimestamp;
 
   SparkMicroBatchStream(JavaSparkContext sparkContext, Table table, SparkReadConf readConf, boolean caseSensitive,
-                        Schema expectedSchema, CaseInsensitiveStringMap options, String checkpointLocation) {
+                        Schema expectedSchema, String checkpointLocation) {
     this.table = table;
     this.caseSensitive = caseSensitive;
     this.expectedSchema = SchemaParser.toJson(expectedSchema);
@@ -90,21 +88,26 @@ public class SparkMicroBatchStream implements MicroBatchStream {
     this.splitSize = readConf.splitSize();
     this.splitLookback = readConf.splitLookback();
     this.splitOpenFileCost = readConf.splitOpenFileCost();
+    this.fromTimestamp = readConf.streamFromTimestamp();
 
-    InitialOffsetStore initialOffsetStore = new InitialOffsetStore(table, checkpointLocation);
+    InitialOffsetStore initialOffsetStore = new InitialOffsetStore(table, checkpointLocation, fromTimestamp);
     this.initialOffset = initialOffsetStore.initialOffset();
 
-    this.skipDelete = Spark3Util.propertyAsBoolean(options, SparkReadOptions.STREAMING_SKIP_DELETE_SNAPSHOTS, false);
+    this.skipDelete = readConf.streamingSkipDeleteSnapshots();
   }
 
   @Override
   public Offset latestOffset() {
     table.refresh();
-    Snapshot latestSnapshot = table.currentSnapshot();
-    if (latestSnapshot == null) {
+    if (isStreamEmpty(table)) {
       return StreamingOffset.START_OFFSET;
     }
 
+    if (isFutureStartTime(table, fromTimestamp)) {
+      return initialFutureStartOffset(table);
+    }
+
+    Snapshot latestSnapshot = table.currentSnapshot();
     return new StreamingOffset(latestSnapshot.snapshotId(), Iterables.size(latestSnapshot.addedFiles()), false);
   }
 
@@ -166,7 +169,7 @@ public class SparkMicroBatchStream implements MicroBatchStream {
   private List<FileScanTask> planFiles(StreamingOffset startOffset, StreamingOffset endOffset) {
     List<FileScanTask> fileScanTasks = Lists.newArrayList();
     StreamingOffset batchStartOffset = StreamingOffset.START_OFFSET.equals(startOffset) ?
-        new StreamingOffset(SnapshotUtil.oldestAncestor(table).snapshotId(), 0, false) :
+        new StreamingOffset(SnapshotUtil.firstSnapshotAfterTimestamp(table, fromTimestamp).snapshotId(), 0, false) :
         startOffset;
 
     StreamingOffset currentOffset = null;
@@ -197,31 +200,47 @@ public class SparkMicroBatchStream implements MicroBatchStream {
 
   private boolean shouldProcess(Snapshot snapshot) {
     String op = snapshot.operation();
-    switch (op) {
-      case DataOperations.APPEND:
-        return true;
-      case DataOperations.REPLACE:
-        return false;
-      case DataOperations.DELETE:
-        Preconditions.checkState(skipDelete,
-            "Cannot process delete snapshot : %s. Set read option %s to allow skipping snapshots of type delete",
-            snapshot.snapshotId(), SparkReadOptions.STREAMING_SKIP_DELETE_SNAPSHOTS);
-        return false;
-      default:
-        throw new IllegalStateException(String.format(
-            "Cannot process %s snapshot: %s", op.toLowerCase(Locale.ROOT), snapshot.snapshotId()));
+    Preconditions.checkState(!op.equals(DataOperations.DELETE) || skipDelete,
+        "Cannot process delete snapshot: %s", snapshot.snapshotId());
+    Preconditions.checkState(
+        op.equals(DataOperations.DELETE) || op.equals(DataOperations.APPEND) || op.equals(DataOperations.REPLACE),
+        "Cannot process %s snapshot: %s", op.toLowerCase(Locale.ROOT), snapshot.snapshotId());
+    return op.equals(DataOperations.APPEND);
+  }
+
+  private static boolean isStreamEmpty(Table table) {
+    return table.currentSnapshot() == null;
+  }
+
+  private static boolean isStreamNotEmpty(Table table) {
+    return table.currentSnapshot() != null;
+  }
+
+  private static boolean isFutureStartTime(Table table, Long streamStartTimeStampMillis) {
+    if (streamStartTimeStampMillis == null) {
+      return false;
     }
+
+    return table.currentSnapshot().timestampMillis() < streamStartTimeStampMillis;
+  }
+
+  private static StreamingOffset initialFutureStartOffset(Table table) {
+    Preconditions.checkNotNull(table, "Cannot process future start offset with invalid table input.");
+    Snapshot latestSnapshot = table.currentSnapshot();
+    return new StreamingOffset(latestSnapshot.snapshotId(), Iterables.size(latestSnapshot.addedFiles()) + 1, false);
   }
 
   private static class InitialOffsetStore {
     private final Table table;
     private final FileIO io;
     private final String initialOffsetLocation;
+    private final Long fromTimestamp;
 
-    InitialOffsetStore(Table table, String checkpointLocation) {
+    InitialOffsetStore(Table table, String checkpointLocation, Long fromTimestamp) {
       this.table = table;
       this.io = table.io();
       this.initialOffsetLocation = SLASH.join(checkpointLocation, "offsets/0");
+      this.fromTimestamp = fromTimestamp;
     }
 
     public StreamingOffset initialOffset() {
@@ -231,9 +250,11 @@ public class SparkMicroBatchStream implements MicroBatchStream {
       }
 
       table.refresh();
-      StreamingOffset offset = table.currentSnapshot() == null ?
-          StreamingOffset.START_OFFSET :
-          new StreamingOffset(SnapshotUtil.oldestAncestor(table).snapshotId(), 0, false);
+      StreamingOffset offset = StreamingOffset.START_OFFSET;
+      if (isStreamNotEmpty(table)) {
+        offset = isFutureStartTime(table, fromTimestamp) ? initialFutureStartOffset(table) :
+            new StreamingOffset(SnapshotUtil.firstSnapshotAfterTimestamp(table, fromTimestamp).snapshotId(), 0, false);
+      }
 
       OutputFile outputFile = io.newOutputFile(initialOffsetLocation);
       writeOffset(offset, outputFile);


### PR DESCRIPTION
Backport the following changes to Spark 3.1 runtime module:
- `SparkReadConf.streamingSkipDeleteSnapshots`.
- Read from timestamp changes (https://github.com/apache/iceberg/pull/3039).