### PR TITLE
Expanding primitive types to individual classes

### DIFF
--- a/python/src/iceberg/types.py
+++ b/python/src/iceberg/types.py
@@ -18,7 +18,7 @@
 from typing import Optional
 
 
-class Type(object):
+class Type:
     def __init__(self, type_string: str, repr_string: str, is_primitive=False):
         self._type_string = type_string
         self._repr_string = repr_string
@@ -157,15 +157,107 @@ class MapType(Type):
         return self._value_field
 
 
-BooleanType = Type("boolean", "BooleanType", is_primitive=True)
-IntegerType = Type("int", "IntegerType", is_primitive=True)
-LongType = Type("long", "LongType", is_primitive=True)
-FloatType = Type("float", "FloatType", is_primitive=True)
-DoubleType = Type("double", "DoubleType", is_primitive=True)
-DateType = Type("date", "DateType", is_primitive=True)
-TimeType = Type("time", "TimeType", is_primitive=True)
-TimestampType = Type("timestamp", "TimestampType", is_primitive=True)
-TimestamptzType = Type("timestamptz", "TimestamptzType", is_primitive=True)
-StringType = Type("string", "StringType", is_primitive=True)
-UUIDType = Type("uuid", "UUIDType", is_primitive=True)
-BinaryType = Type("binary", "BinaryType", is_primitive=True)
+class Boolean(Type):
+    """`boolean` from https://iceberg.apache.org/#spec/#primitive-types"""
+
+    def __init__(self):
+        super().__init__("boolean", "BooleanType", is_primitive=True)
+
+
+class Integer(Type):
+    """32-bit signed integers: `int` from https://iceberg.apache.org/#spec/#primitive-types"""
+
+    max: int = 2147483647
+
+    min: int = -2147483648
+
+    def __init__(self):
+        super().__init__("int", "IntegerType", is_primitive=True)
+
+
+class Long(Type):
+    """64-bit signed integers: `long` from https://iceberg.apache.org/#spec/#primitive-types"""
+
+    max: int = 9223372036854775807
+
+    min: int = -9223372036854775808
+
+    def __init__(self):
+        super().__init__("long", "LongType", is_primitive=True)
+
+
+class Float(Type):
+    """32-bit IEEE 754 floating point: `float` from https://iceberg.apache.org/#spec/#primitive-types"""
+
+    def __init__(self):
+        super().__init__("float", "FloatType", is_primitive=True)
+
+
+class Double(Type):
+    """64-bit IEEE 754 floating point: `double` from https://iceberg.apache.org/#spec/#primitive-types"""
+
+    def __init__(self):
+        super().__init__("double", "DoubleType", is_primitive=True)
+
+
+class Date(Type):
+    """`date` type from https://iceberg.apache.org/#spec/#primitive-types"""
+
+    def __init__(self):
+        super().__init__("date", "DateType", is_primitive=True)
+
+
+class Time(Type):
+    """`time` type from https://iceberg.apache.org/#spec/#primitive-types"""
+
+    def __init__(self):
+        super().__init__("time", "TimeType", is_primitive=True)
+
+
+class Timestamp(Type):
+    """`timestamp` type from https://iceberg.apache.org/#spec/#primitive-types"""
+
+    def __init__(self):
+        super().__init__("timestamp", "TimestampType", is_primitive=True)
+
+
+class Timestamptz(Type):
+    """`timestamptz` type from https://iceberg.apache.org/#spec/#primitive-types"""
+
+    def __init__(self):
+        super().__init__("timestamptz", "TimestamptzType", is_primitive=True)
+
+
+class String(Type):
+    """Arbitrary-length character sequences Encoded with UTF-8: `string` from https://iceberg.apache.org/#spec/#primitive-types"""
+
+    def __init__(self):
+        super().__init__("string", "StringType", is_primitive=True)
+
+
+class UUID(Type):
+    """Universally unique identifiers: `uuid` from https://iceberg.apache.org/#spec/#primitive-types"""
+
+    def __init__(self):
+        super().__init__("uuid", "UUIDType", is_primitive=True)
+
+
+class Binary(Type):
+    """Arbitrary-length byte array from  https://iceberg.apache.org/#spec/#primitive-types"""
+
+    def __init__(self):
+        super().__init__("binary", "BinaryType", is_primitive=True)
+
+
+BooleanType = Boolean()
+IntegerType = Integer()
+LongType = Long()
+FloatType = Float()
+DoubleType = Double()
+DateType = Date()
+TimeType = Time()
+TimestampType = Timestamp()
+TimestamptzType = Timestamptz()
+StringType = String()
+UUIDType = UUID()
+BinaryType = Binary()

