### PR TITLE
Site - Update copyright year in mkdocs file to 2022

### DIFF
--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -28,7 +28,7 @@ use_directory_urls: true
 theme:
   name: windmill
   custom_dir: docs/theme_customization
-copyright: "Copyright 2018-2021 <a href='https://www.apache.org/'>The Apache Software Foundation</a><br />Apache Iceberg, Iceberg, Apache, the Apache feather logo, and the Apache Iceberg project logo are either registered<br />trademarks or trademarks of The Apache Software Foundation in the United States and other countries."
+copyright: "Copyright 2018-2022 <a href='https://www.apache.org/'>The Apache Software Foundation</a><br />Apache Iceberg, Iceberg, Apache, the Apache feather logo, and the Apache Iceberg project logo are either registered<br />trademarks or trademarks of The Apache Software Foundation in the United States and other countries."
 extra_css:
   - css/extra.css
 extra:


### PR DESCRIPTION
As part of updating the copyright year in https://github.com/apache/iceberg/pull/3855, my grep-foo missed the mkdocs file.

cc @smallx thanks for catching this!