### PR TITLE
[SITE] Document cache.expiration-interval-ms in Spark Configuration

### DIFF
--- a/site/docs/spark-configuration.md
+++ b/site/docs/spark-configuration.md
@@ -60,6 +60,7 @@ Both catalogs are configured using properties nested under the catalog name. Com
 | spark.sql.catalog._catalog-name_.uri               | thrift://host:port            | Metastore connect URI; default from `hive-site.xml` |
 | spark.sql.catalog._catalog-name_.warehouse         | hdfs://nn:8020/warehouse/path | Base path for the warehouse directory |
 | spark.sql.catalog._catalog-name_.cache-enabled     | `true` or `false`             | Whether to enable catalog cache, default value is `true` |
+| spark.sql.catalog._catalog-name_.cache.expiration-interval-ms | `30000` (30 seconds)          | Controls the duration for which entries in the catalog are cached; positive values will enable entries to be expired from the catalog cache after that interval if not accessed,`-1` disables cache expiration (same behavior as Iceberg prior to version 0.13.0), and `0` turns off the catalog cache entirely. Default is `30000` (30 sec) ||                                                    |                               |                                                          |
 
 Additional properties can be found in common [catalog configuration](./configuration.md#catalog-properties).
 

--- a/site/docs/spark-configuration.md
+++ b/site/docs/spark-configuration.md
@@ -60,7 +60,7 @@ Both catalogs are configured using properties nested under the catalog name. Com
 | spark.sql.catalog._catalog-name_.uri               | thrift://host:port            | Metastore connect URI; default from `hive-site.xml` |
 | spark.sql.catalog._catalog-name_.warehouse         | hdfs://nn:8020/warehouse/path | Base path for the warehouse directory |
 | spark.sql.catalog._catalog-name_.cache-enabled     | `true` or `false`             | Whether to enable catalog cache, default value is `true` |
-| spark.sql.catalog._catalog-name_.cache.expiration-interval-ms | `30000` (30 seconds)          | Duration after which cached catalog entries are expired; Only effective if `cache-enabled` is `true` and its set to some positive value, `-1` disables cache expiration (same behavior as Iceberg prior to version 0.13.0), and `0` disables caching entirely regardless of the value of `cache-enabled`. Default is `30000` (30 sec) ||                                                    |                               |                                                          |
+| spark.sql.catalog._catalog-name_.cache.expiration-interval-ms | `30000` (30 seconds) | Duration after which cached catalog entries are expired; Only effective if `cache-enabled` is `true` and this is set to some positive value. `-1` disables cache expiration and `0` disables caching entirely without consideration for `cache-enabled`. Default is `30000` (30 sec) ||                                                    |                               |                                                          |
 
 Additional properties can be found in common [catalog configuration](./configuration.md#catalog-properties).
 

--- a/site/docs/spark-configuration.md
+++ b/site/docs/spark-configuration.md
@@ -60,7 +60,7 @@ Both catalogs are configured using properties nested under the catalog name. Com
 | spark.sql.catalog._catalog-name_.uri               | thrift://host:port            | Metastore connect URI; default from `hive-site.xml` |
 | spark.sql.catalog._catalog-name_.warehouse         | hdfs://nn:8020/warehouse/path | Base path for the warehouse directory |
 | spark.sql.catalog._catalog-name_.cache-enabled     | `true` or `false`             | Whether to enable catalog cache, default value is `true` |
-| spark.sql.catalog._catalog-name_.cache.expiration-interval-ms | `30000` (30 seconds) | Duration after which cached catalog entries are expired; Only effective if `cache-enabled` is `true`. `-1` disables cache expiration and `0` disables caching entirely irrespective of `cache-enabled`. Default is `30000` (30 seconds) ||                                                    |                               |                                                          |
+| spark.sql.catalog._catalog-name_.cache.expiration-interval-ms | `30000` (30 seconds) | Duration after which cached catalog entries are expired; Only effective if `cache-enabled` is `true`. `-1` disables cache expiration and `0` disables caching entirely, irrespective of `cache-enabled`. Default is `30000` (30 seconds) ||                                                    |                               |                                                          |
 
 Additional properties can be found in common [catalog configuration](./configuration.md#catalog-properties).
 

--- a/site/docs/spark-configuration.md
+++ b/site/docs/spark-configuration.md
@@ -60,7 +60,7 @@ Both catalogs are configured using properties nested under the catalog name. Com
 | spark.sql.catalog._catalog-name_.uri               | thrift://host:port            | Metastore connect URI; default from `hive-site.xml` |
 | spark.sql.catalog._catalog-name_.warehouse         | hdfs://nn:8020/warehouse/path | Base path for the warehouse directory |
 | spark.sql.catalog._catalog-name_.cache-enabled     | `true` or `false`             | Whether to enable catalog cache, default value is `true` |
-| spark.sql.catalog._catalog-name_.cache.expiration-interval-ms | `30000` (30 seconds)          | Controls the duration for which entries in the catalog are cached; positive values will enable entries to be expired from the catalog cache after that interval if not accessed,`-1` disables cache expiration (same behavior as Iceberg prior to version 0.13.0), and `0` turns off the catalog cache entirely. Default is `30000` (30 sec) ||                                                    |                               |                                                          |
+| spark.sql.catalog._catalog-name_.cache.expiration-interval-ms | `30000` (30 seconds)          | Duration after which cached catalog entries are expired; Only effective if `cache-enabled` is `true` and its set to some positive value, `-1` disables cache expiration (same behavior as Iceberg prior to version 0.13.0), and `0` disables caching entirely regardless of the value of `cache-enabled`. Default is `30000` (30 sec) ||                                                    |                               |                                                          |
 
 Additional properties can be found in common [catalog configuration](./configuration.md#catalog-properties).
 

--- a/site/docs/spark-configuration.md
+++ b/site/docs/spark-configuration.md
@@ -60,7 +60,7 @@ Both catalogs are configured using properties nested under the catalog name. Com
 | spark.sql.catalog._catalog-name_.uri               | thrift://host:port            | Metastore connect URI; default from `hive-site.xml` |
 | spark.sql.catalog._catalog-name_.warehouse         | hdfs://nn:8020/warehouse/path | Base path for the warehouse directory |
 | spark.sql.catalog._catalog-name_.cache-enabled     | `true` or `false`             | Whether to enable catalog cache, default value is `true` |
-| spark.sql.catalog._catalog-name_.cache.expiration-interval-ms | `30000` (30 seconds) | Duration after which cached catalog entries are expired; Only effective if `cache-enabled` is `true` and this is set to some positive value. `-1` disables cache expiration and `0` disables caching entirely without consideration for `cache-enabled`. Default is `30000` (30 sec) ||                                                    |                               |                                                          |
+| spark.sql.catalog._catalog-name_.cache.expiration-interval-ms | `30000` (30 seconds) | Duration after which cached catalog entries are expired; Only effective if `cache-enabled` is `true`. `-1` disables cache expiration and `0` disables caching entirely irrespective of `cache-enabled`. Default is `30000` (30 seconds) ||                                                    |                               |                                                          |
 
 Additional properties can be found in common [catalog configuration](./configuration.md#catalog-properties).
 


### PR DESCRIPTION
Adds documentation to the site for the catalog config key `cache.expiration-interval-ms` for Spark.

This has not been implemented for Flink yet, so I've not added it to the Flink documentation (working on that in a separate PR).

Here's a reference to the JavaDoc for this configuration value: https://github.com/apache/iceberg/blob/9c3e340cd67699c3d2499762d794ab1bc1ee7f45/core/src/main/java/org/apache/iceberg/CatalogProperties.java#L42-L52