### PR TITLE
Spec: Add REST basics for TableOperations

### DIFF
--- a/rest_docs/rest-catalog-open-api.yaml
+++ b/rest_docs/rest-catalog-open-api.yaml
@@ -564,36 +564,6 @@ components:
           example: '{ "owner": "Hank Bendickson" }'
           default: '{ }'
 
-    Namespace:
-      description: Reference to one or more levels of a namespace
-      type: array
-      items:
-        type: string
-      example: [ "accounting", "tax" ]
-
-    RenameTableRequest:
-      type: object
-      properties:
-        source:
-          $ref: '#/components/schemas/TableIdentifier'
-        destination:
-          $ref: '#/components/schemas/TableIdentifier'
-
-    TableIdentifier:
-      type: object
-      required:
-        - namespace
-        - name
-      properties:
-        namespace:
-          type: array
-          description: Individual levels of the namespace
-          items:
-            type: string
-        name:
-          type: string
-          nullable: false
-
     UpdateNamespacePropertiesRequest:
       type: object
       properties:
@@ -609,6 +579,283 @@ components:
           items:
             type: string
           example: { "owner": "Hank Bendickson" }
+
+    RenameTableRequest:
+      type: object
+      properties:
+        source:
+          $ref: '#/components/schemas/TableIdentifier'
+        destination:
+          $ref: '#/components/schemas/TableIdentifier'
+
+    Namespace:
+      description: Reference to one or more levels of a namespace
+      type: array
+      items:
+        type: string
+      example: [ "accounting", "tax" ]
+
+    TableIdentifier:
+      type: object
+      required:
+        - namespace
+        - name
+      properties:
+        namespace:
+          $ref: '#/components/schemas/Namespace'
+        name:
+          type: string
+          nullable: false
+
+    PrimitiveType:
+      type: string
+      example:
+        - "long"
+        - "string"
+        - "fixed[16]"
+        - "decimal(10,2)"
+
+    StructField:
+      type: object
+      required:
+        - id
+        - name
+        - required
+        - type
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        required:
+          type: boolean
+        type:
+          $ref: '#/components/schemas/Type'
+        doc:
+          type: string
+
+    StructType:
+      type: object
+      required:
+        - fields
+      properties:
+        type:
+          type: string
+          enum: ["struct"]
+        fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/StructField'
+
+    ListType:
+      type: object
+      required:
+        - type
+        - element-id
+        - element-required
+        - element
+      properties:
+        type:
+          type: string
+          enum: ["list"]
+        element-id:
+          type: integer
+        element-required:
+          type: boolean
+        element:
+          $ref: '#/components/schemas/Type'
+
+    MapType:
+      type: object
+      required:
+        - type
+        - key-id
+        - key
+        - value-id
+        - value-required
+        - value
+      properties:
+        type:
+          type: string
+          enum: ["map"]
+        key-id:
+          type: integer
+        key:
+          $ref: '#/components/schemas/Type'
+        value-id:
+          type: integer
+        value-required:
+          type: boolean
+        value:
+          $ref: '#/components/schemas/Type'
+
+    Type:
+      anyOf:
+        - $ref: '#/components/schemas/PrimitiveType'
+        - $ref: '#/components/schemas/StructType'
+        - $ref: '#/components/schemas/ListType'
+        - $ref: '#/components/schemas/MapType'
+
+    Schema:
+      allOf:
+        - $ref: '#/components/schemas/StructType'
+        - type: object
+          properties:
+            schema-id:
+              type: integer
+            identifier-field-ids:
+              type: array
+              items:
+                type: integer
+
+    Transform:
+      type: string
+      example:
+        - "identity"
+        - "year"
+        - "month"
+        - "day"
+        - "hour"
+        - "bucket[256]"
+        - "truncate[16]"
+
+    PartitionField:
+      type: object
+      required:
+        - source-id
+        - transform
+        - name
+      properties:
+        field-id:
+          type: integer
+        source-id:
+          type: integer
+        name:
+          type: string
+        transform:
+          $ref: '#/components/schemas/Transform'
+
+    PartitionSpec:
+      type: object
+      required:
+        - fields
+      properties:
+        spec-id:
+          type: integer
+        fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/PartitionField'
+
+    SortDirection:
+      type: string
+      enum: ["asc", "desc"]
+
+    NullOrder:
+      type: string
+      enum: ["nulls-first", "nulls-last"]
+
+    SortField:
+      type: object
+      required:
+        - source-id
+        - transform
+        - direction
+        - null-order
+      properties:
+        source-id:
+          type: integer
+        transform:
+          $ref: '#/components/schemas/Transform'
+        direction:
+          $ref: '#/components/schemas/SortDirection'
+        null-order:
+          $ref: '#/components/schemas/NullOrder'
+
+    SortOrder:
+      type: object
+      required:
+        - fields
+      properties:
+        order-id:
+          type: integer
+        fields:
+          $ref: '#/components/schemas/SortField'
+
+    BaseUpdate:
+      type: object
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          enum:
+            - add-schema
+            - set-current-schema
+            - add-spec
+            - set-default-spec
+            - add-sort-order
+            - set-default-sort-order
+
+    AddSchemaUpdate:
+      allOf:
+        - $ref: '#/components/schemas/BaseUpdate'
+        - type: object
+          properties:
+            schema:
+              $ref: '#/components/schemas/Schema'
+
+    SetCurrentSchemaUpdate:
+      allOf:
+        - $ref: '#/components/schemas/BaseUpdate'
+        - type: object
+          properties:
+            schema-id:
+              type: integer
+              description: Schema ID to set as current, or -1 to set last added schema
+
+    AddPartitionSpecUpdate:
+      allOf:
+        - $ref: '#/components/schemas/BaseUpdate'
+        - type: object
+          properties:
+            spec:
+              $ref: '#/components/schemas/PartitionSpec'
+
+    SetDefaultSpecUpdate:
+      allOf:
+        - $ref: '#/components/schemas/BaseUpdate'
+        - type: object
+          properties:
+            spec-id:
+              type: integer
+              description: Partition spec ID to set as the default, or -1 to set last added spec
+
+    AddSortOrderUpdate:
+      allOf:
+        - $ref: '#/components/schemas/BaseUpdate'
+        - type: object
+          properties:
+            sort-order:
+              $ref: '#/components/schemas/SortOrder'
+
+    SetDefaultSortOrderUpdate:
+      allOf:
+        - $ref: '#/components/schemas/BaseUpdate'
+        - type: object
+          properties:
+            order-id:
+              type: integer
+              description: Sort order ID to set as the default, or -1 to set last added sort order
+
+    TableUpdate:
+      anyOf:
+        - $ref: '#/components/schemas/AddSchemaUpdate'
+        - $ref: '#/components/schemas/SetCurrentSchemaUpdate'
+        - $ref: '#/components/schemas/AddPartitionSpecUpdate'
+        - $ref: '#/components/schemas/SetDefaultSpecUpdate'
+        - $ref: '#/components/schemas/AddSortOrderUpdate'
+        - $ref: '#/components/schemas/SetDefaultSortOrderUpdate'
 
 
   #############################

