### PR TITLE
Hive: Add table UUID to HMS table properties.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -43,7 +43,7 @@ public class TableProperties {
   /**
    * Reserved table property for UUID.
    * <p>
-   * This reserved property is keyword is used to store the UUID of the table.
+   * This reserved property is used to store the UUID of the table.
    */
   public static final String UUID = "uuid";
 

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -41,6 +41,13 @@ public class TableProperties {
   public static final String FORMAT_VERSION = "format-version";
 
   /**
+   * Reserved table property for UUID.
+   * <p>
+   * This reserved property is keyword is used to store the UUID of the table.
+   */
+  public static final String UUID = "uuid";
+
+  /**
    * Reserved Iceberg table properties list.
    * <p>
    * Reserved table properties are only used to control behaviors when creating or updating a table.

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -54,7 +54,8 @@ public class TableProperties {
    * The value of these properties are not persisted as a part of the table metadata.
    */
   public static final Set<String> RESERVED_PROPERTIES = ImmutableSet.of(
-      FORMAT_VERSION
+      FORMAT_VERSION,
+      UUID
   );
 
   public static final String COMMIT_NUM_RETRIES = "commit.retry.num-retries";

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -884,5 +884,11 @@ public class TestTableMetadata {
         "Table properties should not contain reserved properties, but got {format-version=1}",
         () -> TableMetadata.newTableMetadata(schema, PartitionSpec.unpartitioned(), null, "/tmp",
             ImmutableMap.of(TableProperties.FORMAT_VERSION, "1"), 1));
+
+    AssertHelpers.assertThrows("should not allow reserved table property when creating table metadata",
+        IllegalArgumentException.class,
+        "Table properties should not contain reserved properties, but got {uuid=uuid}",
+        () -> TableMetadata.newTableMetadata(schema, PartitionSpec.unpartitioned(), null, "/tmp",
+            ImmutableMap.of(TableProperties.UUID, "uuid"), 1));
   }
 }

--- a/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.apache.flink.table.api.DataTypes;
@@ -178,10 +177,9 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
     sql("CREATE TABLE IF NOT EXISTS tl(id BIGINT)");
     Assert.assertEquals(Maps.newHashMap(), table("tl").properties());
 
-    final String uuid = UUID.randomUUID().toString();
-    final Map<String, String> expectedProperties = ImmutableMap.of("uuid", uuid);
+    final Map<String, String> expectedProperties = ImmutableMap.of("key", "value");
     table("tl").updateProperties()
-        .set("uuid", uuid)
+        .set("key", "value")
         .commit();
     Assert.assertEquals(expectedProperties, table("tl").properties());
 

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.apache.flink.table.api.DataTypes;
@@ -179,10 +178,9 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
     sql("CREATE TABLE IF NOT EXISTS tl(id BIGINT)");
     Assert.assertEquals(Maps.newHashMap(), table("tl").properties());
 
-    final String uuid = UUID.randomUUID().toString();
-    final Map<String, String> expectedProperties = ImmutableMap.of("uuid", uuid);
+    final Map<String, String> expectedProperties = ImmutableMap.of("key", "value");
     table("tl").updateProperties()
