### PR TITLE
Core: Remove duplicate Conf() method.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
@@ -50,10 +50,6 @@ public class HadoopFileIO implements FileIO, HadoopConfigurable {
     this.hadoopConf = hadoopConf;
   }
 
-  public Configuration conf() {
-    return hadoopConf.get();
-  }
-
   @Override
   public InputFile newInputFile(String path) {
     return HadoopInputFile.fromLocation(path, hadoopConf.get());

--- a/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
@@ -130,7 +130,7 @@ public class TestCatalogUtil {
     configuration.set("key", "val");
     FileIO fileIO = CatalogUtil.loadFileIO(HadoopFileIO.class.getName(), Maps.newHashMap(), configuration);
     Assertions.assertThat(fileIO).isInstanceOf(HadoopFileIO.class);
-    Assert.assertEquals("val", ((HadoopFileIO) fileIO).conf().get("key"));
+    Assert.assertEquals("val", ((HadoopFileIO) fileIO).getConf().get("key"));
   }
 
   @Test

--- a/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/TestCatalogTableLoader.java
+++ b/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/TestCatalogTableLoader.java
@@ -110,7 +110,7 @@ public class TestCatalogTableLoader extends FlinkTestBase {
     FileIO io = table.io();
     Assertions.assertThat(io).as("FileIO should be a HadoopFileIO").isInstanceOf(HadoopFileIO.class);
     HadoopFileIO hadoopIO = (HadoopFileIO) io;
-    Assert.assertEquals("my_value", hadoopIO.conf().get("my_key"));
+    Assert.assertEquals("my_value", hadoopIO.getConf().get("my_key"));
   }
 
   @SuppressWarnings("unchecked")

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestCatalogTableLoader.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestCatalogTableLoader.java
@@ -110,7 +110,7 @@ public class TestCatalogTableLoader extends FlinkTestBase {
     FileIO io = table.io();
     Assertions.assertThat(io).as("FileIO should be a HadoopFileIO").isInstanceOf(HadoopFileIO.class);
     HadoopFileIO hadoopIO = (HadoopFileIO) io;
-    Assert.assertEquals("my_value", hadoopIO.conf().get("my_key"));
+    Assert.assertEquals("my_value", hadoopIO.getConf().get("my_key"));
   }
 
   @SuppressWarnings("unchecked")

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestCatalogTableLoader.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestCatalogTableLoader.java
@@ -110,7 +110,7 @@ public class TestCatalogTableLoader extends FlinkTestBase {
     FileIO io = table.io();
     Assertions.assertThat(io).as("FileIO should be a HadoopFileIO").isInstanceOf(HadoopFileIO.class);
     HadoopFileIO hadoopIO = (HadoopFileIO) io;
-    Assert.assertEquals("my_value", hadoopIO.conf().get("my_key"));
+    Assert.assertEquals("my_value", hadoopIO.getConf().get("my_key"));
   }
 
   @SuppressWarnings("unchecked")

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/TestFileIOSerialization.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/TestFileIOSerialization.java
@@ -80,11 +80,11 @@ public class TestFileIOSerialization {
   @Test
   public void testHadoopFileIOKryoSerialization() throws IOException {
     FileIO io = table.io();
-    Configuration expectedConf = ((HadoopFileIO) io).conf();
+    Configuration expectedConf = ((HadoopFileIO) io).getConf();
 
     Table serializableTable = SerializableTable.copyOf(table);
     FileIO deserializedIO = KryoHelpers.roundTripSerialize(serializableTable.io());
-    Configuration actualConf = ((HadoopFileIO) deserializedIO).conf();
+    Configuration actualConf = ((HadoopFileIO) deserializedIO).getConf();
 
     Assert.assertEquals("Conf pairs must match", toMap(expectedConf), toMap(actualConf));
     Assert.assertEquals("Conf values must be present", "v1", actualConf.get("k1"));
@@ -94,11 +94,11 @@ public class TestFileIOSerialization {
   @Test
   public void testHadoopFileIOJavaSerialization() throws IOException, ClassNotFoundException {
     FileIO io = table.io();
-    Configuration expectedConf = ((HadoopFileIO) io).conf();
+    Configuration expectedConf = ((HadoopFileIO) io).getConf();
 
     Table serializableTable = SerializableTable.copyOf(table);
     FileIO deserializedIO = TestHelpers.roundTripSerialize(serializableTable.io());
-    Configuration actualConf = ((HadoopFileIO) deserializedIO).conf();
+    Configuration actualConf = ((HadoopFileIO) deserializedIO).getConf();
 
     Assert.assertEquals("Conf pairs must match", toMap(expectedConf), toMap(actualConf));
     Assert.assertEquals("Conf values must be present", "v1", actualConf.get("k1"));

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/TestFileIOSerialization.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/TestFileIOSerialization.java
@@ -80,11 +80,11 @@ public class TestFileIOSerialization {
   @Test
   public void testHadoopFileIOKryoSerialization() throws IOException {
     FileIO io = table.io();
-    Configuration expectedConf = ((HadoopFileIO) io).conf();
+    Configuration expectedConf = ((HadoopFileIO) io).getConf();
 
     Table serializableTable = SerializableTable.copyOf(table);
     FileIO deserializedIO = KryoHelpers.roundTripSerialize(serializableTable.io());
-    Configuration actualConf = ((HadoopFileIO) deserializedIO).conf();
+    Configuration actualConf = ((HadoopFileIO) deserializedIO).getConf();
 
     Assert.assertEquals("Conf pairs must match", toMap(expectedConf), toMap(actualConf));
     Assert.assertEquals("Conf values must be present", "v1", actualConf.get("k1"));
@@ -94,11 +94,11 @@ public class TestFileIOSerialization {
   @Test
   public void testHadoopFileIOJavaSerialization() throws IOException, ClassNotFoundException {
     FileIO io = table.io();
-    Configuration expectedConf = ((HadoopFileIO) io).conf();
+    Configuration expectedConf = ((HadoopFileIO) io).getConf();
 
     Table serializableTable = SerializableTable.copyOf(table);
     FileIO deserializedIO = TestHelpers.roundTripSerialize(serializableTable.io());
-    Configuration actualConf = ((HadoopFileIO) deserializedIO).conf();
+    Configuration actualConf = ((HadoopFileIO) deserializedIO).getConf();
 
     Assert.assertEquals("Conf pairs must match", toMap(expectedConf), toMap(actualConf));
     Assert.assertEquals("Conf values must be present", "v1", actualConf.get("k1"));

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/TestFileIOSerialization.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/TestFileIOSerialization.java
@@ -80,11 +80,11 @@ public class TestFileIOSerialization {
   @Test
   public void testHadoopFileIOKryoSerialization() throws IOException {
     FileIO io = table.io();
-    Configuration expectedConf = ((HadoopFileIO) io).conf();
+    Configuration expectedConf = ((HadoopFileIO) io).getConf();
 
     Table serializableTable = SerializableTable.copyOf(table);
     FileIO deserializedIO = KryoHelpers.roundTripSerialize(serializableTable.io());
-    Configuration actualConf = ((HadoopFileIO) deserializedIO).conf();
+    Configuration actualConf = ((HadoopFileIO) deserializedIO).getConf();
 
     Assert.assertEquals("Conf pairs must match", toMap(expectedConf), toMap(actualConf));
     Assert.assertEquals("Conf values must be present", "v1", actualConf.get("k1"));
@@ -94,11 +94,11 @@ public class TestFileIOSerialization {
   @Test
   public void testHadoopFileIOJavaSerialization() throws IOException, ClassNotFoundException {
     FileIO io = table.io();
-    Configuration expectedConf = ((HadoopFileIO) io).conf();
+    Configuration expectedConf = ((HadoopFileIO) io).getConf();
 
     Table serializableTable = SerializableTable.copyOf(table);
     FileIO deserializedIO = TestHelpers.roundTripSerialize(serializableTable.io());
-    Configuration actualConf = ((HadoopFileIO) deserializedIO).conf();
+    Configuration actualConf = ((HadoopFileIO) deserializedIO).getConf();
 
     Assert.assertEquals("Conf pairs must match", toMap(expectedConf), toMap(actualConf));
     Assert.assertEquals("Conf values must be present", "v1", actualConf.get("k1"));

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/TestFileIOSerialization.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/TestFileIOSerialization.java
@@ -80,11 +80,11 @@ public class TestFileIOSerialization {
   @Test
   public void testHadoopFileIOKryoSerialization() throws IOException {
     FileIO io = table.io();
-    Configuration expectedConf = ((HadoopFileIO) io).conf();
+    Configuration expectedConf = ((HadoopFileIO) io).getConf();
 
     Table serializableTable = SerializableTable.copyOf(table);
     FileIO deserializedIO = KryoHelpers.roundTripSerialize(serializableTable.io());
-    Configuration actualConf = ((HadoopFileIO) deserializedIO).conf();
+    Configuration actualConf = ((HadoopFileIO) deserializedIO).getConf();
 
     Assert.assertEquals("Conf pairs must match", toMap(expectedConf), toMap(actualConf));
     Assert.assertEquals("Conf values must be present", "v1", actualConf.get("k1"));
@@ -94,11 +94,11 @@ public class TestFileIOSerialization {
   @Test
   public void testHadoopFileIOJavaSerialization() throws IOException, ClassNotFoundException {
     FileIO io = table.io();
-    Configuration expectedConf = ((HadoopFileIO) io).conf();
+    Configuration expectedConf = ((HadoopFileIO) io).getConf();
 
     Table serializableTable = SerializableTable.copyOf(table);
     FileIO deserializedIO = TestHelpers.roundTripSerialize(serializableTable.io());
-    Configuration actualConf = ((HadoopFileIO) deserializedIO).conf();
+    Configuration actualConf = ((HadoopFileIO) deserializedIO).getConf();
 
     Assert.assertEquals("Conf pairs must match", toMap(expectedConf), toMap(actualConf));
     Assert.assertEquals("Conf values must be present", "v1", actualConf.get("k1"));


### PR DESCRIPTION
conf() and getConf() are duplicates.

getConfig():
https://github.com/apache/iceberg/blob/f28ce8113474889c7d1ec40a1bb94a5ca6d82c8c/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java#L84-L86

conf():
https://github.com/apache/iceberg/blob/f28ce8113474889c7d1ec40a1bb94a5ca6d82c8c/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java#L53-L55


