### PR TITLE
Core: Fix metadata table scans when snapshot is null

### DIFF
--- a/core/src/main/java/org/apache/iceberg/HistoryTable.java
+++ b/core/src/main/java/org/apache/iceberg/HistoryTable.java
@@ -78,6 +78,16 @@ public class HistoryTable extends BaseMetadataTable {
       super(ops, table, HISTORY_SCHEMA, HistoryTable.this.metadataTableType().name(), HistoryTable.this::task);
     }
 
+    HistoryScan(TableOperations ops, Table table, TableScanContext context) {
+      super(ops, table, HISTORY_SCHEMA, HistoryTable.this.metadataTableType().name(),
+              HistoryTable.this::task, context);
+    }
+
+    @Override
+    protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
+      return new HistoryScan(ops, table, context);
+    }
+
     @Override
     public CloseableIterable<FileScanTask> planFiles() {
       // override planFiles to avoid the check for a current snapshot because this metadata table is for all snapshots

--- a/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
@@ -75,6 +75,16 @@ public class SnapshotsTable extends BaseMetadataTable {
       super(ops, table, SNAPSHOT_SCHEMA, SnapshotsTable.this.metadataTableType().name(), SnapshotsTable.this::task);
     }
 
+    SnapshotsTableScan(TableOperations ops, Table table, TableScanContext context) {
+      super(ops, table, SNAPSHOT_SCHEMA, SnapshotsTable.this.metadataTableType().name(),
+              SnapshotsTable.this::task, context);
+    }
+
+    @Override
+    protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
+      return new SnapshotsTableScan(ops, table, context);
+    }
+
     @Override
     public CloseableIterable<FileScanTask> planFiles() {
       // override planFiles to avoid the check for a current snapshot because this metadata table is for all snapshots

--- a/core/src/main/java/org/apache/iceberg/StaticTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/StaticTableScan.java
@@ -34,7 +34,7 @@ class StaticTableScan extends BaseMetadataTableScan {
     this.tableType = tableType;
   }
 
-  private StaticTableScan(TableOperations ops, Table table, Schema schema, String tableType,
+  StaticTableScan(TableOperations ops, Table table, Schema schema, String tableType,
                           Function<StaticTableScan, DataTask> buildTask, TableScanContext context) {
     super(ops, table, schema, context);
     this.buildTask = buildTask;


### PR DESCRIPTION
This PR fixes an issue when scanning the snapshots (and history) metadata tables. When the current snapshot for a table is not set, then no snapshots will be returned during the scan. A table can get in this state if it has snapshots, then a `REPLACE TABLE` operation is performed. In this case, the snapshots are still present but will not be returned because the current snapshot is not set. If some data is committed to the table, and the current snapshot is set to something, then the previous snapshots that were not returned will show up again.

Here is an example on how to reproduce with Spark SQL:
```
create table local.default.foobar (id int) using iceberg;  
insert into local.default.foobar values (1);  
replace table local.default.foobar (id int, data string) using iceberg;  
select * from local.default.foobar.snapshots; -- no snapshots returned  
```
