### PR TITLE
Spark 3.0: Fix delete from snapshot of table

### DIFF
--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -244,6 +244,7 @@ public class SparkTable implements org.apache.spark.sql.connector.catalog.Table,
 
   @Override
   public void deleteWhere(Filter[] filters) {
+    canDeleteWhere(filters);
     Expression deleteExpr = SparkFilters.convert(filters);
 
     if (deleteExpr == Expressions.alwaysFalse()) {

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -244,7 +244,10 @@ public class SparkTable implements org.apache.spark.sql.connector.catalog.Table,
 
   @Override
   public void deleteWhere(Filter[] filters) {
-    canDeleteWhere(filters);
+    Preconditions.checkArgument(
+        snapshotId == null,
+        "Cannot delete from table at a specific snapshot: %s", snapshotId);
+
     Expression deleteExpr = SparkFilters.convert(filters);
 
     if (deleteExpr == Expressions.alwaysFalse()) {

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestDeleteFrom.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestDeleteFrom.java
@@ -72,6 +72,7 @@ public class TestDeleteFrom extends SparkCatalogTestBase {
         0L, scalarSql("SELECT count(1) FROM %s", tableName));
   }
 
+  @Test
   public void testDeleteFromTableAtSnapshot() throws NoSuchTableException {
     Assume.assumeFalse(
         "Spark session catalog does not support extended table names",


### PR DESCRIPTION
Fix UT case testDeleteFromTableAtSnapshot. This UT failed in spark version 3.0. I think this is because the [[SPARK-33623][SQL] Add canDeleteWhere to SupportsDelete](https://github.com/apache/spark/pull/30562) does not exist in 3.0.