### PR TITLE
Spark 3.2: Revise distribution and ordering in copy-on-write DELETE

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkDistributionAndOrderingUtil.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkDistributionAndOrderingUtil.java
@@ -123,12 +123,11 @@ public class SparkDistributionAndOrderingUtil {
   }
 
   private static SortOrder[] buildCopyOnWriteDeleteOrdering(Table table, Distribution distribution) {
-    SortOrder[] tableOrdering = buildTableOrdering(table);
-
     if (distribution instanceof UnspecifiedDistribution) {
-      return tableOrdering;
+      return buildTableOrdering(table);
 
     } else if (distribution instanceof ClusteredDistribution) {
+      SortOrder[] tableOrdering = buildTableOrdering(table);
       if (table.sortOrder().isSorted()) {
         return tableOrdering;
       } else {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkDistributionAndOrderingUtil.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkDistributionAndOrderingUtil.java
@@ -23,12 +23,14 @@ import java.util.List;
 import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.relocated.com.google.common.collect.ObjectArrays;
 import org.apache.iceberg.transforms.SortOrderVisitor;
 import org.apache.iceberg.util.SortOrderUtil;
 import org.apache.spark.sql.connector.distributions.ClusteredDistribution;
 import org.apache.spark.sql.connector.distributions.Distribution;
 import org.apache.spark.sql.connector.distributions.Distributions;
 import org.apache.spark.sql.connector.distributions.OrderedDistribution;
+import org.apache.spark.sql.connector.distributions.UnspecifiedDistribution;
 import org.apache.spark.sql.connector.expressions.Expression;
 import org.apache.spark.sql.connector.expressions.Expressions;
 import org.apache.spark.sql.connector.expressions.NamedReference;
@@ -36,7 +38,6 @@ import org.apache.spark.sql.connector.expressions.SortDirection;
 import org.apache.spark.sql.connector.expressions.SortOrder;
 import org.apache.spark.sql.connector.iceberg.write.RowLevelOperation.Command;
 
-import static org.apache.iceberg.DistributionMode.HASH;
 import static org.apache.spark.sql.connector.iceberg.write.RowLevelOperation.Command.DELETE;
 
 public class SparkDistributionAndOrderingUtil {
@@ -51,6 +52,8 @@ public class SparkDistributionAndOrderingUtil {
   private static final SortOrder FILE_PATH_ORDER = Expressions.sort(FILE_PATH, SortDirection.ASCENDING);
   private static final SortOrder ROW_POSITION_ORDER = Expressions.sort(ROW_POSITION, SortDirection.ASCENDING);
 
+  private static final SortOrder[] EXISTING_FILE_ORDERING = new SortOrder[]{FILE_PATH_ORDER, ROW_POSITION_ORDER};
+
   private SparkDistributionAndOrderingUtil() {
   }
 
@@ -63,8 +66,7 @@ public class SparkDistributionAndOrderingUtil {
         return Distributions.clustered(Spark3Util.toTransforms(table.spec()));
 
       case RANGE:
-        org.apache.iceberg.SortOrder requiredSortOrder = SortOrderUtil.buildSortOrder(table);
-        return Distributions.ordered(convert(requiredSortOrder));
+        return Distributions.ordered(buildTableOrdering(table));
 
       default:
         throw new IllegalArgumentException("Unsupported distribution mode: " + distributionMode);
@@ -75,28 +77,70 @@ public class SparkDistributionAndOrderingUtil {
     if (distribution instanceof OrderedDistribution) {
       OrderedDistribution orderedDistribution = (OrderedDistribution) distribution;
       return orderedDistribution.ordering();
-
     } else {
-      org.apache.iceberg.SortOrder requiredSortOrder = SortOrderUtil.buildSortOrder(table);
-      return convert(requiredSortOrder);
+      return buildTableOrdering(table);
     }
   }
 
   public static Distribution buildCopyOnWriteDistribution(Table table, Command command,
                                                           DistributionMode distributionMode) {
-    if (command == DELETE && distributionMode == HASH) {
-      Expression[] clustering = new Expression[]{FILE_PATH};
-      return Distributions.clustered(clustering);
+    if (command == DELETE) {
+      return buildCopyOnWriteDeleteDistribution(table, distributionMode);
     } else {
       return buildRequiredDistribution(table, distributionMode);
     }
   }
 
+  private static Distribution buildCopyOnWriteDeleteDistribution(Table table, DistributionMode distributionMode) {
+    switch (distributionMode) {
+      case NONE:
+        return Distributions.unspecified();
+
+      case HASH:
+        Expression[] clustering = new Expression[]{FILE_PATH};
+        return Distributions.clustered(clustering);
+
+      case RANGE:
+        SortOrder[] tableOrdering = buildTableOrdering(table);
+        if (table.sortOrder().isSorted()) {
+          return Distributions.ordered(tableOrdering);
+        } else {
+          SortOrder[] ordering = ObjectArrays.concat(tableOrdering, EXISTING_FILE_ORDERING, SortOrder.class);
+          return Distributions.ordered(ordering);
+        }
+
+      default:
+        throw new IllegalArgumentException("Unexpected distribution mode: " + distributionMode);
+    }
+  }
+
   public static SortOrder[] buildCopyOnWriteOrdering(Table table, Command command, Distribution distribution) {
-    if (command == DELETE && distribution instanceof ClusteredDistribution) {
-      return new SortOrder[]{FILE_PATH_ORDER, ROW_POSITION_ORDER};
+    if (command == DELETE) {
+      return buildCopyOnWriteDeleteOrdering(table, distribution);
     } else {
       return buildRequiredOrdering(table, distribution);
+    }
+  }
+
+  private static SortOrder[] buildCopyOnWriteDeleteOrdering(Table table, Distribution distribution) {
+    SortOrder[] tableOrdering = buildTableOrdering(table);
+
+    if (distribution instanceof UnspecifiedDistribution) {
+      return tableOrdering;
+
+    } else if (distribution instanceof ClusteredDistribution) {
+      if (table.sortOrder().isSorted()) {
+        return tableOrdering;
+      } else {
+        return ObjectArrays.concat(tableOrdering, EXISTING_FILE_ORDERING, SortOrder.class);
+      }
+
+    } else if (distribution instanceof OrderedDistribution) {
+      OrderedDistribution orderedDistribution = (OrderedDistribution) distribution;
+      return orderedDistribution.ordering();
+
+    } else {
+      throw new IllegalArgumentException("Unexpected distribution type: " + distribution.getClass().getName());
     }
   }
 
@@ -139,5 +183,9 @@ public class SparkDistributionAndOrderingUtil {
   public static SortOrder[] convert(org.apache.iceberg.SortOrder sortOrder) {
     List<SortOrder> converted = SortOrderVisitor.visit(sortOrder, new SortOrderToSpark(sortOrder.schema()));
     return converted.toArray(new SortOrder[0]);
+  }
+
+  private static SortOrder[] buildTableOrdering(Table table) {
+    return convert(SortOrderUtil.buildSortOrder(table));
   }
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -202,19 +202,9 @@ public class SparkWriteConf {
     String deleteModeName = confParser.stringConf()
         .option(SparkWriteOptions.DISTRIBUTION_MODE)
         .tableProperty(TableProperties.DELETE_DISTRIBUTION_MODE)
-        .parseOptional();
-
-    if (deleteModeName != null) {
-      DistributionMode deleteMode = DistributionMode.fromName(deleteModeName);
-      if (deleteMode == RANGE && table.spec().isUnpartitioned() && table.sortOrder().isUnsorted()) {
-        return HASH;
-      } else {
-        return deleteMode;
-      }
-    } else {
-      // use hash distribution by default
-      return HASH;
-    }
+        .defaultValue(TableProperties.WRITE_DISTRIBUTION_MODE_HASH)
+        .parse();
+    return DistributionMode.fromName(deleteModeName);
   }
 
   public DistributionMode copyOnWriteUpdateDistributionMode() {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -212,10 +212,8 @@ public class SparkWriteConf {
         return deleteMode;
       }
     } else {
-      // use hash distribution if write distribution is range or hash
-      // avoid range-based shuffles unless the user asks explicitly
-      DistributionMode writeMode = distributionMode();
-      return writeMode != NONE ? HASH : NONE;
+      // use hash distribution by default
+      return HASH;
     }
   }
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkDistributionAndOrderingUtil.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkDistributionAndOrderingUtil.java
@@ -309,27 +309,27 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
   // delete mode is NOT SET -> CLUSTER BY _file + LOCALLY ORDER BY _file, _pos
   // delete mode is NONE -> unspecified distribution + empty ordering
   // delete mode is HASH -> CLUSTER BY _file + LOCALLY ORDER BY _file, _pos
-  // delete mode is RANGE -> CLUSTER BY _file + LOCALLY ORDER BY _file, _pos
+  // delete mode is RANGE -> ORDER BY _file, _pos
   //
   // UNPARTITIONED ORDERED BY id, data
   // -------------------------------------------------------------------------
-  // delete mode is NOT SET -> CLUSTER BY _file + LOCALLY ORDER BY _file, _pos
+  // delete mode is NOT SET -> CLUSTER BY _file + LOCALLY ORDER BY id, data
   // delete mode is NONE -> unspecified distribution + LOCALLY ORDER BY id, data
-  // delete mode is HASH -> CLUSTER BY _file + LOCALLY ORDER BY _file, _pos
+  // delete mode is HASH -> CLUSTER BY _file + LOCALLY ORDER BY id, data
   // delete mode is RANGE -> ORDER BY id, data
   //
   // PARTITIONED BY date, days(ts) UNORDERED
   // -------------------------------------------------------------------------
-  // delete mode is NOT SET -> CLUSTER BY _file + LOCALLY ORDER BY _file, _pos
+  // delete mode is NOT SET -> CLUSTER BY _file + LOCALLY ORDER BY date, days(ts), _file, _pos
   // delete mode is NONE -> unspecified distribution + LOCALLY ORDERED BY date, days(ts)
-  // delete mode is HASH -> CLUSTER BY _file + LOCALLY ORDER BY _file, _pos
-  // delete mode is RANGE -> ORDER BY date, days(ts)
+  // delete mode is HASH -> CLUSTER BY _file + LOCALLY ORDER BY date, days(ts), _file, _pos
+  // delete mode is RANGE -> ORDER BY date, days(ts), _file, _pos
   //
   // PARTITIONED BY date ORDERED BY id
   // -------------------------------------------------------------------------
-  // delete mode is NOT SET -> CLUSTER BY _file + LOCALLY ORDER BY _file, _pos
+  // delete mode is NOT SET -> CLUSTER BY _file + LOCALLY ORDER BY date, id
   // delete mode is NONE -> unspecified distribution + LOCALLY ORDERED BY date, id
-  // delete mode is HASH -> CLUSTER BY _file + LOCALLY ORDER BY _file, _pos
+  // delete mode is HASH -> CLUSTER BY _file + LOCALLY ORDER BY date, id
   // delete mode is RANGE -> ORDERED BY date, id
 
   @Test
@@ -400,15 +400,12 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         .set(DELETE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_RANGE)
         .commit();
 
-    Expression[] expectedClustering = new Expression[]{
-        Expressions.column(MetadataColumns.FILE_PATH.name()),
-    };
-    Distribution expectedDistribution = Distributions.clustered(expectedClustering);
-
     SortOrder[] expectedOrdering = new SortOrder[]{
         Expressions.sort(Expressions.column(MetadataColumns.FILE_PATH.name()), SortDirection.ASCENDING),
         Expressions.sort(Expressions.column(MetadataColumns.ROW_POSITION.name()), SortDirection.ASCENDING)
     };
+
+    Distribution expectedDistribution = Distributions.ordered(expectedOrdering);
 
     checkCopyOnWriteDeleteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
   }
@@ -430,8 +427,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     Distribution expectedDistribution = Distributions.clustered(expectedClustering);
 
     SortOrder[] expectedOrdering = new SortOrder[]{
-        Expressions.sort(Expressions.column(MetadataColumns.FILE_PATH.name()), SortDirection.ASCENDING),
-        Expressions.sort(Expressions.column(MetadataColumns.ROW_POSITION.name()), SortDirection.ASCENDING)
+        Expressions.sort(Expressions.column("id"), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.column("data"), SortDirection.ASCENDING)
     };
 
     checkCopyOnWriteDeleteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
@@ -483,8 +480,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     Distribution expectedDistribution = Distributions.clustered(expectedClustering);
 
     SortOrder[] expectedOrdering = new SortOrder[]{
-        Expressions.sort(Expressions.column(MetadataColumns.FILE_PATH.name()), SortDirection.ASCENDING),
-        Expressions.sort(Expressions.column(MetadataColumns.ROW_POSITION.name()), SortDirection.ASCENDING)
+        Expressions.sort(Expressions.column("id"), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.column("data"), SortDirection.ASCENDING)
     };
 
     checkCopyOnWriteDeleteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
@@ -529,6 +526,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     Distribution expectedDistribution = Distributions.clustered(expectedClustering);
 
     SortOrder[] expectedOrdering = new SortOrder[]{
+        Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.days("ts"), SortDirection.ASCENDING),
         Expressions.sort(Expressions.column(MetadataColumns.FILE_PATH.name()), SortDirection.ASCENDING),
         Expressions.sort(Expressions.column(MetadataColumns.ROW_POSITION.name()), SortDirection.ASCENDING)
     };
@@ -576,6 +575,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     Distribution expectedDistribution = Distributions.clustered(expectedClustering);
 
     SortOrder[] expectedOrdering = new SortOrder[]{
+        Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.days("ts"), SortDirection.ASCENDING),
         Expressions.sort(Expressions.column(MetadataColumns.FILE_PATH.name()), SortDirection.ASCENDING),
         Expressions.sort(Expressions.column(MetadataColumns.ROW_POSITION.name()), SortDirection.ASCENDING)
     };
@@ -597,7 +598,9 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     SortOrder[] expectedOrdering = new SortOrder[]{
         Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
-        Expressions.sort(Expressions.days("ts"), SortDirection.ASCENDING)
+        Expressions.sort(Expressions.days("ts"), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.column(MetadataColumns.FILE_PATH.name()), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.column(MetadataColumns.ROW_POSITION.name()), SortDirection.ASCENDING)
     };
 
     Distribution expectedDistribution = Distributions.ordered(expectedOrdering);
@@ -623,8 +626,8 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     Distribution expectedDistribution = Distributions.clustered(expectedClustering);
 
     SortOrder[] expectedOrdering = new SortOrder[]{
-        Expressions.sort(Expressions.column(MetadataColumns.FILE_PATH.name()), SortDirection.ASCENDING),
-        Expressions.sort(Expressions.column(MetadataColumns.ROW_POSITION.name()), SortDirection.ASCENDING)
+        Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.column("id"), SortDirection.DESCENDING)
     };
 
     checkCopyOnWriteDeleteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
@@ -678,8 +681,9 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     Distribution expectedDistribution = Distributions.clustered(expectedClustering);
 
     SortOrder[] expectedOrdering = new SortOrder[]{
-        Expressions.sort(Expressions.column(MetadataColumns.FILE_PATH.name()), SortDirection.ASCENDING),
-        Expressions.sort(Expressions.column(MetadataColumns.ROW_POSITION.name()), SortDirection.ASCENDING)
+        Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.bucket(8, "data"), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.column("id"), SortDirection.ASCENDING)
     };
 
     checkCopyOnWriteDeleteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkDistributionAndOrderingUtil.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkDistributionAndOrderingUtil.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 import static org.apache.iceberg.TableProperties.DELETE_DISTRIBUTION_MODE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_HASH;
+import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_NONE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_RANGE;
 import static org.apache.spark.sql.connector.iceberg.write.RowLevelOperation.Command.DELETE;
 
@@ -299,14 +300,70 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     checkWriteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
   }
 
+  // =============================================================
+  // Distribution and ordering for copy-on-write DELETE operations
+  // =============================================================
+  //
+  // UNPARTITIONED UNORDERED
+  // -------------------------------------------------------------------------
+  // delete mode is NOT SET -> CLUSTER BY _file + LOCALLY ORDER BY _file, _pos
+  // delete mode is NONE -> unspecified distribution + empty ordering
+  // delete mode is HASH -> CLUSTER BY _file + LOCALLY ORDER BY _file, _pos
+  // delete mode is RANGE -> CLUSTER BY _file + LOCALLY ORDER BY _file, _pos
+  //
+  // UNPARTITIONED ORDERED BY id, data
+  // -------------------------------------------------------------------------
+  // delete mode is NOT SET -> CLUSTER BY _file + LOCALLY ORDER BY _file, _pos
+  // delete mode is NONE -> unspecified distribution + LOCALLY ORDER BY id, data
+  // delete mode is HASH -> CLUSTER BY _file + LOCALLY ORDER BY _file, _pos
+  // delete mode is RANGE -> ORDER BY id, data
+  //
+  // PARTITIONED BY date, days(ts) UNORDERED
+  // -------------------------------------------------------------------------
+  // delete mode is NOT SET -> CLUSTER BY _file + LOCALLY ORDER BY _file, _pos
+  // delete mode is NONE -> unspecified distribution + LOCALLY ORDERED BY date, days(ts)
+  // delete mode is HASH -> CLUSTER BY _file + LOCALLY ORDER BY _file, _pos
+  // delete mode is RANGE -> ORDER BY date, days(ts)
+  //
+  // PARTITIONED BY date ORDERED BY id
+  // -------------------------------------------------------------------------
+  // delete mode is NOT SET -> CLUSTER BY _file + LOCALLY ORDER BY _file, _pos
+  // delete mode is NONE -> unspecified distribution + LOCALLY ORDERED BY date, id
+  // delete mode is HASH -> CLUSTER BY _file + LOCALLY ORDER BY _file, _pos
+  // delete mode is RANGE -> ORDERED BY date, id
+
   @Test
   public void testDefaultCopyOnWriteDeleteUnpartitionedUnsortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
     Table table = validationCatalog.loadTable(tableIdent);
 
+    Expression[] expectedClustering = new Expression[]{
+        Expressions.column(MetadataColumns.FILE_PATH.name()),
+    };
+    Distribution expectedDistribution = Distributions.clustered(expectedClustering);
+
+    SortOrder[] expectedOrdering = new SortOrder[]{
+        Expressions.sort(Expressions.column(MetadataColumns.FILE_PATH.name()), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.column(MetadataColumns.ROW_POSITION.name()), SortDirection.ASCENDING)
+    };
+
+    checkCopyOnWriteDeleteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
+  }
+
+  @Test
+  public void testNoneCopyOnWriteDeleteUnpartitionedUnsortedTable() {
+    sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    table.updateProperties()
+        .set(DELETE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_NONE)
+        .commit();
+
     Distribution expectedDistribution = Distributions.unspecified();
     SortOrder[] expectedOrdering = new SortOrder[]{};
+
     checkCopyOnWriteDeleteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
   }
 
@@ -381,6 +438,31 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
   }
 
   @Test
