### PR TITLE
[Flink] fix data overflow while convert Integer to Long 

### DIFF
--- a/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/data/FlinkValueWriters.java
+++ b/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/data/FlinkValueWriters.java
@@ -109,7 +109,7 @@ public class FlinkValueWriters {
 
     @Override
     public void write(Integer timeMills, Encoder encoder) throws IOException {
-      encoder.writeLong(timeMills * 1000);
+      encoder.writeLong(timeMills * 1000L);
     }
   }
 

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/data/FlinkValueWriters.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/data/FlinkValueWriters.java
@@ -109,7 +109,7 @@ public class FlinkValueWriters {
 
     @Override
     public void write(Integer timeMills, Encoder encoder) throws IOException {
-      encoder.writeLong(timeMills * 1000);
+      encoder.writeLong(timeMills * 1000L);
     }
   }
 

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/data/FlinkValueWriters.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/data/FlinkValueWriters.java
@@ -109,7 +109,7 @@ public class FlinkValueWriters {
 
     @Override
     public void write(Integer timeMills, Encoder encoder) throws IOException {
-      encoder.writeLong(timeMills * 1000);
+      encoder.writeLong(timeMills * 1000L);
     }
   }
 


### PR DESCRIPTION
1. What this MR does ?
    Fix data overflow while writing data whose type is java.sql.Time.
2. CHANGELOG
    Flink version: 1.12, 1.13, 1.14
    function: org.apache.iceberg.flink.data.FlinkValueWriters.TimeMicrosWriter#write

@openinx @JingsongLi Please help to confirm this Problem. Thanks very much.