### PR TITLE
generics and associated tests - no literals

### DIFF
--- a/python/src/iceberg/types.py
+++ b/python/src/iceberg/types.py
@@ -14,186 +14,123 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Data types used in describing Iceberg schemas
 
+"""Data types used in describing Iceberg schemas
 This module implements the data types described in the Iceberg specification for Iceberg schemas. To
 describe an Iceberg table schema, these classes can be used in the construction of a StructType instance.
 
-Example:
-    >>> StructType(
-        [
-            NestedField(True, 1, "required_field", StringType()),
-            NestedField(False, 2, "optional_field", IntegerType()),
-        ]
-    )
+Examples:
+    >>>StructType[
+        NestedField[Decimal[32, 3], 0, "c1", True],
+        NestedField[Float, 1, "c2", False],
+    ]
+
+    StructType[field0=NestedField[type=Decimal[scale=32, precision=3], field_id=0, name='c1', optional=True, doc=''], field1=NestedField[type=Float, field_id=1, name='c2', optional=False, doc='']]
 
 Notes:
   - https://iceberg.apache.org/#spec/#primitive-types
 """
 
-from typing import Optional
+import re
+from typing import Dict, Optional, Type, Union
 
 
-class Type:
-    def __init__(self, type_string: str, repr_string: str, is_primitive=False):
-        self._type_string = type_string
-        self._repr_string = repr_string
-        self._is_primitive = is_primitive
+class IcebergMetaType(type):
+    """
+    MetaClass to:
+        Generate a repr for an `IcebergType`
+        Facilitate generating generics with __getitem__
+        Covariant `issubclass`
+        Check type genericism/primitivism
 
-    def __repr__(self):
-        return self._repr_string
-
-    def __str__(self):
-        return self._type_string
-
-    @property
-    def is_primitive(self) -> bool:
-        return self._is_primitive
-
-
-class FixedType(Type):
-    def __init__(self, length: int):
-        super().__init__(
-            f"fixed[{length}]", f"FixedType(length={length})", is_primitive=True
-        )
-        self._length = length
-
-    @property
-    def length(self) -> int:
-        return self._length
-
-
-class DecimalType(Type):
-    def __init__(self, precision: int, scale: int):
-        super().__init__(
-            f"decimal({precision}, {scale})",
-            f"DecimalType(precision={precision}, scale={scale})",
-            is_primitive=True,
-        )
-        self._precision = precision
-        self._scale = scale
-
-    @property
-    def precision(self) -> int:
-        return self._precision
-
-    @property
-    def scale(self) -> int:
-        return self._scale
-
-
-class NestedField(object):
-    def __init__(
-        self,
-        is_optional: bool,
-        field_id: int,
-        name: str,
-        field_type: Type,
-        doc: Optional[str] = None,
-    ):
-        self._is_optional = is_optional
-        self._id = field_id
-        self._name = name
-        self._type = field_type
-        self._doc = doc
-
-    @property
-    def is_optional(self) -> bool:
-        return self._is_optional
-
-    @property
-    def is_required(self) -> bool:
-        return not self._is_optional
-
-    @property
-    def field_id(self) -> int:
-        return self._id
-
-    @property
-    def name(self) -> str:
-        return self._name
-
-    @property
-    def type(self) -> Type:
-        return self._type
-
-    def __repr__(self):
-        return (
-            f"NestedField(is_optional={self._is_optional}, field_id={self._id}, "
-            f"name={repr(self._name)}, field_type={repr(self._type)}, doc={repr(self._doc)})"
-        )
-
-    def __str__(self):
-        return (
-            f"{self._id}: {self._name}: {'optional' if self._is_optional else 'required'} {self._type}"
-            ""
-            if self._doc is None
-            else f" ({self._doc})"
-        )
-
-
-class StructType(Type):
-    def __init__(self, fields: list):
-        super().__init__(
-            f"struct<{', '.join(map(str, fields))}>",
-            f"StructType(fields={repr(fields)})",
-        )
-        self._fields = fields
-
-    @property
-    def fields(self) -> list:
-        return self._fields
-
-
-class ListType(Type):
-    def __init__(self, element: NestedField):
-        super().__init__(f"list<{element.type}>", f"ListType(element={repr(element)})")
-        self._element_field = element
-
-    @property
-    def element(self) -> NestedField:
-        return self._element_field
-
-
-class MapType(Type):
-    def __init__(self, key: NestedField, value: NestedField):
-        super().__init__(
-            f"map<{key.type}, {value.type}>",
-            f"MapType(key={repr(key)}, value={repr(value)})",
-        )
-        self._key_field = key
-        self._value_field = value
-
-    @property
-    def key(self) -> NestedField:
-        return self._key_field
-
-    @property
-    def value(self) -> NestedField:
-        return self._value_field
-
-
-class BooleanType(Type):
-    """A boolean data type in Iceberg can be represented using an instance of this class.
-
-    Example:
-        >>> column_foo = BooleanType()
-        >>> isinstance(column_foo, BooleanType)
-        True
+    Note: for internal iceberg use only
     """
 
-    def __init__(self):
-        super().__init__("boolean", "BooleanType()", is_primitive=True)
+    def __repr__(cls):
+        return cls.__name__
+
+    def __str__(cls):
+        return re.sub("[a-zA-Z0-9_]*?=", "", cls.__name__)
+
+    def __eq__(cls, other):
+        try:
+            return cls.generic == other.generic and all(
+                getattr(cls, k) == getattr(other, k)
+                for k in cls.generic_attributes.keys()
+            )
+        except AttributeError:
+            return cls is other
+
+    def __hash__(cls):
+        return id(cls)
+
+    def __subclasscheck__(
+        cls, other
+    ):  # custom subclass check for when checking `issubclass` on an IcebergType to ensure covariance on generics
+        if cls == other:
+            return True
+        if cls.is_specified_generic() and other.is_specified_generic():
+            for a in cls.generic_attributes.keys():
+                sv, tv = getattr(other, a), getattr(cls, a)
+                # check Const values
+                if not isinstance(sv, type):
+                    if not isinstance(tv, type):
+                        if type(sv) == type(tv) and sv == tv:
+                            continue
+                    return False
+                if not issubclass(sv, tv):
+                    return False
+            return True
+        return cls in other.__mro__
+
+    def __getitem__(cls, key):
+        return cls._get_generic(cls, key)
+
+    def is_specified_generic(cls):
+        return bool(getattr(cls, "generic", False))
+
+    def is_generic(cls):
+        return (
+            bool(getattr(cls, "_get_generic", False)) and not cls.is_specified_generic()
+        )
+
+    def is_primitive(cls):
+        return PrimitiveType in cls.__mro__
 
 
-class IntegerType(Type):
+class IcebergType(metaclass=IcebergMetaType):
+    """Base type for all Iceberg Types"""
+
+
+class PrimitiveType(IcebergType):
+    """Base class for all Iceberg Primitive Types"""
+
+    def __init__(self, value: Optional[Union[bytes, bool, int, float, str]] = None):
+        self._value = value
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}"
+
+
+class NumberType(PrimitiveType):
+    """Type base for all numeric types e.g. Integer, Long, Float, Double"""
+
+
+class IntegralType(NumberType):
+    """Type base for all integral types e.g. Integer, Long"""
+
+
+class FloatingType(NumberType):
+    """Type base for all floating types e.g. Float, Double"""
+
+
+class BooleanType(PrimitiveType):
+    """A boolean data type in Iceberg can be represented using an instance of this class."""
+
+
+class IntegerType(IntegralType):
     """An Integer data type in Iceberg can be represented using an instance of this class. Integers in Iceberg are
     32-bit signed and can be promoted to Longs.
