### PR TITLE
Lazily initialize the underlying writer in ParquetWriter

### DIFF
--- a/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java
@@ -32,7 +32,6 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.deletes.EqualityDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
-import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;

--- a/core/src/main/java/org/apache/iceberg/io/RollingFileWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/RollingFileWriter.java
@@ -121,7 +121,11 @@ abstract class RollingFileWriter<T, W extends FileWriter<T, R>, R> implements Fi
       }
 
       if (currentFileRows == 0L) {
-        io.deleteFile(currentFile.encryptingOutputFile());
+        try {
+          io.deleteFile(currentFile.encryptingOutputFile());
+        } catch (UncheckedIOException e) {
+          // the file may not have been created, and it isn't worth failing the job to clean up, skip deleting
+        }
       } else {
         addResult(currentWriter.result());
       }

--- a/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
+++ b/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
@@ -220,14 +220,8 @@ public class TestDeltaTaskWriter extends TableTestBase {
     writer.write(createUpdateBefore(1, "aaa"));
     writer.write(createUpdateAfter(1, "bbb"));
 
-    if (partitioned) {
-      writer.complete();
-    }
-
     writer.write(createUpdateBefore(2, "aaa"));
     writer.write(createUpdateAfter(2, "bbb"));
-
-    writer.complete();
 
     // Assert the current data/delete file count.
     List<Path> files = Files.walk(Paths.get(tableDir.getPath(), "data"))

--- a/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
+++ b/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
@@ -220,8 +220,14 @@ public class TestDeltaTaskWriter extends TableTestBase {
     writer.write(createUpdateBefore(1, "aaa"));
     writer.write(createUpdateAfter(1, "bbb"));
 
+    if (partitioned) {
+      writer.complete();
+    }
+
     writer.write(createUpdateBefore(2, "aaa"));
     writer.write(createUpdateAfter(2, "bbb"));
+
+    writer.complete();
 
     // Assert the current data/delete file count.
     List<Path> files = Files.walk(Paths.get(tableDir.getPath(), "data"))

--- a/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
+++ b/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
@@ -92,7 +92,7 @@ public class TestDeltaTaskWriter extends TableTestBase {
     }
 
     table.updateProperties()
-        .set(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, String.valueOf(8*1024))
+        .set(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, String.valueOf(8 * 1024))
         .defaultFormat(format)
         .commit();
   }

--- a/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
+++ b/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.SerializableTable;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableTestBase;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
@@ -91,6 +92,7 @@ public class TestDeltaTaskWriter extends TableTestBase {
     }
 
     table.updateProperties()
+        .set(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, String.valueOf(8*1024))
         .defaultFormat(format)
         .commit();
   }
@@ -217,11 +219,13 @@ public class TestDeltaTaskWriter extends TableTestBase {
     taskWriterFactory.initialize(1, 1);
 
     TaskWriter<RowData> writer = taskWriterFactory.create();
-    writer.write(createUpdateBefore(1, "aaa"));
-    writer.write(createUpdateAfter(1, "bbb"));
+    for (int i = 0; i < 8_000; i += 2) {
+      writer.write(createUpdateBefore(i + 1, "aaa"));
+      writer.write(createUpdateAfter(i + 1, "aaa"));
 
-    writer.write(createUpdateBefore(2, "aaa"));
-    writer.write(createUpdateAfter(2, "bbb"));
+      writer.write(createUpdateBefore(i + 2, "bbb"));
+      writer.write(createUpdateAfter(i + 2, "bbb"));
+    }
 
     // Assert the current data/delete file count.
     List<Path> files = Files.walk(Paths.get(tableDir.getPath(), "data"))

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
@@ -93,7 +93,7 @@ public class TestDeltaTaskWriter extends TableTestBase {
     }
 
     table.updateProperties()
-        .set(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, String.valueOf(8*1024))
+        .set(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, String.valueOf(8 * 1024))
         .defaultFormat(format)
         .commit();
   }

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
@@ -222,9 +222,9 @@ public class TestDeltaTaskWriter extends TableTestBase {
     TaskWriter<RowData> writer = taskWriterFactory.create();
     for (int i = 0; i < 8_000; i += 2) {
       writer.write(createUpdateBefore(i + 1, "aaa"));
-      writer.write(createUpdateAfter(i + 1, "bbb"));
+      writer.write(createUpdateAfter(i + 1, "aaa"));
 
-      writer.write(createUpdateBefore(i + 2, "aaa"));
+      writer.write(createUpdateBefore(i + 2, "bbb"));
       writer.write(createUpdateAfter(i + 2, "bbb"));
     }
 

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.SerializableTable;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableTestBase;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
@@ -92,6 +93,7 @@ public class TestDeltaTaskWriter extends TableTestBase {
     }
 
     table.updateProperties()
+        .set(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, String.valueOf(8*1024))
         .defaultFormat(format)
         .commit();
   }
