### PR TITLE
[Spark] Backport rewrite data files are eliminated by deletes to Spark v3.0 and Spark v3.1

### DIFF
--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/FileRewriteCoordinator.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/FileRewriteCoordinator.java
@@ -27,7 +27,6 @@ import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.exceptions.ValidationException;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.Pair;
 import org.slf4j.Logger;
@@ -55,7 +54,6 @@ public class FileRewriteCoordinator {
    * @param newDataFiles the new files which have been written
    */
   public void stageRewrite(Table table, String fileSetID, Set<DataFile> newDataFiles) {
-    Preconditions.checkArgument(newDataFiles != null && newDataFiles.size() > 0, "Cannot stage null or empty file set");
     LOG.debug("Staging the output for {} - fileset {} with {} files", table.name(), fileSetID, newDataFiles.size());
     Pair<String, String> id = toID(table, fileSetID);
     resultMap.put(id, newDataFiles);

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/FileRewriteCoordinator.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/FileRewriteCoordinator.java
@@ -55,7 +55,6 @@ public class FileRewriteCoordinator {
    * @param newDataFiles the new files which have been written
    */
   public void stageRewrite(Table table, String fileSetID, Set<DataFile> newDataFiles) {
-    Preconditions.checkArgument(newDataFiles != null && newDataFiles.size() > 0, "Cannot stage null or empty file set");
     LOG.debug("Staging the output for {} - fileset {} with {} files", table.name(), fileSetID, newDataFiles.size());
     Pair<String, String> id = toID(table, fileSetID);
     resultMap.put(id, newDataFiles);

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/FileRewriteCoordinator.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/FileRewriteCoordinator.java
@@ -27,7 +27,6 @@ import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.exceptions.ValidationException;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.Pair;
 import org.slf4j.Logger;


### PR DESCRIPTION
This pr is to backport rewrite data files are eliminated by deletes to spark v3.0 and spark v3.1, see the pr #3724 for more detail.

cc @RussellSpitzer 