### PR TITLE
Core: Don't delete files during transaction commit when commit state is unknown

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -245,8 +245,10 @@ class BaseTransaction implements Transaction {
     // process has created the same table.
     try {
       ops.commit(null, current);
+
     } catch (CommitStateUnknownException e) {
       throw e;
+
     } catch (RuntimeException e) {
       // the commit failed and no files were committed. clean up each update.
       Tasks.foreach(updates)
@@ -256,13 +258,16 @@ class BaseTransaction implements Transaction {
               ((SnapshotProducer) update).cleanAll();
             }
           });
+
+      throw e;
+
+    } finally {
       // create table never needs to retry because the table has no previous state. because retries are not a
       // concern, it is safe to delete all of the deleted files from individual operations
       Tasks.foreach(deletedFiles)
           .suppressFailureWhenFinished()
           .onFailure((file, exc) -> LOG.warn("Failed to delete uncommitted file: {}", file, exc))
           .run(ops.io()::deleteFile);
-      throw e;
     }
   }
 
@@ -296,8 +301,10 @@ class BaseTransaction implements Transaction {
 
             underlyingOps.commit(base, current);
           });
+
     } catch (CommitStateUnknownException e) {
       throw e;
+
     } catch (RuntimeException e) {
       // the commit failed and no files were committed. clean up each update.
       Tasks.foreach(updates)
@@ -307,13 +314,16 @@ class BaseTransaction implements Transaction {
               ((SnapshotProducer) update).cleanAll();
             }
           });
+
+      throw e;
+
+    } finally {
       // replace table never needs to retry because the table state is completely replaced. because retries are not
       // a concern, it is safe to delete all of the deleted files from individual operations
       Tasks.foreach(deletedFiles)
           .suppressFailureWhenFinished()
           .onFailure((file, exc) -> LOG.warn("Failed to delete uncommitted file: {}", file, exc))
           .run(ops.io()::deleteFile);
-      throw e;
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -259,9 +259,9 @@ class BaseTransaction implements Transaction {
       // create table never needs to retry because the table has no previous state. because retries are not a
       // concern, it is safe to delete all of the deleted files from individual operations
       Tasks.foreach(deletedFiles)
-              .suppressFailureWhenFinished()
-              .onFailure((file, exc) -> LOG.warn("Failed to delete uncommitted file: {}", file, exc))
-              .run(ops.io()::deleteFile);
+          .suppressFailureWhenFinished()
+          .onFailure((file, exc) -> LOG.warn("Failed to delete uncommitted file: {}", file, exc))
+          .run(ops.io()::deleteFile);
       throw e;
     }
   }
@@ -310,9 +310,9 @@ class BaseTransaction implements Transaction {
       // replace table never needs to retry because the table state is completely replaced. because retries are not
       // a concern, it is safe to delete all of the deleted files from individual operations
       Tasks.foreach(deletedFiles)
-              .suppressFailureWhenFinished()
-              .onFailure((file, exc) -> LOG.warn("Failed to delete uncommitted file: {}", file, exc))
-              .run(ops.io()::deleteFile);
+          .suppressFailureWhenFinished()
+          .onFailure((file, exc) -> LOG.warn("Failed to delete uncommitted file: {}", file, exc))
+          .run(ops.io()::deleteFile);
       throw e;
     }
   }

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -362,8 +362,10 @@ class BaseTransaction implements Transaction {
             // fix up the snapshot log, which should not contain intermediate snapshots
             underlyingOps.commit(base, current);
           });
