### PR TITLE
Remove unnecessary extra declarations of assertj in build file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -365,7 +365,6 @@ project(':iceberg-gcp') {
     implementation 'com.google.cloud:google-cloud-storage'
 
     testImplementation 'com.google.cloud:google-cloud-nio'
-    testImplementation 'org.assertj:assertj-core'
 
     testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
 
@@ -579,7 +578,6 @@ project(':iceberg-nessie') {
     testImplementation "org.projectnessie:nessie-jaxrs-testextension"
     // Need to "pull in" el-api explicitly :(
     testImplementation "jakarta.el:jakarta.el-api"
-    testImplementation 'org.assertj:assertj-core'
 
     compileOnly "org.apache.hadoop:hadoop-common"
     testImplementation "org.apache.avro:avro"


### PR DESCRIPTION
The `assertj` dependency is included in all sub-modules, by default.

Some submodules are declaring it, which isn't necessary. I've removed them.