### PR TITLE
Spark: Fix SparkCatalog time travel check

### DIFF
--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -493,7 +493,7 @@ public class SparkCatalog extends BaseCatalog {
       Table table;
       try {
         table = icebergCatalog.loadTable(namespaceAsIdent);
-      } catch (org.apache.iceberg.exceptions.NoSuchTableException ignored) {
+      } catch (Exception ignored) {
         // the namespace does not identify a table, so it cannot be a table with a snapshot selector
         // throw the original exception
         throw e;

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -493,7 +493,7 @@ public class SparkCatalog extends BaseCatalog {
       Table table;
       try {
         table = icebergCatalog.loadTable(namespaceAsIdent);
-      } catch (org.apache.iceberg.exceptions.NoSuchTableException ignored) {
+      } catch (Exception ignored) {
         // the namespace does not identify a table, so it cannot be a table with a snapshot selector
         // throw the original exception
         throw e;

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -493,7 +493,7 @@ public class SparkCatalog extends BaseCatalog {
       Table table;
       try {
         table = icebergCatalog.loadTable(namespaceAsIdent);
-      } catch (org.apache.iceberg.exceptions.NoSuchTableException ignored) {
+      } catch (Exception ignored) {
         // the namespace does not identify a table, so it cannot be a table with a snapshot selector
         // throw the original exception
         throw e;


### PR DESCRIPTION
This updates the time travel check in `SparkCatalog`. When loading a table from an Iceberg catalog results in a `NoSuchTableException`, the Spark catalog checks to see if the namespace is a valid table and then if the table name is a time travel name. If loading the namespace as a table fails, the original `NoSuchTableException` is thrown. But this only happened when `NoSuchTableException` was thrown by the second table load. If the Iceberg catalog instead threw `IllegalArgumentException` because the new identifier is invalid, that exception would propagate instead of the correct `NoSuchTableException`.

This updates the check so that if the namespace doesn't load as a table for any reason, the original failure is thrown.