### PR TITLE
Write engine.hive.enabled=true in table properties for Hive-enabled table

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -382,6 +382,9 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
     if (hiveEngineEnabled) {
       parameters.put(hive_metastoreConstants.META_TABLE_STORAGE,
           "org.apache.iceberg.mr.hive.HiveIcebergStorageHandler");
+      // In this case, we should also set engine.hive.enabled=true
+      // if it is not already in the properties passed in
+      parameters.put(TableProperties.ENGINE_HIVE_ENABLED, "true");
     } else {
       parameters.remove(hive_metastoreConstants.META_TABLE_STORAGE);
     }


### PR DESCRIPTION
When creating a table using the `HiveCatalog`, the table will be Hive-enabled if engine.hive.enabled is set to true in the table properties in the `TableMetadata`, or if the Hadoop `Configuration` has iceberg.engine.hive.enabled set to true. Currently, for the latter scenario, we do not write engine.hive.enabled=true in the table properties in the HMS. If  another writer subsequently updates the table, and does not have iceberg.engine.hive.enabled set to true in its Hadoop `Configuration`, then the fact that the table is Hive-enabled will be lost.
To be consistent, we should write engine.hive.enabled=true in the table properties when committing a Hive-enabled table.