### PR TITLE
[Site] - Document max_concurrent_deletes parameter in spark stored procedures.

### DIFF
--- a/site/docs/spark-procedures.md
+++ b/site/docs/spark-procedures.md
@@ -190,7 +190,7 @@ the `expire_snapshots` procedure will never remove files which are still require
 | `table`       | ✔️  | string | Name of the table to update |
 | `older_than`  | ️   | timestamp | Timestamp before which snapshots will be removed (Default: 5 days ago) |
 | `retain_last` |    | int       | Number of ancestor snapshots to preserve regardless of `older_than` (defaults to 1) |
-| `max_concurrent_deletes` |    | int       | Size of the thread pool used for delete file actions (defaults to null, which deletes files serially in the current thread without instantiating a dedicated thread pool) |
+| `max_concurrent_deletes` |    | int       | Size of the thread pool used for delete file actions (by default, no thread pool is used) |
 
 If `older_than` and `retain_last` are omitted, the table's [expiration properties](./configuration/#table-behavior-properties) will be used.
 
@@ -228,7 +228,7 @@ Used to remove files which are not referenced in any metadata files of an Iceber
 | `older_than`  | ️   | timestamp | Remove orphan files created before this timestamp (Defaults to 3 days ago) |
 | `location`    |    | string    | Directory to look for files in (defaults to the table's location) |
 | `dry_run`     |    | boolean   | When true, don't actually remove files (defaults to false) |
-| `max_concurrent_deletes` |    | int       | Size of the thread pool used for delete file actions (defaults to null, which deletes files serially in the current thread without instantiating a dedicated thread pool) |
+| `max_concurrent_deletes` |    | int       | Size of the thread pool used for delete file actions (by default, no thread pool is used) |
 
 #### Output
 

--- a/site/docs/spark-procedures.md
+++ b/site/docs/spark-procedures.md
@@ -190,6 +190,7 @@ the `expire_snapshots` procedure will never remove files which are still require
 | `table`       | ✔️  | string | Name of the table to update |
 | `older_than`  | ️   | timestamp | Timestamp before which snapshots will be removed (Default: 5 days ago) |
 | `retain_last` |    | int       | Number of ancestor snapshots to preserve regardless of `older_than` (defaults to 1) |
+| `max_concurrent_deletes` |    | int       | Size of the thread pool used for delete file actions (defaults to null, which deletes files serially in the current thread without instantiating a dedicated thread pool) |
 
 If `older_than` and `retain_last` are omitted, the table's [expiration properties](./configuration/#table-behavior-properties) will be used.
 
@@ -227,6 +228,7 @@ Used to remove files which are not referenced in any metadata files of an Iceber
 | `older_than`  | ️   | timestamp | Remove orphan files created before this timestamp (Defaults to 3 days ago) |
 | `location`    |    | string    | Directory to look for files in (defaults to the table's location) |
 | `dry_run`     |    | boolean   | When true, don't actually remove files (defaults to false) |
+| `max_concurrent_deletes` |    | int       | Size of the thread pool used for delete file actions (defaults to null, which deletes files serially in the current thread without instantiating a dedicated thread pool) |
 
 #### Output
 


### PR DESCRIPTION
This closes https://github.com/apache/iceberg/issues/4007

As of Iceberg 0.13.0, the Spark stored procedures `expire_snapshots` and `remove_orphan_files` have an added parameter, `max_concurrent_deletes`, which indicates the size of the thread pool that should be instantiated to remove the relevant files in parallel.

Without this parameter, no separate thread pool is instantiated and the files are deleted sequentially in the current thread. For a high volume of deletes, this can be slow. Moreover, we should document every public parameter to procedures.