### PR TITLE
Spark: Generate Spark's SQL literal format for binary and update the toString representation of binary/fixed literals.

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/Literals.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Literals.java
@@ -35,10 +35,12 @@ import java.util.Comparator;
 import java.util.Objects;
 import java.util.UUID;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ByteBuffers;
 import org.apache.iceberg.util.NaNUtil;
 
 class Literals {
@@ -599,6 +601,12 @@ class Literals {
     Object writeReplace() throws ObjectStreamException {
       return new SerializationProxies.FixedLiteralProxy(value());
     }
+
+    @Override
+    public String toString() {
+      byte[] bytes = ByteBuffers.toByteArray(value());
+      return "X'" + BaseEncoding.base16().encode(bytes) + "'";
+    }
   }
 
   static class BinaryLiteral extends BaseLiteral<ByteBuffer> {
@@ -638,6 +646,12 @@ class Literals {
     @Override
     protected Type.TypeID typeId() {
       return Type.TypeID.BINARY;
+    }
+
+    @Override
+    public String toString() {
+      byte[] bytes = ByteBuffers.toByteArray(value());
+      return "X'" + BaseEncoding.base16().encode(bytes) + "'";
     }
   }
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.spark;
 
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -48,6 +49,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.io.BaseEncoding;
 import org.apache.iceberg.spark.SparkTableUtil.SparkPartition;
 import org.apache.iceberg.spark.source.SparkTable;
 import org.apache.iceberg.transforms.PartitionSpecVisitor;
@@ -55,6 +57,7 @@ import org.apache.iceberg.transforms.SortOrderVisitor;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ByteBuffers;
 import org.apache.iceberg.util.Pair;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -596,6 +599,9 @@ public class Spark3Util {
     private static String sqlString(org.apache.iceberg.expressions.Literal<?> lit) {
       if (lit.value() instanceof String) {
         return "'" + lit.value() + "'";
+      } else if (lit.value() instanceof ByteBuffer) {
+        byte[] bytes = ByteBuffers.toByteArray((ByteBuffer) lit.value());
+        return "X'" + BaseEncoding.base16().encode(bytes) + "'";
       } else {
         return lit.value().toString();
       }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -598,7 +598,8 @@ public class Spark3Util {
       if (lit.value() instanceof String) {
         return "'" + lit.value() + "'";
       } else if (lit.value() instanceof ByteBuffer) {
-        throw new IllegalArgumentException("Cannot convert bytes to SQL literal: " + lit);
+        // produce a literal value that Spark can parse
+        return lit.toString();
       } else {
         return lit.value().toString();
       }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.spark;
 
-import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -597,9 +596,6 @@ public class Spark3Util {
     private static String sqlString(org.apache.iceberg.expressions.Literal<?> lit) {
       if (lit.value() instanceof String) {
         return "'" + lit.value() + "'";
-      } else if (lit.value() instanceof ByteBuffer) {
-        // produce a literal value that Spark can parse
-        return lit.toString();
       } else {
         return lit.value().toString();
       }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.spark;
 
+import java.lang.reflect.Array;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -118,6 +119,8 @@ public abstract class SparkTestBase {
             return row.getList(pos);
           } else if (value instanceof scala.collection.Map) {
             return row.getJavaMap(pos);
+          } else if (value instanceof byte[]) {
+            return IntStream.range(0, Array.getLength(value)).mapToObj(i -> Array.get(value, i)).toArray();
           } else {
             return value;
           }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.spark;
 
-import java.lang.reflect.Array;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -119,8 +118,6 @@ public abstract class SparkTestBase {
             return row.getList(pos);
           } else if (value instanceof scala.collection.Map) {
             return row.getJavaMap(pos);
-          } else if (value instanceof byte[]) {
-            return IntStream.range(0, Array.getLength(value)).mapToObj(i -> Array.get(value, i)).toArray();
           } else {
             return value;
           }
@@ -160,7 +157,11 @@ public abstract class SparkTestBase {
       Object actualValue = actualRow[col];
       if (expectedValue != null && expectedValue.getClass().isArray()) {
         String newContext = String.format("%s (nested col %d)", context, col + 1);
-        assertEquals(newContext, (Object[]) expectedValue, (Object[]) actualValue);
+        if (expectedValue instanceof byte[]) {
+          Assert.assertArrayEquals(newContext, (byte[]) expectedValue, (byte[]) actualValue);
+        } else {
+          assertEquals(newContext, (Object[]) expectedValue, (Object[]) actualValue);
+        }
       } else if (expectedValue != ANY) {
         Assert.assertEquals(context + " contents should match", expectedValue, actualValue);
       }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
@@ -210,7 +210,7 @@ public class TestSelect extends SparkCatalogTestBase {
   public void testBinaryInFilter() {
     sql("CREATE TABLE %s (id bigint, binary binary) USING iceberg", binaryTableName);
     sql("INSERT INTO %s VALUES (1, X''), (2, X'1111'), (3, X'11')", binaryTableName);
-    List<Object[]> expected = ImmutableList.of(row(2L, new Byte[]{0x11, 0x11}));
+    List<Object[]> expected = ImmutableList.of(row(2L, new byte[]{0x11, 0x11}));
 
     assertEquals("Should return all expected rows", expected,
         sql("SELECT id, binary FROM %s where binary > X'11'", binaryTableName));

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
@@ -40,6 +40,7 @@ import org.junit.Test;
 public class TestSelect extends SparkCatalogTestBase {
   private int scanEventCount = 0;
   private ScanEvent lastScanEvent = null;
+  private String binaryTableName = tableName("binary_table");
 
   public TestSelect(String catalogName, String implementation, Map<String, String> config) {
     super(catalogName, implementation, config);
@@ -63,6 +64,7 @@ public class TestSelect extends SparkCatalogTestBase {
   @After
   public void removeTables() {
     sql("DROP TABLE IF EXISTS %s", tableName);
+    sql("DROP TABLE IF EXISTS %s", binaryTableName);
   }
 
   @Test
@@ -202,5 +204,15 @@ public class TestSelect extends SparkCatalogTestBase {
             .load(tableName)
             .collectAsList();
         });
+  }
+
+  @Test
+  public void testBinaryInFilter() {
+    sql("CREATE TABLE %s (id bigint, binary binary) USING iceberg", binaryTableName);
+    sql("INSERT INTO %s VALUES (1, X''), (2, X'1111'), (3, X'11')", binaryTableName);
+    List<Object[]> expected = ImmutableList.of(row(2L, new Byte[]{0x11, 0x11}));
+
+    assertEquals("Should return all expected rows", expected,
+        sql("SELECT id, binary FROM %s where binary > X'11'", binaryTableName));
   }
 }


### PR DESCRIPTION
adds the ability to assert binary arrays for "assertEquals"  and  adds  iceberg hexadecimal text parsing

solve cannot convert bytes to SQL literal

cc/ @aokolnychyi  @rdblue 