--- a/python/src/iceberg/types.py
+++ b/python/src/iceberg/types.py
@@ -14,6 +14,22 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""Data types used in describing Iceberg schemas
+
+This module implements the data types described in the Iceberg specification for Iceberg schemas. To
+describe an Iceberg table schema, these classes can be used in the construction of a StructType instance.
+
+Example:
+    >>> StructType(
+        [
+            NestedField(True, 1, "required_field", StringType()),
+            NestedField(False, 2, "optional_field", IntegerType()),
+        ]
+    )
+
+Notes:
+  - https://iceberg.apache.org/#spec/#primitive-types
+"""
 
 from typing import Optional
 
@@ -157,107 +173,190 @@ class MapType(Type):
         return self._value_field
 
 
-class Boolean(Type):
-    """`boolean` from https://iceberg.apache.org/#spec/#primitive-types"""
+class BooleanType(Type):
+    """A boolean data type in Iceberg can be represented using an instance of this class.
+
+    Example:
+        >>> column_foo = BooleanType()
+        >>> isinstance(column_foo, BooleanType)
+        True
+    """
 
     def __init__(self):
-        super().__init__("boolean", "BooleanType", is_primitive=True)
+        super().__init__("boolean", "BooleanType()", is_primitive=True)
 
 
-class Integer(Type):
-    """32-bit signed integers: `int` from https://iceberg.apache.org/#spec/#primitive-types"""
+class IntegerType(Type):
+    """An Integer data type in Iceberg can be represented using an instance of this class. Integers in Iceberg are
+    32-bit signed and can be promoted to Longs.
+
+    Example:
+        >>> column_foo = IntegerType()
+        >>> isinstance(column_foo, IntegerType)
+        True
+
+    Attributes:
+        max (int): The maximum allowed value for Integers, inherited from the canonical Iceberg implementation
+          in Java (returns `2147483647`)
+        min (int): The minimum allowed value for Integers, inherited from the canonical Iceberg implementation
+          in Java (returns `-2147483648`)
+    """
 
     max: int = 2147483647
 
     min: int = -2147483648
 
     def __init__(self):
-        super().__init__("int", "IntegerType", is_primitive=True)
+        super().__init__("int", "IntegerType()", is_primitive=True)
 
 
-class Long(Type):
-    """64-bit signed integers: `long` from https://iceberg.apache.org/#spec/#primitive-types"""
+class LongType(Type):
+    """A Long data type in Iceberg can be represented using an instance of this class. Longs in Iceberg are
+    64-bit signed integers.
+
+    Example:
+        >>> column_foo = LongType()
+        >>> isinstance(column_foo, LongType)
+        True
+
+    Attributes:
+        max (int): The maximum allowed value for Longs, inherited from the canonical Iceberg implementation
+          in Java. (returns `9223372036854775807`)
+        min (int): The minimum allowed value for Longs, inherited from the canonical Iceberg implementation
+          in Java (returns `-9223372036854775808`)
+    """
 
     max: int = 9223372036854775807
 
     min: int = -9223372036854775808
 
     def __init__(self):
