### PR TITLE
Allow using a custom NessieClientBuilder implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -571,6 +571,7 @@ project(':iceberg-nessie') {
 
   dependencies {
     api project(':iceberg-api')
+    implementation project(':iceberg-common')
     implementation project(':iceberg-core')
     implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
     implementation "org.projectnessie:nessie-client"

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
@@ -37,10 +37,12 @@ import org.projectnessie.model.ImmutableCommitMeta;
 
 public final class NessieUtil {
 
+  public static final String NESSIE_CONFIG_PREFIX = "nessie.";
+  public static final String CONFIG_CLIENT_BUILDER_IMPL = NESSIE_CONFIG_PREFIX + "client-builder-impl";
+
   static final String APPLICATION_TYPE = "application-type";
 
   private NessieUtil() {
-
   }
 
   static Predicate<EntriesResponse.Entry> namespacePredicate(Namespace ns) {

--- a/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
@@ -84,7 +84,7 @@ public abstract class BaseTestIceberg {
   protected NessieApiV1 api;
   protected Configuration hadoopConfig;
   protected final String branch;
-  private String uri;
+  protected String uri;
 
   public BaseTestIceberg(String branch) {
     this.branch = branch;

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestCustomNessieClient.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestCustomNessieClient.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.nessie;
+
+import java.net.URI;
+import java.util.function.Function;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+import org.projectnessie.client.NessieClientBuilder;
+import org.projectnessie.client.api.NessieApi;
+import org.projectnessie.client.auth.NessieAuthentication;
+import org.projectnessie.client.http.HttpClientBuilder;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestCustomNessieClient extends BaseTestIceberg {
+
+  public TestCustomNessieClient() {
+    super("main");
+  }
+
+  @Test
+  public void testNoCustomClient() {
+    NessieCatalog catalog = new NessieCatalog();
+    catalog.initialize("nessie",
+        ImmutableMap.of(CatalogProperties.WAREHOUSE_LOCATION, temp.toUri().toString(),
+            CatalogProperties.URI, uri));
+  }
+
+  @Test
+  public void testUnnecessaryDefaultCustomClient() {
+    NessieCatalog catalog = new NessieCatalog();
+    catalog.initialize("nessie",
+        ImmutableMap.of(CatalogProperties.WAREHOUSE_LOCATION, temp.toUri().toString(),
+            CatalogProperties.URI, uri,
+            NessieUtil.CONFIG_CLIENT_BUILDER_IMPL, HttpClientBuilder.class.getName()));
+  }
+
+  @Test
+  public void testNonExistentCustomClient() {
+    String nonExistingClass = "non.existent.ClientBuilderImpl";
+    assertThatThrownBy(() -> {
+      NessieCatalog catalog = new NessieCatalog();
+      catalog.initialize("nessie",
+          ImmutableMap.of(CatalogProperties.WAREHOUSE_LOCATION, temp.toUri().toString(),
+              CatalogProperties.URI, uri,
+              NessieUtil.CONFIG_CLIENT_BUILDER_IMPL, nonExistingClass));
+    })
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining(nonExistingClass);
+  }
+
+  @Test
+  public void testCustomClient() {
+    assertThatThrownBy(() -> {
+      NessieCatalog catalog = new NessieCatalog();
+      catalog.initialize("nessie",
+          ImmutableMap.of(CatalogProperties.WAREHOUSE_LOCATION, temp.toUri().toString(),
+              CatalogProperties.URI, uri,
+              NessieUtil.CONFIG_CLIENT_BUILDER_IMPL, DummyClientBuilderImpl.class.getName()));
+    })
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("BUILD CALLED");
+  }
+
+  @SuppressWarnings("rawtypes")
+  public static final class DummyClientBuilderImpl implements NessieClientBuilder {
+
+    @SuppressWarnings("unused")
+    public static DummyClientBuilderImpl builder() {
+      return new DummyClientBuilderImpl();
+    }
+
+    @Override
+    public NessieClientBuilder fromSystemProperties() {
+      return this;
+    }
+
+    @Override
+    public NessieClientBuilder withAuthentication(
+        NessieAuthentication authentication) {
+      return this;
+    }
+
+    @Override
+    public NessieClientBuilder withUri(URI uri) {
+      return this;
+    }
+
+    @Override
+    public NessieClientBuilder withAuthenticationFromConfig(Function configuration) {
+      return this;
+    }
+
+    @Override
+    public NessieClientBuilder fromConfig(Function configuration) {
+      return this;
+    }
+
+    @Override
+    public NessieApi build(Class apiContract) {
+      throw new RuntimeException("BUILD CALLED");
+    }
+  }
+}


### PR DESCRIPTION
Nessie defaults to use the HttpClientBuilder, but certain use cases
require a custom client builder implementation. This change allows
this by having a new configuration option.