### PR TITLE
Core, Spark: Fallback when snapshot does not have schema id

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotParser.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotParser.java
@@ -89,8 +89,12 @@ public class SnapshotParser {
       generator.writeEndArray();
     }
 
-    // schema ID might be null for snapshots written by old writers
-    if (snapshot.schemaId() != null) {
+    // For test purposes, we want to emulate an old writer; we do this if the system property
+    // iceberg.snapshot.no-schema-id is set to true.
+    boolean noSchemaId = SystemProperties.getBoolean("iceberg.snapshot.no-schema-id", false);
+    // In addition, schema ID might be null for snapshots written by old writers.
+    // In either of these cases, we skip writing schema-id for the snapshot.
+    if (!noSchemaId && snapshot.schemaId() != null) {
       generator.writeNumberField(SCHEMA_ID, snapshot.schemaId());
     }
 

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -58,6 +58,7 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.types.StructType;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -96,6 +97,11 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
   public abstract String loadLocation(TableIdentifier ident, String entriesSuffix);
 
   public abstract String loadLocation(TableIdentifier ident);
+
+  @After
+  public void resetSystem() {
+    System.setProperty("iceberg.snapshot.no-schema-id", "false");
+  }
 
   @Test
   public synchronized void testTablesSupport() {
@@ -1155,8 +1161,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     }
   }
 
