### PR TITLE
AWS: fix Iceberg to Glue schema conversion

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
@@ -331,7 +331,7 @@ public class TestGlueCatalogTable extends GlueTestBase {
             ))
             .build(),
         Column.builder()
-            .name("z")
+            .name("c2.z")
             .type("int")
             .parameters(ImmutableMap.of(
                 IcebergToGlueConverter.ICEBERG_FIELD_USAGE, IcebergToGlueConverter.SCHEMA_SUBFIELD,

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
@@ -311,11 +311,8 @@ public class TestGlueCatalogTable extends GlueTestBase {
             .type("string")
             .comment("c1")
             .parameters(ImmutableMap.of(
-                IcebergToGlueConverter.ICEBERG_FIELD_USAGE, IcebergToGlueConverter.SCHEMA_COLUMN,
                 IcebergToGlueConverter.ICEBERG_FIELD_ID, "1",
-                IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "false",
-                IcebergToGlueConverter.ICEBERG_FIELD_TYPE_STRING, "string",
-                IcebergToGlueConverter.ICEBERG_FIELD_TYPE_TYPE_ID, "STRING"
+                IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "false"
             ))
             .build(),
         Column.builder()
@@ -323,37 +320,9 @@ public class TestGlueCatalogTable extends GlueTestBase {
             .type("struct<z:int>")
             .comment("c2")
             .parameters(ImmutableMap.of(
-                IcebergToGlueConverter.ICEBERG_FIELD_USAGE, IcebergToGlueConverter.SCHEMA_COLUMN,
                 IcebergToGlueConverter.ICEBERG_FIELD_ID, "2",
-                IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "true",
-                IcebergToGlueConverter.ICEBERG_FIELD_TYPE_STRING, "struct<z:int>",
-                IcebergToGlueConverter.ICEBERG_FIELD_TYPE_TYPE_ID, "STRUCT"
+                IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "true"
             ))
-            .build(),
-        Column.builder()
-            .name("c2.z")
-            .type("int")
-            .parameters(ImmutableMap.of(
-                IcebergToGlueConverter.ICEBERG_FIELD_USAGE, IcebergToGlueConverter.SCHEMA_SUBFIELD,
-                IcebergToGlueConverter.ICEBERG_FIELD_ID, "3",
-                IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "false",
-                IcebergToGlueConverter.ICEBERG_FIELD_TYPE_STRING, "int",
-                IcebergToGlueConverter.ICEBERG_FIELD_TYPE_TYPE_ID, "INTEGER"
-            ))
-            .build(),
-        Column.builder()
-            .name("c1_trunc_8")
-            .type("string")
-            .parameters(ImmutableMap.<String, String>builder()
-                .put(IcebergToGlueConverter.ICEBERG_FIELD_USAGE, IcebergToGlueConverter.PARTITION_FIELD)
-                .put(IcebergToGlueConverter.ICEBERG_FIELD_TYPE_TYPE_ID, "STRING")
-                .put(IcebergToGlueConverter.ICEBERG_FIELD_TYPE_STRING, "string")
-                .put(IcebergToGlueConverter.ICEBERG_FIELD_ID, "1000")
-                .put(IcebergToGlueConverter.ICEBERG_PARTITION_FIELD_ID, "1000")
-                .put(IcebergToGlueConverter.ICEBERG_PARTITION_SOURCE_ID, "1")
-                .put(IcebergToGlueConverter.ICEBERG_PARTITION_TRANSFORM, "truncate[8]")
-                .build()
-            )
             .build()
     );
     Assert.assertEquals("Columns do not match", expectedColumns, actualColumns);

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
@@ -26,7 +26,6 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.iceberg.PartitionField;
-import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.catalog.Namespace;
@@ -46,7 +45,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.glue.model.Column;
 import software.amazon.awssdk.services.glue.model.DatabaseInput;
-import software.amazon.awssdk.services.glue.model.Schedule;
 import software.amazon.awssdk.services.glue.model.StorageDescriptor;
 import software.amazon.awssdk.services.glue.model.TableInput;
 
@@ -297,7 +295,7 @@ class IcebergToGlueConverter {
       typeId = type.typeId().name();
       typeString = toTypeString(type);
     } catch (RuntimeException e) {
-      LOG.error("Failed to convert partition field to column", e);
+      LOG.error("Failed to retrieve partition field type information", e);
     }
 
     // avoid identity partition field name collide with schema columns
@@ -318,8 +316,8 @@ class IcebergToGlueConverter {
 
   private static Map<String, String> convertToParameters(String fieldUsage, NestedField field) {
     return ImmutableMap.of(ICEBERG_FIELD_USAGE, fieldUsage,
-        ICEBERG_FIELD_TYPE_TYPE_ID, safeString(field.type().typeId().toString()),
-        ICEBERG_FIELD_TYPE_STRING, safeString(toTypeString(field.type())),
+        ICEBERG_FIELD_TYPE_TYPE_ID, field.type().typeId().toString(),
+        ICEBERG_FIELD_TYPE_STRING, toTypeString(field.type()),
         ICEBERG_FIELD_ID, Integer.toString(field.fieldId()),
         ICEBERG_FIELD_OPTIONAL, Boolean.toString(field.isOptional())
     );
@@ -338,7 +336,7 @@ class IcebergToGlueConverter {
         .build();
   }
 
-  private static String safeString(String s) {
-    return s != null ? s : "unknown";
+  private static String safeString(String str) {
+    return str != null ? str : "unknown";
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
@@ -244,29 +244,24 @@ class IcebergToGlueConverter {
     Set<String> addedNames = Sets.newHashSet();
 
     for (NestedField field : metadata.schema().columns()) {
-      addColumnWithDedupe(columns, addedNames, field, field.name());
+      addColumnWithDedupe(columns, addedNames, field);
     }
 
     return columns;
   }
 
-  private static void addColumnWithDedupe(List<Column> columns, Set<String> dedupe,
-                                          NestedField field, String fieldName) {
-    if (!dedupe.contains(fieldName)) {
+  private static void addColumnWithDedupe(List<Column> columns, Set<String> dedupe, NestedField field) {
+    if (!dedupe.contains(field.name())) {
       columns.add(Column.builder()
-          .name(fieldName)
+          .name(field.name())
           .type(toTypeString(field.type()))
           .comment(field.doc())
-          .parameters(convertToParameters(field))
+          .parameters(ImmutableMap.of(
+              ICEBERG_FIELD_ID, Integer.toString(field.fieldId()),
+              ICEBERG_FIELD_OPTIONAL, Boolean.toString(field.isOptional())
+          ))
           .build());
-      dedupe.add(fieldName);
+      dedupe.add(field.name());
     }
-  }
-
-  private static Map<String, String> convertToParameters(NestedField field) {
-    return ImmutableMap.of(
-        ICEBERG_FIELD_ID, Integer.toString(field.fieldId()),
-        ICEBERG_FIELD_OPTIONAL, Boolean.toString(field.isOptional())
-    );
   }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestIcebergToGlueConverter.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestIcebergToGlueConverter.java
@@ -157,7 +157,7 @@ public class TestIcebergToGlueConverter {
                     ))
                     .build(),
                 Column.builder()
-                    .name("z")
+                    .name("y.z")
                     .type("int")
                     .parameters(ImmutableMap.of(
                         IcebergToGlueConverter.ICEBERG_FIELD_USAGE, IcebergToGlueConverter.SCHEMA_SUBFIELD,
@@ -168,7 +168,7 @@ public class TestIcebergToGlueConverter {
                     ))
                     .build(),
                 Column.builder()
-                    .name("x")
+                    .name("x_identity")
                     .type("string")
                     .parameters(ImmutableMap.<String, String>builder()
                         .put(IcebergToGlueConverter.ICEBERG_FIELD_USAGE, IcebergToGlueConverter.PARTITION_FIELD)

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestIcebergToGlueConverter.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestIcebergToGlueConverter.java
@@ -137,11 +137,8 @@ public class TestIcebergToGlueConverter {
                     .type("string")
                     .comment("comment1")
                     .parameters(ImmutableMap.of(
-                        IcebergToGlueConverter.ICEBERG_FIELD_USAGE, IcebergToGlueConverter.SCHEMA_COLUMN,
                         IcebergToGlueConverter.ICEBERG_FIELD_ID, "1",
-                        IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "false",
-                        IcebergToGlueConverter.ICEBERG_FIELD_TYPE_STRING, "string",
-                        IcebergToGlueConverter.ICEBERG_FIELD_TYPE_TYPE_ID, "STRING"
+                        IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "false"
                     ))
                     .build(),
                 Column.builder()
@@ -149,40 +146,11 @@ public class TestIcebergToGlueConverter {
                     .type("struct<z:int>")
                     .comment("comment2")
                     .parameters(ImmutableMap.of(
-                        IcebergToGlueConverter.ICEBERG_FIELD_USAGE, IcebergToGlueConverter.SCHEMA_COLUMN,
                         IcebergToGlueConverter.ICEBERG_FIELD_ID, "2",
-                        IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "false",
-                        IcebergToGlueConverter.ICEBERG_FIELD_TYPE_STRING, "struct<z:int>",
-                        IcebergToGlueConverter.ICEBERG_FIELD_TYPE_TYPE_ID, "STRUCT"
+                        IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "false"
                     ))
-                    .build(),
-                Column.builder()
-                    .name("y.z")
-                    .type("int")
-                    .parameters(ImmutableMap.of(
-                        IcebergToGlueConverter.ICEBERG_FIELD_USAGE, IcebergToGlueConverter.SCHEMA_SUBFIELD,
-                        IcebergToGlueConverter.ICEBERG_FIELD_ID, "3",
-                        IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "false",
-                        IcebergToGlueConverter.ICEBERG_FIELD_TYPE_STRING, "int",
-                        IcebergToGlueConverter.ICEBERG_FIELD_TYPE_TYPE_ID, "INTEGER"
-                    ))
-                    .build(),
-                Column.builder()
-                    .name("x_identity")
-                    .type("string")
-                    .parameters(ImmutableMap.<String, String>builder()
-                        .put(IcebergToGlueConverter.ICEBERG_FIELD_USAGE, IcebergToGlueConverter.PARTITION_FIELD)
-                        .put(IcebergToGlueConverter.ICEBERG_FIELD_TYPE_TYPE_ID, "STRING")
-                        .put(IcebergToGlueConverter.ICEBERG_FIELD_TYPE_STRING, "string")
-                        .put(IcebergToGlueConverter.ICEBERG_FIELD_ID, "1000")
-                        .put(IcebergToGlueConverter.ICEBERG_PARTITION_FIELD_ID, "1000")
-                        .put(IcebergToGlueConverter.ICEBERG_PARTITION_SOURCE_ID, "1")
-                        .put(IcebergToGlueConverter.ICEBERG_PARTITION_TRANSFORM, "identity")
-                        .build()
-                    )
-                    .build()
-                )
-            ).build())
+                    .build()))
+            .build())
         .build();
 
     Assert.assertEquals(


### PR DESCRIPTION
some bugs fixed:
- if identity transform, duplicated column name and will fail
- use full column name, `y.z` instead of `z`
- convert null to "unknown" to avoid null pointer error
- improve dedupe logic

@jackye1995 @yyanyy 