### PR TITLE
Disable metrics for very wide tables to reduce metadata size

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetricsConfig.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsConfig.java
@@ -44,8 +44,10 @@ public final class MetricsConfig implements Serializable {
   private static final Logger LOG = LoggerFactory.getLogger(MetricsConfig.class);
   private static final Joiner DOT = Joiner.on('.');
 
+  // Disable metrics by default for very wide tables to prevent excessive metadata
+  private static final int MAX_COLUMNS = 100;
   private static final MetricsConfig DEFAULT = new MetricsConfig(ImmutableMap.of(),
-      MetricsModes.fromString(DEFAULT_WRITE_METRICS_MODE_DEFAULT));
+      DEFAULT_WRITE_METRICS_MODE_DEFAULT);
 
   private final Map<String, MetricsMode> columnModes;
   private final MetricsMode defaultMode;
@@ -94,7 +96,7 @@ public final class MetricsConfig implements Serializable {
    **/
   @Deprecated
   public static MetricsConfig fromProperties(Map<String, String> props) {
-    return from(props, null);
+    return from(props, null, DEFAULT_WRITE_METRICS_MODE_DEFAULT);
   }
 
   /**
@@ -102,7 +104,13 @@ public final class MetricsConfig implements Serializable {
    * @param table iceberg table
    */
   public static MetricsConfig forTable(Table table) {
-    return from(table.properties(), table.sortOrder());
+    MetricsMode defaultMode;
+    if (table.schema().columns().size() <= MAX_COLUMNS) {
+      defaultMode = DEFAULT_WRITE_METRICS_MODE_DEFAULT;
+    } else {
+      defaultMode = MetricsModes.None.get();
+    }
+    return from(table.properties(), table.sortOrder(), defaultMode);
   }
 
   /**
@@ -127,16 +135,30 @@ public final class MetricsConfig implements Serializable {
     return new MetricsConfig(columnModes.build(), defaultMode);
   }
 
-  private static MetricsConfig from(Map<String, String> props, SortOrder order) {
+  /**
+   * Generate a MetricsConfig for all columns based on overrides, sortOrder, and defaultMode.
+   * @param props will be read for metrics overrides (write.metadata.metrics.column.*) and default
+   *              (write.metadata.metrics.default)
+   * @param order sort order columns, will be promoted to truncate(16)
+   * @param defaultMode MetricsConfig default, if not set by user property
+   * @return metrics configuration
+   */
+  private static MetricsConfig from(Map<String, String> props, SortOrder order, MetricsMode defaultMode) {
     Map<String, MetricsMode> columnModes = Maps.newHashMap();
-    MetricsMode defaultMode;
-    String defaultModeAsString = props.getOrDefault(DEFAULT_WRITE_METRICS_MODE, DEFAULT_WRITE_METRICS_MODE_DEFAULT);
-    try {
-      defaultMode = MetricsModes.fromString(defaultModeAsString);
-    } catch (IllegalArgumentException err) {
-      // Mode was invalid, log the error and use the default
-      LOG.warn("Ignoring invalid default metrics mode: {}", defaultModeAsString, err);
-      defaultMode = MetricsModes.fromString(DEFAULT_WRITE_METRICS_MODE_DEFAULT);
+
+    // Handle user override of default mode
+    MetricsMode finalDefaultMode;
+    String defaultModeProp = props.get(DEFAULT_WRITE_METRICS_MODE);
+    if (defaultModeProp != null) {
+      try {
+        finalDefaultMode = MetricsModes.fromString(defaultModeProp);
+      } catch (IllegalArgumentException err) {
+        // User override was invalid, log the error and use the default
+        LOG.warn("Ignoring invalid default metrics mode: {}", defaultModeProp, err);
+        finalDefaultMode = defaultMode;
+      }
+    } else {
+      finalDefaultMode = defaultMode;
     }
 
     // First set sorted column with sorted column default (can be overridden by user)
@@ -144,7 +166,8 @@ public final class MetricsConfig implements Serializable {
     Set<String> sortedCols = SortOrderUtil.orderPreservingSortedColumns(order);
     sortedCols.forEach(sc -> columnModes.put(sc, sortedColDefaultMode));
 
-    MetricsMode defaultModeFinal = defaultMode;
+    // Handle user overrides of defaults
+    MetricsMode finalDefaultModeVar = finalDefaultMode;
     props.keySet().stream()
         .filter(key -> key.startsWith(METRICS_MODE_COLUMN_CONF_PREFIX))
         .forEach(key -> {
@@ -155,12 +178,12 @@ public final class MetricsConfig implements Serializable {
           } catch (IllegalArgumentException err) {
             // Mode was invalid, log the error and use the default
             LOG.warn("Ignoring invalid metrics mode for column {}: {}", columnAlias, props.get(key), err);
-            mode = defaultModeFinal;
+            mode = finalDefaultModeVar;
           }
           columnModes.put(columnAlias, mode);
         });
 
-    return new MetricsConfig(columnModes, defaultMode);
+    return new MetricsConfig(columnModes, finalDefaultMode);
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/MetricsConfig.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsConfig.java
@@ -27,8 +27,10 @@ import javax.annotation.concurrent.Immutable;
 import org.apache.iceberg.MetricsModes.MetricsMode;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.SerializableMap;
 import org.apache.iceberg.util.SortOrderUtil;
 import org.slf4j.Logger;
@@ -43,9 +45,6 @@ public final class MetricsConfig implements Serializable {
 
   private static final Logger LOG = LoggerFactory.getLogger(MetricsConfig.class);
   private static final Joiner DOT = Joiner.on('.');
-
-  // Disable metrics by default for very wide tables to prevent excessive metadata
-  private static final int MAX_COLUMNS = 100;
   private static final MetricsConfig DEFAULT = new MetricsConfig(ImmutableMap.of(),
       MetricsModes.fromString(DEFAULT_WRITE_METRICS_MODE_DEFAULT));
 
@@ -105,11 +104,19 @@ public final class MetricsConfig implements Serializable {
    */
   public static MetricsConfig forTable(Table table) {
     String defaultMode;
-    if (table.schema().columns().size() <= MAX_COLUMNS) {
+    // Disable metrics for very wide tables to prevent excessive metadata size
+    int maxColumns = PropertyUtil.propertyAsInt(
+        table.properties(),
+        TableProperties.METRICS_MAX_COLUMNS,
+        TableProperties.METRICS_MAX_COLUMNS_DEFAULT);
+    Preconditions.checkArgument(maxColumns >= 0,
+        TableProperties.METRICS_MAX_COLUMNS + " should have a positive value");
+    if (table.schema().columns().size() <= maxColumns) {
       defaultMode = DEFAULT_WRITE_METRICS_MODE_DEFAULT;
     } else {
       defaultMode = MetricsModes.None.get().toString();
     }
+
     return from(table.properties(), table.sortOrder(), defaultMode);
   }
 

--- a/core/src/main/java/org/apache/iceberg/MetricsConfig.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsConfig.java
@@ -44,8 +44,8 @@ public final class MetricsConfig implements Serializable {
   private static final Logger LOG = LoggerFactory.getLogger(MetricsConfig.class);
   private static final Joiner DOT = Joiner.on('.');
 
-  // Disable metrics by default for very wide tables to prevent excessive metadata
-  private static final int MAX_COLUMNS = 100;
+  // Disable metrics by default for wide tables to prevent excessive metadata
+  private static final int MAX_COLUMNS = 32;
   private static final MetricsConfig DEFAULT = new MetricsConfig(ImmutableMap.of(),
       MetricsModes.fromString(DEFAULT_WRITE_METRICS_MODE_DEFAULT));
 

--- a/core/src/main/java/org/apache/iceberg/MetricsConfig.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsConfig.java
@@ -109,9 +109,9 @@ public final class MetricsConfig implements Serializable {
         table.properties(),
         TableProperties.METRICS_MAX_COLUMNS,
         TableProperties.METRICS_MAX_COLUMNS_DEFAULT);
-    Preconditions.checkArgument(maxColumns >= 0,
-        TableProperties.METRICS_MAX_COLUMNS + " should have a positive value");
-    if (table.schema().columns().size() <= maxColumns) {
+    Preconditions.checkArgument(maxColumns >= -1,
+        TableProperties.METRICS_MAX_COLUMNS + " should be a positive value or -1 (unlimited)");
+    if (maxColumns == -1 || table.schema().columns().size() <= maxColumns) {
       defaultMode = DEFAULT_WRITE_METRICS_MODE_DEFAULT;
     } else {
       defaultMode = MetricsModes.None.get().toString();

--- a/core/src/main/java/org/apache/iceberg/MetricsConfig.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsConfig.java
@@ -109,9 +109,9 @@ public final class MetricsConfig implements Serializable {
         table.properties(),
         TableProperties.METRICS_MAX_COLUMNS,
         TableProperties.METRICS_MAX_COLUMNS_DEFAULT);
-    Preconditions.checkArgument(maxColumns >= -1,
-        TableProperties.METRICS_MAX_COLUMNS + " should be a positive value or -1 (unlimited)");
-    if (maxColumns == -1 || table.schema().columns().size() <= maxColumns) {
+    Preconditions.checkArgument(maxColumns >= 0,
+        TableProperties.METRICS_MAX_COLUMNS + " should have a positive value");
+    if (table.schema().columns().size() <= maxColumns) {
       defaultMode = DEFAULT_WRITE_METRICS_MODE_DEFAULT;
     } else {
       defaultMode = MetricsModes.None.get().toString();

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -197,7 +197,6 @@ public class TableProperties {
   public static final String DEFAULT_WRITE_METRICS_MODE_DEFAULT = "truncate(16)";
 
   // Beyond this number of columns, metrics are disabled by default unless in special cases (ex, sort-order columns)
-  // A value of -1 indicates no limit
   public static final String METRICS_MAX_COLUMNS = "write.metadata.metrics.max.columns";
   public static final int METRICS_MAX_COLUMNS_DEFAULT = 100;
 

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -194,7 +194,8 @@ public class TableProperties {
 
   public static final String METRICS_MODE_COLUMN_CONF_PREFIX = "write.metadata.metrics.column.";
   public static final String DEFAULT_WRITE_METRICS_MODE = "write.metadata.metrics.default";
-  public static final String DEFAULT_WRITE_METRICS_MODE_DEFAULT = "truncate(16)";
+  public static final MetricsModes.MetricsMode DEFAULT_WRITE_METRICS_MODE_DEFAULT =
+      MetricsModes.Truncate.withLength(16);
 
   public static final String DEFAULT_NAME_MAPPING = "schema.name-mapping.default";
 

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -197,6 +197,7 @@ public class TableProperties {
   public static final String DEFAULT_WRITE_METRICS_MODE_DEFAULT = "truncate(16)";
 
   // Beyond this number of columns, metrics are disabled by default unless in special cases (ex, sort-order columns)
+  // A value of -1 indicates no limit
   public static final String METRICS_MAX_COLUMNS = "write.metadata.metrics.max.columns";
   public static final int METRICS_MAX_COLUMNS_DEFAULT = 100;
 

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -194,8 +194,7 @@ public class TableProperties {
 
   public static final String METRICS_MODE_COLUMN_CONF_PREFIX = "write.metadata.metrics.column.";
   public static final String DEFAULT_WRITE_METRICS_MODE = "write.metadata.metrics.default";
-  public static final MetricsModes.MetricsMode DEFAULT_WRITE_METRICS_MODE_DEFAULT =
-      MetricsModes.Truncate.withLength(16);
+  public static final String DEFAULT_WRITE_METRICS_MODE_DEFAULT = "truncate(16)";
 
   public static final String DEFAULT_NAME_MAPPING = "schema.name-mapping.default";
 

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -196,10 +196,6 @@ public class TableProperties {
   public static final String DEFAULT_WRITE_METRICS_MODE = "write.metadata.metrics.default";
   public static final String DEFAULT_WRITE_METRICS_MODE_DEFAULT = "truncate(16)";
 
-  // Beyond this number of columns, metrics are disabled by default unless in special cases (ex, sort-order columns)
-  public static final String METRICS_MAX_COLUMNS = "write.metadata.metrics.max.columns";
-  public static final int METRICS_MAX_COLUMNS_DEFAULT = 100;
-
   public static final String DEFAULT_NAME_MAPPING = "schema.name-mapping.default";
 
   public static final String WRITE_AUDIT_PUBLISH_ENABLED = "write.wap.enabled";

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -196,6 +196,10 @@ public class TableProperties {
   public static final String DEFAULT_WRITE_METRICS_MODE = "write.metadata.metrics.default";
   public static final String DEFAULT_WRITE_METRICS_MODE_DEFAULT = "truncate(16)";
 
+  // Beyond this number of columns, metrics are disabled by default unless in special cases (ex, sort-order columns)
+  public static final String METRICS_MAX_COLUMNS = "write.metadata.metrics.max.columns";
+  public static final int METRICS_MAX_COLUMNS_DEFAULT = 100;
+
   public static final String DEFAULT_NAME_MAPPING = "schema.name-mapping.default";
 
   public static final String WRITE_AUDIT_PUBLISH_ENABLED = "write.wap.enabled";

--- a/data/src/test/java/org/apache/iceberg/io/TestWriterMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestWriterMetrics.java
@@ -210,8 +210,8 @@ public abstract class TestWriterMetrics<T> {
     File tableDir = temp.newFolder();
     tableDir.delete(); // created by table create
 
-    int numColumns = 101;
-    List<Types.NestedField> fields = Lists.newArrayListWithCapacity(101);
+    int numColumns = 33;
+    List<Types.NestedField> fields = Lists.newArrayListWithCapacity(numColumns);
     for (int i = 0; i < numColumns; i++) {
       fields.add(required(i, "col" + i, Types.IntegerType.get()));
     }
@@ -250,8 +250,8 @@ public abstract class TestWriterMetrics<T> {
     File tableDir = temp.newFolder();
     tableDir.delete(); // created by table create
 
-    int numColumns = 101;
-    List<Types.NestedField> fields = Lists.newArrayListWithCapacity(101);
+    int numColumns = 33;
+    List<Types.NestedField> fields = Lists.newArrayListWithCapacity(numColumns);
     for (int i = 0; i < numColumns; i++) {
       fields.add(required(i, "col" + i, Types.IntegerType.get()));
     }

--- a/data/src/test/java/org/apache/iceberg/io/TestWriterMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestWriterMetrics.java
@@ -265,7 +265,7 @@ public abstract class TestWriterMetrics<T> {
         SortOrder.unsorted(),
         FORMAT_V2);
     maxColumnTable.updateProperties().set(TableProperties.DEFAULT_WRITE_METRICS_MODE,
-        TableProperties.DEFAULT_WRITE_METRICS_MODE_DEFAULT.toString()).commit();
+        TableProperties.DEFAULT_WRITE_METRICS_MODE_DEFAULT).commit();
     OutputFileFactory maxColFactory = OutputFileFactory.builderFor(maxColumnTable, 1, 1)
         .format(fileFormat).build();
 

--- a/data/src/test/java/org/apache/iceberg/io/TestWriterMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestWriterMetrics.java
@@ -211,7 +211,7 @@ public abstract class TestWriterMetrics<T> {
     tableDir.delete(); // created by table create
 
     int numColumns = 101;
-    List<Types.NestedField> fields = Lists.newArrayListWithCapacity(101);
+    List<Types.NestedField> fields = Lists.newArrayListWithCapacity(numColumns);
     for (int i = 0; i < numColumns; i++) {
       fields.add(required(i, "col" + i, Types.IntegerType.get()));
     }
@@ -251,7 +251,7 @@ public abstract class TestWriterMetrics<T> {
     tableDir.delete(); // created by table create
 
     int numColumns = 101;
-    List<Types.NestedField> fields = Lists.newArrayListWithCapacity(101);
+    List<Types.NestedField> fields = Lists.newArrayListWithCapacity(numColumns);
     for (int i = 0; i < numColumns; i++) {
       fields.add(required(i, "col" + i, Types.IntegerType.get()));
     }
@@ -286,5 +286,92 @@ public abstract class TestWriterMetrics<T> {
       Assert.assertEquals(1, (int) Conversions.fromByteBuffer(Types.IntegerType.get(), upperBounds.get(1)));
       Assert.assertEquals(1, (int) Conversions.fromByteBuffer(Types.IntegerType.get(), lowerBounds.get(1)));
     }
+  }
+
+  @Test
+  public void testBelowMaxColumnsSetting() throws IOException {
+    File tableDir = temp.newFolder();
+    tableDir.delete(); // created by table create
+
+    int numColumns = 50;
+
+    // Table with number of columns below the config should have metrics
+    List<Types.NestedField> fields = Lists.newArrayListWithCapacity(numColumns);
+    for (int i = 0; i < numColumns; i++) {
+      fields.add(required(i, "col" + i, Types.IntegerType.get()));
+    }
+    Schema maxColSchema = new Schema(fields);
+
+    Table belowColumnCountTable = TestTables.create(
+        tableDir,
+        "below_col_count_table",
+        maxColSchema,
+        PartitionSpec.unpartitioned(),
+        SortOrder.unsorted(),
+        FORMAT_V2);
+    OutputFileFactory maxColFactory = OutputFileFactory.builderFor(belowColumnCountTable, 1, 1)
+        .format(fileFormat).build();
+
+    T row = toGenericRow(1, numColumns);
+    DataWriter dataWriter = newWriterFactory(belowColumnCountTable).newDataWriter(
+        maxColFactory.newOutputFile(),
+        PartitionSpec.unpartitioned(),
+        null
+    );
+    dataWriter.add(row);
+    dataWriter.close();
+    DataFile dataFile = dataWriter.toDataFile();
+
+    // Field should have metrics because the column count is less than the max column setting
+    Map<Integer, ByteBuffer> upperBounds = dataFile.upperBounds();
+    Map<Integer, ByteBuffer> lowerBounds = dataFile.upperBounds();
+    for (int i = 0; i < numColumns; i++) {
+      Assert.assertEquals(1, (int) Conversions.fromByteBuffer(Types.IntegerType.get(), upperBounds.get(1)));
+      Assert.assertEquals(1, (int) Conversions.fromByteBuffer(Types.IntegerType.get(), lowerBounds.get(1)));
+    }
+  }
+
+  @Test
+  public void testAboveMaxColumnsSetting() throws IOException {
+    File tableDir = temp.newFolder();
+    tableDir.delete(); // created by table create
+
+    int numColumns = 50;
+
+    // Table with number of columns below the config should have metrics
+    List<Types.NestedField> fields = Lists.newArrayListWithCapacity(numColumns);
+    for (int i = 0; i < numColumns; i++) {
+      fields.add(required(i, "col" + i, Types.IntegerType.get()));
+    }
+    Schema maxColSchema = new Schema(fields);
+
+    Table aboveColumnCountTable = TestTables.create(
+        tableDir,
+        "above_col_count_table",
+        maxColSchema,
+        PartitionSpec.unpartitioned(),
+        SortOrder.unsorted(),
+        FORMAT_V2);
+    aboveColumnCountTable.updateProperties().set(
+        TableProperties.METRICS_MAX_COLUMNS, String.valueOf(numColumns - 1)).commit();
+    OutputFileFactory maxColFactory = OutputFileFactory.builderFor(aboveColumnCountTable, 1, 1)
+        .format(fileFormat).build();
+
+    T row = toGenericRow(1, numColumns);
+    DataWriter dataWriter = newWriterFactory(aboveColumnCountTable).newDataWriter(
+        maxColFactory.newOutputFile(),
+        PartitionSpec.unpartitioned(),
+        null
+    );
+    dataWriter.add(row);
+    dataWriter.close();
+    DataFile dataFile = dataWriter.toDataFile();
+
+    // Fields should not have metrics because the column count is above than the max column setting
+    Assert.assertTrue("Should not have any lower bound metrics", dataFile.lowerBounds().isEmpty());
+    Assert.assertTrue("Should not have any upper bound metrics", dataFile.upperBounds().isEmpty());
+    Assert.assertTrue("Should not have any nan value metrics", dataFile.nanValueCounts().isEmpty());
+    Assert.assertTrue("Should not have any null value metrics", dataFile.nullValueCounts().isEmpty());
+    Assert.assertTrue("Should not have any value metrics", dataFile.valueCounts().isEmpty());
   }
 }

--- a/data/src/test/java/org/apache/iceberg/io/TestWriterMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestWriterMetrics.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
+import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
@@ -31,12 +32,14 @@ import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TestTables;
 import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Types;
 import org.junit.After;
@@ -83,7 +86,6 @@ public abstract class TestWriterMetrics<T> {
 
   protected FileFormat fileFormat;
   protected TestTables.TestTable table = null;
-  protected File metadataDir = null;
   private OutputFileFactory fileFactory = null;
 
   @Parameterized.Parameters(name = "FileFormat = {0}")
@@ -98,16 +100,16 @@ public abstract class TestWriterMetrics<T> {
     this.fileFormat = fileFormat;
   }
 
-  protected abstract FileWriterFactory<T> newWriterFactory(Schema dataSchema);
+  protected abstract FileWriterFactory<T> newWriterFactory(Table sourceTable);
 
   protected abstract T toRow(Integer id, String data, boolean boolValue, Long longValue);
+
+  protected abstract T toGenericRow(int value, int repeated);
 
   @Before
   public void setupTable() throws Exception {
     File tableDir = temp.newFolder();
     tableDir.delete(); // created by table create
-
-    this.metadataDir = new File(tableDir, "metadata");
 
     this.table = TestTables.create(
         tableDir,
@@ -129,7 +131,7 @@ public abstract class TestWriterMetrics<T> {
   @Test
   public void verifySortedColMetric() throws Exception {
     T row = toRow(3, "3", true, 3L);
-    DataWriter dataWriter = newWriterFactory(SCHEMA).newDataWriter(
+    DataWriter dataWriter = newWriterFactory(table).newDataWriter(
         fileFactory.newOutputFile(),
         PartitionSpec.unpartitioned(),
         null
@@ -156,7 +158,7 @@ public abstract class TestWriterMetrics<T> {
 
   @Test
   public void testPositionDeleteMetrics() throws IOException {
-    FileWriterFactory<T> writerFactory = newWriterFactory(SCHEMA);
+    FileWriterFactory<T> writerFactory = newWriterFactory(table);
     EncryptedOutputFile outputFile = fileFactory.newOutputFile();
     PositionDeleteWriter<T> deleteWriter = writerFactory.newPositionDeleteWriter(outputFile, table.spec(), null);
 
@@ -201,5 +203,88 @@ public abstract class TestWriterMetrics<T> {
     Assert.assertFalse(upperBounds.containsKey(3));
     Assert.assertFalse(upperBounds.containsKey(4));
     Assert.assertEquals(3L, (long) Conversions.fromByteBuffer(Types.LongType.get(), upperBounds.get(5)));
+  }
+
+  @Test
+  public void testMaxColumns() throws IOException {
+    File tableDir = temp.newFolder();
+    tableDir.delete(); // created by table create
+
+    int numColumns = 101;
+    List<Types.NestedField> fields = Lists.newArrayListWithCapacity(101);
+    for (int i = 0; i < numColumns; i++) {
+      fields.add(required(i, "col" + i, Types.IntegerType.get()));
+    }
+    Schema maxColSchema = new Schema(fields);
+
+    Table maxColumnTable = TestTables.create(
+        tableDir,
+        "max_col_table",
+        maxColSchema,
+        PartitionSpec.unpartitioned(),
+        SortOrder.unsorted(),
+        FORMAT_V2);
+    OutputFileFactory maxColFactory = OutputFileFactory.builderFor(maxColumnTable, 1, 1)
+        .format(fileFormat).build();
+
+    T row = toGenericRow(1, numColumns);
+    DataWriter dataWriter = newWriterFactory(maxColumnTable).newDataWriter(
+        maxColFactory.newOutputFile(),
+        PartitionSpec.unpartitioned(),
+        null
+    );
+    dataWriter.add(row);
+    dataWriter.close();
+    DataFile dataFile = dataWriter.toDataFile();
+
+    // No field should have metrics
+    Assert.assertTrue("Should not have any lower bound metrics", dataFile.lowerBounds().isEmpty());
+    Assert.assertTrue("Should not have any upper bound metrics", dataFile.upperBounds().isEmpty());
+    Assert.assertTrue("Should not have any nan value metrics", dataFile.nanValueCounts().isEmpty());
+    Assert.assertTrue("Should not have any null value metrics", dataFile.nullValueCounts().isEmpty());
+    Assert.assertTrue("Should not have any value metrics", dataFile.valueCounts().isEmpty());
+  }
+
+  @Test
+  public void testMaxColumnsWithDefaultOverride() throws IOException {
+    File tableDir = temp.newFolder();
+    tableDir.delete(); // created by table create
+
+    int numColumns = 101;
+    List<Types.NestedField> fields = Lists.newArrayListWithCapacity(101);
+    for (int i = 0; i < numColumns; i++) {
+      fields.add(required(i, "col" + i, Types.IntegerType.get()));
+    }
+    Schema maxColSchema = new Schema(fields);
+
+    Table maxColumnTable = TestTables.create(
+        tableDir,
+        "max_col_table",
+        maxColSchema,
+        PartitionSpec.unpartitioned(),
+        SortOrder.unsorted(),
+        FORMAT_V2);
+    maxColumnTable.updateProperties().set(TableProperties.DEFAULT_WRITE_METRICS_MODE,
+        TableProperties.DEFAULT_WRITE_METRICS_MODE_DEFAULT.toString()).commit();
+    OutputFileFactory maxColFactory = OutputFileFactory.builderFor(maxColumnTable, 1, 1)
+        .format(fileFormat).build();
+
+    T row = toGenericRow(1, numColumns);
+    DataWriter dataWriter = newWriterFactory(maxColumnTable).newDataWriter(
+        maxColFactory.newOutputFile(),
+        PartitionSpec.unpartitioned(),
+        null
+    );
+    dataWriter.add(row);
+    dataWriter.close();
+    DataFile dataFile = dataWriter.toDataFile();
+
+    // Field should have metrics because the user set the default explicitly
+    Map<Integer, ByteBuffer> upperBounds = dataFile.upperBounds();
+    Map<Integer, ByteBuffer> lowerBounds = dataFile.upperBounds();
+    for (int i = 0; i < numColumns; i++) {
+      Assert.assertEquals(1, (int) Conversions.fromByteBuffer(Types.IntegerType.get(), upperBounds.get(1)));
+      Assert.assertEquals(1, (int) Conversions.fromByteBuffer(Types.IntegerType.get(), lowerBounds.get(1)));
+    }
   }
 }

--- a/data/src/test/java/org/apache/iceberg/io/TestWriterMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestWriterMetrics.java
@@ -289,6 +289,48 @@ public abstract class TestWriterMetrics<T> {
   }
 
   @Test
+  public void testUnlimitedColumns() throws IOException {
+    File tableDir = temp.newFolder();
+    tableDir.delete(); // created by table create
+
+    int numColumns = 101;
+    List<Types.NestedField> fields = Lists.newArrayListWithCapacity(numColumns);
+    for (int i = 0; i < numColumns; i++) {
+      fields.add(required(i, "col" + i, Types.IntegerType.get()));
+    }
+    Schema maxColSchema = new Schema(fields);
+
+    Table maxColumnTable = TestTables.create(
+        tableDir,
+        "max_col_table",
+        maxColSchema,
+        PartitionSpec.unpartitioned(),
+        SortOrder.unsorted(),
+        FORMAT_V2);
+    maxColumnTable.updateProperties().set(TableProperties.METRICS_MAX_COLUMNS, "-1").commit();
+    OutputFileFactory maxColFactory = OutputFileFactory.builderFor(maxColumnTable, 1, 1)
+        .format(fileFormat).build();
+
+    T row = toGenericRow(1, numColumns);
+    DataWriter dataWriter = newWriterFactory(maxColumnTable).newDataWriter(
+        maxColFactory.newOutputFile(),
+        PartitionSpec.unpartitioned(),
+        null
+    );
+    dataWriter.add(row);
+    dataWriter.close();
+    DataFile dataFile = dataWriter.toDataFile();
+
+    // Field should have metrics because the max columns is set at -1
+    Map<Integer, ByteBuffer> upperBounds = dataFile.upperBounds();
+    Map<Integer, ByteBuffer> lowerBounds = dataFile.upperBounds();
+    for (int i = 0; i < numColumns; i++) {
+      Assert.assertEquals(1, (int) Conversions.fromByteBuffer(Types.IntegerType.get(), upperBounds.get(1)));
+      Assert.assertEquals(1, (int) Conversions.fromByteBuffer(Types.IntegerType.get(), lowerBounds.get(1)));
+    }
+  }
+
+  @Test
   public void testBelowMaxColumnsSetting() throws IOException {
     File tableDir = temp.newFolder();
     tableDir.delete(); // created by table create

--- a/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkWriterMetrics.java
+++ b/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkWriterMetrics.java
@@ -23,7 +23,7 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.iceberg.FileFormat;
-import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.io.FileWriterFactory;
 import org.apache.iceberg.io.TestWriterMetrics;
 
@@ -34,12 +34,12 @@ public class TestFlinkWriterMetrics extends TestWriterMetrics<RowData> {
   }
 
   @Override
-  protected FileWriterFactory<RowData> newWriterFactory(Schema dataSchema) {
-    return FlinkFileWriterFactory.builderFor(table)
-        .dataSchema(table.schema())
+  protected FileWriterFactory<RowData> newWriterFactory(Table sourceTable) {
+    return FlinkFileWriterFactory.builderFor(sourceTable)
+        .dataSchema(sourceTable.schema())
         .dataFileFormat(fileFormat)
         .deleteFileFormat(fileFormat)
-        .positionDeleteRowSchema(table.schema())
+        .positionDeleteRowSchema(sourceTable.schema())
         .build();
   }
 
@@ -47,6 +47,15 @@ public class TestFlinkWriterMetrics extends TestWriterMetrics<RowData> {
   protected RowData toRow(Integer id, String data, boolean boolValue, Long longValue) {
     GenericRowData nested = GenericRowData.of(boolValue, longValue);
     GenericRowData row = GenericRowData.of(id, StringData.fromString(data), nested);
+    return row;
+  }
+
+  @Override
+  public RowData toGenericRow(int value, int repeated) {
+    GenericRowData row = new GenericRowData(repeated);
+    for (int i = 0; i < repeated; i++) {
+      row.setField(i, value);
+    }
     return row;
   }
 }

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkWriterMetrics.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkWriterMetrics.java
@@ -23,7 +23,7 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.iceberg.FileFormat;
-import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.io.FileWriterFactory;
 import org.apache.iceberg.io.TestWriterMetrics;
 
@@ -34,12 +34,12 @@ public class TestFlinkWriterMetrics extends TestWriterMetrics<RowData> {
   }
 
   @Override
-  protected FileWriterFactory<RowData> newWriterFactory(Schema dataSchema) {
-    return FlinkFileWriterFactory.builderFor(table)
-        .dataSchema(table.schema())
+  protected FileWriterFactory<RowData> newWriterFactory(Table sourceTable) {
+    return FlinkFileWriterFactory.builderFor(sourceTable)
+        .dataSchema(sourceTable.schema())
         .dataFileFormat(fileFormat)
         .deleteFileFormat(fileFormat)
-        .positionDeleteRowSchema(table.schema())
+        .positionDeleteRowSchema(sourceTable.schema())
         .build();
   }
 
@@ -47,6 +47,15 @@ public class TestFlinkWriterMetrics extends TestWriterMetrics<RowData> {
   protected RowData toRow(Integer id, String data, boolean boolValue, Long longValue) {
     GenericRowData nested = GenericRowData.of(boolValue, longValue);
     GenericRowData row = GenericRowData.of(id, StringData.fromString(data), nested);
+    return row;
+  }
+
+  @Override
+  public RowData toGenericRow(int value, int repeated) {
+    GenericRowData row = new GenericRowData(repeated);
+    for (int i = 0; i < repeated; i++) {
+      row.setField(i, value);
+    }
     return row;
   }
 }

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkWriterMetrics.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkWriterMetrics.java
@@ -23,7 +23,7 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.iceberg.FileFormat;
-import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.io.FileWriterFactory;
 import org.apache.iceberg.io.TestWriterMetrics;
 
@@ -34,12 +34,12 @@ public class TestFlinkWriterMetrics extends TestWriterMetrics<RowData> {
   }
 
   @Override
-  protected FileWriterFactory<RowData> newWriterFactory(Schema dataSchema) {
-    return FlinkFileWriterFactory.builderFor(table)
-        .dataSchema(table.schema())
+  protected FileWriterFactory<RowData> newWriterFactory(Table sourceTable) {
+    return FlinkFileWriterFactory.builderFor(sourceTable)
+        .dataSchema(sourceTable.schema())
         .dataFileFormat(fileFormat)
         .deleteFileFormat(fileFormat)
-        .positionDeleteRowSchema(table.schema())
+        .positionDeleteRowSchema(sourceTable.schema())
         .build();
   }
 
@@ -47,6 +47,15 @@ public class TestFlinkWriterMetrics extends TestWriterMetrics<RowData> {
   protected RowData toRow(Integer id, String data, boolean boolValue, Long longValue) {
     GenericRowData nested = GenericRowData.of(boolValue, longValue);
     GenericRowData row = GenericRowData.of(id, StringData.fromString(data), nested);
+    return row;
+  }
+
+  @Override
+  public RowData toGenericRow(int value, int repeated) {
+    GenericRowData row = new GenericRowData(repeated);
+    for (int i = 0; i < repeated; i++) {
+      row.setField(i, value);
+    }
     return row;
   }
 }

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkWriterMetrics.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkWriterMetrics.java
@@ -20,7 +20,7 @@
 package org.apache.iceberg.spark.source;
 
 import org.apache.iceberg.FileFormat;
-import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.io.FileWriterFactory;
 import org.apache.iceberg.io.TestWriterMetrics;
 import org.apache.spark.sql.catalyst.InternalRow;
@@ -34,12 +34,12 @@ public class TestSparkWriterMetrics extends TestWriterMetrics<InternalRow> {
   }
 
   @Override
-  protected FileWriterFactory<InternalRow> newWriterFactory(Schema dataSchema) {
-    return SparkFileWriterFactory.builderFor(table)
-        .dataSchema(table.schema())
+  protected FileWriterFactory<InternalRow> newWriterFactory(Table sourceTable) {
+    return SparkFileWriterFactory.builderFor(sourceTable)
+        .dataSchema(sourceTable.schema())
         .dataFileFormat(fileFormat)
         .deleteFileFormat(fileFormat)
-        .positionDeleteRowSchema(table.schema())
+        .positionDeleteRowSchema(sourceTable.schema())
         .build();
   }
 
@@ -54,6 +54,15 @@ public class TestSparkWriterMetrics extends TestWriterMetrics<InternalRow> {
     nested.update(1, longValue);
 
     row.update(2, nested);
+    return row;
+  }
+
+  @Override
+  protected InternalRow toGenericRow(int value, int repeated) {
+    InternalRow row = new GenericInternalRow(repeated);
+    for (int i = 0; i < repeated; i++) {
+      row.update(i, value);
+    }
     return row;
   }
 }

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkWriterMetrics.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkWriterMetrics.java
@@ -20,7 +20,7 @@
 package org.apache.iceberg.spark.source;
 
 import org.apache.iceberg.FileFormat;
-import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.io.FileWriterFactory;
 import org.apache.iceberg.io.TestWriterMetrics;
 import org.apache.spark.sql.catalyst.InternalRow;
@@ -34,12 +34,12 @@ public class TestSparkWriterMetrics extends TestWriterMetrics<InternalRow> {
   }
 
   @Override
-  protected FileWriterFactory<InternalRow> newWriterFactory(Schema dataSchema) {
-    return SparkFileWriterFactory.builderFor(table)
-        .dataSchema(table.schema())
+  protected FileWriterFactory<InternalRow> newWriterFactory(Table sourceTable) {
+    return SparkFileWriterFactory.builderFor(sourceTable)
+        .dataSchema(sourceTable.schema())
         .dataFileFormat(fileFormat)
         .deleteFileFormat(fileFormat)
-        .positionDeleteRowSchema(table.schema())
+        .positionDeleteRowSchema(sourceTable.schema())
         .build();
   }
 
@@ -54,6 +54,15 @@ public class TestSparkWriterMetrics extends TestWriterMetrics<InternalRow> {
     nested.update(1, longValue);
 
     row.update(2, nested);
+    return row;
+  }
+
+  @Override
+  protected InternalRow toGenericRow(int value, int repeated) {
+    InternalRow row = new GenericInternalRow(repeated);
+    for (int i = 0; i < repeated; i++) {
+      row.update(i, value);
+    }
     return row;
   }
 }

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkWriterMetrics.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkWriterMetrics.java
@@ -20,7 +20,7 @@
 package org.apache.iceberg.spark.source;
 
 import org.apache.iceberg.FileFormat;
-import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.io.FileWriterFactory;
 import org.apache.iceberg.io.TestWriterMetrics;
 import org.apache.spark.sql.catalyst.InternalRow;
@@ -34,12 +34,12 @@ public class TestSparkWriterMetrics extends TestWriterMetrics<InternalRow> {
   }
 
   @Override
-  protected FileWriterFactory<InternalRow> newWriterFactory(Schema dataSchema) {
-    return SparkFileWriterFactory.builderFor(table)
-        .dataSchema(table.schema())
+  protected FileWriterFactory<InternalRow> newWriterFactory(Table sourceTable) {
+    return SparkFileWriterFactory.builderFor(sourceTable)
+        .dataSchema(sourceTable.schema())
         .dataFileFormat(fileFormat)
         .deleteFileFormat(fileFormat)
-        .positionDeleteRowSchema(table.schema())
+        .positionDeleteRowSchema(sourceTable.schema())
         .build();
   }
 
@@ -54,6 +54,15 @@ public class TestSparkWriterMetrics extends TestWriterMetrics<InternalRow> {
     nested.update(1, longValue);
 
     row.update(2, nested);
+    return row;
+  }
+
+  @Override
+  protected InternalRow toGenericRow(int value, int repeated) {
+    InternalRow row = new GenericInternalRow(repeated);
+    for (int i = 0; i < repeated; i++) {
+      row.update(i, value);
+    }
     return row;
   }
 }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkWriterMetrics.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkWriterMetrics.java
@@ -20,7 +20,7 @@
 package org.apache.iceberg.spark.source;
 
 import org.apache.iceberg.FileFormat;
-import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.io.FileWriterFactory;
 import org.apache.iceberg.io.TestWriterMetrics;
 import org.apache.spark.sql.catalyst.InternalRow;
@@ -34,12 +34,12 @@ public class TestSparkWriterMetrics extends TestWriterMetrics<InternalRow> {
   }
 
   @Override
-  protected FileWriterFactory<InternalRow> newWriterFactory(Schema dataSchema) {
-    return SparkFileWriterFactory.builderFor(table)
-        .dataSchema(table.schema())
+  protected FileWriterFactory<InternalRow> newWriterFactory(Table sourceTable) {
+    return SparkFileWriterFactory.builderFor(sourceTable)
+        .dataSchema(sourceTable.schema())
         .dataFileFormat(fileFormat)
         .deleteFileFormat(fileFormat)
-        .positionDeleteRowSchema(table.schema())
+        .positionDeleteRowSchema(sourceTable.schema())
         .build();
   }
 
@@ -54,6 +54,15 @@ public class TestSparkWriterMetrics extends TestWriterMetrics<InternalRow> {
     nested.update(1, longValue);
 
     row.update(2, nested);
+    return row;
+  }
+
+  @Override
+  protected InternalRow toGenericRow(int value, int repeated) {
+    InternalRow row = new GenericInternalRow(repeated);
+    for (int i = 0; i < repeated; i++) {
+      row.update(i, value);
+    }
     return row;
   }
 }


### PR DESCRIPTION
Giving a try to the suggestion in the last community sync to address very-wide-table.

This changes the default MetricsMode from "truncate(16)" to "none" if there are over 100 columns (should it be counts?).  This is overriden if the user explicitly sets a default, and of course if a user explicitly sets metrics on a particular column.