### PR TITLE
[SPARK] Backport SpakTestBaseWithCatalog to Spark 3.0 to simplify run…

### DIFF
--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkCatalogConfig.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkCatalogConfig.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark;
+
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+
+public enum SparkCatalogConfig {
+  HIVE("testhive", SparkCatalog.class.getName(), ImmutableMap.of(
+      "type", "hive",
+      "default-namespace", "default"
+  )),
+  HADOOP("testhadoop", SparkCatalog.class.getName(), ImmutableMap.of(
+      "type", "hadoop"
+  )),
+  SPARK("spark_catalog", SparkSessionCatalog.class.getName(), ImmutableMap.of(
+      "type", "hive",
+      "default-namespace", "default",
+      "parquet-enabled", "true",
+      "cache-enabled", "false" // Spark will delete tables using v1, leaving the cache out of sync
+  ));
+
+  private final String catalogName;
+  private final String implementation;
+  private final Map<String, String> properties;
+
+  SparkCatalogConfig(String catalogName, String implementation, Map<String, String> properties) {
+    this.catalogName = catalogName;
+    this.implementation = implementation;
+    this.properties = properties;
+  }
+
+  public String catalogName() {
+    return catalogName;
+  }
+
+  public String implementation() {
+    return implementation;
+  }
+
+  public Map<String, String> properties() {
+    return properties;
+  }
+}

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkCatalogTestBase.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkCatalogTestBase.java
@@ -19,91 +19,41 @@
 
 package org.apache.iceberg.spark;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.Map;