-
-    Example:
-        >>> column_foo = IntegerType()
-        >>> isinstance(column_foo, IntegerType)
-        True
 
     Attributes:
         max (int): The maximum allowed value for Integers, inherited from the canonical Iceberg implementation
@@ -206,18 +143,10 @@ class IntegerType(Type):
 
     min: int = -2147483648
 
-    def __init__(self):
-        super().__init__("int", "IntegerType()", is_primitive=True)
 
-
-class LongType(Type):
+class LongType(IntegralType):
     """A Long data type in Iceberg can be represented using an instance of this class. Longs in Iceberg are
     64-bit signed integers.
-
-    Example:
-        >>> column_foo = LongType()
-        >>> isinstance(column_foo, LongType)
-        True
 
     Attributes:
         max (int): The maximum allowed value for Longs, inherited from the canonical Iceberg implementation
@@ -230,133 +159,259 @@ class LongType(Type):
 
     min: int = -9223372036854775808
 
-    def __init__(self):
-        super().__init__("long", "LongType()", is_primitive=True)
 
-
-class FloatType(Type):
+class FloatType(FloatingType):
     """A Float data type in Iceberg can be represented using an instance of this class. Floats in Iceberg are
     32-bit IEEE 754 floating points and can be promoted to Doubles.
-
-    Example:
-        >>> column_foo = FloatType()
-        >>> isinstance(column_foo, FloatType)
-        True
     """
 
-    def __init__(self):
-        super().__init__("float", "FloatType()", is_primitive=True)
 
-
-class DoubleType(Type):
+class DoubleType(FloatingType):
     """A Double data type in Iceberg can be represented using an instance of this class. Doubles in Iceberg are
     64-bit IEEE 754 floating points.
