### PR TITLE
Core: Deprecate default distribution constant in TableProperties

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -210,6 +210,10 @@ public class TableProperties {
   public static final String WRITE_DISTRIBUTION_MODE_NONE = "none";
   public static final String WRITE_DISTRIBUTION_MODE_HASH = "hash";
   public static final String WRITE_DISTRIBUTION_MODE_RANGE = "range";
+  /**
+   * @deprecated will be removed in 0.14.0, use specific modes instead
+   */
+  @Deprecated
   public static final String WRITE_DISTRIBUTION_MODE_DEFAULT = WRITE_DISTRIBUTION_MODE_NONE;
 
   public static final String GC_ENABLED = "gc.enabled";

--- a/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -62,7 +62,7 @@ import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
 import static org.apache.iceberg.TableProperties.UPSERT_ENABLED;
 import static org.apache.iceberg.TableProperties.UPSERT_ENABLED_DEFAULT;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE;
-import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_DEFAULT;
+import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_NONE;
 import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT;
 
@@ -403,7 +403,7 @@ public class FlinkSink {
         // Fallback to use distribution mode parsed from table properties if don't specify in job level.
         String modeName = PropertyUtil.propertyAsString(properties,
             WRITE_DISTRIBUTION_MODE,
-            WRITE_DISTRIBUTION_MODE_DEFAULT);
+            WRITE_DISTRIBUTION_MODE_NONE);
 
         writeMode = DistributionMode.fromName(modeName);
       } else {

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -62,7 +62,7 @@ import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
 import static org.apache.iceberg.TableProperties.UPSERT_ENABLED;
 import static org.apache.iceberg.TableProperties.UPSERT_ENABLED_DEFAULT;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE;
-import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_DEFAULT;
+import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_NONE;
 import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT;
 
@@ -403,7 +403,7 @@ public class FlinkSink {
         // Fallback to use distribution mode parsed from table properties if don't specify in job level.
         String modeName = PropertyUtil.propertyAsString(properties,
             WRITE_DISTRIBUTION_MODE,
-            WRITE_DISTRIBUTION_MODE_DEFAULT);
+            WRITE_DISTRIBUTION_MODE_NONE);
 
         writeMode = DistributionMode.fromName(modeName);
       } else {

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -62,7 +62,7 @@ import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
 import static org.apache.iceberg.TableProperties.UPSERT_ENABLED;
 import static org.apache.iceberg.TableProperties.UPSERT_ENABLED_DEFAULT;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE;
-import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_DEFAULT;
+import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_NONE;
 import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT;
 
@@ -403,7 +403,7 @@ public class FlinkSink {
         // Fallback to use distribution mode parsed from table properties if don't specify in job level.
         String modeName = PropertyUtil.propertyAsString(properties,
             WRITE_DISTRIBUTION_MODE,
-            WRITE_DISTRIBUTION_MODE_DEFAULT);
+            WRITE_DISTRIBUTION_MODE_NONE);
 
         writeMode = DistributionMode.fromName(modeName);
       } else {

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -94,7 +94,7 @@ import scala.collection.JavaConverters;
 import scala.collection.Seq;
 
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE;
-import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_DEFAULT;
+import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_NONE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_RANGE;
 
 public class Spark3Util {
@@ -337,7 +337,7 @@ public class Spark3Util {
 
   public static DistributionMode distributionModeFor(org.apache.iceberg.Table table) {
     boolean isSortedTable = !table.sortOrder().isUnsorted();
-    String defaultModeName = isSortedTable ? WRITE_DISTRIBUTION_MODE_RANGE : WRITE_DISTRIBUTION_MODE_DEFAULT;
+    String defaultModeName = isSortedTable ? WRITE_DISTRIBUTION_MODE_RANGE : WRITE_DISTRIBUTION_MODE_NONE;
     String modeName = table.properties().getOrDefault(WRITE_DISTRIBUTION_MODE, defaultModeName);
     return DistributionMode.fromName(modeName);
   }

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -94,7 +94,7 @@ import scala.collection.JavaConverters;
 import scala.collection.Seq;
 
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE;
-import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_DEFAULT;
+import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_NONE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_RANGE;
 
 public class Spark3Util {
@@ -337,7 +337,7 @@ public class Spark3Util {
 
   public static DistributionMode distributionModeFor(org.apache.iceberg.Table table) {
     boolean isSortedTable = !table.sortOrder().isUnsorted();
-    String defaultModeName = isSortedTable ? WRITE_DISTRIBUTION_MODE_RANGE : WRITE_DISTRIBUTION_MODE_DEFAULT;
+    String defaultModeName = isSortedTable ? WRITE_DISTRIBUTION_MODE_RANGE : WRITE_DISTRIBUTION_MODE_NONE;
     String modeName = table.properties().getOrDefault(WRITE_DISTRIBUTION_MODE, defaultModeName);
     return DistributionMode.fromName(modeName);
   }


### PR DESCRIPTION
This PR deprecates `WRITE_DISTRIBUTION_MODE_DEFAULT` in `TableProperties` as discussed [here](https://github.com/apache/iceberg/pull/3720#discussion_r767310772).