### PR TITLE
AWS: fix Glue catalog for unknown commit status

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -114,6 +114,8 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
       Map<String, String> properties = prepareProperties(glueTable, newMetadataLocation);
       persistGlueTable(glueTable, properties, metadata);
       commitStatus = CommitStatus.SUCCESS;
+    } catch (CommitFailedException e) {
+      throw e;
     } catch (ConcurrentModificationException e) {
       throw new CommitFailedException(e, "Cannot commit %s because Glue detected concurrent update", tableName());
     } catch (software.amazon.awssdk.services.glue.model.AlreadyExistsException e) {


### PR DESCRIPTION
#3717 changed the exception in Glue integration test. Fix test name and behavior.

@jackye1995 