### PR TITLE
Core: Use changed partition to validate file confilct

### DIFF
--- a/core/src/main/java/org/apache/iceberg/PartitionData.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionData.java
@@ -191,8 +191,10 @@ class PartitionData
   @Override
   public int hashCode() {
     Hasher hasher = Hashing.goodFastHash(32).newHasher();
-    Stream.of(data).map(Objects::hashCode).forEach(hasher::putInt);
-    partitionType.fields().stream().map(Objects::hashCode).forEach(hasher::putInt);
+    if (size > 0) {
+      Stream.of(data).map(Objects::hashCode).forEach(hasher::putInt);
+      partitionType.fields().stream().map(Objects::hashCode).forEach(hasher::putInt);
+    }
     return hasher.hash().hashCode();
   }
 


### PR DESCRIPTION
When I use `MERGE INTO` to fix the history data, I found it has a conflict even though the modified files are on different partitions. I think if we can record the changed partitions to filter the conflicts. In this way, we can reduce the probability of conflict.