-
-    Example:
-        >>> column_foo = DoubleType()
-        >>> isinstance(column_foo, DoubleType)
-        True
     """
 
-    def __init__(self):
-        super().__init__("double", "DoubleType()", is_primitive=True)
 
-
-class DateType(Type):
+class DateType(PrimitiveType):
     """A Date data type in Iceberg can be represented using an instance of this class. Dates in Iceberg are
     calendar dates without a timezone or time.
-
-    Example:
-        >>> column_foo = DateType()
-        >>> isinstance(column_foo, DateType)
-        True
     """
 
-    def __init__(self):
-        super().__init__("date", "DateType()", is_primitive=True)
 
-
-class TimeType(Type):
+class TimeType(PrimitiveType):
     """A Time data type in Iceberg can be represented using an instance of this class. Times in Iceberg
     have microsecond precision and are a time of day without a date or timezone.
-
-    Example:
-        >>> column_foo = TimeType()
-        >>> isinstance(column_foo, TimeType)
-        True
-
     """
 
-    def __init__(self):
-        super().__init__("time", "TimeType()", is_primitive=True)
 
-
-class TimestampType(Type):
+class TimestampType(PrimitiveType):
     """A Timestamp data type in Iceberg can be represented using an instance of this class. Timestamps in
     Iceberg have microsecond precision and include a date and a time of day without a timezone.
-
-    Example:
-        >>> column_foo = TimestampType()
-        >>> isinstance(column_foo, TimestampType)
-        True
-
     """
 
-    def __init__(self):
-        super().__init__("timestamp", "TimestampType()", is_primitive=True)
 
-
-class TimestamptzType(Type):
+class TimestamptzType(PrimitiveType):
     """A Timestamptz data type in Iceberg can be represented using an instance of this class. Timestamptzs in
     Iceberg are stored as UTC and include a date and a time of day with a timezone.
-
-    Example:
-        >>> column_foo = TimestamptzType()
-        >>> isinstance(column_foo, TimestamptzType)
-        True
     """
 
-    def __init__(self):
-        super().__init__("timestamptz", "TimestamptzType()", is_primitive=True)
 
-
-class StringType(Type):
+class StringType(PrimitiveType):
     """A String data type in Iceberg can be represented using an instance of this class. Strings in
     Iceberg are arbitrary-length character sequences and are encoded with UTF-8.
-
-    Example:
-        >>> column_foo = StringType()
-        >>> isinstance(column_foo, StringType)
-        True
     """
 
-    def __init__(self):
-        super().__init__("string", "StringType()", is_primitive=True)
 
-
-class UUIDType(Type):
+class UUIDType(PrimitiveType):
     """A UUID data type in Iceberg can be represented using an instance of this class. UUIDs in
     Iceberg are universally unique identifiers.
