### PR TITLE
Core: Use min sequence number on each partition to remove old delete files

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.expressions.StrictMetricsEvaluator;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -72,7 +73,6 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
   private final PartitionSet dropPartitions;
   private final CharSequenceSet deletePaths = CharSequenceSet.empty();
   private Expression deleteExpression = Expressions.alwaysFalse();
-  private long minSequenceNumber = 0;
   private boolean hasPathOnlyDeletes = false;
   private boolean failAnyDelete = false;
   private boolean failMissingDeletePaths = false;
@@ -85,6 +85,9 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
   // tracking where files were deleted to validate retries quickly
   private final Map<ManifestFile, Iterable<F>> filteredManifestToDeletedFiles =
       Maps.newConcurrentMap();
+
+  // tracking the min sequence number of data files on each partition
+  private final Map<String, Long> minSequenceNumberByPartition = Maps.newConcurrentMap();
 
   protected ManifestFilterManager(Map<Integer, PartitionSpec> specsById) {
     this.specsById = specsById;
@@ -126,18 +129,18 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
   }
 
   /**
-   * Set the sequence number used to remove old delete files.
+   * Set the min sequence number of data file on each partition used to remove old delete files.
    * <p>
-   * Delete files with a sequence number older than the given value will be removed. By setting this to the sequence
-   * number of the oldest data file in the table, this will continuously remove delete files that are no longer needed
-   * because deletes cannot match any existing rows in the table.
+   * Delete files with a sequence number older than the value on the same partition will be removed. By setting
+   * this to the sequence number of the oldest data file on each partition in the table, this will continuously remove
+   * delete files that are no longer needed because deletes cannot match any existing rows on the partition in the
+   * table.
    *
-   * @param sequenceNumber a sequence number used to remove old delete files
+   * @param minSequenceNumbers the sequence number of data file on each partition
    */
-  protected void dropDeleteFilesOlderThan(long sequenceNumber) {
-    Preconditions.checkArgument(sequenceNumber >= 0,
-        "Invalid minimum data sequence number: %s", sequenceNumber);
-    this.minSequenceNumber = sequenceNumber;
+  protected void dropDeleteFilesOlderthan(Map<String, Long> minSequenceNumbers) {
+    minSequenceNumberByPartition.clear();
+    minSequenceNumberByPartition.putAll(minSequenceNumbers);
   }
 
   void caseSensitive(boolean newCaseSensitive) {
@@ -273,6 +276,37 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
     }
   }
 
+  /**
+   * Found the min sequence number of data file on each partition.
+   * @param manifestFiles filtered data manifests
+   * @param deleteManifests delete manifests
+   * @return the min sequence number of data file on each partition
+   */
+  Map<String, Long> findMinDataSequenceNumbers(List<ManifestFile> manifestFiles, List<ManifestFile> deleteManifests) {
+    if (deleteManifests == null || deleteManifests.isEmpty()) {
+      return ImmutableMap.of();
+    }
+
+    minSequenceNumberByPartition.clear();
+    for (ManifestFile manifest : manifestFiles) {
+      if (ManifestContent.DATA == manifest.content()) {
+        try (ManifestReader<F> reader = newManifestReader(manifest);) {
+          reader.entries().forEach(entry -> {
+            F file = entry.file();
+
+            if (entry.status() != ManifestEntry.Status.DELETED &&
+                !deletePaths.contains(file.path()) && !dropPartitions.contains(file.specId(), file.partition())) {
+              minSequenceNumberByPartition.merge(file.partition().toString(), entry.sequenceNumber(), Math::min);
+            }
+          });
+        } catch (IOException e) {
+          throw new RuntimeIOException(e, "Failed to close manifest: %s", manifest);
+        }
+      }
+    }
+    return minSequenceNumberByPartition;
+  }
+
   private void invalidateFilteredCache() {
     cleanUncommitted(SnapshotProducer.EMPTY_SET);
   }
@@ -286,10 +320,13 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
       return cached;
     }
 
