### PR TITLE
Spark: Fix jmh Spark parquet benchmark

### DIFF
--- a/.github/workflows/jmh-bechmarks.yml
+++ b/.github/workflows/jmh-bechmarks.yml
@@ -76,6 +76,9 @@ jobs:
       SPARK_LOCAL_IP: localhost
     steps:
     - uses: actions/checkout@v2
+      with:
+        repository: ${{ github.event.inputs.repo }}
+        ref: ${{ github.event.inputs.ref }}
     - uses: actions/setup-java@v1
       with:
         java-version: 11

--- a/spark/v2.4/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersNestedDataBenchmark.java
+++ b/spark/v2.4/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersNestedDataBenchmark.java
@@ -35,6 +35,7 @@ import org.apache.spark.sql.types.StructType;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Scope;
@@ -84,7 +85,7 @@ public class SparkParquetWritersNestedDataBenchmark {
     dataFile.delete();
   }
 
-  @TearDown
+  @TearDown(Level.Iteration)
   public void tearDownBenchmark() {
     if (dataFile != null) {
       dataFile.delete();

--- a/spark/v3.0/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersNestedDataBenchmark.java
+++ b/spark/v3.0/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersNestedDataBenchmark.java
@@ -35,6 +35,7 @@ import org.apache.spark.sql.types.StructType;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Scope;
@@ -84,7 +85,7 @@ public class SparkParquetWritersNestedDataBenchmark {
     dataFile.delete();
   }
 
-  @TearDown
+  @TearDown(Level.Iteration)
   public void tearDownBenchmark() {
     if (dataFile != null) {
       dataFile.delete();

--- a/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersNestedDataBenchmark.java
+++ b/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersNestedDataBenchmark.java
@@ -35,6 +35,7 @@ import org.apache.spark.sql.types.StructType;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Scope;
@@ -84,7 +85,7 @@ public class SparkParquetWritersNestedDataBenchmark {
     dataFile.delete();
   }
 
-  @TearDown
+  @TearDown(Level.Iteration)
   public void tearDownBenchmark() {
     if (dataFile != null) {
       dataFile.delete();

--- a/spark/v3.2/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersNestedDataBenchmark.java
+++ b/spark/v3.2/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersNestedDataBenchmark.java
@@ -85,7 +85,7 @@ public class SparkParquetWritersNestedDataBenchmark {
     dataFile.delete();
   }
 
-  @TearDown(Level.Invocation)
+  @TearDown(Level.Iteration)
   public void tearDownBenchmark() {
     if (dataFile != null) {
       dataFile.delete();

--- a/spark/v3.2/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersNestedDataBenchmark.java
+++ b/spark/v3.2/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersNestedDataBenchmark.java
@@ -35,6 +35,7 @@ import org.apache.spark.sql.types.StructType;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Scope;
@@ -84,7 +85,7 @@ public class SparkParquetWritersNestedDataBenchmark {
     dataFile.delete();
   }
 
-  @TearDown
+  @TearDown(Level.Invocation)
   public void tearDownBenchmark() {
     if (dataFile != null) {
       dataFile.delete();


### PR DESCRIPTION
This PR fixs jmh Spark parquet benchmark, now the SparkParquetWritersFlatDataBenchmark throws the following exception:
```
# Warmup Iteration   2: <failure>

org.apache.iceberg.exceptions.AlreadyExistsException: File already exists: /Users/zhongyujiang/projects/github/iceberg/spark/v3.2/spark/build/tmp/jmh/parquet-flat-data-benchmark6286636693589332554.parquet
 at org.apache.iceberg.Files$LocalOutputFile.create(Files.java:58)
 at org.apache.iceberg.parquet.ParquetIO$ParquetOutputFile.create(ParquetIO.java:148)
 at org.apache.parquet.hadoop.ParquetFileWriter.<init>(ParquetFileWriter.java:329)
 at org.apache.parquet.hadoop.ParquetFileWriter.<init>(ParquetFileWriter.java:305)
 at org.apache.parquet.hadoop.ParquetFileWriter.<init>(ParquetFileWriter.java:284)
 at org.apache.iceberg.parquet.ParquetWriter.ensureWriterInitialized(ParquetWriter.java:114)
 at org.apache.iceberg.parquet.ParquetWriter.flushRowGroup(ParquetWriter.java:200)
 at org.apache.iceberg.parquet.ParquetWriter.close(ParquetWriter.java:233)
 at org.apache.iceberg.spark.data.parquet.SparkParquetWritersFlatDataBenchmark.writeUsingIcebergWriter(SparkParquetWritersFlatDataBenchmark.java:105)
 at org.apache.iceberg.spark.data.parquet.jmh_generated.SparkParquetWritersFlatDataBenchmark_writeUsingIcebergWriter_jmhTest.writeUsingIcebergWriter_ss_jmhStub(SparkParquetWritersFlatDataBenchmark_writeUsingIcebergWriter_jmhTest.java:416)
 at org.apache.iceberg.spark.data.parquet.jmh_generated.SparkParquetWritersFlatDataBenchmark_writeUsingIcebergWriter_jmhTest.writeUsingIcebergWriter_SingleShotTime(SparkParquetWritersFlatDataBenchmark_writeUsingIcebergWriter_jmhTest.java:371)
```
This PR set the level of `TearDown` to `Level.Invocation` to clean up `dataFile`  for each benchmark method execution.
@aokolnychyi could you take a look? thx.