### PR TITLE
Infra: fix release script signing and checksum commands

### DIFF
--- a/dev/source-release.sh
+++ b/dev/source-release.sh
@@ -113,8 +113,8 @@ git archive $release_hash --worktree-attributes --prefix $tag/ -o $projectdir/$t
 
 echo "Signing the tarball..."
 [[ -z "$keyid" ]] && keyopt="-u $keyid"
-gpg --detach-sig $keyopt --armor --output ${projectdir}/${tarball}.asc ${projectdir}/$tarball
-shasum -a 512 ${projectdir}/$tarball > ${projectdir}/${tarball}.sha512
+gpg $keyopt --armor --output ${projectdir}/${tarball}.asc --detach-sig ${projectdir}/$tarball
+shasum -a 512 $tarball > ${projectdir}/${tarball}.sha512
 
 
 echo "Checking out Iceberg RC subversion repo..."


### PR DESCRIPTION
Fix 2 issues found during release:
1. checksum uses absolute path, but should just use the relative path
2. gpg command order is wrong, causing the key configuration to be not respected