### PR TITLE
Push down partition filter to Spark when Importing File Based Tables

### DIFF
--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
@@ -42,6 +42,7 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -359,6 +360,25 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
     assertEquals("Iceberg table contains correct data",
         sql("SELECT id, name, dept, subdept FROM %s WHERE id = 1 ORDER BY id", sourceTableName),
         sql("SELECT id, name, dept, subdept FROM %s ORDER BY id", tableName));
+  }
+
+  @Test
+  public void addDataPartitionedByDateToPartitioned() {
+    createDatePartitionedFileTable("parquet");
+
+    String createIceberg =
+        "CREATE TABLE %s (id Integer, name String, dept String, date Date) USING iceberg PARTITIONED BY (date)";
+
+    sql(createIceberg, tableName);
+
+    Object result = scalarSql("CALL %s.system.add_files('%s', '`parquet`.`%s`', map('date', '2021-01-01'))",
+        catalogName, tableName, fileTableDir.getAbsolutePath());
+
+    Assert.assertEquals(2L, result);
+
+    assertEquals("Iceberg table contains correct data",
+        sql("SELECT id, name, dept, date FROM %s WHERE date = '2021-01-01' ORDER BY id", sourceTableName),
+        sql("SELECT id, name, dept, date FROM %s ORDER BY id", tableName));
   }
 
   @Test
@@ -779,6 +799,25 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
           unpartitionedDF.col("dept"),
           unpartitionedDF.col("name").as("naMe"));
 
