### PR TITLE
Core: Add SnapshotRef entity to API

### DIFF
--- a/api/src/main/java/org/apache/iceberg/SnapshotRef.java
+++ b/api/src/main/java/org/apache/iceberg/SnapshotRef.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.io.Serializable;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+public class SnapshotRef implements Serializable {
+
+  public static final String MAIN_BRANCH = "main";
+
+  private final long snapshotId;
+  private final SnapshotRefType type;
+  private final Integer minSnapshotsToKeep;
+  private final Long maxSnapshotAgeMs;
+  private final Long maxRefAgeMs;
+
+  private SnapshotRef(
+      long snapshotId,
+      SnapshotRefType type,
+      Integer minSnapshotsToKeep,
+      Long maxSnapshotAgeMs,
+      Long maxRefAgeMs) {
+    this.snapshotId = snapshotId;
+    this.type = type;
+    this.minSnapshotsToKeep = minSnapshotsToKeep;
+    this.maxSnapshotAgeMs = maxSnapshotAgeMs;
+    this.maxRefAgeMs = maxRefAgeMs;
+  }
+
+  public long snapshotId() {
+    return snapshotId;
+  }
+
+  public SnapshotRefType type() {
+    return type;
+  }
+
+  public Integer minSnapshotsToKeep() {
+    return minSnapshotsToKeep;
+  }
+
+  public Long maxSnapshotAgeMs() {
+    return maxSnapshotAgeMs;
+  }
+
+  public Long maxRefAgeMs() {
+    return maxRefAgeMs;
+  }
+
+  public static Builder tagBuilder(long snapshotId) {
+    return builderFor(snapshotId, SnapshotRefType.TAG);
+  }
+
+  public static Builder branchBuilder(long snapshotId) {
+    return builderFor(snapshotId, SnapshotRefType.BRANCH);
+  }
+
+  public static Builder builderFrom(SnapshotRef ref) {
+    return new Builder(ref.type(), ref.snapshotId())
+        .minSnapshotsToKeep(ref.minSnapshotsToKeep())
+        .maxSnapshotAgeMs(ref.maxSnapshotAgeMs())
+        .maxRefAgeMs(ref.maxRefAgeMs());
+  }
+
+  /**
+   * Creates a ref builder from the given ref and its properties but the ref will now point to the given snapshotId.
+   *
+   * @param ref Ref to build from
+   * @param snapshotId snapshotID to use.
+   * @return ref builder with the same retention properties as given ref, but the ref will point to the passed in id
+   */
+  public static Builder builderFrom(SnapshotRef ref, long snapshotId) {
+    return new Builder(ref.type(), snapshotId)
+        .minSnapshotsToKeep(ref.minSnapshotsToKeep())
+        .maxSnapshotAgeMs(ref.maxSnapshotAgeMs())
+        .maxRefAgeMs(ref.maxRefAgeMs());
+  }
+
+  public static Builder builderFor(long snapshotId, SnapshotRefType type) {
+    return new Builder(type, snapshotId);
+  }
+
+  public static class Builder {
+
+    private final SnapshotRefType type;
+    private final long snapshotId;
+    private Integer minSnapshotsToKeep;
+    private Long maxSnapshotAgeMs;
+    private Long maxRefAgeMs;
+
+    Builder(SnapshotRefType type, long snapshotId) {
+      Preconditions.checkArgument(type != null, "Snapshot reference type must not be null");
+      this.type = type;
+      this.snapshotId = snapshotId;
+    }
+
+    public Builder minSnapshotsToKeep(Integer value) {
+      Preconditions.checkArgument(value == null || !type.equals(SnapshotRefType.TAG),
+          "Tags do not support setting minSnapshotsToKeep");
+      Preconditions.checkArgument(value == null || value > 0,
+          "Min snapshots to keep must be greater than 0");
+      this.minSnapshotsToKeep = value;
+      return this;
+    }
+
+    public Builder maxSnapshotAgeMs(Long value) {
+      Preconditions.checkArgument(value == null || !type.equals(SnapshotRefType.TAG),
+          "Tags do not support setting maxSnapshotAgeMs");
+      Preconditions.checkArgument(value == null || value > 0,
+          "Max snapshot age must be greater than 0 ms");
+      this.maxSnapshotAgeMs = value;
+      return this;
+    }
+
+    public Builder maxRefAgeMs(Long value) {
+      Preconditions.checkArgument(value == null || value > 0, "Max reference age must be greater than 0");
+      this.maxRefAgeMs = value;
+      return this;
+    }
+
+    public SnapshotRef build() {
+      return new SnapshotRef(snapshotId, type, minSnapshotsToKeep, maxSnapshotAgeMs, maxRefAgeMs);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("snapshotId", snapshotId)
+        .add("type", type)
+        .add("minSnapshotsToKeep", minSnapshotsToKeep)
+        .add("maxSnapshotAgeMs", maxSnapshotAgeMs)
+        .add("maxRefAgeMs", maxRefAgeMs)
+        .toString();
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/SnapshotRefType.java
+++ b/api/src/main/java/org/apache/iceberg/SnapshotRefType.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+enum SnapshotRefType {
+    BRANCH,
+    TAG
+}

--- a/api/src/test/java/org/apache/iceberg/TestSnapshotRef.java
+++ b/api/src/test/java/org/apache/iceberg/TestSnapshotRef.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestSnapshotRef {
+
+  @Test
+  public void testTagDefault() {
+    SnapshotRef ref = SnapshotRef.tagBuilder(1L).build();
+    Assert.assertEquals(1L, ref.snapshotId());
+    Assert.assertEquals(SnapshotRefType.TAG, ref.type());
+    Assert.assertNull(ref.minSnapshotsToKeep());
+    Assert.assertNull(ref.maxSnapshotAgeMs());
+    Assert.assertNull(ref.maxRefAgeMs());
+  }
+
+  @Test
+  public void testBranchDefault() {
+    SnapshotRef ref = SnapshotRef.branchBuilder(1L).build();
+    Assert.assertEquals(1L, ref.snapshotId());
+    Assert.assertEquals(SnapshotRefType.BRANCH, ref.type());
+    Assert.assertNull(ref.minSnapshotsToKeep());
+    Assert.assertNull(ref.maxSnapshotAgeMs());
+  }
+
+  @Test
+  public void testTagWithOverride() {
+    SnapshotRef ref = SnapshotRef.branchBuilder(1L)
+        .maxRefAgeMs(10L)
+        .build();
+    Assert.assertEquals(1L, ref.snapshotId());
+    Assert.assertEquals(SnapshotRefType.BRANCH, ref.type());
+    Assert.assertEquals(10L, (long) ref.maxRefAgeMs());
+  }
+
+  @Test
+  public void testBranchWithOverride() {
+    SnapshotRef ref = SnapshotRef.branchBuilder(1L)
+        .minSnapshotsToKeep(10)
+        .maxSnapshotAgeMs(20L)
+        .maxRefAgeMs(30L)
+        .build();
+    Assert.assertEquals(1L, ref.snapshotId());
+    Assert.assertEquals(SnapshotRefType.BRANCH, ref.type());
+    Assert.assertEquals(10, (int) ref.minSnapshotsToKeep());
+    Assert.assertEquals(20L, (long) ref.maxSnapshotAgeMs());
+    Assert.assertEquals(30L, (long) ref.maxRefAgeMs());
+  }
+
+  @Test
+  public void testNoTypeFailure() {
+    AssertHelpers.assertThrows("Snapshot reference type must be specified",
+        IllegalArgumentException.class,
+        "Snapshot reference type must not be null",
+        () -> SnapshotRef.builderFor(1L, null).build());
+  }
+
+  @Test
+  public void testTagBuildFailures() {
+    AssertHelpers.assertThrows("Max reference age must be greater than 0 for tag",
+        IllegalArgumentException.class,
+        "Max reference age must be greater than 0",
+        () -> SnapshotRef.tagBuilder(1L)
+            .maxRefAgeMs(-1L)
+            .build());
+
+    AssertHelpers.assertThrows("Tags do not support setting minSnapshotsToKeep",
+        IllegalArgumentException.class,
+        "Tags do not support setting minSnapshotsToKeep",
+        () -> SnapshotRef.tagBuilder(1L)
+            .minSnapshotsToKeep(2)
+            .build());
+
+    AssertHelpers.assertThrows("Tags do not support setting maxSnapshotAgeMs",
+        IllegalArgumentException.class,
+        "Tags do not support setting maxSnapshotAgeMs",
+        () -> SnapshotRef.tagBuilder(1L)
+            .maxSnapshotAgeMs(2L)
+            .build());
+  }
+
+  @Test
+  public void testBranchBuildFailures() {
+    AssertHelpers.assertThrows("Max snapshot age must be greater than 0",
+        IllegalArgumentException.class,
+        "Max snapshot age must be greater than 0",
+        () -> SnapshotRef.branchBuilder(1L)
+            .maxSnapshotAgeMs(-1L)
+            .build());
+
+    AssertHelpers.assertThrows("Min snapshots to keep must be greater than 0",
+        IllegalArgumentException.class,
+        "Min snapshots to keep must be greater than 0",
+        () -> SnapshotRef.branchBuilder(1L)
+            .minSnapshotsToKeep(-1)
+            .build());
+
+    AssertHelpers.assertThrows("Max reference age must be greater than 0 for branch",
+        IllegalArgumentException.class,
+        "Max reference age must be greater than 0",
+        () -> SnapshotRef.branchBuilder(1L)
+            .maxRefAgeMs(-1L)
+            .build());
+  }
+}


### PR DESCRIPTION
Co-authored-by: wangzeyu <1249369293@qq.com>
Co-authored-by: Jack Ye <yzhaoqin@amazon.com>

This is a smaller PR as part of breaking up the changes in https://github.com/apache/iceberg/pull/3883/files. This change includes the SnapshotRef entity in the Iceberg API.

Will include serializing/deserializing reference metadata, and reference/table API changes in separate PRs following this.