+
     } catch (CommitStateUnknownException e) {
       throw e;
+
     } catch (RuntimeException e) {
       // the commit failed and no files were committed. clean up each update.
       Tasks.foreach(updates)

--- a/core/src/test/java/org/apache/iceberg/TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TableTestBase.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -191,6 +192,10 @@ public class TableTestBase {
   List<File> listManifestFiles(File tableDirToList) {
     return Lists.newArrayList(new File(tableDirToList, "metadata").listFiles((dir, name) ->
         !name.startsWith("snap") && Files.getFileExtension(name).equalsIgnoreCase("avro")));
+  }
+
+  public static long countAllMetadataFiles(File tableDir) {
+    return Arrays.stream(new File(tableDir, "metadata").listFiles()).filter(f -> f.isFile()).count();
   }
 
   protected TestTables.TestTable create(Schema schema, PartitionSpec spec) {

--- a/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
@@ -431,7 +431,7 @@ public class TestReplaceTransaction extends TableTestBase {
     Assert.assertNotNull("Table should have a current snapshot", table.currentSnapshot());
     Assert.assertEquals("Schema should use new schema, not compatible with previous",
         schema.asStruct(), table.schema().asStruct());
-
+    Assert.assertEquals("Should have 4 files in metadata", 4, countAllMetadataFiles(tableDir));
     validateSnapshot(null, table.currentSnapshot(), FILE_B);
   }
 
@@ -468,7 +468,7 @@ public class TestReplaceTransaction extends TableTestBase {
     Assert.assertNotNull("Table metadata should be created after transaction commits", meta);
     Assert.assertEquals("Should have metadata version 0", 0, (int) TestTables.metadataVersion("test_append"));
     Assert.assertEquals("Should have 1 manifest file", 1, listManifestFiles(tableDir).size());
-
+    Assert.assertEquals("Should have 2 files in metadata", 2, countAllMetadataFiles(tableDir));
     Assert.assertEquals("Table schema should match with reassigned IDs", assignFreshIds(SCHEMA).asStruct(),
         meta.schema().asStruct());
     Assert.assertEquals("Table spec should match", unpartitioned(), meta.spec());

--- a/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.transforms.Transform;
@@ -380,6 +382,89 @@ public class TestReplaceTransaction extends TableTestBase {
         TestTables.metadataVersion("test_append"));
 
     replace.commitTransaction();
+
+    TableMetadata meta = TestTables.readMetadata("test_append");
+    Assert.assertNotNull("Table metadata should be created after transaction commits", meta);
+    Assert.assertEquals("Should have metadata version 0",
+        0, (int) TestTables.metadataVersion("test_append"));
+    Assert.assertEquals("Should have 1 manifest file",
+        1, listManifestFiles(tableDir).size());
+
+    Assert.assertEquals("Table schema should match with reassigned IDs",
+        assignFreshIds(SCHEMA).asStruct(), meta.schema().asStruct());
+    Assert.assertEquals("Table spec should match", unpartitioned(), meta.spec());
+    Assert.assertEquals("Table should have one snapshot", 1, meta.snapshots().size());
+
+    validateSnapshot(null, meta.currentSnapshot(), FILE_A, FILE_B);
+  }
+
+  @Test
+  public void testReplaceTransactionWithUnknownState() {
+    Schema newSchema = new Schema(
+        required(4, "id", Types.IntegerType.get()),
+        required(5, "data", Types.StringType.get()));
+
+    Snapshot start = table.currentSnapshot();
+    Schema schema = table.schema();
+
+    table.newAppend()
+        .appendFile(FILE_A)
+        .commit();
+
+    Assert.assertEquals("Version should be 1", 1L, (long) version());
+    validateSnapshot(start, table.currentSnapshot(), FILE_A);
+
+    TestTables.TestTableOperations ops = TestTables.opsWithCommitSucceedButStateUnknown(tableDir, "test");
+    Transaction replace = TestTables.beginReplace(tableDir, "test", newSchema, unpartitioned(),
+        SortOrder.unsorted(),  ImmutableMap.of(), ops);
+
+    replace.newAppend()
+        .appendFile(FILE_B)
+        .commit();
+
+    AssertHelpers.assertThrows("Transaction commit should fail with CommitStateUnknownException",
+        CommitStateUnknownException.class, "datacenter on fire", () -> replace.commitTransaction());
+
+    table.refresh();
+
+    Assert.assertEquals("Version should be 2", 2L, (long) version());
+    Assert.assertNotNull("Table should have a current snapshot", table.currentSnapshot());
+    Assert.assertEquals("Schema should use new schema, not compatible with previous",
+        schema.asStruct(), table.schema().asStruct());
+
+    validateSnapshot(null, table.currentSnapshot(), FILE_B);
+  }
+
+  @Test
+  public void testCreateTransactionWithUnknownState() throws IOException {
+    File tableDir = temp.newFolder();
+    Assert.assertTrue(tableDir.delete());
+
+    // this table doesn't exist.
+    TestTables.TestTableOperations ops = TestTables.opsWithCommitSucceedButStateUnknown(tableDir, "test_append");
+    Transaction replace = TestTables.beginReplace(tableDir, "test_append", SCHEMA, unpartitioned(),
+        SortOrder.unsorted(),  ImmutableMap.of(), ops);
+
+    Assert.assertNull("Starting a create transaction should not commit metadata",
+        TestTables.readMetadata("test_append"));
+    Assert.assertNull("Should have no metadata version",
+        TestTables.metadataVersion("test_append"));
+
+    Assert.assertTrue("Should return a transaction table",
+        replace.table() instanceof BaseTransaction.TransactionTable);
+
+    replace.newAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+
+    Assert.assertNull("Appending in a transaction should not commit metadata",
+        TestTables.readMetadata("test_append"));
+    Assert.assertNull("Should have no metadata version",
+        TestTables.metadataVersion("test_append"));
+
+    AssertHelpers.assertThrows("Transaction commit should fail with CommitStateUnknownException",
+        CommitStateUnknownException.class, "datacenter on fire", () -> replace.commitTransaction());
 
     TableMetadata meta = TestTables.readMetadata("test_append");
     Assert.assertNotNull("Table metadata should be created after transaction commits", meta);

--- a/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
@@ -416,22 +416,21 @@ public class TestReplaceTransaction extends TableTestBase {
 
     TestTables.TestTableOperations ops = TestTables.opsWithCommitSucceedButStateUnknown(tableDir, "test");
     Transaction replace = TestTables.beginReplace(tableDir, "test", newSchema, unpartitioned(),
-                                                  SortOrder.unsorted(),  ImmutableMap.of(), ops);
+        SortOrder.unsorted(),  ImmutableMap.of(), ops);
 
     replace.newAppend()
         .appendFile(FILE_B)
         .commit();
 
     AssertHelpers.assertThrows("Transaction commit should fail with CommitStateUnknownException",
-                               CommitStateUnknownException.class, "datacenter on fire",
-                               () -> replace.commitTransaction());
+        CommitStateUnknownException.class, "datacenter on fire", () -> replace.commitTransaction());
 
     table.refresh();
 
     Assert.assertEquals("Version should be 2", 2L, (long) version());
     Assert.assertNotNull("Table should have a current snapshot", table.currentSnapshot());
     Assert.assertEquals("Schema should use new schema, not compatible with previous",
-                        schema.asStruct(), table.schema().asStruct());
+        schema.asStruct(), table.schema().asStruct());
 
     validateSnapshot(null, table.currentSnapshot(), FILE_B);
   }
@@ -444,15 +443,13 @@ public class TestReplaceTransaction extends TableTestBase {
     // this table doesn't exist.
     TestTables.TestTableOperations ops = TestTables.opsWithCommitSucceedButStateUnknown(tableDir, "test_append");
     Transaction replace = TestTables.beginReplace(tableDir, "test_append", SCHEMA, unpartitioned(),
-        SortOrder.unsorted(),  ImmutableMap.of(), ops);
+        SortOrder.unsorted(), ImmutableMap.of(), ops);
 
     Assert.assertNull("Starting a create transaction should not commit metadata",
-                      TestTables.readMetadata("test_append"));
-    Assert.assertNull("Should have no metadata version",
-                      TestTables.metadataVersion("test_append"));
+        TestTables.readMetadata("test_append"));
+    Assert.assertNull("Should have no metadata version", TestTables.metadataVersion("test_append"));
 
