### PR TITLE
[python legacy] Stripping quotes in convert_string_to_expr() when predicate value is a string type

### DIFF
--- a/python_legacy/iceberg/api/expressions/expression_parser.py
+++ b/python_legacy/iceberg/api/expressions/expression_parser.py
@@ -146,7 +146,12 @@ def get_expr(node, expr_map):
     elif isinstance(node, (int, float)):
         return node
     elif isinstance(node, str):
-        return node.strip("'").strip('"')
+        if node.startswith("'") and node.endswith("'"):
+            return node.strip("'")
+        elif node.startswith("\"") and node.endswith("\""):
+            return node.strip("\"")
+        else:
+            return node
     else:
         raise RuntimeError("unknown node type" % node)
 

--- a/python_legacy/iceberg/api/expressions/expression_parser.py
+++ b/python_legacy/iceberg/api/expressions/expression_parser.py
@@ -143,8 +143,10 @@ def get_expr(node, expr_map):
         return mapped_op(*get_expr(node[op], expr_map))
     elif isinstance(node, (list, tuple)):
         return (get_expr(item, expr_map) for item in node)
-    elif isinstance(node, (str, int, float)):
+    elif isinstance(node, (int, float)):
         return node
+    elif isinstance(node, str):
+        return node.strip("'").strip('"')
     else:
         raise RuntimeError("unknown node type" % node)
 

--- a/python_legacy/iceberg/api/expressions/expression_parser.py
+++ b/python_legacy/iceberg/api/expressions/expression_parser.py
@@ -126,6 +126,15 @@ def get_expr_tree(tokens):
                  binary_tuples]}
 
 
+def handle_str_expr(node):
+    if node.startswith("'") and node.endswith("'"):
+        return node.strip("'")
+    elif node.startswith("\"") and node.endswith("\""):
+        return node.strip("\"")
+    else:
+        return node
+
+
 def get_expr(node, expr_map):
     if isinstance(node, dict):
         for i in node.keys():
@@ -146,12 +155,7 @@ def get_expr(node, expr_map):
     elif isinstance(node, (int, float)):
         return node
     elif isinstance(node, str):
-        if node.startswith("'") and node.endswith("'"):
-            return node.strip("'")
-        elif node.startswith("\"") and node.endswith("\""):
-            return node.strip("\"")
-        else:
-            return node
+        return handle_str_expr(node)
     else:
         raise RuntimeError("unknown node type" % node)
 

--- a/python_legacy/iceberg/api/expressions/expression_parser.py
+++ b/python_legacy/iceberg/api/expressions/expression_parser.py
@@ -30,6 +30,7 @@ from pyparsing import (
     opAssoc,
     pyparsing_common as ppc,
     quotedString,
+    removeQuotes,
     Word
 )
 
@@ -50,7 +51,7 @@ intNum = ppc.signed_integer()
 
 columnRval = (realNum
               | intNum
-              | quotedString
+              | quotedString.setParseAction(removeQuotes)
               | columnName)  # need to add support for alg expressions
 whereCondition = Group(
     (columnName + binop + columnRval)
@@ -126,15 +127,6 @@ def get_expr_tree(tokens):
                  binary_tuples]}
 
 
-def handle_str_expr(node):
-    if node.startswith("'") and node.endswith("'"):
-        return node.strip("'")
-    elif node.startswith("\"") and node.endswith("\""):
-        return node.strip("\"")
-    else:
-        return node
-
-
 def get_expr(node, expr_map):
     if isinstance(node, dict):
         for i in node.keys():
@@ -152,10 +144,8 @@ def get_expr(node, expr_map):
         return mapped_op(*get_expr(node[op], expr_map))
     elif isinstance(node, (list, tuple)):
         return (get_expr(item, expr_map) for item in node)
-    elif isinstance(node, (int, float)):
+    elif isinstance(node, (str, int, float)):
         return node
-    elif isinstance(node, str):
-        return handle_str_expr(node)
     else:
         raise RuntimeError("unknown node type" % node)
 

--- a/python_legacy/tests/api/expressions/test_str_to_expr.py
+++ b/python_legacy/tests/api/expressions/test_str_to_expr.py
@@ -21,15 +21,18 @@ def test_equal():
     conv_expr = Expressions.convert_string_to_expr("col_a=1")
     assert expected_expr == conv_expr
 
+
 def test_str_equal_single_quotes():
     expected_expr = Expressions.equal("col_a", "123")
     conv_expr = Expressions.convert_string_to_expr("col_a='123'")
     assert expected_expr == conv_expr
 
+
 def test_str_equal_double_quotes():
     expected_expr = Expressions.equal("col_a", "123")
     conv_expr = Expressions.convert_string_to_expr("col_a=\"123\"")
     assert expected_expr == conv_expr
+
 
 def test_equal_alt_syntax():
     expected_expr = Expressions.equal("col_a", 1)

--- a/python_legacy/tests/api/expressions/test_str_to_expr.py
+++ b/python_legacy/tests/api/expressions/test_str_to_expr.py
@@ -21,6 +21,15 @@ def test_equal():
     conv_expr = Expressions.convert_string_to_expr("col_a=1")
     assert expected_expr == conv_expr
 
+def test_str_equal_single_quotes():
+    expected_expr = Expressions.equal("col_a", "123")
+    conv_expr = Expressions.convert_string_to_expr("col_a='123'")
+    assert expected_expr == conv_expr
+
+def test_str_equal_double_quotes():
+    expected_expr = Expressions.equal("col_a", "123")
+    conv_expr = Expressions.convert_string_to_expr("col_a=\"123\"")
+    assert expected_expr == conv_expr
 
 def test_equal_alt_syntax():
     expected_expr = Expressions.equal("col_a", 1)


### PR DESCRIPTION
This fixes #3874