### PR TITLE
Spec: Fix REST response objects

### DIFF
--- a/rest_docs/rest-catalog-open-api.yaml
+++ b/rest_docs/rest-catalog-open-api.yaml
@@ -142,16 +142,7 @@ paths:
           example: "accounting%00tax"
       responses:
         200:
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/ListNamespacesResponse'
-              examples:
-                NonEmptyResponse:
-                  $ref: '#/components/examples/ListNamespacesNonEmptyExample'
-                EmptyResponse:
-                  $ref: '#/components/examples/ListNamespacesEmptyExample'
+          $ref: '#/components/responses/ListNamespacesResponse'
         400:
           $ref: '#/components/responses/BadRequestErrorResponse'
         401:
@@ -163,7 +154,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/responses/IcebergErrorResponse'
+                $ref: '#/components/schemas/ErrorModel'
               examples:
                 NoSuchNamespaceExample:
                   $ref: '#/components/examples/NoSuchNamespaceError'
@@ -199,7 +190,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/responses/IcebergErrorResponse'
+                $ref: '#/components/schemas/ErrorModel'
               examples:
                 NamespaceAlreadyExists:
                   $ref: '#/components/examples/NamespaceAlreadyExistsError'
@@ -218,11 +209,7 @@ paths:
       description: Return all stored metadata properties for a given namespace
       responses:
         200:
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/GetNamespaceResponse'
+          $ref: '#/components/responses/GetNamespaceResponse'
         400:
           $ref: '#/components/responses/BadRequestErrorResponse'
         401:
@@ -234,7 +221,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/responses/IcebergErrorResponse'
+                $ref: '#/components/schemas/ErrorModel'
               examples:
                 NoSuchNamespaceExample:
                   $ref: '#/components/examples/NoSuchNamespaceError'
@@ -248,12 +235,7 @@ paths:
       operationId: dropNamespace
       responses:
         200:
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/DropNamespaceResponse'
-              example: { "dropped": true }
+          $ref: '#/components/responses/DropNamespaceResponse'
         400:
           $ref: '#/components/responses/BadRequestErrorResponse'
         401:
@@ -265,7 +247,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/responses/IcebergErrorResponse'
+                $ref: '#/components/schemas/ErrorModel'
               examples:
                 NoSuchNamespaceExample:
                   $ref: '#/components/examples/NoSuchNamespaceError'
@@ -299,16 +281,7 @@ paths:
                 $ref: '#/components/examples/UpdateAndRemoveNamespacePropertiesRequest'
       responses:
         200:
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/UpdateNamespacePropertiesResponse'
-              example: {
-                "updated": [ "owner" ],
-                "removed": [ "foo" ],
-                "missing": [ "bar" ]
-              }
+          $ref: '#/components/responses/UpdateNamespacePropertiesResponse'
         400:
           $ref: '#/components/responses/BadRequestErrorResponse'
         401:
@@ -320,7 +293,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/responses/IcebergErrorResponse'
+                $ref: '#/components/schemas/ErrorModel'
               examples:
                 NamespaceNotFound:
                   $ref: '#/components/examples/NoSuchNamespaceError'
@@ -331,7 +304,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/responses/IcebergErrorResponse'
+                $ref: '#/components/schemas/ErrorModel'
               examples:
                 UnprocessableEntityDuplicateKey:
                   $ref: '#/components/examples/UnprocessableEntityDuplicateKey'
@@ -350,16 +323,7 @@ paths:
       operationId: listTables
       responses:
         200:
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/ListTablesResponse'
-              examples:
-                NonEmptyResponse:
-                  $ref: '#/components/examples/ListTablesNonEmptyExample'
-                EmptyNamespaceResponse:
-                  $ref: '#/components/examples/ListTablesEmptyExample'
+          $ref: '#/components/responses/ListTablesResponse'
         400:
           $ref: '#/components/responses/BadRequestErrorResponse'
         401:
@@ -371,7 +335,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/responses/IcebergErrorResponse'
+                $ref: '#/components/schemas/ErrorModel'
               examples:
                 NamespaceNotFound:
                   $ref: '#/components/examples/NoSuchNamespaceError'
@@ -403,7 +367,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/responses/IcebergErrorResponse'
+                $ref: '#/components/schemas/ErrorModel'
               examples:
                 NamespaceNotFound:
                   $ref: '#/components/examples/NoSuchNamespaceError'
@@ -412,7 +376,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/responses/IcebergErrorResponse'
+                $ref: '#/components/schemas/ErrorModel'
               examples:
                 NamespaceAlreadyExists:
                   $ref: '#/components/examples/TableAlreadyExistsError'
