### PR TITLE
Core: SnapshotRef parser and serialization logic

### DIFF
--- a/api/src/main/java/org/apache/iceberg/SnapshotRef.java
+++ b/api/src/main/java/org/apache/iceberg/SnapshotRef.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg;
 
 import java.io.Serializable;
+import java.util.Objects;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
@@ -64,6 +65,35 @@ public class SnapshotRef implements Serializable {
 
   public Long maxRefAgeMs() {
     return maxRefAgeMs;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) {
+      return true;
+    }
+
+    if (!(other instanceof SnapshotRef)) {
+      return false;
+    }
+
+    SnapshotRef ref = (SnapshotRef) other;
+    return Objects.equals(ref.snapshotId(), snapshotId) &&
+        Objects.equals(ref.type(), type) &&
+        Objects.equals(ref.maxRefAgeMs(), maxRefAgeMs) &&
+        Objects.equals(ref.minSnapshotsToKeep(), minSnapshotsToKeep) &&
+        Objects.equals(ref.maxSnapshotAgeMs(), maxSnapshotAgeMs);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        this.snapshotId,
+        this.type,
+        this.maxRefAgeMs,
+        this.maxSnapshotAgeMs,
+        this.minSnapshotsToKeep
+    );
   }
 
   public static Builder tagBuilder(long snapshotId) {

--- a/core/src/main/java/org/apache/iceberg/SnapshotRefParser.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotRefParser.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.UncheckedIOException;
+import java.util.Locale;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.JsonUtil;
+
+public class SnapshotRefParser {
+
+  private SnapshotRefParser() {
+  }
+
+  private static final String SNAPSHOT_ID = "snapshot-id";
+  private static final String TYPE = "type";
+  private static final String MIN_SNAPSHOTS_TO_KEEP = "min-snapshots-to-keep";
+  private static final String MAX_SNAPSHOT_AGE_MS = "max-snapshot-age-ms";
+  private static final String MAX_REF_AGE_MS = "max-ref-age-ms";
+
+  public static String toJson(SnapshotRef ref) {
+    return toJson(ref, false);
+  }
+
+  public static String toJson(SnapshotRef ref, boolean pretty) {
+    try {
+      StringWriter writer = new StringWriter();
+      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
+      if (pretty) {
+        generator.useDefaultPrettyPrinter();
+      }
+
+      toJson(ref, generator);
+      generator.flush();
+      return writer.toString();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  public static void toJson(SnapshotRef ref, JsonGenerator generator) throws IOException {
+    generator.writeStartObject();
+    generator.writeNumberField(SNAPSHOT_ID, ref.snapshotId());
+    generator.writeStringField(TYPE, ref.type().name().toLowerCase(Locale.ENGLISH));
+    JsonUtil.writeIntegerFieldIf(ref.minSnapshotsToKeep() != null, MIN_SNAPSHOTS_TO_KEEP, ref.minSnapshotsToKeep(),
+        generator);
+    JsonUtil.writeLongFieldIf(ref.maxSnapshotAgeMs() != null, MAX_SNAPSHOT_AGE_MS, ref.maxSnapshotAgeMs(), generator);
+    JsonUtil.writeLongFieldIf(ref.maxRefAgeMs() != null, MAX_REF_AGE_MS, ref.maxRefAgeMs(), generator);
+    generator.writeEndObject();
+  }
+
+  public static SnapshotRef fromJson(String json) {
+    Preconditions.checkArgument(json != null && !json.isEmpty(), "Cannot parse snapshot ref from invalid JSON: %s",
+        json);
+    try {
+      return fromJson(JsonUtil.mapper().readValue(json, JsonNode.class));
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to parse snapshot ref: " + json, e);
+    }
+  }
+
+  public static SnapshotRef fromJson(JsonNode node) {
+    Preconditions.checkArgument(node.isObject(), "Cannot parse snapshot reference from a non-object: %s", node);
+    long snapshotId = JsonUtil.getLong(SNAPSHOT_ID, node);
+    SnapshotRefType type = SnapshotRefType.valueOf(JsonUtil.getString(TYPE, node).toUpperCase(Locale.ENGLISH));
+    Integer minSnapshotsToKeep = JsonUtil.getIntOrNull(MIN_SNAPSHOTS_TO_KEEP, node);
+    Long maxSnapshotAgeMs = JsonUtil.getLongOrNull(MAX_SNAPSHOT_AGE_MS, node);
+    Long maxRefAgeMs = JsonUtil.getLongOrNull(MAX_REF_AGE_MS, node);
+    return SnapshotRef.builderFor(snapshotId, type)
+        .minSnapshotsToKeep(minSnapshotsToKeep)
+        .maxSnapshotAgeMs(maxSnapshotAgeMs)
+        .maxRefAgeMs(maxRefAgeMs)
+        .build();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
@@ -20,8 +20,10 @@
 package org.apache.iceberg.util;
 
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -51,7 +53,7 @@ public class JsonUtil {
     Preconditions.checkArgument(node.has(property), "Cannot parse missing int %s", property);
     JsonNode pNode = node.get(property);
     Preconditions.checkArgument(pNode != null && !pNode.isNull() && pNode.isNumber(),
-        "Cannot parse %s from non-numeric value: %s", property, pNode);
+        "Cannot parse %s to an integer value: %s", property, pNode);
     return pNode.asInt();
   }
 
@@ -61,15 +63,25 @@ public class JsonUtil {
     }
     JsonNode pNode = node.get(property);
     Preconditions.checkArgument(pNode != null && !pNode.isNull() && pNode.isIntegralNumber() && pNode.canConvertToInt(),
-        "Cannot parse %s from non-string value: %s", property, pNode);
+        "Cannot parse %s to an integer value: %s", property, pNode);
     return pNode.asInt();
+  }
+
+  public static Long getLongOrNull(String property, JsonNode node) {
+    if (!node.has(property)) {
+      return null;
+    }
+    JsonNode pNode = node.get(property);
+    Preconditions.checkArgument(pNode != null && !pNode.isNull() && pNode.isIntegralNumber() &&
+        pNode.canConvertToLong(), "Cannot parse %s to a long value: %s", property, pNode);
+    return pNode.asLong();
   }
 
   public static long getLong(String property, JsonNode node) {
     Preconditions.checkArgument(node.has(property), "Cannot parse missing long %s", property);
     JsonNode pNode = node.get(property);
     Preconditions.checkArgument(pNode != null && !pNode.isNull() && pNode.isNumber(),
-        "Cannot parse %s from non-numeric value: %s", property, pNode);
+        "Cannot parse %s to a long value: %s", property, pNode);
     return pNode.asLong();
   }
 
@@ -77,7 +89,7 @@ public class JsonUtil {
     Preconditions.checkArgument(node.has(property), "Cannot parse missing boolean %s", property);
     JsonNode pNode = node.get(property);
     Preconditions.checkArgument(pNode != null && !pNode.isNull() && pNode.isBoolean(),
-        "Cannot parse %s from non-boolean value: %s", property, pNode);
+        "Cannot parse %s to a boolean value: %s", property, pNode);
     return pNode.asBoolean();
   }
 