-  @Test
-  public synchronized void testSnapshotReadAfterAddColumn() {
+  private void snapshotReadAfterAddColumn() {
     TableIdentifier tableIdentifier = TableIdentifier.of("db", "table");
     Table table = createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
 
@@ -1220,7 +1225,17 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
   }
 
   @Test
-  public synchronized void testSnapshotReadAfterDropColumn() {
+  public synchronized void testSnapshotReadAfterAddColumn() {
+    snapshotReadAfterAddColumn();
+  }
+
+  @Test
+  public synchronized void testOldSnapshotReadAfterAddColumn() {
+    System.setProperty("iceberg.snapshot.no-schema-id", "true");
+    snapshotReadAfterAddColumn();
+  }
+
+  private void snapshotReadAfterDropColumn() {
     TableIdentifier tableIdentifier = TableIdentifier.of("db", "table");
     Table table = createTable(tableIdentifier, SCHEMA2, PartitionSpec.unpartitioned());
 
@@ -1294,7 +1309,17 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
   }
 
   @Test
-  public synchronized void testSnapshotReadAfterAddAndDropColumn() {
+  public synchronized void testSnapshotReadAfterDropColumn() {
+    snapshotReadAfterDropColumn();
+  }
+
+  @Test
+  public synchronized void testOldSnapshotReadAfterDropColumn() {
+    System.setProperty("iceberg.snapshot.no-schema-id", "true");
+    snapshotReadAfterDropColumn();
+  }
+
+  private void snapshotReadAfterAddAndDropColumn() {
     TableIdentifier tableIdentifier = TableIdentifier.of("db", "table");
     Table table = createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
 
@@ -1370,6 +1395,17 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     Assert.assertEquals("Records should match", originalRecords,
         resultDf4.orderBy("id").collectAsList());
     Assert.assertEquals("Schemas should match", originalSparkSchema, resultDf4.schema());
+  }
+
+  @Test
+  public synchronized void testSnapshotReadAfterAddAndDropColumn() {
+    snapshotReadAfterAddAndDropColumn();
+  }
+
+  @Test
+  public synchronized void testOldSnapshotReadAfterAddAndDropColumn() {
+    System.setProperty("iceberg.snapshot.no-schema-id", "true");
+    snapshotReadAfterAddAndDropColumn();
   }
 
   @Test

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -58,6 +58,7 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.types.StructType;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -96,6 +97,11 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
   public abstract String loadLocation(TableIdentifier ident, String entriesSuffix);
 
   public abstract String loadLocation(TableIdentifier ident);
+
+  @After
+  public void resetSystem() {
+    System.setProperty("iceberg.snapshot.no-schema-id", "false");
+  }
 
   @Test
   public synchronized void testTablesSupport() {
@@ -1155,8 +1161,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     }
   }
 
-  @Test
-  public synchronized void testSnapshotReadAfterAddColumn() {
+  private void snapshotReadAfterAddColumn() {
     TableIdentifier tableIdentifier = TableIdentifier.of("db", "table");
     Table table = createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
 
@@ -1220,7 +1225,17 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
   }
 
   @Test
-  public synchronized void testSnapshotReadAfterDropColumn() {
+  public synchronized void testSnapshotReadAfterAddColumn() {
+    snapshotReadAfterAddColumn();
+  }
+
+  @Test
+  public synchronized void testOldSnapshotReadAfterAddColumn() {
+    System.setProperty("iceberg.snapshot.no-schema-id", "true");
+    snapshotReadAfterAddColumn();
+  }
+
+  private void snapshotReadAfterDropColumn() {
     TableIdentifier tableIdentifier = TableIdentifier.of("db", "table");
     Table table = createTable(tableIdentifier, SCHEMA2, PartitionSpec.unpartitioned());
 
@@ -1294,7 +1309,17 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
   }
 
   @Test
-  public synchronized void testSnapshotReadAfterAddAndDropColumn() {
+  public synchronized void testSnapshotReadAfterDropColumn() {
+    snapshotReadAfterDropColumn();
+  }
+
+  @Test
+  public synchronized void testOldSnapshotReadAfterDropColumn() {
+    System.setProperty("iceberg.snapshot.no-schema-id", "true");
+    snapshotReadAfterDropColumn();
+  }
+
+  private void snapshotReadAfterAddAndDropColumn() {
     TableIdentifier tableIdentifier = TableIdentifier.of("db", "table");
     Table table = createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
 
@@ -1370,6 +1395,17 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     Assert.assertEquals("Records should match", originalRecords,
         resultDf4.orderBy("id").collectAsList());
     Assert.assertEquals("Schemas should match", originalSparkSchema, resultDf4.schema());
+  }
+
+  @Test
+  public synchronized void testSnapshotReadAfterAddAndDropColumn() {
+    snapshotReadAfterAddAndDropColumn();
+  }
+
+  @Test
+  public synchronized void testOldSnapshotReadAfterAddAndDropColumn() {
+    System.setProperty("iceberg.snapshot.no-schema-id", "true");
+    snapshotReadAfterAddAndDropColumn();
   }
 
   @Test

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -58,6 +58,7 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.types.StructType;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -96,6 +97,11 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
   public abstract String loadLocation(TableIdentifier ident, String entriesSuffix);
 
   public abstract String loadLocation(TableIdentifier ident);
+
+  @After
+  public void resetSystem() {
+    System.setProperty("iceberg.snapshot.no-schema-id", "false");
+  }
 
   @Test
   public synchronized void testTablesSupport() {
@@ -1155,8 +1161,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     }
   }
 
-  @Test
-  public synchronized void testSnapshotReadAfterAddColumn() {
+  private void snapshotReadAfterAddColumn() {
     TableIdentifier tableIdentifier = TableIdentifier.of("db", "table");
     Table table = createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
 
@@ -1220,7 +1225,17 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
   }
 
   @Test
-  public synchronized void testSnapshotReadAfterDropColumn() {
+  public synchronized void testSnapshotReadAfterAddColumn() {
+    snapshotReadAfterAddColumn();
+  }
+
+  @Test
+  public synchronized void testOldSnapshotReadAfterAddColumn() {
+    System.setProperty("iceberg.snapshot.no-schema-id", "true");
+    snapshotReadAfterAddColumn();
+  }
+
+  private void snapshotReadAfterDropColumn() {
     TableIdentifier tableIdentifier = TableIdentifier.of("db", "table");
     Table table = createTable(tableIdentifier, SCHEMA2, PartitionSpec.unpartitioned());
 
@@ -1294,7 +1309,17 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
   }
 
   @Test
-  public synchronized void testSnapshotReadAfterAddAndDropColumn() {
+  public synchronized void testSnapshotReadAfterDropColumn() {
+    snapshotReadAfterDropColumn();
+  }
+
+  @Test
+  public synchronized void testOldSnapshotReadAfterDropColumn() {
+    System.setProperty("iceberg.snapshot.no-schema-id", "true");
+    snapshotReadAfterDropColumn();
+  }
+
+  private void snapshotReadAfterAddAndDropColumn() {
     TableIdentifier tableIdentifier = TableIdentifier.of("db", "table");
     Table table = createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
 
@@ -1373,6 +1398,17 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
   }
 
   @Test
+  public synchronized void testSnapshotReadAfterAddAndDropColumn() {
+    snapshotReadAfterAddAndDropColumn();
+  }
+
+  @Test
+  public synchronized void testOldSnapshotReadAfterAddAndDropColumn() {
+    System.setProperty("iceberg.snapshot.no-schema-id", "true");
+    snapshotReadAfterAddAndDropColumn();
+  }
+
+  @Test
   public void testRemoveOrphanFilesActionSupport() throws InterruptedException {
     TableIdentifier tableIdentifier = TableIdentifier.of("db", "table");
     Table table = createTable(tableIdentifier, SCHEMA, PartitionSpec.unpartitioned());
@@ -1413,7 +1449,6 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
 
     Assert.assertEquals("Rows must match", records, actualRecords);
   }
-
 
   @Test
   public void testFilesTablePartitionId() throws Exception {


### PR DESCRIPTION
In `SnapshotUtil`, when a snapshot does not have a schema id (written before schema id was added to snapshots), we fall back to reading each of the previous metadata files until we find one whose current snapshot id matches the snapshot id we seek, and read its schema from there.

We introduce a setting for testing purposes that makes the `SnapshotParser` write JSON without `schema-id` for snapshots. We add variants of existing tests for reading snapshots after schema evolution where the metadata is written without `schema-id` in the snapshots. The tests fail without the change in `SnapshotUtil`.
