### PR TITLE
Docs: Add stream-from-timestamp in spark-configuration.md

### DIFF
--- a/site/docs/spark-configuration.md
+++ b/site/docs/spark-configuration.md
@@ -155,7 +155,7 @@ spark.read
 | file-open-cost  | As per table property | Overrides this table's read.split.open-file-cost                                          |
 | vectorization-enabled  | As per table property | Overrides this table's read.parquet.vectorization.enabled                                          |
 | batch-size  | As per table property | Overrides this table's read.parquet.vectorization.batch-size                                          |
-| stream-from-timestamp | Long.MIN_VALUE | Timestamp in milliseconds, start streaming this table from the first snapshot that occurs at or after this timestamp |
+| stream-from-timestamp | Long.MIN_VALUE | Timestamp in milliseconds, start streaming this table from the first known ancestor snapshot that occurs at or after this timestamp. !!! Note If `stream-from-timestamp` is before the oldest ancestor snapshot in the table, the oldest ancestor will be used. |
 
 ### Write options
 

--- a/site/docs/spark-configuration.md
+++ b/site/docs/spark-configuration.md
@@ -155,7 +155,7 @@ spark.read
 | file-open-cost  | As per table property | Overrides this table's read.split.open-file-cost                                          |
 | vectorization-enabled  | As per table property | Overrides this table's read.parquet.vectorization.enabled                                          |
 | batch-size  | As per table property | Overrides this table's read.parquet.vectorization.batch-size                                          |
-| stream-from-timestamp | Long.MIN_VALUE | Timestamp in milliseconds, start streaming this table from the first known ancestor snapshot that occurs at or after this timestamp. !!! Note If `stream-from-timestamp` is before the oldest ancestor snapshot in the table, the oldest ancestor will be used. |
+| stream-from-timestamp | (stream from the oldest ancestor snapshot) | Timestamp in milliseconds, start streaming this table from the first known ancestor snapshot that occurs at or after this timestamp. !!! Note If `stream-from-timestamp` is before the oldest ancestor snapshot in the table, the oldest ancestor will be used. |
 
 ### Write options
 

--- a/site/docs/spark-configuration.md
+++ b/site/docs/spark-configuration.md
@@ -155,7 +155,7 @@ spark.read
 | file-open-cost  | As per table property | Overrides this table's read.split.open-file-cost                                          |
 | vectorization-enabled  | As per table property | Overrides this table's read.parquet.vectorization.enabled                                          |
 | batch-size  | As per table property | Overrides this table's read.parquet.vectorization.batch-size                                          |
-| stream-from-timestamp | (stream from the oldest ancestor snapshot) | Timestamp in milliseconds, start streaming this table from the first known ancestor snapshot that occurs at or after this timestamp. !!! Note If `stream-from-timestamp` is before the oldest ancestor snapshot in the table, the oldest ancestor will be used. |
+| stream-from-timestamp | (none) | A timestamp in milliseconds to stream from; if before the oldest known ancestor snapshot, the oldest will be used |
 
 ### Write options
 

--- a/site/docs/spark-configuration.md
+++ b/site/docs/spark-configuration.md
@@ -155,6 +155,7 @@ spark.read
 | file-open-cost  | As per table property | Overrides this table's read.split.open-file-cost                                          |
 | vectorization-enabled  | As per table property | Overrides this table's read.parquet.vectorization.enabled                                          |
 | batch-size  | As per table property | Overrides this table's read.parquet.vectorization.batch-size                                          |
+| stream-from-timestamp | Long.MIN_VALUE | Timestamp in milliseconds; start a stream from the snapshot that occurs after this timestamp. |
 
 ### Write options
 

--- a/site/docs/spark-configuration.md
+++ b/site/docs/spark-configuration.md
@@ -155,7 +155,7 @@ spark.read
 | file-open-cost  | As per table property | Overrides this table's read.split.open-file-cost                                          |
 | vectorization-enabled  | As per table property | Overrides this table's read.parquet.vectorization.enabled                                          |
 | batch-size  | As per table property | Overrides this table's read.parquet.vectorization.batch-size                                          |
-| stream-from-timestamp | Long.MIN_VALUE | Timestamp in milliseconds, start streaming this table from the first snapshot that occurs after this timestamp |
+| stream-from-timestamp | Long.MIN_VALUE | Timestamp in milliseconds, start streaming this table from the first snapshot that occurs at or after this timestamp |
 
 ### Write options
 

--- a/site/docs/spark-configuration.md
+++ b/site/docs/spark-configuration.md
@@ -155,7 +155,7 @@ spark.read
 | file-open-cost  | As per table property | Overrides this table's read.split.open-file-cost                                          |
 | vectorization-enabled  | As per table property | Overrides this table's read.parquet.vectorization.enabled                                          |
 | batch-size  | As per table property | Overrides this table's read.parquet.vectorization.batch-size                                          |
-| stream-from-timestamp | Long.MIN_VALUE | Timestamp in milliseconds; start a stream from the snapshot that occurs after this timestamp. |
+| stream-from-timestamp | Long.MIN_VALUE | Timestamp in milliseconds, start streaming this table from the first snapshot that occurs after this timestamp |
 
 ### Write options
 


### PR DESCRIPTION
Add `stream-from-timestamp` in `spark-configuration.md`.

Reference: [Code](https://github.com/apache/iceberg/blob/master/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java#L70-L71)