### PR TITLE
Hive: Do not skip IO config serialization for metadata queries

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -187,7 +187,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
    * @param table The Iceberg table object
    */
   public static void checkAndSetIoConfig(Configuration config, Table table) {
-    if (config.getBoolean(InputFormatConfig.CONFIG_SERIALIZATION_DISABLED,
+    if (table != null && config.getBoolean(InputFormatConfig.CONFIG_SERIALIZATION_DISABLED,
         InputFormatConfig.CONFIG_SERIALIZATION_DISABLED_DEFAULT) && table.io() instanceof HadoopConfigurable) {
       ((HadoopConfigurable) table.io()).setConf(config);
     }
@@ -204,7 +204,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
    * @param table The Iceberg table object
    */
   public static void checkAndSkipIoConfigSerialization(Configuration config, Table table) {
-    if (config.getBoolean(InputFormatConfig.CONFIG_SERIALIZATION_DISABLED,
+    if (table != null && config.getBoolean(InputFormatConfig.CONFIG_SERIALIZATION_DISABLED,
         InputFormatConfig.CONFIG_SERIALIZATION_DISABLED_DEFAULT) && table.io() instanceof HadoopConfigurable) {
       ((HadoopConfigurable) table.io()).serializeConfWith(conf -> new NonSerializingConfig(config)::get);
     }


### PR DESCRIPTION
Skipping the IO config serialization (introduced [here](https://github.com/apache/iceberg/commit/da712eaf60744c933c08fe1cab7a00cdcb2f4829)), followed by injecting the config on the deserialization-side saves a lot of memory on the query coordinator (e.g. Tez AM), but this approach does not work for some of the metadata queries. 

When running standard queries, the tasks use the IO of the table object, which provides a way to inject the config via the `HadoopConfigurable` interface. However, some metadata table tasks, such as [DataFilesTable#ManifestReadTask](https://github.com/apache/iceberg/blob/master/core/src/main/java/org/apache/iceberg/DataFilesTable.java#L139) keep their own IO instance for reading, and they provide no API to replace/inject their IO instance.

We might want to tackle this in the future so that config serialization skipping can work for metadata queries too. In the interim, this PR disables IO config skipping for these queries.