### PR TITLE
Core: Deprecate the MERGE cardinality check property

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -249,7 +249,15 @@ public class TableProperties {
   public static final String MERGE_MODE = "write.merge.mode";
   public static final String MERGE_MODE_DEFAULT = "copy-on-write";
 
+  /**
+   * @deprecated will be removed in 0.14.0, the cardinality check is always performed starting from 0.13.0.
+   */
+  @Deprecated
   public static final String MERGE_CARDINALITY_CHECK_ENABLED = "write.merge.cardinality-check.enabled";
+  /**
+   * @deprecated will be removed in 0.14.0, the cardinality check is always performed starting from 0.13.0.
+   */
+  @Deprecated
   public static final boolean MERGE_CARDINALITY_CHECK_ENABLED_DEFAULT = true;
 
   public static final String MERGE_DISTRIBUTION_MODE = "write.merge.distribution-mode";


### PR DESCRIPTION
This PR removes the no longer used MERGE cardinality check property. After the refactoring, the check is always executed.