### PR TITLE
[SPARK] Add in NOT_STARTS_WITH support to Spark 3.0

### DIFF
--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -649,6 +649,8 @@ public class Spark3Util {
           return pred.ref().name() + " != " + sqlString(pred.literal());
         case STARTS_WITH:
           return pred.ref().name() + " LIKE '" + pred.literal() + "%'";
+        case NOT_STARTS_WITH:
+          return pred.ref().name() + " NOT LIKE '" + pred.literal() + "%'";
         case IN:
           return pred.ref().name() + " IN (" + sqlString(pred.literals()) + ")";
         case NOT_IN:


### PR DESCRIPTION
This is a followup for Spark 3.0 to backport the small changes needed to make `NOT_STARTS_WITH` work with Spark 3.0

Parent: https://github.com/apache/iceberg/pull/2062