--- a/rest_docs/rest-catalog-open-api.yaml
+++ b/rest_docs/rest-catalog-open-api.yaml
@@ -367,6 +367,36 @@ paths:
       - $ref: '#/components/parameters/namespace'
       - $ref: '#/components/parameters/table'
 
+    get:
+      tags:
+        - Catalog API
+      summary: Load a table from the catalog
+      operationId: loadTable
+      description: Load a table from the catalog
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/responses/LoadTableResponse'
+        400:
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        401:
+          $ref: '#/components/responses/UnauthorizedResponse'
+        404:
+          description:
+            Not Found - NoSuchTableException, table to load does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/responses/IcebergErrorResponse'
+              examples:
+                TableToRenameDoesNotExist:
+                  $ref: '#/components/examples/NoSuchTableError'
+        5XX:
+          $ref: '#/components/responses/ServerErrorResponse'
+
     delete:
       tags:
         - Catalog API
@@ -1141,6 +1171,9 @@ components:
 
     TableCommitResponse:
       type: object
+      properties:
+        metadata:
+          $ref: '#/components/schemas/TableMetadata'
 
 
   #############################
@@ -1345,6 +1378,18 @@ components:
                   in the namespace's properties. Represents a partial success response.
                   Server's do not need to implement this.
                 nullable: true
+
+    LoadTableResponse:
+      type: object
+      required:
+        - metadata
+      properties:
+        config:
+          type: object
+          additionalProperties:
+            type: string
+        metadata:
+          $ref: '#/components/schemas/TableMetadata'
 
   #######################################
   # Common examples of different values #