@@ -452,7 +416,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/responses/IcebergErrorResponse'
+                $ref: '#/components/schemas/ErrorModel'
               examples:
                 TableToLoadDoesNotExist:
                   $ref: '#/components/examples/NoSuchTableError'
@@ -481,11 +445,7 @@ paths:
               $ref: '#/components/schemas/CommitTableRequest'
       responses:
         200:
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/CommitTableResponse'
+          $ref: '#/components/responses/CommitTableResponse'
         400:
           $ref: '#/components/responses/BadRequestErrorResponse'
         401:
@@ -498,7 +458,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/responses/IcebergErrorResponse'
+                $ref: '#/components/schemas/ErrorModel'
               examples:
                 TableToUpdateDoesNotExist:
                   $ref: '#/components/examples/NoSuchTableError'
@@ -508,7 +468,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/responses/IcebergErrorResponse'
+                $ref: '#/components/schemas/ErrorModel'
         5XX:
           description:
             A server-side problem that might not be addressable from the client side.
@@ -518,7 +478,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/responses/IcebergErrorResponse'
+                $ref: '#/components/schemas/ErrorModel'
               example: {
                 "error": {
                   "message": "Internal Server Error",
@@ -543,14 +503,7 @@ paths:
             default: false
       responses:
         200:
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/DropTableResponse'
-              example: { "dropped": true, "purged": false }
-        202:
-          description: Accepted - for use if purgeRequested is implemented as an asynchronous action.
+          $ref: '#/components/responses/DropTableResponse'
         400:
           $ref: '#/components/responses/BadRequestErrorResponse'
         401:
@@ -563,7 +516,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/responses/IcebergErrorResponse'
+                $ref: '#/components/schemas/ErrorModel'
               examples:
                 TableToDeleteDoesNotExist:
                   $ref: '#/components/examples/NoSuchTableError'
@@ -624,7 +577,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/responses/IcebergErrorResponse'
+                $ref: '#/components/schemas/ErrorModel'
               examples:
                 TableToRenameDoesNotExist:
                   $ref: '#/components/examples/NoSuchTableError'
@@ -637,7 +590,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/responses/IcebergErrorResponse'
+                $ref: '#/components/schemas/ErrorModel'
               example:
                 $ref: '#/components/examples/TableAlreadyExistsError'
         5XX:
@@ -677,7 +630,7 @@ components:
   ##############################
   schemas:
 
-    StandardErrorWrapper:
+    ErrorModel:
       type: object
       description: JSON error payload returned in a response with further details on the error
       required:
@@ -706,7 +659,7 @@ components:
         - defaults
         - overrides
       properties:
-        overrrides:
+        overrides:
           type: object
           description:
             Properties that should be used to override client configuration; applied after defaults and client configuration.
@@ -1352,7 +1305,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/responses/IcebergErrorResponse'
+            $ref: '#/components/schemas/ErrorModel'
           example: {
             "error": {
               "message": "Malformed request",
@@ -1369,7 +1322,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/responses/IcebergErrorResponse'
+            $ref: '#/components/schemas/ErrorModel'
           example: {
             "error": {
               "message": "Not authorized to make this request",
@@ -1385,7 +1338,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/responses/IcebergErrorResponse'
+            $ref: '#/components/schemas/ErrorModel'
           example: {
             "error": {
               "message": "Not authorized to make this request",
@@ -1401,7 +1354,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/responses/IcebergErrorResponse'
+            $ref: '#/components/schemas/ErrorModel'
           example: {
             "error": {
               "message": "The server does not support this operation",
@@ -1418,7 +1371,7 @@ components:
             type: object
             properties:
               error:
-                $ref: '#/components/schemas/StandardErrorWrapper'
+                $ref: '#/components/schemas/ErrorModel'
             additionalProperties: false
             example: {
               "error": {
@@ -1451,6 +1404,10 @@ components:
               purged:
                 type: boolean
                 description: whether the underlying data was purged or is being purged
+          example: {
+            "dropped": true,
+            "purged": false
+          }
 
     DropNamespaceResponse:
       description: A successful call to drop a namespace
@@ -1462,6 +1419,9 @@ components:
               dropped:
                 description: true if the namespace was dropped
                 type: boolean
+          example: {
+            "dropped": true
+          }
 
     GetNamespaceResponse:
       description:
@@ -1498,6 +1458,11 @@ components:
                 uniqueItems: true
                 items:
                   $ref: '#/components/schemas/TableIdentifier'
+          examples:
+            ListTablesResponseNonEmpty:
+              $ref: '#/components/examples/ListTablesNonEmptyExample'
+            ListTablesResponseEmpty:
+              $ref: '#/components/examples/ListTablesEmptyExample'
 
     ListNamespacesResponse:
       description: A list of namespaces
@@ -1511,6 +1476,11 @@ components:
                 uniqueItems: true
                 items:
                   $ref: '#/components/schemas/Namespace'
+          examples:
+            NonEmptyResponse:
+              $ref: '#/components/examples/ListNamespacesNonEmptyExample'
+            EmptyResponse:
+              $ref: '#/components/examples/ListNamespacesEmptyExample'
 
     ServerErrorResponse:
       description:
@@ -1518,7 +1488,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/responses/IcebergErrorResponse'
+            $ref: '#/components/schemas/ErrorModel'
           example: {
             "error": {
               "message": "Internal Server Error",
@@ -1557,6 +1527,11 @@ components:
                   in the namespace's properties. Represents a partial success response.
                   Server's do not need to implement this.
                 nullable: true
+          example: {
+            "updated": [ "owner" ],
+            "removed": [ "foo" ],
+            "missing": [ "bar" ]
+          }
 
     CreateTableResponse:
       description: Table metadata result after creating a table
@@ -1631,7 +1606,7 @@ components:
       summary: The requested namespace already exists
       value: {
         "error": {
-          "message": "The given namepace already exists",
+          "message": "The given namespace already exists",
           "type": "AlreadyExistsException",
           "code": 409
         }
@@ -1641,9 +1616,9 @@ components:
       summary: The requested table does not
       value: {
         "error": {
-          message: "The given table does not exist",
-          type: "NoSuchTableException",
-          code: 404
+          "message": "The given table does not exist",
+          "type": "NoSuchTableException",
+          "code": 404
         }
       }
 


### PR DESCRIPTION
This and closes https://github.com/apache/iceberg/issues/4026

In some places in the OpenAPI spec for the REST catalog, we're using `response` type components where `schema` type components are expected and vice versa.

This passes many parsers (we're still on the hunt for a canonical parser), but I've been using a NodeJS / NPM module from https://openapi.tools called `openapi-spec-validator`. It can be installed, hopefully with an up to date nodejs, using `npm install -h openapi-spec-validator`.

The output is kind of cryptic, but once it gets to `OK` then it's `OK`.

This PR fixes any issues from that with the minimal change set possible (barring one schema name change to make things a bit more clear).

## What has changed

1. Renamed `StandardErrorWrapper`, the inner base schema element for IcebergErrorResponse, to be `ErrorModel`. I've found examples named similarly in the OpenAPI docs, and it seems more clear.
2. Replaced components that require a component from the "schema" section of the doc that were using `IcebergErrorResponse` to use `ErrorModel`, as `IcebergErrorResponse` comes from the "request" section of components)
3. Replaced components that were written out in long form to just have a `$ref` when it uses a component from the request component that is clear.
4. Fixed a small typo

#### Validating via CLI tool

Before this PR - The error output is somewhat cryptic using `openapi-spec-validator`, but this is the best tool I've found so far:
```bash
$  openapi-spec-validator  rest_docs/rest-catalog-open-api.yaml
{'description': 'OK', 'content': {'application/json': {'schema': {'$ref': '#/components/responses/CommitTableResponse', 'x-scope': ['file:///Users/kylebendickson/repos/kbendick-iceberg/rest_docs/rest-catalog-open-api.yaml']}}}} is not valid under any of the given schemas

Failed validating 'oneOf' in schema['properties']['paths']['patternProperties']['^\\/']['patternProperties']['^(get|put|post|delete|options|head|patch|trace)$']['properties']['responses']['patternProperties']['^[1-5](?:\\d{2}|XX)$']:
    {'oneOf': [{'$ref': '#/definitions/Response'},
               {'$ref': '#/definitions/Reference'}]}

On instance['paths']['/v1/namespaces/{namespace}/tables/{table}']['post']['responses']['200']:
    {'content': {'application/json': {'schema': {'$ref': '#/components/responses/CommitTableResponse',
                                                 'x-scope': ['file:///Users/kylebendickson/repos/kbendick-iceberg/rest_docs/rest-catalog-open-api.yaml']}}},
```

After this PR:
```bash
$ openapi-spec-validator  rest_docs/rest-catalog-open-api.yaml
OK
```