@@ -218,11 +220,13 @@ public class TestDeltaTaskWriter extends TableTestBase {
     taskWriterFactory.initialize(1, 1);
 
     TaskWriter<RowData> writer = taskWriterFactory.create();
-    writer.write(createUpdateBefore(1, "aaa"));
-    writer.write(createUpdateAfter(1, "bbb"));
+    for (int i = 0; i < 8_000; i += 2) {
+      writer.write(createUpdateBefore(i + 1, "aaa"));
+      writer.write(createUpdateAfter(i + 1, "bbb"));
 
-    writer.write(createUpdateBefore(2, "aaa"));
-    writer.write(createUpdateAfter(2, "bbb"));
+      writer.write(createUpdateBefore(i + 2, "aaa"));
+      writer.write(createUpdateAfter(i + 2, "bbb"));
+    }
 
     // Assert the current data/delete file count.
     List<Path> files = Files.walk(Paths.get(tableDir.getPath(), "data"))

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
@@ -93,7 +93,7 @@ public class TestDeltaTaskWriter extends TableTestBase {
     }
 
     table.updateProperties()
-        .set(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, String.valueOf(8*1024))
+        .set(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, String.valueOf(8 * 1024))
         .defaultFormat(format)
         .commit();
   }

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/sink/TestDeltaTaskWriter.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.SerializableTable;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableTestBase;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
@@ -92,6 +93,7 @@ public class TestDeltaTaskWriter extends TableTestBase {
     }
 
     table.updateProperties()
+        .set(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, String.valueOf(8*1024))
         .defaultFormat(format)
         .commit();
   }
@@ -218,11 +220,13 @@ public class TestDeltaTaskWriter extends TableTestBase {
     taskWriterFactory.initialize(1, 1);
 
     TaskWriter<RowData> writer = taskWriterFactory.create();
-    writer.write(createUpdateBefore(1, "aaa"));
-    writer.write(createUpdateAfter(1, "bbb"));
+    for (int i = 0; i < 8_000; i += 2) {
+      writer.write(createUpdateBefore(i + 1, "aaa"));
+      writer.write(createUpdateAfter(i + 1, "aaa"));
 
-    writer.write(createUpdateBefore(2, "aaa"));
-    writer.write(createUpdateAfter(2, "bbb"));
+      writer.write(createUpdateBefore(i + 2, "bbb"));
+      writer.write(createUpdateAfter(i + 2, "bbb"));
+    }
 
     // Assert the current data/delete file count.
     List<Path> files = Files.walk(Paths.get(tableDir.getPath(), "data"))

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
@@ -159,7 +159,8 @@ class ParquetWriter<T> implements FileAppender<T>, Closeable {
         length += writer.getPos();
       }
 
-      if (!closed && writeStore.isColumnFlushNeeded()) {
+      if (!closed && recordCount > 0) {
+        // recordCount > 0 when there are records in the write store that have not been flushed to the Parquet file
         length += writeStore.getBufferedSize();
       }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
@@ -153,17 +153,18 @@ class ParquetWriter<T> implements FileAppender<T>, Closeable {
   @Override
   public long length() {
     try {
-      if (closed) {
-        if (writer != null) {
-          return writer.getPos();
-        } else {
-          return 0L;
-        }
-      } else if (writer != null) {
-        return writer.getPos() + (writeStore.isColumnFlushNeeded() ? writeStore.getBufferedSize() : 0);
-      } else {
-        return writeStore.isColumnFlushNeeded() ? writeStore.getBufferedSize() : 0;
+      long length = 0L;
+
+      if (writer != null) {
+        length += writer.getPos();
       }
+
+      if (!closed && writeStore.isColumnFlushNeeded()) {
+        length += writeStore.getBufferedSize();
+      }
+
+      return length;
+
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to get file length");
     }


### PR DESCRIPTION
This is an update to #3293 that implements the `FileAppender` contract more closely to avoid test failures.

This renames `writer` to `ensureWriterInitialized` and updates previous calls to `writer()` that would initialize the writer -- even if the appender was closed -- with null checks. `ensureWriterInitialized` is called when flushing a row group from the column write store to the file.