### PR TITLE
Docs: Add `Streaming upsert write`  in flink.md

### DIFF
--- a/site/docs/flink.md
+++ b/site/docs/flink.md
@@ -522,6 +522,20 @@ FlinkSink.forRowData(input)
 env.execute("Test Iceberg DataStream");
 ```
 
+## Streaming upsert write
+
+Iceberg supports upsert based on the primary key when writing streaming data into v2 table format.
+
+```sql
+CREATE TABLE `hive_catalog`.`default`.`sample` (
+  `id`  INT UNIQUE COMMENT 'unique id',
+  `data` STRING NOT NULL,
+ PRIMARY KEY(`id`) NOT ENFORCED
+) with ('format-version'='2', 'write.upsert.enabled'='true');
+```
+!!! Note
+    OVERWRITE mode shouldn't be enable when configuring to use UPSERT data stream.
+
 ## Inspecting tables.
 
 Iceberg does not support inspecting table in flink sql now, we need to use [iceberg's Java API](./api.md) to read iceberg's meta data to get those table information.

--- a/site/docs/flink.md
+++ b/site/docs/flink.md
@@ -534,7 +534,8 @@ CREATE TABLE `hive_catalog`.`default`.`sample` (
 ) with ('format-version'='2', 'write.upsert.enabled'='true');
 ```
 !!! Note
-    When configured to use the UPSERT stream, the OVERWRITE mode should not be enabled and the partition field should be included in the equality field.
+    OVERWRITE mode shouldn't be enable when configuring to use UPSERT data stream.
+    In UPSERT mode, if the table is partitioned, the partition fields should be a part of equality fields.
 
 ## Inspecting tables.
 

--- a/site/docs/flink.md
+++ b/site/docs/flink.md
@@ -534,7 +534,7 @@ CREATE TABLE `hive_catalog`.`default`.`sample` (
 ) with ('format-version'='2', 'write.upsert.enabled'='true');
 ```
 !!! Note
-    OVERWRITE mode shouldn't be enable when configuring to use UPSERT data stream.
+    When configured to use the UPSERT stream, the OVERWRITE mode should not be enabled and the partition field should be included in the equality field.
 
 ## Inspecting tables.
 


### PR DESCRIPTION
Add a separate use case of `write.upsert.enabled` in the flink document to answer some questions of flink users. Is this necessary?