--- a/rest_docs/rest-catalog-open-api.yaml
+++ b/rest_docs/rest-catalog-open-api.yaml
@@ -703,6 +703,7 @@ components:
           properties:
             schema-id:
               type: integer
+              readOnly: true
             identifier-field-ids:
               type: array
               items:
@@ -742,6 +743,7 @@ components:
       properties:
         spec-id:
           type: integer
+          readOnly: true
         fields:
           type: array
           items:
@@ -779,8 +781,36 @@ components:
       properties:
         order-id:
           type: integer
+          readOnly: true
         fields:
           $ref: '#/components/schemas/SortField'
+
+    Snapshot:
+      type: object
+      required:
+        - snapshot-id
+        - timestamp-ms
+        - manifest-list
+      properties:
+        snapshot-id:
+          type: integer
+        timestamp-ms:
+          type: integer
+        manifest-list:
+          type: string
+          description: Location of the snapshot's manifest list file
+        schema-id:
+          type: integer
+        summary:
+          type: object
+          required:
+            - summary
+          properties:
+            summary:
+              type: string
+              enum: ["append", "replace", "overwrite", "delete"]
+          additionalProperties:
+            type: string
 
     BaseUpdate:
       type: object
@@ -790,12 +820,27 @@ components:
         action:
           type: string
           enum:
+            - upgrade-format-version
             - add-schema
             - set-current-schema
             - add-spec
             - set-default-spec
             - add-sort-order
             - set-default-sort-order
+            - add-snapshot
+            - set-current-snapshot
+            - remove-snapshots
+            - set-location
+            - set-properties
+            - remove-properties
+
+    UpgradeFormatVersionUpdate:
+      allOf:
+        - $ref: '#/components/schemas/BaseUpdate'
+        - type: object
+          properties:
+            format-version:
+              type: integer
 
     AddSchemaUpdate:
       allOf:
@@ -848,14 +893,75 @@ components:
               type: integer
               description: Sort order ID to set as the default, or -1 to set last added sort order
 
+    AddSnapshotUpdate:
+      allOf:
+        - $ref: '#/components/schemas/BaseUpdate'
+        - type: object
+          properties:
+            snapshot:
+              $ref: '#/components/schemas/Snapshot'
+
+    SetCurrentSnapshotUpdate:
+      allOf:
+        - $ref: '#/components/schemas/BaseUpdate'
+        - type: object
+          properties:
+            snapshot-id:
+              type: integer
+
+    RemoveSnapshotsUpdate:
+      allOf:
+        - $ref: '#/components/schemas/BaseUpdate'
+        - type: object
+          properties:
+            snapshot-ids:
+              type: array
+              items:
+                type: integer
+
+    SetLocationUpdate:
+      allOf:
+        - $ref: '#/components/schemas/BaseUpdate'
+        - type: object
+          properties:
+            location:
+              type: string
+
+    SetPropertiesUpdate:
+      allOf:
+        - $ref: '#/components/schemas/BaseUpdate'
+        - type: object
+          properties:
+            updates:
+              type: object
+              additionalProperties:
+                type: string
+
+    RemovePropertiesUpdate:
+      allOf:
+        - $ref: '#/components/schemas/BaseUpdate'
+        - type: object
+          properties:
+            removals:
+              type: array
+              items:
+                type: string
+
     TableUpdate:
       anyOf:
+        - $ref: '#/components/schemas/UpgradeFormatVersionUpdate'
         - $ref: '#/components/schemas/AddSchemaUpdate'
         - $ref: '#/components/schemas/SetCurrentSchemaUpdate'
         - $ref: '#/components/schemas/AddPartitionSpecUpdate'
         - $ref: '#/components/schemas/SetDefaultSpecUpdate'
         - $ref: '#/components/schemas/AddSortOrderUpdate'
         - $ref: '#/components/schemas/SetDefaultSortOrderUpdate'
+        - $ref: '#/components/schemas/AddSnapshotUpdate'
+        - $ref: '#/components/schemas/SetCurrentSnapshotUpdate'
+        - $ref: '#/components/schemas/RemoveSnapshotsUpdate'
+        - $ref: '#/components/schemas/SetLocationUpdate'
+        - $ref: '#/components/schemas/SetPropertiesUpdate'
+        - $ref: '#/components/schemas/RemovePropertiesUpdate'
 
 
   #############################

