### PR TITLE
Docs: Add --check to verify checksum doc

### DIFF
--- a/site/docs/how-to-verify-a-release.md
+++ b/site/docs/how-to-verify-a-release.md
@@ -55,7 +55,7 @@ gpg --verify apache-iceberg-{{ extra.versions.iceberg }}.tar.gz.asc
 ### Verifying Checksums
 
 ```bash
-shasum -a 512 apache-iceberg-{{ extra.versions.iceberg }}.tar.gz.sha512
+shasum -a 512 --check apache-iceberg-{{ extra.versions.iceberg }}.tar.gz.sha512
 ```
 
 ### Verifying License Documentation


### PR DESCRIPTION
Adds `--check` option to `shasum` command for verifying checksum of a release. 

```
➜  my-release-verification git:(master) ✗ shasum -a 512 --check apache-iceberg-0.13.0.tar.gz.sha512
apache-iceberg-0.13.0.tar.gz: OK
```