### PR TITLE
Spark 3.2: Revise distribution and ordering in copy-on-write UPDATE

### DIFF
--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -209,13 +209,17 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     sql("INSERT INTO TABLE %s VALUES (2, 'hardware')", tableName);
     sql("INSERT INTO TABLE %s VALUES (null, 'hr')", tableName);
 
-    sql("UPDATE %s SET id = -1", tableName);
+    // set the num of shuffle partitions to 200 instead of default 4 to reduce the chance of hashing
+    // records for multiple source files to one writing task (needed for a predictable num of output files)
+    withSQLConf(ImmutableMap.of(SQLConf.SHUFFLE_PARTITIONS().key(), "200"), () -> {
+      sql("UPDATE %s SET id = -1", tableName);
+    });
 
     Table table = validationCatalog.loadTable(tableIdent);
     Assert.assertEquals("Should have 4 snapshots", 4, Iterables.size(table.snapshots()));
 
     Snapshot currentSnapshot = table.currentSnapshot();
-    validateCopyOnWrite(currentSnapshot, "2", "3", "2");
+    validateCopyOnWrite(currentSnapshot, "2", "3", "3");
 
     assertEquals("Should have expected rows",
         ImmutableList.of(row(-1, "hardware"), row(-1, "hr"), row(-1, "hr")),

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkDistributionAndOrderingUtil.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkDistributionAndOrderingUtil.java
@@ -39,6 +39,7 @@ import org.apache.spark.sql.connector.expressions.SortOrder;
 import org.apache.spark.sql.connector.iceberg.write.RowLevelOperation.Command;
 
 import static org.apache.spark.sql.connector.iceberg.write.RowLevelOperation.Command.DELETE;
+import static org.apache.spark.sql.connector.iceberg.write.RowLevelOperation.Command.UPDATE;
 
 public class SparkDistributionAndOrderingUtil {
 
@@ -84,14 +85,14 @@ public class SparkDistributionAndOrderingUtil {
 
   public static Distribution buildCopyOnWriteDistribution(Table table, Command command,
                                                           DistributionMode distributionMode) {
-    if (command == DELETE) {
-      return buildCopyOnWriteDeleteDistribution(table, distributionMode);
+    if (command == DELETE || command == UPDATE) {
+      return buildCopyOnWriteDeleteUpdateDistribution(table, distributionMode);
     } else {
       return buildRequiredDistribution(table, distributionMode);
     }
   }
 
-  private static Distribution buildCopyOnWriteDeleteDistribution(Table table, DistributionMode distributionMode) {
+  private static Distribution buildCopyOnWriteDeleteUpdateDistribution(Table table, DistributionMode distributionMode) {
     switch (distributionMode) {
       case NONE:
         return Distributions.unspecified();
@@ -115,14 +116,14 @@ public class SparkDistributionAndOrderingUtil {
   }
 
   public static SortOrder[] buildCopyOnWriteOrdering(Table table, Command command, Distribution distribution) {
-    if (command == DELETE) {
-      return buildCopyOnWriteDeleteOrdering(table, distribution);
+    if (command == DELETE || command == UPDATE) {
+      return buildCopyOnWriteDeleteUpdateOrdering(table, distribution);
     } else {
       return buildRequiredOrdering(table, distribution);
     }
   }
 
-  private static SortOrder[] buildCopyOnWriteDeleteOrdering(Table table, Distribution distribution) {
+  private static SortOrder[] buildCopyOnWriteDeleteUpdateOrdering(Table table, Distribution distribution) {
     if (distribution instanceof UnspecifiedDistribution) {
       return buildTableOrdering(table);
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -211,14 +211,9 @@ public class SparkWriteConf {
     String updateModeName = confParser.stringConf()
         .option(SparkWriteOptions.DISTRIBUTION_MODE)
         .tableProperty(TableProperties.UPDATE_DISTRIBUTION_MODE)
-        .parseOptional();
-
-    if (updateModeName != null) {
-      DistributionMode updateMode = DistributionMode.fromName(updateModeName);
-      return adjustWriteDistributionMode(updateMode);
-    } else {
-      return distributionMode();
-    }
+        .defaultValue(TableProperties.WRITE_DISTRIBUTION_MODE_HASH)
+        .parse();
+    return DistributionMode.fromName(updateModeName);
   }
 
   public DistributionMode copyOnWriteMergeDistributionMode() {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteOperation.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteOperation.java
@@ -35,6 +35,7 @@ import org.apache.spark.sql.connector.write.WriteBuilder;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
 import static org.apache.spark.sql.connector.iceberg.write.RowLevelOperation.Command.DELETE;
+import static org.apache.spark.sql.connector.iceberg.write.RowLevelOperation.Command.UPDATE;
 
 class SparkCopyOnWriteOperation implements RowLevelOperation {
 
@@ -93,7 +94,7 @@ class SparkCopyOnWriteOperation implements RowLevelOperation {
     NamedReference file = Expressions.column(MetadataColumns.FILE_PATH.name());
     NamedReference pos = Expressions.column(MetadataColumns.ROW_POSITION.name());
 
-    if (command == DELETE) {
+    if (command == DELETE || command == UPDATE) {
       return new NamedReference[]{file, pos};
     } else {
       return new NamedReference[]{file};

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkDistributionAndOrderingUtil.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/TestSparkDistributionAndOrderingUtil.java
@@ -29,18 +29,32 @@ import org.apache.spark.sql.connector.expressions.Expression;
 import org.apache.spark.sql.connector.expressions.Expressions;
 import org.apache.spark.sql.connector.expressions.SortDirection;
 import org.apache.spark.sql.connector.expressions.SortOrder;
+import org.apache.spark.sql.connector.iceberg.write.RowLevelOperation.Command;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
 import static org.apache.iceberg.TableProperties.DELETE_DISTRIBUTION_MODE;
+import static org.apache.iceberg.TableProperties.UPDATE_DISTRIBUTION_MODE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_HASH;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_NONE;
 import static org.apache.iceberg.TableProperties.WRITE_DISTRIBUTION_MODE_RANGE;
 import static org.apache.spark.sql.connector.iceberg.write.RowLevelOperation.Command.DELETE;
+import static org.apache.spark.sql.connector.iceberg.write.RowLevelOperation.Command.UPDATE;
 
 public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatalog {
+
+  private static final Distribution UNSPECIFIED_DISTRIBUTION = Distributions.unspecified();
+  private static final Distribution FILE_CLUSTERED_DISTRIBUTION = Distributions.clustered(new Expression[]{
+      Expressions.column(MetadataColumns.FILE_PATH.name())
+  });
+
+  private static final SortOrder[] EMPTY_ORDERING = new SortOrder[]{};
+  private static final SortOrder[] FILE_POSITION_ORDERING = new SortOrder[]{
+      Expressions.sort(Expressions.column(MetadataColumns.FILE_PATH.name()), SortDirection.ASCENDING),
+      Expressions.sort(Expressions.column(MetadataColumns.ROW_POSITION.name()), SortDirection.ASCENDING)
+  };
 
   @After
   public void dropTable() {
@@ -53,9 +67,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Distribution expectedDistribution = Distributions.unspecified();
-    SortOrder[] expectedOrdering = new SortOrder[]{};
-    checkWriteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
+    checkWriteDistributionAndOrdering(table, UNSPECIFIED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
   @Test
@@ -68,9 +80,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         .set(WRITE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_HASH)
         .commit();
 
-    Distribution expectedDistribution = Distributions.unspecified();
-    SortOrder[] expectedOrdering = new SortOrder[]{};
-    checkWriteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
+    checkWriteDistributionAndOrdering(table, UNSPECIFIED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
   @Test
@@ -83,9 +93,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         .set(WRITE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_RANGE)
         .commit();
 
-    Distribution expectedDistribution = Distributions.unspecified();
-    SortOrder[] expectedOrdering = new SortOrder[]{};
-    checkWriteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
+    checkWriteDistributionAndOrdering(table, UNSPECIFIED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
   @Test
@@ -124,14 +132,12 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         .asc("data")
         .commit();
 
-    Distribution expectedDistribution = Distributions.unspecified();
-
     SortOrder[] expectedOrdering = new SortOrder[]{
         Expressions.sort(Expressions.column("id"), SortDirection.ASCENDING),
         Expressions.sort(Expressions.column("data"), SortDirection.ASCENDING)
     };
 
-    checkWriteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
+    checkWriteDistributionAndOrdering(table, UNSPECIFIED_DISTRIBUTION, expectedOrdering);
   }
 
   @Test
@@ -167,14 +173,12 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Distribution expectedDistribution = Distributions.unspecified();
-
     SortOrder[] expectedOrdering = new SortOrder[]{
         Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
         Expressions.sort(Expressions.days("ts"), SortDirection.ASCENDING)
     };
 
-    checkWriteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
+    checkWriteDistributionAndOrdering(table, UNSPECIFIED_DISTRIBUTION, expectedOrdering);
   }
 
   @Test
@@ -338,17 +342,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Expression[] expectedClustering = new Expression[]{
-        Expressions.column(MetadataColumns.FILE_PATH.name()),
-    };
-    Distribution expectedDistribution = Distributions.clustered(expectedClustering);
-
-    SortOrder[] expectedOrdering = new SortOrder[]{
-        Expressions.sort(Expressions.column(MetadataColumns.FILE_PATH.name()), SortDirection.ASCENDING),
-        Expressions.sort(Expressions.column(MetadataColumns.ROW_POSITION.name()), SortDirection.ASCENDING)
-    };
-
-    checkCopyOnWriteDeleteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
+    checkCopyOnWriteDistributionAndOrdering(table, DELETE, FILE_CLUSTERED_DISTRIBUTION, FILE_POSITION_ORDERING);
   }
 
   @Test
@@ -361,10 +355,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         .set(DELETE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_NONE)
         .commit();
 
-    Distribution expectedDistribution = Distributions.unspecified();
-    SortOrder[] expectedOrdering = new SortOrder[]{};
-
-    checkCopyOnWriteDeleteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
+    checkCopyOnWriteDistributionAndOrdering(table, DELETE, UNSPECIFIED_DISTRIBUTION, EMPTY_ORDERING);
   }
 
   @Test
@@ -377,17 +368,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         .set(DELETE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_HASH)
         .commit();
 
-    Expression[] expectedClustering = new Expression[]{
-        Expressions.column(MetadataColumns.FILE_PATH.name()),
-    };
-    Distribution expectedDistribution = Distributions.clustered(expectedClustering);
-
-    SortOrder[] expectedOrdering = new SortOrder[]{
-        Expressions.sort(Expressions.column(MetadataColumns.FILE_PATH.name()), SortDirection.ASCENDING),
-        Expressions.sort(Expressions.column(MetadataColumns.ROW_POSITION.name()), SortDirection.ASCENDING)
-    };
-
-    checkCopyOnWriteDeleteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
+    checkCopyOnWriteDistributionAndOrdering(table, DELETE, FILE_CLUSTERED_DISTRIBUTION, FILE_POSITION_ORDERING);
   }
 
   @Test
@@ -400,14 +381,9 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         .set(DELETE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_RANGE)
         .commit();
 
-    SortOrder[] expectedOrdering = new SortOrder[]{
-        Expressions.sort(Expressions.column(MetadataColumns.FILE_PATH.name()), SortDirection.ASCENDING),
-        Expressions.sort(Expressions.column(MetadataColumns.ROW_POSITION.name()), SortDirection.ASCENDING)
-    };
+    Distribution expectedDistribution = Distributions.ordered(FILE_POSITION_ORDERING);
 
-    Distribution expectedDistribution = Distributions.ordered(expectedOrdering);
-
-    checkCopyOnWriteDeleteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
+    checkCopyOnWriteDistributionAndOrdering(table, DELETE, expectedDistribution, FILE_POSITION_ORDERING);
   }
 
   @Test
@@ -421,17 +397,12 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         .asc("data")
         .commit();
 
-    Expression[] expectedClustering = new Expression[]{
-        Expressions.column(MetadataColumns.FILE_PATH.name()),
-    };
-    Distribution expectedDistribution = Distributions.clustered(expectedClustering);
-
     SortOrder[] expectedOrdering = new SortOrder[]{
         Expressions.sort(Expressions.column("id"), SortDirection.ASCENDING),
         Expressions.sort(Expressions.column("data"), SortDirection.ASCENDING)
     };
 
-    checkCopyOnWriteDeleteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
+    checkCopyOnWriteDistributionAndOrdering(table, DELETE, FILE_CLUSTERED_DISTRIBUTION, expectedOrdering);
   }
 
   @Test
@@ -449,14 +420,12 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         .asc("data")
         .commit();
 
-    Distribution expectedDistribution = Distributions.unspecified();
-
     SortOrder[] expectedOrdering = new SortOrder[]{
         Expressions.sort(Expressions.column("id"), SortDirection.ASCENDING),
         Expressions.sort(Expressions.column("data"), SortDirection.ASCENDING)
     };
 
-    checkCopyOnWriteDeleteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
+    checkCopyOnWriteDistributionAndOrdering(table, DELETE, UNSPECIFIED_DISTRIBUTION, expectedOrdering);
   }
 
   @Test
@@ -474,17 +443,12 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         .asc("data")
         .commit();
 
-    Expression[] expectedClustering = new Expression[]{
-        Expressions.column(MetadataColumns.FILE_PATH.name()),
-    };
-    Distribution expectedDistribution = Distributions.clustered(expectedClustering);
-
     SortOrder[] expectedOrdering = new SortOrder[]{
         Expressions.sort(Expressions.column("id"), SortDirection.ASCENDING),
         Expressions.sort(Expressions.column("data"), SortDirection.ASCENDING)
     };
 
-    checkCopyOnWriteDeleteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
+    checkCopyOnWriteDistributionAndOrdering(table, DELETE, FILE_CLUSTERED_DISTRIBUTION, expectedOrdering);
   }
 
   @Test
@@ -509,7 +473,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     Distribution expectedDistribution = Distributions.ordered(expectedOrdering);
 
-    checkCopyOnWriteDeleteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
+    checkCopyOnWriteDistributionAndOrdering(table, DELETE, expectedDistribution, expectedOrdering);
   }
 
   @Test
@@ -520,11 +484,6 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     Table table = validationCatalog.loadTable(tableIdent);
 
-    Expression[] expectedClustering = new Expression[]{
-        Expressions.column(MetadataColumns.FILE_PATH.name()),
-    };
-    Distribution expectedDistribution = Distributions.clustered(expectedClustering);
-
     SortOrder[] expectedOrdering = new SortOrder[]{
         Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
         Expressions.sort(Expressions.days("ts"), SortDirection.ASCENDING),
@@ -532,7 +491,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         Expressions.sort(Expressions.column(MetadataColumns.ROW_POSITION.name()), SortDirection.ASCENDING)
     };
 
-    checkCopyOnWriteDeleteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
+    checkCopyOnWriteDistributionAndOrdering(table, DELETE, FILE_CLUSTERED_DISTRIBUTION, expectedOrdering);
   }
 
   @Test
@@ -547,14 +506,12 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         .set(DELETE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_NONE)
         .commit();
 
-    Distribution expectedDistribution = Distributions.unspecified();
-
     SortOrder[] expectedOrdering = new SortOrder[]{
         Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
         Expressions.sort(Expressions.days("ts"), SortDirection.ASCENDING)
     };
 
-    checkCopyOnWriteDeleteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
+    checkCopyOnWriteDistributionAndOrdering(table, DELETE, UNSPECIFIED_DISTRIBUTION, expectedOrdering);
   }
 
   @Test
@@ -569,11 +526,6 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         .set(DELETE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_HASH)
         .commit();
 
-    Expression[] expectedClustering = new Expression[]{
-        Expressions.column(MetadataColumns.FILE_PATH.name()),
-    };
-    Distribution expectedDistribution = Distributions.clustered(expectedClustering);
-
     SortOrder[] expectedOrdering = new SortOrder[]{
         Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
         Expressions.sort(Expressions.days("ts"), SortDirection.ASCENDING),
@@ -581,7 +533,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         Expressions.sort(Expressions.column(MetadataColumns.ROW_POSITION.name()), SortDirection.ASCENDING)
     };
 
-    checkCopyOnWriteDeleteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
+    checkCopyOnWriteDistributionAndOrdering(table, DELETE, FILE_CLUSTERED_DISTRIBUTION, expectedOrdering);
   }
 
   @Test
@@ -605,7 +557,7 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     Distribution expectedDistribution = Distributions.ordered(expectedOrdering);
 
-    checkCopyOnWriteDeleteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
+    checkCopyOnWriteDistributionAndOrdering(table, DELETE, expectedDistribution, expectedOrdering);
   }
 
   @Test
@@ -620,17 +572,12 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         .desc("id")
         .commit();
 
-    Expression[] expectedClustering = new Expression[]{
-        Expressions.column(MetadataColumns.FILE_PATH.name()),
-    };
-    Distribution expectedDistribution = Distributions.clustered(expectedClustering);
-
     SortOrder[] expectedOrdering = new SortOrder[]{
         Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
         Expressions.sort(Expressions.column("id"), SortDirection.DESCENDING)
     };
 
-    checkCopyOnWriteDeleteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
+    checkCopyOnWriteDistributionAndOrdering(table, DELETE, FILE_CLUSTERED_DISTRIBUTION, expectedOrdering);
   }
 
   @Test
@@ -649,14 +596,12 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         .desc("id")
         .commit();
 
-    Distribution expectedDistribution = Distributions.unspecified();
-
     SortOrder[] expectedOrdering = new SortOrder[]{
         Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
         Expressions.sort(Expressions.column("id"), SortDirection.DESCENDING)
     };
 
-    checkCopyOnWriteDeleteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
+    checkCopyOnWriteDistributionAndOrdering(table, DELETE, UNSPECIFIED_DISTRIBUTION, expectedOrdering);
   }
 
   @Test
@@ -675,18 +620,13 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
         .asc("id")
         .commit();
 
-    Expression[] expectedClustering = new Expression[]{
-        Expressions.column(MetadataColumns.FILE_PATH.name()),
-    };
-    Distribution expectedDistribution = Distributions.clustered(expectedClustering);
-
     SortOrder[] expectedOrdering = new SortOrder[]{
         Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
         Expressions.sort(Expressions.bucket(8, "data"), SortDirection.ASCENDING),
         Expressions.sort(Expressions.column("id"), SortDirection.ASCENDING)
     };
 
-    checkCopyOnWriteDeleteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
+    checkCopyOnWriteDistributionAndOrdering(table, DELETE, FILE_CLUSTERED_DISTRIBUTION, expectedOrdering);
   }
 
   @Test
@@ -712,7 +652,359 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
 
     Distribution expectedDistribution = Distributions.ordered(expectedOrdering);
 
-    checkCopyOnWriteDeleteDistributionAndOrdering(table, expectedDistribution, expectedOrdering);
+    checkCopyOnWriteDistributionAndOrdering(table, DELETE, expectedDistribution, expectedOrdering);
+  }
+
+  // =============================================================
+  // Distribution and ordering for copy-on-write UPDATE operations
+  // =============================================================
+  //
+  // UNPARTITIONED UNORDERED
+  // -------------------------------------------------------------------------
+  // update mode is NOT SET -> CLUSTER BY _file + LOCALLY ORDER BY _file, _pos
+  // update mode is NONE -> unspecified distribution + empty ordering
+  // update mode is HASH -> CLUSTER BY _file + LOCALLY ORDER BY _file, _pos
+  // update mode is RANGE -> ORDER BY _file, _pos
+  //
+  // UNPARTITIONED ORDERED BY id, data
+  // -------------------------------------------------------------------------
+  // update mode is NOT SET -> CLUSTER BY _file + LOCALLY ORDER BY id, data
+  // update mode is NONE -> unspecified distribution + LOCALLY ORDER BY id, data
+  // update mode is HASH -> CLUSTER BY _file + LOCALLY ORDER BY id, data
+  // update mode is RANGE -> ORDER BY id, data
+  //
+  // PARTITIONED BY date, days(ts) UNORDERED
+  // -------------------------------------------------------------------------
+  // update mode is NOT SET -> CLUSTER BY _file + LOCALLY ORDER BY date, days(ts), _file, _pos
+  // update mode is NONE -> unspecified distribution + LOCALLY ORDERED BY date, days(ts)
+  // update mode is HASH -> CLUSTER BY _file + LOCALLY ORDER BY date, days(ts), _file, _pos
+  // update mode is RANGE -> ORDER BY date, days(ts), _file, _pos
+  //
+  // PARTITIONED BY date ORDERED BY id
+  // -------------------------------------------------------------------------
+  // update mode is NOT SET -> CLUSTER BY _file + LOCALLY ORDER BY date, id
+  // update mode is NONE -> unspecified distribution + LOCALLY ORDERED BY date, id
+  // update mode is HASH -> CLUSTER BY _file + LOCALLY ORDER BY date, id
+  // update mode is RANGE -> ORDERED BY date, id
+
+  @Test
+  public void testDefaultCopyOnWriteUpdateUnpartitionedUnsortedTable() {
+    sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    checkCopyOnWriteDistributionAndOrdering(table, UPDATE, FILE_CLUSTERED_DISTRIBUTION, FILE_POSITION_ORDERING);
+  }
+
+  @Test
+  public void testNoneCopyOnWriteUpdateUnpartitionedUnsortedTable() {
+    sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    table.updateProperties()
+        .set(UPDATE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_NONE)
+        .commit();
+
+    checkCopyOnWriteDistributionAndOrdering(table, UPDATE, UNSPECIFIED_DISTRIBUTION, EMPTY_ORDERING);
+  }
+
+  @Test
+  public void testHashCopyOnWriteUpdateUnpartitionedUnsortedTable() {
+    sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    table.updateProperties()
+        .set(UPDATE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_HASH)
+        .commit();
+
+    checkCopyOnWriteDistributionAndOrdering(table, UPDATE, FILE_CLUSTERED_DISTRIBUTION, FILE_POSITION_ORDERING);
+  }
+
+  @Test
+  public void testRangeCopyOnWriteUpdateUnpartitionedUnsortedTable() {
+    sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    table.updateProperties()
+        .set(UPDATE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_RANGE)
+        .commit();
+
+    Distribution expectedDistribution = Distributions.ordered(FILE_POSITION_ORDERING);
+
+    checkCopyOnWriteDistributionAndOrdering(table, UPDATE, expectedDistribution, FILE_POSITION_ORDERING);
+  }
+
+  @Test
+  public void testDefaultCopyOnWriteUpdateUnpartitionedSortedTable() {
+    sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    table.replaceSortOrder()
+        .asc("id")
+        .asc("data")
+        .commit();
+
+    SortOrder[] expectedOrdering = new SortOrder[]{
+        Expressions.sort(Expressions.column("id"), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.column("data"), SortDirection.ASCENDING)
+    };
+
+    checkCopyOnWriteDistributionAndOrdering(table, UPDATE, FILE_CLUSTERED_DISTRIBUTION, expectedOrdering);
+  }
+
+  @Test
+  public void testNoneCopyOnWriteUpdateUnpartitionedSortedTable() {
+    sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    table.updateProperties()
+        .set(UPDATE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_NONE)
+        .commit();
+
+    table.replaceSortOrder()
+        .asc("id")
+        .asc("data")
+        .commit();
+
+    SortOrder[] expectedOrdering = new SortOrder[]{
+        Expressions.sort(Expressions.column("id"), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.column("data"), SortDirection.ASCENDING)
+    };
+
+    checkCopyOnWriteDistributionAndOrdering(table, UPDATE, UNSPECIFIED_DISTRIBUTION, expectedOrdering);
+  }
+
+  @Test
+  public void testHashCopyOnWriteUpdateUnpartitionedSortedTable() {
+    sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    table.updateProperties()
+        .set(UPDATE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_HASH)
+        .commit();
+
+    table.replaceSortOrder()
+        .asc("id")
+        .asc("data")
+        .commit();
+
+    SortOrder[] expectedOrdering = new SortOrder[]{
+        Expressions.sort(Expressions.column("id"), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.column("data"), SortDirection.ASCENDING)
+    };
+
+    checkCopyOnWriteDistributionAndOrdering(table, UPDATE, FILE_CLUSTERED_DISTRIBUTION, expectedOrdering);
+  }
+
+  @Test
+  public void testRangeCopyOnWriteUpdateUnpartitionedSortedTable() {
+    sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    table.updateProperties()
+        .set(UPDATE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_RANGE)
+        .commit();
+
+    table.replaceSortOrder()
+        .asc("id")
+        .asc("data")
+        .commit();
+
+    SortOrder[] expectedOrdering = new SortOrder[]{
+        Expressions.sort(Expressions.column("id"), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.column("data"), SortDirection.ASCENDING)
+    };
+
+    Distribution expectedDistribution = Distributions.ordered(expectedOrdering);
+
+    checkCopyOnWriteDistributionAndOrdering(table, UPDATE, expectedDistribution, expectedOrdering);
+  }
+
+  @Test
+  public void testDefaultCopyOnWriteUpdatePartitionedUnsortedTable() {
+    sql("CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) " +
+        "USING iceberg " +
+        "PARTITIONED BY (date, days(ts))", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    SortOrder[] expectedOrdering = new SortOrder[]{
+        Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.days("ts"), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.column(MetadataColumns.FILE_PATH.name()), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.column(MetadataColumns.ROW_POSITION.name()), SortDirection.ASCENDING)
+    };
+
+    checkCopyOnWriteDistributionAndOrdering(table, UPDATE, FILE_CLUSTERED_DISTRIBUTION, expectedOrdering);
+  }
+
+
+  @Test
+  public void testNoneCopyOnWriteUpdatePartitionedUnsortedTable() {
+    sql("CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) " +
+        "USING iceberg " +
+        "PARTITIONED BY (date, days(ts))", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    table.updateProperties()
+        .set(UPDATE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_NONE)
+        .commit();
+
+    SortOrder[] expectedOrdering = new SortOrder[]{
+        Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.days("ts"), SortDirection.ASCENDING)
+    };
+
+    checkCopyOnWriteDistributionAndOrdering(table, UPDATE, UNSPECIFIED_DISTRIBUTION, expectedOrdering);
+  }
+
+  @Test
+  public void testHashCopyOnWriteUpdatePartitionedUnsortedTable() {
+    sql("CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) " +
+        "USING iceberg " +
+        "PARTITIONED BY (date, days(ts))", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    table.updateProperties()
+        .set(UPDATE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_HASH)
+        .commit();
+
+    SortOrder[] expectedOrdering = new SortOrder[]{
+        Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.days("ts"), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.column(MetadataColumns.FILE_PATH.name()), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.column(MetadataColumns.ROW_POSITION.name()), SortDirection.ASCENDING)
+    };
+
+    checkCopyOnWriteDistributionAndOrdering(table, UPDATE, FILE_CLUSTERED_DISTRIBUTION, expectedOrdering);
+  }
+
+  @Test
+  public void testRangeCopyOnWriteUpdatePartitionedUnsortedTable() {
+    sql("CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) " +
+        "USING iceberg " +
+        "PARTITIONED BY (date, days(ts))", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    table.updateProperties()
+        .set(UPDATE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_RANGE)
+        .commit();
+
+    SortOrder[] expectedOrdering = new SortOrder[]{
+        Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.days("ts"), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.column(MetadataColumns.FILE_PATH.name()), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.column(MetadataColumns.ROW_POSITION.name()), SortDirection.ASCENDING)
+    };
+
+    Distribution expectedDistribution = Distributions.ordered(expectedOrdering);
+
+    checkCopyOnWriteDistributionAndOrdering(table, UPDATE, expectedDistribution, expectedOrdering);
+  }
+
+  @Test
+  public void testDefaultCopyOnWriteUpdatePartitionedSortedTable() {
+    sql("CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) " +
+        "USING iceberg " +
+        "PARTITIONED BY (date)", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    table.replaceSortOrder()
+        .desc("id")
+        .commit();
+
+    SortOrder[] expectedOrdering = new SortOrder[]{
+        Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.column("id"), SortDirection.DESCENDING)
+    };
+
+    checkCopyOnWriteDistributionAndOrdering(table, UPDATE, FILE_CLUSTERED_DISTRIBUTION, expectedOrdering);
+  }
+
+  @Test
+  public void testNoneCopyOnWriteUpdatePartitionedSortedTable() {
+    sql("CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) " +
+        "USING iceberg " +
+        "PARTITIONED BY (date)", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    table.updateProperties()
+        .set(UPDATE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_NONE)
+        .commit();
+
+    table.replaceSortOrder()
+        .desc("id")
+        .commit();
+
+    SortOrder[] expectedOrdering = new SortOrder[]{
+        Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.column("id"), SortDirection.DESCENDING)
+    };
+
+    checkCopyOnWriteDistributionAndOrdering(table, UPDATE, UNSPECIFIED_DISTRIBUTION, expectedOrdering);
+  }
+
+  @Test
+  public void testHashCopyOnWriteUpdatePartitionedSortedTable() {
+    sql("CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) " +
+        "USING iceberg " +
+        "PARTITIONED BY (date, bucket(8, data))", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    table.updateProperties()
+        .set(UPDATE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_HASH)
+        .commit();
+
+    table.replaceSortOrder()
+        .asc("id")
+        .commit();
+
+    SortOrder[] expectedOrdering = new SortOrder[]{
+        Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.bucket(8, "data"), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.column("id"), SortDirection.ASCENDING)
+    };
+
+    checkCopyOnWriteDistributionAndOrdering(table, UPDATE, FILE_CLUSTERED_DISTRIBUTION, expectedOrdering);
+  }
+
+  @Test
+  public void testRangeCopyOnWriteUpdatePartitionedSortedTable() {
+    sql("CREATE TABLE %s (id BIGINT, data STRING, date DATE, ts TIMESTAMP) " +
+        "USING iceberg " +
+        "PARTITIONED BY (date)", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    table.updateProperties()
+        .set(UPDATE_DISTRIBUTION_MODE, WRITE_DISTRIBUTION_MODE_RANGE)
+        .commit();
+
+    table.replaceSortOrder()
+        .asc("id")
+        .commit();
+
+    SortOrder[] expectedOrdering = new SortOrder[]{
+        Expressions.sort(Expressions.column("date"), SortDirection.ASCENDING),
+        Expressions.sort(Expressions.column("id"), SortDirection.ASCENDING)
+    };
+
+    Distribution expectedDistribution = Distributions.ordered(expectedOrdering);
+
+    checkCopyOnWriteDistributionAndOrdering(table, UPDATE, expectedDistribution, expectedOrdering);
   }
 
   private void checkWriteDistributionAndOrdering(Table table, Distribution expectedDistribution,
@@ -726,14 +1018,30 @@ public class TestSparkDistributionAndOrderingUtil extends SparkTestBaseWithCatal
     Assert.assertArrayEquals("Ordering must match", expectedOrdering, ordering);
   }
 
-  private void checkCopyOnWriteDeleteDistributionAndOrdering(Table table, Distribution expectedDistribution,
-                                                             SortOrder[] expectedOrdering) {
+  private void checkCopyOnWriteDistributionAndOrdering(Table table, Command command,
+                                                       Distribution expectedDistribution,
+                                                       SortOrder[] expectedOrdering) {
     SparkWriteConf writeConf = new SparkWriteConf(spark, table, ImmutableMap.of());
-    DistributionMode mode = writeConf.copyOnWriteDeleteDistributionMode();
-    Distribution distribution = SparkDistributionAndOrderingUtil.buildCopyOnWriteDistribution(table, DELETE, mode);
+
+    DistributionMode mode = copyOnWriteDistributionMode(command, writeConf);
+
+    Distribution distribution = SparkDistributionAndOrderingUtil.buildCopyOnWriteDistribution(table, command, mode);
     Assert.assertEquals("Distribution must match", expectedDistribution, distribution);
 
-    SortOrder[] ordering = SparkDistributionAndOrderingUtil.buildCopyOnWriteOrdering(table, DELETE, distribution);
+    SortOrder[] ordering = SparkDistributionAndOrderingUtil.buildCopyOnWriteOrdering(table, command, distribution);
     Assert.assertArrayEquals("Ordering must match", expectedOrdering, ordering);
+  }
+
+  private DistributionMode copyOnWriteDistributionMode(Command command, SparkWriteConf writeConf) {
+    switch (command) {
+      case DELETE:
+        return writeConf.copyOnWriteDeleteDistributionMode();
+      case UPDATE:
+        return writeConf.copyOnWriteUpdateDistributionMode();
+      case MERGE:
+        return writeConf.copyOnWriteMergeDistributionMode();
+      default:
+        throw new IllegalArgumentException("Unexpected command: " + command);
+    }
   }
 }


### PR DESCRIPTION
This PR changes the distribution and ordering in copy-on-write UPDATEs to match the new logic in DELETEs.