### PR TITLE
Flink: Support write options in FlinkSink builder

### DIFF
--- a/docs/flink-getting-started.md
+++ b/docs/flink-getting-started.md
@@ -545,9 +545,9 @@ FlinkSink.Builder builder = FlinkSink.forRow(dataStream, SimpleDataUtil.FLINK_SC
 | ---------------------- | -------------------------- | ------------------------------------------------------------ |
 | write-format           | Table write.format.default | File format to use for this write operation; parquet, avro, or orc |
 | target-file-size-bytes | As per table property      | Overrides this table's write.target-file-size-bytes          |
-| write.upsert.enabled | Table write.upsert.enabled | Overrides this table's write.upsert.enabled |
+| upsert-enabled | Table write.upsert.enabled | Overrides this table's write.upsert.enabled |
 | overwrite | false | Overwrite the table's data |
-| write.distribution-mode | Table write.distribution-mode | Overrides this table's write.distribution-mode |
+| distribution-mode | Table write.distribution-mode | Overrides this table's write.distribution-mode |
 
 
 ## Inspecting tables.

--- a/docs/flink-getting-started.md
+++ b/docs/flink-getting-started.md
@@ -529,6 +529,27 @@ FlinkSink.forRowData(input)
 env.execute("Test Iceberg DataStream");
 ```
 
+## Write options
+
+Flink write options are passed when configuring the FlinkSink, like this:
+
+```
+FlinkSink.Builder builder = FlinkSink.forRow(dataStream, SimpleDataUtil.FLINK_SCHEMA)
+    .table(table)
+    .tableLoader(tableLoader)
+    .writeParallelism(parallelism)
+    .set("write-format", "orc");
+```
+
+| Flink option           | Default                    | Description                                                  |
+| ---------------------- | -------------------------- | ------------------------------------------------------------ |
+| write-format           | Table write.format.default | File format to use for this write operation; parquet, avro, or orc |
+| target-file-size-bytes | As per table property      | Overrides this table's write.target-file-size-bytes          |
+| write.upsert.enabled | Table write.upsert.enabled | Overrides this table's write.upsert.enabled |
+| overwrite | false | Overwrite the table's data |
+| write.distribution-mode | Table write.distribution-mode | Overrides this table's write.distribution-mode |
+
+
 ## Inspecting tables.
 
 Iceberg does not support inspecting table in flink sql now, we need to use [iceberg's Java API](../api) to read iceberg's meta data to get those table information.

--- a/docs/flink-getting-started.md
+++ b/docs/flink-getting-started.md
@@ -541,13 +541,13 @@ FlinkSink.Builder builder = FlinkSink.forRow(dataStream, SimpleDataUtil.FLINK_SC
     .set(FlinkWriteOptions.OVERWRITE_MODE, "true");
 ```
 
-| Flink option           | Default                    | Description                                                  |
-| ---------------------- | -------------------------- | ------------------------------------------------------------ |
-| write-format           | Table write.format.default | File format to use for this write operation; parquet, avro, or orc |
-| target-file-size-bytes | As per table property      | Overrides this table's write.target-file-size-bytes          |
-| upsert-enabled | Table write.upsert.enabled | Overrides this table's write.upsert.enabled |
-| overwrite | false | Overwrite the table's data |
-| distribution-mode | Table write.distribution-mode | Overrides this table's write.distribution-mode |
+| Flink option           | Default                    | Description                                                                                                |
+|------------------------| -------------------------- |------------------------------------------------------------------------------------------------------------|
+| write-file-format      | Table write.format.default | File format to use for this write operation; parquet, avro, or orc                                         |
+| target-file-size-bytes | As per table property      | Overrides this table's write.target-file-size-bytes                                                        |
+| upsert-enabled         | Table write.upsert.enabled | Overrides this table's write.upsert.enabled                                                                |
+| overwrite-enabled      | false | Overwrite the table's data, overwrite mode shouldn't be enable when configuring to use UPSERT data stream. |
+| distribution-mode      | Table write.distribution-mode | Overrides this table's write.distribution-mode                                                             |
 
 
 ## Inspecting tables.

--- a/docs/flink-getting-started.md
+++ b/docs/flink-getting-started.md
@@ -543,7 +543,7 @@ FlinkSink.Builder builder = FlinkSink.forRow(dataStream, SimpleDataUtil.FLINK_SC
 
 | Flink option           | Default                    | Description                                                                                                |
 |------------------------| -------------------------- |------------------------------------------------------------------------------------------------------------|
-| write-file-format      | Table write.format.default | File format to use for this write operation; parquet, avro, or orc                                         |
+| write-format           | Table write.format.default | File format to use for this write operation; parquet, avro, or orc                                         |
 | target-file-size-bytes | As per table property      | Overrides this table's write.target-file-size-bytes                                                        |
 | upsert-enabled         | Table write.upsert.enabled | Overrides this table's write.upsert.enabled                                                                |
 | overwrite-enabled      | false | Overwrite the table's data, overwrite mode shouldn't be enable when configuring to use UPSERT data stream. |

--- a/docs/flink-getting-started.md
+++ b/docs/flink-getting-started.md
@@ -537,8 +537,8 @@ Flink write options are passed when configuring the FlinkSink, like this:
 FlinkSink.Builder builder = FlinkSink.forRow(dataStream, SimpleDataUtil.FLINK_SCHEMA)
     .table(table)
     .tableLoader(tableLoader)
-    .writeParallelism(parallelism)
-    .set("write-format", "orc");
+    .set("write-format", "orc")
+    .set(FlinkWriteOptions.OVERWRITE_MODE, "true");
 ```
 
 | Flink option           | Default                    | Description                                                  |

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkConfParser.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkConfParser.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Function;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+
+class FlinkConfParser {
+
+  private final Map<String, String> tableProperties;
+  private final Map<String, String> options;
+
+  FlinkConfParser(Table table, Map<String, String> options) {
+    this.tableProperties = table.properties();
+    this.options = options;
+  }
+
+  public Map<String, String> props() {
+    Map<String, String> merged = Maps.newHashMap(tableProperties);
+    merged.putAll(options);
+    return merged;
+  }
+
+  public BooleanConfParser booleanConf() {
+    return new BooleanConfParser();
+  }
+
+  public IntConfParser intConf() {
+    return new IntConfParser();
+  }
+
+  public LongConfParser longConf() {
+    return new LongConfParser();
+  }
+
+  public StringConfParser stringConf() {
+    return new StringConfParser();
+  }
+
+  class BooleanConfParser extends ConfParser<BooleanConfParser, Boolean> {
+    private Boolean defaultValue;
+
+    @Override
+    protected BooleanConfParser self() {
+      return this;
+    }
+
+    public BooleanConfParser defaultValue(boolean value) {
+      this.defaultValue = value;
+      return self();
+    }
+
+    public BooleanConfParser defaultValue(String value) {
+      this.defaultValue = Boolean.parseBoolean(value);
+      return self();
+    }
+
+    public boolean parse() {
+      Preconditions.checkArgument(defaultValue != null, "Default value cannot be null");
+      return parse(Boolean::parseBoolean, defaultValue);
+    }
+  }
+
+  class IntConfParser extends ConfParser<IntConfParser, Integer> {
+    private Integer defaultValue;
+
+    @Override
+    protected IntConfParser self() {
+      return this;
+    }
+
+    public IntConfParser defaultValue(int value) {
+      this.defaultValue = value;
+      return self();
+    }
+
+    public int parse() {
+      Preconditions.checkArgument(defaultValue != null, "Default value cannot be null");
+      return parse(Integer::parseInt, defaultValue);
+    }
+
+    public Integer parseOptional() {
+      return parse(Integer::parseInt, null);
+    }
+  }
+
+  class LongConfParser extends ConfParser<LongConfParser, Long> {
+    private Long defaultValue;
+
+    @Override
+    protected LongConfParser self() {
+      return this;
+    }
+
+    public LongConfParser defaultValue(long value) {
+      this.defaultValue = value;
+      return self();
+    }
+
+    public long parse() {
+      Preconditions.checkArgument(defaultValue != null, "Default value cannot be null");
+      return parse(Long::parseLong, defaultValue);
+    }
+
+    public Long parseOptional() {
+      return parse(Long::parseLong, null);
+    }
+  }
+
+  class StringConfParser extends ConfParser<StringConfParser, String> {
+    private String defaultValue;
+
+    @Override
+    protected StringConfParser self() {
+      return this;
+    }
+
+    public StringConfParser defaultValue(String value) {
+      this.defaultValue = value;
+      return self();
+    }
+
+    public String parse() {
+      Preconditions.checkArgument(defaultValue != null, "Default value cannot be null");
+      return parse(Function.identity(), defaultValue);
+    }
+
+    public String parseOptional() {
+      return parse(Function.identity(), null);
+    }
+  }
+
+  abstract class ConfParser<ThisT, T> {
+    private final List<String> optionNames = Lists.newArrayList();
+    private String tablePropertyName;
+
+    protected abstract ThisT self();
+
+    public ThisT option(String name) {
+      this.optionNames.add(name);
+      return self();
+    }
+
+    public ThisT tableProperty(String name) {
+      this.tablePropertyName = name;
+      return self();
+    }
+
+    protected T parse(Function<String, T> conversion, T defaultValue) {
+      if (!optionNames.isEmpty()) {
+        for (String optionName : optionNames) {
+          // use lower case comparison as DataSourceOptions.asMap() in Spark 2 returns a lower case map
+          String optionValue = options.get(optionName.toLowerCase(Locale.ROOT));
+          if (optionValue != null) {
+            return conversion.apply(optionValue);
+          }
+        }
+      }
+
+      if (tablePropertyName != null) {
+        String propertyValue = tableProperties.get(tablePropertyName);
+        if (propertyValue != null) {
+          return conversion.apply(propertyValue);
+        }
+      }
+
+      return defaultValue;
+    }
+  }
+}

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkConfParser.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkConfParser.java
@@ -162,8 +162,8 @@ class FlinkConfParser {
       return self();
     }
 
-    public ThisT sessionConf(ConfigOption<T> configOption) {
-      this.configOption = configOption;
+    public ThisT sessionConf(ConfigOption<T> newConfigOption) {
+      this.configOption = newConfigOption;
       return self();
     }
 

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkConfParser.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkConfParser.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.flink;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 import org.apache.flink.configuration.ConfigOption;
@@ -162,7 +161,7 @@ class FlinkConfParser {
       return self();
     }
 
-    public ThisT sessionConf(ConfigOption<T> newConfigOption) {
+    public ThisT flinkConfig(ConfigOption<T> newConfigOption) {
       this.configOption = newConfigOption;
       return self();
     }
@@ -175,8 +174,7 @@ class FlinkConfParser {
     protected T parse(Function<String, T> conversion, T defaultValue) {
       if (!optionNames.isEmpty()) {
         for (String optionName : optionNames) {
-          // use lower case comparison as DataSourceOptions.asMap() in Spark 2 returns a lower case map
-          String optionValue = options.get(optionName.toLowerCase(Locale.ROOT));
+          String optionValue = options.get(optionName);
           if (optionValue != null) {
             return conversion.apply(optionValue);
           }

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink;
+
+import java.util.Locale;
+import java.util.Map;
+import org.apache.iceberg.DistributionMode;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+
+/**
+ * A class for common Iceberg configs for Flink writes.
+ * <p>
+ * If a config is set at multiple levels, the following order of precedence is used (top to bottom):
+ * <ol>
+ *   <li>Write options</li>
+ *   <li>Table metadata</li>
+ * </ol>
+ * The most specific value is set in write options and takes precedence over all other configs.
+ * If no applicable value is found in the write options, this class uses the table metadata.
+ * <p>
+ * Note this class is NOT meant to be serialized.
+ */
+public class FlinkWriteConf {
+
+  private final FlinkConfParser confParser;
+
+  public FlinkWriteConf(Table table, Map<String, String> writeOptions) {
+    this.confParser = new FlinkConfParser(table, writeOptions);
+  }
+
+  public boolean overwriteMode() {
+    return confParser.booleanConf()
+        .option(FlinkWriteOptions.OVERWRITE_MODE)
+        .defaultValue(false)
+        .parse();
+  }
+
+  public boolean upsertMode() {
+    return confParser.booleanConf()
+        .option(FlinkWriteOptions.WRITE_UPSERT_ENABLED)
+        .tableProperty(TableProperties.UPSERT_ENABLED)
+        .defaultValue(TableProperties.UPSERT_ENABLED_DEFAULT)
+        .parse();
+  }
+
+  public FileFormat dataFileFormat() {
+    String valueAsString = confParser.stringConf()
+        .option(FlinkWriteOptions.WRITE_FORMAT)
+        .tableProperty(TableProperties.DEFAULT_FILE_FORMAT)
+        .defaultValue(TableProperties.DEFAULT_FILE_FORMAT_DEFAULT)
+        .parse();
+    return FileFormat.valueOf(valueAsString.toUpperCase(Locale.ENGLISH));
+  }
+
+  public long targetDataFileSize() {
+    return confParser.longConf()
+        .option(FlinkWriteOptions.TARGET_FILE_SIZE_BYTES)
+        .tableProperty(TableProperties.WRITE_TARGET_FILE_SIZE_BYTES)
+        .defaultValue(TableProperties.WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT)
+        .parse();
+  }
+
+  public DistributionMode distributionMode() {
+    String modeName = confParser.stringConf()
+        .option(FlinkWriteOptions.DISTRIBUTION_MODE)
+        .tableProperty(TableProperties.WRITE_DISTRIBUTION_MODE)
+        .defaultValue(TableProperties.WRITE_DISTRIBUTION_MODE_NONE)
+        .parse();
+
+    return DistributionMode.fromName(modeName);
+  }
+
+  public Map<String, String> props() {
+    return confParser.props();
+  }
+}

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.flink;
 
 import java.util.Locale;
 import java.util.Map;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Table;
@@ -32,9 +33,11 @@ import org.apache.iceberg.TableProperties;
  * If a config is set at multiple levels, the following order of precedence is used (top to bottom):
  * <ol>
  *   <li>Write options</li>
+ *   <li>flink ReadableConfig</li>
  *   <li>Table metadata</li>
  * </ol>
  * The most specific value is set in write options and takes precedence over all other configs.
+ * If no write option is provided, this class checks the flink configuration for any overrides.
  * If no applicable value is found in the write options, this class uses the table metadata.
  * <p>
  * Note this class is NOT meant to be serialized.
@@ -43,8 +46,8 @@ public class FlinkWriteConf {
 
   private final FlinkConfParser confParser;
 
-  public FlinkWriteConf(Table table, Map<String, String> writeOptions) {
-    this.confParser = new FlinkConfParser(table, writeOptions);
+  public FlinkWriteConf(Table table, Map<String, String> writeOptions, ReadableConfig readableConfig) {
+    this.confParser = new FlinkConfParser(table, writeOptions, readableConfig);
   }
 
   public boolean overwriteMode() {
@@ -85,11 +88,13 @@ public class FlinkWriteConf {
         .tableProperty(TableProperties.WRITE_DISTRIBUTION_MODE)
         .defaultValue(TableProperties.WRITE_DISTRIBUTION_MODE_NONE)
         .parse();
-
     return DistributionMode.fromName(modeName);
   }
 
-  public Map<String, String> props() {
-    return confParser.props();
+  public int workerPoolSize() {
+    return confParser.intConf()
+        .sessionConf(FlinkConfigOptions.TABLE_EXEC_ICEBERG_WORKER_POOL_SIZE)
+        .defaultValue(FlinkConfigOptions.TABLE_EXEC_ICEBERG_WORKER_POOL_SIZE.defaultValue())
+        .parse();
   }
 }

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
@@ -54,7 +54,7 @@ public class FlinkWriteConf {
     return confParser.booleanConf()
         .option(FlinkWriteOptions.OVERWRITE_MODE.key())
         .flinkConfig(FlinkWriteOptions.OVERWRITE_MODE)
-        .defaultValue(false)
+        .defaultValue(FlinkWriteOptions.OVERWRITE_MODE.defaultValue())
         .parse();
   }
 

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
@@ -52,14 +52,16 @@ public class FlinkWriteConf {
 
   public boolean overwriteMode() {
     return confParser.booleanConf()
-        .option(FlinkWriteOptions.OVERWRITE_MODE)
+        .option(FlinkWriteOptions.OVERWRITE_MODE.key())
+        .flinkConfig(FlinkWriteOptions.OVERWRITE_MODE)
         .defaultValue(false)
         .parse();
   }
 
   public boolean upsertMode() {
     return confParser.booleanConf()
-        .option(FlinkWriteOptions.WRITE_UPSERT_ENABLED)
+        .option(FlinkWriteOptions.WRITE_UPSERT_ENABLED.key())
+        .flinkConfig(FlinkWriteOptions.WRITE_UPSERT_ENABLED)
         .tableProperty(TableProperties.UPSERT_ENABLED)
         .defaultValue(TableProperties.UPSERT_ENABLED_DEFAULT)
         .parse();
@@ -67,7 +69,8 @@ public class FlinkWriteConf {
 
   public FileFormat dataFileFormat() {
     String valueAsString = confParser.stringConf()
-        .option(FlinkWriteOptions.WRITE_FORMAT)
+        .option(FlinkWriteOptions.WRITE_FORMAT.key())
+        .flinkConfig(FlinkWriteOptions.WRITE_FORMAT)
         .tableProperty(TableProperties.DEFAULT_FILE_FORMAT)
         .defaultValue(TableProperties.DEFAULT_FILE_FORMAT_DEFAULT)
         .parse();
@@ -76,7 +79,8 @@ public class FlinkWriteConf {
 
   public long targetDataFileSize() {
     return confParser.longConf()
-        .option(FlinkWriteOptions.TARGET_FILE_SIZE_BYTES)
+        .option(FlinkWriteOptions.TARGET_FILE_SIZE_BYTES.key())
+        .flinkConfig(FlinkWriteOptions.TARGET_FILE_SIZE_BYTES)
         .tableProperty(TableProperties.WRITE_TARGET_FILE_SIZE_BYTES)
         .defaultValue(TableProperties.WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT)
         .parse();
@@ -84,7 +88,8 @@ public class FlinkWriteConf {
 
   public DistributionMode distributionMode() {
     String modeName = confParser.stringConf()
-        .option(FlinkWriteOptions.DISTRIBUTION_MODE)
+        .option(FlinkWriteOptions.DISTRIBUTION_MODE.key())
+        .flinkConfig(FlinkWriteOptions.DISTRIBUTION_MODE)
         .tableProperty(TableProperties.WRITE_DISTRIBUTION_MODE)
         .defaultValue(TableProperties.WRITE_DISTRIBUTION_MODE_NONE)
         .parse();
@@ -93,7 +98,7 @@ public class FlinkWriteConf {
 
   public int workerPoolSize() {
     return confParser.intConf()
-        .sessionConf(FlinkConfigOptions.TABLE_EXEC_ICEBERG_WORKER_POOL_SIZE)
+        .flinkConfig(FlinkConfigOptions.TABLE_EXEC_ICEBERG_WORKER_POOL_SIZE)
         .defaultValue(FlinkConfigOptions.TABLE_EXEC_ICEBERG_WORKER_POOL_SIZE.defaultValue())
         .parse();
   }

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
@@ -27,7 +27,7 @@ public class FlinkWriteOptions {
   private FlinkWriteOptions() {
   }
 
-  // Fileformat for write operations(default: Table write.format.default )
+  // File format for write operations(default: Table write.format.default )
   public static final String WRITE_FORMAT = "write-format";
 
   // Overrides this table's write.target-file-size-bytes

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
@@ -32,7 +32,7 @@ public class FlinkWriteOptions {
 
   // File format for write operations(default: Table write.format.default )
   public static final ConfigOption<String> WRITE_FORMAT =
-      ConfigOptions.key("write-file-format")
+      ConfigOptions.key("write-format")
           .stringType().noDefaultValue();
 
   // Overrides this table's write.target-file-size-bytes

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
@@ -32,7 +32,7 @@ public class FlinkWriteOptions {
 
   // File format for write operations(default: Table write.format.default )
   public static final ConfigOption<String> WRITE_FORMAT =
-      ConfigOptions.key("write-format")
+      ConfigOptions.key("write-file-format")
           .stringType().noDefaultValue();
 
   // Overrides this table's write.target-file-size-bytes
@@ -46,8 +46,8 @@ public class FlinkWriteOptions {
           .booleanType().noDefaultValue();
 
   public static final ConfigOption<Boolean> OVERWRITE_MODE =
-      ConfigOptions.key("overwrite")
-          .booleanType().noDefaultValue();
+      ConfigOptions.key("overwrite-enabled")
+          .booleanType().defaultValue(false);
 
   // Overrides the table's write.distribution-mode
   public static final ConfigOption<String> DISTRIBUTION_MODE =

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
@@ -19,6 +19,9 @@
 
 package org.apache.iceberg.flink;
 
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
 /**
  * Flink sink write options
  */
@@ -28,16 +31,27 @@ public class FlinkWriteOptions {
   }
 
   // File format for write operations(default: Table write.format.default )
-  public static final String WRITE_FORMAT = "write-format";
+  public static final ConfigOption<String> WRITE_FORMAT =
+      ConfigOptions.key("write-format")
+          .stringType().noDefaultValue();
 
   // Overrides this table's write.target-file-size-bytes
-  public static final String TARGET_FILE_SIZE_BYTES = "target-file-size-bytes";
+  public static final ConfigOption<Long> TARGET_FILE_SIZE_BYTES =
+      ConfigOptions.key("target-file-size-bytes")
+          .longType().noDefaultValue();
 
   // Overrides this table's write.upsert.enabled
-  public static final String WRITE_UPSERT_ENABLED = "upsert-enabled";
+  public static final ConfigOption<Boolean> WRITE_UPSERT_ENABLED =
+      ConfigOptions.key("upsert-enabled")
+          .booleanType().noDefaultValue();
 
-  public static final String OVERWRITE_MODE = "overwrite";
+  public static final ConfigOption<Boolean> OVERWRITE_MODE =
+      ConfigOptions.key("overwrite")
+          .booleanType().noDefaultValue();
 
   // Overrides the table's write.distribution-mode
-  public static final String DISTRIBUTION_MODE = "distribution-mode";
+  public static final ConfigOption<String> DISTRIBUTION_MODE =
+      ConfigOptions.key("distribution-mode")
+          .stringType().noDefaultValue();
+
 }

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
@@ -31,13 +31,13 @@ public class FlinkWriteOptions {
   public static final String WRITE_FORMAT = "write-format";
 
   // Overrides this table's write.target-file-size-bytes
-  public static final String TARGET_FILE_SIZE_BYTES = "write.target-file-size-bytes";
+  public static final String TARGET_FILE_SIZE_BYTES = "target-file-size-bytes";
 
   // Overrides this table's write.upsert.enabled
-  public static final String WRITE_UPSERT_ENABLED = "write.upsert.enabled";
+  public static final String WRITE_UPSERT_ENABLED = "upsert-enabled";
 
   public static final String OVERWRITE_MODE = "overwrite";
 
-  // Overrides the default distribution mode for a write operation
-  public static final String DISTRIBUTION_MODE = "write.distribution-mode";
+  // Overrides the table's write.distribution-mode
+  public static final String DISTRIBUTION_MODE = "distribution-mode";
 }

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.flink;
+
+/**
+ * Flink sink write options
+ */
+public class FlinkWriteOptions {
+
+  private FlinkWriteOptions() {
+  }
+
+  // Fileformat for write operations(default: Table write.format.default )
+  public static final String WRITE_FORMAT = "write-format";
+
+  // Overrides this table's write.target-file-size-bytes
+  public static final String TARGET_FILE_SIZE_BYTES = "write.target-file-size-bytes";
+
+  // Overrides this table's write.upsert.enabled
+  public static final String WRITE_UPSERT_ENABLED = "write.upsert.enabled";
+
+  public static final String OVERWRITE_MODE = "overwrite";
+
+  // Overrides the default distribution mode for a write operation
+  public static final String DISTRIBUTION_MODE = "write.distribution-mode";
+}

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -205,7 +205,7 @@ public class FlinkSink {
     }
 
     public Builder overwrite(boolean newOverwrite) {
-      writeOptions.put(FlinkWriteOptions.OVERWRITE_MODE, Boolean.toString(newOverwrite));
+      writeOptions.put(FlinkWriteOptions.OVERWRITE_MODE.key(), Boolean.toString(newOverwrite));
       return this;
     }
 
@@ -225,7 +225,7 @@ public class FlinkSink {
       Preconditions.checkArgument(!DistributionMode.RANGE.equals(mode),
           "Flink does not support 'range' write distribution mode now.");
       if (mode != null) {
-        writeOptions.put(FlinkWriteOptions.DISTRIBUTION_MODE, mode.modeName());
+        writeOptions.put(FlinkWriteOptions.DISTRIBUTION_MODE.key(), mode.modeName());
       }
       return this;
     }
@@ -251,7 +251,7 @@ public class FlinkSink {
      * @return {@link Builder} to connect the iceberg table.
      */
     public Builder upsert(boolean enabled) {
-      writeOptions.put(FlinkWriteOptions.WRITE_UPSERT_ENABLED, Boolean.toString(enabled));
+      writeOptions.put(FlinkWriteOptions.WRITE_UPSERT_ENABLED.key(), Boolean.toString(enabled));
       return this;
     }
 

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -184,8 +184,8 @@ public class FlinkSink {
     }
 
     /**
-     * Set the write properties for Flink sink. Write properties (with the same keys) defined in table properties
-     * will be overwritten by properties provided here.
+     * Set the write properties for Flink sink.
+     * View the supported properties in {@link FlinkWriteOptions}
      */
     public Builder set(String property, String value) {
       writeOptions.put(property, value);
@@ -193,8 +193,8 @@ public class FlinkSink {
     }
 
     /**
-     * Set the write properties for Flink sink. Write properties (with the same keys) defined in table properties
-     * will be overwritten by properties provided here.
+     * Set the write properties for Flink sink.
+     * View the supported properties in {@link FlinkWriteOptions}
      */
     public Builder setAll(Map<String, String> properties) {
       writeOptions.putAll(properties);

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/RowDataTaskWriterFactory.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/RowDataTaskWriterFactory.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.flink.sink;
 
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
@@ -40,14 +39,9 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.ArrayUtil;
-import org.apache.iceberg.util.PropertyUtil;
-
-import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
-import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
 
 public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
   private final Table table;
-  private final Map<String, String> properties;
   private final Schema schema;
   private final RowType flinkSchema;
   private final PartitionSpec spec;
@@ -77,7 +71,6 @@ public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
                                   List<Integer> equalityFieldIds,
                                   boolean upsert) {
     this.table = table;
-    this.properties = properties;
     this.schema = table.schema();
     this.flinkSchema = flinkSchema;
     this.spec = table.spec();
@@ -103,10 +96,8 @@ public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
 
   @Override
   public void initialize(int taskId, int attemptId) {
-    String formatAsString = PropertyUtil.propertyAsString(properties, DEFAULT_FILE_FORMAT, DEFAULT_FILE_FORMAT_DEFAULT);
-    FileFormat fileFormat = FileFormat.valueOf(formatAsString.toUpperCase(Locale.ROOT));
     this.outputFileFactory = OutputFileFactory.builderFor(table, taskId, attemptId)
-        .format(fileFormat)
+        .format(format)
         .build();
   }
 

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/RowDataTaskWriterFactory.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/RowDataTaskWriterFactory.java
@@ -20,7 +20,6 @@
 package org.apache.iceberg.flink.sink;
 
 import java.util.List;
-import java.util.Map;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.iceberg.FileFormat;
@@ -60,16 +59,6 @@ public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
                                   FileFormat format,
                                   List<Integer> equalityFieldIds,
                                   boolean upsert) {
-    this(table, table.properties(), flinkSchema, targetFileSizeBytes, format, equalityFieldIds, upsert);
-  }
-
-  public RowDataTaskWriterFactory(Table table,
-                                  Map<String, String> properties,
-                                  RowType flinkSchema,
-                                  long targetFileSizeBytes,
-                                  FileFormat format,
-                                  List<Integer> equalityFieldIds,
-                                  boolean upsert) {
     this.table = table;
     this.schema = table.schema();
     this.flinkSchema = flinkSchema;
@@ -81,15 +70,15 @@ public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
     this.upsert = upsert;
 
     if (equalityFieldIds == null || equalityFieldIds.isEmpty()) {
-      this.appenderFactory = new FlinkAppenderFactory(schema, flinkSchema, properties, spec);
+      this.appenderFactory = new FlinkAppenderFactory(schema, flinkSchema, table.properties(), spec);
     } else if (upsert) {
       // In upsert mode, only the new row is emitted using INSERT row kind. Therefore, any column of the inserted row
       // may differ from the deleted row other than the primary key fields, and the delete file must contain values
       // that are correct for the deleted row. Therefore, only write the equality delete fields.
-      this.appenderFactory = new FlinkAppenderFactory(schema, flinkSchema, properties, spec,
+      this.appenderFactory = new FlinkAppenderFactory(schema, flinkSchema, table.properties(), spec,
           ArrayUtil.toIntArray(equalityFieldIds), TypeUtil.select(schema, Sets.newHashSet(equalityFieldIds)), null);
     } else {
-      this.appenderFactory = new FlinkAppenderFactory(schema, flinkSchema, properties, spec,
+      this.appenderFactory = new FlinkAppenderFactory(schema, flinkSchema, table.properties(), spec,
           ArrayUtil.toIntArray(equalityFieldIds), schema, null);
     }
   }

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
@@ -330,7 +330,7 @@ public class TestFlinkIcebergSink {
   @Test
   public void testOverrideWriteConfigWithUnknownDistributionMode() {
     Map<String, String> newProps = Maps.newHashMap();
-    newProps.put(FlinkWriteOptions.DISTRIBUTION_MODE, "UNRECOGNIZED");
+    newProps.put(FlinkWriteOptions.DISTRIBUTION_MODE.key(), "UNRECOGNIZED");
 
     List<Row> rows = createRows("");
     DataStream<Row> dataStream = env.addSource(createBoundedSource(rows), ROW_TYPE_INFO);
@@ -355,7 +355,7 @@ public class TestFlinkIcebergSink {
   @Test
   public void testOverrideWriteConfigWithUnknownFileFormat() {
     Map<String, String> newProps = Maps.newHashMap();
-    newProps.put(FlinkWriteOptions.WRITE_FORMAT, "UNRECOGNIZED");
+    newProps.put(FlinkWriteOptions.WRITE_FORMAT.key(), "UNRECOGNIZED");
 
     List<Row> rows = createRows("");
     DataStream<Row> dataStream = env.addSource(createBoundedSource(rows), ROW_TYPE_INFO);

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
@@ -40,6 +40,7 @@ import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.flink.FlinkWriteOptions;
 import org.apache.iceberg.flink.MiniClusterResource;
 import org.apache.iceberg.flink.SimpleDataUtil;
 import org.apache.iceberg.flink.TableLoader;
@@ -329,7 +330,7 @@ public class TestFlinkIcebergSink {
   @Test
   public void testOverrideWriteConfigWithUnknownDistributionMode() {
     Map<String, String> newProps = Maps.newHashMap();
-    newProps.put(TableProperties.WRITE_DISTRIBUTION_MODE, "UNRECOGNIZED");
+    newProps.put(FlinkWriteOptions.DISTRIBUTION_MODE, "UNRECOGNIZED");
 
     List<Row> rows = createRows("");
     DataStream<Row> dataStream = env.addSource(createBoundedSource(rows), ROW_TYPE_INFO);
@@ -354,7 +355,7 @@ public class TestFlinkIcebergSink {
   @Test
   public void testOverrideWriteConfigWithUnknownFileFormat() {
     Map<String, String> newProps = Maps.newHashMap();
-    newProps.put(TableProperties.DEFAULT_FILE_FORMAT, "UNRECOGNIZED");
+    newProps.put(FlinkWriteOptions.WRITE_FORMAT, "UNRECOGNIZED");
 
     List<Row> rows = createRows("");
     DataStream<Row> dataStream = env.addSource(createBoundedSource(rows), ROW_TYPE_INFO);

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergStreamWriter.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergStreamWriter.java
@@ -333,7 +333,8 @@ public class TestIcebergStreamWriter {
   private OneInputStreamOperatorTestHarness<RowData, WriteResult> createIcebergStreamWriter(
       Table icebergTable, TableSchema flinkSchema) throws Exception {
     RowType flinkRowType = FlinkSink.toFlinkRowType(icebergTable.schema(), flinkSchema);
-    IcebergStreamWriter<RowData> streamWriter = FlinkSink.createStreamWriter(icebergTable, flinkRowType, null, false);
+    IcebergStreamWriter<RowData> streamWriter = FlinkSink.createStreamWriter(icebergTable, icebergTable.properties(),
+        flinkRowType, null, false);
     OneInputStreamOperatorTestHarness<RowData, WriteResult> harness = new OneInputStreamOperatorTestHarness<>(
         streamWriter, 1, 1, 0);
 

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergStreamWriter.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergStreamWriter.java
@@ -55,6 +55,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.PropertyUtil;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
@@ -333,7 +334,17 @@ public class TestIcebergStreamWriter {
   private OneInputStreamOperatorTestHarness<RowData, WriteResult> createIcebergStreamWriter(
       Table icebergTable, TableSchema flinkSchema) throws Exception {
     RowType flinkRowType = FlinkSink.toFlinkRowType(icebergTable.schema(), flinkSchema);
-    IcebergStreamWriter<RowData> streamWriter = FlinkSink.createStreamWriter(icebergTable, icebergTable.properties(),
+    IcebergStreamWriter<RowData> streamWriter = FlinkSink.createStreamWriter(
+        icebergTable,
+        PropertyUtil.propertyAsLong(
+            icebergTable.properties(),
+            TableProperties.WRITE_TARGET_FILE_SIZE_BYTES,
+            TableProperties.WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT),
+        FileFormat.valueOf(PropertyUtil.propertyAsString(
+            icebergTable.properties(),
+            TableProperties.DEFAULT_FILE_FORMAT,
+            TableProperties.DEFAULT_FILE_FORMAT_DEFAULT).toUpperCase(Locale.ENGLISH)),
+        icebergTable.properties(),
         flinkRowType, null, false);
     OneInputStreamOperatorTestHarness<RowData, WriteResult> harness = new OneInputStreamOperatorTestHarness<>(
         streamWriter, 1, 1, 0);


### PR DESCRIPTION
Supports overwriting table configuration, such upsert \ overwirte\ file-format, when creating Flink sink.