### PR TITLE
Hive: Parquet vectorization support for Hive 3

### DIFF
--- a/hive3/src/main/java/org/apache/iceberg/mr/hive/vector/HiveVectorizedReader.java
+++ b/hive3/src/main/java/org/apache/iceberg/mr/hive/vector/HiveVectorizedReader.java
@@ -25,10 +25,13 @@ import java.util.Map;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.hadoop.hive.ql.io.IOConstants;
 import org.apache.hadoop.hive.ql.io.orc.OrcSplit;
 import org.apache.hadoop.hive.ql.io.orc.VectorizedOrcInputFormat;
+import org.apache.hadoop.hive.ql.io.parquet.VectorizedParquetInputFormat;
 import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
 import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.RecordReader;
@@ -38,13 +41,18 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.mr.mapred.MapredIcebergInputFormat;
 import org.apache.iceberg.orc.VectorizedReadUtils;
+import org.apache.iceberg.parquet.ParquetSchemaUtil;
+import org.apache.iceberg.parquet.TypeWithSchemaVisitor;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.orc.impl.OrcTail;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.schema.MessageType;
 
 /**
  * Utility class to create vectorized readers for Hive.
@@ -98,26 +106,64 @@ public class HiveVectorizedReader {
     }
 
     try {
+
+      long start = task.start();
+      long length = task.length();
+
+      RecordReader<NullWritable, VectorizedRowBatch> recordReader = null;
+
       switch (format) {
         case ORC:
-
-          // Metadata information has to be passed along in the OrcSplit. Without specifying this, the vectorized
-          // reader will assume that the ORC file ends at the task's start + length, and might fail reading the tail..
-          OrcTail orcTail = VectorizedReadUtils.getOrcTail(inputFile, job);
-
-          InputSplit split = new OrcSplit(path, null, task.start(), task.length(), (String[]) null, orcTail,
-              false, false, Lists.newArrayList(), 0, task.length(), path.getParent());
-          RecordReader<NullWritable, VectorizedRowBatch> recordReader =
-              new VectorizedOrcInputFormat().getRecordReader(split, job, reporter);
-          return createVectorizedRowBatchIterable(recordReader, job, partitionColIndices, partitionValues);
+          recordReader = orcRecordReader(job, reporter, task, inputFile, path, start, length);
+          break;
+        case PARQUET:
+          recordReader = parquetRecordReader(job, reporter, task, path, start, length);
+          break;
 
         default:
           throw new UnsupportedOperationException("Vectorized Hive reading unimplemented for format: " + format);
       }
 
+      return createVectorizedRowBatchIterable(recordReader, job, partitionColIndices, partitionValues);
+
     } catch (IOException ioe) {
       throw new RuntimeException("Error creating vectorized record reader for " + inputFile, ioe);
     }
+  }
+
+
+  private static RecordReader<NullWritable, VectorizedRowBatch> orcRecordReader(JobConf job, Reporter reporter,
+      FileScanTask task, InputFile inputFile, Path path, long start, long length) throws IOException {
+    // Metadata information has to be passed along in the OrcSplit. Without specifying this, the vectorized
+    // reader will assume that the ORC file ends at the task's start + length, and might fail reading the tail..
+    OrcTail orcTail = VectorizedReadUtils.getOrcTail(inputFile, job);
+
+    InputSplit split = new OrcSplit(path, null, start, length, (String[]) null, orcTail,
+        false, false, Lists.newArrayList(), 0, task.length(), path.getParent());
+    return new VectorizedOrcInputFormat().getRecordReader(split, job, reporter);
+  }
+
+  private static RecordReader<NullWritable, VectorizedRowBatch> parquetRecordReader(JobConf job, Reporter reporter,
+      FileScanTask task, Path path, long start, long length) throws IOException {
+    InputSplit split = new FileSplit(path, start, length, job);
+    VectorizedParquetInputFormat inputFormat = new VectorizedParquetInputFormat();
+
+    MessageType fileSchema = ParquetFileReader.readFooter(job, path).getFileMetaData().getSchema();
+    MessageType typeWithIds = null;
+    Schema expectedSchema = task.spec().schema();
+
+    if (ParquetSchemaUtil.hasIds(fileSchema)) {
+      typeWithIds = ParquetSchemaUtil.pruneColumns(fileSchema, expectedSchema);
+    } else {
+      typeWithIds = ParquetSchemaUtil.pruneColumnsFallback(ParquetSchemaUtil.addFallbackIds(fileSchema),
+          expectedSchema);
+    }
+
+    ParquetSchemaFieldNameVisitor psv = new ParquetSchemaFieldNameVisitor();
+    TypeWithSchemaVisitor.visit(expectedSchema.asStruct(), typeWithIds, psv);
+    job.set(IOConstants.COLUMNS, psv.retrieveColumnNameList());
+
+    return inputFormat.getRecordReader(split, job, reporter);
   }
 
   private static <D> CloseableIterable<D> createVectorizedRowBatchIterable(

--- a/hive3/src/main/java/org/apache/iceberg/mr/hive/vector/HiveVectorizedReader.java
+++ b/hive3/src/main/java/org/apache/iceberg/mr/hive/vector/HiveVectorizedReader.java
@@ -159,7 +159,7 @@ public class HiveVectorizedReader {
           expectedSchema);
     }
 
-    ParquetSchemaFieldNameVisitor psv = new ParquetSchemaFieldNameVisitor();
+    ParquetSchemaFieldNameVisitor psv = new ParquetSchemaFieldNameVisitor(fileSchema);
     TypeWithSchemaVisitor.visit(expectedSchema.asStruct(), typeWithIds, psv);
     job.set(IOConstants.COLUMNS, psv.retrieveColumnNameList());
 

--- a/hive3/src/main/java/org/apache/iceberg/mr/hive/vector/ParquetSchemaFieldNameVisitor.java
+++ b/hive3/src/main/java/org/apache/iceberg/mr/hive/vector/ParquetSchemaFieldNameVisitor.java
@@ -31,7 +31,7 @@ import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Type;
 
 /**
- * Collects to top level field names from Parquet schema. During schema visit it translates the expected schema's
+ * Collects the top level field names from Parquet schema. During schema visit it translates the expected schema's
  * field names to what fields the visitor can match in the file schema to support column renames.
  */
 class ParquetSchemaFieldNameVisitor extends TypeWithSchemaVisitor<Type> {

--- a/hive3/src/main/java/org/apache/iceberg/mr/hive/vector/ParquetSchemaFieldNameVisitor.java
+++ b/hive3/src/main/java/org/apache/iceberg/mr/hive/vector/ParquetSchemaFieldNameVisitor.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive.vector;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.parquet.TypeWithSchemaVisitor;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.Types;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.Type;
+
+/**
+ * Collects to top level field names from Parquet schema. During schema visit it translates the expected schema's
+ * field names to what fields the visitor can match in the file schema to support column renames.
+ */
+class ParquetSchemaFieldNameVisitor extends TypeWithSchemaVisitor<Type> {
+  private final Map<Integer, Type> typesById = Maps.newHashMap();
+  private StringBuilder sb = new StringBuilder();
+
+  ParquetSchemaFieldNameVisitor() {
+  }
+
+  @Override
+  public Type message(Types.StructType expected, MessageType message, List<Type> fields) {
+    return this.struct(expected, message.asGroupType(), fields);
+  }
+
+  @Override
+  public Type struct(Types.StructType expected, GroupType struct, List<Type> fields) {
+    boolean isMessageType = struct instanceof MessageType;
+
+    List<Types.NestedField> expectedFields = expected != null ? expected.fields() : ImmutableList.of();
+    List<Type> types = Lists.newArrayListWithExpectedSize(expectedFields.size());
+
+    for (Types.NestedField field : expectedFields) {
+      int id = field.fieldId();
+      if (id != MetadataColumns.ROW_POSITION.fieldId() && id != MetadataColumns.IS_DELETED.fieldId()) {
+        Type fieldInFileSchema = typesById.get(id);
+        if (fieldInFileSchema == null) {
+          // New field - not in this parquet file yet, add the new field name instead of null
+          appendToColNamesList(isMessageType, field.name());
+        } else {
+          // Already present column in this parquet file, add the original name
+          types.add(fieldInFileSchema);
+          appendToColNamesList(isMessageType, fieldInFileSchema.getName());
+        }
+      }
+    }
+
+    if (!isMessageType) {
+      GroupType groupType = new GroupType(Type.Repetition.REPEATED, fieldNames.peek(), types);
+      typesById.put(struct.getId().intValue(), groupType);
+      return groupType;
+    } else {
+      return new MessageType("table", types);
+    }
+  }
+
+  private void appendToColNamesList(boolean isMessageType, String colName) {
+    if (isMessageType) {
+      sb.append(colName).append(',');
+    }
+  }
+
+  @Override
+  public Type primitive(org.apache.iceberg.types.Type.PrimitiveType expected,
+      org.apache.parquet.schema.PrimitiveType primitive) {
+    typesById.put(primitive.getId().intValue(), primitive);
+    return primitive;
+  }
+
+  @Override
+  public Type list(Types.ListType iList, GroupType array, Type element) {
+    typesById.put(array.getId().intValue(), array);
+    return array;
+  }
+
+  @Override
+  public Type map(Types.MapType iMap, GroupType map, Type key, Type value) {
+    typesById.put(map.getId().intValue(), map);
+    return map;
+  }
+
+  public String retrieveColumnNameList() {
+    sb.setLength(sb.length() - 1);
+    return sb.toString();
+  }
+}

--- a/hive3/src/main/java/org/apache/iceberg/mr/hive/vector/ParquetSchemaFieldNameVisitor.java
+++ b/hive3/src/main/java/org/apache/iceberg/mr/hive/vector/ParquetSchemaFieldNameVisitor.java
@@ -1,7 +1,11 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -16,7 +20,6 @@ package org.apache.iceberg.mr.hive.vector;
 
 import java.util.List;
 import java.util.Map;
-
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.parquet.TypeWithSchemaVisitor;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;

--- a/hive3/src/main/java/org/apache/iceberg/mr/hive/vector/ParquetSchemaFieldNameVisitor.java
+++ b/hive3/src/main/java/org/apache/iceberg/mr/hive/vector/ParquetSchemaFieldNameVisitor.java
@@ -58,9 +58,10 @@ class ParquetSchemaFieldNameVisitor extends TypeWithSchemaVisitor<Type> {
 
     for (Types.NestedField field : expectedFields) {
       int id = field.fieldId();
-      if (id == MetadataColumns.ROW_POSITION.fieldId() || id == MetadataColumns.IS_DELETED.fieldId()) {
+      if (MetadataColumns.metadataFieldIds().contains(id)) {
         continue;
       }
+
       Type fieldInPrunedFileSchema = typesById.get(id);
       if (fieldInPrunedFileSchema == null) {
         if (!originalFileSchema.containsField(field.name())) {
@@ -76,7 +77,6 @@ class ParquetSchemaFieldNameVisitor extends TypeWithSchemaVisitor<Type> {
         types.add(fieldInPrunedFileSchema);
         appendToColNamesList(isMessageType, fieldInPrunedFileSchema.getName());
       }
-
     }
 
     if (!isMessageType) {

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergInputFormat.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergInputFormat.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.SerializationUtilities;
+import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedInputFormatInterface;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedSupport;
 import org.apache.hadoop.hive.ql.io.CombineHiveInputFormat;
@@ -106,8 +107,12 @@ public class HiveIcebergInputFormat extends MapredIcebergInputFormat<Record>
     String[] selectedColumns = ColumnProjectionUtils.getReadColumnNames(job);
     job.setStrings(InputFormatConfig.SELECTED_COLUMNS, selectedColumns);
 
-    if (HiveConf.getBoolVar(job, HiveConf.ConfVars.HIVE_VECTORIZATION_ENABLED)) {
+    if (HiveConf.getBoolVar(job, HiveConf.ConfVars.HIVE_VECTORIZATION_ENABLED) &&
+        Utilities.getVectorizedRowBatchCtx(job) != null) {
       Preconditions.checkArgument(MetastoreUtil.hive3PresentOnClasspath(), "Vectorization only supported for Hive 3+");
+
+      job.setEnum(InputFormatConfig.IN_MEMORY_DATA_MODEL, InputFormatConfig.InMemoryDataModel.HIVE);
+      job.setBoolean(InputFormatConfig.SKIP_RESIDUAL_FILTERING, true);
 
       IcebergSplit icebergSplit = ((IcebergSplitContainer) split).icebergSplit();
       // bogus cast for favouring code reuse over syntax

--- a/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Properties;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaHook;
 import org.apache.hadoop.hive.ql.metadata.HiveStorageHandler;
 import org.apache.hadoop.hive.ql.metadata.HiveStoragePredicateHandler;
@@ -128,11 +127,6 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
       if (catalogName != null) {
         jobConf.set(InputFormatConfig.TABLE_CATALOG_PREFIX + tableName, catalogName);
       }
-    }
-
-    if (HiveConf.getBoolVar(jobConf, HiveConf.ConfVars.HIVE_VECTORIZATION_ENABLED)) {
-      jobConf.setEnum(InputFormatConfig.IN_MEMORY_DATA_MODEL, InputFormatConfig.InMemoryDataModel.HIVE);
-      conf.setBoolean(InputFormatConfig.SKIP_RESIDUAL_FILTERING, true);
     }
   }
 

--- a/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -357,29 +357,37 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
     }
 
     private CloseableIterable<T> newParquetIterable(InputFile inputFile, FileScanTask task, Schema readSchema) {
-      Parquet.ReadBuilder parquetReadBuilder = Parquet.read(inputFile)
-          .project(readSchema)
-          .filter(task.residual())
-          .caseSensitive(caseSensitive)
-          .split(task.start(), task.length());
-      if (reuseContainers) {
-        parquetReadBuilder.reuseContainers();
-      }
-      if (nameMapping != null) {
-        parquetReadBuilder.withNameMapping(NameMappingParser.fromJson(nameMapping));
-      }
+      Map<Integer, ?> idToConstant = constantsMap(task, IdentityPartitionConverters::convertConstant);
+      CloseableIterable<T> parquetIterator = null;
 
       switch (inMemoryDataModel) {
         case PIG:
+          throw new UnsupportedOperationException("Parquet support not yet supported for Pig");
         case HIVE:
-          // TODO implement value readers for Pig and Hive
-          throw new UnsupportedOperationException("Parquet support not yet supported for Pig and Hive");
+          if (MetastoreUtil.hive3PresentOnClasspath()) {
+            parquetIterator = HIVE_VECTORIZED_READER_BUILDER.invoke(inputFile, task, idToConstant, context);
+          } else {
+            throw new UnsupportedOperationException("Vectorized read is unsupported for Hive 2 integration.");
+          }
+          break;
         case GENERIC:
+          Parquet.ReadBuilder parquetReadBuilder = Parquet.read(inputFile)
+              .project(readSchema)
+              .filter(task.residual())
+              .caseSensitive(caseSensitive)
+              .split(task.start(), task.length());
+          if (reuseContainers) {
+            parquetReadBuilder.reuseContainers();
+          }
+          if (nameMapping != null) {
+            parquetReadBuilder.withNameMapping(NameMappingParser.fromJson(nameMapping));
+          }
           parquetReadBuilder.createReaderFunc(
               fileSchema -> GenericParquetReaders.buildReader(
                   readSchema, fileSchema, constantsMap(task, IdentityPartitionConverters::convertConstant)));
+          parquetIterator = parquetReadBuilder.build();
       }
-      return applyResidualFiltering(parquetReadBuilder.build(), task.residual(), readSchema);
+      return applyResidualFiltering(parquetIterator, task.residual(), readSchema);
     }
 
     private CloseableIterable<T> newOrcIterable(InputFile inputFile, FileScanTask task, Schema readSchema) {


### PR DESCRIPTION
Adding support or Parquet vectorization. Similarly to how this was done with ORC, we are reusing the already implemented Parquet vectorized read implementation of Hive. It is hooked into IcebergInputFormat to create the record reader from the split and fileScanTask information.

This change also reuses parts of the proposed solution in https://github.com/apache/iceberg/pull/3242 by @tprelle so that query plans that failed to get vectorized during Hive query compilation are correctly falling back to the non-vectorized read path.