+  public void testNoneCopyOnWriteDeleteUnpartitionedSortedTable() {
+    sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    table.updateProperties()
+        .set(DELETE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_NONE)
+        .commit();
+
+    table.replaceSortOrder()
+        .asc("id")
+        .asc("data")
+        .commit();
+
+    Distribution expectedDistribution = Distributions.unspecified();
+
+    SortOrder[] expectedOrdering = new SortOrder[]{
+        Expressions.sort(Expressions.column("id"), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.column("data"), SortDirection.ASCENDING)
+    };
+
+    checkCopyOnWriteDeleteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
+  }
+
+  @Test
   public void testHashCopyOnWriteDeleteUnpartitionedSortedTable() {
     sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
 
@@ -440,6 +522,31 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         "PARTITIONED BY (date, days(ts))", tableName);
 
     Table table = validationCatalog.loadTable(tableIdent);
+
+    Expression[] expectedClustering = new Expression[]{
+        Expressions.column(MetadataColumns.FILE_PATH.name()),
+    };
+    Distribution expectedDistribution = Distributions.clustered(expectedClustering);
+
+    SortOrder[] expectedOrdering = new SortOrder[]{
+        Expressions.sort(Expressions.column(MetadataColumns.FILE_PATH.name()), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.column(MetadataColumns.ROW_POSITION.name()), SortDirection.ASCENDING)
+    };
+
+    checkCopyOnWriteDeleteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
+  }
+
+  @Test
+  public void testNoneCopyOnWriteDeletePartitionedUnsortedTable() {
+    sql("CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) " +
+        "USING iceberg " +
+        "PARTITIONED BY (date, days(ts))", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    table.updateProperties()
+        .set(DELETE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_NONE)
+        .commit();
 
     Distribution expectedDistribution = Distributions.unspecified();
 
@@ -518,6 +625,32 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     SortOrder[] expectedOrdering = new SortOrder[]{
         Expressions.sort(Expressions.column(MetadataColumns.FILE_PATH.name()), SortDirection.ASCENDING),
         Expressions.sort(Expressions.column(MetadataColumns.ROW_POSITION.name()), SortDirection.ASCENDING)
+    };
+
+    checkCopyOnWriteDeleteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
+  }
+
+  @Test
+  public void testNoneCopyOnWriteDeletePartitionedSortedTable() {
+    sql("CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) " +
+        "USING iceberg " +
+        "PARTITIONED BY (date)", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    table.updateProperties()
+        .set(DELETE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_NONE)
+        .commit();
+
+    table.replaceSortOrder()
+        .desc("id")
+        .commit();
+
+    Distribution expectedDistribution = Distributions.unspecified();
+
+    SortOrder[] expectedOrdering = new SortOrder[]{
+        Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.column("id"), SortDirection.DESCENDING)
     };
 
     checkCopyOnWriteDeleteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);


### PR DESCRIPTION
This PR changes the default distribution mode for copy-on-write DELETE. Previously, if the table was unpartitioned, unsorted and the write and delete distributions were not set, we did not request anything. It is a follow-up on the original PR.