### PR TITLE
Core: Replace SnapshotUtil firstSnapshotAfterTimestamp

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
@@ -102,43 +102,35 @@ public class SnapshotUtil {
   }
 
   /**
-   * Traverses the history of the table's current snapshot and:
-   * 1. returns null, if no snapshot exists or target timestamp is more recent than the current snapshot.
-   * 2. else return the first snapshot which satisfies {@literal >=} targetTimestamp.
-   * <p>
-   * Given the snapshots (with timestamp): [S1 (10), S2 (11), S3 (12), S4 (14)]
-   * <p>
-   * firstSnapshotAfterTimestamp(table, x {@literal <=} 10) = S1
-   * firstSnapshotAfterTimestamp(table, 11) = S2
-   * firstSnapshotAfterTimestamp(table, 13) = S4
-   * firstSnapshotAfterTimestamp(table, 14) = S4
-   * firstSnapshotAfterTimestamp(table, x {@literal >} 14) = null
-   * <p>
-   * where x is the target timestamp in milliseconds and Si is the snapshot
+   * Traverses the history of the table's current snapshot and finds the first snapshot after the given timestamp.
    *
    * @param table a table
-   * @param targetTimestampMillis a timestamp in milliseconds
-   * @return the first snapshot which satisfies {@literal >=} targetTimestamp, or null if the current snapshot is
-   * more recent than the target timestamp
+   * @param timestampMillis a timestamp in milliseconds
+   * @return the first snapshot after the given timestamp, or null if the current snapshot is older than the timestamp
+   * @throws IllegalStateException if the first ancestor after the given time can't be determined
    */
