### PR TITLE
Test: Make sure to delete temp folders

### DIFF
--- a/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/FlinkTestBase.java
+++ b/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/FlinkTestBase.java
@@ -63,7 +63,7 @@ public abstract class FlinkTestBase extends TestBaseUtils {
   }
 
   @AfterClass
-  public static void stopMetastore() {
+  public static void stopMetastore() throws Exception {
     metastore.stop();
     FlinkTestBase.catalog = null;
   }

--- a/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkReaderDeletesBase.java
+++ b/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkReaderDeletesBase.java
@@ -80,7 +80,7 @@ public abstract class TestFlinkReaderDeletesBase extends DeleteReadTests {
   }
 
   @AfterClass
-  public static void stopMetastore() {
+  public static void stopMetastore() throws Exception {
     metastore.stop();
     catalog = null;
   }

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/FlinkTestBase.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/FlinkTestBase.java
@@ -63,7 +63,7 @@ public abstract class FlinkTestBase extends TestBaseUtils {
   }
 
   @AfterClass
-  public static void stopMetastore() {
+  public static void stopMetastore() throws Exception {
     metastore.stop();
     FlinkTestBase.catalog = null;
   }

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkReaderDeletesBase.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkReaderDeletesBase.java
@@ -80,7 +80,7 @@ public abstract class TestFlinkReaderDeletesBase extends DeleteReadTests {
   }
 
   @AfterClass
-  public static void stopMetastore() {
+  public static void stopMetastore() throws Exception {
     metastore.stop();
     catalog = null;
   }

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/FlinkTestBase.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/FlinkTestBase.java
@@ -63,7 +63,7 @@ public abstract class FlinkTestBase extends TestBaseUtils {
   }
 
   @AfterClass
-  public static void stopMetastore() {
+  public static void stopMetastore() throws Exception {
     metastore.stop();
     FlinkTestBase.catalog = null;
   }

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestCatalogTableLoader.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestCatalogTableLoader.java
@@ -59,8 +59,10 @@ public class TestCatalogTableLoader extends FlinkTestBase {
   }
 
   @AfterClass
-  public static void dropWarehouse() {
-    FileUtils.deleteQuietly(warehouse);
+  public static void dropWarehouse() throws IOException {
+    if (warehouse != null && warehouse.exists()) {
+      FileUtils.forceDelete(warehouse);
+    }
   }
 
   @Test

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestCatalogTableLoader.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestCatalogTableLoader.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Map;
+import org.apache.commons.io.FileUtils;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -59,9 +60,7 @@ public class TestCatalogTableLoader extends FlinkTestBase {
 
   @AfterClass
   public static void dropWarehouse() {
-    if (warehouse != null && warehouse.exists()) {
-      warehouse.delete();
-    }
+    FileUtils.deleteQuietly(warehouse);
   }
 
   @Test

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestCatalogTableLoader.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestCatalogTableLoader.java
@@ -26,7 +26,8 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Map;
-import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -61,7 +62,9 @@ public class TestCatalogTableLoader extends FlinkTestBase {
   @AfterClass
   public static void dropWarehouse() throws IOException {
     if (warehouse != null && warehouse.exists()) {
-      FileUtils.forceDelete(warehouse);
+      Path warehousePath = new Path(warehouse.getAbsolutePath());
+      FileSystem fs = warehousePath.getFileSystem(hiveConf);
+      Assert.assertTrue("Failed to delete " + warehousePath, fs.delete(warehousePath, true));
     }
   }
 

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkReaderDeletesBase.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkReaderDeletesBase.java
@@ -80,7 +80,7 @@ public abstract class TestFlinkReaderDeletesBase extends DeleteReadTests {
   }
 
   @AfterClass
-  public static void stopMetastore() {
+  public static void stopMetastore() throws Exception {
     metastore.stop();
     catalog = null;
   }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveMetastoreTest.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/HiveMetastoreTest.java
@@ -55,7 +55,7 @@ public abstract class HiveMetastoreTest {
   }
 
   @AfterClass
-  public static void stopMetastore() {
+  public static void stopMetastore() throws Exception {
     HiveMetastoreTest.catalog = null;
 
     metastoreClient.close();

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -286,9 +286,8 @@ public class TestHiveCatalog extends HiveMetastoreTest {
           catalog.createNamespace(namespace1);
         });
     String hiveLocalDir = temp.newFolder().toURI().toString();
-    if (hiveLocalDir.endsWith("/")) {
-      hiveLocalDir = hiveLocalDir.substring(0, hiveLocalDir.length() - 1);
-    }
+    // remove the trailing slash of the URI
+    hiveLocalDir = hiveLocalDir.substring(0, hiveLocalDir.length() - 1);
     ImmutableMap newMeta = ImmutableMap.<String, String>builder()
         .putAll(meta)
         .put("location", hiveLocalDir)

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -53,7 +53,7 @@ import static org.apache.iceberg.SortDirection.ASC;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class TestHiveCatalog extends HiveMetastoreTest {
-  private static final ImmutableMap<String, String> meta = ImmutableMap.of(
+  private static ImmutableMap meta = ImmutableMap.of(
       "owner", "apache",
       "group", "iceberg",
       "comment", "iceberg  hiveCatalog test");
@@ -289,7 +289,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
     if (hiveLocalDir.endsWith("/")) {
       hiveLocalDir = hiveLocalDir.substring(0, hiveLocalDir.length() - 1);
     }
-    ImmutableMap<String, String> newMeta = ImmutableMap.<String, String>builder()
+    ImmutableMap newMeta = ImmutableMap.<String, String>builder()
         .putAll(meta)
         .put("location", hiveLocalDir)
         .build();
@@ -298,7 +298,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
     catalog.createNamespace(namespace2, newMeta);
     Database database2 = metastoreClient.getDatabase(namespace2.toString());
     Assert.assertEquals("There no same location for db and namespace",
-        hiveLocalDir, database2.getLocationUri());
+        database2.getLocationUri(), hiveLocalDir);
   }
 
   @Test

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -298,7 +298,7 @@ public class TestHiveCatalog extends HiveMetastoreTest {
     catalog.createNamespace(namespace2, newMeta);
     Database database2 = metastoreClient.getDatabase(namespace2.toString());
     Assert.assertEquals("There no same location for db and namespace",
-            hiveLocalDir, database2.getLocationUri());
+        hiveLocalDir, database2.getLocationUri());
   }
 
   @Test

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerLocalScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerLocalScan.java
@@ -98,7 +98,7 @@ public class TestHiveIcebergStorageHandlerLocalScan {
   }
 
   @AfterClass
-  public static void afterClass() {
+  public static void afterClass() throws Exception {
     shell.stop();
   }
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -138,7 +138,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
   }
 
   @AfterClass
-  public static void afterClass() {
+  public static void afterClass() throws Exception {
     shell.stop();
   }
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerTimezone.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerTimezone.java
@@ -92,7 +92,7 @@ public class TestHiveIcebergStorageHandlerTimezone {
   }
 
   @AfterClass
-  public static void afterClass() {
+  public static void afterClass() throws Exception {
     shell.stop();
   }
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -158,7 +158,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
   }
 
   @AfterClass
-  public static void afterClass() {
+  public static void afterClass() throws Exception {
     shell.stop();
   }
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithMultipleCatalogs.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithMultipleCatalogs.java
@@ -94,7 +94,7 @@ public class TestHiveIcebergStorageHandlerWithMultipleCatalogs {
   }
 
   @AfterClass
-  public static void afterClass() {
+  public static void afterClass() throws Exception {
     shell.stop();
   }
 

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveShell.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveShell.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.mr.hive;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
@@ -98,7 +97,7 @@ public class TestHiveShell {
     started = true;
   }
 
-  public void stop() throws IOException {
+  public void stop() throws Exception {
     if (client != null) {
       client.stop();
     }

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveShell.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveShell.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.mr.hive;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
@@ -97,7 +98,7 @@ public class TestHiveShell {
     started = true;
   }
 
-  public void stop() {
+  public void stop() throws IOException {
     if (client != null) {
       client.stop();
     }

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -75,7 +75,7 @@ public abstract class SparkTestBase {
   }
 
   @AfterClass
-  public static void stopMetastoreAndSpark() {
+  public static void stopMetastoreAndSpark() throws Exception {
     SparkTestBase.catalog = null;
     metastore.stop();
     SparkTestBase.metastore = null;

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -92,7 +92,7 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
   }
 
   @AfterClass
-  public static void stopMetastoreAndSpark() {
+  public static void stopMetastoreAndSpark() throws Exception {
     catalog = null;
     metastore.stop();
     metastore = null;

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -75,7 +75,7 @@ public abstract class SparkTestBase {
   }
 
   @AfterClass
-  public static void stopMetastoreAndSpark() {
+  public static void stopMetastoreAndSpark() throws Exception {
     SparkTestBase.catalog = null;
     metastore.stop();
     SparkTestBase.metastore = null;

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -92,7 +92,7 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
   }
 
   @AfterClass
-  public static void stopMetastoreAndSpark() {
+  public static void stopMetastoreAndSpark() throws Exception {
     catalog = null;
     metastore.stop();
     metastore = null;

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -75,7 +75,7 @@ public abstract class SparkTestBase {
   }
 
   @AfterClass
-  public static void stopMetastoreAndSpark() {
+  public static void stopMetastoreAndSpark() throws Exception {
     SparkTestBase.catalog = null;
     metastore.stop();
     SparkTestBase.metastore = null;

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -92,7 +92,7 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
   }
 
   @AfterClass
-  public static void stopMetastoreAndSpark() {
+  public static void stopMetastoreAndSpark() throws Exception {
     catalog = null;
     metastore.stop();
     metastore = null;

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -75,7 +75,7 @@ public abstract class SparkTestBase {
   }
 
   @AfterClass
-  public static void stopMetastoreAndSpark() {
+  public static void stopMetastoreAndSpark() throws Exception {
     SparkTestBase.catalog = null;
     metastore.stop();
     SparkTestBase.metastore = null;

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
@@ -22,7 +22,8 @@ package org.apache.iceberg.spark;
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
-import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
@@ -46,7 +47,9 @@ public abstract class SparkTestBaseWithCatalog extends SparkTestBase {
   @AfterClass
   public static void dropWarehouse() throws IOException {
     if (warehouse != null && warehouse.exists()) {
-      FileUtils.forceDelete(warehouse);
+      Path warehousePath = new Path(warehouse.getAbsolutePath());
+      FileSystem fs = warehousePath.getFileSystem(hiveConf);
+      Assert.assertTrue("Failed to delete " + warehousePath, fs.delete(warehousePath, true));
     }
   }
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
@@ -44,8 +44,10 @@ public abstract class SparkTestBaseWithCatalog extends SparkTestBase {
   }
 
   @AfterClass
-  public static void dropWarehouse() {
-    FileUtils.deleteQuietly(warehouse);
+  public static void dropWarehouse() throws IOException {
+    if (warehouse != null && warehouse.exists()) {
+      FileUtils.forceDelete(warehouse);
+    }
   }
 
   @Rule

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBaseWithCatalog.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.spark;
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
+import org.apache.commons.io.FileUtils;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
@@ -44,9 +45,7 @@ public abstract class SparkTestBaseWithCatalog extends SparkTestBase {
 
   @AfterClass
   public static void dropWarehouse() {
-    if (warehouse != null && warehouse.exists()) {
-      warehouse.delete();
-    }
+    FileUtils.deleteQuietly(warehouse);
   }
 
   @Rule

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -110,7 +110,7 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
   }
 
   @AfterClass
-  public static void stopMetastoreAndSpark() {
+  public static void stopMetastoreAndSpark() throws Exception {
     catalog = null;
     metastore.stop();
     metastore = null;


### PR DESCRIPTION
Use `FileUtils.deleteQuietly` to delete the temp folders created in `TestHiveMetastore`, `SparkTestBaseWithCatalog` and `TestCatalogTableLoader`. Use JUnit `TemporaryFolder` in `TestHiveCatalog`.

Closes #3750