-import org.apache.iceberg.catalog.Catalog;
-import org.apache.iceberg.catalog.Namespace;
-import org.apache.iceberg.catalog.SupportsNamespaces;
-import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.hadoop.HadoopCatalog;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 @RunWith(Parameterized.class)
-public abstract class SparkCatalogTestBase extends SparkTestBase {
-  private static File warehouse = null;
+public abstract class SparkCatalogTestBase extends SparkTestBaseWithCatalog {
 
-  @BeforeClass
-  public static void createWarehouse() throws IOException {
-    SparkCatalogTestBase.warehouse = File.createTempFile("warehouse", null);
-    Assert.assertTrue(warehouse.delete());
-  }
-
-  @AfterClass
-  public static void dropWarehouse() {
-    if (warehouse != null && warehouse.exists()) {
-      warehouse.delete();
-    }
-  }
-
+  // these parameters are broken out to avoid changes that need to modify lots of test suites
   @Parameterized.Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
   public static Object[][] parameters() {
-    return new Object[][] {
-        { "testhive", SparkCatalog.class.getName(),
-          ImmutableMap.of(
-            "type", "hive",
-            "default-namespace", "default"
-         ) },
-        { "testhadoop", SparkCatalog.class.getName(),
-          ImmutableMap.of(
-            "type", "hadoop"
-        ) },
-        { "spark_catalog", SparkSessionCatalog.class.getName(),
-          ImmutableMap.of(
-            "type", "hive",
-            "default-namespace", "default",
-            "parquet-enabled", "true",
-            "cache-enabled", "false" // Spark will delete tables using v1, leaving the cache out of sync
-        ) }
-    };
+    return new Object[][] {{
+                               SparkCatalogConfig.HIVE.catalogName(),
+                               SparkCatalogConfig.HIVE.implementation(),
+                               SparkCatalogConfig.HIVE.properties()
+                           }, {
+                               SparkCatalogConfig.HADOOP.catalogName(),
+                               SparkCatalogConfig.HADOOP.implementation(),
+                               SparkCatalogConfig.HADOOP.properties()
+                           }, {
+                               SparkCatalogConfig.SPARK.catalogName(),
+                               SparkCatalogConfig.SPARK.implementation(),
+                               SparkCatalogConfig.SPARK.properties()
+                           }};
   }
 
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
 
-  protected final String catalogName;
-  protected final Catalog validationCatalog;
-  protected final SupportsNamespaces validationNamespaceCatalog;
-  protected final TableIdentifier tableIdent = TableIdentifier.of(Namespace.of("default"), "table");
-  protected final String tableName;
-
-  public SparkCatalogTestBase(String catalogName, String implementation, Map<String, String> config) {
-    this.catalogName = catalogName;
-    this.validationCatalog = catalogName.equals("testhadoop") ?
-        new HadoopCatalog(spark.sessionState().newHadoopConf(), "file:" + warehouse) :
-        catalog;
-    this.validationNamespaceCatalog = (SupportsNamespaces) validationCatalog;
-
-    spark.conf().set("spark.sql.catalog." + catalogName, implementation);
-    config.forEach((key, value) -> spark.conf().set("spark.sql.catalog." + catalogName + "." + key, value));
-
-    if (config.get("type").equalsIgnoreCase("hadoop")) {
-      spark.conf().set("spark.sql.catalog." + catalogName + ".warehouse", "file:" + warehouse);
-    }
-
-    this.tableName = (catalogName.equals("spark_catalog") ? "" : catalogName + ".") + "default.table";
-
-    sql("CREATE NAMESPACE IF NOT EXISTS default");
+  public SparkCatalogTestBase(SparkCatalogConfig config) {
+    super(config);
   }
 
-  protected String tableName(String name) {
-    return (catalogName.equals("spark_catalog") ? "" : catalogName + ".") + "default." + name;
+  public SparkCatalogTestBase(String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
   }
 }

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+public abstract class SparkTestBaseWithCatalog extends SparkTestBase {
+  private static File warehouse = null;
+
+  @BeforeClass
+  public static void createWarehouse() throws IOException {
+    SparkTestBaseWithCatalog.warehouse = File.createTempFile("warehouse", null);
+    Assert.assertTrue(warehouse.delete());
+  }
+
+  @AfterClass
+  public static void dropWarehouse() {
+    if (warehouse != null && warehouse.exists()) {
+      warehouse.delete();
+    }
+  }
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  protected final String catalogName;
+  protected final Catalog validationCatalog;
+  protected final SupportsNamespaces validationNamespaceCatalog;
+  protected final TableIdentifier tableIdent = TableIdentifier.of(Namespace.of("default"), "table");
+  protected final String tableName;
+
+  public SparkTestBaseWithCatalog() {
+    this(SparkCatalogConfig.HADOOP);
+  }
+
+  public SparkTestBaseWithCatalog(SparkCatalogConfig config) {
+    this(config.catalogName(), config.implementation(), config.properties());
+  }
+
+  public SparkTestBaseWithCatalog(String catalogName, String implementation, Map<String, String> config) {
+    this.catalogName = catalogName;
+    this.validationCatalog = catalogName.equals("testhadoop") ?
+        new HadoopCatalog(spark.sessionState().newHadoopConf(), "file:" + warehouse) :
+        catalog;
+    this.validationNamespaceCatalog = (SupportsNamespaces) validationCatalog;
+
+    spark.conf().set("spark.sql.catalog." + catalogName, implementation);
+    config.forEach((key, value) -> spark.conf().set("spark.sql.catalog." + catalogName + "." + key, value));
+
+    if (config.get("type").equalsIgnoreCase("hadoop")) {
+      spark.conf().set("spark.sql.catalog." + catalogName + ".warehouse", "file:" + warehouse);
+    }
+
+    this.tableName = (catalogName.equals("spark_catalog") ? "" : catalogName + ".") + "default.table";
+
+    sql("CREATE NAMESPACE IF NOT EXISTS default");
+  }
+
+  protected String tableName(String name) {
+    return (catalogName.equals("spark_catalog") ? "" : catalogName + ".") + "default." + name;
+  }
+}


### PR DESCRIPTION
…ning tests with only one catalog

This backports https://github.com/apache/iceberg/pull/3549 to Spark 3.0.

This is needed so that https://github.com/apache/iceberg/pull/3735 can be reviewed, as it uses `SparkTestBaseWithCatalog`.

cc @rdblue @jackye1995 