@@ -85,7 +97,7 @@ public class JsonUtil {
     Preconditions.checkArgument(node.has(property), "Cannot parse missing string %s", property);
     JsonNode pNode = node.get(property);
     Preconditions.checkArgument(pNode != null && !pNode.isNull() && pNode.isTextual(),
-        "Cannot parse %s from non-string value: %s", property, pNode);
+        "Cannot parse %s to a string value: %s", property, pNode);
     return pNode.asText();
   }
 
@@ -132,6 +144,20 @@ public class JsonUtil {
     return ImmutableSet.<Integer>builder()
         .addAll(new JsonIntegerArrayIterator(property, node))
         .build();
+  }
+
+  public static void writeIntegerFieldIf(boolean condition, String key, Integer value, JsonGenerator generator)
+      throws IOException {
+    if (condition) {
+      generator.writeNumberField(key, value);
+    }
+  }
+
+  public static void writeLongFieldIf(boolean condition, String key, Long value, JsonGenerator generator)
+      throws IOException {
+    if (condition) {
+      generator.writeNumberField(key, value);
+    }
   }
 
   abstract static class JsonArrayIterator<T> implements Iterator<T> {

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotRefParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotRefParser.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestSnapshotRefParser {
+
+  @Test
+  public void testTagToJsonDefault() {
+    String json = "{\"snapshot-id\":1,\"type\":\"tag\"}";
+    SnapshotRef ref = SnapshotRef.tagBuilder(1L).build();
+    Assert.assertEquals("Should be able to serialize default tag",
+        json, SnapshotRefParser.toJson(ref));
+  }
+
+  @Test
+  public void testTagToJsonAllFields() {
+    String json = "{\"snapshot-id\":1,\"type\":\"tag\",\"max-ref-age-ms\":1}";
+    SnapshotRef ref = SnapshotRef.tagBuilder(1L)
+        .maxRefAgeMs(1L)
+        .build();
+    Assert.assertEquals("Should be able to serialize tag with all fields",
+        json, SnapshotRefParser.toJson(ref));
+  }
+
+  @Test
+  public void testBranchToJsonDefault() {
+    String json = "{\"snapshot-id\":1,\"type\":\"branch\"}";
+    SnapshotRef ref = SnapshotRef.branchBuilder(1L).build();
+    Assert.assertEquals("Should be able to serialize default branch",
+        json, SnapshotRefParser.toJson(ref));
+  }
+
+  @Test
+  public void testBranchToJsonAllFields() {
+    String json = "{\"snapshot-id\":1,\"type\":\"branch\",\"min-snapshots-to-keep\":2," +
+        "\"max-snapshot-age-ms\":3,\"max-ref-age-ms\":4}";
+    SnapshotRef ref = SnapshotRef.branchBuilder(1L)
+        .minSnapshotsToKeep(2)
+        .maxSnapshotAgeMs(3L)
+        .maxRefAgeMs(4L)
+        .build();
+    Assert.assertEquals("Should be able to serialize branch with all fields",
+        json, SnapshotRefParser.toJson(ref));
+  }
+
+  @Test
+  public void testTagFromJsonDefault() {
+    String json = "{\"snapshot-id\":1,\"type\":\"tag\"}";
+    SnapshotRef ref = SnapshotRef.tagBuilder(1L).build();
+    Assert.assertEquals("Should be able to deserialize default tag", ref, SnapshotRefParser.fromJson(json));
+  }
+
+  @Test
+  public void testTagFromJsonAllFields() {
+    String json = "{\"snapshot-id\":1,\"type\":\"tag\",\"max-ref-age-ms\":1}";
+    SnapshotRef ref = SnapshotRef.tagBuilder(1L)
+        .maxRefAgeMs(1L)
+        .build();
+    Assert.assertEquals("Should be able to deserialize tag with all fields", ref, SnapshotRefParser.fromJson(json));
+  }
+
+  @Test
+  public void testBranchFromJsonDefault() {
+    String json = "{\"snapshot-id\":1,\"type\":\"branch\"}";
+    SnapshotRef ref = SnapshotRef.branchBuilder(1L).build();
+    Assert.assertEquals("Should be able to deserialize default branch", ref, SnapshotRefParser.fromJson(json));
+  }
+
+  @Test
+  public void testBranchFromJsonAllFields() {
+    String json = "{\"snapshot-id\":1,\"type\":\"branch\",\"min-snapshots-to-keep\":2," +
+        "\"max-snapshot-age-ms\":3,\"max-ref-age-ms\":4}";
+    SnapshotRef ref = SnapshotRef.branchBuilder(1L)
+        .minSnapshotsToKeep(2)
+        .maxSnapshotAgeMs(3L)
+        .maxRefAgeMs(4L)
+        .build();
+    Assert.assertEquals("Should be able to deserialize branch with all fields", ref, SnapshotRefParser.fromJson(json));
+  }
+
+  @Test
+  public void testFailParsingWhenNullOrEmptyJson() {
+    String nullJson = null;
+    AssertHelpers.assertThrows("SnapshotRefParser should fail to deserialize null JSON string",
+        IllegalArgumentException.class, "Cannot parse snapshot ref from invalid JSON",
+        () ->  SnapshotRefParser.fromJson(nullJson));
+
+    String emptyJson = "";
+    AssertHelpers.assertThrows("SnapshotRefParser should fail to deserialize empty JSON string",
+        IllegalArgumentException.class, "Cannot parse snapshot ref from invalid JSON",
+        () ->  SnapshotRefParser.fromJson(emptyJson));
+  }
+
+  @Test
+  public void testFailParsingWhenMissingRequiredFields() {
+    String refMissingType = "{\"snapshot-id\":1}";
+    AssertHelpers.assertThrows("SnapshotRefParser should fail to deserialize ref with missing type",
+        IllegalArgumentException.class, "Cannot parse missing string",
+        () ->  SnapshotRefParser.fromJson(refMissingType));
+
+    String refMissingSnapshotId = "{\"type\":\"branch\"}";
+    AssertHelpers.assertThrows("SnapshotRefParser should fail to deserialize ref with missing snapshot id",
+        IllegalArgumentException.class, "Cannot parse missing long",
+        () ->  SnapshotRefParser.fromJson(refMissingSnapshotId));
+  }
+
+  @Test
+  public void testFailWhenFieldsHaveInvalidValues() {
+    String invalidSnapshotId = "{\"snapshot-id\":\"invalid-snapshot-id\",\"type\":\"not-a-valid-tag-type\"}";
+    AssertHelpers.assertThrows("SnapshotRefParser should fail to deserialize ref with invalid snapshot id",
+        IllegalArgumentException.class,
+        "Cannot parse snapshot-id to a long value",
+        () ->  SnapshotRefParser.fromJson(invalidSnapshotId));
+
+    String invalidTagType = "{\"snapshot-id\":1,\"type\":\"not-a-valid-tag-type\"}";
+    AssertHelpers.assertThrows("SnapshotRefParser should fail to deserialize ref with invalid tag",
+        IllegalArgumentException.class,
+        "No enum constant",
+        () ->  SnapshotRefParser.fromJson(invalidTagType));
+
+    String invalidRefAge = "{\"snapshot-id\":1,\"type\":\"tag\",\"max-ref-age-ms\":\"not-a-valid-value\"}";
+    AssertHelpers.assertThrows("SnapshotRefParser should fail to deserialize ref with invalid ref age",
+        IllegalArgumentException.class, "Cannot parse max-ref-age-ms to a long",
+        () ->  SnapshotRefParser.fromJson(invalidRefAge));
+
+    String invalidSnapshotsToKeep = "{\"snapshot-id\":1,\"type\":\"branch\", " +
+        "\"min-snapshots-to-keep\":\"invalid-number\"}";
+    AssertHelpers.assertThrows("SnapshotRefParser should fail to deserialize ref with missing snapshot id",
+        IllegalArgumentException.class, "Cannot parse min-snapshots-to-keep to an integer value",
+        () ->  SnapshotRefParser.fromJson(invalidSnapshotsToKeep));
+
+    String invalidMaxSnapshotAge = "{\"snapshot-id\":1,\"type\":\"branch\", " +
+        "\"max-snapshot-age-ms\":\"invalid-age\"}";
+    AssertHelpers.assertThrows("SnapshotRefParser should fail to deserialize ref with missing snapshot id",
+        IllegalArgumentException.class, "Cannot parse max-snapshot-age-ms to a long value",
+        () ->  SnapshotRefParser.fromJson(invalidMaxSnapshotAge));
+  }
+}


### PR DESCRIPTION
This change adds serialization and parsing logic for SnapshotReferences. We do not yet call this in the Metadata serialization logic, that will be in a separate PR.

Co-authored-by: wangzeyu <1249369293@qq.com>
Co-authored-by: Jack Ye <yzhaoqin@amazon.com>