-
-    Example:
-        >>> column_foo = UUIDType()
-        >>> isinstance(column_foo, UUIDType)
-        True
     """
 
-    def __init__(self):
-        super().__init__("uuid", "UUIDType()", is_primitive=True)
 
-
-class BinaryType(Type):
+class BinaryType(PrimitiveType):
     """A Binary data type in Iceberg can be represented using an instance of this class. Binarys in
     Iceberg are arbitrary-length byte arrays.
-
-    Example:
-        >>> column_foo = BinaryType()
-        >>> isinstance(column_foo, BinaryType)
-        True
     """
 
-    def __init__(self):
-        super().__init__("binary", "BinaryType()", is_primitive=True)
+
+# a factory for generic type factories
+class generic_class(type):
+    def __new__(
+        cls,
+        name: str,
+        generic_attributes: Dict[
+            str, Union[Type[IcebergType], Type[int], Type[str], Type[bool]]
+        ],
+        base_type: type = IcebergType,
+        doc: str = "",
+        meta_doc: str = "",
+        defaults: Dict[str, Union[IcebergType, int, float, str, bool]] = {},
+    ):
+        """facilitates generating generic type factories such as `List` e.g. `List[Integer]`
+
+        Args:
+            name: the name of the generic type used in repr and str
+            generic_attributes: dict of generic attribute names:types
+            base_type: class for generic to inherit from
+            doc: docstring of specfied generic type e.g. FixedType[8]
+            meta_doc: docstring of unspecified generic e.g. FixedType
+
+        Examples:
+            >>>FixedType = generic_class("FixedType", {"length", Const[int])], PrimitiveType)
+            >>>FixedType[8]
+            FixedType[length=8]
+        """
+
+        def get_generic(cls, attrs):
+            # take the attribute value specified at type definition
+            attrs = attrs if isinstance(attrs, tuple) else (attrs,)
+            if attrs in cls._implemented:
+                return cls._implemented[attrs]
+
+            kwargs = defaults.copy()
+            kwargs = {**kwargs, **dict(zip(generic_attributes.keys(), attrs))}
+            kwargs = {k: kwargs[k] for k in generic_attributes.keys()}
+
+            # basic check of generic attributes
+            if len(kwargs) != len(generic_attributes):
+                raise TypeError(
+                    f"""Wrong number of generic parameters provided. Expected {len(generic_attributes)}
+                    parameter(s) of subtypes of ({",".join(repr(i) for i in generic_attributes.values())}).
+                    Provided {attrs}"""
+                )
+            # specified generic type class
+            class _Type(_Factory):
+                __doc__ = f"""Generic instance of {name} with generic attributes {generic_attributes}
+
+                {doc}
+                """
+                generic = _Factory
+
+            # add generic attrs as class attributes
+            for k, v in list(kwargs.items()) + [
+                ("generic_attributes", generic_attributes)
+            ]:
+                setattr(_Type, k, v)
+
+            # pretty name for repr
+            setattr(
+                _Type,
+                "__name__",
+                f"{name}[{', '.join(f'{k}={repr(v)}' for k,v in kwargs.items())}]",
+            )
+
+            # save type in _Factory so generics can equate Fixed[8]==Fixed[8]
+            cls._implemented[attrs] = _Type
+            return _Type
+
+        class _Factory(base_type):  # type: ignore
+            __doc__ = f"{meta_doc if meta_doc else name}"
+            _implemented: Dict[Type[IcebergType], Type[IcebergType]] = dict()
+
+        setattr(
+            _Factory,
+            "_get_generic",
+            get_generic,
+        )
+
+        setattr(
+            _Factory,
+            "__name__",
+            name,
+        )
+        return _Factory
+
+
+FixedType = generic_class(
+    "FixedType",
+    {"length": int},
+    PrimitiveType,
+    doc="""A fixed data type in Iceberg.
+
+    Example:
+        >>> FixedType[8]
+        FixedType[length=8]
+        >>> FixedType[8]==FixedType[8]
+        True
+    """,
+)
+
+DecimalType = generic_class(
+    "DecimalType",
+    {"precision": int, "scale": int},
+    PrimitiveType,
+    doc="""A decimal data type in Iceberg.
+
+    Example:
+        >>> DecimalType[32, 3]
+        DecimalType[precision=32, scale=3]
+        >>> DecimalType[32, 3]==DecimalType[32, 3]
+        True
+    """,
+)
+
+NestedField = generic_class(
+    "NestedField",
+    {"type": IcebergType, "field_id": int, "name": str, "optional": bool, "doc": str},
+    meta_doc="""equivalent of `NestedField` type from Java implementation""",
+    defaults={"optional": True, "doc": ""},
+)
+
+
+ListType = generic_class(
+    "ListType",
+    {"type": NestedField},  # type: ignore
+    doc="""a variable length array type in Iceberg
+    Example:
+        >>> ListType[NestedField[DecimalType[32, 3], 0, "c1", True]]
+        ListType[type=NestedField[type=DecimalType[scale=32, precision=3], field_id=0, name='c1', optional=True, doc='']]
+""",
+)
+
+MapType = generic_class(
+    "MapType",
+    {"key_type": NestedField, "value_type": NestedField},  # type: ignore
+    doc="""a variable length set of key, value pairs type in Iceberg
+    Example:
+        >>> MapType[NestedField[DecimalType[32, 3], 0, "c1", True], NestedField[Float, 1, "c2", False]]
+        MapType[key_type=NestedField[type=DecimalType[scale=32, precision=3], field_id=0, name='c1', optional=True, doc=''], value_type=NestedField[type=Float, field_id=1, name='c2', optional=False, doc='']]
+""",
+)
+
+
+def _struct():
+    def get_generic(cls, types):
+        types = types if isinstance(types, tuple) else (types,)
+        if types in cls._implemented:
+            return cls._implemented[types]
+
+        generic_attributes = {f"field{i}": f for i, f in enumerate(types)}
+
+        class _StructType(StructType):
+            """
+            A generic instance of Struct
+            """
+
+            def __repr__(self):
+                return f"{type(self)}({', '.join(repr(f) for f in self.fields)})"
+
+        for k, v in list(generic_attributes.items()) + [
+            ("generic_attributes", generic_attributes),
+            ("generic", StructType),
+            ("fields", list(generic_attributes.values())),
+        ]:
+            setattr(_StructType, k, v)
+
+        setattr(
+            _StructType,
+            "__name__",
+            f'StructType{[k+"="+repr(v) for k, v in _StructType.generic_attributes.items()]}'.replace(
+                '"', ""
+            ),
+        )
+        cls._implemented[types] = _StructType
+        return _StructType
+
+    class StructType(IcebergType):
+        """A record with named fields of any data type: `struct` from https://iceberg.apache.org/#schemas/
+
+        Examples:
+            >>>StructType[
+                NestedField[Decimal[32, 3], 0, "c1", True],
+                NestedField[Float, 1, "c2", False],
+            ]
+
+            StructType[field0=NestedField[type=Decimal[scale=32, precision=3], field_id=0, name='c1', optional=True, doc=''], field1=NestedField[type=Float, field_id=1, name='c2', optional=False, doc='']]"""
+
+        _implemented: Dict[Type[IcebergType], Type[IcebergType]] = dict()
+
+    setattr(
+        StructType,
+        "_get_generic",
+        get_generic,
+    )
+
+    return StructType
+
+
+StructType = _struct()

--- a/python/src/iceberg/types.py
+++ b/python/src/iceberg/types.py
@@ -15,7 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Data types used in describing Iceberg schemas
+"""
+Data types used in describing Iceberg schemas
 This module implements the data types described in the Iceberg specification for Iceberg schemas. To
 describe an Iceberg table schema, these classes can be used in the construction of a StructType instance.
 

