### PR TITLE
Core: Set the worker pool size to be at least 2 threads

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
+++ b/core/src/main/java/org/apache/iceberg/util/ThreadPools.java
@@ -36,7 +36,7 @@ public class ThreadPools {
 
   public static final int WORKER_THREAD_POOL_SIZE = getPoolSize(
       WORKER_THREAD_POOL_SIZE_PROP,
-      Runtime.getRuntime().availableProcessors());
+      Math.max(2, Runtime.getRuntime().availableProcessors()));
 
   private static final ExecutorService WORKER_POOL = MoreExecutors.getExitingExecutorService(
       (ThreadPoolExecutor) Executors.newFixedThreadPool(


### PR DESCRIPTION
This small PR sets the minimum size of the worker pool to be 2 threads. Many of the processes that use the pool are doing file I/O and are not necessarily CPU bound, like query planning, and often times people leave the number of Spark driver cores at the default of 1 core. This results in just one thread being used for query planning and other processes by default, which is a bit conservative.