### PR TITLE
Core: Fix the incorrectly log description in BinPackStrategy

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/BinPackStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BinPackStrategy.java
@@ -259,7 +259,7 @@ public abstract class BinPackStrategy implements RewriteStrategy {
         MIN_FILE_SIZE_BYTES, RewriteDataFiles.TARGET_FILE_SIZE_BYTES, minFileSize, targetFileSize);
 
     Preconditions.checkArgument(targetFileSize < maxFileSize,
-        "Cannot set %s is less than or equal to %s, all files written will be larger than the threshold, %d >= %d",
+        "Cannot set %s is less than or equal to %s, all files written will be larger than the threshold, %d <= %d",
         MAX_FILE_SIZE_BYTES, RewriteDataFiles.TARGET_FILE_SIZE_BYTES, maxFileSize, targetFileSize);
 
     Preconditions.checkArgument(minInputFiles > 0,

--- a/core/src/main/java/org/apache/iceberg/actions/BinPackStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BinPackStrategy.java
@@ -259,8 +259,8 @@ public abstract class BinPackStrategy implements RewriteStrategy {
         MIN_FILE_SIZE_BYTES, RewriteDataFiles.TARGET_FILE_SIZE_BYTES, minFileSize, targetFileSize);
 
     Preconditions.checkArgument(targetFileSize < maxFileSize,
-        "Cannot set %s is less than or equal to %s, all files written will be larger than the threshold, %d <= %d",
-        MAX_FILE_SIZE_BYTES, RewriteDataFiles.TARGET_FILE_SIZE_BYTES, maxFileSize, targetFileSize);
+        "Cannot set %s is greater than or equal to %s, all files written will be larger than the threshold, %d >= %d",
+        RewriteDataFiles.TARGET_FILE_SIZE_BYTES, MAX_FILE_SIZE_BYTES, targetFileSize, maxFileSize);
 
     Preconditions.checkArgument(minInputFiles > 0,
         "Cannot set %s is less than 1. All values less than 1 have the same effect as 1. %d < 1",

--- a/core/src/main/java/org/apache/iceberg/actions/BinPackStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BinPackStrategy.java
@@ -259,7 +259,7 @@ public abstract class BinPackStrategy implements RewriteStrategy {
         MIN_FILE_SIZE_BYTES, RewriteDataFiles.TARGET_FILE_SIZE_BYTES, minFileSize, targetFileSize);
 
     Preconditions.checkArgument(targetFileSize < maxFileSize,
-        "Cannot set %s is greater than or equal to %s, all files written will be larger than the threshold, %d >= %d",
+        "Cannot set %s is less than or equal to %s, all files written will be larger than the threshold, %d >= %d",
         MAX_FILE_SIZE_BYTES, RewriteDataFiles.TARGET_FILE_SIZE_BYTES, maxFileSize, targetFileSize);
 
     Preconditions.checkArgument(minInputFiles > 0,


### PR DESCRIPTION
This PR fixes a log error for rewrite parameter max-file-size-bytes, when I set the target-file-size-bytes less than max-file-size-bytes, spark throwed a checkAgument exception "Cannot set max-file-size-bytes is greater than or equal to target-file-size-bytes, all files written will be larger than the threshold", it's puzzling, so I fix this error.