-    Assert.assertTrue("Should return a transaction table",
-                      replace.table() instanceof BaseTransaction.TransactionTable);
+    Assert.assertTrue("Should return a transaction table", replace.table() instanceof BaseTransaction.TransactionTable);
 
     replace.newAppend()
         .appendFile(FILE_A)
@@ -465,8 +462,7 @@ public class TestReplaceTransaction extends TableTestBase {
                       TestTables.metadataVersion("test_append"));
 
     AssertHelpers.assertThrows("Transaction commit should fail with CommitStateUnknownException",
-                               CommitStateUnknownException.class, "datacenter on fire",
-                               () -> replace.commitTransaction());
+        CommitStateUnknownException.class, "datacenter on fire", () -> replace.commitTransaction());
 
     TableMetadata meta = TestTables.readMetadata("test_append");
     Assert.assertNotNull("Table metadata should be created after transaction commits", meta);
@@ -474,7 +470,7 @@ public class TestReplaceTransaction extends TableTestBase {
     Assert.assertEquals("Should have 1 manifest file", 1, listManifestFiles(tableDir).size());
 
     Assert.assertEquals("Table schema should match with reassigned IDs", assignFreshIds(SCHEMA).asStruct(),
-                        meta.schema().asStruct());
+        meta.schema().asStruct());
     Assert.assertEquals("Table spec should match", unpartitioned(), meta.spec());
     Assert.assertEquals("Table should have one snapshot", 1, meta.snapshots().size());
 

