### PR TITLE
rewriting the operation when removing and adding the same partition col with the same transformation 

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
@@ -127,11 +127,10 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
   private BaseUpdatePartitionSpec rewriteDeleteAndAddField(
       PartitionField existing, String name, Pair<Integer, Transform<?, ?>> sourceTransform) {
     deletes.remove(existing.fieldId());
-    if (existing.name().equals(name)) {
+    if (name == null || existing.name().equals(name)) {
       return this;
     } else {
-      String newName = name == null ? sourceTransform.second().toString() : name;
-      return renameField(existing.name(), newName);
+      return renameField(existing.name(), name);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
@@ -235,7 +235,7 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
         "Cannot find partition field to rename: %s", name);
     Preconditions.checkArgument(!deletes.contains(field.fieldId()),
         "Cannot delete and rename partition field: %s", name);
-    
+
     renames.put(name, newName);
 
     return this;

--- a/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
@@ -143,7 +143,7 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
         return renameField(existing.name(), newName);
       }
     }
-    
+
     Preconditions.checkArgument(existing == null ||
         (deletes.contains(existing.fieldId()) &&
             !existing.transform().toString().equals(sourceTransform.second().toString())),
@@ -235,6 +235,7 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
         "Cannot find partition field to rename: %s", name);
     Preconditions.checkArgument(!deletes.contains(field.fieldId()),
         "Cannot delete and rename partition field: %s", name);
+    
     renames.put(name, newName);
 
     return this;

--- a/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
@@ -134,10 +134,16 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
 
     PartitionField existing = transformToField.get(validationKey);
     if (existing != null && deletes.contains(existing.fieldId()) &&
-        existing.transform().toString().equals(sourceTransform.second().toString())) {
+        existing.transform().equals(sourceTransform.second())) {
       deletes.remove(existing.fieldId());
-      return this;
+      if (existing.name().equals(name)) {
+        return this;
+      } else {
+        String newName = name == null ? sourceTransform.second().toString() : name;
+        return renameField(existing.name(), newName);
+      }
     }
+    
     Preconditions.checkArgument(existing == null ||
         (deletes.contains(existing.fieldId()) &&
             !existing.transform().toString().equals(sourceTransform.second().toString())),
@@ -229,7 +235,6 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
         "Cannot find partition field to rename: %s", name);
     Preconditions.checkArgument(!deletes.contains(field.fieldId()),
         "Cannot delete and rename partition field: %s", name);
-
     renames.put(name, newName);
 
     return this;

--- a/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
@@ -133,6 +133,11 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
     Pair<Integer, String> validationKey = Pair.of(sourceTransform.first(), sourceTransform.second().toString());
 
     PartitionField existing = transformToField.get(validationKey);
+    if (existing != null && deletes.contains(existing.fieldId()) &&
+        existing.transform().toString().equals(sourceTransform.second().toString())) {
+      deletes.remove(existing.fieldId());
+      return this;
+    }
     Preconditions.checkArgument(existing == null ||
         (deletes.contains(existing.fieldId()) &&
             !existing.transform().toString().equals(sourceTransform.second().toString())),

--- a/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
@@ -124,7 +124,7 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
     return addField(null, term);
   }
 