-  public static Snapshot firstSnapshotAfterTimestamp(Table table, Long targetTimestampMillis) {
-    Snapshot currentSnapshot = table.currentSnapshot();
-    // Return null if no snapshot exists or target timestamp is more recent than the current snapshot
-    if (currentSnapshot == null || currentSnapshot.timestampMillis() < targetTimestampMillis) {
+  public static Snapshot oldestAncestorAfter(Table table, long timestampMillis) {
+    if (table.currentSnapshot() == null) {
+      // there are no snapshots or ancestors
       return null;
     }
 
-    // Return the oldest snapshot which satisfies >= targetTimestamp
     Snapshot lastSnapshot = null;
     for (Snapshot snapshot : currentAncestors(table)) {
-      if (snapshot.timestampMillis() < targetTimestampMillis) {
+      if (snapshot.timestampMillis() <= timestampMillis) {
         return lastSnapshot;
       }
+
       lastSnapshot = snapshot;
     }
 
-    // Return the oldest snapshot if the target timestamp is less than the oldest snapshot of the table
-    return lastSnapshot;
+    if (lastSnapshot != null && lastSnapshot.parentId() == null) {
+      // this is the first snapshot in the table, return it
+      return lastSnapshot;
+    }
+
+    throw new IllegalStateException(
+        "Cannot find snapshot older than " + DateTimeUtil.formatTimestampMillis(timestampMillis));
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
@@ -102,7 +102,7 @@ public class SnapshotUtil {
   }
 
   /**
-   * Traverses the history of the table's current snapshot and finds the first snapshot after the given timestamp.
+   * Traverses the history of the table's current snapshot and finds the first snapshot committed after the given time.
    *
    * @param table a table
    * @param timestampMillis a timestamp in milliseconds
@@ -117,8 +117,10 @@ public class SnapshotUtil {
 
     Snapshot lastSnapshot = null;
     for (Snapshot snapshot : currentAncestors(table)) {
-      if (snapshot.timestampMillis() <= timestampMillis) {
+      if (snapshot.timestampMillis() < timestampMillis) {
         return lastSnapshot;
+      } else if (snapshot.timestampMillis() == timestampMillis) {
+        return snapshot;
       }
 
       lastSnapshot = snapshot;

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -99,12 +99,12 @@ public class SparkMicroBatchStream implements MicroBatchStream {
   @Override
   public Offset latestOffset() {
     table.refresh();
-    if (isStreamEmpty(table)) {
+    if (table.currentSnapshot() == null) {
       return StreamingOffset.START_OFFSET;
     }
 
-    if (isFutureStartTime(table, fromTimestamp)) {
-      return initialFutureStartOffset(table);
+    if (table.currentSnapshot().timestampMillis() < fromTimestamp) {
+      return StreamingOffset.START_OFFSET;
     }
 
     Snapshot latestSnapshot = table.currentSnapshot();
@@ -169,8 +169,7 @@ public class SparkMicroBatchStream implements MicroBatchStream {
   private List<FileScanTask> planFiles(StreamingOffset startOffset, StreamingOffset endOffset) {
     List<FileScanTask> fileScanTasks = Lists.newArrayList();
     StreamingOffset batchStartOffset = StreamingOffset.START_OFFSET.equals(startOffset) ?
-        new StreamingOffset(SnapshotUtil.firstSnapshotAfterTimestamp(table, fromTimestamp).snapshotId(), 0, false) :
-        startOffset;
+        determineStartingOffset(table, fromTimestamp) : startOffset;
 
     StreamingOffset currentOffset = null;
 
@@ -208,26 +207,31 @@ public class SparkMicroBatchStream implements MicroBatchStream {
     return op.equals(DataOperations.APPEND);
   }
 
-  private static boolean isStreamEmpty(Table table) {
-    return table.currentSnapshot() == null;
-  }
-
-  private static boolean isStreamNotEmpty(Table table) {
-    return table.currentSnapshot() != null;
-  }
-
-  private static boolean isFutureStartTime(Table table, Long streamStartTimeStampMillis) {
-    if (streamStartTimeStampMillis == null) {
-      return false;
+  private static StreamingOffset determineStartingOffset(Table table, Long fromTimestamp) {
+    if (table.currentSnapshot() == null) {
+      return StreamingOffset.START_OFFSET;
     }
 
-    return table.currentSnapshot().timestampMillis() < streamStartTimeStampMillis;
-  }
+    if (fromTimestamp == null) {
+      // match existing behavior and start from the oldest snapshot
+      return new StreamingOffset(SnapshotUtil.oldestAncestor(table).snapshotId(), 0, false);
+    }
 
-  private static StreamingOffset initialFutureStartOffset(Table table) {
-    Preconditions.checkNotNull(table, "Cannot process future start offset with invalid table input.");
-    Snapshot latestSnapshot = table.currentSnapshot();
-    return new StreamingOffset(latestSnapshot.snapshotId(), Iterables.size(latestSnapshot.addedFiles()) + 1, false);
+    if (table.currentSnapshot().timestampMillis() < fromTimestamp) {
+      return StreamingOffset.START_OFFSET;
+    }
+
+    try {
+      Snapshot snapshot = SnapshotUtil.oldestAncestorAfter(table, fromTimestamp);
+      if (snapshot != null) {
+        return new StreamingOffset(snapshot.snapshotId(), 0, false);
+      } else {
+        return StreamingOffset.START_OFFSET;
+      }
+    } catch (IllegalStateException e) {
+      // could not determine the first snapshot after the timestamp. use the oldest ancestor instead
+      return new StreamingOffset(SnapshotUtil.oldestAncestor(table).snapshotId(), 0, false);
+    }
   }
 
   private static class InitialOffsetStore {
@@ -250,11 +254,7 @@ public class SparkMicroBatchStream implements MicroBatchStream {
       }
 
       table.refresh();
-      StreamingOffset offset = StreamingOffset.START_OFFSET;
-      if (isStreamNotEmpty(table)) {
-        offset = isFutureStartTime(table, fromTimestamp) ? initialFutureStartOffset(table) :
-            new StreamingOffset(SnapshotUtil.firstSnapshotAfterTimestamp(table, fromTimestamp).snapshotId(), 0, false);
-      }
+      StreamingOffset offset = determineStartingOffset(table, fromTimestamp);
 
       OutputFile outputFile = io.newOutputFile(initialOffsetLocation);
       writeOffset(offset, outputFile);

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -99,12 +99,12 @@ public class SparkMicroBatchStream implements MicroBatchStream {
   @Override
   public Offset latestOffset() {
     table.refresh();
-    if (isStreamEmpty(table)) {
+    if (table.currentSnapshot() == null) {
       return StreamingOffset.START_OFFSET;
     }
 
-    if (isFutureStartTime(table, fromTimestamp)) {
-      return initialFutureStartOffset(table);
+    if (table.currentSnapshot().timestampMillis() < fromTimestamp) {
+      return StreamingOffset.START_OFFSET;
     }
 
     Snapshot latestSnapshot = table.currentSnapshot();
@@ -169,8 +169,7 @@ public class SparkMicroBatchStream implements MicroBatchStream {
   private List<FileScanTask> planFiles(StreamingOffset startOffset, StreamingOffset endOffset) {
     List<FileScanTask> fileScanTasks = Lists.newArrayList();
     StreamingOffset batchStartOffset = StreamingOffset.START_OFFSET.equals(startOffset) ?
-        new StreamingOffset(SnapshotUtil.firstSnapshotAfterTimestamp(table, fromTimestamp).snapshotId(), 0, false) :
-        startOffset;
+        determineStartingOffset(table, fromTimestamp) : startOffset;
 
     StreamingOffset currentOffset = null;
 
@@ -208,26 +207,31 @@ public class SparkMicroBatchStream implements MicroBatchStream {
     return op.equals(DataOperations.APPEND);
   }
 
-  private static boolean isStreamEmpty(Table table) {
-    return table.currentSnapshot() == null;
-  }
-
-  private static boolean isStreamNotEmpty(Table table) {
-    return table.currentSnapshot() != null;
-  }
-
-  private static boolean isFutureStartTime(Table table, Long streamStartTimeStampMillis) {
-    if (streamStartTimeStampMillis == null) {
-      return false;
+  private static StreamingOffset determineStartingOffset(Table table, Long fromTimestamp) {
+    if (table.currentSnapshot() == null) {
+      return StreamingOffset.START_OFFSET;
     }
 
-    return table.currentSnapshot().timestampMillis() < streamStartTimeStampMillis;
-  }
+    if (fromTimestamp == null) {
+      // match existing behavior and start from the oldest snapshot
+      return new StreamingOffset(SnapshotUtil.oldestAncestor(table).snapshotId(), 0, false);
+    }
 
-  private static StreamingOffset initialFutureStartOffset(Table table) {
-    Preconditions.checkNotNull(table, "Cannot process future start offset with invalid table input.");
-    Snapshot latestSnapshot = table.currentSnapshot();
-    return new StreamingOffset(latestSnapshot.snapshotId(), Iterables.size(latestSnapshot.addedFiles()) + 1, false);
+    if (table.currentSnapshot().timestampMillis() < fromTimestamp) {
+      return StreamingOffset.START_OFFSET;
+    }
+
+    try {
+      Snapshot snapshot = SnapshotUtil.oldestAncestorAfter(table, fromTimestamp);
+      if (snapshot != null) {
+        return new StreamingOffset(snapshot.snapshotId(), 0, false);
+      } else {
+        return StreamingOffset.START_OFFSET;
+      }
+    } catch (IllegalStateException e) {
+      // could not determine the first snapshot after the timestamp. use the oldest ancestor instead
+      return new StreamingOffset(SnapshotUtil.oldestAncestor(table).snapshotId(), 0, false);
+    }
   }
 
   private static class InitialOffsetStore {
@@ -250,11 +254,7 @@ public class SparkMicroBatchStream implements MicroBatchStream {
       }
 
       table.refresh();
-      StreamingOffset offset = StreamingOffset.START_OFFSET;
-      if (isStreamNotEmpty(table)) {
-        offset = isFutureStartTime(table, fromTimestamp) ? initialFutureStartOffset(table) :
-            new StreamingOffset(SnapshotUtil.firstSnapshotAfterTimestamp(table, fromTimestamp).snapshotId(), 0, false);
-      }
+      StreamingOffset offset = determineStartingOffset(table, fromTimestamp);
 
       OutputFile outputFile = io.newOutputFile(initialOffsetLocation);
       writeOffset(offset, outputFile);

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -99,12 +99,12 @@ public class SparkMicroBatchStream implements MicroBatchStream {
   @Override
   public Offset latestOffset() {
     table.refresh();
-    if (isStreamEmpty(table)) {
+    if (table.currentSnapshot() == null) {
       return StreamingOffset.START_OFFSET;
     }
 
-    if (isFutureStartTime(table, fromTimestamp)) {
-      return initialFutureStartOffset(table);
+    if (table.currentSnapshot().timestampMillis() < fromTimestamp) {
+      return StreamingOffset.START_OFFSET;
     }
 
     Snapshot latestSnapshot = table.currentSnapshot();
@@ -169,8 +169,7 @@ public class SparkMicroBatchStream implements MicroBatchStream {
   private List<FileScanTask> planFiles(StreamingOffset startOffset, StreamingOffset endOffset) {
     List<FileScanTask> fileScanTasks = Lists.newArrayList();
     StreamingOffset batchStartOffset = StreamingOffset.START_OFFSET.equals(startOffset) ?
-        new StreamingOffset(SnapshotUtil.firstSnapshotAfterTimestamp(table, fromTimestamp).snapshotId(), 0, false) :
-        startOffset;
+        determineStartingOffset(table, fromTimestamp) : startOffset;
 
     StreamingOffset currentOffset = null;
 
@@ -208,26 +207,31 @@ public class SparkMicroBatchStream implements MicroBatchStream {
     return op.equals(DataOperations.APPEND);
   }
 
-  private static boolean isStreamEmpty(Table table) {
-    return table.currentSnapshot() == null;
-  }
-
-  private static boolean isStreamNotEmpty(Table table) {
-    return table.currentSnapshot() != null;
-  }
-
-  private static boolean isFutureStartTime(Table table, Long streamStartTimeStampMillis) {
-    if (streamStartTimeStampMillis == null) {
-      return false;
+  private static StreamingOffset determineStartingOffset(Table table, Long fromTimestamp) {
+    if (table.currentSnapshot() == null) {
+      return StreamingOffset.START_OFFSET;
     }
 
-    return table.currentSnapshot().timestampMillis() < streamStartTimeStampMillis;
-  }
+    if (fromTimestamp == null) {
+      // match existing behavior and start from the oldest snapshot
+      return new StreamingOffset(SnapshotUtil.oldestAncestor(table).snapshotId(), 0, false);
+    }
 
-  private static StreamingOffset initialFutureStartOffset(Table table) {
-    Preconditions.checkNotNull(table, "Cannot process future start offset with invalid table input.");
-    Snapshot latestSnapshot = table.currentSnapshot();
-    return new StreamingOffset(latestSnapshot.snapshotId(), Iterables.size(latestSnapshot.addedFiles()) + 1, false);
+    if (table.currentSnapshot().timestampMillis() < fromTimestamp) {
+      return StreamingOffset.START_OFFSET;
+    }
+
+    try {
+      Snapshot snapshot = SnapshotUtil.oldestAncestorAfter(table, fromTimestamp);
+      if (snapshot != null) {
+        return new StreamingOffset(snapshot.snapshotId(), 0, false);
+      } else {
+        return StreamingOffset.START_OFFSET;
+      }
+    } catch (IllegalStateException e) {
+      // could not determine the first snapshot after the timestamp. use the oldest ancestor instead
+      return new StreamingOffset(SnapshotUtil.oldestAncestor(table).snapshotId(), 0, false);
+    }
   }
 
   private static class InitialOffsetStore {
@@ -250,11 +254,7 @@ public class SparkMicroBatchStream implements MicroBatchStream {
       }
 
       table.refresh();
-      StreamingOffset offset = StreamingOffset.START_OFFSET;
-      if (isStreamNotEmpty(table)) {
-        offset = isFutureStartTime(table, fromTimestamp) ? initialFutureStartOffset(table) :
-            new StreamingOffset(SnapshotUtil.firstSnapshotAfterTimestamp(table, fromTimestamp).snapshotId(), 0, false);
-      }
+      StreamingOffset offset = determineStartingOffset(table, fromTimestamp);
 
       OutputFile outputFile = io.newOutputFile(initialOffsetLocation);
       writeOffset(offset, outputFile);


### PR DESCRIPTION
The util class `SnapshotUtil` is shared, so it needs to have fairly strict method contracts. This replaces `SnapshotUtil.firstSnapshotAfterTimestamp` with `oldestAncestorAfter`:
* The new implementation throws `IllegalStateException` if the correct ancestor cannot be determined
* The new name is clear that the snapshots considered are ancestors, not all snapshots

This also updates places that called `firstSnapshotAfterTimestamp` and attempts to have the same behavior by catching the `IllegalStateException` (cannot determine ancestor) and uses the oldest ancestor instead. However, in updating the Spark streaming code, I noticed a few bugs:
* `planFiles` will call `.snapshotId()` without checking the snapshot, which can be null if the timestamp is newer than the current, resulting in a `NullPointerException`
* The initial offset store checks for a future timestamp, but `planFiles` does not
* The initial offset store handles null `fromTimestamp`, but `planFiles` does not
* The `initialFutureStartOffset` creates an offset after the current snapshot, but not necessarily after the given future time

I'm also attempting to fix those issues. This simplifies the code by removing several static helper methods. These assisted readability, but made assumptions about whether the table has a current snapshot and so were prone to `NullPointerExceptions`. Instead, this adds `determineStartingOffset` that is responsible for getting a starting offset or returning `StreamingOffset.START_OFFSET` if it cannot be determined because of the table state or a timestamp in the future.

Now, `StreamingOffset.START_OFFSET` means that the job cannot start because the start offset has not been determined, and there is no "initial future offset".