### PR TITLE
AWS: show old fields in Glue table

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
@@ -252,7 +252,7 @@ class IcebergToGlueConverter {
     for (Schema schema : metadata.schemas()) {
       if (schema.schemaId() != metadata.currentSchemaId()) {
         for (NestedField field : schema.columns()) {
-          addColumnWithDedupe(columns, addedNames, field, false /* is current */);
+          addColumnWithDedupe(columns, addedNames, field, false /* is not current */);
         }
       }
     }

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -58,6 +59,7 @@ class IcebergToGlueConverter {
   public static final String GLUE_DB_DESCRIPTION_KEY = "comment";
   public static final String ICEBERG_FIELD_ID = "iceberg.field.id";
   public static final String ICEBERG_FIELD_OPTIONAL = "iceberg.field.optional";
+  public static final String ICEBERG_FIELD_CURRENT = "iceberg.field.current";
 
   /**
    * A Glue database name cannot be longer than 252 characters.
@@ -244,13 +246,22 @@ class IcebergToGlueConverter {
     Set<String> addedNames = Sets.newHashSet();
 
     for (NestedField field : metadata.schema().columns()) {
-      addColumnWithDedupe(columns, addedNames, field);
+      addColumnWithDedupe(columns, addedNames, field, true);
+    }
+
+    for (Schema schema : metadata.schemas()) {
+      if (schema.schemaId() != metadata.currentSchemaId()) {
+        for (NestedField field : schema.columns()) {
+          addColumnWithDedupe(columns, addedNames, field, false);
+        }
+      }
     }
 
     return columns;
   }
 
-  private static void addColumnWithDedupe(List<Column> columns, Set<String> dedupe, NestedField field) {
+  private static void addColumnWithDedupe(List<Column> columns, Set<String> dedupe,
+                                          NestedField field, boolean isCurrent) {
     if (!dedupe.contains(field.name())) {
       columns.add(Column.builder()
           .name(field.name())
@@ -258,7 +269,8 @@ class IcebergToGlueConverter {
           .comment(field.doc())
           .parameters(ImmutableMap.of(
               ICEBERG_FIELD_ID, Integer.toString(field.fieldId()),
-              ICEBERG_FIELD_OPTIONAL, Boolean.toString(field.isOptional())
+              ICEBERG_FIELD_OPTIONAL, Boolean.toString(field.isOptional()),
+              ICEBERG_FIELD_CURRENT, Boolean.toString(isCurrent)
           ))
           .build());
       dedupe.add(field.name());

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
@@ -246,13 +246,13 @@ class IcebergToGlueConverter {
     Set<String> addedNames = Sets.newHashSet();
 
     for (NestedField field : metadata.schema().columns()) {
-      addColumnWithDedupe(columns, addedNames, field, true);
+      addColumnWithDedupe(columns, addedNames, field, true /* is current */);
     }
 
     for (Schema schema : metadata.schemas()) {
       if (schema.schemaId() != metadata.currentSchemaId()) {
         for (NestedField field : schema.columns()) {
-          addColumnWithDedupe(columns, addedNames, field, false);
+          addColumnWithDedupe(columns, addedNames, field, false /* is current */);
         }
       }
     }

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestIcebergToGlueConverter.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestIcebergToGlueConverter.java
@@ -138,7 +138,8 @@ public class TestIcebergToGlueConverter {
                     .comment("comment1")
                     .parameters(ImmutableMap.of(
                         IcebergToGlueConverter.ICEBERG_FIELD_ID, "1",
-                        IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "false"
+                        IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "false",
+                        IcebergToGlueConverter.ICEBERG_FIELD_CURRENT, "true"
                     ))
                     .build(),
                 Column.builder()
@@ -147,7 +148,8 @@ public class TestIcebergToGlueConverter {
                     .comment("comment2")
                     .parameters(ImmutableMap.of(
                         IcebergToGlueConverter.ICEBERG_FIELD_ID, "2",
-                        IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "false"
+                        IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "false",
+                        IcebergToGlueConverter.ICEBERG_FIELD_CURRENT, "true"
                     ))
                     .build()))
             .build())


### PR DESCRIPTION
based on #3887 

My organization wants to have Glue show old fields for Iceberg tables, so that people know what were the columns that were already used in the past and avoid adding the same name column.

@jackye1995 @yyanyy 