### PR TITLE
[HiveCatalog] Make Hive's external table behavior match with Iceberg table's gc.enabled behavior.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -159,7 +159,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
 
       String baseLocation = location != null ? location : defaultWarehouseLocation(identifier);
       Map<String, String> properties = propertiesBuilder.build();
-      TableMetadata metadata = TableMetadata.newTableMetadata(schema, spec, sortOrder, baseLocation, properties);
+      TableMetadata metadata = createTableMetadata(baseLocation, properties);
 
       try {
         ops.commit(null, metadata);
@@ -179,7 +179,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
 
       String baseLocation = location != null ? location : defaultWarehouseLocation(identifier);
       Map<String, String> properties = propertiesBuilder.build();
-      TableMetadata metadata = TableMetadata.newTableMetadata(schema, spec, sortOrder, baseLocation, properties);
+      TableMetadata metadata = createTableMetadata(baseLocation, properties);
       return Transactions.createTableTransaction(identifier.toString(), ops, metadata);
     }
 
@@ -205,7 +205,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
         metadata = ops.current().buildReplacement(schema, spec, sortOrder, baseLocation, propertiesBuilder.build());
       } else {
         String baseLocation = location != null ? location : defaultWarehouseLocation(identifier);
-        metadata = TableMetadata.newTableMetadata(schema, spec, sortOrder, baseLocation, propertiesBuilder.build());
+        metadata = createTableMetadata(baseLocation, propertiesBuilder.build());
       }
 
       if (orCreate) {
@@ -213,6 +213,10 @@ public abstract class BaseMetastoreCatalog implements Catalog {
       } else {
         return Transactions.replaceTableTransaction(identifier.toString(), ops, metadata);
       }
+    }
+
+    protected TableMetadata createTableMetadata(String baseLocation, Map<String, String> properties) {
+      return TableMetadata.newTableMetadata(schema, spec, sortOrder, baseLocation, properties);
     }
   }
 


### PR DESCRIPTION
Users accustomed to hive's external and managed table behavior may accidentally delete data without this change. 

When a user create an external table from hive or spark sql, they expect that on dropping the table the underlying data should not be deleted. However, when using Iceberg dropping an external table will drop underlying data as well (unless user explicitly specify `gc.enabled=false`. In this diff, I want to align external hive table behavior with Iceberg table drop behavior.