### PR TITLE
[Api][Spark]Add cleanExpiredFiles to Actions/ExpireSnapshots

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/ExpireSnapshots.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ExpireSnapshots.java
@@ -93,6 +93,16 @@ public interface ExpireSnapshots extends Action<ExpireSnapshots, ExpireSnapshots
   ExpireSnapshots executeDeleteWith(ExecutorService executorService);
 
   /**
+   * Allows expiration of snapshots without any cleanup of underlying manifest or data files.
+   * <p>
+   * If {@code cleanEnabled} is set to false, data and manifest files should not been cleaned after expiration.
+   *
+   * @param cleanEnabled setting this to false will skip deleting expired manifests and files
+   * @return this for method chaining
+   */
+  ExpireSnapshots cleanExpiredFiles(boolean cleanEnabled);
+
+  /**
    * The action result that contains a summary of the execution.
    */
   interface Result {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
@@ -50,7 +50,8 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
       ProcedureParameter.required("table", DataTypes.StringType),
       ProcedureParameter.optional("older_than", DataTypes.TimestampType),
       ProcedureParameter.optional("retain_last", DataTypes.IntegerType),
-      ProcedureParameter.optional("max_concurrent_deletes", DataTypes.IntegerType)
+      ProcedureParameter.optional("max_concurrent_deletes", DataTypes.IntegerType),
+      ProcedureParameter.optional("clean_enabled", DataTypes.BooleanType)
   };
 
   private static final StructType OUTPUT_TYPE = new StructType(new StructField[]{
@@ -88,6 +89,7 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
     Long olderThanMillis = args.isNullAt(1) ? null : DateTimeUtil.microsToMillis(args.getLong(1));
     Integer retainLastNum = args.isNullAt(2) ? null : args.getInt(2);
     Integer maxConcurrentDeletes = args.isNullAt(3) ? null : args.getInt(3);
+    Boolean cleanEnabled = args.isNullAt(4) ? null : args.getBoolean(4);
 
     Preconditions.checkArgument(maxConcurrentDeletes == null || maxConcurrentDeletes > 0,
         "max_concurrent_deletes should have value > 0,  value: " + maxConcurrentDeletes);
@@ -103,7 +105,12 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
         action.retainLast(retainLastNum);
       }
 
-      if (maxConcurrentDeletes != null && maxConcurrentDeletes > 0) {
+      if (cleanEnabled != null) {
+        action.cleanExpiredFiles(cleanEnabled);
+      }
+
+      if ((cleanEnabled == null || cleanEnabled == true) && maxConcurrentDeletes != null &&
+          maxConcurrentDeletes > 0) {
         action.executeDeleteWith(expireService(maxConcurrentDeletes));
       }
 


### PR DESCRIPTION
I found that the _expire_snapshots_ and _remove_orphan_files_ may confilct when _remove_orphan_files_  procedure happens to start right after _expire_snapshots's_ commit and delete files before _expire_snapshots'_ delete, which will cause _expire_snapshots_ fails.
This PR adds cleanExpiredFiles to Actions/ExpireSnapshots, which allows expiration of snapshots without any cleanup of files just like Iceberg/ExpireSnapshots. And the expired files will be left to _remove_orphan_files_.
This PR only implent it in Spark3.2, so I convert it to draft.
@aokolnychyi Do you think this is a reasonable way to avoid such conflict? Can you help review this pr? Thanks!

