### PR TITLE
Core: fix it will not be rewritten when only one large file is divided into several target files

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
@@ -223,7 +223,6 @@ public abstract class BaseRewriteDataFilesAction<ThisT>
 
     Map<StructLikeWrapper, Collection<FileScanTask>> groupedTasks = groupTasksByPartition(fileScanTasks.iterator());
     Map<StructLikeWrapper, Collection<FileScanTask>> filteredGroupedTasks = groupedTasks.entrySet().stream()
-        .filter(kv -> kv.getValue().size() > 1)
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     // Nothing to rewrite if there's only one DataFile in each partition.


### PR DESCRIPTION
If there is only one huge datafile, it will be ignore. So it should not judge the number of files in a task at first. 
In the following process, the number of files in the task is judged, so it can be deleted directly here.