-        .set("uuid", uuid)
+        .set("key", "value")
         .commit();
     Assert.assertEquals(expectedProperties, table("tl").properties());
 

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.apache.flink.table.api.DataTypes;
@@ -179,10 +178,9 @@ public class TestFlinkCatalogTable extends FlinkCatalogTestBase {
     sql("CREATE TABLE IF NOT EXISTS tl(id BIGINT)");
     Assert.assertEquals(Maps.newHashMap(), table("tl").properties());
 
-    final String uuid = UUID.randomUUID().toString();
-    final Map<String, String> expectedProperties = ImmutableMap.of("uuid", uuid);
+    final Map<String, String> expectedProperties = ImmutableMap.of("key", "value");
     table("tl").updateProperties()
-        .set("uuid", uuid)
+        .set("key", "value")
         .commit();
     Assert.assertEquals(expectedProperties, table("tl").properties());
 

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -262,8 +262,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
       Map<String, String> summary = Optional.ofNullable(metadata.currentSnapshot())
           .map(Snapshot::summary)
           .orElseGet(ImmutableMap::of);
-      setHmsTableParameters(newMetadataLocation, tbl, metadata.properties(), removedProps, hiveEngineEnabled, summary,
-          metadata.uuid());
+      setHmsTableParameters(newMetadataLocation, tbl, metadata, removedProps, hiveEngineEnabled, summary);
 
       if (!keepHiveStats) {
         tbl.getParameters().remove(StatsSetupConst.COLUMN_STATS_ACCURATE);
@@ -353,20 +352,20 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     return newTable;
   }
 
-  private void setHmsTableParameters(String newMetadataLocation, Table tbl, Map<String, String> icebergTableProps,
+  private void setHmsTableParameters(String newMetadataLocation, Table tbl, TableMetadata metadata,
                                      Set<String> obsoleteProps, boolean hiveEngineEnabled,
-                                     Map<String, String> summary, String uuid) {
+                                     Map<String, String> summary) {
     Map<String, String> parameters = Optional.ofNullable(tbl.getParameters())
         .orElseGet(Maps::newHashMap);
 
     // push all Iceberg table properties into HMS
-    icebergTableProps.forEach((key, value) -> {
+    metadata.properties().forEach((key, value) -> {
       // translate key names between Iceberg and HMS where needed
       String hmsKey = ICEBERG_TO_HMS_TRANSLATION.getOrDefault(key, key);
       parameters.put(hmsKey, value);
     });
-    if (uuid != null) {
-      parameters.put(TableProperties.UUID, uuid);
+    if (metadata.uuid() != null) {
+      parameters.put(TableProperties.UUID, metadata.uuid());
     }
 
     // remove any props from HMS that are no longer present in Iceberg table props

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -262,7 +262,8 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
       Map<String, String> summary = Optional.ofNullable(metadata.currentSnapshot())
           .map(Snapshot::summary)
           .orElseGet(ImmutableMap::of);
-      setHmsTableParameters(newMetadataLocation, tbl, metadata.properties(), removedProps, hiveEngineEnabled, summary);
+      setHmsTableParameters(newMetadataLocation, tbl, metadata.properties(), removedProps, hiveEngineEnabled, summary,
+          metadata.uuid());
 
       if (!keepHiveStats) {
         tbl.getParameters().remove(StatsSetupConst.COLUMN_STATS_ACCURATE);
@@ -354,7 +355,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
 
   private void setHmsTableParameters(String newMetadataLocation, Table tbl, Map<String, String> icebergTableProps,
                                      Set<String> obsoleteProps, boolean hiveEngineEnabled,
-                                     Map<String, String> summary) {
+                                     Map<String, String> summary, String uuid) {
     Map<String, String> parameters = Optional.ofNullable(tbl.getParameters())
         .orElseGet(Maps::newHashMap);
 
@@ -364,6 +365,9 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
       String hmsKey = ICEBERG_TO_HMS_TRANSLATION.getOrDefault(key, key);
       parameters.put(hmsKey, value);
     });
+    if (uuid != null) {
+      parameters.put(TableProperties.UUID, uuid);
+    }
 
     // remove any props from HMS that are no longer present in Iceberg table props
     obsoleteProps.forEach(parameters::remove);

--- a/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -624,7 +624,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
     Assert.assertEquals(expectedIcebergProperties, icebergTable.properties());
 
     if (Catalogs.hiveCatalog(shell.getHiveConf(), tableProperties)) {
-      Assert.assertEquals(10, hmsParams.size());
+      Assert.assertEquals(11, hmsParams.size());
       Assert.assertEquals("initial_val", hmsParams.get("custom_property"));
       Assert.assertEquals("TRUE", hmsParams.get(InputFormatConfig.EXTERNAL_TABLE_PURGE));
       Assert.assertEquals("TRUE", hmsParams.get("EXTERNAL"));
@@ -662,7 +662,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     if (Catalogs.hiveCatalog(shell.getHiveConf(), tableProperties)) {
-      Assert.assertEquals(13, hmsParams.size()); // 2 newly-added properties + previous_metadata_location prop
+      Assert.assertEquals(14, hmsParams.size()); // 2 newly-added properties + previous_metadata_location prop
       Assert.assertEquals("true", hmsParams.get("new_prop_1"));
       Assert.assertEquals("false", hmsParams.get("new_prop_2"));
       Assert.assertEquals("new_val", hmsParams.get("custom_property"));

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.util.Map;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.BaseTable;
-import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -66,7 +65,6 @@ public class TestCreateTable extends SparkCatalogTestBase {
     Assert.assertEquals("Should not be partitioned", 0, table.spec().fields().size());
     Assert.assertNull("Should not have the default format set",
         table.properties().get(TableProperties.DEFAULT_FILE_FORMAT));
-    Assert.assertNotNull(((HasTableOperations) table).operations().current().uuid());
   }
 
   @Test

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestCreateTable.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.Map;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -65,6 +66,7 @@ public class TestCreateTable extends SparkCatalogTestBase {
     Assert.assertEquals("Should not be partitioned", 0, table.spec().fields().size());
     Assert.assertNull("Should not have the default format set",
         table.properties().get(TableProperties.DEFAULT_FILE_FORMAT));
+    Assert.assertNotNull(((HasTableOperations) table).operations().current().uuid());
   }
 
   @Test


### PR DESCRIPTION
#2123 pushes Iceberg table property values to HMS table properties. It'd be nice to add table uuid to HMS table properties as well. Uuid is critical to identify a table. This change is to support the application that wants to identify a table through its uuid by only access the HMS.