### PR TITLE
ORC: Add ORC bloom filter attributes to iceberg table

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -129,6 +129,8 @@ public class TableProperties {
   public static final String PARQUET_BATCH_SIZE = "read.parquet.vectorization.batch-size";
   public static final int PARQUET_BATCH_SIZE_DEFAULT = 5000;
 
+  public static final String ORC_BLOOM_FILTER_COLUMNS = "orc.bloom.filter.columns";
+  public static final String ORC_BLOOM_FILTER_FPP = "orc.bloom.filter.fpp";
   public static final String ORC_VECTORIZATION_ENABLED = "read.orc.vectorization.enabled";
   public static final boolean ORC_VECTORIZATION_ENABLED_DEFAULT = false;
 

--- a/site/docs/configuration.md
+++ b/site/docs/configuration.md
@@ -52,6 +52,8 @@ Iceberg tables support table properties to configure table behavior, like the de
 | write.metadata.delete-after-commit.enabled | false      | Controls whether to delete the oldest version metadata files after commit |
 | write.metadata.previous-versions-max       | 100        | The max number of previous version metadata files to keep before deleting after commit |
 | write.spark.fanout.enabled       | false        | Enables Partitioned-Fanout-Writer writes in Spark |
+| orc.bloom.filter.columns         | null         | Orc bloom filter config key     |
+| orc.bloom.filter.fpp             | null         | Orc bloom filter fpp config key |
 
 ### Table behavior properties
 


### PR DESCRIPTION
Hi ALL，this PR add ORC bloom filter attributes to iceberg table.In this way, the upper computing engine (Presto/Trino) can implement the orc bloom filter function