### PR TITLE
Spark : Support parallelism in RemoveOrphanFiles

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/DeleteOrphanFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/DeleteOrphanFiles.java
@@ -19,6 +19,7 @@
 
 package org.apache.iceberg.actions;
 
+import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
 /**
@@ -66,6 +67,18 @@ public interface DeleteOrphanFiles extends Action<DeleteOrphanFiles, DeleteOrpha
    * @return this for method chaining
    */
   DeleteOrphanFiles deleteWith(Consumer<String> deleteFunc);
+
+  /**
+   * Passes an alternative executor service that will be used for removing orphaned files.
+   * <p>
+   * If this method is not called, orphaned manifests and data files will still be deleted in
+   * the current thread.
+   * <p>
+   *
+   * @param executorService the service to use
+   * @return this for method chaining
+   */
+  DeleteOrphanFiles executeDeleteWith(ExecutorService executorService);
 
   /**
    * The action result that contains a summary of the execution.

--- a/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/actions/BaseDeleteOrphanFilesSparkAction.java
+++ b/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/actions/BaseDeleteOrphanFilesSparkAction.java
@@ -86,6 +86,7 @@ public class BaseDeleteOrphanFilesSparkAction
       return path.substring(lastIndex + 1);
     }
   }, DataTypes.StringType);
+
   private static final ExecutorService DEFAULT_DELETE_EXECUTOR_SERVICE = null;
 
   private final SerializableConfiguration hadoopConf;
@@ -100,6 +101,7 @@ public class BaseDeleteOrphanFilesSparkAction
       table.io().deleteFile(file);
     }
   };
+
   private ExecutorService deleteExecutorService = DEFAULT_DELETE_EXECUTOR_SERVICE;
 
   public BaseDeleteOrphanFilesSparkAction(SparkSession spark, Table table) {

--- a/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/actions/BaseDeleteOrphanFilesSparkAction.java
+++ b/spark/v2.4/spark/src/main/java/org/apache/iceberg/spark/actions/BaseDeleteOrphanFilesSparkAction.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -85,6 +86,7 @@ public class BaseDeleteOrphanFilesSparkAction
       return path.substring(lastIndex + 1);
     }
   }, DataTypes.StringType);
+  private static final ExecutorService DEFAULT_DELETE_EXECUTOR_SERVICE = null;
 
   private final SerializableConfiguration hadoopConf;
   private final int partitionDiscoveryParallelism;
@@ -98,6 +100,7 @@ public class BaseDeleteOrphanFilesSparkAction
       table.io().deleteFile(file);
     }
   };
+  private ExecutorService deleteExecutorService = DEFAULT_DELETE_EXECUTOR_SERVICE;
 
   public BaseDeleteOrphanFilesSparkAction(SparkSession spark, Table table) {
     super(spark);
@@ -114,6 +117,12 @@ public class BaseDeleteOrphanFilesSparkAction
 
   @Override
   protected DeleteOrphanFiles self() {
+    return this;
+  }
+
+  @Override
+  public BaseDeleteOrphanFilesSparkAction executeDeleteWith(ExecutorService executorService) {
+    this.deleteExecutorService = executorService;
     return this;
   }
 
@@ -167,6 +176,7 @@ public class BaseDeleteOrphanFilesSparkAction
 
     Tasks.foreach(orphanFiles)
         .noRetry()
+        .executeWith(deleteExecutorService)
         .suppressFailureWhenFinished()
         .onFailure((file, exc) -> LOG.warn("Failed to delete file: {}", file, exc))
         .run(deleteFunc::accept);

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -24,6 +24,11 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.apache.hadoop.conf.Configuration;
@@ -46,6 +51,7 @@ import org.apache.iceberg.hadoop.HiddenPathFilter;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.spark.SparkTestBase;
 import org.apache.iceberg.spark.source.ThreeColumnRecord;
 import org.apache.iceberg.types.Types;
@@ -237,6 +243,76 @@ public class TestRemoveOrphanFilesAction extends SparkTestBase {
     for (String fileLocation : snapshotFiles3) {
       Assert.assertTrue("All snapshot files must remain", fs.exists(new Path(fileLocation)));
     }
+  }
+
+  @Test
+  public void orphanedFileRemovedWithParallelTasks() throws InterruptedException, IOException {
+    Table table = TABLES.create(SCHEMA, SPEC, Maps.newHashMap(), tableLocation);
+
+    List<ThreeColumnRecord> records1 = Lists.newArrayList(
+            new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA")
+    );
+    Dataset<Row> df1 = spark.createDataFrame(records1, ThreeColumnRecord.class).coalesce(1);
+
+    // original append
+    df1.select("c1", "c2", "c3")
+            .write()
+            .format("iceberg")
+            .mode("append")
+            .save(tableLocation);
+
+    List<ThreeColumnRecord> records2 = Lists.newArrayList(
+            new ThreeColumnRecord(2, "AAAAAAAAAA", "AAAA")
+    );
+    Dataset<Row> df2 = spark.createDataFrame(records2, ThreeColumnRecord.class).coalesce(1);
+
+    // dynamic partition overwrite
+    df2.select("c1", "c2", "c3")
+            .write()
+            .format("iceberg")
+            .mode("overwrite")
+            .save(tableLocation);
+
+    // second append
+    df2.select("c1", "c2", "c3")
+            .write()
+            .format("iceberg")
+            .mode("append")
+            .save(tableLocation);
+
+    df2.coalesce(1).write().mode("append").parquet(tableLocation + "/data");
+    df2.coalesce(1).write().mode("append").parquet(tableLocation + "/data/c2_trunc=AA");
+    df2.coalesce(1).write().mode("append").parquet(tableLocation + "/data/c2_trunc=AA/c3=AAAA");
+    df2.coalesce(1).write().mode("append").parquet(tableLocation + "/data/invalid/invalid");
+
+    // sleep for 1 second to unsure files will be old enough
+    Thread.sleep(1000);
+
+    Set<String> deletedFiles = Sets.newHashSet();
+    Set<String> deleteThreads = ConcurrentHashMap.newKeySet();
+    AtomicInteger deleteThreadsIndex = new AtomicInteger(0);
+
+    ExecutorService executorService = Executors.newFixedThreadPool(4, runnable -> {
+      Thread thread = new Thread(runnable);
+      thread.setName("remove-orphan-" + deleteThreadsIndex.getAndIncrement());
+      thread.setDaemon(true);
+      return thread;
+    });
+
+    DeleteOrphanFiles.Result result = SparkActions.get().deleteOrphanFiles(table)
+            .executeDeleteWith(executorService)
+            .olderThan(System.currentTimeMillis())
+            .deleteWith(file -> {
+              deleteThreads.add(Thread.currentThread().getName());
+              deletedFiles.add(file);
+            })
+            .execute();
+
+    // Verifies that the delete methods ran in the threads created by the provided ExecutorService ThreadFactory
+    Assert.assertEquals(deleteThreads,
+            Sets.newHashSet("remove-orphan-0", "remove-orphan-1", "remove-orphan-2", "remove-orphan-3"));
+
+    Assert.assertEquals("Should delete 4 files", 4, deletedFiles.size());
   }
 
   @Test

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/actions/BaseDeleteOrphanFilesSparkAction.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/actions/BaseDeleteOrphanFilesSparkAction.java
@@ -86,6 +86,7 @@ public class BaseDeleteOrphanFilesSparkAction
       return path.substring(lastIndex + 1);
     }
   }, DataTypes.StringType);
+
   private static final ExecutorService DEFAULT_DELETE_EXECUTOR_SERVICE = null;
 
   private final SerializableConfiguration hadoopConf;
@@ -100,6 +101,7 @@ public class BaseDeleteOrphanFilesSparkAction
       table.io().deleteFile(file);
     }
   };
+
   private ExecutorService deleteExecutorService = DEFAULT_DELETE_EXECUTOR_SERVICE;
 
   public BaseDeleteOrphanFilesSparkAction(SparkSession spark, Table table) {

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/actions/BaseDeleteOrphanFilesSparkAction.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/actions/BaseDeleteOrphanFilesSparkAction.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -85,6 +86,7 @@ public class BaseDeleteOrphanFilesSparkAction
       return path.substring(lastIndex + 1);
     }
   }, DataTypes.StringType);
+  private static final ExecutorService DEFAULT_DELETE_EXECUTOR_SERVICE = null;
 
   private final SerializableConfiguration hadoopConf;
   private final int partitionDiscoveryParallelism;
@@ -98,6 +100,7 @@ public class BaseDeleteOrphanFilesSparkAction
       table.io().deleteFile(file);
     }
   };
+  private ExecutorService deleteExecutorService = DEFAULT_DELETE_EXECUTOR_SERVICE;
 
   public BaseDeleteOrphanFilesSparkAction(SparkSession spark, Table table) {
     super(spark);
@@ -114,6 +117,12 @@ public class BaseDeleteOrphanFilesSparkAction
 
   @Override
   protected DeleteOrphanFiles self() {
+    return this;
+  }
+
+  @Override
+  public BaseDeleteOrphanFilesSparkAction executeDeleteWith(ExecutorService executorService) {
+    this.deleteExecutorService = executorService;
     return this;
   }
 
@@ -167,6 +176,7 @@ public class BaseDeleteOrphanFilesSparkAction
 
     Tasks.foreach(orphanFiles)
         .noRetry()
+        .executeWith(deleteExecutorService)
         .suppressFailureWhenFinished()
         .onFailure((file, exc) -> LOG.warn("Failed to delete file: {}", file, exc))
         .run(deleteFunc::accept);

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseDeleteOrphanFilesSparkAction.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseDeleteOrphanFilesSparkAction.java
@@ -86,6 +86,7 @@ public class BaseDeleteOrphanFilesSparkAction
       return path.substring(lastIndex + 1);
     }
   }, DataTypes.StringType);
+
   private static final ExecutorService DEFAULT_DELETE_EXECUTOR_SERVICE = null;
 
   private final SerializableConfiguration hadoopConf;
@@ -100,6 +101,7 @@ public class BaseDeleteOrphanFilesSparkAction
       table.io().deleteFile(file);
     }
   };
+
   private ExecutorService deleteExecutorService = DEFAULT_DELETE_EXECUTOR_SERVICE;
 
   public BaseDeleteOrphanFilesSparkAction(SparkSession spark, Table table) {

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseDeleteOrphanFilesSparkAction.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseDeleteOrphanFilesSparkAction.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -85,6 +86,7 @@ public class BaseDeleteOrphanFilesSparkAction
       return path.substring(lastIndex + 1);
     }
   }, DataTypes.StringType);
+  private static final ExecutorService DEFAULT_DELETE_EXECUTOR_SERVICE = null;
 
   private final SerializableConfiguration hadoopConf;
   private final int partitionDiscoveryParallelism;
@@ -98,6 +100,7 @@ public class BaseDeleteOrphanFilesSparkAction
       table.io().deleteFile(file);
     }
   };
+  private ExecutorService deleteExecutorService = DEFAULT_DELETE_EXECUTOR_SERVICE;
 
   public BaseDeleteOrphanFilesSparkAction(SparkSession spark, Table table) {
     super(spark);
@@ -114,6 +117,12 @@ public class BaseDeleteOrphanFilesSparkAction
 
   @Override
   protected DeleteOrphanFiles self() {
+    return this;
+  }
+
+  @Override
+  public BaseDeleteOrphanFilesSparkAction executeDeleteWith(ExecutorService executorService) {
+    this.deleteExecutorService = executorService;
     return this;
   }
 
@@ -167,6 +176,7 @@ public class BaseDeleteOrphanFilesSparkAction
 
     Tasks.foreach(orphanFiles)
         .noRetry()
+        .executeWith(deleteExecutorService)
         .suppressFailureWhenFinished()
         .onFailure((file, exc) -> LOG.warn("Failed to delete file: {}", file, exc))
         .run(deleteFunc::accept);

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseDeleteOrphanFilesSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseDeleteOrphanFilesSparkAction.java
@@ -86,6 +86,7 @@ public class BaseDeleteOrphanFilesSparkAction
       return path.substring(lastIndex + 1);
     }
   }, DataTypes.StringType);
+
   private static final ExecutorService DEFAULT_DELETE_EXECUTOR_SERVICE = null;
 
   private final SerializableConfiguration hadoopConf;
@@ -100,6 +101,7 @@ public class BaseDeleteOrphanFilesSparkAction
       table.io().deleteFile(file);
     }
   };
+
   private ExecutorService deleteExecutorService = DEFAULT_DELETE_EXECUTOR_SERVICE;
 
   public BaseDeleteOrphanFilesSparkAction(SparkSession spark, Table table) {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseDeleteOrphanFilesSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseDeleteOrphanFilesSparkAction.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -85,6 +86,7 @@ public class BaseDeleteOrphanFilesSparkAction
       return path.substring(lastIndex + 1);
     }
   }, DataTypes.StringType);
+  private static final ExecutorService DEFAULT_DELETE_EXECUTOR_SERVICE = null;
 
   private final SerializableConfiguration hadoopConf;
   private final int partitionDiscoveryParallelism;
@@ -98,6 +100,7 @@ public class BaseDeleteOrphanFilesSparkAction
       table.io().deleteFile(file);
     }
   };
+  private ExecutorService deleteExecutorService = DEFAULT_DELETE_EXECUTOR_SERVICE;
 
   public BaseDeleteOrphanFilesSparkAction(SparkSession spark, Table table) {
     super(spark);
@@ -114,6 +117,12 @@ public class BaseDeleteOrphanFilesSparkAction
 
   @Override
   protected DeleteOrphanFiles self() {
+    return this;
+  }
+
+  @Override
+  public BaseDeleteOrphanFilesSparkAction executeDeleteWith(ExecutorService executorService) {
+    this.deleteExecutorService = executorService;
     return this;
   }
 
@@ -167,6 +176,7 @@ public class BaseDeleteOrphanFilesSparkAction
 
     Tasks.foreach(orphanFiles)
         .noRetry()
+        .executeWith(deleteExecutorService)
         .suppressFailureWhenFinished()
         .onFailure((file, exc) -> LOG.warn("Failed to delete file: {}", file, exc))
         .run(deleteFunc::accept);


### PR DESCRIPTION
# Notes

Allow parallelism in removing orphan files using Spark procedures and Spark Actions, like how it was implemented in expire snapshots, This change close #3582 

Since I need to change the `DeleteOrphanFiles` interface in api, ends up also updating the code for spark2.4/3.0/3.1/3.2 BaseDeleteOrphanFilesSparkAction as they are implement the same interface, also update the spark procedures to allow calling from spark SQL.

## Tests

I update the tests for `TestRemoveOrphanFilesAction` and `TestRemoveOrphanFilesProcedure` in respective spark version. I did not touch any tests in  `TestRemoveOrphanFilesAction3` as it mostly cover different catalogs

```
$ ./gradlew -DsparkVersions=3.2 \
-DhiveVersions= -DflinkVersions= \
:iceberg-spark:iceberg-spark-3.2_2.12:check \
:iceberg-spark:iceberg-spark-extensions-3.2_2.12:check \
:iceberg-spark:iceberg-spark-runtime-3.2_2.12:check \
-Pquick=true -x javadoc

BUILD SUCCESSFUL in 29s
54 actionable tasks: 41 executed, 13 up-to-date

```

