### PR TITLE
[Draft] Snapshot reference retention evaluation

### DIFF
--- a/api/src/main/java/org/apache/iceberg/SnapshotRef.java
+++ b/api/src/main/java/org/apache/iceberg/SnapshotRef.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.io.Serializable;
+import java.util.Objects;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+
+public class SnapshotRef implements Serializable {
+
+  public static final String MAIN_BRANCH = "main";
+
+  private final long snapshotId;
+  private final SnapshotRefType type;
+  private final Integer minSnapshotsToKeep;
+  private final Long maxSnapshotAgeMs;
+  private final Long maxRefAgeMs;
+
+  private SnapshotRef(
+      long snapshotId,
+      SnapshotRefType type,
+      Integer minSnapshotsToKeep,
+      Long maxSnapshotAgeMs,
+      Long maxRefAgeMs) {
+    this.snapshotId = snapshotId;
+    this.type = type;
+    this.minSnapshotsToKeep = minSnapshotsToKeep;
+    this.maxSnapshotAgeMs = maxSnapshotAgeMs;
+    this.maxRefAgeMs = maxRefAgeMs;
+  }
+
+  public long snapshotId() {
+    return snapshotId;
+  }
+
+  public SnapshotRefType type() {
+    return type;
+  }
+
+  public Integer minSnapshotsToKeep() {
+    return minSnapshotsToKeep;
+  }
+
+  public Long maxSnapshotAgeMs() {
+    return maxSnapshotAgeMs;
+  }
+
+  public Long maxRefAgeMs() {
+    return maxRefAgeMs;
+  }
+
+  public static Builder builderForTag(long snapshotId) {
+    return builderFor(snapshotId, SnapshotRefType.TAG);
+  }
+
+  public static Builder builderForBranch(long snapshotId) {
+    return builderFor(snapshotId, SnapshotRefType.BRANCH);
+  }
+
+  public static Builder builderFrom(SnapshotRef ref) {
+    return new Builder(ref.type())
+        .snapshotId(ref.snapshotId())
+        .minSnapshotsToKeep(ref.minSnapshotsToKeep())
+        .maxSnapshotAgeMs(ref.maxSnapshotAgeMs())
+        .maxRefAgeMs(ref.maxRefAgeMs());
+  }
+
+  public static Builder builderFor(long snapshotId, SnapshotRefType type) {
+    return new Builder(type).snapshotId(snapshotId);
+  }
+
+  public static class Builder {
+
+    private final SnapshotRefType type;
+
+    private Long snapshotId;
+    private Integer minSnapshotsToKeep;
+    private Long maxSnapshotAgeMs;
+    private Long maxRefAgeMs;
+
+    Builder(SnapshotRefType type) {
+      ValidationException.check(type != null, "Snapshot reference type must not be null");
+      this.type = type;
+    }
+
+    public Builder snapshotId(long id) {
+      this.snapshotId = id;
+      return this;
+    }
+
+    public Builder minSnapshotsToKeep(Integer value) {
+      this.minSnapshotsToKeep = value;
+      return this;
+    }
+
+    public Builder maxSnapshotAgeMs(Long value) {
+      this.maxSnapshotAgeMs = value;
+      return this;
+    }
+
+    public Builder maxRefAgeMs(Long value) {
+      this.maxRefAgeMs = value;
+      return this;
+    }
+
+    public SnapshotRef build() {
+      if (type.equals(SnapshotRefType.TAG)) {
+        ValidationException.check(minSnapshotsToKeep == null,
+            "TAG type snapshot reference does not support setting minSnapshotsToKeep");
+        ValidationException.check(maxSnapshotAgeMs == null,
+            "TAG type snapshot reference does not support setting maxSnapshotAgeMs");
+      } else {
+        if (minSnapshotsToKeep != null) {
+          ValidationException.check(minSnapshotsToKeep > 0,
+              "Min snapshots to keep must be greater than 0");
+        }
+
+        if (maxSnapshotAgeMs != null) {
+          ValidationException.check(maxSnapshotAgeMs > 0, "Max snapshot age must be greater than 0");
+        }
+      }
+
+      if (maxRefAgeMs != null) {
+        ValidationException.check(maxRefAgeMs > 0, "Max reference age must be greater than 0");
+      }
+
+      return new SnapshotRef(snapshotId, type, minSnapshotsToKeep, maxSnapshotAgeMs, maxRefAgeMs);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)  {
+      return true;
+    } else if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    SnapshotRef that = (SnapshotRef) o;
+    return snapshotId == that.snapshotId &&
+        type == that.type &&
+        Objects.equals(minSnapshotsToKeep, that.minSnapshotsToKeep) &&
+        Objects.equals(maxSnapshotAgeMs, that.maxSnapshotAgeMs) &&
+        Objects.equals(maxRefAgeMs, that.maxRefAgeMs);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(snapshotId, type, minSnapshotsToKeep, maxSnapshotAgeMs, maxRefAgeMs);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("snapshotId", snapshotId)
+        .add("type", type)
+        .add("minSnapshotsToKeep", minSnapshotsToKeep)
+        .add("maxSnapshotAgeMs", maxSnapshotAgeMs)
+        .add("maxRefAgeMs", maxRefAgeMs)
+        .toString();
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/SnapshotRef.java
+++ b/api/src/main/java/org/apache/iceberg/SnapshotRef.java
@@ -21,8 +21,8 @@ package org.apache.iceberg;
 
 import java.io.Serializable;
 import java.util.Objects;
-import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 public class SnapshotRef implements Serializable {
 
@@ -67,81 +67,78 @@ public class SnapshotRef implements Serializable {
     return maxRefAgeMs;
   }
 
-  public static Builder builderForTag(long snapshotId) {
+  public static Builder tagBuilder(long snapshotId) {
     return builderFor(snapshotId, SnapshotRefType.TAG);
   }
 
-  public static Builder builderForBranch(long snapshotId) {
+  public static Builder branchBuilder(long snapshotId) {
     return builderFor(snapshotId, SnapshotRefType.BRANCH);
   }
 
   public static Builder builderFrom(SnapshotRef ref) {
-    return new Builder(ref.type())
-        .snapshotId(ref.snapshotId())
+    return new Builder(ref.type(), ref.snapshotId())
+        .minSnapshotsToKeep(ref.minSnapshotsToKeep())
+        .maxSnapshotAgeMs(ref.maxSnapshotAgeMs())
+        .maxRefAgeMs(ref.maxRefAgeMs());
+  }
+  /**
+   * Creates a ref builder from the given ref and its properties but the ref will now point to the given snapshotId.
+   *
+   * @param ref Ref to build from
+   * @param snapshotId snapshotID to use.
+   * @return ref builder with the same retention properties as given ref, but the ref will point to the passed in id
+   */
+  public static Builder builderFrom(SnapshotRef ref, long snapshotId) {
+    return new Builder(ref.type(), snapshotId)
         .minSnapshotsToKeep(ref.minSnapshotsToKeep())
         .maxSnapshotAgeMs(ref.maxSnapshotAgeMs())
         .maxRefAgeMs(ref.maxRefAgeMs());
   }
 
   public static Builder builderFor(long snapshotId, SnapshotRefType type) {
-    return new Builder(type).snapshotId(snapshotId);
+    return new Builder(type, snapshotId);
   }
 
   public static class Builder {
 
     private final SnapshotRefType type;
+    private final long snapshotId;
 
-    private Long snapshotId;
     private Integer minSnapshotsToKeep;
     private Long maxSnapshotAgeMs;
     private Long maxRefAgeMs;
 
-    Builder(SnapshotRefType type) {
-      ValidationException.check(type != null, "Snapshot reference type must not be null");
+    Builder(SnapshotRefType type, long snapshotId) {
+      Preconditions.checkArgument(type != null, "Snapshot reference type must not be null");
       this.type = type;
-    }
-
-    public Builder snapshotId(long id) {
-      this.snapshotId = id;
-      return this;
+      this.snapshotId = snapshotId;
     }
 
     public Builder minSnapshotsToKeep(Integer value) {
+      Preconditions.checkArgument(value == null || !type.equals(SnapshotRefType.TAG),
+              "Tags do not support setting minSnapshotsToKeep");
+      Preconditions.checkArgument(value == null || value > 0,
+              "Min snapshots to keep must be greater than 0");
       this.minSnapshotsToKeep = value;
       return this;
     }
 
     public Builder maxSnapshotAgeMs(Long value) {
+      Preconditions.checkArgument(value == null || !type.equals(SnapshotRefType.TAG),
+              "Tags do not support setting maxSnapshotAgeMs");
+      Preconditions.checkArgument(value == null || value > 0,
+              "Max snapshot age must be greater than 0");
       this.maxSnapshotAgeMs = value;
       return this;
     }
 
     public Builder maxRefAgeMs(Long value) {
+      Preconditions.checkArgument(value == null || value > 0, "Max reference age must be greater than 0");
       this.maxRefAgeMs = value;
       return this;
     }
 
     public SnapshotRef build() {
-      if (type.equals(SnapshotRefType.TAG)) {
-        ValidationException.check(minSnapshotsToKeep == null,
-            "TAG type snapshot reference does not support setting minSnapshotsToKeep");
-        ValidationException.check(maxSnapshotAgeMs == null,
-            "TAG type snapshot reference does not support setting maxSnapshotAgeMs");
-      } else {
-        if (minSnapshotsToKeep != null) {
-          ValidationException.check(minSnapshotsToKeep > 0,
-              "Min snapshots to keep must be greater than 0");
-        }
-
-        if (maxSnapshotAgeMs != null) {
-          ValidationException.check(maxSnapshotAgeMs > 0, "Max snapshot age must be greater than 0");
-        }
-      }
-
-      if (maxRefAgeMs != null) {
-        ValidationException.check(maxRefAgeMs > 0, "Max reference age must be greater than 0");
-      }
-
       return new SnapshotRef(snapshotId, type, minSnapshotsToKeep, maxSnapshotAgeMs, maxRefAgeMs);
     }
   }

--- a/api/src/main/java/org/apache/iceberg/SnapshotRef.java
+++ b/api/src/main/java/org/apache/iceberg/SnapshotRef.java
@@ -33,18 +33,21 @@ public class SnapshotRef implements Serializable {
   private final Integer minSnapshotsToKeep;
   private final Long maxSnapshotAgeMs;
   private final Long maxRefAgeMs;
+  private final long timestampMillis;
 
   private SnapshotRef(
       long snapshotId,
       SnapshotRefType type,
       Integer minSnapshotsToKeep,
       Long maxSnapshotAgeMs,
-      Long maxRefAgeMs) {
+      Long maxRefAgeMs,
+      long timestampMillis) {
     this.snapshotId = snapshotId;
     this.type = type;
     this.minSnapshotsToKeep = minSnapshotsToKeep;
     this.maxSnapshotAgeMs = maxSnapshotAgeMs;
     this.maxRefAgeMs = maxRefAgeMs;
+    this.timestampMillis = timestampMillis;
   }
 
   public long snapshotId() {
@@ -53,6 +56,10 @@ public class SnapshotRef implements Serializable {
 
   public SnapshotRefType type() {
     return type;
+  }
+
+  public long timestampMillis() {
+    return timestampMillis;
   }
 
   public Integer minSnapshotsToKeep() {
@@ -139,7 +146,7 @@ public class SnapshotRef implements Serializable {
     }
 
     public SnapshotRef build() {
-      return new SnapshotRef(snapshotId, type, minSnapshotsToKeep, maxSnapshotAgeMs, maxRefAgeMs);
+      return new SnapshotRef(snapshotId, type, minSnapshotsToKeep, maxSnapshotAgeMs, maxRefAgeMs, System.currentTimeMillis());
     }
   }
 

--- a/api/src/main/java/org/apache/iceberg/SnapshotRefType.java
+++ b/api/src/main/java/org/apache/iceberg/SnapshotRefType.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+enum SnapshotRefType {
+  BRANCH,
+  TAG
+}

--- a/api/src/main/java/org/apache/iceberg/Table.java
+++ b/api/src/main/java/org/apache/iceberg/Table.java
@@ -21,7 +21,6 @@ package org.apache.iceberg;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
@@ -140,20 +139,19 @@ public interface Table {
   List<HistoryEntry> history();
 
   /**
-   * Get the snapshot references of this table.
-   *
+   * Get the snapshot references of this table. There is always a snapshot reference for the main branch.
+   * If there are no snapshots in the table, the main branch will point to -1.
    * @return a map with ref name as key, {@link SnapshotRef} as value
    */
   Map<String, SnapshotRef> refs();
 
   /**
-   * Get the snapshot references of a snapshot.
+   * Get the snapshot reference with the given name
    *
-   * @param snapshotId snapshot ID
-   * @return a set of {@link SnapshotRef snapshot references} of a snapshot.
-   *         Note that when there is no ref, it returns an empty set but not null.
+   * @param refName snapshot reference name
+   * @return the snapshot ref with the given name if it exists, null otherwise.
    */
-  Set<SnapshotRef> refs(long snapshotId);
+  SnapshotRef ref(String refName);
 
   /**
    * Create a new {@link UpdateSchema} to alter the columns of this table and commit the change.

--- a/api/src/main/java/org/apache/iceberg/Table.java
+++ b/api/src/main/java/org/apache/iceberg/Table.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
@@ -139,6 +140,22 @@ public interface Table {
   List<HistoryEntry> history();
 
   /**
+   * Get the snapshot references of this table.
+   *
+   * @return a map with ref name as key, {@link SnapshotRef} as value
+   */
+  Map<String, SnapshotRef> refs();
+
+  /**
+   * Get the snapshot references of a snapshot.
+   *
+   * @param snapshotId snapshot ID
+   * @return a set of {@link SnapshotRef snapshot references} of a snapshot.
+   *         Note that when there is no ref, it returns an empty set but not null.
+   */
+  Set<SnapshotRef> refs(long snapshotId);
+
+  /**
    * Create a new {@link UpdateSchema} to alter the columns of this table and commit the change.
    *
    * @return a new {@link UpdateSchema}
@@ -172,6 +189,13 @@ public interface Table {
    * @return a new {@link UpdateLocation}
    */
   UpdateLocation updateLocation();
+
+  /**
+   * Create a new {@link UpdateSnapshotRefs} to update snapshot references and commit the changes.
+   *
+   * @return a new {@link UpdateSnapshotRefs}
+   */
+  UpdateSnapshotRefs updateRefs();
 
   /**
    * Create a new {@link AppendFiles append API} to add files to this table and commit.

--- a/api/src/main/java/org/apache/iceberg/Transaction.java
+++ b/api/src/main/java/org/apache/iceberg/Transaction.java
@@ -69,6 +69,13 @@ public interface Transaction {
   UpdateLocation updateLocation();
 
   /**
+   * Create a new {@link UpdateSnapshotRefs} to update snapshot references.
+   *
+   * @return a new {@link UpdateSnapshotRefs}
+   */
+  UpdateSnapshotRefs updateRefs();
+
+  /**
    * Create a new {@link AppendFiles append API} to add files to this table.
    *
    * @return a new {@link AppendFiles}

--- a/api/src/main/java/org/apache/iceberg/UpdateSnapshotRefs.java
+++ b/api/src/main/java/org/apache/iceberg/UpdateSnapshotRefs.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.Map;
+import org.apache.iceberg.exceptions.CommitFailedException;
+
+/**
+ * API for snapshot reference evolution.
+ * <p>
+ * When committing, these changes will be applied to the current table metadata. Commit conflicts
+ * will not be resolved and will result in a {@link CommitFailedException}.
+ */
+public interface UpdateSnapshotRefs extends PendingUpdate<Map<String, SnapshotRef>> {
+
+  /**
+   * Assign a tag to a snapshot.
+   *
+   * @param name tag name
+   * @param snapshotId ID of the snapshot to tag
+   * @return this for method chaining
+   * @throws IllegalArgumentException if ref with the same name already exists
+   */
+  UpdateSnapshotRefs tag(String name, long snapshotId);
+
+  /**
+   * Create a branch and set a snapshot as the branch head.
+   *
+   * @param name branch name
+   * @param snapshotId ID of the snapshot to set as the branch head
+   * @return this for method chaining
+   * @throws IllegalArgumentException if ref with the same name already exists
+   */
+  UpdateSnapshotRefs branch(String name, long snapshotId);
+
+  /**
+   * Remove a tag or branch reference.
+   *
+   * @param name reference name
+   * @return this for method chaining
+   * @throws IllegalArgumentException if the reference does not exist
+   */
+  UpdateSnapshotRefs remove(String name);
+
+  /**
+   * Rename a tag or branch reference.
+   * Any configuration associated with the ref does not change.
+   *
+   * @param from ref to rename
+   * @param to renamed ref
+   * @throws IllegalArgumentException if from ref does not exist or to ref already exists
+   */
+  UpdateSnapshotRefs rename(String from, String to);
+
+  /**
+   * Set the maximum age of the tag or branch reference while expiring snapshots
+   *
+   * @param name reference name
+   * @param ageMs maximum age in millisecond
+   * @return this for method chaining
+   * @throws IllegalArgumentException if the reference does not exist
+   */
+  UpdateSnapshotRefs setLifetime(String name, long ageMs);
+
+  /**
+   * Set the maximum age of snapshots in a branch while expiring snapshots
+   *
+   * @param name branch name
+   * @param ageMs maximum age in millisecond
+   * @return this for method chaining
+   * @throws IllegalArgumentException if the reference does not exist
+   */
+  UpdateSnapshotRefs setBranchSnapshotLifetime(String name, long ageMs);
+
+  /**
+   * Set the minimum number of snapshots to keep in a branch while expiring snapshots
+   *
+   * @param name branch name
+   * @param numToKeep minimum number of snapshots to keep
+   * @return this for method chaining
+   * @throws IllegalArgumentException if the reference does not exist
+   */
+  UpdateSnapshotRefs setMinSnapshotsInBranch(String name, int numToKeep);
+
+}

--- a/api/src/main/java/org/apache/iceberg/UpdateSnapshotRefs.java
+++ b/api/src/main/java/org/apache/iceberg/UpdateSnapshotRefs.java
@@ -25,8 +25,8 @@ import org.apache.iceberg.exceptions.CommitFailedException;
 /**
  * API for snapshot reference evolution.
  * <p>
- * When committing, these changes will be applied to the current table metadata. Commit conflicts
- * will not be resolved and will result in a {@link CommitFailedException}.
+ * When committing, these changes will be applied to the current table metadata.
+ * Commit conflicts will not be resolved and will result in a {@link CommitFailedException}.
  */
 public interface UpdateSnapshotRefs extends PendingUpdate<Map<String, SnapshotRef>> {
 

--- a/api/src/test/java/org/apache/iceberg/TestSnapshotRef.java
+++ b/api/src/test/java/org/apache/iceberg/TestSnapshotRef.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import org.apache.iceberg.exceptions.ValidationException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestSnapshotRef {
+
+  @Test
+  public void testTagDefault() {
+    SnapshotRef ref = SnapshotRef.builderForTag(1L).build();
+    Assert.assertEquals(1L, ref.snapshotId());
+    Assert.assertEquals(SnapshotRefType.TAG, ref.type());
+    Assert.assertNull(ref.minSnapshotsToKeep());
+    Assert.assertNull(ref.maxSnapshotAgeMs());
+    Assert.assertNull(ref.maxRefAgeMs());
+  }
+
+  @Test
+  public void testBranchDefault() {
+    SnapshotRef ref = SnapshotRef.builderForBranch(1L).build();
+    Assert.assertEquals(1L, ref.snapshotId());
+    Assert.assertEquals(SnapshotRefType.BRANCH, ref.type());
+    Assert.assertNull(ref.minSnapshotsToKeep());
+    Assert.assertNull(ref.maxSnapshotAgeMs());
+  }
+
+  @Test
+  public void testTagWithOverride() {
+    SnapshotRef ref = SnapshotRef.builderForBranch(1L)
+        .maxRefAgeMs(10L)
+        .build();
+    Assert.assertEquals(1L, ref.snapshotId());
+    Assert.assertEquals(SnapshotRefType.BRANCH, ref.type());
+    Assert.assertEquals(10L, (long) ref.maxRefAgeMs());
+  }
+
+  @Test
+  public void testBranchWithOverride() {
+    SnapshotRef ref = SnapshotRef.builderForBranch(1L)
+        .minSnapshotsToKeep(10)
+        .maxSnapshotAgeMs(20L)
+        .maxRefAgeMs(30L)
+        .build();
+    Assert.assertEquals(1L, ref.snapshotId());
+    Assert.assertEquals(SnapshotRefType.BRANCH, ref.type());
+    Assert.assertEquals(10, (int) ref.minSnapshotsToKeep());
+    Assert.assertEquals(20L, (long) ref.maxSnapshotAgeMs());
+    Assert.assertEquals(30L, (long) ref.maxRefAgeMs());
+  }
+
+  @Test
+  public void testNoTypeFailure() {
+    AssertHelpers.assertThrows("Snapshot reference type must be specified",
+        ValidationException.class,
+        "Snapshot reference type must not be null",
+        () -> SnapshotRef.builderFor(1L, null).build());
+  }
+
+  @Test
+  public void testTagBuildFailures() {
+    AssertHelpers.assertThrows("Max reference age must be greater than 0 for tag",
+        ValidationException.class,
+        "Max reference age must be greater than 0",
+        () -> SnapshotRef.builderForTag(1L)
+            .maxRefAgeMs(-1L)
+            .build());
+
+    AssertHelpers.assertThrows("TAG type snapshot reference does not support setting minSnapshotsToKeep",
+        ValidationException.class,
+        "TAG type snapshot reference does not support setting minSnapshotsToKeep",
+        () -> SnapshotRef.builderForTag(1L)
+            .minSnapshotsToKeep(2)
+            .build());
+
+    AssertHelpers.assertThrows("TAG type snapshot reference does not support setting maxSnapshotAgeMs",
+        ValidationException.class,
+        "TAG type snapshot reference does not support setting maxSnapshotAgeMs",
+        () -> SnapshotRef.builderForTag(1L)
+            .maxSnapshotAgeMs(2L)
+            .build());
+  }
+
+  @Test
+  public void testBranchBuildFailures() {
+    AssertHelpers.assertThrows("Max snapshot age must be greater than 0",
+        ValidationException.class,
+        "Max snapshot age must be greater than 0",
+        () -> SnapshotRef.builderForBranch(1L)
+            .maxSnapshotAgeMs(-1L)
+            .build());
+
+    AssertHelpers.assertThrows("Min snapshots to keep must be greater than 0",
+        ValidationException.class,
+        "Min snapshots to keep must be greater than 0",
+        () -> SnapshotRef.builderForBranch(1L)
+            .minSnapshotsToKeep(-1)
+            .build());
+
+    AssertHelpers.assertThrows("Max reference age must be greater than 0 for branch",
+        ValidationException.class,
+        "Max reference age must be greater than 0",
+        () -> SnapshotRef.builderForBranch(1L)
+            .maxRefAgeMs(-1L)
+            .build());
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/TestSnapshotRef.java
+++ b/api/src/test/java/org/apache/iceberg/TestSnapshotRef.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg;
 
-import org.apache.iceberg.exceptions.ValidationException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -27,7 +26,7 @@ public class TestSnapshotRef {
 
   @Test
   public void testTagDefault() {
-    SnapshotRef ref = SnapshotRef.builderForTag(1L).build();
+    SnapshotRef ref = SnapshotRef.tagBuilder(1L).build();
     Assert.assertEquals(1L, ref.snapshotId());
     Assert.assertEquals(SnapshotRefType.TAG, ref.type());
     Assert.assertNull(ref.minSnapshotsToKeep());
@@ -37,7 +36,7 @@ public class TestSnapshotRef {
 
   @Test
   public void testBranchDefault() {
-    SnapshotRef ref = SnapshotRef.builderForBranch(1L).build();
+    SnapshotRef ref = SnapshotRef.branchBuilder(1L).build();
     Assert.assertEquals(1L, ref.snapshotId());
     Assert.assertEquals(SnapshotRefType.BRANCH, ref.type());
     Assert.assertNull(ref.minSnapshotsToKeep());
@@ -46,7 +45,7 @@ public class TestSnapshotRef {
 
   @Test
   public void testTagWithOverride() {
-    SnapshotRef ref = SnapshotRef.builderForBranch(1L)
+    SnapshotRef ref = SnapshotRef.branchBuilder(1L)
         .maxRefAgeMs(10L)
         .build();
     Assert.assertEquals(1L, ref.snapshotId());
@@ -56,7 +55,7 @@ public class TestSnapshotRef {
 
   @Test
   public void testBranchWithOverride() {
-    SnapshotRef ref = SnapshotRef.builderForBranch(1L)
+    SnapshotRef ref = SnapshotRef.branchBuilder(1L)
         .minSnapshotsToKeep(10)
         .maxSnapshotAgeMs(20L)
         .maxRefAgeMs(30L)
@@ -71,7 +70,7 @@ public class TestSnapshotRef {
   @Test
   public void testNoTypeFailure() {
     AssertHelpers.assertThrows("Snapshot reference type must be specified",
-        ValidationException.class,
+        IllegalArgumentException.class,
         "Snapshot reference type must not be null",
         () -> SnapshotRef.builderFor(1L, null).build());
   }
@@ -79,23 +78,23 @@ public class TestSnapshotRef {
   @Test
   public void testTagBuildFailures() {
     AssertHelpers.assertThrows("Max reference age must be greater than 0 for tag",
-        ValidationException.class,
+        IllegalArgumentException.class,
         "Max reference age must be greater than 0",
-        () -> SnapshotRef.builderForTag(1L)
+        () -> SnapshotRef.tagBuilder(1L)
             .maxRefAgeMs(-1L)
             .build());
 
-    AssertHelpers.assertThrows("TAG type snapshot reference does not support setting minSnapshotsToKeep",
-        ValidationException.class,
-        "TAG type snapshot reference does not support setting minSnapshotsToKeep",
-        () -> SnapshotRef.builderForTag(1L)
+    AssertHelpers.assertThrows("Tags do not support setting minSnapshotsToKeep",
+        IllegalArgumentException.class,
+        "Tags do not support setting minSnapshotsToKeep",
+        () -> SnapshotRef.tagBuilder(1L)
             .minSnapshotsToKeep(2)
             .build());
 
-    AssertHelpers.assertThrows("TAG type snapshot reference does not support setting maxSnapshotAgeMs",
-        ValidationException.class,
-        "TAG type snapshot reference does not support setting maxSnapshotAgeMs",
-        () -> SnapshotRef.builderForTag(1L)
+    AssertHelpers.assertThrows("Tags do not support setting maxSnapshotAgeMs",
+        IllegalArgumentException.class,
+        "Tags do not support setting maxSnapshotAgeMs",
+        () -> SnapshotRef.tagBuilder(1L)
             .maxSnapshotAgeMs(2L)
             .build());
   }
@@ -103,23 +102,23 @@ public class TestSnapshotRef {
   @Test
   public void testBranchBuildFailures() {
     AssertHelpers.assertThrows("Max snapshot age must be greater than 0",
-        ValidationException.class,
+        IllegalArgumentException.class,
         "Max snapshot age must be greater than 0",
-        () -> SnapshotRef.builderForBranch(1L)
+        () -> SnapshotRef.branchBuilder(1L)
             .maxSnapshotAgeMs(-1L)
             .build());
 
     AssertHelpers.assertThrows("Min snapshots to keep must be greater than 0",
-        ValidationException.class,
+        IllegalArgumentException.class,
         "Min snapshots to keep must be greater than 0",
-        () -> SnapshotRef.builderForBranch(1L)
+        () -> SnapshotRef.branchBuilder(1L)
             .minSnapshotsToKeep(-1)
             .build());
 
     AssertHelpers.assertThrows("Max reference age must be greater than 0 for branch",
-        ValidationException.class,
+        IllegalArgumentException.class,
         "Max reference age must be greater than 0",
-        () -> SnapshotRef.builderForBranch(1L)
+        () -> SnapshotRef.branchBuilder(1L)
             .maxRefAgeMs(-1L)
             .build());
   }

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -22,6 +22,7 @@ package org.apache.iceberg;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
@@ -159,6 +160,16 @@ abstract class BaseMetadataTable implements Table, HasTableOperations, Serializa
   }
 
   @Override
+  public Map<String, SnapshotRef> refs() {
+    return table().refs();
+  }
+
+  @Override
+  public Set<SnapshotRef> refs(long snapshotId) {
+    return table().refs(snapshotId);
+  }
+
+  @Override
   public UpdateSchema updateSchema() {
     throw new UnsupportedOperationException("Cannot update the schema of a metadata table");
   }
@@ -181,6 +192,11 @@ abstract class BaseMetadataTable implements Table, HasTableOperations, Serializa
   @Override
   public UpdateLocation updateLocation() {
     throw new UnsupportedOperationException("Cannot update the location of a metadata table");
+  }
+
+  @Override
+  public UpdateSnapshotRefs updateRefs() {
+    throw new UnsupportedOperationException("Cannot update the snapshot references of a metadata table");
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -22,7 +22,6 @@ package org.apache.iceberg;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
@@ -165,8 +164,8 @@ abstract class BaseMetadataTable implements Table, HasTableOperations, Serializa
   }
 
   @Override
-  public Set<SnapshotRef> refs(long snapshotId) {
-    return table().refs(snapshotId);
+  public SnapshotRef ref(String refName) {
+    return table().ref(refName);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTable.java
@@ -22,6 +22,7 @@ package org.apache.iceberg;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
@@ -125,6 +126,16 @@ public class BaseTable implements Table, HasTableOperations, Serializable {
   }
 
   @Override
+  public Map<String, SnapshotRef> refs() {
+    return ops.current().refs();
+  }
+
+  @Override
+  public Set<SnapshotRef> refs(long snapshotId) {
+    return ops.current().refs(snapshotId);
+  }
+
+  @Override
   public UpdateSchema updateSchema() {
     return new SchemaUpdate(ops);
   }
@@ -147,6 +158,11 @@ public class BaseTable implements Table, HasTableOperations, Serializable {
   @Override
   public UpdateLocation updateLocation() {
     return new SetLocation(ops);
+  }
+
+  @Override
+  public UpdateSnapshotRefs updateRefs() {
+    return new BaseUpdateSnapshotRefs(ops);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTable.java
@@ -22,7 +22,6 @@ package org.apache.iceberg;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
@@ -131,8 +130,8 @@ public class BaseTable implements Table, HasTableOperations, Serializable {
   }
 
   @Override
-  public Set<SnapshotRef> refs(long snapshotId) {
-    return ops.current().refs(snapshotId);
+  public SnapshotRef ref(String refName) {
+    return ops.current().ref(refName);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -137,6 +137,14 @@ class BaseTransaction implements Transaction {
   }
 
   @Override
+  public UpdateSnapshotRefs updateRefs() {
+    checkLastOperationCommitted("UpdateRefs");
+    UpdateSnapshotRefs updateRefs = new BaseUpdateSnapshotRefs(transactionOps);
+    updates.add(updateRefs);
+    return updateRefs;
+  }
+
+  @Override
   public AppendFiles newAppend() {
     checkLastOperationCommitted("AppendFiles");
     AppendFiles append = new MergeAppend(tableName, transactionOps);
@@ -588,6 +596,16 @@ class BaseTransaction implements Transaction {
     }
 
     @Override
+    public Map<String, SnapshotRef> refs() {
+      return current.refs();
+    }
+
+    @Override
+    public Set<SnapshotRef> refs(long snapshotId) {
+      return current.refs(snapshotId);
+    }
+
+    @Override
     public UpdateSchema updateSchema() {
       return BaseTransaction.this.updateSchema();
     }
@@ -610,6 +628,11 @@ class BaseTransaction implements Transaction {
     @Override
     public UpdateLocation updateLocation() {
       return BaseTransaction.this.updateLocation();
+    }
+
+    @Override
+    public UpdateSnapshotRefs updateRefs() {
+      return BaseTransaction.this.updateRefs();
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -601,8 +601,8 @@ class BaseTransaction implements Transaction {
     }
 
     @Override
-    public Set<SnapshotRef> refs(long snapshotId) {
-      return current.refs(snapshotId);
+    public SnapshotRef ref(String refName) {
+      return current.ref(refName);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/BaseUpdateSnapshotRefs.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdateSnapshotRefs.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+
+public class BaseUpdateSnapshotRefs implements UpdateSnapshotRefs {
+
+  private final TableOperations ops;
+  private final TableMetadata base;
+  private final Map<String, SnapshotRef> refs;
+
+  BaseUpdateSnapshotRefs(TableOperations ops) {
+    this.ops = ops;
+    this.base = ops.current();
+    this.refs = Maps.newHashMap(base.refs());
+  }
+
+  @Override
+  public UpdateSnapshotRefs tag(String name, long snapshotId) {
+    Preconditions.checkArgument(name != null, "Tag name must not be null");
+    Preconditions.checkArgument(base.snapshot(snapshotId) != null, "Cannot find snapshot with ID: %s", snapshotId);
+    Preconditions.checkArgument(!refs.containsKey(name), "Cannot tag snapshot, ref already exists: %s", name);
+
+    refs.put(name, SnapshotRef.builderForTag(snapshotId).build());
+    return this;
+  }
+
+  @Override
+  public UpdateSnapshotRefs branch(String name, long snapshotId) {
+    Preconditions.checkArgument(name != null, "Branch name must not be null");
+    Preconditions.checkArgument(base.snapshot(snapshotId) != null, "Cannot find snapshot with ID: %s", snapshotId);
+    Preconditions.checkArgument(!refs.containsKey(name), "Cannot create branch, ref already exists: %s", name);
+
+    refs.put(name, SnapshotRef.builderForBranch(snapshotId).build());
+    return this;
+  }
+
+  @Override
+  public UpdateSnapshotRefs remove(String name) {
+    Preconditions.checkArgument(name != null, "Ref name must not be null");
+    Preconditions.checkArgument(refs.containsKey(name), "Cannot find ref to remove: %s", name);
+    Preconditions.checkArgument(!SnapshotRef.MAIN_BRANCH.equals(name), "Main branch must not be removed");
+
+    refs.remove(name);
+    return this;
+  }
+
+  @Override
+  public UpdateSnapshotRefs rename(String from, String to) {
+    Preconditions.checkArgument(from != null && to != null, "Names must not be null");
+    Preconditions.checkArgument(refs.containsKey(from), "Cannot find ref to rename from: %s", from);
+    Preconditions.checkArgument(!refs.containsKey(to), "Cannot rename to an existing ref: %s", to);
+
+    refs.put(to, refs.remove(from));
+    return this;
+  }
+
+  @Override
+  public UpdateSnapshotRefs setLifetime(String name, long ageMs) {
+    Preconditions.checkArgument(name != null, "Branch name must not be null");
+    Preconditions.checkArgument(ageMs > 0, "Lifetime must be positive");
+    Preconditions.checkArgument(refs.containsKey(name), "Cannot find ref to set lifetime: %s", name);
+    Preconditions.checkArgument(!SnapshotRef.MAIN_BRANCH.equals(name), "Main branch is retained forever");
+
+    SnapshotRef oldRef = refs.get(name);
+    refs.put(name, SnapshotRef.builderFrom(oldRef).maxRefAgeMs(ageMs).build());
+    return this;
+  }
+
+  @Override
+  public UpdateSnapshotRefs setBranchSnapshotLifetime(String name, long ageMs) {
+    Preconditions.checkArgument(name != null, "Branch name must not be null");
+    Preconditions.checkArgument(ageMs > 0, "Lifetime must be positive");
+    Preconditions.checkArgument(refs.containsKey(name), "Cannot find ref to set branch snapshot lifetime: %s", name);
+
+    SnapshotRef oldRef = refs.get(name);
+    Preconditions.checkArgument(oldRef.type() == SnapshotRefType.BRANCH,
+        "Branch snapshot lifetime cannot be set for %s of type %s", name, oldRef.type());
+
+    refs.put(name, SnapshotRef.builderFrom(oldRef).maxSnapshotAgeMs(ageMs).build());
+    return this;
+  }
+
+  @Override
+  public UpdateSnapshotRefs setMinSnapshotsInBranch(String name, int numToKeep) {
+    Preconditions.checkArgument(name != null, "Branch name must not be null");
+    Preconditions.checkArgument(numToKeep > 0, "Snapshots to keep number must be positive");
+    Preconditions.checkArgument(refs.containsKey(name), "Cannot find ref to set snapshots in branch: %s", name);
+
+    SnapshotRef oldRef = refs.get(name);
+    Preconditions.checkArgument(oldRef.type() == SnapshotRefType.BRANCH,
+        "Branch snapshots to keep cannot be set for %s of type %s", name, oldRef.type());
+
+    refs.put(name, SnapshotRef.builderFrom(oldRef).minSnapshotsToKeep(numToKeep).build());
+    return this;
+  }
+
+  @Override
+  public Map<String, SnapshotRef> apply() {
+    return refs;
+  }
+
+  @Override
+  public void commit() {
+    TableMetadata updated = base.replaceRefs(apply());
+    ops.commit(base, updated);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/BaseUpdateSnapshotRefs.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdateSnapshotRefs.java
@@ -41,7 +41,7 @@ public class BaseUpdateSnapshotRefs implements UpdateSnapshotRefs {
     Preconditions.checkArgument(base.snapshot(snapshotId) != null, "Cannot find snapshot with ID: %s", snapshotId);
     Preconditions.checkArgument(!refs.containsKey(name), "Cannot tag snapshot, ref already exists: %s", name);
 
-    refs.put(name, SnapshotRef.builderForTag(snapshotId).build());
+    refs.put(name, SnapshotRef.tagBuilder(snapshotId).build());
     return this;
   }
 
@@ -51,7 +51,7 @@ public class BaseUpdateSnapshotRefs implements UpdateSnapshotRefs {
     Preconditions.checkArgument(base.snapshot(snapshotId) != null, "Cannot find snapshot with ID: %s", snapshotId);
     Preconditions.checkArgument(!refs.containsKey(name), "Cannot create branch, ref already exists: %s", name);
 
-    refs.put(name, SnapshotRef.builderForBranch(snapshotId).build());
+    refs.put(name, SnapshotRef.branchBuilder(snapshotId).build());
     return this;
   }
 

--- a/core/src/main/java/org/apache/iceberg/CommitCallbackTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/CommitCallbackTransaction.java
@@ -63,6 +63,11 @@ class CommitCallbackTransaction implements Transaction {
   }
 
   @Override
+  public UpdateSnapshotRefs updateRefs() {
+    return wrapped.updateRefs();
+  }
+
+  @Override
   public AppendFiles newFastAppend() {
     return wrapped.newFastAppend();
   }

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
@@ -200,4 +200,28 @@ public interface MetadataUpdate extends Serializable {
       return location;
     }
   }
+
+  class SetSnapshotRefs implements MetadataUpdate {
+    private final Map<String, SnapshotRef> updated;
+
+    public SetSnapshotRefs(Map<String, SnapshotRef> updated) {
+      this.updated = updated;
+    }
+
+    public Map<String, SnapshotRef> updated() {
+      return updated;
+    }
+  }
+
+  class RemoveSnapshotRefs implements MetadataUpdate {
+    private final Set<String> removed;
+
+    public RemoveSnapshotRefs(Set<String> removed) {
+      this.removed = removed;
+    }
+
+    public Set<String> removed() {
+      return removed;
+    }
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/SerializableTable.java
+++ b/core/src/main/java/org/apache/iceberg/SerializableTable.java
@@ -22,7 +22,6 @@ package org.apache.iceberg;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.hadoop.HadoopConfigurable;
@@ -269,8 +268,8 @@ public class SerializableTable implements Table, Serializable {
   }
 
   @Override
-  public Set<SnapshotRef> refs(long snapshotId) {
-    return lazyTable().refs(snapshotId);
+  public SnapshotRef ref(String refName) {
+    return lazyTable().ref(refName);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/SerializableTable.java
+++ b/core/src/main/java/org/apache/iceberg/SerializableTable.java
@@ -22,6 +22,7 @@ package org.apache.iceberg;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.hadoop.HadoopConfigurable;
@@ -263,6 +264,16 @@ public class SerializableTable implements Table, Serializable {
   }
 
   @Override
+  public Map<String, SnapshotRef> refs() {
+    return lazyTable().refs();
+  }
+
+  @Override
+  public Set<SnapshotRef> refs(long snapshotId) {
+    return lazyTable().refs(snapshotId);
+  }
+
+  @Override
   public UpdateSchema updateSchema() {
     throw new UnsupportedOperationException(errorMsg("updateSchema"));
   }
@@ -285,6 +296,11 @@ public class SerializableTable implements Table, Serializable {
   @Override
   public UpdateLocation updateLocation() {
     throw new UnsupportedOperationException(errorMsg("updateLocation"));
+  }
+
+  @Override
+  public UpdateSnapshotRefs updateRefs() {
+    throw new UnsupportedOperationException(errorMsg("updateRefs"));
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/SnapshotReferenceParser.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotReferenceParser.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.UncheckedIOException;
+import java.util.Locale;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.JsonUtil;
+
+public class SnapshotReferenceParser {
+
+  private SnapshotReferenceParser() {
+  }
+
+  private static final String SNAPSHOT_ID = "snapshot-id";
+  private static final String TYPE = "type";
+  private static final String MIN_SNAPSHOTS_TO_KEEP = "min-snapshots-to-keep";
+  private static final String MAX_SNAPSHOT_AGE_MS = "max-snapshot-age-ms";
+  private static final String MAX_REF_AGE_MS = "max-ref-age-ms";
+
+  public static String toJson(SnapshotRef ref) {
+    return toJson(ref, false);
+  }
+
+  public static String toJson(SnapshotRef ref, boolean pretty) {
+    try {
+      StringWriter writer = new StringWriter();
+      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
+      if (pretty) {
+        generator.useDefaultPrettyPrinter();
+      }
+
+      toJson(ref, generator);
+      generator.flush();
+      return writer.toString();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  public static void toJson(SnapshotRef ref, JsonGenerator generator) throws IOException {
+    generator.writeStartObject();
+    generator.writeNumberField(SNAPSHOT_ID, ref.snapshotId());
+    generator.writeStringField(TYPE, ref.type().name().toLowerCase(Locale.ENGLISH));
+    JsonUtil.writeIntegerIfExists(MIN_SNAPSHOTS_TO_KEEP, ref.minSnapshotsToKeep(), generator);
+    JsonUtil.writeLongIfExists(MAX_SNAPSHOT_AGE_MS, ref.maxSnapshotAgeMs(), generator);
+    JsonUtil.writeLongIfExists(MAX_REF_AGE_MS, ref.maxRefAgeMs(), generator);
+    generator.writeEndObject();
+  }
+
+  public static SnapshotRef fromJson(String json) {
+    try {
+      return fromJson(JsonUtil.mapper().readValue(json, JsonNode.class));
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to parse snapshot ref: " + json, e);
+    }
+  }
+
+  public static SnapshotRef fromJson(JsonNode node) {
+    Preconditions.checkArgument(node.isObject(), "Cannot parse snapshot reference from a non-object: %s", node);
+    long snapshotId = JsonUtil.getLong(SNAPSHOT_ID, node);
+    SnapshotRefType type = SnapshotRefType.valueOf(
+        JsonUtil.getString(TYPE, node).toUpperCase(Locale.ENGLISH));
+    Integer minSnapshotsToKeep = JsonUtil.getIntOrNull(MIN_SNAPSHOTS_TO_KEEP, node);
+    Long maxSnapshotAgeMs = JsonUtil.getLongOrNull(MAX_SNAPSHOT_AGE_MS, node);
+    Long maxRefAgeMs = JsonUtil.getLongOrNull(MAX_REF_AGE_MS, node);
+    return SnapshotRef.builderFor(snapshotId, type)
+        .minSnapshotsToKeep(minSnapshotsToKeep)
+        .maxSnapshotAgeMs(maxSnapshotAgeMs)
+        .maxRefAgeMs(maxRefAgeMs)
+        .build();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/SnapshotReferenceParser.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotReferenceParser.java
@@ -80,8 +80,7 @@ public class SnapshotReferenceParser {
   public static SnapshotRef fromJson(JsonNode node) {
     Preconditions.checkArgument(node.isObject(), "Cannot parse snapshot reference from a non-object: %s", node);
     long snapshotId = JsonUtil.getLong(SNAPSHOT_ID, node);
-    SnapshotRefType type = SnapshotRefType.valueOf(
-        JsonUtil.getString(TYPE, node).toUpperCase(Locale.ENGLISH));
+    SnapshotRefType type = SnapshotRefType.valueOf(JsonUtil.getString(TYPE, node).toUpperCase(Locale.ENGLISH));
     Integer minSnapshotsToKeep = JsonUtil.getIntOrNull(MIN_SNAPSHOTS_TO_KEEP, node);
     Long maxSnapshotAgeMs = JsonUtil.getLongOrNull(MAX_SNAPSHOT_AGE_MS, node);
     Long maxRefAgeMs = JsonUtil.getLongOrNull(MAX_REF_AGE_MS, node);

--- a/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
@@ -20,8 +20,10 @@
 package org.apache.iceberg.util;
 
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -70,6 +72,17 @@ public class JsonUtil {
     JsonNode pNode = node.get(property);
     Preconditions.checkArgument(pNode != null && !pNode.isNull() && pNode.isNumber(),
         "Cannot parse %s from non-numeric value: %s", property, pNode);
+    return pNode.asLong();
+  }
+
+  public static Long getLongOrNull(String property, JsonNode node) {
+    if (!node.has(property)) {
+      return null;
+    }
+
+    JsonNode pNode = node.get(property);
+    Preconditions.checkArgument(pNode != null && !pNode.isNull() && pNode.isIntegralNumber() &&
+        pNode.canConvertToLong(), "Cannot parse %s from non-numeric value: %s", property, pNode);
     return pNode.asLong();
   }
 
@@ -132,6 +145,18 @@ public class JsonUtil {
     return ImmutableSet.<Integer>builder()
         .addAll(new JsonIntegerArrayIterator(property, node))
         .build();
+  }
+
+  public static void writeIntegerIfExists(String key, Integer value, JsonGenerator generator) throws IOException {
+    if (value != null) {
+      generator.writeNumberField(key, value);
+    }
+  }
+
+  public static void writeLongIfExists(String key, Long value, JsonGenerator generator) throws IOException {
+    if (value != null) {
+      generator.writeNumberField(key, value);
+    }
   }
 
   abstract static class JsonArrayIterator<T> implements Iterator<T> {

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotRefParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotRefParser.java
@@ -27,7 +27,7 @@ public class TestSnapshotRefParser {
   @Test
   public void testTagToJsonDefault() {
     String json = "{\"snapshot-id\":1,\"type\":\"tag\"}";
-    SnapshotRef ref = SnapshotRef.builderForTag(1L).build();
+    SnapshotRef ref = SnapshotRef.tagBuilder(1L).build();
     Assert.assertEquals("Should be able to serialize default tag",
         json, SnapshotReferenceParser.toJson(ref));
   }
@@ -35,7 +35,7 @@ public class TestSnapshotRefParser {
   @Test
   public void testTagToJsonAllFields() {
     String json = "{\"snapshot-id\":1,\"type\":\"tag\",\"max-ref-age-ms\":1}";
-    SnapshotRef ref = SnapshotRef.builderForTag(1L)
+    SnapshotRef ref = SnapshotRef.tagBuilder(1L)
         .maxRefAgeMs(1L)
         .build();
     Assert.assertEquals("Should be able to serialize tag with all fields",
@@ -45,7 +45,7 @@ public class TestSnapshotRefParser {
   @Test
   public void testBranchToJsonDefault() {
     String json = "{\"snapshot-id\":1,\"type\":\"branch\"}";
-    SnapshotRef ref = SnapshotRef.builderForBranch(1L).build();
+    SnapshotRef ref = SnapshotRef.branchBuilder(1L).build();
     Assert.assertEquals("Should be able to serialize default branch",
         json, SnapshotReferenceParser.toJson(ref));
   }
@@ -54,7 +54,7 @@ public class TestSnapshotRefParser {
   public void testBranchToJsonAllFields() {
     String json = "{\"snapshot-id\":1,\"type\":\"branch\",\"min-snapshots-to-keep\":2," +
         "\"max-snapshot-age-ms\":3,\"max-ref-age-ms\":4}";
-    SnapshotRef ref = SnapshotRef.builderForBranch(1L)
+    SnapshotRef ref = SnapshotRef.branchBuilder(1L)
         .minSnapshotsToKeep(2)
         .maxSnapshotAgeMs(3L)
         .maxRefAgeMs(4L)
@@ -66,7 +66,7 @@ public class TestSnapshotRefParser {
   @Test
   public void testTagFromJsonDefault() {
     String json = "{\"snapshot-id\":1,\"type\":\"tag\"}";
-    SnapshotRef ref = SnapshotRef.builderForTag(1L).build();
+    SnapshotRef ref = SnapshotRef.tagBuilder(1L).build();
     Assert.assertEquals("Should be able to deserialize default tag",
         ref, SnapshotReferenceParser.fromJson(json));
   }
@@ -74,7 +74,7 @@ public class TestSnapshotRefParser {
   @Test
   public void testTagFromJsonAllFields() {
     String json = "{\"snapshot-id\":1,\"type\":\"tag\",\"max-ref-age-ms\":1}";
-    SnapshotRef ref = SnapshotRef.builderForTag(1L)
+    SnapshotRef ref = SnapshotRef.tagBuilder(1L)
         .maxRefAgeMs(1L)
         .build();
     Assert.assertEquals("Should be able to deserialize tag with all fields",
@@ -84,7 +84,7 @@ public class TestSnapshotRefParser {
   @Test
   public void testBranchFromJsonDefault() {
     String json = "{\"snapshot-id\":1,\"type\":\"branch\"}";
-    SnapshotRef ref = SnapshotRef.builderForBranch(1L).build();
+    SnapshotRef ref = SnapshotRef.branchBuilder(1L).build();
     Assert.assertEquals("Should be able to deserialize default branch",
         ref, SnapshotReferenceParser.fromJson(json));
   }
@@ -93,7 +93,7 @@ public class TestSnapshotRefParser {
   public void testBranchFromJsonAllFields() {
     String json = "{\"snapshot-id\":1,\"type\":\"branch\",\"min-snapshots-to-keep\":2," +
         "\"max-snapshot-age-ms\":3,\"max-ref-age-ms\":4}";
-    SnapshotRef ref = SnapshotRef.builderForBranch(1L)
+    SnapshotRef ref = SnapshotRef.branchBuilder(1L)
         .minSnapshotsToKeep(2)
         .maxSnapshotAgeMs(3L)
         .maxRefAgeMs(4L)

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotRefParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotRefParser.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestSnapshotRefParser {
+
+  @Test
+  public void testTagToJsonDefault() {
+    String json = "{\"snapshot-id\":1,\"type\":\"tag\"}";
+    SnapshotRef ref = SnapshotRef.builderForTag(1L).build();
+    Assert.assertEquals("Should be able to serialize default tag",
+        json, SnapshotReferenceParser.toJson(ref));
+  }
+
+  @Test
+  public void testTagToJsonAllFields() {
+    String json = "{\"snapshot-id\":1,\"type\":\"tag\",\"max-ref-age-ms\":1}";
+    SnapshotRef ref = SnapshotRef.builderForTag(1L)
+        .maxRefAgeMs(1L)
+        .build();
+    Assert.assertEquals("Should be able to serialize tag with all fields",
+        json, SnapshotReferenceParser.toJson(ref));
+  }
+
+  @Test
+  public void testBranchToJsonDefault() {
+    String json = "{\"snapshot-id\":1,\"type\":\"branch\"}";
+    SnapshotRef ref = SnapshotRef.builderForBranch(1L).build();
+    Assert.assertEquals("Should be able to serialize default branch",
+        json, SnapshotReferenceParser.toJson(ref));
+  }
+
+  @Test
+  public void testBranchToJsonAllFields() {
+    String json = "{\"snapshot-id\":1,\"type\":\"branch\",\"min-snapshots-to-keep\":2," +
+        "\"max-snapshot-age-ms\":3,\"max-ref-age-ms\":4}";
+    SnapshotRef ref = SnapshotRef.builderForBranch(1L)
+        .minSnapshotsToKeep(2)
+        .maxSnapshotAgeMs(3L)
+        .maxRefAgeMs(4L)
+        .build();
+    Assert.assertEquals("Should be able to serialize branch with all fields",
+        json, SnapshotReferenceParser.toJson(ref));
+  }
+
+  @Test
+  public void testTagFromJsonDefault() {
+    String json = "{\"snapshot-id\":1,\"type\":\"tag\"}";
+    SnapshotRef ref = SnapshotRef.builderForTag(1L).build();
+    Assert.assertEquals("Should be able to deserialize default tag",
+        ref, SnapshotReferenceParser.fromJson(json));
+  }
+
+  @Test
+  public void testTagFromJsonAllFields() {
+    String json = "{\"snapshot-id\":1,\"type\":\"tag\",\"max-ref-age-ms\":1}";
+    SnapshotRef ref = SnapshotRef.builderForTag(1L)
+        .maxRefAgeMs(1L)
+        .build();
+    Assert.assertEquals("Should be able to deserialize tag with all fields",
+        ref, SnapshotReferenceParser.fromJson(json));
+  }
+
+  @Test
+  public void testBranchFromJsonDefault() {
+    String json = "{\"snapshot-id\":1,\"type\":\"branch\"}";
+    SnapshotRef ref = SnapshotRef.builderForBranch(1L).build();
+    Assert.assertEquals("Should be able to deserialize default branch",
+        ref, SnapshotReferenceParser.fromJson(json));
+  }
+
+  @Test
+  public void testBranchFromJsonAllFields() {
+    String json = "{\"snapshot-id\":1,\"type\":\"branch\",\"min-snapshots-to-keep\":2," +
+        "\"max-snapshot-age-ms\":3,\"max-ref-age-ms\":4}";
+    SnapshotRef ref = SnapshotRef.builderForBranch(1L)
+        .minSnapshotsToKeep(2)
+        .maxSnapshotAgeMs(3L)
+        .maxRefAgeMs(4L)
+        .build();
+    Assert.assertEquals("Should be able to deserialize branch with all fields",
+        ref, SnapshotReferenceParser.fromJson(json));
+  }
+
+}

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -892,10 +892,10 @@ public class TestTableMetadata {
     String data = readTableMetadataInputFile("TableMetadataV2Valid.json");
     TableMetadata parsed = TableMetadataParser.fromJson(ops.io(), data);
 
-    SnapshotRef mainBranch = SnapshotRef.builderForBranch(3055729675574597004L).build();
-    SnapshotRef testTag = SnapshotRef.builderForTag(3055729675574597004L)
+    SnapshotRef mainBranch = SnapshotRef.branchBuilder(3055729675574597004L).build();
+    SnapshotRef testTag = SnapshotRef.tagBuilder(3055729675574597004L)
         .maxRefAgeMs(100L).build();
-    SnapshotRef devBranch = SnapshotRef.builderForBranch(3051729675574597004L)
+    SnapshotRef devBranch = SnapshotRef.branchBuilder(3051729675574597004L)
         .minSnapshotsToKeep(2).maxSnapshotAgeMs(200L).build();
 
     Assert.assertEquals(ImmutableMap.of("main", mainBranch, "test", testTag, "dev", devBranch), parsed.refs());
@@ -907,7 +907,7 @@ public class TestTableMetadata {
     TableMetadata meta = TableMetadata.newTableMetadata(
         schema, PartitionSpec.unpartitioned(), null, ImmutableMap.of());
     Assert.assertEquals("Metadata should have a main branch",
-        ImmutableMap.of("main", SnapshotRef.builderForBranch(-1).build()),
+        ImmutableMap.of("main", SnapshotRef.branchBuilder(-1).build()),
         meta.refs());
   }
 
@@ -922,7 +922,7 @@ public class TestTableMetadata {
         ImmutableList.of(new GenericManifestFile(Files.localInput("file:/tmp/manfiest.2.avro"), meta.spec().specId())));
     TableMetadata newMeta = meta.replaceCurrentSnapshot(currentSnapshot);
     Assert.assertEquals("Main branch should be updated to the replaced snapshot",
-        ImmutableMap.of("main", SnapshotRef.builderForBranch(currentSnapshotId).build()),
+        ImmutableMap.of("main", SnapshotRef.branchBuilder(currentSnapshotId).build()),
         newMeta.refs());
   }
 
@@ -930,18 +930,19 @@ public class TestTableMetadata {
   public void testSnapshotWithRefShouldNotBeRemoved() {
     Schema schema = new Schema(Types.NestedField.required(10, "x", Types.StringType.get()));
     TableMetadata meta = TableMetadata.newTableMetadata(
-        schema, PartitionSpec.unpartitioned(), null, ImmutableMap.of());
+            schema, PartitionSpec.unpartitioned(), null, ImmutableMap.of());
     long currentSnapshotId = System.currentTimeMillis();
     Snapshot currentSnapshot = new BaseSnapshot(
-        ops.io(), currentSnapshotId, -1L, currentSnapshotId, null, null, meta.schema().schemaId(),
-        ImmutableList.of(new GenericManifestFile(Files.localInput("file:/tmp/manfiest.2.avro"), meta.spec().specId())));
+            ops.io(), currentSnapshotId, -1L, currentSnapshotId, null, null, meta.schema().schemaId(),
+            ImmutableList.of(new GenericManifestFile(Files.localInput("file:/tmp/manfiest.2.avro"),
+            meta.spec().specId())));
     TableMetadata newMeta = meta.replaceCurrentSnapshot(currentSnapshot);
     newMeta = newMeta.removeSnapshotsIf(s -> s.snapshotId() == currentSnapshotId);
     Assert.assertEquals("The current snapshot should not be removed",
-        currentSnapshotId, newMeta.currentSnapshot().snapshotId());
+            currentSnapshotId, newMeta.currentSnapshot().snapshotId());
     Assert.assertEquals("The current snapshot still be the main branch",
-        ImmutableMap.of("main", SnapshotRef.builderForBranch(currentSnapshotId).build()),
-        newMeta.refs());
+            ImmutableMap.of("main", SnapshotRef.branchBuilder(currentSnapshotId).build()),
+            newMeta.refs());
   }
 
   @Test
@@ -957,7 +958,7 @@ public class TestTableMetadata {
     newMeta = newMeta.buildReplacement(newMeta.schema(), newMeta.spec(), newMeta.sortOrder(), newMeta.location(),
         ImmutableMap.of("key", "val"));
     Assert.assertEquals("Main branch should be reset to snapshot ID -1",
-        ImmutableMap.of("main", SnapshotRef.builderForBranch(-1).build()),
+        ImmutableMap.of("main", SnapshotRef.branchBuilder(-1).build()),
         newMeta.refs());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadataSerialization.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadataSerialization.java
@@ -81,5 +81,6 @@ public class TestTableMetadataSerialization extends TableTestBase {
         Lists.transform(meta.snapshots(), Snapshot::snapshotId),
         Lists.transform(result.snapshots(), Snapshot::snapshotId));
     Assert.assertEquals("History should match", meta.snapshotLog(), result.snapshotLog());
+    Assert.assertEquals("Refs should match", meta.refs(), result.refs());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestUpdateSnapshotRefs.java
+++ b/core/src/test/java/org/apache/iceberg/TestUpdateSnapshotRefs.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+@RunWith(Parameterized.class)
+public class TestUpdateSnapshotRefs extends TableTestBase {
+
+  private static final String TEST_BRANCH = "testBranch";
+  private static final String TEST_TAG = "testTag";
+
+  @Parameterized.Parameters(name = "formatVersion = {0}")
+  public static Object[] parameters() {
+    return new Object[] { 2 };
+  }
+
+  public TestUpdateSnapshotRefs(int formatVersion) {
+    super(formatVersion);
+  }
+
+  @Before
+  public void setupTable() throws Exception {
+    super.setupTable();
+
+    TableMetadata base = table.ops().current();
+
+    Map<String, SnapshotRef> refs = ImmutableMap.of(
+        TEST_BRANCH, SnapshotRef.builderForBranch(123).maxSnapshotAgeMs(1L).minSnapshotsToKeep(1).build(),
+        TEST_TAG, SnapshotRef.builderForTag(456).maxRefAgeMs(1L).build());
+
+    List<Snapshot> snapshots = Lists.newArrayList(
+        new BaseSnapshot(table.ops().io(), 789, null, "file:/tmp/manifest1.avro"),
+        new BaseSnapshot(table.ops().io(), 456, null, "file:/tmp/manifest1.avro"),
+        new BaseSnapshot(table.ops().io(), 123, null, "file:/tmp/manifest1.avro"));
+
+    List<HistoryEntry> snapshotLogs = snapshots.stream()
+        .map(snapshot -> new TableMetadata.SnapshotLogEntry(snapshot.snapshotId(), snapshot.snapshotId()))
+        .collect(Collectors.toList());
+
+    TableMetadata newTableMetadata = new TableMetadata(
+        metadataDir.getAbsolutePath(), base.formatVersion(), base.uuid(), base.location(),
+        base.lastSequenceNumber(), base.lastUpdatedMillis(), base.lastColumnId(), base.currentSchemaId(),
+        base.schemas(), base.defaultSpecId(), base.specs(), base.lastAssignedPartitionId(),
+        base.defaultSortOrderId(), base.sortOrders(), base.properties(), 123, snapshots,
+        snapshotLogs, base.previousFiles(), refs, ImmutableList.of());
+
+    table.ops().commit(base, newTableMetadata);
+    table.refresh();
+  }
+
+  @Test
+  public void testCreateTag() {
+    String tag = "newTag";
+    table.updateRefs().tag(tag, 789).commit();
+    table.refresh();
+    Assert.assertTrue("Should contain new tag", table.refs().containsKey(tag));
+    SnapshotRef ref = table.refs().get(tag);
+    Assert.assertEquals("Should create tag type ref", SnapshotRefType.TAG, ref.type());
+    Assert.assertEquals("Should create tag for the given snapshot", 789, ref.snapshotId());
+  }
+
+  @Test
+  public void testCreateTagNameInvalid() {
+    AssertHelpers.assertThrows("Should fail when tag name is null",
+        IllegalArgumentException.class,
+        "Tag name must not be null",
+        () -> table.updateRefs().tag(null, 789));
+
+    AssertHelpers.assertThrows("Should fail when tag name already exists as a tag",
+        IllegalArgumentException.class,
+        "Cannot tag snapshot, ref already exists: testTag",
+        () -> table.updateRefs().tag("testTag", 789));
+
+    AssertHelpers.assertThrows("Should fail when tag name already exists as a branch",
+        IllegalArgumentException.class,
+        "Cannot tag snapshot, ref already exists: testBranch",
+        () -> table.updateRefs().tag("testBranch", 789));
+  }
+
+  @Test
+  public void testCreateBranch() {
+    String branch = "newBranch";
+    table.updateRefs().branch(branch, 789).commit();
+    table.refresh();
+    Assert.assertTrue("Should contain new branch", table.refs().containsKey(branch));
+    SnapshotRef ref = table.refs().get(branch);
+    Assert.assertEquals("Should create branch type ref", SnapshotRefType.BRANCH, ref.type());
+    Assert.assertEquals("Should create branch for the given snapshot", 789, ref.snapshotId());
+  }
+
+  @Test
+  public void testCreateBranchNameInvalid() {
+    AssertHelpers.assertThrows("Should fail when branch name is null",
+        IllegalArgumentException.class,
+        "Branch name must not be null",
+        () -> table.updateRefs().branch(null, 789));
+
+    AssertHelpers.assertThrows("Should fail when branch name already exists as a tag",
+        IllegalArgumentException.class,
+        "Cannot create branch, ref already exists: testTag",
+        () -> table.updateRefs().branch(TEST_TAG, 789));
+
+    AssertHelpers.assertThrows("Should fail when branch name already exists as a branch",
+        IllegalArgumentException.class,
+        "Cannot create branch, ref already exists: testBranch",
+        () -> table.updateRefs().branch(TEST_BRANCH, 789));
+  }
+
+  @Test
+  public void testCreateRefSnapshotNotExist() {
+    AssertHelpers.assertThrows("Should fail when snapshot to create tag does not exist",
+        IllegalArgumentException.class,
+        "Cannot find snapshot with ID: 233",
+        () -> table.updateRefs().tag("tag", 233));
+
+    AssertHelpers.assertThrows("Should fail when snapshot to create branch does not exist",
+        IllegalArgumentException.class,
+        "Cannot find snapshot with ID: 233",
+        () -> table.updateRefs().branch("branch", 233));
+  }
+
+  @Test
+  public void testSetRefLifetime() {
+    table.updateRefs()
+        .setLifetime(TEST_BRANCH, 10000)
+        .setLifetime(TEST_TAG, 20000)
+        .commit();
+    table.refresh();
+    Assert.assertEquals("Should have latest lifetime config for branch",
+        10000, (long) table.refs().get(TEST_BRANCH).maxRefAgeMs());
+    Assert.assertEquals("Should have latest lifetime config for tag",
+        20000, (long) table.refs().get(TEST_TAG).maxRefAgeMs());
+  }
+
+  @Test
+  public void testSetMainBranchLifetimeShouldFail() {
+    AssertHelpers.assertThrows("Should not be able to set lifetime for main branch",
+        IllegalArgumentException.class,
+        "Main branch is retained forever",
+        () -> table.updateRefs().setLifetime(SnapshotRef.MAIN_BRANCH, 100));
+  }
+
+  @Test
+  public void testSetBranchSnapshotLifetime() {
+    table.updateRefs()
+        .setBranchSnapshotLifetime(TEST_BRANCH, 10000)
+        .commit();
+    table.refresh();
+    Assert.assertEquals("Should have latest snapshot lifetime config for branch",
+        10000, (long) table.refs().get(TEST_BRANCH).maxSnapshotAgeMs());
+  }
+
+  @Test
+  public void testSetMinSnapshotsInBranch() {
+    table.updateRefs()
+        .setMinSnapshotsInBranch(TEST_BRANCH, 10000)
+        .commit();
+    table.refresh();
+    Assert.assertEquals("Should have latest snapshot in branch config for branch",
+        10000, (int) table.refs().get(TEST_BRANCH).minSnapshotsToKeep());
+  }
+
+  @Test
+  public void testRenameTag() {
+    SnapshotRef tagRef = table.refs().get(TEST_TAG);
+    table.updateRefs().rename(TEST_TAG, "tag2").commit();
+    Assert.assertEquals("Renamed tag should have the same config", tagRef, table.refs().get("tag2"));
+  }
+
+  @Test
+  public void testRenameBranch() {
+    SnapshotRef tagRef = table.refs().get(TEST_BRANCH);
+    table.updateRefs().rename(TEST_BRANCH, "branch2").commit();
+    Assert.assertEquals("Renamed branch should have the same config", tagRef, table.refs().get("branch2"));
+  }
+
+  @Test
+  public void testInvalidRename() {
+    AssertHelpers.assertThrows("Should not have null from name",
+        IllegalArgumentException.class,
+        "Names must not be null",
+        () -> table.updateRefs().rename(null, "to"));
+
+    AssertHelpers.assertThrows("Should not have null to name",
+        IllegalArgumentException.class,
+        "Names must not be null",
+        () -> table.updateRefs().rename("from", null));
+
+    AssertHelpers.assertThrows("From ref must exist",
+        IllegalArgumentException.class,
+        "Cannot find ref to rename from: tag",
+        () -> table.updateRefs().rename("tag", "tag2"));
+
+    AssertHelpers.assertThrows("To ref must not exist",
+        IllegalArgumentException.class,
+        "Cannot rename to an existing ref: " + TEST_BRANCH,
+        () -> table.updateRefs().rename(TEST_TAG, TEST_BRANCH));
+  }
+
+  @Test
+  public void testRemoveTag() {
+    table.updateRefs().remove(TEST_TAG).commit();
+    Assert.assertNull("Removed tag should not exist", table.refs().get(TEST_TAG));
+  }
+
+  @Test
+  public void testRemoveBranch() {
+    table.updateRefs().remove(TEST_BRANCH).commit();
+    Assert.assertNull("Removed branch should not exist", table.refs().get(TEST_BRANCH));
+  }
+
+  @Test
+  public void testRemoveMainBranchShouldFail() {
+    AssertHelpers.assertThrows("Should fail when removing main branch",
+        IllegalArgumentException.class,
+        "Main branch must not be removed",
+        () -> table.updateRefs().remove(SnapshotRef.MAIN_BRANCH));
+  }
+
+  @Test
+  public void testRemoveRefNotExist() {
+    AssertHelpers.assertThrows("Should fail when removing ref not exist",
+        IllegalArgumentException.class,
+        "Cannot find ref to remove",
+        () -> table.updateRefs().remove("tag"));
+  }
+}

--- a/core/src/test/resources/TableMetadataV2Valid.json
+++ b/core/src/test/resources/TableMetadataV2Valid.json
@@ -118,5 +118,22 @@
       "timestamp-ms": 1555100955770
     }
   ],
-  "metadata-log": []
+  "metadata-log": [],
+  "refs": {
+    "main": {
+      "snapshot-id": 3055729675574597004,
+      "type": "branch"
+    },
+    "test": {
+      "snapshot-id": 3055729675574597004,
+      "type": "tag",
+      "max-ref-age-ms": 100
+    },
+    "dev": {
+      "snapshot-id": 3051729675574597004,
+      "type": "branch",
+      "min-snapshots-to-keep": 2,
+      "max-snapshot-age-ms": 200
+    }
+  }
 }


### PR DESCRIPTION
This is a draft PR for addressing https://github.com/apache/iceberg/issues/3897. It builds on the implementation of references in this PR https://github.com/apache/iceberg/pull/3883 . While we get clarity on what the APIs should look like, wanted to start a draft PR on the retention logic based on https://docs.google.com/document/d/1PvxK_0ebEoX3s7nS6-LOJJZdBYr_olTWH9oepNUfJ-A/edit#.

Some aspects I want to get feedback on: 

1.) Currently, for the global expiration age, we set the expiration age in the operation based on a timestamp obtained in the constructor (this can be overridden in a setter as well). However in the calculation in the draft we are using timestamps closer to the time of calculating what should be retained. So we should certainly define a consistent time for comparisons.

2.) For the retention policy evaluation, we identify what are the snapshots to retain based on branch policies such as minSnapshots and max age for the branch and the global max age. After this it could be possible that we have not retained the min snapshots for the table level. So we go through the snapshots we would expire,  using a heap to identify what are the latest snapshots to retain to reach the global table policy. Those snapshots are removed from expiration, and the remaining set is then passed to the removeSnapshots API. This logic maybe overkill so would like to get feedback on that. 


3.) Related to 2, would also like to get feedback on how global snapshot age should fit in with retention? Should it be possible for global snapshot age to override what's on the branch level (as implemented)? This would force users to really have to think about what's defined at the table level and the branch level to make sure they get the retention experience they desire.

There's a lot of code cleanup to do, and will definitely write tests which span multiple commit graph shapes and retention policies as we get clarity on what we want the behavior to be.


Thank you!  