--- a/rest_docs/rest-catalog-open-api.yaml
+++ b/rest_docs/rest-catalog-open-api.yaml
@@ -382,11 +382,7 @@ paths:
         The response also contains the table's full metadata.
       responses:
         200:
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/LoadTableResponse'
+          $ref: '#/components/responses/LoadTableResponse'
         400:
           $ref: '#/components/responses/BadRequestErrorResponse'
         401:
@@ -1115,16 +1111,12 @@ components:
     SetSnapshotRefUpdate:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
+        - $ref: '#/components/schemas/SnapshotReference'
         - type: object
           required:
             - ref
-            - snapshot-id
           properties:
             ref:
-              type: string
-            snapshot-id:
-              type: integer
-            additionalProperties:
               type: string
 
     RemoveSnapshotsUpdate:

--- a/rest_docs/rest-catalog-open-api.yaml
+++ b/rest_docs/rest-catalog-open-api.yaml
@@ -362,6 +362,38 @@ paths:
         5XX:
           $ref: '#/components/responses/ServerErrorResponse'
 
+    post:
+      tags:
+        - Catalog API
+      summary: Create a table in the given namespace
+      description: Create table
+      operationId: createTable
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateTableRequest'
+      responses:
+        200:
+          $ref: '#/components/responses/CreateTableResponse'
+        400:
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        401:
+          $ref: '#/components/responses/UnauthorizedResponse'
+        404:
+          description: Not Found - The namespace specified does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/responses/IcebergErrorResponse'
+              examples:
+                NamespaceNotFound:
+                  $ref: '#/components/examples/NoSuchNamespaceError'
+        5XX:
+          $ref: '#/components/responses/ServerErrorResponse'
+
+  /v1/namespaces/{namespace}/tables:
+
   /v1/namespaces/{namespace}/tables/{table}:
     parameters:
       - $ref: '#/components/parameters/namespace'
@@ -1204,6 +1236,18 @@ components:
         default-sort-order-id:
           type: integer
 
+    LoadTableResult:
+      type: object
+      required:
+        - metadata
+      properties:
+        config:
+          type: object
+          additionalProperties:
+            type: string
+        metadata:
+          $ref: '#/components/schemas/TableMetadata'
+
     CommitTableRequest:
       type: object
       required:
@@ -1218,6 +1262,28 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TableUpdate'
+
+    CreateTableRequest:
+      type: object
+      required:
+        - name
+        - schema
+      properties:
+        name:
+          type: string
+        location:
+          type: string
+        schema:
+          $ref: '#/components/schemas/Schema'
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+        partition-spec:
+          $ref: '#/components/schemas/PartitionSpec'
+        sort-order:
+          $ref: '#/components/schemas/SortOrder'
+
 
 
   #############################
@@ -1423,21 +1489,19 @@ components:
                   Server's do not need to implement this.
                 nullable: true
 
+    CreateTableResponse:
+      description: Table metadata result after creating a table
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/LoadTableResult'
+
     LoadTableResponse:
       description: Table metadata result when loading a table
       content:
         application/json:
           schema:
-            type: object
-            required:
-              - metadata
-            properties:
-              config:
-                type: object
-                additionalProperties:
-                  type: string
-              metadata:
-                $ref: '#/components/schemas/TableMetadata'
+            $ref: '#/components/schemas/LoadTableResult'
 
     CommitTableResponse:
       description: Table metadata result after committing updates to a table

--- a/rest_docs/rest-catalog-open-api.yaml
+++ b/rest_docs/rest-catalog-open-api.yaml
@@ -372,7 +372,14 @@ paths:
         - Catalog API
       summary: Load a table from the catalog
       operationId: loadTable
-      description: Load a table from the catalog
+      description:
+        Load a table from the catalog.
+
+        The response contains both configuration and table metadata. The configuration, if non-empty is used
+        as additional configuration for the table that overrides catalog configuration. For example, this
+        configuration may change the FileIO implemented used for the table.
+
+        The response also contains the table's full metadata.
       responses:
         200:
           description: OK

--- a/rest_docs/rest-catalog-open-api.yaml
+++ b/rest_docs/rest-catalog-open-api.yaml
@@ -893,8 +893,8 @@ components:
             summary:
               type: string
               enum: ["append", "replace", "overwrite", "delete"]
-          additionalProperties:
-            type: string
+            additionalProperties:
+              type: string
 
     SnapshotReference:
       type: object