-        super().__init__("long", "LongType", is_primitive=True)
+        super().__init__("long", "LongType()", is_primitive=True)
 
 
-class Float(Type):
-    """32-bit IEEE 754 floating point: `float` from https://iceberg.apache.org/#spec/#primitive-types"""
+class FloatType(Type):
+    """A Float data type in Iceberg can be represented using an instance of this class. Floats in Iceberg are
+    32-bit IEEE 754 floating points and can be promoted to Doubles.
 
-    def __init__(self):
-        super().__init__("float", "FloatType", is_primitive=True)
-
-
-class Double(Type):
-    """64-bit IEEE 754 floating point: `double` from https://iceberg.apache.org/#spec/#primitive-types"""
-
-    def __init__(self):
-        super().__init__("double", "DoubleType", is_primitive=True)
-
-
-class Date(Type):
-    """`date` type from https://iceberg.apache.org/#spec/#primitive-types"""
+    Example:
+        >>> column_foo = FloatType()
+        >>> isinstance(column_foo, FloatType)
+        True
+    """
 
     def __init__(self):
-        super().__init__("date", "DateType", is_primitive=True)
+        super().__init__("float", "FloatType()", is_primitive=True)
 
 
-class Time(Type):
-    """`time` type from https://iceberg.apache.org/#spec/#primitive-types"""
+class DoubleType(Type):
+    """A Double data type in Iceberg can be represented using an instance of this class. Doubles in Iceberg are
+    64-bit IEEE 754 floating points.
 
-    def __init__(self):
-        super().__init__("time", "TimeType", is_primitive=True)
-
-
-class Timestamp(Type):
-    """`timestamp` type from https://iceberg.apache.org/#spec/#primitive-types"""
-
-    def __init__(self):
-        super().__init__("timestamp", "TimestampType", is_primitive=True)
-
-
-class Timestamptz(Type):
-    """`timestamptz` type from https://iceberg.apache.org/#spec/#primitive-types"""
+    Example:
+        >>> column_foo = DoubleType()
+        >>> isinstance(column_foo, DoubleType)
+        True
+    """
 
     def __init__(self):
-        super().__init__("timestamptz", "TimestamptzType", is_primitive=True)
+        super().__init__("double", "DoubleType()", is_primitive=True)
 
 
-class String(Type):
-    """Arbitrary-length character sequences Encoded with UTF-8: `string` from https://iceberg.apache.org/#spec/#primitive-types"""
+class DateType(Type):
+    """A Date data type in Iceberg can be represented using an instance of this class. Dates in Iceberg are
+    calendar dates without a timezone or time.
 
-    def __init__(self):
-        super().__init__("string", "StringType", is_primitive=True)
-
-
-class UUID(Type):
-    """Universally unique identifiers: `uuid` from https://iceberg.apache.org/#spec/#primitive-types"""
-
-    def __init__(self):
-        super().__init__("uuid", "UUIDType", is_primitive=True)
-
-
-class Binary(Type):
-    """Arbitrary-length byte array from  https://iceberg.apache.org/#spec/#primitive-types"""
+    Example:
+        >>> column_foo = DateType()
+        >>> isinstance(column_foo, DateType)
+        True
+    """
 
     def __init__(self):
-        super().__init__("binary", "BinaryType", is_primitive=True)
+        super().__init__("date", "DateType()", is_primitive=True)
 
 
-BooleanType = Boolean()
-IntegerType = Integer()
-LongType = Long()
-FloatType = Float()
-DoubleType = Double()
-DateType = Date()
-TimeType = Time()
-TimestampType = Timestamp()
-TimestamptzType = Timestamptz()
-StringType = String()
-UUIDType = UUID()
-BinaryType = Binary()
+class TimeType(Type):
+    """A Time data type in Iceberg can be represented using an instance of this class. Times in Iceberg
+    have microsecond precision and are a time of day without a date or timezone.
+
+    Example:
+        >>> column_foo = TimeType()
+        >>> isinstance(column_foo, TimeType)
+        True
+
+    """
+
+    def __init__(self):
+        super().__init__("time", "TimeType()", is_primitive=True)
+
+
+class TimestampType(Type):
+    """A Timestamp data type in Iceberg can be represented using an instance of this class. Timestamps in
+    Iceberg have microsecond precision and include a date and a time of day without a timezone.
+
+    Example:
+        >>> column_foo = TimestampType()
+        >>> isinstance(column_foo, TimestampType)
+        True
+
+    """
+
+    def __init__(self):
+        super().__init__("timestamp", "TimestampType()", is_primitive=True)
+
+
+class TimestamptzType(Type):
+    """A Timestamptz data type in Iceberg can be represented using an instance of this class. Timestamptzs in
+    Iceberg are stored as UTC and include a date and a time of day with a timezone.
+
+    Example:
+        >>> column_foo = TimestamptzType()
+        >>> isinstance(column_foo, TimestamptzType)
+        True
+    """
+
+    def __init__(self):
+        super().__init__("timestamptz", "TimestamptzType()", is_primitive=True)
+
+
+class StringType(Type):
+    """A String data type in Iceberg can be represented using an instance of this class. Strings in
+    Iceberg are arbitrary-length character sequences and are encoded with UTF-8.
+
+    Example:
+        >>> column_foo = StringType()
+        >>> isinstance(column_foo, StringType)
+        True
+    """
+
+    def __init__(self):
+        super().__init__("string", "StringType()", is_primitive=True)
+
+
+class UUIDType(Type):
+    """A UUID data type in Iceberg can be represented using an instance of this class. UUIDs in
+    Iceberg are universally unique identifiers.
+
+    Example:
+        >>> column_foo = UUIDType()
+        >>> isinstance(column_foo, UUIDType)
+        True
+    """
+
+    def __init__(self):
+        super().__init__("uuid", "UUIDType()", is_primitive=True)
+
+
+class BinaryType(Type):
+    """A Binary data type in Iceberg can be represented using an instance of this class. Binarys in
+    Iceberg are arbitrary-length byte arrays.
+
+    Example:
+        >>> column_foo = BinaryType()
+        >>> isinstance(column_foo, BinaryType)
+        True
+    """
+
+    def __init__(self):
+        super().__init__("binary", "BinaryType()", is_primitive=True)

--- a/python/tests/test_types.py
+++ b/python/tests/test_types.py
@@ -57,7 +57,7 @@ from iceberg.types import (
     ],
 )
 def test_repr_primitive_types(input_type):
-    assert input_type == eval(repr(input_type))
+    assert isinstance(eval(repr(input_type())), input_type)
 
 
 def test_fixed_type():
@@ -80,7 +80,7 @@ def test_decimal_type():
 def test_struct_type():
     type_var = StructType(
         [
-            NestedField(True, 1, "optional_field", IntegerType),
+            NestedField(True, 1, "optional_field", IntegerType()),
             NestedField(False, 2, "required_field", FixedType(5)),
             NestedField(
                 False,
@@ -89,7 +89,7 @@ def test_struct_type():
                 StructType(
                     [
                         NestedField(True, 4, "optional_field", DecimalType(8, 2)),
-                        NestedField(False, 5, "required_field", LongType),
+                        NestedField(False, 5, "required_field", LongType()),
                     ]
                 ),
             ),
@@ -108,7 +108,7 @@ def test_list_type():
             StructType(
                 [
                     NestedField(True, 2, "optional_field", DecimalType(8, 2)),
-                    NestedField(False, 3, "required_field", LongType),
+                    NestedField(False, 3, "required_field", LongType()),
                 ]
             ),
         )
@@ -121,12 +121,12 @@ def test_list_type():
 
 def test_map_type():
     type_var = MapType(
-        NestedField(True, 1, "optional_field", DoubleType),
-        NestedField(False, 2, "required_field", UUIDType),
+        NestedField(True, 1, "optional_field", DoubleType()),
+        NestedField(False, 2, "required_field", UUIDType()),
     )
-    assert type_var.key.type == DoubleType
+    assert isinstance(type_var.key.type, DoubleType)
     assert type_var.key.field_id == 1
-    assert type_var.value.type == UUIDType
+    assert isinstance(type_var.value.type, UUIDType)
     assert type_var.value.field_id == 2
     assert str(type_var) == str(eval(repr(type_var)))
 
@@ -142,15 +142,15 @@ def test_nested_field():
                     True,
                     2,
                     "optional_field2",
-                    ListType(NestedField(False, 3, "required_field3", DoubleType)),
+                    ListType(NestedField(False, 3, "required_field3", DoubleType())),
                 ),
                 NestedField(
                     False,
                     4,
                     "required_field4",
                     MapType(
-                        NestedField(True, 5, "optional_field5", TimeType),
-                        NestedField(False, 6, "required_field6", UUIDType),
+                        NestedField(True, 5, "optional_field5", TimeType()),
+                        NestedField(False, 6, "required_field6", UUIDType()),
                     ),
                 ),
             ]


### PR DESCRIPTION
This PR is to solve having to do `isinstance` or `==` when checking types. 

```python
from iceberg.types import BooleanType, Boolean
x = BooleanType
isinstance(x, Boolean)  # True
```
No changes to tests. This also should not conflict with other PRs.

