### PR TITLE
Add --diff to show the line diff when black fails

### DIFF
--- a/python/tox.ini
+++ b/python/tox.ini
@@ -51,7 +51,7 @@ deps =
 commands =
     autoflake -r --check --ignore-init-module-imports --remove-all-unused-imports setup.py src tests
     isort --profile black --check-only setup.py src tests
-    black --line-length 130 --check setup.py src tests
+    black --line-length 130 --check --diff setup.py src tests
 
 [testenv:format]
 deps =


### PR DESCRIPTION
During our tox run we call black with `--check` to validate that there are no formatting suggestions unaddressed. When that validation fails, the CI logs will show something like this:
```
would reformat src/iceberg/types.py

Oh no! 💥 💔 💥
1 file would be reformatted, 15 files would be left unchanged.
```
I find that it's helpful to show the line diff, as an example:
```
linters run-test: commands[2] | black --line-length 130 --check --diff setup.py src tests
--- src/iceberg/types.py	2022-02-03 15:58:58.471627 +0000
+++ src/iceberg/types.py	2022-02-03 15:59:03.477538 +0000
@@ -60,11 +60,11 @@
         return self._is_primitive
 
 
 class FixedType(Type):
     def __init__(self, length: int):
-        super().__init__(f'fixed[{length}]', f"FixedType(length={length})", is_primitive=True)
+        super().__init__(f"fixed[{length}]", f"FixedType(length={length})", is_primitive=True)
         self._length = length
 
     @property
     def length(self) -> int:
         return self._length
would reformat src/iceberg/types.py

Oh no! 💥 💔 💥
1 file would be reformatted, 15 files would be left unchanged.
```