--- a/rest_docs/rest-catalog-open-api.yaml
+++ b/rest_docs/rest-catalog-open-api.yaml
@@ -963,6 +963,44 @@ components:
         - $ref: '#/components/schemas/SetPropertiesUpdate'
         - $ref: '#/components/schemas/RemovePropertiesUpdate'
 
+    TableRequirement:
+      type: object
+      required:
+        - requirement
+      properties:
+        requirement:
+          type: string
+          enum:
+            - assert-ref-snapshot-id
+            - assert-current-schema-id
+            - assert-default-spec-id
+            - assert-default-sort-order-id
+        ref:
+          type: string
+        snapshot-id:
+          type: integer
+        schema-id:
+          type: integer
+        default-spec-id:
+          type: integer
+        default-sort-order-id:
+          type: integer
+
+    TableCommitRequest:
+      type: object
+      required:
+        - requirements
+        - updates
+      properties:
+        requirements:
+          type: array
+          items:
+            $ref: '#/components/schemas/TableRequirement'
+        updates:
+          type: array
+          items:
+            $ref: '#/components/schemas/TableUpdate'
+
 
   #############################
   # Reusable Response Objects #

--- a/rest_docs/rest-catalog-open-api.yaml
+++ b/rest_docs/rest-catalog-open-api.yaml
@@ -481,7 +481,22 @@ paths:
               schema:
                 $ref: '#/components/responses/IcebergErrorResponse'
         5XX:
-          $ref: '#/components/responses/ServerErrorResponse'
+          description:
+            A server-side problem that might not be addressable from the client side.
+
+            Error codes 500 and 504 indicate that the commit state is unknown and the client should
+            check the table state before considering the commit successful or failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/responses/IcebergErrorResponse'
+              example: {
+                "error": {
+                  "message": "Internal Server Error",
+                  "type": "InternalServerError",
+                  "code": 500
+                }
+              }
 
     delete:
       tags:

--- a/rest_docs/rest-catalog-open-api.yaml
+++ b/rest_docs/rest-catalog-open-api.yaml
@@ -1000,6 +1000,8 @@ components:
       properties:
         format-version:
           type: integer
+          minimum: 1
+          maximum: 2
         table-uuid:
           type: string
         location:

--- a/rest_docs/rest-catalog-open-api.yaml
+++ b/rest_docs/rest-catalog-open-api.yaml
@@ -397,6 +397,57 @@ paths:
         5XX:
           $ref: '#/components/responses/ServerErrorResponse'
 
+    post:
+      tags:
+        - Catalog API
+      summary: Commit updates to a table
+      operationId: updateTable
+      description:
+        Commit updates to a table.
+
+        Commits have two parts, requirements and updates. Requirements are assertions that will be validated
+        before attempting to make and commit changes. For example, assert-ref-snapshot-id will check that a
+        named ref's snapshot ID has a certain value.
+
+        Updates are changes to make to table metadata. For example, after asserting that the current main ref
+        is at the expected snapshot, a commit may add a new child snapshot and set the ref to the new
+        snapshot id.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CommitTableRequest'
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/responses/CommitTableResponse'
+        400:
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        401:
+          $ref: '#/components/responses/UnauthorizedResponse'
+        404:
+          description:
+            Not Found - NoSuchTableException, table to load does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/responses/IcebergErrorResponse'
+              examples:
+                TableToRenameDoesNotExist:
+                  $ref: '#/components/examples/NoSuchTableError'
+        409:
+          description:
+            Conflict - CommitFailedException, one or more requirements failed. The client may retry.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/responses/IcebergErrorResponse'
+        5XX:
+          $ref: '#/components/responses/ServerErrorResponse'
+
     delete:
       tags:
         - Catalog API
@@ -1154,7 +1205,7 @@ components:
         default-sort-order-id:
           type: integer
 
-    TableCommitRequest:
+    CommitTableRequest:
       type: object
       required:
         - requirements
@@ -1168,12 +1219,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TableUpdate'
-
-    TableCommitResponse:
-      type: object
-      properties:
-        metadata:
-          $ref: '#/components/schemas/TableMetadata'
 
 
   #############################
@@ -1380,16 +1425,32 @@ components:
                 nullable: true
 
     LoadTableResponse:
