### PR TITLE
Set black line-length to 130 in tox settings

### DIFF
--- a/python/src/iceberg/types.py
+++ b/python/src/iceberg/types.py
@@ -53,9 +53,7 @@ class Type:
 
 class FixedType(Type):
     def __init__(self, length: int):
-        super().__init__(
-            f"fixed[{length}]", f"FixedType(length={length})", is_primitive=True
-        )
+        super().__init__(f"fixed[{length}]", f"FixedType(length={length})", is_primitive=True)
         self._length = length
 
     @property
@@ -125,8 +123,7 @@ class NestedField(object):
 
     def __str__(self):
         return (
-            f"{self._id}: {self._name}: {'optional' if self._is_optional else 'required'} {self._type}"
-            ""
+            f"{self._id}: {self._name}: {'optional' if self._is_optional else 'required'} {self._type}" ""
             if self._doc is None
             else f" ({self._doc})"
         )

--- a/python/src/iceberg/utils/bin_packing.py
+++ b/python/src/iceberg/utils/bin_packing.py
@@ -17,9 +17,7 @@
 
 
 class PackingIterator:
-    def __init__(
-        self, items, target_weight, lookback, weight_func, largest_bin_first=False
-    ):
+    def __init__(self, items, target_weight, lookback, weight_func, largest_bin_first=False):
         self.items = iter(items)
         self.target_weight = target_weight
         self.lookback = lookback

--- a/python/tests/io/test_base.py
+++ b/python/tests/io/test_base.py
@@ -31,14 +31,10 @@ class LocalInputFile(InputFile):
     def __init__(self, location: str):
 
         parsed_location = urlparse(location)  # Create a ParseResult from the uri
-        if (
-            parsed_location.scheme != "file"
-        ):  # Validate that a uri is provided with a scheme of `file`
+        if parsed_location.scheme != "file":  # Validate that a uri is provided with a scheme of `file`
             raise ValueError("LocalInputFile location must have a scheme of `file`")
         elif parsed_location.netloc:
-            raise ValueError(
-                f"Network location is not allowed for LocalInputFile: {parsed_location.netloc}"
-            )
+            raise ValueError(f"Network location is not allowed for LocalInputFile: {parsed_location.netloc}")
 
         super().__init__(location=location)
         self._parsed_location = parsed_location
@@ -63,14 +59,10 @@ class LocalOutputFile(OutputFile):
     def __init__(self, location: str):
 
         parsed_location = urlparse(location)  # Create a ParseResult from the uri
-        if (
-            parsed_location.scheme != "file"
-        ):  # Validate that a uri is provided with a scheme of `file`
+        if parsed_location.scheme != "file":  # Validate that a uri is provided with a scheme of `file`
             raise ValueError("LocalOutputFile location must have a scheme of `file`")
         elif parsed_location.netloc:
-            raise ValueError(
-                f"Network location is not allowed for LocalOutputFile: {parsed_location.netloc}"
-            )
+            raise ValueError(f"Network location is not allowed for LocalOutputFile: {parsed_location.netloc}")
 
         super().__init__(location=location)
         self._parsed_location = parsed_location
@@ -102,11 +94,7 @@ class LocalFileIO(FileIO):
         return LocalOutputFile(location=location)
 
     def delete(self, location: Union[str, LocalInputFile, LocalOutputFile]):
-        parsed_location = (
-            location.parsed_location
-            if isinstance(location, (InputFile, OutputFile))
-            else urlparse(location)
-        )
+        parsed_location = location.parsed_location if isinstance(location, (InputFile, OutputFile)) else urlparse(location)
         os.remove(parsed_location.path)
 
 
@@ -262,9 +250,7 @@ def test_deleting_local_file_using_file_io(CustomFileIO):
         assert not os.path.exists(output_file_location)
 
 
-@pytest.mark.parametrize(
-    "CustomFileIO, CustomInputFile", [(LocalFileIO, LocalInputFile)]
-)
+@pytest.mark.parametrize("CustomFileIO, CustomInputFile", [(LocalFileIO, LocalInputFile)])
 def test_deleting_local_file_using_file_io_InputFile(CustomFileIO, CustomInputFile):
 
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -289,9 +275,7 @@ def test_deleting_local_file_using_file_io_InputFile(CustomFileIO, CustomInputFi
         assert not os.path.exists(file_location)
 
 
-@pytest.mark.parametrize(
-    "CustomFileIO, CustomOutputFile", [(LocalFileIO, LocalOutputFile)]
-)
+@pytest.mark.parametrize("CustomFileIO, CustomOutputFile", [(LocalFileIO, LocalOutputFile)])
 def test_deleting_local_file_using_file_io_OutputFile(CustomFileIO, CustomOutputFile):
 
     with tempfile.TemporaryDirectory() as tmpdirname:

--- a/python/tests/utils/test_bin_packing.py
+++ b/python/tests/utils/test_bin_packing.py
@@ -39,9 +39,7 @@ def test_bin_packing(splits, lookback, split_size, open_cost):
     def weight_func(x):
         return max(x, open_cost)
 
-    item_list_sums = [
-        sum(item) for item in PackingIterator(splits, split_size, lookback, weight_func)
-    ]
+    item_list_sums = [sum(item) for item in PackingIterator(splits, split_size, lookback, weight_func)]
     assert all([split_size >= item_sum >= 0 for item_sum in item_list_sums])
 
 
@@ -78,15 +76,8 @@ def test_bin_packing(splits, lookback, split_size, open_cost):
         ),
     ],
 )
-def test_bin_packing_lookback(
-    splits, target_weight, lookback, largest_bin_first, expected_lists
-):
+def test_bin_packing_lookback(splits, target_weight, lookback, largest_bin_first, expected_lists):
     def weight_func(x):
         return x
 
-    assert [
-        item
-        for item in PackingIterator(
-            splits, target_weight, lookback, weight_func, largest_bin_first
-        )
-    ] == expected_lists
+    assert [item for item in PackingIterator(splits, target_weight, lookback, weight_func, largest_bin_first)] == expected_lists

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -51,7 +51,7 @@ deps =
 commands =
     autoflake -r --check --ignore-init-module-imports --remove-all-unused-imports setup.py src tests
     isort --profile black --check-only setup.py src tests
-    black --check setup.py src tests
+    black --line-length 130 --check setup.py src tests
 
 [testenv:format]
 deps =
@@ -59,7 +59,7 @@ deps =
 commands =
     autoflake -r --in-place --ignore-init-module-imports --remove-all-unused-imports setup.py src tests
     isort --profile black setup.py src tests
-    black setup.py src tests
+    black --line-length 130 setup.py src tests
 
 [testenv:type-check]
 deps =


### PR DESCRIPTION
This adds `--line-length` to the black autoformatter and format checker commands in tox.ini

This may cause some open PRs to require rebasing (there's never a good time to change an auto-formatter) but alternatively we can keep this PR open and wait for a dip in open PRs to rebase this PR, run `tox -e format`, and commit the updates.

The first commit [fcddb35](https://github.com/apache/iceberg/pull/4025/commits/fcddb3545a1aa28184d8860a075207cb1a0f2fdc) is the actual change to the formatter, the second commit [66325f4](https://github.com/apache/iceberg/pull/4025/commits/66325f4d7e3a784fca08ae8b8930c7f74476395d) is the result of running `tox -e format` on the project.