### PR TITLE
NPE in Parquet Writer Metrics when data value max bound will overflow

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
@@ -287,11 +287,17 @@ public class ParquetUtil {
         int truncateLength = truncateMode.length();
         switch (type.typeId()) {
           case STRING:
-            upperBounds.put(id, UnicodeUtil.truncateStringMax((Literal<CharSequence>) max, truncateLength));
+            Literal<CharSequence> truncatedMaxString = UnicodeUtil.truncateStringMax((Literal<CharSequence>) max, truncateLength);
+            if (truncatedMaxString != null) {
+              upperBounds.put(id, truncatedMaxString);
+            }
             break;
           case FIXED:
           case BINARY:
-            upperBounds.put(id, BinaryUtil.truncateBinaryMax((Literal<ByteBuffer>) max, truncateLength));
+            Literal<ByteBuffer> truncatedMaxBinary = BinaryUtil.truncateBinaryMax((Literal<ByteBuffer>) max, truncateLength);
+            if (truncatedMaxBinary != null) {
+              upperBounds.put(id, truncatedMaxBinary);
+            }
             break;
           default:
             upperBounds.put(id, max);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetUtil.java
@@ -287,14 +287,16 @@ public class ParquetUtil {
         int truncateLength = truncateMode.length();
         switch (type.typeId()) {
           case STRING:
-            Literal<CharSequence> truncatedMaxString = UnicodeUtil.truncateStringMax((Literal<CharSequence>) max, truncateLength);
+            Literal<CharSequence> truncatedMaxString = UnicodeUtil.truncateStringMax((Literal<CharSequence>) max,
+                truncateLength);
             if (truncatedMaxString != null) {
               upperBounds.put(id, truncatedMaxString);
             }
             break;
           case FIXED:
           case BINARY:
-            Literal<ByteBuffer> truncatedMaxBinary = BinaryUtil.truncateBinaryMax((Literal<ByteBuffer>) max, truncateLength);
+            Literal<ByteBuffer> truncatedMaxBinary = BinaryUtil.truncateBinaryMax((Literal<ByteBuffer>) max,
+                truncateLength);
             if (truncatedMaxBinary != null) {
               upperBounds.put(id, truncatedMaxBinary);
             }

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetDataWriter.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetDataWriter.java
@@ -106,6 +106,7 @@ public class TestParquetDataWriter {
     Assert.assertEquals("Written records should match", records, writtenRecords);
   }
 
+  @SuppressWarnings("checkstyle:AvoidEscapedUnicodeCharacters")
   @Test
   public void testCorruptString() throws Exception {
     OutputFile file = Files.localOutput(temp.newFile());
@@ -126,9 +127,9 @@ public class TestParquetDataWriter {
     GenericRecord genericRecord = GenericRecord.create(SCHEMA);
     ImmutableList.Builder<Record> builder = ImmutableList.builder();
     char[] charArray = new char[61];
-    for (int i = 0; i < 60; i=i+2) {
+    for (int i = 0; i < 60; i = i + 2) {
       charArray[i] = '\uDBFF';
-      charArray[i+1] = '\uDFFF';
+      charArray[i + 1] = '\uDFFF';
     }
     builder.add(genericRecord.copy(ImmutableMap.of("id", 1L, "data", String.valueOf(charArray))));
     List<Record> records = builder.build();

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetDataWriter.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetDataWriter.java
@@ -20,14 +20,19 @@
 package org.apache.iceberg.parquet;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.List;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Files;
+import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.TestTables;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.data.parquet.GenericParquetReaders;
@@ -40,6 +45,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -47,10 +53,27 @@ import org.junit.rules.TemporaryFolder;
 public class TestParquetDataWriter {
   private static final Schema SCHEMA = new Schema(
       Types.NestedField.required(1, "id", Types.LongType.get()),
-      Types.NestedField.optional(2, "data", Types.StringType.get()));
+      Types.NestedField.optional(2, "data", Types.StringType.get()),
+      Types.NestedField.optional(3, "binary", Types.BinaryType.get()));
+
+  private List<Record> records;
 
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
+
+  @Before
+  public void createRecords() {
+    GenericRecord record = GenericRecord.create(SCHEMA);
+
+    ImmutableList.Builder<Record> builder = ImmutableList.builder();
+    builder.add(record.copy(ImmutableMap.of("id", 1L, "data", "a")));
+    builder.add(record.copy(ImmutableMap.of("id", 2L, "data", "b")));
+    builder.add(record.copy(ImmutableMap.of("id", 3L, "data", "c")));
+    builder.add(record.copy(ImmutableMap.of("id", 4L, "data", "d")));
+    builder.add(record.copy(ImmutableMap.of("id", 5L, "data", "e")));
+
+    this.records = builder.build();
+  }
 
   @Test
   public void testDataWriter() throws IOException {
@@ -68,15 +91,6 @@ public class TestParquetDataWriter {
         .withSpec(PartitionSpec.unpartitioned())
         .withSortOrder(sortOrder)
         .build();
-
-    GenericRecord genericRecord = GenericRecord.create(SCHEMA);
-    ImmutableList.Builder<Record> builder = ImmutableList.builder();
-    builder.add(genericRecord.copy(ImmutableMap.of("id", 1L, "data", "a")));
-    builder.add(genericRecord.copy(ImmutableMap.of("id", 2L, "data", "b")));
-    builder.add(genericRecord.copy(ImmutableMap.of("id", 3L, "data", "c")));
-    builder.add(genericRecord.copy(ImmutableMap.of("id", 4L, "data", "d")));
-    builder.add(genericRecord.copy(ImmutableMap.of("id", 5L, "data", "e")));
-    List<Record> records = builder.build();
 
     try {
       for (Record record : records) {
@@ -108,22 +122,24 @@ public class TestParquetDataWriter {
 
   @SuppressWarnings("checkstyle:AvoidEscapedUnicodeCharacters")
   @Test
-  public void testCorruptString() throws Exception {
+  public void testInvalidUpperBoundString() throws Exception {
     OutputFile file = Files.localOutput(temp.newFile());
 
-    SortOrder sortOrder = SortOrder.builderFor(SCHEMA)
-        .withOrderId(10)
-        .asc("id")
-        .build();
+    Table testTable = TestTables.create(temp.newFile(), "test_invalid_string_bound",
+        SCHEMA, PartitionSpec.unpartitioned(), SortOrder.unsorted(), 2);
+    testTable.updateProperties()
+        .set(TableProperties.DEFAULT_WRITE_METRICS_MODE, "truncate(16)")
+        .commit();
 
     DataWriter<Record> dataWriter = Parquet.writeData(file)
+        .metricsConfig(MetricsConfig.forTable(testTable))
         .schema(SCHEMA)
         .createWriterFunc(GenericParquetWriter::buildWriter)
         .overwrite()
         .withSpec(PartitionSpec.unpartitioned())
-        .withSortOrder(sortOrder)
         .build();
 
+    // These high code points cause an overflow
     GenericRecord genericRecord = GenericRecord.create(SCHEMA);
     ImmutableList.Builder<Record> builder = ImmutableList.builder();
     char[] charArray = new char[61];
@@ -132,10 +148,10 @@ public class TestParquetDataWriter {
       charArray[i + 1] = '\uDFFF';
     }
     builder.add(genericRecord.copy(ImmutableMap.of("id", 1L, "data", String.valueOf(charArray))));
-    List<Record> records = builder.build();
+    List<Record> overflowRecords = builder.build();
 
     try {
-      for (Record record : records) {
+      for (Record record : overflowRecords) {
         dataWriter.add(record);
       }
     } finally {
@@ -146,9 +162,8 @@ public class TestParquetDataWriter {
 
     Assert.assertEquals("Format should be Parquet", FileFormat.PARQUET, dataFile.format());
     Assert.assertEquals("Should be data file", FileContent.DATA, dataFile.content());
-    Assert.assertEquals("Record count should match", records.size(), dataFile.recordCount());
+    Assert.assertEquals("Record count should match", overflowRecords.size(), dataFile.recordCount());
     Assert.assertEquals("Partition should be empty", 0, dataFile.partition().size());
-    Assert.assertEquals("Sort order should match", sortOrder.orderId(), (int) dataFile.sortOrderId());
     Assert.assertNull("Key metadata should be null", dataFile.keyMetadata());
 
     List<Record> writtenRecords;
@@ -159,11 +174,73 @@ public class TestParquetDataWriter {
       writtenRecords = Lists.newArrayList(reader);
     }
 
-    Assert.assertEquals("Written records should match", records, writtenRecords);
+    Assert.assertEquals("Written records should match", overflowRecords, writtenRecords);
 
     Assert.assertTrue("Should have a valid lower bound", dataFile.lowerBounds().containsKey(1));
     Assert.assertTrue("Should have a valid upper bound", dataFile.upperBounds().containsKey(1));
     Assert.assertTrue("Should have a valid lower bound", dataFile.lowerBounds().containsKey(2));
-    Assert.assertFalse("Should not have found a valid upper bound", dataFile.upperBounds().containsKey(2));
+    Assert.assertFalse("Should have a null upper bound", dataFile.upperBounds().containsKey(2));
+  }
+
+  @SuppressWarnings("checkstyle:AvoidEscapedUnicodeCharacters")
+  @Test
+  public void testInvalidUpperBoundBinary() throws Exception {
+    OutputFile file = Files.localOutput(temp.newFile());
+
+    Table testTable = TestTables.create(temp.newFile(), "test_invalid_binary_bound",
+        SCHEMA, PartitionSpec.unpartitioned(), SortOrder.unsorted(), 2);
+    testTable.updateProperties()
+        .set(TableProperties.DEFAULT_WRITE_METRICS_MODE, "truncate(16)")
+        .commit();
+
+    DataWriter<Record> dataWriter = Parquet.writeData(file)
+        .metricsConfig(MetricsConfig.forTable(testTable))
+        .schema(SCHEMA)
+        .createWriterFunc(GenericParquetWriter::buildWriter)
+        .overwrite()
+        .withSpec(PartitionSpec.unpartitioned())
+        .build();
+
+    // This max binary value causes an overflow
+    GenericRecord genericRecord = GenericRecord.create(SCHEMA);
+    ImmutableList.Builder<Record> builder = ImmutableList.builder();
+    ByteBuffer bytes = ByteBuffer.allocate(17);
+    for (int i = 0; i < 17; i++) {
+      bytes.put(i, (byte) 0xff);
+    }
+    builder.add(genericRecord.copy(ImmutableMap.of("id", 1L, "binary",
+        bytes)));
+    List<Record> overflowRecords = builder.build();
+
+    try {
+      for (Record record : overflowRecords) {
+        dataWriter.add(record);
+      }
+    } finally {
+      dataWriter.close();
+    }
+
+    DataFile dataFile = dataWriter.toDataFile();
+
+    Assert.assertEquals("Format should be Parquet", FileFormat.PARQUET, dataFile.format());
+    Assert.assertEquals("Should be data file", FileContent.DATA, dataFile.content());
+    Assert.assertEquals("Record count should match", overflowRecords.size(), dataFile.recordCount());
+    Assert.assertEquals("Partition should be empty", 0, dataFile.partition().size());
+    Assert.assertNull("Key metadata should be null", dataFile.keyMetadata());
+
+    List<Record> writtenRecords;
+    try (CloseableIterable<Record> reader = Parquet.read(file.toInputFile())
+        .project(SCHEMA)
+        .createReaderFunc(fileSchema -> GenericParquetReaders.buildReader(SCHEMA, fileSchema))
+        .build()) {
+      writtenRecords = Lists.newArrayList(reader);
+    }
+
+    Assert.assertEquals("Written records should match", overflowRecords, writtenRecords);
+
+    Assert.assertTrue("Should have a valid lower bound", dataFile.lowerBounds().containsKey(1));
+    Assert.assertTrue("Should have a valid upper bound", dataFile.upperBounds().containsKey(1));
+    Assert.assertTrue("Should have a valid lower bound", dataFile.lowerBounds().containsKey(3));
+    Assert.assertFalse("Should have a null upper bound", dataFile.upperBounds().containsKey(3));
   }
 }


### PR DESCRIPTION
A certain string in the input data (with a prefix of over 16 unparseable chars like high/low surrogates) triggered a NullPointerException in Parquet writer close:

```
java.lang.NullPointerException
		at org.apache.iceberg.parquet.ParquetUtil.toBufferMap(ParquetUtil.java:267)
		at org.apache.iceberg.parquet.ParquetUtil.footerMetrics(ParquetUtil.java:152)
		at org.apache.iceberg.parquet.ParquetUtil.footerMetrics(ParquetUtil.java:85)
		at org.apache.iceberg.parquet.ParquetWriter.metrics(ParquetWriter.java:151)
		at org.apache.iceberg.io.DataWriter.close(DataWriter.java:78)
		at org.apache.iceberg.io.BaseTaskWriter$BaseRollingWriter.closeCurrent(BaseTaskWriter.java:282)
		at org.apache.iceberg.io.BaseTaskWriter$BaseRollingWriter.close(BaseTaskWriter.java:298)
		at org.apache.iceberg.io.PartitionedWriter.close(PartitionedWriter.java:82)
		at org.apache.iceberg.io.BaseTaskWriter.abort(BaseTaskWriter.java:72)
		at org.apache.spark.sql.execution.datasources.v2.DataWritingSparkTask$.$anonfun$run$6(WriteToDataSourceV2Exec.scala:447)
		at org.apache.spark.util.Utils$.tryWithSafeFinallyAndFailureCallbacks(Utils.scala:1484)
```

The problem is that UnicodeUtil and BinaryUtil return null if fail to calculate a truncated upper bound for the string/binary (see UnicodeUtil.truncateStringMax() and BinaryUtil.truncateBinaryMax()).  A null value in the upperBound map then triggers a NPE in the ParquetUtil.toBufferMap class as it tries to call .getValue() on it.

```
  private static Map<Integer, ByteBuffer> toBufferMap(Schema schema, Map<Integer, Literal<?>> map) {
    Map<Integer, ByteBuffer> bufferMap = Maps.newHashMap();
    for (Map.Entry<Integer, Literal<?>> entry : map.entrySet()) {
      bufferMap.put(entry.getKey(),
          Conversions.toByteBuffer(schema.findType(entry.getKey()), entry.getValue().value()));
    }
    return bufferMap;
  }
```