-      type: object
-      required:
-        - metadata
-      properties:
-        config:
-          type: object
-          additionalProperties:
-            type: string
-        metadata:
-          $ref: '#/components/schemas/TableMetadata'
+      description: Table metadata result when loading a table
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - metadata
+            properties:
+              config:
+                type: object
+                additionalProperties:
+                  type: string
+              metadata:
+                $ref: '#/components/schemas/TableMetadata'
+
+    CommitTableResponse:
+      description: Table metadata result after committing updates to a table
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - metadata
+            properties:
+              metadata:
+                $ref: '#/components/schemas/TableMetadata'
 
   #######################################
   # Common examples of different values #

--- a/rest_docs/rest-catalog-open-api.yaml
+++ b/rest_docs/rest-catalog-open-api.yaml
@@ -392,8 +392,6 @@ paths:
         5XX:
           $ref: '#/components/responses/ServerErrorResponse'
 
-  /v1/namespaces/{namespace}/tables:
-
   /v1/namespaces/{namespace}/tables/{table}:
     parameters:
       - $ref: '#/components/parameters/namespace'

--- a/rest_docs/rest-catalog-open-api.yaml
+++ b/rest_docs/rest-catalog-open-api.yaml
@@ -812,6 +812,113 @@ components:
           additionalProperties:
             type: string
 
+    SnapshotReference:
+      type: object
+      required:
+        - type
+        - snapshot-id
+      properties:
+        type:
+          type: string
+          enum: ["tag", "branch"]
+        snapshot-id:
+          type: integer
+        max-ref-age-ms:
+          type: integer
+        max-snapshot-age-ms:
+          type: integer
+        min-snapshots-to-keep:
+          type: integer
+
+    SnapshotReferences:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/SnapshotReference'
+
+    SnapshotLog:
+      type: array
+      items:
+        type: object
+        required:
+          - snapshot-id
+          - timestamp-ms
+        properties:
+          snapshot-id:
+            type: integer
+          timestamp-ms:
+            type: integer
+
+    MetadataLog:
+      type: array
+      items:
+        type: object
+        required:
+          - metadata-file
+          - timestamp-ms
+        properties:
+          metadata-file:
+            type: string
+          timestamp-ms:
+            type: integer
+
+    TableMetadata:
+      type: object
+      required:
+        - format-version
+        - table-uuid
+      properties:
+        format-version:
+          type: integer
+        table-uuid:
+          type: string
+        location:
+          type: string
+        last-updated-ms:
+          type: integer
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+        # schema tracking
+        schemas:
+          type: array
+          items:
+            $ref: '#/components/schemas/Schema'
+        current-schema-id:
+          type: integer
+        last-column-id:
+          type: integer
+        # partition spec tracking
+        partition-specs:
+          type: array
+          items:
+            $ref: '#/components/schemas/PartitionSpec'
+        default-spec-id:
+          type: integer
+        last-partition-id:
+          type: integer
+        # sort order tracking
+        sort-orders:
+          type: array
+          items:
+            $ref: '#/components/schemas/SortOrder'
+        default-sort-order-id:
+          type: integer
+        # snapshot tracking
+        snapshots:
+          type: array
+          items:
+            $ref: '#/components/schemas/Snapshot'
+        refs:
+          $ref: '#/components/schemas/SnapshotReferences'
+        current-snapshot-id:
+          type: integer
+        # logs
+        snapshot-log:
+          $ref: '#/components/schemas/SnapshotLog'
+        metadata-log:
+          $ref: '#/components/schemas/MetadataLog'
+
     BaseUpdate:
       type: object
       required:
@@ -828,7 +935,7 @@ components:
             - add-sort-order
             - set-default-sort-order
             - add-snapshot
-            - set-current-snapshot
+            - set-snapshot-ref
             - remove-snapshots
             - set-location
             - set-properties
@@ -838,6 +945,8 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
         - type: object
+          required:
+            - format-version
           properties:
             format-version:
               type: integer
@@ -846,6 +955,8 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
         - type: object
+          required:
+            - schema
           properties:
             schema:
               $ref: '#/components/schemas/Schema'
@@ -854,6 +965,8 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
         - type: object
+          required:
+            - schema-id
           properties:
             schema-id:
               type: integer
@@ -863,6 +976,8 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
         - type: object
+          required:
+            - spec
           properties:
             spec:
               $ref: '#/components/schemas/PartitionSpec'
@@ -871,6 +986,8 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
         - type: object
+          required:
+            - spec-id
           properties:
             spec-id:
               type: integer
@@ -880,6 +997,8 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
         - type: object
+          required:
+            - sort-order
           properties:
             sort-order:
               $ref: '#/components/schemas/SortOrder'
