### PR TITLE
Hotfix: Attach Test annotation to testDeleteFromTableAtSnapshot

### DIFF
--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestDeleteFrom.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestDeleteFrom.java
@@ -72,6 +72,7 @@ public class TestDeleteFrom extends SparkCatalogTestBase {
         0L, scalarSql("SELECT count(1) FROM %s", tableName));
   }
 
+  @Test
   public void testDeleteFromTableAtSnapshot() throws NoSuchTableException {
     Assume.assumeFalse(
         "Spark session catalog does not support extended table names",


### PR DESCRIPTION
When I cherry-pick, I found that the method testDeleteFromTableAtSnapshot is missing a Test annotation.