### PR TITLE
slove the problem that unable to delete table files by hivecatalog

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/FileIO.java
+++ b/api/src/main/java/org/apache/iceberg/io/FileIO.java
@@ -47,6 +47,11 @@ public interface FileIO extends Serializable {
   void deleteFile(String path);
 
   /**
+   * Delete the directory at the given path.
+   */
+  void deleteDirectory(String path);
+
+  /**
    * Convenience method to {@link #deleteFile(String) delete} an {@link InputFile}.
    */
   default void deleteFile(InputFile file) {

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -92,6 +92,12 @@ public class S3FileIO implements FileIO {
     client().deleteObject(deleteRequest);
   }
 
+  @Override
+  public void deleteDirectory(String path) {
+    // TODO
+  }
+
+
   private S3Client client() {
     if (client == null) {
       client = s3.get();

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
@@ -76,6 +76,17 @@ public class HadoopFileIO implements FileIO, HadoopConfigurable {
   }
 
   @Override
+  public void deleteDirectory(String path) {
+    Path toDelete = new Path(path);
+    FileSystem fs = Util.getFs(toDelete, hadoopConf.get());
+    try {
+      fs.delete(toDelete, true /* recursive */);
+    } catch (IOException e) {
+      throw new RuntimeIOException(e, "Failed to delete directory: %s", path);
+    }
+  }
+
+  @Override
   public void setConf(Configuration conf) {
     this.hadoopConf = new SerializableConfiguration(conf)::get;
   }

--- a/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
@@ -322,6 +322,11 @@ public class TestCatalogUtil {
 
     }
 
+    @Override
+    public void deleteDirectory(String path) {
+
+    }
+
     public Configuration getConfiguration() {
       return configuration;
     }
@@ -346,6 +351,11 @@ public class TestCatalogUtil {
 
     @Override
     public void deleteFile(String path) {
+
+    }
+
+    @Override
+    public void deleteDirectory(String path) {
 
     }
 
@@ -379,6 +389,11 @@ public class TestCatalogUtil {
 
     @Override
     public void deleteFile(String path) {
+
+    }
+
+    @Override
+    public void deleteDirectory(String path) {
 
     }
 

--- a/core/src/test/java/org/apache/iceberg/TestTables.java
+++ b/core/src/test/java/org/apache/iceberg/TestTables.java
@@ -243,5 +243,34 @@ public class TestTables {
         throw new RuntimeIOException("Failed to delete file: " + path);
       }
     }
+
+    @Override
+    public void deleteDirectory(String path) {
+      try {
+        File file = new File(path);
+        if (file.isDirectory()) {
+          deleteDir(file);
+        } else {
+          throw new RuntimeException("Failed to delete as it isn't a directory");
+        }
+      } catch (Exception ex) {
+        throw new RuntimeException("Failed to delete directory.");
+      }
+    }
+
+    public boolean deleteDir(File file) {
+      boolean success = false;
+      if (file.isDirectory()) {
+        String[] children = file.list();
+        //递归删除目录中的子目录下
+        for (int i=0; i<children.length; i++) {
+          success = deleteDir(new File(file, children[i]));
+          if (!success) {
+            throw new RuntimeException("Failed to delete directory.");
+          }
+        }
+      }
+      return file.delete() ? true:false;
+    }
   }
 }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -166,7 +166,7 @@ public class HiveCatalog extends BaseMetastoreCatalog implements SupportsNamespa
       });
 
       if (!isExist) {
-        LOG.warn("Drop table: {}", identifier);
+        LOG.warn("Failed to drop: {}", identifier);
         throw new RuntimeException("Failed to drop " + identifier + " as the table doesn't exists in MetaStore.");
       }
 

--- a/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
+++ b/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
@@ -202,5 +202,35 @@ class TestTables {
         throw new RuntimeIOException("Failed to delete file: " + path);
       }
     }
+
+
+    @Override
+    public void deleteDirectory(String path) {
+      try {
+        File file = new File(path);
+        if (file.isDirectory()) {
+          deleteDir(file);
+        } else {
+          throw new RuntimeException("Failed to delete as it isn't a directory");
+        }
+      } catch (Exception ex) {
+        throw new RuntimeException("Failed to delete directory.");
+      }
+    }
+
+    public boolean deleteDir(File file) {
+      boolean success = false;
+      if (file.isDirectory()) {
+        String[] children = file.list();
+        //递归删除目录中的子目录下
+        for (int i=0; i<children.length; i++) {
+          success = deleteDir(new File(file, children[i]));
+          if (!success) {
+            throw new RuntimeException("Failed to delete directory.");
+          }
+        }
+      }
+      return file.delete() ? true:false;
+    }
   }
 }


### PR DESCRIPTION
Add the cleanTable in HiveCatalog to slove the problem that unable to delete table files when the table is already deleted in metastore. Then we don't need to delete the table files by hadoop command. It will fail for security if the table exists. 