--- a/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
@@ -416,21 +416,22 @@ public class TestReplaceTransaction extends TableTestBase {
 
     TestTables.TestTableOperations ops = TestTables.opsWithCommitSucceedButStateUnknown(tableDir, "test");
     Transaction replace = TestTables.beginReplace(tableDir, "test", newSchema, unpartitioned(),
-        SortOrder.unsorted(),  ImmutableMap.of(), ops);
+                                                  SortOrder.unsorted(),  ImmutableMap.of(), ops);
 
     replace.newAppend()
         .appendFile(FILE_B)
         .commit();
 
     AssertHelpers.assertThrows("Transaction commit should fail with CommitStateUnknownException",
-        CommitStateUnknownException.class, "datacenter on fire", () -> replace.commitTransaction());
+                               CommitStateUnknownException.class, "datacenter on fire",
+                               () -> replace.commitTransaction());
 
     table.refresh();
 
     Assert.assertEquals("Version should be 2", 2L, (long) version());
     Assert.assertNotNull("Table should have a current snapshot", table.currentSnapshot());
     Assert.assertEquals("Schema should use new schema, not compatible with previous",
-        schema.asStruct(), table.schema().asStruct());
+                        schema.asStruct(), table.schema().asStruct());
 
     validateSnapshot(null, table.currentSnapshot(), FILE_B);
   }
@@ -446,12 +447,12 @@ public class TestReplaceTransaction extends TableTestBase {
         SortOrder.unsorted(),  ImmutableMap.of(), ops);
 
     Assert.assertNull("Starting a create transaction should not commit metadata",
-        TestTables.readMetadata("test_append"));
+                      TestTables.readMetadata("test_append"));
     Assert.assertNull("Should have no metadata version",
-        TestTables.metadataVersion("test_append"));
+                      TestTables.metadataVersion("test_append"));
 
     Assert.assertTrue("Should return a transaction table",
-        replace.table() instanceof BaseTransaction.TransactionTable);
+                      replace.table() instanceof BaseTransaction.TransactionTable);
 
     replace.newAppend()
         .appendFile(FILE_A)
