### PR TITLE
Build: Fix source-release script to run anywhere automated and add validation that remote git repo exists

### DIFF
--- a/dev/source-release.sh
+++ b/dev/source-release.sh
@@ -36,7 +36,7 @@ usage () {
 }
 
 # Default repository remote name
-remote="apache"
+remote="origin"
 
 while getopts "v:r:k:g:d" opt; do
   case "${opt}" in
@@ -65,6 +65,11 @@ shift $((OPTIND-1))
 
 if [ -z "$version" ] || [ -z "$rc" ]; then
   echo "You must specify the version and RC numbers using the -v and -r switches"
+  usage
+fi
+
+if ! git ls-remote --quiet --exit-code "$remote"; then
+  echo "The target remote git repository, ${remote}, is not configured in git. Please pass a valid value for the remote git repository to target via the -g switch"
   usage
 fi
 

--- a/dev/source-release.sh
+++ b/dev/source-release.sh
@@ -68,7 +68,7 @@ if [ -z "$version" ] || [ -z "$rc" ]; then
   usage
 fi
 
-if ! git ls-remote --quiet --exit-code "$remote"; then
+if ! git ls-remote --exit-code "$remote" >/dev/null 2>&1 ; then
   echo "The target remote git repository, ${remote}, is not configured in git. Please pass a valid value for the remote git repository to target via the -g switch"
   usage
 fi


### PR DESCRIPTION
In a previous PR, https://github.com/apache/iceberg/pull/3824, the default repo name was changed to `apache`.

However, this was originally kept as `origin` so we can run this in automation (GH action, on ASF infra - anywhere that clones the repository locally first). Additionally, all users are guaranteed to have `origin` locally.

The choice of `apache` is somewhat non-standard (all of the github docs etc use `upstream`). Though I know many committers / PMC that use `apache` to differentiate from forks or just to be more specific.

If we only do that from the release manager's laptop, we can keep it as `apache` as likely they have it set up that way.

In either case, I've added a check early on to ensure that the git remote exists, so that a tag and version file are not committed unnecessarily.

```
$ ./dev/source-release.sh -v 0.99.1 -r 0 -g oh-no-im-not-registered
The target remote git repository, oh-no-im-not-registered, is not configured in git. Please pass a valid value for the remote git repository to target via the -g switch
usage: ./dev/source-release.sh [-k <key_id>] [-g <git_remote>] -v <version_num> -r <rc_num>
  -v      Version number of release
  -r      Release candidate number
  -k      Specify signing key. Defaults to "GPG default key"
  -g      Specify Git remote name. Defaults to "apache"
  -d      Turn on DEBUG output
```