### PR TITLE
Python: fix wrong encoding for lower/upper bounds boolean value (#3924)

### DIFF
--- a/python_legacy/iceberg/api/types/conversions.py
+++ b/python_legacy/iceberg/api/types/conversions.py
@@ -39,7 +39,7 @@ class Conversions(object):
                      TypeID.DECIMAL: lambda as_str: Decimal(as_str),
                      }
 
-    to_byte_buff_mapping = {TypeID.BOOLEAN: lambda type_id, value: struct.pack("<h", 1 if value else 0),
+    to_byte_buff_mapping = {TypeID.BOOLEAN: lambda type_id, value: struct.pack("<?", 1 if value else 0),
                             TypeID.INTEGER: lambda type_id, value: struct.pack("<i", value),
                             TypeID.DATE: lambda type_id, value: struct.pack("<i", value),
                             TypeID.LONG: lambda type_id, value: struct.pack("<q", value),
@@ -57,7 +57,7 @@ class Conversions(object):
                             #     Decimal('.' + "".join(['0' for x in range(0, type_var.scale)]) + '1'))
                             }
 
-    from_byte_buff_mapping = {TypeID.BOOLEAN: lambda type_id, value: struct.unpack('<h', value)[0] != 0,
+    from_byte_buff_mapping = {TypeID.BOOLEAN: lambda type_id, value: struct.unpack('<?', value)[0] != 0,
                               TypeID.INTEGER: lambda type_id, value: struct.unpack('<i', value)[0],
                               TypeID.DATE: lambda type_id, value: struct.unpack('<i', value)[0],
                               TypeID.LONG: lambda type_id, value: struct.unpack('<q', value)[0],

--- a/python_legacy/tests/api/test_conversions.py
+++ b/python_legacy/tests/api/test_conversions.py
@@ -37,8 +37,8 @@ from iceberg.api.types.conversions import Conversions
 class TestConversions(unittest.TestCase):
 
     def test_from_bytes(self):
-        self.assertEqual(False, Conversions.from_byte_buffer(BooleanType.get(), b'\x00\x00'))
-        self.assertEqual(True, Conversions.from_byte_buffer(BooleanType.get(), b'\x01\x00'))
+        self.assertEqual(False, Conversions.from_byte_buffer(BooleanType.get(), b'\x00'))
+        self.assertEqual(True, Conversions.from_byte_buffer(BooleanType.get(), b'\x01'))
         self.assertEqual(1234, Conversions.from_byte_buffer(IntegerType.get(),
                                                             b'\xd2\x04\x00\x00'))
         self.assertEqual(1234, Conversions.from_byte_buffer(LongType.get(),
@@ -62,8 +62,8 @@ class TestConversions(unittest.TestCase):
         self.assertEqual(b'foo', Conversions.from_byte_buffer(BinaryType.get(), b'foo'))
 
     def test_to_bytes(self):
-        self.assertEqual(b'\x00\x00', Literal.of(False).to_byte_buffer())
-        self.assertEqual(b'\x01\x00', Literal.of(True).to_byte_buffer())
+        self.assertEqual(b'\x00', Literal.of(False).to_byte_buffer())
+        self.assertEqual(b'\x01', Literal.of(True).to_byte_buffer())
         self.assertEqual(b'\xd2\x04\x00\x00', Literal.of(1234).to_byte_buffer())
         self.assertEqual(b'\xd2\x04\x00\x00\x00\x00\x00\x00', Literal.of(1234).to(LongType.get()).to_byte_buffer())
         self.assertEqual(b'\x19\x04\x9e?', Literal.of(1.2345).to_byte_buffer())


### PR DESCRIPTION
See issue #3924 

@samredai As discussed in Slack, here is the PR fixing the conversion of boolean types.