--- a/python/tests/test_types.py
+++ b/python/tests/test_types.py
@@ -24,12 +24,15 @@ from iceberg.types import (
     DecimalType,
     DoubleType,
     FixedType,
+    FloatingType,
     FloatType,
     IntegerType,
     ListType,
     LongType,
     MapType,
     NestedField,
+    NumberType,
+    PrimitiveType,
     StringType,
     StructType,
     TimestampType,
@@ -40,124 +43,207 @@ from iceberg.types import (
 
 
 @pytest.mark.parametrize(
-    "input_type",
+    ("input_type", "_repr"),
     [
-        BooleanType,
-        IntegerType,
-        LongType,
-        FloatType,
-        DoubleType,
-        DateType,
-        TimeType,
-        TimestampType,
-        TimestamptzType,
-        StringType,
-        UUIDType,
-        BinaryType,
+        (BooleanType, "BooleanType"),
+        (IntegerType, "IntegerType"),
+        (LongType, "LongType"),
+        (FloatType, "FloatType"),
+        (DoubleType, "DoubleType"),
+        (DateType, "DateType"),
+        (TimeType, "TimeType"),
+        (TimestampType, "TimestampType"),
+        (TimestamptzType, "TimestamptzType"),
+        (StringType, "StringType"),
+        (UUIDType, "UUIDType"),
+        (BinaryType, "BinaryType"),
     ],
 )
-def test_repr_primitive_types(input_type):
-    assert isinstance(eval(repr(input_type())), input_type)
+def test_non_generic_primitive_repr_str(input_type, _repr):
+    assert str(input_type) == repr(input_type) == _repr
 
 
 def test_fixed_type():
-    type_var = FixedType(length=5)
+    type_var = FixedType[5]
     assert type_var.length == 5
-    assert str(type_var) == "fixed[5]"
-    assert repr(type_var) == "FixedType(length=5)"
-    assert str(type_var) == str(eval(repr(type_var)))
+    assert str(type_var) == "FixedType[5]"
+    assert repr(type_var) == "FixedType[length=5]"
+    assert type_var == eval(str(type_var))
 
 
 def test_decimal_type():
-    type_var = DecimalType(precision=9, scale=2)
+    type_var = DecimalType[9, 2]
     assert type_var.precision == 9
     assert type_var.scale == 2
-    assert str(type_var) == "decimal(9, 2)"
-    assert repr(type_var) == "DecimalType(precision=9, scale=2)"
-    assert str(type_var) == str(eval(repr(type_var)))
+    assert str(type_var) == "DecimalType[9, 2]"
+    assert repr(type_var) == "DecimalType[precision=9, scale=2]"
+    assert type_var == eval(str(type_var))
 
 
 def test_struct_type():
-    type_var = StructType(
-        [
-            NestedField(True, 1, "optional_field", IntegerType()),
-            NestedField(False, 2, "required_field", FixedType(5)),
-            NestedField(
-                False,
-                3,
-                "required_field",
-                StructType(
-                    [
-                        NestedField(True, 4, "optional_field", DecimalType(8, 2)),
-                        NestedField(False, 5, "required_field", LongType()),
-                    ]
-                ),
-            ),
-        ]
+    type_var = StructType[
+        NestedField[IntegerType, 1, "optional_field"],
+        NestedField[FixedType[5], 2, "required_field", False],
+        NestedField[
+            StructType[
+                NestedField[DecimalType[8, 2], 4, "optional_field"],
+                NestedField[LongType, 5, "required_field", False],
+            ],
+            3,
+            "required_field",
+            False,
+        ],
+    ]
+
+    assert (
+        repr(type_var)
+        == "StructType[field0=NestedField[type=IntegerType, field_id=1, name='optional_field', optional=True, doc=''], field1=NestedField[type=FixedType[length=5], field_id=2, name='required_field', optional=False, doc=''], field2=NestedField[type=StructType[field0=NestedField[type=DecimalType[precision=8, scale=2], field_id=4, name='optional_field', optional=True, doc=''], field1=NestedField[type=LongType, field_id=5, name='required_field', optional=False, doc='']], field_id=3, name='required_field', optional=False, doc='']]"
+    )
+    assert (
+        str(type_var)
+        == "StructType[NestedField[IntegerType, 1, 'optional_field', True, ''], NestedField[FixedType[5], 2, 'required_field', False, ''], NestedField[StructType[NestedField[DecimalType[8, 2], 4, 'optional_field', True, ''], NestedField[LongType, 5, 'required_field', False, '']], 3, 'required_field', False, '']]"
     )
     assert len(type_var.fields) == 3
-    assert str(type_var) == str(eval(repr(type_var)))
+    assert type_var == eval(str(type_var))
 
 
 def test_list_type():
-    type_var = ListType(
-        NestedField(
-            False,
+    type_var = ListType[
+        NestedField[
+            StructType[
+                NestedField[DecimalType[8, 2], 2, "optional_field"],
+                NestedField[LongType, 3, "required_field", False],
+            ],
             1,
             "required_field",
-            StructType(
-                [
-                    NestedField(True, 2, "optional_field", DecimalType(8, 2)),
-                    NestedField(False, 3, "required_field", LongType()),
-                ]
-            ),
-        )
-    )
-    assert isinstance(type_var.element.type, StructType)
-    assert len(type_var.element.type.fields) == 2
-    assert type_var.element.field_id == 1
-    assert str(type_var) == str(eval(repr(type_var)))
+            False,
+        ]
+    ]
+    assert issubclass(type_var.type.type, StructType)
+    assert len(type_var.type.type.fields) == 2
+    assert type_var.type.field_id == 1
+    assert type_var == eval(str(type_var))
 
 
 def test_map_type():
-    type_var = MapType(
-        NestedField(True, 1, "optional_field", DoubleType()),
-        NestedField(False, 2, "required_field", UUIDType()),
-    )
-    assert isinstance(type_var.key.type, DoubleType)
-    assert type_var.key.field_id == 1
-    assert isinstance(type_var.value.type, UUIDType)
-    assert type_var.value.field_id == 2
-    assert str(type_var) == str(eval(repr(type_var)))
+    type_var = MapType[
+        NestedField[DoubleType, 1, "optional_field"],
+        NestedField[UUIDType, 2, "required_field", False],
+    ]
+    assert type_var.key_type.type == DoubleType
+    assert type_var.key_type.field_id == 1
+    assert type_var.value_type.type == UUIDType
+    assert type_var.value_type.field_id == 2
+    assert type_var == eval(str(type_var))
 
 
 def test_nested_field():
-    field_var = NestedField(
-        True,
+    field_var = NestedField[
+        StructType[
+            NestedField[
+                ListType[NestedField[DoubleType, 3, "required_field3", False]],
+                2,
+                "optional_field2",
+            ],
+            NestedField[
+                4,
+                "required_field4",
+                MapType[
+                    NestedField[TimeType, 5, "optional_field5"],
+                    NestedField[UUIDType, 6, "required_field6", False],
+                ],
+            ],
+        ],
         1,
         "optional_field1",
-        StructType(
-            [
-                NestedField(
-                    True,
-                    2,
-                    "optional_field2",
-                    ListType(NestedField(False, 3, "required_field3", DoubleType())),
-                ),
-                NestedField(
-                    False,
-                    4,
-                    "required_field4",
-                    MapType(
-                        NestedField(True, 5, "optional_field5", TimeType()),
-                        NestedField(False, 6, "required_field6", UUIDType()),
-                    ),
-                ),
-            ]
-        ),
-    )
-    assert field_var.is_optional
-    assert not field_var.is_required
+    ]
+    assert field_var.optional
     assert field_var.field_id == 1
-    assert isinstance(field_var.type, StructType)
-    assert str(field_var) == str(eval(repr(field_var)))
+    assert issubclass(field_var.type, StructType)
+    assert field_var == eval(str(field_var))
+
+
+@pytest.mark.parametrize(
+    ("cls", "other", "res"),
+    [
+        (BooleanType, PrimitiveType, True),
+        (IntegerType, PrimitiveType, True),
+        (DoubleType, NumberType, True),
+        (FloatType, FloatingType, True),
+        (
+            NestedField[DecimalType[8, 2], 4, "optional_field"],
+            NestedField[DecimalType[8, 2], 4, "optional_field"],
+            True,
+        ),
+        (
+            NestedField[DecimalType[8, 1], 4, "optional_field"],
+            NestedField[DecimalType[8, 2], 4, "optional_field"],
+            False,
+        ),
+        (
+            NestedField[DecimalType[8, 2], 4, "optional_field"],
+            NestedField[DecimalType[8, 2], 4, "an_optional_field"],
+            False,
+        ),
+        (
+            StructType[
+                NestedField[IntegerType, 1, "optional_field"],
+                NestedField[FixedType[5], 2, "required_field", False],
+                NestedField[
+                    StructType[
+                        NestedField[DecimalType[8, 2], 4, "optional_field"],
+                        NestedField[LongType, 5, "required_field", False],
+                    ],
+                    3,
+                    "required_field",
+                    False,
+                ],
+            ],
+            StructType[
+                NestedField[IntegerType, 1, "optional_field"],
+                NestedField[FixedType[5], 2, "required_field", False],
+                NestedField[
+                    StructType[
+                        NestedField[DecimalType[8, 2], 4, "optional_field"],
+                        NestedField[LongType, 5, "required_field", False],
+                    ],
+                    3,
+                    "required_field",
+                    False,
+                ],
+            ],
+            True,
+        ),
+        (
+            StructType[
+                NestedField[IntegerType, 1, "optional_field"],
+                NestedField[FixedType[5], 2, "required_field", False],
+                NestedField[
+                    StructType[
+                        NestedField[DecimalType[8, 2], 4, "optional_field"],
+                        NestedField[LongType, 23, "required_field", False],
+                    ],
+                    3,
+                    "required_field",
+                    False,
+                ],
+            ],
+            StructType[
+                NestedField[IntegerType, 1, "optional_field"],
+                NestedField[FixedType[5], 2, "required_field", False],
+                NestedField[
+                    StructType[
+                        NestedField[DecimalType[8, 2], 4, "optional_field"],
+                        NestedField[LongType, 5, "required_field", False],
+                    ],
+                    3,
+                    "required_field",
+                    False,
+                ],
+            ],
+            False,
+        ),
+    ],
+)
+def test_subclass(cls, other, res):
+    assert issubclass(cls, other) == res


### PR DESCRIPTION
This PR is in contrast to https://github.com/apache/iceberg/pull/3952 which saw an attempt to use optional arguments to get a semblance of combined type/literal functionality. This one steps back to offer true generics e.g. `FixedType[8]` as opposed to `FixedType(length=8)` with all the intuitive functionality that comes from using true types and not class instances.

Examples:

```python
IntegerType==IntegerType
DecimalType[32, 3]==DecimalType[32, 3]
StructType[
        NestedField[DecimalType[32, 3], 0, "c1", True],
        NestedField[FloatType, 1, "c2", False],
    ] ==
StructType[
        NestedField[DecimalType[32, 3], 0, "c1", True],
        NestedField[FloatType, 1, "c2", False],
    ]
```

```python
>>> issubclass(NestedField[DecimalType[32, 3], 0, "c1", True], NestedField)
True

>>> issubclass(StructType[
        NestedField[DecimalType[32, 3], 0, "c1", True],
        NestedField[FloatType, 1, "c2", False],
    ], StructType[
        NestedField[DoubleType, 0, "c1", True],
        NestedField[FloatType, 1, "c2", False],
    ])
False

>>>issubclass(StructType[
        NestedField[DecimalType[32, 3], 0, "c1", True],
        NestedField[FloatType, 1, "c2", False],
    ], StructType[
        NestedField[IcebergType, 0, "c1", True],
        NestedField[FloatType, 1, "c2", False],
    ])
True
```

It provides the functionality to create further types possibly necessary in the future such as the transforms. For example, 

```python
>>> BucketTransform = generic_class(
    "BucketTransform",
   {
            "type": Union[
                DateType,
                TimeType,
                TimestampType,
                TimestamptzType,
                StringType,
                BinaryType,
                UUIDType,
                NumberType,
                FixedType,
            ],
        "num_buckets", int})

>>>BucketTransform[IntegerType, 10]
BucketTransform[type=IntegerType, num_buckets=10]
```
