### PR TITLE
Support timestamp in partition path

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Conversions.java
+++ b/api/src/main/java/org/apache/iceberg/types/Conversions.java
@@ -71,6 +71,12 @@ public class Conversions {
         return new BigDecimal(asString);
       case DATE:
         return Literal.of(asString).to(Types.DateType.get()).value();
+      case TIMESTAMP:
+        if (!asString.contains("T")) {
+          return java.sql.Timestamp.valueOf(asString).getTime() * 1000;
+        } else {
+          return Literal.of(asString).to(Types.TimestampType.withoutZone()).value();
+        }
       default:
         throw new UnsupportedOperationException(
             "Unsupported type for fromPartitionString: " + type);

--- a/api/src/main/java/org/apache/iceberg/types/Conversions.java
+++ b/api/src/main/java/org/apache/iceberg/types/Conversions.java
@@ -28,8 +28,10 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.util.UUIDUtil;
@@ -73,7 +75,9 @@ public class Conversions {
         return Literal.of(asString).to(Types.DateType.get()).value();
       case TIMESTAMP:
         if (!asString.contains("T")) {
-          return java.sql.Timestamp.valueOf(asString).getTime() * 1000;
+          Instant instant = java.sql.Timestamp.valueOf(asString).toInstant();
+          return TimeUnit.SECONDS.toMicros(instant.getEpochSecond()) +
+              TimeUnit.NANOSECONDS.toMicros(instant.getNano());
         } else {
           return Literal.of(asString).to(Types.TimestampType.withoutZone()).value();
         }

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
@@ -850,7 +850,7 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
   };
 
   private static Timestamp toTimestamp(String value) {
-    Literal<Long> timestamp = Literal.of(value).to(Types.TimestampType.withZone());
+    Literal<Long> timestamp = Literal.of(value).to(Types.TimestampType.withoutZone());
     return Timestamp.valueOf(DateTimeUtil.timestampFromMicros(timestamp.value()));
   }
 

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
@@ -855,7 +855,6 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
   }
 
   private static final Dataset<Row> timestampDF =
-
       spark.createDataFrame(
           ImmutableList.of(
               RowFactory.create(1, "John Doe", "hr", toTimestamp("2021-01-01T00:00:00.999999999")),

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
@@ -34,8 +34,11 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumWriter;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
@@ -847,10 +850,12 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
   };
 
   private static Timestamp toTimestamp(String value) {
-    return new Timestamp(DateTime.parse(value).getMillis());
+    Literal<Long> timestamp = Literal.of(value).to(Types.TimestampType.withZone());
+    return Timestamp.valueOf(DateTimeUtil.timestampFromMicros(timestamp.value()));
   }
 
   private static final Dataset<Row> timestampDF =
+
       spark.createDataFrame(
           ImmutableList.of(
               RowFactory.create(1, "John Doe", "hr", toTimestamp("2021-01-01T00:00:00.999999999")),


### PR DESCRIPTION
Partition path containing timestamp such as `ts=2021-01-01 00:00:00.999` is not supported and iceberg throws Exception [here](https://github.com/apache/iceberg/blob/master/api/src/main/java/org/apache/iceberg/types/Conversions.java#L74). It seems to me that timestamp in partition path should be supported and this PR lifts the restriction.