### PR TITLE
Python: MapType missing required methods and visit() not supporting MapType

### DIFF
--- a/python_legacy/iceberg/api/types/type.py
+++ b/python_legacy/iceberg/api/types/type.py
@@ -63,7 +63,7 @@ class Type(object):
     def as_list_type(self):
         raise ValueError("Not a list type: " + self)
 
-    def asMapType(self):
+    def as_map_type(self):
         raise ValueError("Not a map type: " + self)
 
     def is_nested_type(self):

--- a/python_legacy/iceberg/api/types/type_util.py
+++ b/python_legacy/iceberg/api/types/type_util.py
@@ -143,7 +143,30 @@ def visit(arg, visitor): # noqa: ignore=C901
 
             return visitor.list(list_var, element_result)
         elif type_var.type_id == TypeID.MAP:
-            raise NotImplementedError()
+            # TODO: How could this be improved to avoid copy-pasting the same logic for key and value fields?
+            map_var = type_var.as_nested_type().asMapType()
+            visitor.field_ids.append(map_var.key_field.field_id)
+            visitor.field_names.append(map_var.key_field.name)
+            try:
+                key_result = visit(map_var.key_type(), visitor)
+            except NotImplementedError:
+                # will remove it after missing functions are implemented.
+                pass
+            finally:
+                visitor.field_ids.pop()
+                visitor.field_names.pop()
+
+            visitor.field_ids.append(map_var.value_field.field_id)
+            visitor.field_names.append(map_var.value_field.name)
+            try:
+                value_result = visit(map_var.value_type(), visitor)
+            except NotImplementedError:
+                # will remove it after missing functions are implemented.
+                pass
+            finally:
+                visitor.field_ids.pop()
+                visitor.field_names.pop()
+            return visitor.map(map_var, key_result, value_result)
         else:
             return visitor.primitive(arg.as_primitive_type())
     else:
@@ -385,7 +408,7 @@ class IndexById(SchemaVisitor):
             self.index[field.field_id] = field
 
     def map(self, map_var, key_result, value_result):
-        for field in map_var.fields:
+        for field in map_var.fields():
             self.index[field.field_id] = field
 
 

--- a/python_legacy/iceberg/api/types/type_util.py
+++ b/python_legacy/iceberg/api/types/type_util.py
@@ -143,8 +143,7 @@ def visit(arg, visitor): # noqa: ignore=C901
 
             return visitor.list(list_var, element_result)
         elif type_var.type_id == TypeID.MAP:
-            # TODO: How could this be improved to avoid copy-pasting the same logic for key and value fields?
-            map_var = type_var.as_nested_type().asMapType()
+            map_var = type_var.as_nested_type().as_map_type()
             visitor.field_ids.append(map_var.key_field.field_id)
             visitor.field_names.append(map_var.key_field.name)
             try:

--- a/python_legacy/iceberg/api/types/types.py
+++ b/python_legacy/iceberg/api/types/types.py
@@ -696,6 +696,9 @@ class MapType(NestedType):
     def value_id(self):
         return self.value_field.field_id
 
+    def is_map_type(self):
+        return True
+
     def is_value_optional(self):
         return self.value_field.is_optional
 

--- a/python_legacy/iceberg/api/types/types.py
+++ b/python_legacy/iceberg/api/types/types.py
@@ -696,7 +696,7 @@ class MapType(NestedType):
     def value_id(self):
         return self.value_field.field_id
 
-    def asMapType(self):
+    def as_map_type(self):
         return self
 
     def is_map_type(self):

--- a/python_legacy/iceberg/api/types/types.py
+++ b/python_legacy/iceberg/api/types/types.py
@@ -696,6 +696,9 @@ class MapType(NestedType):
     def value_id(self):
         return self.value_field.field_id
 
+    def asMapType(self):
+        return self
+
     def is_map_type(self):
         return True
 
@@ -726,4 +729,4 @@ class MapType(NestedType):
         return MapType.__class__, self.key_field, self.value_field
 
     def _lazy_field_list(self):
-        return tuple(self.key_field, self.value_field)
+        return (self.key_field, self.value_field)


### PR DESCRIPTION
MapType is missing `is_map_type()` method, so when calling it, it returns `False`.  That simply breaks the API.  I've checked and the other types are fine.  Map was the only one with such a problem.