### PR TITLE
close parquet writer compressor to avoid leaking the native memory #3950

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
@@ -235,6 +235,7 @@ class ParquetWriter<T> implements FileAppender<T>, Closeable {
       if (writer != null) {
         writer.end(metadata);
       }
+      this.compressor.release();
     }
   }
 }


### PR DESCRIPTION
link to issue https://github.com/apache/iceberg/issues/3950,
this issue report "the compressor of ParquetWriter, the compressor needs to be released once the writer is closed. If this doesn't happen we are leaking the native memory associated with the compressor."