### PR TITLE
[Core][Rewrite]Fix merge manifests lost sequence number for added files when rewrite using staring sequnce number

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestWriter.java
@@ -117,7 +117,11 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
   }
 
   void add(ManifestEntry<F> entry) {
-    addEntry(reused.wrapAppend(snapshotId, entry.sequenceNumber(), entry.file()));
+    if (entry.sequenceNumber() != null && entry.sequenceNumber() >= 0) {
+      addEntry(reused.wrapAppend(snapshotId, entry.sequenceNumber(), entry.file()));
+    } else {
+      addEntry(reused.wrapAppend(snapshotId, entry.file()));
+    }
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/ManifestWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestWriter.java
@@ -117,7 +117,7 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
   }
 
   void add(ManifestEntry<F> entry) {
-    addEntry(reused.wrapAppend(snapshotId, entry.file()));
+    addEntry(reused.wrapAppend(snapshotId, entry.sequenceNumber(), entry.file()));
   }
 
   /**


### PR DESCRIPTION
We use the starting-sequence-number configuration when rewriting, then the data written in this rewrite will set the `status` to `ADDED` in the manifest entry, and set the `sequence_number` to the sequence number of the snapshot read before the rewrite. If this rewrite also triggers the manifest merge at the end, the sequence number of the new added data file's manifest entry will be lost. 

For example: after an overwrite, a new data file data file 1 is added