### PR TITLE
Docs: Fix broken link of Dremio with Iceberg

### DIFF
--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -89,7 +89,7 @@ nav:
   - Hive: hive.md
   - Trino: https://trino.io/docs/current/connector/iceberg.html
   - PrestoDB: https://prestodb.io/docs/current/connector/iceberg.html
-  - Dremio: https://docs.dremio.com/data-formats/iceberg-enabling/
+  - Dremio: https://docs.dremio.com/data-formats/apache-iceberg/
   - Integrations:
     - AWS: aws.md
     - Nessie: nessie.md


### PR DESCRIPTION
Broken link of https://docs.dremio.com/data-formats/iceberg-enabling/
New link https://docs.dremio.com/data-formats/apache-iceberg/