### PR TITLE
Build: publish snapshot packages for all known versions

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -39,4 +39,4 @@ jobs:
           java-version: 8
       - run: |
           ./gradlew printVersion
-          ./gradlew publishApachePublicationToMavenRepository -PmavenUser=${{ secrets.NEXUS_USER }} -PmavenPassword=${{ secrets.NEXUS_PW }}
+          ./gradlew -DflinkVersions=1.12,1.13,1.14 -DsparkVersions=2.4,3.0,3.1,3.2 -DhiveVersions=2,3 publishApachePublicationToMavenRepository -PmavenUser=${{ secrets.NEXUS_USER }} -PmavenPassword=${{ secrets.NEXUS_PW }}


### PR DESCRIPTION
Currently, only the default versions are being published to the
snapshots repo (e.g only spark 3.2). In order to allow testing of other
versions, we should publish packages all supported versions of spark,
flink and hive.