-    boolean hasLiveFiles = manifest.hasAddedFiles() || manifest.hasExistingFiles();
-    if (!hasLiveFiles || !canContainDeletedFiles(manifest)) {
-      filteredManifests.put(manifest, manifest);
-      return manifest;
+    boolean isDataManifest = ManifestContent.DATA == manifest.content();
+    if (isDataManifest) {
+      boolean hasLiveFiles = manifest.hasAddedFiles() || manifest.hasExistingFiles();
+      if (!hasLiveFiles || !canContainDeletedFiles(manifest)) {
+        filteredManifests.put(manifest, manifest);
+        return manifest;
+      }
     }
 
     try (ManifestReader<F> reader = newManifestReader(manifest)) {
@@ -339,10 +376,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
       canContainDroppedFiles = false;
     }
 
-    boolean canContainDropBySeq = manifest.content() == ManifestContent.DELETES &&
-        manifest.minSequenceNumber() < minSequenceNumber;
-
-    return canContainExpressionDeletes || canContainDroppedPartitions || canContainDroppedFiles || canContainDropBySeq;
+    return canContainExpressionDeletes || canContainDroppedPartitions || canContainDroppedFiles;
   }
 
   @SuppressWarnings("CollectionUndefinedEquality")
@@ -351,9 +385,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
     boolean hasDeletedFiles = false;
     for (ManifestEntry<F> entry : reader.liveEntries()) {
       F file = entry.file();
-      boolean fileDelete = deletePaths.contains(file.path()) ||
-          dropPartitions.contains(file.specId(), file.partition()) ||
-          (isDelete && entry.sequenceNumber() > 0 && entry.sequenceNumber() < minSequenceNumber);
+      boolean fileDelete = canFileDelete(file, isDelete, entry);
       if (fileDelete || evaluator.rowsMightMatch(file)) {
         ValidationException.check(
             fileDelete || evaluator.rowsMustMatch(file),
@@ -365,6 +397,8 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
           throw new DeleteException(reader.spec().partitionToPath(file.partition()));
         }
         break; // as soon as a deleted file is detected, stop scanning
+      } else {
+        keepDeleteFiles(file.path(), isDelete);
       }
     }
     return hasDeletedFiles;
@@ -384,9 +418,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
       try {
         reader.entries().forEach(entry -> {
           F file = entry.file();
-          boolean fileDelete = deletePaths.contains(file.path()) ||
-              dropPartitions.contains(file.specId(), file.partition()) ||
-              (isDelete && entry.sequenceNumber() > 0 && entry.sequenceNumber() < minSequenceNumber);
+          boolean fileDelete = canFileDelete(file, isDelete, entry);
           if (entry.status() != ManifestEntry.Status.DELETED) {
             if (fileDelete || evaluator.rowsMightMatch(file)) {
               ValidationException.check(
@@ -409,6 +441,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
               deletedPaths.add(wrapper);
 
             } else {
+              keepDeleteFiles(file.path(), isDelete);
               writer.existing(entry);
             }
           }
@@ -428,6 +461,26 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
 
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to close manifest writer");
+    }
+  }
+
+  private void keepDeleteFiles(CharSequence filePath, boolean isDelete) {
+    // delete file should not be removed because sequence number of delete file
+    // may larger than the min sequence number of data file on the same partition
+    if (isDelete) {
+      deletePaths.remove(filePath);
+    }
+  }
+
+  private boolean canFileDelete(F file, boolean isDelete, ManifestEntry<F> entry) {
+    if (isDelete) {
+      // if not contains the partition, this means the partition have no data files,
+      // so the delete file can be dropped
+      return !minSequenceNumberByPartition.containsKey(file.partition().toString()) ||
+          (entry.sequenceNumber() > 0 &&
+              entry.sequenceNumber() < minSequenceNumberByPartition.get(file.partition().toString()));
+    } else {
+      return deletePaths.contains(file.path()) || dropPartitions.contains(file.specId(), file.partition());
     }
   }
 


### PR DESCRIPTION
In https://github.com/apache/iceberg/blob/master/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java#L137, we use the min sequence number to filter the delete-manifests, then we can find the older delete file and drop them.

But if we have some cold partition that never compaction again, then the min sequence number will never change. That makes the older delete file in other partitions will never be dropped. This will be worse and worse. It will make the spark driver oom and finally, the table becomes unavailable.

In this PR, I use a map that contains a min sequence number on each partition instead of the global min sequence number. But I found the code changed a lot. I am not sure it's a good solution.

And this PR can solve another problem. Currently, when we enabled partial compaction, we didn't drop the delete files as well. Because we can not make sure the delete files are not referenced by other data files when commit replace. That will leave a lot of useless delete files.