@@ -459,22 +460,21 @@ public class TestReplaceTransaction extends TableTestBase {
         .commit();
 
     Assert.assertNull("Appending in a transaction should not commit metadata",
-        TestTables.readMetadata("test_append"));
+                      TestTables.readMetadata("test_append"));
     Assert.assertNull("Should have no metadata version",
-        TestTables.metadataVersion("test_append"));
+                      TestTables.metadataVersion("test_append"));
 
     AssertHelpers.assertThrows("Transaction commit should fail with CommitStateUnknownException",
-        CommitStateUnknownException.class, "datacenter on fire", () -> replace.commitTransaction());
+                               CommitStateUnknownException.class, "datacenter on fire",
+                               () -> replace.commitTransaction());
 
     TableMetadata meta = TestTables.readMetadata("test_append");
     Assert.assertNotNull("Table metadata should be created after transaction commits", meta);
-    Assert.assertEquals("Should have metadata version 0",
-        0, (int) TestTables.metadataVersion("test_append"));
-    Assert.assertEquals("Should have 1 manifest file",
-        1, listManifestFiles(tableDir).size());
+    Assert.assertEquals("Should have metadata version 0", 0, (int) TestTables.metadataVersion("test_append"));
+    Assert.assertEquals("Should have 1 manifest file", 1, listManifestFiles(tableDir).size());
 
-    Assert.assertEquals("Table schema should match with reassigned IDs",
-        assignFreshIds(SCHEMA).asStruct(), meta.schema().asStruct());
+    Assert.assertEquals("Table schema should match with reassigned IDs", assignFreshIds(SCHEMA).asStruct(),
+                        meta.schema().asStruct());
     Assert.assertEquals("Table spec should match", unpartitioned(), meta.spec());
     Assert.assertEquals("Table should have one snapshot", 1, meta.snapshots().size());
 

--- a/core/src/test/java/org/apache/iceberg/TestTables.java
+++ b/core/src/test/java/org/apache/iceberg/TestTables.java
@@ -21,7 +21,6 @@ package org.apache.iceberg;
 
 import java.io.File;
 import java.util.Map;