+  private static final StructField[] dateStruct = {
+      new StructField("id", DataTypes.IntegerType, true, Metadata.empty()),
+      new StructField("name", DataTypes.StringType, true, Metadata.empty()),
+      new StructField("dept", DataTypes.StringType, true, Metadata.empty()),
+      new StructField("ts", DataTypes.DateType, true, Metadata.empty())
+  };
+
+  private static java.sql.Date toDate(String value) {
+    return new java.sql.Date(DateTime.parse(value).getMillis());
+  }
+
+  private static final Dataset<Row> dateDF =
+      spark.createDataFrame(
+          ImmutableList.of(
+              RowFactory.create(1, "John Doe", "hr", toDate("2021-01-01")),
+              RowFactory.create(2, "Jane Doe", "hr", toDate("2021-01-01")),
+              RowFactory.create(3, "Matt Doe", "hr", toDate("2021-01-02")),
+              RowFactory.create(4, "Will Doe", "facilities", toDate("2021-01-02"))),
+          new StructType(dateStruct)).repartition(2);
 
   private void  createUnpartitionedFileTable(String format) {
     String createParquet =
@@ -851,5 +890,14 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
 
     partitionedDF.write().insertInto(sourceTableName);
     partitionedDF.write().insertInto(sourceTableName);
+  }
+
+  private void  createDatePartitionedFileTable(String format) {
+    String createParquet = "CREATE TABLE %s (id Integer, name String, dept String, date Date) USING %s " +
+        "PARTITIONED BY (date) LOCATION '%s'";
+
+    sql(createParquet, sourceTableName, format, fileTableDir.getAbsolutePath());
+
+    dateDF.write().insertInto(sourceTableName);
   }
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -751,7 +751,7 @@ public class Spark3Util {
    * @param partitionFilter partitionFilter of the file
    * @return all table's partitions
    */
-  public static List<SparkPartition> getPartitions(SparkSession spark, String tableName, Path rootPath, String format,
+  public static List<SparkPartition> getPartitions(SparkSession spark, Path rootPath, String format,
                                                    Map<String, String> partitionFilter) {
     FileStatusCache fileStatusCache = FileStatusCache.getOrCreate(spark);
     Map<String, String> emptyMap = Collections.emptyMap();
@@ -778,7 +778,7 @@ public class Spark3Util {
     }
 
     List<org.apache.spark.sql.catalyst.expressions.Expression> filterExpressions =
-        SparkUtil.getSparkFilterExpressions(schema, partitionFilter);
+        SparkUtil.partitionMapToExpression(schema, partitionFilter);
     Seq<org.apache.spark.sql.catalyst.expressions.Expression> scalaPartitionFilters =
         JavaConverters.asScalaBufferConverter(filterExpressions).asScala().toSeq();
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.spark;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -762,19 +762,19 @@ public class Spark3Util {
     Map<String, String> emptyMap = Collections.emptyMap();
 
     InMemoryFileIndex fileIndex = new InMemoryFileIndex(
-            spark,
-            JavaConverters
-                .collectionAsScalaIterableConverter(ImmutableList.of(rootPath))
-                .asScala()
-                .toSeq(),
-            JavaConverters
-                .mapAsScalaMapConverter(emptyMap)
-                .asScala()
-                .toMap(Predef.conforms()),
-            Option.empty(),
-            fileStatusCache,
-            Option.empty(),
-            Option.empty());
+        spark,
+        JavaConverters
+            .collectionAsScalaIterableConverter(ImmutableList.of(rootPath))
+            .asScala()
+            .toSeq(),
+        JavaConverters
+            .mapAsScalaMapConverter(emptyMap)
+            .asScala()
+            .toMap(Predef.conforms()),
+        Option.empty(),
+        fileStatusCache,
+        Option.empty(),
+        Option.empty());
 
     org.apache.spark.sql.execution.datasources.PartitionSpec spec = fileIndex.partitionSpec();
     StructType schema = spec.partitionColumns();

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -808,8 +808,8 @@ public class Spark3Util {
         }).collect(Collectors.toList());
   }
 
-  private static List getPartitionFilterExpressions(SparkSession spark, String tableName,
-                                                    Map<String, String> partitionFilter) {
+  private static List<org.apache.spark.sql.catalyst.expressions.Expression> getPartitionFilterExpressions(
+      SparkSession spark, String tableName, Map<String, String> partitionFilter) {
     List<org.apache.spark.sql.catalyst.expressions.Expression> filterExpressions = Lists.newArrayList();
     for (Map.Entry<String, String> entry : partitionFilter.entrySet()) {
       String filter = entry.getKey() + " = '" + entry.getValue() + "'";
@@ -818,11 +818,12 @@ public class Spark3Util {
             SparkExpressionConverter.collectResolvedSparkExpression(spark, tableName, filter);
         filterExpressions.add(expression);
       } catch (AnalysisException e) {
-        // ignore if filter cannot be converted to Spark expression
+        throw new IllegalArgumentException("filter " + filter + " cannot be converted to Spark expression");
       }
     }
     return filterExpressions;
   }
+
   public static org.apache.spark.sql.catalyst.TableIdentifier toV1TableIdentifier(Identifier identifier) {
     String[] namespace = identifier.namespace();
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
@@ -19,7 +19,10 @@
 
 package org.apache.iceberg.spark;
 
+import java.sql.Date;
+import java.sql.Timestamp;
 import java.util.List;
+import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -31,6 +34,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.hadoop.HadoopConfigurable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.transforms.UnknownTransform;
 import org.apache.iceberg.types.TypeUtil;
@@ -38,7 +42,15 @@ import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.Pair;
 import org.apache.spark.sql.RuntimeConfig;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.expressions.BoundReference;
+import org.apache.spark.sql.catalyst.expressions.EqualTo;
+import org.apache.spark.sql.catalyst.expressions.Expression;
+import org.apache.spark.sql.catalyst.expressions.Literal;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
 import org.apache.spark.util.SerializableConfiguration;
+import org.joda.time.DateTime;
 
 public class SparkUtil {
 
@@ -178,5 +190,64 @@ public class SparkUtil {
 
   private static String hadoopConfPrefixForCatalog(String catalogName) {
     return String.format(SPARK_CATALOG_HADOOP_CONF_OVERRIDE_FMT_STR, catalogName);
+  }
+
+  /**
+   * Get a List of Spark filter Expression.
+   *
+   * @param schema table schema
+   * @param filters filters in the format of a Map, where key is one of the table column name,
+   *                and value is the specific value to be filtered on the column.
+   * @return a List of filters in the format of Spark Expression.
+   */
+  public static List getSparkFilterExpressions(StructType schema,
+                                               Map<String, String> filters) {
+    List<Expression> filterExpressions = Lists.newArrayList();
+    for (Map.Entry<String, String> entry : filters.entrySet()) {
+      try {
+        int index = schema.fieldIndex(entry.getKey());
+        DataType dataType = schema.fields()[index].dataType();
+        BoundReference ref = new BoundReference(index, dataType, true);
+        switch (dataType.typeName()) {
+          case "integer":
+            filterExpressions.add(new EqualTo(ref,
+                Literal.create(Integer.parseInt(entry.getValue()), DataTypes.IntegerType)));
+            break;
+          case "string":
+            filterExpressions.add(new EqualTo(ref, Literal.create(entry.getValue(), DataTypes.StringType)));
+            break;
+          case "short":
+            filterExpressions.add(new EqualTo(ref,
+                Literal.create(Short.parseShort(entry.getValue()), DataTypes.ShortType)));
+            break;
+          case "long":
+            filterExpressions.add(new EqualTo(ref,
+                Literal.create(Long.parseLong(entry.getValue()), DataTypes.LongType)));
+            break;
+          case "float":
+            filterExpressions.add(new EqualTo(ref,
+                Literal.create(Float.parseFloat(entry.getValue()), DataTypes.FloatType)));
+            break;
+          case "double":
+            filterExpressions.add(new EqualTo(ref,
+                Literal.create(Double.parseDouble(entry.getValue()), DataTypes.DoubleType)));
+            break;
+          case "date":
+            filterExpressions.add(new EqualTo(ref,
+                Literal.create(new Date(DateTime.parse(entry.getValue()).getMillis()), DataTypes.DateType)));
+            break;
+          case "timestamp":
+            filterExpressions.add(new EqualTo(ref,
+                Literal.create(new Timestamp(DateTime.parse(entry.getValue()).getMillis()), DataTypes.TimestampType)));
+            break;
+          default:
+            throw new IllegalStateException("Unexpected data type in partition filters: " + dataType);
+        }
+      } catch (IllegalArgumentException e) {
+        // ignore if filter is not on table columns
+      }
+    }
+
+    return filterExpressions;
   }
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkUtil.java
@@ -200,8 +200,8 @@ public class SparkUtil {
    *                and value is the specific value to be filtered on the column.
    * @return a List of filters in the format of Spark Expression.
    */
-  public static List getSparkFilterExpressions(StructType schema,
-                                               Map<String, String> filters) {
+  public static List<Expression> partitionMapToExpression(StructType schema,
+                                                          Map<String, String> filters) {
     List<Expression> filterExpressions = Lists.newArrayList();
     for (Map.Entry<String, String> entry : filters.entrySet()) {
       try {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
@@ -160,7 +160,7 @@ class AddFilesProcedure extends BaseProcedure {
                                boolean checkDuplicateFiles) {
     // List Partitions via Spark InMemory file search interface
     List<SparkPartition> partitions =
-        Spark3Util.getPartitions(spark(), table.name(), tableLocation, format, partitionFilter);
+        Spark3Util.getPartitions(spark(), tableLocation, format, partitionFilter);
 
     if (table.spec().isUnpartitioned()) {
       Preconditions.checkArgument(partitions.isEmpty(), "Cannot add partitioned files to an unpartitioned table");

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
@@ -172,7 +172,7 @@ class AddFilesProcedure extends BaseProcedure {
       importPartitions(table, ImmutableList.of(partition), checkDuplicateFiles);
     } else {
       Preconditions.checkArgument(!partitions.isEmpty(),
-          "Cannot find any partitions in table %s", partitions);
+          "Cannot find any matching partitions in table %s", partitions);
       importPartitions(table, partitions, checkDuplicateFiles);
     }
   }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
@@ -159,7 +159,8 @@ class AddFilesProcedure extends BaseProcedure {
   private void importFileTable(Table table, Path tableLocation, String format, Map<String, String> partitionFilter,
                                boolean checkDuplicateFiles) {
     // List Partitions via Spark InMemory file search interface
-    List<SparkPartition> partitions = Spark3Util.getPartitions(spark(), tableLocation, format, partitionFilter);
+    List<SparkPartition> partitions =
+        Spark3Util.getPartitions(spark(), table.name(), tableLocation, format, partitionFilter);
 
     if (table.spec().isUnpartitioned()) {
       Preconditions.checkArgument(partitions.isEmpty(), "Cannot add partitioned files to an unpartitioned table");

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
@@ -159,7 +159,7 @@ class AddFilesProcedure extends BaseProcedure {
   private void importFileTable(Table table, Path tableLocation, String format, Map<String, String> partitionFilter,
                                boolean checkDuplicateFiles) {
     // List Partitions via Spark InMemory file search interface
-    List<SparkPartition> partitions = Spark3Util.getPartitions(spark(), tableLocation, format);
+    List<SparkPartition> partitions = Spark3Util.getPartitions(spark(), tableLocation, format, partitionFilter);
 
     if (table.spec().isUnpartitioned()) {
       Preconditions.checkArgument(partitions.isEmpty(), "Cannot add partitioned files to an unpartitioned table");
@@ -172,11 +172,7 @@ class AddFilesProcedure extends BaseProcedure {
     } else {
       Preconditions.checkArgument(!partitions.isEmpty(),
           "Cannot find any partitions in table %s", partitions);
-      List<SparkPartition> filteredPartitions = SparkTableUtil.filterPartitions(partitions, partitionFilter);
-      Preconditions.checkArgument(!filteredPartitions.isEmpty(),
-          "Cannot find any partitions which match the given filter. Partition filter is %s",
-          MAP_JOINER.join(partitionFilter));
-      importPartitions(table, filteredPartitions, checkDuplicateFiles);
+      importPartitions(table, partitions, checkDuplicateFiles);
     }
   }
 


### PR DESCRIPTION
When getting files from Spark, we want to push down partition filters to Spark, so only the partitions that match the filters will be returned.
Basically, I am using this Spark API to prune partitions
```
FileIndex
  def listFiles(
      partitionFilters: Seq[Expression], dataFilters: Seq[Expression]): Seq[PartitionDirectory]
```