### PR TITLE
[Core][Rewrite] Fix merge manifests lost sequence number for added files when rewriting using staring sequence number

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestWriter.java
@@ -117,7 +117,11 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
   }
 
   void add(ManifestEntry<F> entry) {
-    addEntry(reused.wrapAppend(snapshotId, entry.sequenceNumber(), entry.file()));
+    if (entry.sequenceNumber() != null && entry.sequenceNumber() >= 0) {
+      addEntry(reused.wrapAppend(snapshotId, entry.sequenceNumber(), entry.file()));
+    } else {
+      addEntry(reused.wrapAppend(snapshotId, entry.file()));
+    }
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/ManifestWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestWriter.java
@@ -117,7 +117,7 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
   }
 
   void add(ManifestEntry<F> entry) {
-    addEntry(reused.wrapAppend(snapshotId, entry.file()));
+    addEntry(reused.wrapAppend(snapshotId, entry.sequenceNumber(), entry.file()));
   }
 
   /**


### PR DESCRIPTION
We use the starting-sequence-number configuration when rewriting, then the data written in this rewrite will set the `status` to `ADDED` in the manifest entry, and set the `sequence_number` to the sequence number of the snapshot read before the rewrite. If this rewrite also triggers the `manifest merge` at the end, the sequence number of the new added data file's manifest entry will be lost.  

For example:   
We rewrite the snapshot with sequence number equals to `1` and enable `use-starting-sequence-number`, which triggers the rewriting of some data files and the merging of manifests. It is expected that the sequence number of the new manifest entries of the new rewritten data files should be `1`. When actually rewriting, because the manifest merge is triggered, the current logic sets the sequence number to `null`, which does not meet the actual expectations.

cc @rdblue @jackye1995 @RussellSpitzer 