-import java.util.function.BiFunction;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
@@ -107,11 +106,6 @@ public class TestTables {
 
   public static TestTable load(File temp, String name) {
     TestTableOperations ops = new TestTableOperations(name, temp);
-    return new TestTable(ops, name);
-  }
-
-  public static TestTable load(File temp, String name, BiFunction<File, String, TestTableOperations> opsSupplier) {
-    TestTableOperations ops = opsSupplier.apply(temp, name);
     return new TestTable(ops, name);
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestTables.java
+++ b/core/src/test/java/org/apache/iceberg/TestTables.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 
 import java.io.File;
 import java.util.Map;
+import java.util.function.BiFunction;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
@@ -100,6 +101,11 @@ public class TestTables {
 
   public static TestTable load(File temp, String name) {
     TestTableOperations ops = new TestTableOperations(name, temp);
+    return new TestTable(ops, name);
+  }
+
+  public static TestTable load(File temp, String name, BiFunction<File, String, TestTableOperations> opsSupplier) {
+    TestTableOperations ops = opsSupplier.apply(temp, name);
     return new TestTable(ops, name);
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestTables.java
+++ b/core/src/test/java/org/apache/iceberg/TestTables.java
@@ -81,26 +81,25 @@ public class TestTables {
   }
 
   public static Transaction beginReplace(File temp, String name, Schema schema, PartitionSpec spec) {
-    return beginReplace(temp, name, schema, spec, SortOrder.unsorted(), ImmutableMap.of(), null);
+    return beginReplace(temp, name, schema, spec, SortOrder.unsorted(), ImmutableMap.of(),
+                        new TestTableOperations(name, temp));
   }
 
   public static Transaction beginReplace(File temp, String name, Schema schema, PartitionSpec spec,
       SortOrder sortOrder, Map<String, String> properties) {
-    return beginReplace(temp, name, schema, spec, sortOrder, properties, null);
+    return beginReplace(temp, name, schema, spec, sortOrder, properties, new TestTableOperations(name, temp));
   }
 
   public static Transaction beginReplace(File temp, String name, Schema schema, PartitionSpec spec,
                                          SortOrder sortOrder, Map<String, String> properties, TestTableOperations ops) {
-    TestTableOperations finalOps = ops != null ? ops : new TestTableOperations(name, temp);
-    TableMetadata current = finalOps.current();
-
+    TableMetadata current = ops.current();
     TableMetadata metadata;
     if (current != null) {
       metadata = current.buildReplacement(schema, spec, sortOrder, current.location(), properties);
-      return Transactions.replaceTableTransaction(name, finalOps, metadata);
+      return Transactions.replaceTableTransaction(name, ops, metadata);
     } else {
       metadata = newTableMetadata(schema, spec, sortOrder, temp.toString(), properties);
-      return Transactions.createTableTransaction(name, finalOps, metadata);
+      return Transactions.createTableTransaction(name, ops, metadata);
     }
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestTransaction.java
@@ -709,9 +709,11 @@ public class TestTransaction extends TableTestBase {
     transaction.newAppend()
         .appendFile(FILE_A)
         .commit();
-    AssertHelpers.assertThrows("Transaction commit should fail with CommitStateUnknownException",
-                               CommitStateUnknownException.class, "datacenter on fire",
-                               () -> transaction.commitTransaction());
+
+    AssertHelpers.assertThrows(
+        "Transaction commit should fail with CommitStateUnknownException",
+        CommitStateUnknownException.class, "datacenter on fire",
+        () -> transaction.commitTransaction());
 
     // Make sure metadata files still exist
     Snapshot current = table.currentSnapshot();

--- a/core/src/test/java/org/apache/iceberg/TestTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestTransaction.java
@@ -718,5 +718,6 @@ public class TestTransaction extends TableTestBase {
     List<ManifestFile> manifests = current.allManifests();
     Assert.assertEquals("Should have 1 manifest file", 1, manifests.size());
     Assert.assertTrue("Manifest file should exist", new File(manifests.get(0).path()).exists());
+    Assert.assertEquals("Should have 2 files in metadata", 2, countAllMetadataFiles(tableDir));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestTransaction.java
@@ -708,19 +708,19 @@ public class TestTransaction extends TableTestBase {
 
     // Create a table ops such that: the commit actually succeeds but it throws CommitStateUnknownException at the end
     BiFunction<File, String, TestTables.TestTableOperations> opsSupplier = (file, name) ->
-            new TestTables.TestTableOperations(name, file) {
-              @Override
-              public void commit(TableMetadata base, TableMetadata updatedMetadata) {
-                super.commit(base, updatedMetadata);
-                throw new CommitStateUnknownException(new RuntimeException(errorMsg));
-              }
-            };
+        new TestTables.TestTableOperations(name, file) {
+          @Override
+          public void commit(TableMetadata base, TableMetadata updatedMetadata) {
+            super.commit(base, updatedMetadata);
+            throw new CommitStateUnknownException(new RuntimeException(errorMsg));
+          }
+        };
     Table table = TestTables.load(tableDir, "test", opsSupplier);
 
     Transaction txn = table.newTransaction();
     txn.newAppend()
-            .appendFile(FILE_A)
-            .commit();
+        .appendFile(FILE_A)
+        .commit();
     try {
       txn.commitTransaction();
       Assert.fail("Transaction commit should have failed with CommitStateUnknownException");

--- a/core/src/test/java/org/apache/iceberg/TestTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestTransaction.java
@@ -710,7 +710,8 @@ public class TestTransaction extends TableTestBase {
         .appendFile(FILE_A)
         .commit();
     AssertHelpers.assertThrows("Transaction commit should fail with CommitStateUnknownException",
-        CommitStateUnknownException.class, "datacenter on fire", () -> transaction.commitTransaction());
+                               CommitStateUnknownException.class, "datacenter on fire",
+                               () -> transaction.commitTransaction());
 
     // Make sure metadata files still exist
     Snapshot current = table.currentSnapshot();


### PR DESCRIPTION
Deleting files when commit state is unknown can leave table in bad state, similar fixes have been there in some places some places like "SnapshotProducer.commit".