@@ -888,6 +1007,8 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
         - type: object
+          required:
+            - order-id
           properties:
             order-id:
               type: integer
@@ -897,22 +1018,33 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
         - type: object
+          required:
+            - snapshot
           properties:
             snapshot:
               $ref: '#/components/schemas/Snapshot'
 
-    SetCurrentSnapshotUpdate:
+    SetSnapshotRefUpdate:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
         - type: object
+          required:
+            - ref
+            - snapshot-id
           properties:
+            ref:
+              type: string
             snapshot-id:
               type: integer
+            additionalProperties:
+              type: string
 
     RemoveSnapshotsUpdate:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
         - type: object
+          required:
+            - snapshot-ids
           properties:
             snapshot-ids:
               type: array
@@ -923,6 +1055,8 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
         - type: object
+          required:
+            - location
           properties:
             location:
               type: string
@@ -931,6 +1065,8 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
         - type: object
+          required:
+            - updates
           properties:
             updates:
               type: object
@@ -941,6 +1077,8 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
         - type: object
+          required:
+            - removals
           properties:
             removals:
               type: array
@@ -957,7 +1095,7 @@ components:
         - $ref: '#/components/schemas/AddSortOrderUpdate'
         - $ref: '#/components/schemas/SetDefaultSortOrderUpdate'
         - $ref: '#/components/schemas/AddSnapshotUpdate'
-        - $ref: '#/components/schemas/SetCurrentSnapshotUpdate'
+        - $ref: '#/components/schemas/SetSnapshotRefUpdate'
         - $ref: '#/components/schemas/RemoveSnapshotsUpdate'
         - $ref: '#/components/schemas/SetLocationUpdate'
         - $ref: '#/components/schemas/SetPropertiesUpdate'
@@ -1000,6 +1138,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TableUpdate'
+
+    TableCommitResponse:
+      type: object
 
 
   #############################

--- a/rest_docs/rest-catalog-open-api.yaml
+++ b/rest_docs/rest-catalog-open-api.yaml
@@ -899,7 +899,9 @@ components:
           type: integer
           readOnly: true
         fields:
-          $ref: '#/components/schemas/SortField'
+          type: array
+          items:
+            $ref: '#/components/schemas/SortField'
 
     Snapshot:
       type: object

--- a/rest_docs/rest-catalog-open-api.yaml
+++ b/rest_docs/rest-catalog-open-api.yaml
@@ -427,7 +427,7 @@ paths:
               schema:
                 $ref: '#/components/responses/IcebergErrorResponse'
               examples:
-                TableToRenameDoesNotExist:
+                TableToLoadDoesNotExist:
                   $ref: '#/components/examples/NoSuchTableError'
         5XX:
           $ref: '#/components/responses/ServerErrorResponse'
@@ -471,7 +471,7 @@ paths:
               schema:
                 $ref: '#/components/responses/IcebergErrorResponse'
               examples:
-                TableToRenameDoesNotExist:
+                TableToUpdateDoesNotExist:
                   $ref: '#/components/examples/NoSuchTableError'
         409:
           description:
@@ -519,7 +519,7 @@ paths:
               schema:
                 $ref: '#/components/responses/IcebergErrorResponse'
               examples:
-                TableToRenameDoesNotExist:
+                TableToDeleteDoesNotExist:
                   $ref: '#/components/examples/NoSuchTableError'
         5XX:
           $ref: '#/components/responses/ServerErrorResponse'


### PR DESCRIPTION
This adds two new routes to the REST catalog spec:
* `GET /v1/namespaces/{namespace}/tables/{table}` is used to load a table. This returns:
    * Table-specific configuration for the catalog (e.g., a specific FileIO implementation for the table)
    * The current table metadata
* `POST /v1/namespaces/{namespace}/tables/{table}` is used to commit updates a table
    * The request body contains `requirements` and `updates` as in the [REST commit proposal](https://docs.google.com/document/d/1D0R3G0slssEhggH5XnIzMwsUIP-c385Qp2sjv5E7e6E/edit#heading=h.eo4x0coo8esy), but complete
    * The response contains the updated table metadata

This PR includes the metadata JSON format expressed in OpenAPI to be able to return full `TableMetadata`.

Note that this updates the proposed change set slightly to account for the addition of branching and tagging. Instead of `SetCurrentSnapshot` the change is `SetSnapshotRef`.