### PR TITLE
AWS: Support checksum validation with S3 eTags

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3MultipartUpload.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3MultipartUpload.java
@@ -56,6 +56,7 @@ public class TestS3MultipartUpload {
     prefix = UUID.randomUUID().toString();
     properties = new AwsProperties();
     properties.setS3FileIoMultiPartSize(AwsProperties.S3FILEIO_MULTIPART_SIZE_MIN);
+    properties.setS3ChecksumEnabled(true);
     io = new S3FileIO(() -> s3, properties);
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -212,7 +212,7 @@ public class AwsProperties implements Serializable {
   /**
    * Enables eTag checks for S3 PUT and MULTIPART upload requests.
    */
-  public static final String CLIENT_ENABLE_ETAG_CHECK = "client.enable.etag-check";
+  public static final String CLIENT_ENABLE_ETAG_CHECK = "s3.checksum.enabled";
   public static final boolean CLIENT_ENABLE_ETAG_CHECK_DEFAULT = false;
 
   private String s3FileIoSseType;

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -212,7 +212,7 @@ public class AwsProperties implements Serializable {
   /**
    * Enables eTag checks for S3 PUT and MULTIPART upload requests.
    */
-  public static final String S3_CHECKSUM_ENABLED = "s3.checksum.enabled";
+  public static final String S3_CHECKSUM_ENABLED = "s3.checksum-enabled";
   public static final boolean CLIENT_ENABLE_ETAG_CHECK_DEFAULT = false;
 
   private String s3FileIoSseType;

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -209,6 +209,12 @@ public class AwsProperties implements Serializable {
    */
   public static final String CLIENT_ASSUME_ROLE_REGION = "client.assume-role.region";
 
+  /**
+   * Enables eTag checks for S3 PUT and MULTIPART upload requests.
+   */
+  public static final String CLIENT_ENABLE_ETAG_CHECK = "client.enable.etag-check";
+  public static final boolean CLIENT_ENABLE_ETAG_CHECK_DEFAULT = false;
+
   private String s3FileIoSseType;
   private String s3FileIoSseKey;
   private String s3FileIoSseMd5;
@@ -222,6 +228,8 @@ public class AwsProperties implements Serializable {
   private boolean glueCatalogSkipArchive;
 
   private String dynamoDbTableName;
+
+  private boolean isEtagCheckEnabled;
 
   public AwsProperties() {
     this.s3FileIoSseType = S3FILEIO_SSE_TYPE_NONE;
@@ -284,6 +292,9 @@ public class AwsProperties implements Serializable {
 
     this.dynamoDbTableName = PropertyUtil.propertyAsString(properties, DYNAMODB_TABLE_NAME,
         DYNAMODB_TABLE_NAME_DEFAULT);
+
+    this.isEtagCheckEnabled = PropertyUtil.propertyAsBoolean(properties, CLIENT_ENABLE_ETAG_CHECK,
+        CLIENT_ENABLE_ETAG_CHECK_DEFAULT);
   }
 
   public String s3FileIoSseType() {
@@ -372,5 +383,13 @@ public class AwsProperties implements Serializable {
 
   public void setDynamoDbTableName(String name) {
     this.dynamoDbTableName = name;
+  }
+
+  public boolean isETagCheckEnabled() {
+    return this.isEtagCheckEnabled;
+  }
+
+  public void setETagCheckEnabled(boolean eTagCheckEnabled) {
+    this.isEtagCheckEnabled = eTagCheckEnabled;
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -212,7 +212,7 @@ public class AwsProperties implements Serializable {
   /**
    * Enables eTag checks for S3 PUT and MULTIPART upload requests.
    */
-  public static final String CLIENT_ENABLE_ETAG_CHECK = "s3.checksum.enabled";
+  public static final String S3_CHECKSUM_ENABLED = "s3.checksum.enabled";
   public static final boolean CLIENT_ENABLE_ETAG_CHECK_DEFAULT = false;
 
   private String s3FileIoSseType;
@@ -229,7 +229,7 @@ public class AwsProperties implements Serializable {
 
   private String dynamoDbTableName;
 
-  private boolean isEtagCheckEnabled;
+  private boolean isS3ChecksumEnabled;
 
   public AwsProperties() {
     this.s3FileIoSseType = S3FILEIO_SSE_TYPE_NONE;
@@ -293,7 +293,7 @@ public class AwsProperties implements Serializable {
     this.dynamoDbTableName = PropertyUtil.propertyAsString(properties, DYNAMODB_TABLE_NAME,
         DYNAMODB_TABLE_NAME_DEFAULT);
 
-    this.isEtagCheckEnabled = PropertyUtil.propertyAsBoolean(properties, CLIENT_ENABLE_ETAG_CHECK,
+    this.isS3ChecksumEnabled = PropertyUtil.propertyAsBoolean(properties, S3_CHECKSUM_ENABLED,
         CLIENT_ENABLE_ETAG_CHECK_DEFAULT);
   }
 
@@ -385,11 +385,11 @@ public class AwsProperties implements Serializable {
     this.dynamoDbTableName = name;
   }
 
-  public boolean isETagCheckEnabled() {
-    return this.isEtagCheckEnabled;
+  public boolean isS3ChecksumEnabled() {
+    return this.isS3ChecksumEnabled;
   }
 
-  public void setETagCheckEnabled(boolean eTagCheckEnabled) {
-    this.isEtagCheckEnabled = eTagCheckEnabled;
+  public void setS3ChecksumEnabled(boolean eTagCheckEnabled) {
+    this.isS3ChecksumEnabled = eTagCheckEnabled;
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -116,7 +116,7 @@ class S3OutputStream extends PositionOutputStream {
     multiPartSize = awsProperties.s3FileIoMultiPartSize();
     multiPartThresholdSize =  (int) (multiPartSize * awsProperties.s3FileIOMultipartThresholdFactor());
     stagingDirectory = new File(awsProperties.s3fileIoStagingDirectory());
-    isEtagCheckEnabled = awsProperties.isETagCheckEnabled();
+    isEtagCheckEnabled = awsProperties.isS3ChecksumEnabled();
     try {
       completeMessageDigest = isEtagCheckEnabled ? MessageDigest.getInstance(digestAlgorithm) : null;
     } catch (NoSuchAlgorithmException e) {

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -122,7 +122,7 @@ class S3OutputStream extends PositionOutputStream {
     try {
       completeMessageDigest = isChecksumEnabled ? MessageDigest.getInstance(digestAlgorithm) : null;
     } catch (NoSuchAlgorithmException e) {
-      throw new RuntimeException("Failed to create message digest needed for s3 checksum checks.", e);
+      throw new RuntimeException("Failed to create message digest needed for s3 checksum checks", e);
     }
 
     newStream();
@@ -201,12 +201,15 @@ class S3OutputStream extends PositionOutputStream {
     stagingFiles.add(new FileAndDigest(currentStagingFile, currentPartMessageDigest));
 
     if (isChecksumEnabled) {
-      DigestOutputStream digestOutputStream = new DigestOutputStream(new DigestOutputStream(new BufferedOutputStream(
-          new FileOutputStream(currentStagingFile)), currentPartMessageDigest), completeMessageDigest);
+      DigestOutputStream digestOutputStream;
 
       // if switched over to multipart threshold already, no need to update complete message digest
       if (multipartUploadId != null) {
-        digestOutputStream.on(false);
+        digestOutputStream = new DigestOutputStream(new BufferedOutputStream(
+            new FileOutputStream(currentStagingFile)), currentPartMessageDigest);
+      } else {
+        digestOutputStream = new DigestOutputStream(new DigestOutputStream(new BufferedOutputStream(
+            new FileOutputStream(currentStagingFile)), currentPartMessageDigest), completeMessageDigest);
       }
 
       stream = new CountingOutputStream(digestOutputStream);
@@ -264,7 +267,7 @@ class S3OutputStream extends PositionOutputStream {
               .contentLength(f.length());
 
           if (fileAndDigest.hasDigest()) {
-            requestBuilder.contentMD5(BinaryUtils.toBase64(fileAndDigest.getDigest()));
+            requestBuilder.contentMD5(BinaryUtils.toBase64(fileAndDigest.digest()));
           }
 
           S3RequestUtil.configureEncryption(awsProperties, requestBuilder);
@@ -417,7 +420,7 @@ class S3OutputStream extends PositionOutputStream {
       return file;
     }
 
-    byte[] getDigest() {
+    byte[] digest() {
       return digest.digest();
     }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -147,7 +147,6 @@ class S3OutputStream extends PositionOutputStream {
     }
 
     stream.write(b);
-
     pos += 1;
 
     // switch to multipart upload
@@ -169,7 +168,6 @@ class S3OutputStream extends PositionOutputStream {
       int writeSize = multiPartSize - (int) stream.getCount();
 
       stream.write(b, relativeOffset, writeSize);
-
       remaining -= writeSize;
       relativeOffset += writeSize;
 
@@ -178,7 +176,6 @@ class S3OutputStream extends PositionOutputStream {
     }
 
     stream.write(b, relativeOffset, remaining);
-
     pos += len;
 
     // switch to multipart upload

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -27,7 +27,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.SequenceInputStream;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.DigestException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Comparator;

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
@@ -25,8 +25,14 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.DigestException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Random;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -35,6 +41,7 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,9 +56,11 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+import software.amazon.awssdk.utils.BinaryUtils;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeastOnce;
@@ -66,6 +75,7 @@ import static org.mockito.Mockito.verify;
 public class TestS3OutputStream {
   private static final Logger LOG = LoggerFactory.getLogger(TestS3OutputStream.class);
   private static final String BUCKET = "test-bucket";
+  private static final int FIVE_MBS = 5 * 1024 * 1024;
 
   @ClassRule
   public static final S3MockRule S3_MOCK_RULE = S3MockRule.builder().silent().build();
@@ -77,7 +87,7 @@ public class TestS3OutputStream {
   private final String newTmpDirectory = "/tmp/newStagingDirectory";
 
   private final AwsProperties properties = new AwsProperties(ImmutableMap.of(
-      AwsProperties.S3FILEIO_MULTIPART_SIZE, Integer.toString(5 * 1024 * 1024),
+      AwsProperties.S3FILEIO_MULTIPART_SIZE, Integer.toString(FIVE_MBS),
       AwsProperties.S3FILEIO_STAGING_DIRECTORY, tmpDir.toString()));
 
   public TestS3OutputStream() throws IOException {
@@ -149,25 +159,80 @@ public class TestS3OutputStream {
     // Run tests for both byte and array write paths
     Stream.of(true, false).forEach(arrayWrite -> {
       // Test small file write (less than multipart threshold)
-      writeAndVerify(s3mock, randomURI(), randomData(1024), arrayWrite);
-      verify(s3mock, times(1)).putObject((PutObjectRequest) any(), (RequestBody) any());
+      byte[] data = randomData(1024);
+      writeAndVerify(s3mock, randomURI(), data, arrayWrite);
+      ArgumentCaptor<PutObjectRequest> putObjectRequestArgumentCaptor =
+          ArgumentCaptor.forClass(PutObjectRequest.class);
+      verify(s3mock, times(1)).putObject(putObjectRequestArgumentCaptor.capture(),
+          (RequestBody) any());
+      checkPutObjectRequestContent(data, putObjectRequestArgumentCaptor);
       reset(s3mock);
 
       // Test file larger than part size but less than multipart threshold
-      writeAndVerify(s3mock, randomURI(), randomData(6 * 1024 * 1024), arrayWrite);
-      verify(s3mock, times(1)).putObject((PutObjectRequest) any(), (RequestBody) any());
+      data = randomData(6 * 1024 * 1024);
+      writeAndVerify(s3mock, randomURI(), data, arrayWrite);
+      putObjectRequestArgumentCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+      verify(s3mock, times(1)).putObject(putObjectRequestArgumentCaptor.capture(),
+          (RequestBody) any());
+      checkPutObjectRequestContent(data, putObjectRequestArgumentCaptor);
       reset(s3mock);
 
       // Test file large enough to trigger multipart upload
-      writeAndVerify(s3mock, randomURI(), randomData(10 * 1024 * 1024), arrayWrite);
-      verify(s3mock, times(2)).uploadPart((UploadPartRequest) any(), (RequestBody) any());
+      data = randomData(10 * 1024 * 1024);
+      writeAndVerify(s3mock, randomURI(), data, arrayWrite);
+      ArgumentCaptor<UploadPartRequest> uploadPartRequestArgumentCaptor =
+          ArgumentCaptor.forClass(UploadPartRequest.class);
+      verify(s3mock, times(2)).uploadPart(uploadPartRequestArgumentCaptor.capture(),
+          (RequestBody) any());
+      checkUploadPartRequestContent(data, uploadPartRequestArgumentCaptor);
       reset(s3mock);
 
       // Test uploading many parts
-      writeAndVerify(s3mock, randomURI(), randomData(22 * 1024 * 1024), arrayWrite);
-      verify(s3mock, times(5)).uploadPart((UploadPartRequest) any(), (RequestBody) any());
+      data = randomData(22 * 1024 * 1024);
+      writeAndVerify(s3mock, randomURI(), data, arrayWrite);
+      uploadPartRequestArgumentCaptor =
+          ArgumentCaptor.forClass(UploadPartRequest.class);
+      verify(s3mock, times(5)).uploadPart(uploadPartRequestArgumentCaptor.capture(),
+          (RequestBody) any());
+      checkUploadPartRequestContent(data, uploadPartRequestArgumentCaptor);
       reset(s3mock);
     });
+  }
+
+  private void checkUploadPartRequestContent(
+      byte[] data,
+      ArgumentCaptor<UploadPartRequest> uploadPartRequestArgumentCaptor) {
+    if (properties.isS3ChecksumEnabled()) {
+      List<UploadPartRequest> uploadPartRequests =
+          uploadPartRequestArgumentCaptor.getAllValues().stream()
+              .sorted(Comparator.comparingInt(UploadPartRequest::partNumber))
+              .collect(Collectors.toList());
+      for (int i = 0; i < uploadPartRequests.size(); ++i) {
+        int offset = i * FIVE_MBS;
+        int len = (i + 1) * FIVE_MBS - 1 > data.length ? data.length - offset : FIVE_MBS;
+        assertEquals(getDigest(data, offset, len), uploadPartRequests.get(i).contentMD5());
+      }
+    }
+  }
+
+  private void checkPutObjectRequestContent(
+      byte[] data,
+      ArgumentCaptor<PutObjectRequest> putObjectRequestArgumentCaptor) {
+    if (properties.isS3ChecksumEnabled()) {
+      List<PutObjectRequest> putObjectRequests = putObjectRequestArgumentCaptor.getAllValues();
+      assertEquals(getDigest(data, 0, data.length), putObjectRequests.get(0).contentMD5());
+    }
+  }
+
+  private String getDigest(byte[] data, int offset, int length) {
+    try {
+      MessageDigest md5 = MessageDigest.getInstance("MD5");
+      md5.update(data, offset, length);
+      return BinaryUtils.toBase64(md5.digest());
+    } catch (NoSuchAlgorithmException e) {
+      fail(String.format("Failed to get MD5 MessageDigest. %s", e));
+    }
+    return null;
   }
 
   private void writeAndVerify(S3Client client, S3URI uri, byte [] data, boolean arrayWrite) {

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
@@ -86,7 +86,7 @@ public class TestS3OutputStream {
   private final String newTmpDirectory = "/tmp/newStagingDirectory";
 
   private final AwsProperties properties = new AwsProperties(ImmutableMap.of(
-      AwsProperties.S3FILEIO_MULTIPART_SIZE, Integer.toString(FIVE_MBS),
+      AwsProperties.S3FILEIO_MULTIPART_SIZE, Integer.toString(5 * 1024 * 1024),
       AwsProperties.S3FILEIO_STAGING_DIRECTORY, tmpDir.toString()));
 
   public TestS3OutputStream() throws IOException {
@@ -149,7 +149,7 @@ public class TestS3OutputStream {
   }
 
   @Test
-  public void testWriteWithEtagEnabled() {
+  public void testWriteWithChecksumEnabled() {
     properties.setS3ChecksumEnabled(true);
     writeTest();
   }

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
@@ -85,7 +85,7 @@ public class TestS3OutputStream {
 
   @Before
   public void before() {
-    properties.setETagCheckEnabled(false);
+    properties.setS3ChecksumEnabled(false);
     s3.createBucket(CreateBucketRequest.builder().bucket(BUCKET).build());
   }
 
@@ -141,7 +141,7 @@ public class TestS3OutputStream {
 
   @Test
   public void testWriteWithEtagEnabled() {
-    properties.setETagCheckEnabled(true);
+    properties.setS3ChecksumEnabled(true);
     writeTest();
   }
 


### PR DESCRIPTION
This PR adds capability to perform checksum validations on data uploads using S3 eTags. This should help in capturing hardware issues like corrupt disks that may affect the staged files generated while uploading data to S3.