-  private BaseUpdatePartitionSpec rewriteDeleteAndField(
+  private BaseUpdatePartitionSpec rewriteDeleteAndAddField(
       PartitionField existing, String name, Pair<Integer, Transform<?, ?>> sourceTransform) {
     deletes.remove(existing.fieldId());
     if (existing.name().equals(name)) {
@@ -146,7 +146,7 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
     PartitionField existing = transformToField.get(validationKey);
     if (existing != null && deletes.contains(existing.fieldId()) &&
         existing.transform().equals(sourceTransform.second())) {
-      return rewriteDeleteAndField(existing, name, sourceTransform);
+      return rewriteDeleteAndAddField(existing, name, sourceTransform);
     }
 
     Preconditions.checkArgument(existing == null ||

--- a/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
+++ b/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
@@ -477,12 +477,12 @@ public class TestUpdatePartitionSpec extends TableTestBase {
   }
 
   @Test
-  public void testAddDeletedField() {
-    AssertHelpers.assertThrows("Should fail adding a duplicate field",
-        IllegalArgumentException.class, "Cannot add duplicate partition field",
-        () -> new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
-            .removeField("shard")
-            .addField(bucket("id", 16))); // duplicates shard
+  public void testNoEffectAddDeletedSameField() {
+    PartitionSpec updated = new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
+        .removeField("shard")
+        .addField(bucket("id", 16))
+        .apply();
+    Assert.assertEquals(PARTITIONED, updated);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
+++ b/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
@@ -477,12 +477,33 @@ public class TestUpdatePartitionSpec extends TableTestBase {
   }
 
   @Test
-  public void testNoEffectAddDeletedSameField() {
+  public void testNoEffectAddDeletedSameFieldWithSameName() {
+    PartitionSpec updated = new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
+        .removeField("shard")
+        .addField("shard", bucket("id", 16))
+        .apply();
+    Assert.assertEquals(PARTITIONED, updated);
+  }
+
+  @Test
+  public void testGenerateNewSpecAddDeletedSameFieldWithDifferentName() {
     PartitionSpec updated = new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
         .removeField("shard")
         .addField(bucket("id", 16))
         .apply();
-    Assert.assertEquals(PARTITIONED, updated);
+    Assert.assertEquals("Should match expected field size", 3, updated.fields().size());
+    Assert.assertEquals("Should match expected field name", "category",
+        updated.fields().get(0).name());
+    Assert.assertEquals("Should match expected field name", "ts_day",
+        updated.fields().get(1).name());
+    Assert.assertEquals("Should match expected field name", "bucket[16]",
+        updated.fields().get(2).name());
+    Assert.assertEquals("Should match expected field transform", "identity",
+        updated.fields().get(0).transform().toString());
+    Assert.assertEquals("Should match expected field transform", "day",
+        updated.fields().get(1).transform().toString());
+    Assert.assertEquals("Should match expected field transform", "bucket[16]",
+        updated.fields().get(2).transform().toString());
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
+++ b/core/src/test/java/org/apache/iceberg/TestUpdatePartitionSpec.java
@@ -483,20 +483,25 @@ public class TestUpdatePartitionSpec extends TableTestBase {
         .addField("shard", bucket("id", 16))
         .apply();
     Assert.assertEquals(PARTITIONED, updated);
+    updated = new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
+        .removeField("shard")
+        .addField(bucket("id", 16))
+        .apply();
+    Assert.assertEquals(PARTITIONED, updated);
   }
 
   @Test
   public void testGenerateNewSpecAddDeletedSameFieldWithDifferentName() {
     PartitionSpec updated = new BaseUpdatePartitionSpec(formatVersion, PARTITIONED)
         .removeField("shard")
-        .addField(bucket("id", 16))
+        .addField("new_shard", bucket("id", 16))
         .apply();
     Assert.assertEquals("Should match expected field size", 3, updated.fields().size());
     Assert.assertEquals("Should match expected field name", "category",
         updated.fields().get(0).name());
     Assert.assertEquals("Should match expected field name", "ts_day",
         updated.fields().get(1).name());
-    Assert.assertEquals("Should match expected field name", "bucket[16]",
+    Assert.assertEquals("Should match expected field name", "new_shard",
         updated.fields().get(2).name());
     Assert.assertEquals("Should match expected field transform", "identity",
         updated.fields().get(0).transform().toString());


### PR DESCRIPTION
this PR is a followup of https://github.com/apache/iceberg/pull/3632#discussion_r776515101 . It rewrites the operation when deleting and adding the same partition col so that users will not encounter an error

specifically:

* when the user removes and adds the partition col with the same transformation and the same name, we ensure it is a no-op
* when the user remove and adds the partition col with the same transformation but DIFFERENT name, we just rewrite the remove and add as rename

We have this scenario that we need to change the partition column of a table with an API call, as said in the last PR, with the functionality in PR, we can just remove all "conflicted" column names without the burden to check whether the transformation is the same 