### PR TITLE
SPEC - Convert string typed examples to JSON in REST API

### DIFF
--- a/rest_docs/rest-catalog-open-api.yaml
+++ b/rest_docs/rest-catalog-open-api.yaml
@@ -690,8 +690,8 @@ components:
         properties:
           type: object
           description: Configured string to string map of properties for the namespace
-          example: '{ "owner": "Hank Bendickson" }'
-          default: '{ }'
+          example: { "owner": "Hank Bendickson" }
+          default: { }
 
     UpdateNamespacePropertiesRequest:
       type: object
@@ -701,7 +701,7 @@ components:
           uniqueItems: true
           items:
             type: string
-          example: '[ "department", "access_group" ]'
+          example: [ "department", "access_group" ]
         updates:
           uniqueItems: true
           type: object


### PR DESCRIPTION
I've been using various swagger & open-api CLI tools to validate the OpenAPI spec doc as we've been working on it.

I have yet to find one that I love, or that is considered "canonical", so I tend to use a handful of them as well as reference the spec. Some of the tools Ive been using include `widdershins` and others from https://openapi.tools/

For the `example` values in `schema` components, they are allowed to be expressed as a single string according to the spec (namely if they can't be properly expressed as JSON or YAML). However, some tools struggle to parse these properly and thus render the example as an explicit string.

Given that these examples can be expressed as JSON or YAML, I've updated the ones I've noticed giving trouble.

While these are technically allowed, the require care in escaping that adds unneeded complexity, and some tools still struggle anyway. Note that editor.swagger.io doesn't fail on these, but some 3rd party tools do. These examples are arguably more correct anyway as JSON / YAML per the openapi specification.

What the docs have to say on this: https://swagger.io/specification/
```
example ... A free-form property to include an example of an instance for this schema.
To represent examples that cannot be naturally represented in JSON or YAML,
a string value can be used to contain the example with escaping where necessary.
```


