### PR TITLE
REST Catalog - Initial request / response objects and Jackson-based SerDe module for some components

### DIFF
--- a/api/src/main/java/org/apache/iceberg/catalog/Namespace.java
+++ b/api/src/main/java/org/apache/iceberg/catalog/Namespace.java
@@ -72,6 +72,10 @@ public class Namespace {
     return levels.length == 0;
   }
 
+  public int length() {
+    return levels.length;
+  }
+
   @Override
   public boolean equals(Object other) {
     if (this == other) {

--- a/core/src/main/java/org/apache/iceberg/catalog/TableIdentifierParser.java
+++ b/core/src/main/java/org/apache/iceberg/catalog/TableIdentifierParser.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.catalog;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.UncheckedIOException;
+import java.util.List;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.JsonUtil;
+
+/**
+ * Parses TableIdentifiers from a JSON representation, which is the JSON
+ * representation utilized in the REST catalog.
+ * <p>
+ * For TableIdentifier.of("dogs", "owners.and.handlers", "food"), we'd have
+ * the following JSON representation, where the dot character of an
+ * individual level is in the namespace is replaced by the null byte character.
+ * <pre>
+ * {
+ *   "namespace": ["dogs", "owners.and.handlers"],
+ *   "name": "food"
+ * }
+ * </pre>
+ */
+public class TableIdentifierParser {
+
+  private static final String NAMESPACE = "namespace";
+  private static final String NAME = "name";
+
+  private TableIdentifierParser() {
+  }
+
+  public static String toJson(TableIdentifier identifier) {
+    return toJson(identifier, false);
+  }
+
+  public static String toJson(TableIdentifier identifier, boolean pretty) {
+    try {
+      StringWriter writer = new StringWriter();
+      JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
+      if (pretty) {
+        generator.useDefaultPrettyPrinter();
+      }
+      toJson(identifier, generator);
+      generator.flush();
+      return writer.toString();
+    } catch (IOException e) {
+      throw new UncheckedIOException(String.format("Failed to write json for: %s", identifier), e);
+    }
+  }
+
+  public static void toJson(TableIdentifier identifier, JsonGenerator generator) throws IOException {
+    generator.writeStartObject();
+    generator.writeFieldName(NAMESPACE);
+    generator.writeArray(identifier.namespace().levels(), 0, identifier.namespace().length());
+    generator.writeStringField(NAME, identifier.name());
+    generator.writeEndObject();
+  }
+
+  public static TableIdentifier fromJson(String json) {
+    Preconditions.checkArgument(json != null,
+        "Cannot parse table identifier from invalid JSON: null");
+    Preconditions.checkArgument(!json.isEmpty(),
+        "Cannot parse table identifier from invalid JSON: ''");
+    try {
+      return fromJson(JsonUtil.mapper().readValue(json, JsonNode.class));
+    } catch (IOException e) {
+      throw new UncheckedIOException(String.format("Cannot parse table identifier from invalid JSON: %s", json), e);
+    }
+  }
+
+  public static TableIdentifier fromJson(JsonNode node) {
+    Preconditions.checkArgument(node != null && !node.isNull() && node.isObject(),
+        "Cannot parse missing or non-object table identifier: %s", node);
+    List<String> levels = JsonUtil.getStringListOrNull(NAMESPACE, node);
+    String tableName = JsonUtil.getString(NAME, node);
+    Namespace namespace = levels == null ? Namespace.empty() : Namespace.of(levels.toArray(new String[0]));
+    return TableIdentifier.of(namespace, tableName);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.io.IOException;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.PartitionSpecParser;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.SortOrderParser;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.catalog.TableIdentifierParser;
+import org.apache.iceberg.util.JsonUtil;
+
+public class RESTSerializers {
+
+  private RESTSerializers() {
+  }
+
+  public static void registerAll(ObjectMapper mapper) {
+    SimpleModule module = new SimpleModule();
+    module
+        .addSerializer(TableIdentifier.class, new TableIdentifierSerializer())
+        .addDeserializer(TableIdentifier.class, new TableIdentifierDeserializer())
+        .addSerializer(Namespace.class, new NamespaceSerializer())
+        .addDeserializer(Namespace.class, new NamespaceDeserializer())
+        .addSerializer(Schema.class, new SchemaSerializer())
+        .addDeserializer(Schema.class, new SchemaDeserializer())
+        .addSerializer(PartitionSpec.class, new PartitionSpecSerializer())
+        .addDeserializer(PartitionSpec.class, new PartitionSpecDeserializer())
+        .addSerializer(SortOrder.class, new SortOrderSerializer())
+        .addDeserializer(SortOrder.class, new SortOrderDeserializer());
+    mapper.registerModule(module);
+  }
+
+  public static class NamespaceDeserializer extends JsonDeserializer<Namespace> {
+    @Override
+    public Namespace deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+      String[] levels = JsonUtil.getStringArray(p.getCodec().readTree(p));
+      return Namespace.of(levels);
+    }
+  }
+
+  public static class NamespaceSerializer extends JsonSerializer<Namespace> {
+    @Override
+    public void serialize(Namespace namespace, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
+      String[] parts = namespace.levels();
+      gen.writeArray(parts, 0, parts.length);
+    }
+  }
+
+  public static class TableIdentifierDeserializer extends JsonDeserializer<TableIdentifier> {
+    @Override
+    public TableIdentifier deserialize(JsonParser p, DeserializationContext context)
+        throws IOException {
+      JsonNode jsonNode = p.getCodec().readTree(p);
+      return TableIdentifierParser.fromJson(jsonNode);
+    }
+  }
+
+  public static class TableIdentifierSerializer extends JsonSerializer<TableIdentifier> {
+    @Override
+    public void serialize(TableIdentifier identifier, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
+      TableIdentifierParser.toJson(identifier, gen);
+    }
+  }
+
+  public static class SchemaDeserializer extends JsonDeserializer<Schema> {
+    @Override
+    public Schema deserialize(JsonParser p, DeserializationContext context) throws IOException {
+      JsonNode jsonNode = p.getCodec().readTree(p);
+      Schema schema = SchemaParser.fromJson(jsonNode);
+      // Store the schema in the context so that it can be used when parsing PartitionSpec / SortOrder
+      context.setAttribute("schema", schema);
+      return schema;
+    }
+  }
+
+  public static class SchemaSerializer extends JsonSerializer<Schema> {
+    @Override
+    public void serialize(Schema schema, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
+      SchemaParser.toJson(schema, gen);
+    }
+  }
+
+  public static class PartitionSpecSerializer extends JsonSerializer<PartitionSpec> {
+    @Override
+    public void serialize(
+        PartitionSpec partitionSpec, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
+      PartitionSpecParser.toJson(partitionSpec, gen);
+    }
+  }
+
+  public static class PartitionSpecDeserializer extends JsonDeserializer<PartitionSpec> {
+    @Override
+    public PartitionSpec deserialize(JsonParser p, DeserializationContext context)
+        throws IOException {
+      JsonNode jsonNode = p.getCodec().readTree(p);
+      Schema schema = (Schema) context.getAttribute("schema");
+      return PartitionSpecParser.fromJson(schema, jsonNode);
+    }
+  }
+
+  public static class SortOrderSerializer extends JsonSerializer<SortOrder> {
+    @Override
+    public void serialize(SortOrder sortOrder, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
+      SortOrderParser.toJson(sortOrder, gen);
+    }
+  }
+
+  public static class SortOrderDeserializer extends JsonDeserializer<SortOrder> {
+    @Override
+    public SortOrder deserialize(JsonParser p, DeserializationContext context) throws IOException {
+      JsonNode jsonNode = p.getCodec().readTree(p);
+      Schema schema = (Schema) context.getAttribute("schema");
+      return SortOrderParser.fromJson(schema, jsonNode);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/requests/CreateNamespaceRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/CreateNamespaceRequest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest.requests;
+
+import java.util.Map;
+import java.util.Objects;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+
+/**
+ * A REST request to create a namespace, with an optional set of properties.
+ */
+public class CreateNamespaceRequest {
+
+  private Namespace namespace;
+  private Map<String, String> properties;
+
+  public CreateNamespaceRequest() {
+    // Needed for Jackson Deserialization.
+  }
+
+  private CreateNamespaceRequest(Namespace namespace, Map<String, String> properties) {
+    this.namespace = namespace;
+    this.properties = properties;
+    validate();
+  }
+
+  CreateNamespaceRequest validate() {
+    Preconditions.checkArgument(namespace != null, "Invalid namespace: null");
+    return this;
+  }
+
+  public Namespace namespace() {
+    return namespace;
+  }
+
+  public Map<String, String> properties() {
+    return properties != null ? properties : ImmutableMap.of();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("namespace", namespace)
+        .add("properties", properties)
+        .toString();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Namespace namespace;
+    private final ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
+
+    private Builder() {
+    }
+
+    public Builder withNamespace(Namespace ns) {
+      Preconditions.checkNotNull(ns, "Invalid namespace: null");
+      this.namespace = ns;
+      return this;
+    }
+
+    public Builder setProperties(Map<String, String> props) {
+      Preconditions.checkNotNull(props, "Invalid collection of properties: null");
+      Preconditions.checkArgument(!props.containsKey(null), "Invalid property: null");
+      Preconditions.checkArgument(!props.containsValue(null),
+          "Invalid value for properties %s: null", Maps.filterValues(props, Objects::isNull).keySet());
+      properties.putAll(props);
+      return this;
+    }
+
+    public CreateNamespaceRequest build() {
+      return new CreateNamespaceRequest(namespace, properties.build());
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateNamespacePropertiesRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateNamespacePropertiesRequest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest.requests;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+
+/**
+ * A REST request to set and/or remove properties on a namespace.
+ */
+public class UpdateNamespacePropertiesRequest {
+
+  private List<String> removals;
+  private Map<String, String> updates;
+
+  public UpdateNamespacePropertiesRequest() {
+    // Required for Jackson deserialization.
+  }
+
+  private UpdateNamespacePropertiesRequest(List<String> removals, Map<String, String> updates) {
+    this.removals = removals;
+    this.updates = updates;
+    validate();
+  }
+
+  UpdateNamespacePropertiesRequest validate() {
+    return this;
+  }
+
+  public List<String> removals() {
+    return removals == null ? ImmutableList.of() : removals;
+  }
+
+  public Map<String, String> updates() {
+    return updates == null ? ImmutableMap.of() : updates;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("removals", removals)
+        .add("updates", updates)
+        .toString();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private final ImmutableSet.Builder<String> removalsBuilder = ImmutableSet.builder();
+    private final ImmutableMap.Builder<String, String> updatesBuilder = ImmutableMap.builder();
+
+    private Builder() {
+    }
+
+    public Builder remove(String removal) {
+      Preconditions.checkNotNull(removal,
+          "Invalid property to remove: null");
+      removalsBuilder.add(removal);
+      return this;
+    }
+
+    public Builder removeAll(Collection<String> removals) {
+      Preconditions.checkNotNull(removals,
+          "Invalid list of properties to remove: null");
+      Preconditions.checkArgument(!removals.contains(null),
+          "Invalid property to remove: null");
+      removalsBuilder.addAll(removals);
+      return this;
+    }
+
+    public Builder update(String key, String value) {
+      Preconditions.checkNotNull(key,
+          "Invalid property to update: null");
+      Preconditions.checkNotNull(value,
+          "Invalid value to update for key [%s]: null. Use remove instead", key);
+      updatesBuilder.put(key, value);
+      return this;
+    }
+
+    public Builder updateAll(Map<String, String> updates) {
+      Preconditions.checkNotNull(updates,
+          "Invalid collection of properties to update: null");
+      Preconditions.checkArgument(!updates.containsKey(null),
+          "Invalid property to update: null");
+      Preconditions.checkArgument(!updates.containsValue(null),
+          "Invalid value to update for properties %s: null. Use remove instead",
+          Maps.filterValues(updates, Objects::isNull).keySet());
+      updatesBuilder.putAll(updates);
+      return this;
+    }
+
+    public UpdateNamespacePropertiesRequest build() {
+      List<String> removals = removalsBuilder.build().asList();
+      Map<String, String> updates = updatesBuilder.build();
+
+      return new UpdateNamespacePropertiesRequest(removals, updates);
+    }
+  }
+}
+

--- a/core/src/main/java/org/apache/iceberg/rest/responses/CreateNamespaceResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/CreateNamespaceResponse.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest.responses;
+
+import java.util.Map;
+import java.util.Objects;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+
+/**
+ * Represents a REST response for a request to create a namespace / database.
+ */
+public class CreateNamespaceResponse {
+
+  private Namespace namespace;
+  private Map<String, String> properties;
+
+  public CreateNamespaceResponse() {
+    // Required for Jackson deserialization.
+  }
+
+  private CreateNamespaceResponse(Namespace namespace, Map<String, String> properties) {
+    this.namespace = namespace;
+    this.properties = properties;
+    validate();
+  }
+
+  CreateNamespaceResponse validate() {
+    Preconditions.checkArgument(namespace != null, "Invalid namespace: null");
+    return this;
+  }
+
+  public Namespace namespace() {
+    return namespace;
+  }
+
+  public Map<String, String> properties() {
+    return properties != null ? properties : ImmutableMap.of();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("namespace", namespace)
+        .add("properties", properties)
+        .toString();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  static class Builder {
+    private Namespace namespace;
+    private final ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
+
+    private Builder() {
+    }
+
+    public Builder withNamespace(Namespace ns) {
+      Preconditions.checkNotNull(ns, "Invalid namespace: null");
+      this.namespace = ns;
+      return this;
+    }
+
+    public Builder setProperties(Map<String, String> props) {
+      Preconditions.checkNotNull(props,
+          "Invalid collection of properties: null");
+      Preconditions.checkArgument(!props.containsKey(null),
+          "Invalid property to set: null");
+      Preconditions.checkArgument(!props.containsValue(null),
+          "Invalid value to set for properties %s: null", Maps.filterValues(props, Objects::isNull).keySet());
+      properties.putAll(props);
+      return this;
+    }
+
+    public CreateNamespaceResponse build() {
+      return new CreateNamespaceResponse(namespace, properties.build());
+    }
+  }
+}
+

--- a/core/src/main/java/org/apache/iceberg/rest/responses/DropNamespaceResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/DropNamespaceResponse.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest.responses;
+
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+/**
+ * Represents a REST response to drop a namespace.
+ * <p>
+ * The server may choose to return an error if the namespace is not empty.
+ */
+public class DropNamespaceResponse {
+
+  // For Jackson to properly fail when deserializing, this needs to be boxed.
+  // Otherwise, the boolean is parsed according to "loose" javascript JSON rules.
+  private Boolean dropped;
+
+  public DropNamespaceResponse() {
+    // Required for Jackson deserialization
+  }
+
+  private DropNamespaceResponse(boolean dropped) {
+    this.dropped = dropped;
+    validate();
+  }
+
+  DropNamespaceResponse validate() {
+    Preconditions.checkArgument(dropped != null, "Invalid response, missing field: dropped");
+    return this;
+  }
+
+  public boolean isDropped() {
+    return dropped;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("dropped", dropped)
+        .toString();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Boolean dropped;
+
+    private Builder() {
+    }
+
+    public Builder dropped(boolean isDropped) {
+      this.dropped = isDropped;
+      return this;
+    }
+
+    public DropNamespaceResponse build() {
+      Preconditions.checkArgument(dropped != null, "Invalid response, missing field: dropped");
+      return new DropNamespaceResponse(dropped);
+    }
+  }
+}
+

--- a/core/src/main/java/org/apache/iceberg/rest/responses/GetNamespaceResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/GetNamespaceResponse.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest.responses;
+
+import java.util.Map;
+import java.util.Objects;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+
+/**
+ * Represents a REST response to fetch a namespace and its metadata properties
+ */
+public class GetNamespaceResponse {
+
+  private Namespace namespace;
+  private Map<String, String> properties;
+
+  public GetNamespaceResponse() {
+    // Required for Jackson deserialization
+  }
+
+  private GetNamespaceResponse(Namespace namespace, Map<String, String> properties) {
+    this.namespace = namespace;
+    this.properties = properties;
+    validate();
+  }
+
+  GetNamespaceResponse validate() {
+    Preconditions.checkArgument(namespace != null, "Invalid namespace: null");
+    return this;
+  }
+
+  public Namespace namespace() {
+    return namespace;
+  }
+
+  public Map<String, String> properties() {
+    return properties != null ? properties : ImmutableMap.of();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("namespace", namespace)
+        .add("properties", properties)
+        .toString();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  static class Builder {
+    private Namespace namespace;
+    private final ImmutableMap.Builder<String, String> properties =  ImmutableMap.builder();
+
+    private Builder() {
+    }
+
+    public Builder withNamespace(Namespace ns) {
+      Preconditions.checkNotNull(ns, "Invalid namespace: null");
+      namespace = ns;
+      return this;
+    }
+
+    public Builder setProperties(Map<String, String> props) {
+      Preconditions.checkNotNull(props, "Invalid properties map: null");
+      Preconditions.checkArgument(!props.containsKey(null),
+          "Invalid property: null");
+      Preconditions.checkArgument(!props.containsValue(null),
+          "Invalid value for properties %s: null",
+          Maps.filterValues(props, Objects::isNull).keySet());
+      properties.putAll(props);
+      return this;
+    }
+
+    public GetNamespaceResponse build() {
+      return new GetNamespaceResponse(namespace, properties.build());
+    }
+  }
+}
+

--- a/core/src/main/java/org/apache/iceberg/rest/responses/ListNamespacesResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/ListNamespacesResponse.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.apache.iceberg.rest.responses;
+
+import java.util.Collection;
+import java.util.List;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+
+public class ListNamespacesResponse {
+
+  private List<Namespace> namespaces;
+
+  public ListNamespacesResponse() {
+    // Required for Jackson deserialization
+  }
+
+  private ListNamespacesResponse(List<Namespace> namespaces) {
+    this.namespaces = namespaces;
+    validate();
+  }
+
+  ListNamespacesResponse validate() {
+    Preconditions.checkArgument(namespaces != null, "Invalid namespace: null");
+    return this;
+  }
+
+
+  public List<Namespace> namespaces() {
+    return namespaces != null ? namespaces : ImmutableList.of();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("namespaces", namespaces())
+        .toString();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  static class Builder {
+    private final ImmutableList.Builder<Namespace> namespaces = ImmutableList.builder();
+
+    private Builder() {
+    }
+
+    public Builder add(Namespace toAdd) {
+      Preconditions.checkNotNull(toAdd, "Invalid namespace: null");
+      namespaces.add(toAdd);
+      return this;
+    }
+
+    public Builder addAll(Collection<Namespace> toAdd) {
+      Preconditions.checkNotNull(toAdd, "Invalid namespace list: null");
+      Preconditions.checkArgument(!toAdd.contains(null), "Invalid namespace: null");
+      namespaces.addAll(toAdd);
+      return this;
+    }
+
+    public ListNamespacesResponse build() {
+      return new ListNamespacesResponse(namespaces.build());
+    }
+  }
+}
+

--- a/core/src/main/java/org/apache/iceberg/rest/responses/ListTablesResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/ListTablesResponse.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.apache.iceberg.rest.responses;
+
+import java.util.Collection;
+import java.util.List;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+
+/**
+ * A list of table identifiers in a given namespace.
+ */
+public class ListTablesResponse {
+
+  private List<TableIdentifier> identifiers;
+
+  public ListTablesResponse() {
+    // Required for Jackson deserialization
+  }
+
+  private ListTablesResponse(List<TableIdentifier> identifiers) {
+    this.identifiers = identifiers;
+    validate();
+  }
+
+  ListTablesResponse validate() {
+    Preconditions.checkArgument(identifiers != null, "Invalid identifier list: null");
+    return this;
+  }
+
+  public List<TableIdentifier> identifiers() {
+    return identifiers != null ? identifiers : ImmutableList.of();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("identifiers", identifiers)
+        .toString();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  static class Builder {
+    private final ImmutableList.Builder<TableIdentifier> identifiers = ImmutableList.builder();
+
+    private Builder() {
+    }
+
+    public Builder add(TableIdentifier toAdd) {
+      Preconditions.checkNotNull(toAdd, "Invalid table identifier: null");
+      identifiers.add(toAdd);
+      return this;
+    }
+
+    public Builder addAll(Collection<TableIdentifier> toAdd) {
+      Preconditions.checkNotNull(toAdd, "Invalid table identifier list: null");
+      Preconditions.checkArgument(!toAdd.contains(null), "Invalid table identifier: null");
+      identifiers.addAll(toAdd);
+      return this;
+    }
+
+    public ListTablesResponse build() {
+      return new ListTablesResponse(identifiers.build());
+    }
+  }
+}
+

--- a/core/src/main/java/org/apache/iceberg/rest/responses/UpdateNamespacePropertiesResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/UpdateNamespacePropertiesResponse.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest.responses;
+
+import java.util.Collection;
+import java.util.List;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+
+/**
+ * A REST response to a request to set and/or remove properties on a namespace.
+ */
+public class UpdateNamespacePropertiesResponse {
+
+  // List of namespace property keys that were removed
+  private List<String> removed;
+  // List of namespace property keys that were added or updated
+  private List<String> updated;
+  // List of properties that were requested for removal that were not found in the namespace's properties
+  private List<String> missing;
+
+  public UpdateNamespacePropertiesResponse() {
+    // Required for Jackson deserialization
+  }
+
+  private UpdateNamespacePropertiesResponse(List<String> removed, List<String> updated, List<String> missing) {
+    this.removed = removed;
+    this.updated = updated;
+    this.missing = missing;
+    validate();
+  }
+
+  UpdateNamespacePropertiesResponse validate() {
+    return this;
+  }
+
+  public List<String> removed() {
+    return removed != null ? removed : ImmutableList.of();
+  }
+
+  public List<String> updated() {
+    return updated != null ? updated : ImmutableList.of();
+  }
+
+  public List<String> missing() {
+    return missing != null ? missing : ImmutableList.of();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("removed", removed)
+        .add("updates", updated)
+        .add("missing", missing)
+        .toString();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private final ImmutableSet.Builder<String> removedBuilder = ImmutableSet.builder();
+    private final ImmutableSet.Builder<String> updatedBuilder = ImmutableSet.builder();
+    private final ImmutableSet.Builder<String> missingBuilder = ImmutableSet.builder();
+
+    private Builder() {
+    }
+
+    public Builder addMissing(String key) {
+      Preconditions.checkNotNull(key, "Invalid missing property: null");
+      missingBuilder.add(key);
+      return this;
+    }
+
+    public Builder addMissing(Collection<String> missing) {
+      Preconditions.checkNotNull(missing, "Invalid missing property list: null");
+      Preconditions.checkArgument(!missing.contains(null), "Invalid missing property: null");
+      missingBuilder.addAll(missing);
+      return this;
+    }
+
+    public Builder addRemoved(String key) {
+      Preconditions.checkNotNull(key, "Invalid removed property: null");
+      removedBuilder.add(key);
+      return this;
+    }
+
+    public Builder addRemoved(Collection<String> removed) {
+      Preconditions.checkNotNull(removed, "Invalid removed property list: null");
+      Preconditions.checkArgument(!removed.contains(null),
+          "Invalid removed property: null");
+      removedBuilder.addAll(removed);
+      return this;
+    }
+
+    public Builder addUpdated(String key) {
+      Preconditions.checkNotNull(key, "Invalid updated property: null");
+      updatedBuilder.add(key);
+      return this;
+    }
+
+    public Builder addUpdated(Collection<String> updated) {
+      Preconditions.checkNotNull(updated, "Invalid updated property list: null");
+      Preconditions.checkArgument(!updated.contains(null), "Invalid updated property: null");
+      updatedBuilder.addAll(updated);
+      return this;
+    }
+
+    public UpdateNamespacePropertiesResponse build() {
+      List<String> removed = removedBuilder.build().asList();
+      List<String> updated = updatedBuilder.build().asList();
+      List<String> missing = missingBuilder.build().asList();
+      return new UpdateNamespacePropertiesResponse(removed, updated, missing);
+    }
+  }
+}
+

--- a/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
@@ -129,8 +130,29 @@ public class JsonUtil {
     return builder.build();
   }
 
+  public static String[] getStringArray(JsonNode node) {
+    Preconditions.checkArgument(node != null && !node.isNull() && node.isArray(),
+        "Cannot parse string array from non-array: %s", node);
+    ArrayNode arrayNode = (ArrayNode) node;
+    String[] arr = new String[arrayNode.size()];
+    for (int i = 0; i < arr.length; i++) {
+      arr[i] = arrayNode.get(i).asText();
+    }
+    return arr;
+  }
+
   public static List<String> getStringList(String property, JsonNode node) {
     Preconditions.checkArgument(node.has(property), "Cannot parse missing list %s", property);
+    return ImmutableList.<String>builder()
+        .addAll(new JsonStringArrayIterator(property, node))
+        .build();
+  }
+
+  public static List<String> getStringListOrNull(String property, JsonNode node) {
+    if (!node.has(property)) {
+      return null;
+    }
+
     return ImmutableList.<String>builder()
         .addAll(new JsonStringArrayIterator(property, node))
         .build();

--- a/core/src/test/java/org/apache/iceberg/catalog/TestTableIdentifierParser.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/TestTableIdentifierParser.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.catalog;
+
+import org.apache.iceberg.AssertHelpers;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestTableIdentifierParser {
+
+  @Test
+  public void testTableIdentifierToJson() {
+    String json = "{\"namespace\":[\"accounting\",\"tax\"],\"name\":\"paid\"}";
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("accounting", "tax"), "paid");
+    Assert.assertEquals("Should be able to serialize a table identifier with both namespace and name",
+        json, TableIdentifierParser.toJson(identifier));
+
+    TableIdentifier identifierWithEmptyNamespace = TableIdentifier.of(Namespace.empty(), "paid");
+    String jsonWithEmptyNamespace = "{\"namespace\":[],\"name\":\"paid\"}";
+    Assert.assertEquals("Should be able to serialize a table identifier that uses the empty namespace",
+        jsonWithEmptyNamespace, TableIdentifierParser.toJson(identifierWithEmptyNamespace));
+  }
+
+  @Test
+  public void testTableIdentifierFromJson() {
+    String json = "{\"namespace\":[\"accounting\",\"tax\"],\"name\":\"paid\"}";
+    TableIdentifier identifier = TableIdentifier.of(Namespace.of("accounting", "tax"), "paid");
+    Assert.assertEquals("Should be able to deserialize a valid table identifier",
+        identifier, TableIdentifierParser.fromJson(json));
+
+    TableIdentifier identifierWithEmptyNamespace = TableIdentifier.of(Namespace.empty(), "paid");
+    String jsonWithEmptyNamespace = "{\"namespace\":[],\"name\":\"paid\"}";
+    Assert.assertEquals("Should be able to deserialize a valid multi-level table identifier",
+        identifierWithEmptyNamespace, TableIdentifierParser.fromJson(jsonWithEmptyNamespace));
+
+    String identifierMissingNamespace = "{\"name\":\"paid\"}";
+    Assert.assertEquals("Should implicitly convert a missing namespace into the the empty namespace when parsing",
+        identifierWithEmptyNamespace, TableIdentifierParser.fromJson(identifierMissingNamespace));
+  }
+
+  @Test
+  public void testFailParsingWhenNullOrEmptyJson() {
+    String nullJson = null;
+    AssertHelpers.assertThrows("TableIdentifierParser should fail to deserialize null JSON string",
+        IllegalArgumentException.class, "Cannot parse table identifier from invalid JSON: null",
+        () ->  TableIdentifierParser.fromJson(nullJson));
+
+    String emptyString = "";
+    AssertHelpers.assertThrows("TableIdentifierParser should fail to deserialize an empty string",
+        IllegalArgumentException.class, "Cannot parse table identifier from invalid JSON: ''",
+        () ->  TableIdentifierParser.fromJson(emptyString));
+
+    String emptyJson = "{}";
+    AssertHelpers.assertThrows("TableIdentifierParser should fail to deserialize an empty JSON string",
+        IllegalArgumentException.class, "Cannot parse missing string name",
+        () ->  TableIdentifierParser.fromJson(emptyJson));
+
+    String emptyJsonArray = "[]";
+    AssertHelpers.assertThrows("TableIdentifierParser should fail to deserialize an empty JSON array",
+        IllegalArgumentException.class, "Cannot parse missing or non-object table identifier: []",
+        () ->  TableIdentifierParser.fromJson(emptyJsonArray));
+  }
+
+  @Test
+  public void testFailParsingWhenMissingRequiredFields() {
+    String identifierMissingName = "{\"namespace\":[\"accounting\",\"tax\"]}";
+    AssertHelpers.assertThrows("TableIdentifierParser should fail to deserialize table with missing name",
+        IllegalArgumentException.class, "Cannot parse missing string name",
+        () ->  TableIdentifierParser.fromJson(identifierMissingName));
+  }
+
+  @Test
+  public void testFailWhenFieldsHaveInvalidValues() {
+    String invalidNamespace = "{\"namespace\":\"accounting.tax\",\"name\":\"paid\"}";
+    AssertHelpers.assertThrows("TableIdentifierParser should fail to deserialize table with invalid namespace",
+        IllegalArgumentException.class,
+        "Cannot parse namespace from non-array value: \"accounting.tax\"",
+        () ->  TableIdentifierParser.fromJson(invalidNamespace));
+
+    String invalidName = "{\"namespace\":[\"accounting\",\"tax\"],\"name\":1234}";
+    AssertHelpers.assertThrows("TableIdentifierParser should fail to deserialize table with invalid name",
+        IllegalArgumentException.class, "Cannot parse name to a string value: 1234",
+        () ->  TableIdentifierParser.fromJson(invalidName));
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/RequestResponseTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RequestResponseTestBase.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.api.Assertions;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public abstract class RequestResponseTestBase<T> {
+
+  private static final JsonFactory FACTORY = new JsonFactory();
+  private static final ObjectMapper MAPPER = new ObjectMapper(FACTORY);
+
+  @BeforeClass
+  public static void beforeClass() {
+    RESTSerializers.registerAll(MAPPER);
+    // This is a workaround for Jackson since Iceberg doesn't use the standard get/set bean notation.
+    // This allows Jackson to work with the fields directly (both public and private) and not require
+    // custom serializers for all the request/response objects.
+    MAPPER.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+  }
+
+  public static ObjectMapper mapper() {
+    return MAPPER;
+  }
+
+  /**
+   * Return a list of all the fields used in this class, as defined in the spec.
+   */
+  public abstract String[] allFieldsFromSpec();
+
+  /**
+   * Return a valid instance of the request / response object. Used when validating fields.
+   */
+  public abstract T createExampleInstance();
+
+  /**
+   * Compare if two request / response objects are equivalent.
+   * <p>
+   * This helper method is used as opposed to implementing equals so that fields that deserialize into
+   * null can be compared to the fields of instances created via the corresponding Builder, which typically
+   * have a default value (such as an empty collection) for those fields.
+   * @param actual - request / response object to validate
+   * @param expected - the corresponding object to check that {@code actual} is semantically equivalent to.
+   */
+  public abstract void assertEquals(T actual, T expected);
+
+  /**
+   * Parse and return the input json into a value of type T.
+   */
+  public abstract T deserialize(String json) throws JsonProcessingException;
+
+  /**
+   * This test ensures that only the fields that are expected, e.g. from the spec, are found on the class.
+   * If new fields are added to the spec, they should be added to the function
+   * {@link RequestResponseTestBase#allFieldsFromSpec()}
+   */
+  @Test
+  public void testHasOnlyKnownFields() {
+    T value = createExampleInstance();
+
+    Assertions.assertThat(value)
+        .hasOnlyFields(allFieldsFromSpec());
+  }
+
+  /**
+   * Test that the input JSON can be parsed into an equivalent object as {@code expected}, and then
+   * re-serialized into the same JSON.
+   */
+  protected void assertRoundTripSerializesEquallyFrom(String json, T expected) throws JsonProcessingException {
+    // Check that the JSON deserializes into the expected value;
+    T actual = deserialize(json);
+    assertEquals(actual, expected);
+
+    // Check that the deserialized value serializes back into the original JSON
+    Assertions.assertThat(MAPPER.writeValueAsString(actual))
+        .isEqualTo(json);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestCreateNamespaceRequest.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestCreateNamespaceRequest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest.requests;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.Map;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.rest.RequestResponseTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestCreateNamespaceRequest extends RequestResponseTestBase<CreateNamespaceRequest> {
+
+  /* Values used to fill in request fields */
+  private static final Namespace NAMESPACE = Namespace.of("accounting", "tax");
+  private static final Map<String, String> PROPERTIES = ImmutableMap.of("owner", "Hank");
+  private static final Map<String, String> EMPTY_PROPERTIES = ImmutableMap.of();
+
+  @Test
+  // Test cases that are JSON that can be created via the Builder
+  public void testRoundTripSerDe() throws JsonProcessingException {
+    String fullJson = "{\"namespace\":[\"accounting\",\"tax\"],\"properties\":{\"owner\":\"Hank\"}}";
+    CreateNamespaceRequest req = CreateNamespaceRequest.builder()
+        .withNamespace(NAMESPACE).setProperties(PROPERTIES).build();
+    assertRoundTripSerializesEquallyFrom(fullJson, req);
+
+    String jsonEmptyProperties = "{\"namespace\":[\"accounting\",\"tax\"],\"properties\":{}}";
+    CreateNamespaceRequest reqWithExplicitEmptyProperties = CreateNamespaceRequest.builder()
+        .withNamespace(NAMESPACE).setProperties(EMPTY_PROPERTIES).build();
+    assertRoundTripSerializesEquallyFrom(jsonEmptyProperties, reqWithExplicitEmptyProperties);
+
+    CreateNamespaceRequest reqWithImplicitEmptyProperties = CreateNamespaceRequest.builder()
+        .withNamespace(NAMESPACE).build();
+    assertRoundTripSerializesEquallyFrom(jsonEmptyProperties, reqWithImplicitEmptyProperties);
+
+    String jsonWithEmptyNamespace = "{\"namespace\":[],\"properties\":{}}";
+    CreateNamespaceRequest reqUsingEmptyNamespace = CreateNamespaceRequest.builder()
+        .withNamespace(Namespace.empty()).build();
+    assertRoundTripSerializesEquallyFrom(jsonWithEmptyNamespace, reqUsingEmptyNamespace);
+  }
+
+  @Test
+  // Test cases that can't be constructed with our Builder class but that will parse correctly
+  public void testCanDeserializeWithoutDefaultValues() throws JsonProcessingException {
+    CreateNamespaceRequest req = CreateNamespaceRequest.builder().withNamespace(NAMESPACE).build();
+    String jsonWithNullProperties = "{\"namespace\":[\"accounting\",\"tax\"],\"properties\":null}";
+    assertEquals(deserialize(jsonWithNullProperties), req);
+
+    String jsonWithMissingProperties = "{\"namespace\":[\"accounting\",\"tax\"]}";
+    assertEquals(deserialize(jsonWithMissingProperties), req);
+  }
+
+  @Test
+  public void testDeserializeInvalidRequest() {
+    String jsonIncorrectTypeForNamespace = "{\"namespace\":\"accounting%00tax\",\"properties\":null}";
+    AssertHelpers.assertThrows(
+        "A JSON request with incorrect types for fields should fail to deserialize and validate",
+        JsonProcessingException.class,
+        "Cannot parse string array from non-array",
+        () -> deserialize(jsonIncorrectTypeForNamespace)
+    );
+
+    String jsonIncorrectTypeForProperties = "{\"namespace\":[\"accounting\",\"tax\"],\"properties\":[]}";
+    AssertHelpers.assertThrows(
+        "A JSON request with incorrect types for fields should fail to parse and validate",
+        JsonProcessingException.class,
+        () -> deserialize(jsonIncorrectTypeForProperties)
+    );
+
+    String jsonMisspelledKeys = "{\"namepsace\":[\"accounting\",\"tax\"],\"propertiezzzz\":{\"owner\":\"Hank\"}}";
+    AssertHelpers.assertThrows(
+        "A JSON request with the keys spelled incorrectly should fail to deserialize and validate",
+        JsonProcessingException.class, "Unrecognized field \"namepsace\"",
+        () -> deserialize(jsonMisspelledKeys)
+    );
+
+    String emptyJson = "{}";
+    AssertHelpers.assertThrows(
+        "An empty JSON object should not parse into a CreateNamespaceRequest instance that passes validation",
+        IllegalArgumentException.class,
+        "Invalid namespace: null",
+        () -> deserialize(emptyJson)
+    );
+
+    AssertHelpers.assertThrows(
+        "An empty JSON request should fail to deserialize",
+        IllegalArgumentException.class,
+        () -> deserialize(null)
+    );
+  }
+
+  @Test
+  public void testBuilderDoesNotBuildInvalidRequests() {
+    AssertHelpers.assertThrows(
+        "The builder should not allow using null for the namespace",
+        NullPointerException.class,
+        "Invalid namespace: null",
+        () -> CreateNamespaceRequest.builder().withNamespace(null).build()
+    );
+
+    AssertHelpers.assertThrows(
+        "The builder should not allow passing a null collection of properties",
+        NullPointerException.class,
+        "Invalid collection of properties: null",
+        () -> CreateNamespaceRequest.builder().setProperties(null).build()
+    );
+
+    Map<String, String> mapWithNullKey = Maps.newHashMap();
+    mapWithNullKey.put(null, "hello");
+    AssertHelpers.assertThrows(
+        "The builder should not allow using null as a key in the properties to set",
+        IllegalArgumentException.class,
+        "Invalid property: null",
+        () -> CreateNamespaceRequest.builder().setProperties(mapWithNullKey).build()
+    );
+
+    Map<String, String> mapWithMultipleNullValues = Maps.newHashMap();
+    mapWithMultipleNullValues.put("a", null);
+    mapWithMultipleNullValues.put("b", "b");
+    AssertHelpers.assertThrows(
+        "The builder should not allow using null as a value in the properties to set",
+        IllegalArgumentException.class,
+        "Invalid value for properties [a]: null",
+        () -> CreateNamespaceRequest.builder().setProperties(mapWithMultipleNullValues).build()
+    );
+  }
+
+  @Override
+  public String[] allFieldsFromSpec() {
+    return new String[] {"namespace", "properties"};
+  }
+
+  @Override
+  public CreateNamespaceRequest createExampleInstance() {
+    return CreateNamespaceRequest.builder()
+        .withNamespace(NAMESPACE)
+        .setProperties(PROPERTIES)
+        .build();
+  }
+
+  @Override
+  public void assertEquals(CreateNamespaceRequest actual, CreateNamespaceRequest expected) {
+    Assert.assertEquals("Namespaces should be equal", actual.namespace(), expected.namespace());
+    Assert.assertEquals("Properties should be equal", actual.properties(), expected.properties());
+  }
+
+  @Override
+  public CreateNamespaceRequest deserialize(String json) throws JsonProcessingException {
+    return mapper().readValue(json, CreateNamespaceRequest.class).validate();
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateNamespacePropertiesRequest.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateNamespacePropertiesRequest.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest.requests;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.rest.RequestResponseTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestUpdateNamespacePropertiesRequest extends RequestResponseTestBase<UpdateNamespacePropertiesRequest> {
+
+  /* Values used to fill in request fields */
+  private static final Map<String, String> UPDATES = ImmutableMap.of("owner", "Hank");
+  private static final List<String> REMOVALS = ImmutableList.of("foo", "bar");
+  private static final Map<String, String> EMPTY_UPDATES = ImmutableMap.of();
+  private static final List<String> EMPTY_REMOVALS = ImmutableList.of();
+
+  @Test
+  public void testRoundTripSerDe() throws JsonProcessingException {
+    // Full request
+    String fullJson = "{\"removals\":[\"foo\",\"bar\"],\"updates\":{\"owner\":\"Hank\"}}";
+    assertRoundTripSerializesEquallyFrom(
+        fullJson, UpdateNamespacePropertiesRequest.builder().updateAll(UPDATES).removeAll(REMOVALS).build());
+
+    // Only updates
+    String emptyRemoval = "{\"removals\":[],\"updates\":{\"owner\":\"Hank\"}}";
+    assertRoundTripSerializesEquallyFrom(
+        emptyRemoval, UpdateNamespacePropertiesRequest.builder().updateAll(UPDATES).removeAll(EMPTY_REMOVALS).build());
+
+    assertRoundTripSerializesEquallyFrom(
+        emptyRemoval, UpdateNamespacePropertiesRequest.builder().update("owner", "Hank").build());
+
+    // Only removals
+    String emptyUpdates = "{\"removals\":[\"foo\",\"bar\"],\"updates\":{}}";
+    assertRoundTripSerializesEquallyFrom(
+        emptyUpdates, UpdateNamespacePropertiesRequest.builder().removeAll(REMOVALS).updateAll(EMPTY_UPDATES).build());
+
+    assertRoundTripSerializesEquallyFrom(
+        emptyUpdates, UpdateNamespacePropertiesRequest.builder().remove("foo").remove("bar").build());
+
+    // All empty
+    String jsonAllFieldsEmpty = "{\"removals\":[],\"updates\":{}}";
+    assertRoundTripSerializesEquallyFrom(
+        jsonAllFieldsEmpty, UpdateNamespacePropertiesRequest.builder().build());
+  }
+
+  @Test
+  // Test cases that can't be constructed with our Builder class e2e but that will parse correctly
+  public void testCanDeserializeWithoutDefaultValues() throws JsonProcessingException {
+    // `removals` is null
+    UpdateNamespacePropertiesRequest noRemovals = UpdateNamespacePropertiesRequest.builder().updateAll(UPDATES).build();
+    String jsonWithNullRemovals = "{\"removals\":null,\"updates\":{\"owner\":\"Hank\"}}";
+    UpdateNamespacePropertiesRequest parsed = deserialize(jsonWithNullRemovals);
+    assertEquals(parsed, noRemovals);
+
+    // `removals` is missing from the JSON
+    String jsonWithMissingRemovals = "{\"updates\":{\"owner\":\"Hank\"}}";
+    assertEquals(deserialize(jsonWithMissingRemovals), noRemovals);
+
+    // `updates` is null
+    UpdateNamespacePropertiesRequest noUpdates = UpdateNamespacePropertiesRequest.builder().removeAll(REMOVALS).build();
+    String jsonWithNullUpdates = "{\"removals\":[\"foo\",\"bar\"],\"updates\":null}";
+    assertEquals(deserialize(jsonWithNullUpdates), noUpdates);
+
+    // `updates` is missing from the JSON
+    String jsonWithMissingUpdates = "{\"removals\":[\"foo\",\"bar\"]}";
+    assertEquals(deserialize(jsonWithMissingUpdates), noUpdates);
+
+    // all null / no values set
+    UpdateNamespacePropertiesRequest allMissing = UpdateNamespacePropertiesRequest.builder().build();
+    String jsonAllNull = "{\"removals\":null,\"updates\":null}";
+    assertEquals(deserialize(jsonAllNull), allMissing);
+
+    String jsonAllMissing = "{}";
+    assertEquals(deserialize(jsonAllMissing), allMissing);
+  }
+
+  @Test
+  public void testParseInvalidJson() {
+    // Invalid top-level types
+    String jsonInvalidTypeOnRemovalField =
+        "{\"removals\":{\"foo\":\"bar\"},\"updates\":{\"owner\":\"Hank\"}}";
+    AssertHelpers.assertThrows(
+        "A JSON request with an invalid type for one of the fields should fail to parse",
+        JsonProcessingException.class,
+        () -> deserialize(jsonInvalidTypeOnRemovalField)
+    );
+
+    String jsonInvalidTypeOnUpdatesField =
+        "{\"removals\":[\"foo\":\"bar\"],\"updates\":[\"owner\"]}";
+    AssertHelpers.assertThrows(
+        "A JSON value with an invalid type for one of the fields should fail to parse",
+        JsonProcessingException.class,
+        () -> deserialize(jsonInvalidTypeOnUpdatesField)
+    );
+
+    // Valid top-level (array) types, but at least one entry in the list is not the expected type
+    // NOTE: non-string values that are integral types will still parse into a string list.
+    //    e.g. { removals: [ "foo", "bar", 1234 ] } will parse correctly.
+    String invalidJsonWrongTypeInRemovalsList =
+        "{\"removals\":[\"foo\",\"bar\", {\"owner\": \"Hank\"}],\"updates\":{\"owner\":\"Hank\"}}";
+    AssertHelpers.assertThrows(
+        "A JSON value with an invalid type inside one of the list fields should fail to parse",
+        JsonProcessingException.class,
+        () -> deserialize(invalidJsonWrongTypeInRemovalsList)
+    );
+
+    String nullJson = null;
+    AssertHelpers.assertThrows(
+        "A null JSON should fail to parse",
+        IllegalArgumentException.class,
+        "argument \"content\" is null",
+        () -> deserialize(nullJson)
+    );
+  }
+
+  @Test
+  public void testBuilderDoesNotCreateInvalidObjects() {
+    AssertHelpers.assertThrows(
+        "The builder should not allow using null as a key to remove",
+        NullPointerException.class,
+        "Invalid property to remove: null",
+        () -> UpdateNamespacePropertiesRequest.builder().remove(null).build()
+    );
+
+    AssertHelpers.assertThrows(
+        "The builder should not allow passing a null list of properties to remove",
+        NullPointerException.class,
+        "Invalid list of properties to remove: null",
+        () -> UpdateNamespacePropertiesRequest.builder().removeAll(null).build()
+    );
+
+    List<String> listWithNull = Lists.newArrayList("a", null, null);
+    AssertHelpers.assertThrows(
+        "The builder should not allow passing a list of properties to remove with a null element",
+        IllegalArgumentException.class,
+        "Invalid property to remove: null",
+        () -> UpdateNamespacePropertiesRequest.builder().removeAll(listWithNull).build()
+    );
+
+    AssertHelpers.assertThrows(
+        "The builder should not allow using null as a key to update",
+        NullPointerException.class,
+        "Invalid property to update: null",
+        () -> UpdateNamespacePropertiesRequest.builder().update(null, "100").build()
+    );
+
+    AssertHelpers.assertThrows(
+        "The builder should not allow using null as a value to update",
+        NullPointerException.class,
+        "Invalid value to update for key [owner]: null. Use remove instead",
+        () -> UpdateNamespacePropertiesRequest.builder().update("owner", null).build()
+    );
+
+    AssertHelpers.assertThrows(
+        "The builder should not allow passing a null collection of properties to update",
+        NullPointerException.class,
+        "Invalid collection of properties to update: null",
+        () -> UpdateNamespacePropertiesRequest.builder().updateAll(null).build()
+    );
+
+    Map<String, String> mapWithNullKey = Maps.newHashMap();
+    mapWithNullKey.put(null, "hello");
+    AssertHelpers.assertThrows(
+        "The builder should not allow using null as a key to update from a collection of updates",
+        IllegalArgumentException.class,
+        "Invalid property to update: null",
+        () -> UpdateNamespacePropertiesRequest.builder().updateAll(mapWithNullKey).build()
+    );
+
+    Map<String, String> mapWithMultipleNullValues = Maps.newHashMap();
+    mapWithMultipleNullValues.put("a", null);
+    mapWithMultipleNullValues.put("b", "b");
+    AssertHelpers.assertThrows(
+        "The builder should not allow using null as a value to update from a collection of updates",
+        IllegalArgumentException.class,
+        "Invalid value to update for properties [a]: null. Use remove instead",
+        () -> UpdateNamespacePropertiesRequest.builder().updateAll(mapWithMultipleNullValues).build()
+    );
+  }
+
+  @Override
+  public String[] allFieldsFromSpec() {
+    return new String[] { "updates", "removals" };
+  }
+
+  @Override
+  public UpdateNamespacePropertiesRequest createExampleInstance() {
+    return UpdateNamespacePropertiesRequest.builder()
+        .updateAll(UPDATES)
+        .removeAll(REMOVALS)
+        .build();
+  }
+
+  @Override
+  public void assertEquals(UpdateNamespacePropertiesRequest actual, UpdateNamespacePropertiesRequest expected) {
+    Assert.assertEquals("Properties to update should be equal", actual.updates(), expected.updates());
+    Assert.assertEquals("Properties to remove should be equal",
+        Sets.newHashSet(actual.removals()), Sets.newHashSet(expected.removals()));
+  }
+
+  @Override
+  public UpdateNamespacePropertiesRequest deserialize(String json) throws JsonProcessingException {
+    return mapper().readValue(json, UpdateNamespacePropertiesRequest.class).validate();
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestCreateNamespaceResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestCreateNamespaceResponse.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest.responses;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.Map;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.rest.RequestResponseTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestCreateNamespaceResponse extends RequestResponseTestBase<CreateNamespaceResponse> {
+
+  /* Values used to fill in response fields */
+  private static final Namespace NAMESPACE = Namespace.of("accounting", "tax");
+  private static final Map<String, String> PROPERTIES = ImmutableMap.of("owner", "Hank");
+  private static final Map<String, String> EMPTY_PROPERTIES = ImmutableMap.of();
+
+  @Test
+  // Test cases that are JSON that can be created via the Builder
+  public void testRoundTripSerDe() throws JsonProcessingException {
+    String fullJson = "{\"namespace\":[\"accounting\",\"tax\"],\"properties\":{\"owner\":\"Hank\"}}";
+    CreateNamespaceResponse req = CreateNamespaceResponse
+        .builder().withNamespace(NAMESPACE).setProperties(PROPERTIES).build();
+    assertRoundTripSerializesEquallyFrom(fullJson, req);
+
+    String jsonEmptyProperties = "{\"namespace\":[\"accounting\",\"tax\"],\"properties\":{}}";
+    CreateNamespaceResponse responseWithExplicitEmptyProperties = CreateNamespaceResponse.builder()
+        .withNamespace(NAMESPACE).setProperties(EMPTY_PROPERTIES).build();
+    assertRoundTripSerializesEquallyFrom(jsonEmptyProperties, responseWithExplicitEmptyProperties);
+
+    CreateNamespaceResponse responseWithImplicitEmptyProperties = CreateNamespaceResponse.builder()
+        .withNamespace(NAMESPACE).build();
+    assertRoundTripSerializesEquallyFrom(jsonEmptyProperties, responseWithImplicitEmptyProperties);
+
+    String jsonEmptyNamespace = "{\"namespace\":[],\"properties\":{}}";
+    CreateNamespaceResponse responseWithEmptyNamespace = CreateNamespaceResponse.builder()
+        .withNamespace(Namespace.empty()).build();
+    assertRoundTripSerializesEquallyFrom(jsonEmptyNamespace, responseWithEmptyNamespace);
+  }
+
+  @Test
+  public void testCanDeserializeWithoutDefaultValues() throws JsonProcessingException {
+    CreateNamespaceResponse noProperties = CreateNamespaceResponse.builder().withNamespace(NAMESPACE).build();
+    String jsonWithMissingProperties = "{\"namespace\":[\"accounting\",\"tax\"]}";
+    assertEquals(deserialize(jsonWithMissingProperties), noProperties);
+
+    String jsonWithNullProperties = "{\"namespace\":[\"accounting\",\"tax\"],\"properties\":null}";
+    assertEquals(deserialize(jsonWithNullProperties), noProperties);
+
+    String jsonEmptyNamespaceMissingProperties = "{\"namespace\":[]}";
+    CreateNamespaceResponse responseWithEmptyNamespace = CreateNamespaceResponse.builder()
+        .withNamespace(Namespace.empty()).build();
+    assertEquals(deserialize(jsonEmptyNamespaceMissingProperties), responseWithEmptyNamespace);
+  }
+
+  @Test
+  public void testDeserializeInvalidResponse() {
+    String jsonResponseMalformedNamespaceValue = "{\"namespace\":\"accounting%00tax\",\"properties\":null}";
+    AssertHelpers.assertThrows(
+        "A JSON response with the wrong type for the namespace field should fail to deserialize",
+        JsonProcessingException.class,
+        "Cannot parse string array from non-array",
+        () -> deserialize(jsonResponseMalformedNamespaceValue)
+    );
+
+    String jsonResponsePropertiesHasWrongType = "{\"namespace\":[\"accounting\",\"tax\"],\"properties\":[]}";
+    AssertHelpers.assertThrows(
+        "A JSON response with the wrong type for the properties field should fail to deserialize",
+        JsonProcessingException.class,
+        () -> deserialize(jsonResponsePropertiesHasWrongType)
+    );
+
+    AssertHelpers.assertThrows(
+        "An empty JSON response should fail to deserialize",
+        IllegalArgumentException.class,
+        "Invalid namespace: null",
+        () -> deserialize("{}")
+    );
+
+    String jsonMisspelledKeys = "{\"namepsace\":[\"accounting\",\"tax\"],\"propertiezzzz\":{\"owner\":\"Hank\"}}";
+    AssertHelpers.assertThrows(
+        "A JSON response with the keys spelled incorrectly should fail to deserialize and validate",
+        JsonProcessingException.class,
+        () -> deserialize(jsonMisspelledKeys)
+    );
+
+    AssertHelpers.assertThrows(
+        "A null JSON response body should fail to deserialize",
+        IllegalArgumentException.class,
+        () -> deserialize(null)
+    );
+  }
+
+  @Test
+  public void testBuilderDoesNotBuildInvalidRequests() {
+    AssertHelpers.assertThrows(
+        "The builder should not allow using null for the namespace",
+        NullPointerException.class,
+        "Invalid namespace: null",
+        () -> CreateNamespaceResponse.builder().withNamespace(null).build()
+    );
+
+    AssertHelpers.assertThrows(
+        "The builder should not allow passing a null collection of properties",
+        NullPointerException.class,
+        "Invalid collection of properties: null",
+        () -> CreateNamespaceResponse.builder().setProperties(null).build()
+    );
+
+    Map<String, String> mapWithNullKey = Maps.newHashMap();
+    mapWithNullKey.put(null, "hello");
+    AssertHelpers.assertThrows(
+        "The builder should not allow using null as a key in the properties to set",
+        IllegalArgumentException.class,
+        "Invalid property to set: null",
+        () -> CreateNamespaceResponse.builder().setProperties(mapWithNullKey).build()
+    );
+
+    Map<String, String> mapWithMultipleNullValues = Maps.newHashMap();
+    mapWithMultipleNullValues.put("a", null);
+    mapWithMultipleNullValues.put("b", "b");
+    AssertHelpers.assertThrows(
+        "The builder should not allow using null as a value in the properties to set",
+        IllegalArgumentException.class,
+        "Invalid value to set for properties [a]: null",
+        () -> CreateNamespaceResponse.builder().setProperties(mapWithMultipleNullValues).build()
+    );
+  }
+
+  @Override
+  public String[] allFieldsFromSpec() {
+    return new String[] { "namespace", "properties" };
+  }
+
+  @Override
+  public CreateNamespaceResponse createExampleInstance() {
+    return CreateNamespaceResponse.builder()
+        .withNamespace(NAMESPACE)
+        .setProperties(PROPERTIES)
+        .build();
+  }
+
+  @Override
+  public void assertEquals(CreateNamespaceResponse actual, CreateNamespaceResponse expected) {
+    Assert.assertEquals("Namespaces should be equal", actual.namespace(), expected.namespace());
+    Assert.assertEquals("Properties should be equal", actual.properties(), expected.properties());
+  }
+
+  @Override
+  public CreateNamespaceResponse deserialize(String json) throws JsonProcessingException {
+    return mapper().readValue(json, CreateNamespaceResponse.class).validate();
+  }
+}
+

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestDropNamespaceResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestDropNamespaceResponse.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest.responses;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.rest.RequestResponseTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestDropNamespaceResponse extends RequestResponseTestBase<DropNamespaceResponse> {
+
+  @Test
+  public void testRoundTripSerDe() throws JsonProcessingException {
+    assertRoundTripSerializesEquallyFrom(
+        "{\"dropped\":true}", DropNamespaceResponse.builder().dropped(true).build());
+
+    assertRoundTripSerializesEquallyFrom(
+        "{\"dropped\":false}", DropNamespaceResponse.builder().dropped(false).build());
+  }
+
+  @Test
+  public void testFailParsingWhenNullOrEmptyJson() {
+    String nullJson = null;
+    AssertHelpers.assertThrows("DropNamespaceResponse should fail to deserialize from a null JSON string",
+        IllegalArgumentException.class, "argument \"content\" is null",
+        () ->  deserialize(nullJson));
+
+    String emptyString = "";
+    AssertHelpers.assertThrows("DropNamespaceResponse should fail to deserialize empty string as JSON",
+        JsonProcessingException.class, "No content to map due to end-of-input",
+        () ->  deserialize(emptyString));
+
+    String emptyJson = "{}";
+    AssertHelpers.assertThrows(
+        "DropNamespaceResponse should fail to deserialize and validate if missing the field dropped",
+        IllegalArgumentException.class,
+        "Invalid response, missing field: dropped",
+        () -> deserialize(emptyJson));
+  }
+
+  @Test
+  public void testFailWhenFieldsHaveInvalidValues() {
+    String invalidJsonWithStringType = "{\"dropped\":\"421\"}";
+    AssertHelpers.assertThrows("DropNamespaceResponse should fail to deserialize if the dropped field is invalid",
+        JsonProcessingException.class,
+        () -> deserialize(invalidJsonWithStringType));
+
+    // Note that Jackson follows JSON rules to some degree, so integers wil parse into booleans.
+    String invalidJsonWithFloatingPointType = "{\"dropped\":421.62}";
+    AssertHelpers.assertThrows("DropNamespaceResponse should fail to deserialize if the dropped field is invalid",
+        JsonProcessingException.class,
+        () -> deserialize(invalidJsonWithFloatingPointType));
+
+    String invalidJsonWithNullType = "{\"dropped\":null}";
+    AssertHelpers.assertThrows("DropNamespaceResponse should fail to deserialize if the dropped field is invalid",
+        IllegalArgumentException.class,
+        "Invalid response, missing field: dropped",
+        () -> deserialize(invalidJsonWithNullType));
+  }
+
+  @Test
+  public void testBuilderDoesNotBuildInvalidResponse() {
+    AssertHelpers.assertThrows(
+        "The builder should not allow not setting the dropped field",
+        IllegalArgumentException.class,
+        "Invalid response, missing field: dropped",
+        () -> DropNamespaceResponse.builder().build()
+    );
+  }
+
+  @Override
+  public String[] allFieldsFromSpec() {
+    return new String[] { "dropped" };
+  }
+
+  @Override
+  public DropNamespaceResponse createExampleInstance() {
+    return DropNamespaceResponse.builder().dropped(true).build();
+  }
+
+  @Override
+  public void assertEquals(DropNamespaceResponse actual, DropNamespaceResponse expected) {
+    Assert.assertEquals(actual.isDropped(), expected.isDropped());
+  }
+
+  @Override
+  public DropNamespaceResponse deserialize(String json) throws JsonProcessingException {
+    return mapper().readValue(json, DropNamespaceResponse.class).validate();
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestGetNamespaceResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestGetNamespaceResponse.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest.responses;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.Map;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.rest.RequestResponseTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestGetNamespaceResponse extends RequestResponseTestBase<GetNamespaceResponse> {
+
+  /* Values used to fill in request fields */
+  private static final Namespace NAMESPACE = Namespace.of("accounting", "tax");
+  private static final Map<String, String> PROPERTIES = ImmutableMap.of("owner", "Hank");
+  private static final Map<String, String> EMPTY_PROPERTIES = ImmutableMap.of();
+
+  @Test
+  // Test cases that are JSON that can be created via the Builder
+  public void testRoundTripSerDe() throws JsonProcessingException {
+    String fullJson = "{\"namespace\":[\"accounting\",\"tax\"],\"properties\":{\"owner\":\"Hank\"}}";
+    GetNamespaceResponse fullValue = GetNamespaceResponse.builder()
+        .withNamespace(NAMESPACE).setProperties(PROPERTIES).build();
+    assertRoundTripSerializesEquallyFrom(fullJson, fullValue);
+
+    String emptyProps = "{\"namespace\":[\"accounting\",\"tax\"],\"properties\":{}}";
+    assertRoundTripSerializesEquallyFrom(
+        emptyProps, GetNamespaceResponse.builder().withNamespace(NAMESPACE).build());
+    assertRoundTripSerializesEquallyFrom(
+        emptyProps, GetNamespaceResponse.builder().withNamespace(NAMESPACE).setProperties(EMPTY_PROPERTIES).build());
+  }
+
+  @Test
+  // Test cases that can't be constructed with our Builder class but that will parse correctly
+  public void testCanDeserializeWithoutDefaultValues() throws JsonProcessingException {
+    GetNamespaceResponse withoutProps = GetNamespaceResponse.builder().withNamespace(NAMESPACE).build();
+    String jsonWithNullProperties = "{\"namespace\":[\"accounting\",\"tax\"],\"properties\":null}";
+    assertEquals(deserialize(jsonWithNullProperties), withoutProps);
+  }
+
+  @Test
+  public void testDeserializeInvalidResponse() {
+    String jsonNamespaceHasWrongType = "{\"namespace\":\"accounting%00tax\",\"properties\":null}";
+    AssertHelpers.assertThrows(
+        "A JSON response with the wrong type for a field should fail to deserialize",
+        JsonProcessingException.class,
+        "Cannot parse string array from non-array",
+        () -> deserialize(jsonNamespaceHasWrongType)
+    );
+
+    String jsonPropertiesHasWrongType = "{\"namespace\":[\"accounting\",\"tax\"],\"properties\":[]}";
+    AssertHelpers.assertThrows(
+        "A JSON response with the wrong type for a field should fail to deserialize",
+        JsonProcessingException.class,
+        () -> deserialize(jsonPropertiesHasWrongType)
+    );
+
+    String emptyJson = "{}";
+    AssertHelpers.assertThrows(
+        "An empty JSON request should fail to deserialize after validation",
+        IllegalArgumentException.class,
+        "Invalid namespace: null",
+        () -> deserialize(emptyJson)
+    );
+
+    String jsonWithKeysSpelledIncorrectly =
+        "{\"namepsace\":[\"accounting\",\"tax\"],\"propertiezzzz\":{\"owner\":\"Hank\"}}";
+    AssertHelpers.assertThrows(
+        "A JSON response with the keys spelled incorrectly should fail to deserialize",
+        JsonProcessingException.class,
+        () -> deserialize(jsonWithKeysSpelledIncorrectly)
+    );
+
+    String nullJson = null;
+    AssertHelpers.assertThrows(
+        "An empty JSON request should fail to deserialize",
+        IllegalArgumentException.class,
+        () -> deserialize(nullJson)
+    );
+  }
+
+  @Test
+  public void testBuilderDoesNotBuildInvalidRequests() {
+    AssertHelpers.assertThrows(
+        "The builder should not allow using null for the namespace",
+        NullPointerException.class,
+        "Invalid namespace: null",
+        () -> GetNamespaceResponse.builder().withNamespace(null).build()
+    );
+
+    AssertHelpers.assertThrows(
+        "The builder should not allow passing a null collection of properties",
+        NullPointerException.class,
+        "Invalid properties map: null",
+        () -> GetNamespaceResponse.builder().setProperties(null).build()
+    );
+
+    Map<String, String> mapWithNullKey = Maps.newHashMap();
+    mapWithNullKey.put(null, "hello");
+    AssertHelpers.assertThrows(
+        "The builder should not allow using null as a key in the properties to set",
+        IllegalArgumentException.class,
+        "Invalid property: null",
+        () -> GetNamespaceResponse.builder().setProperties(mapWithNullKey).build()
+    );
+
+    Map<String, String> mapWithMultipleNullValues = Maps.newHashMap();
+    mapWithMultipleNullValues.put("a", null);
+    mapWithMultipleNullValues.put("b", "b");
+    AssertHelpers.assertThrows(
+        "The builder should not allow using null as a value in the properties to set",
+        IllegalArgumentException.class,
+        "Invalid value for properties [a]: null",
+        () -> GetNamespaceResponse.builder().setProperties(mapWithMultipleNullValues).build()
+    );
+  }
+
+  @Override
+  public String[] allFieldsFromSpec() {
+    return new String[] { "namespace", "properties" };
+  }
+
+  @Override
+  public GetNamespaceResponse createExampleInstance() {
+    return GetNamespaceResponse.builder()
+        .withNamespace(NAMESPACE)
+        .setProperties(PROPERTIES)
+        .build();
+  }
+
+  @Override
+  public void assertEquals(GetNamespaceResponse actual, GetNamespaceResponse expected) {
+    Assert.assertEquals("Namespace should be equal", actual.namespace(), expected.namespace());
+    Assert.assertEquals("Properties should be equal", actual.properties(), expected.properties());
+  }
+
+  @Override
+  public GetNamespaceResponse deserialize(String json) throws JsonProcessingException {
+    return mapper().readValue(json, GetNamespaceResponse.class).validate();
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestListNamespacesResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestListNamespacesResponse.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest.responses;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.List;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.rest.RequestResponseTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestListNamespacesResponse extends RequestResponseTestBase<ListNamespacesResponse> {
+
+  private static final List<Namespace> NAMESPACES = ImmutableList.of(
+      Namespace.of("accounting"),
+      Namespace.of("tax"));
+
+  @Test
+  public void testRoundTripSerDe() throws JsonProcessingException {
+    String fullJson = "{\"namespaces\":[[\"accounting\"],[\"tax\"]]}";
+    ListNamespacesResponse fullValue = ListNamespacesResponse.builder().addAll(NAMESPACES).build();
+    assertRoundTripSerializesEquallyFrom(fullJson, fullValue);
+
+    String emptyNamespaces = "{\"namespaces\":[]}";
+    assertRoundTripSerializesEquallyFrom(emptyNamespaces, ListNamespacesResponse.builder().build());
+  }
+
+  @Test
+  public void testDeserializeInvalidResponseThrows() {
+    String jsonNamespacesHasWrongType = "{\"namespaces\":\"accounting\"}";
+    AssertHelpers.assertThrows(
+        "A malformed JSON response with the wrong type for a field should fail to deserialize",
+        JsonProcessingException.class,
+        () -> deserialize(jsonNamespacesHasWrongType)
+    );
+
+    String emptyJson = "{}";
+    AssertHelpers.assertThrows(
+        "An empty JSON response will deserialize, but not into a valid object",
+        IllegalArgumentException.class,
+        "Invalid namespace: null",
+        () -> deserialize(emptyJson)
+    );
+
+    String jsonWithKeysSpelledIncorrectly =
+        "{\"namepsacezz\":[\"accounting\",\"tax\"]}";
+    AssertHelpers.assertThrows(
+        "A JSON response with the keys spelled incorrectly should fail to deserialize",
+        JsonProcessingException.class,
+        () -> deserialize(jsonWithKeysSpelledIncorrectly)
+    );
+
+    String nullJson = null;
+    AssertHelpers.assertThrows(
+        "A null JSON response should fail to deserialize",
+        IllegalArgumentException.class,
+        () -> deserialize(nullJson)
+    );
+  }
+
+  @Test
+  public void testBuilderDoesNotCreateInvalidObjects() {
+    AssertHelpers.assertThrows(
+        "The builder should not allow using null as a namespace to add to the list",
+        NullPointerException.class,
+        "Invalid namespace: null",
+        () -> ListNamespacesResponse.builder().add(null).build()
+    );
+
+    AssertHelpers.assertThrows(
+        "The builder should not allow passing a null list of namespaces to add",
+        NullPointerException.class,
+        "Invalid namespace list: null",
+        () -> ListNamespacesResponse.builder().addAll(null).build()
+    );
+
+    List<Namespace> listWithNullElement = Lists.newArrayList(Namespace.of("a"), null);
+    AssertHelpers.assertThrows(
+        "The builder should not allow passing a collection of namespaces with a null element in it",
+        IllegalArgumentException.class,
+        "Invalid namespace: null",
+        () -> ListNamespacesResponse.builder().addAll(listWithNullElement).build()
+    );
+  }
+
+
+  @Override
+  public String[] allFieldsFromSpec() {
+    return new String[] { "namespaces" };
+  }
+
+  @Override
+  public ListNamespacesResponse createExampleInstance() {
+    return ListNamespacesResponse.builder()
+        .addAll(NAMESPACES)
+        .build();
+  }
+
+  @Override
+  public void assertEquals(ListNamespacesResponse actual, ListNamespacesResponse expected) {
+    Assert.assertTrue("Namespaces list should be equal",
+        actual.namespaces().size() == expected.namespaces().size() &&
+            Sets.newHashSet(actual.namespaces()).equals(Sets.newHashSet(expected.namespaces())));
+  }
+
+  @Override
+  public ListNamespacesResponse deserialize(String json) throws JsonProcessingException {
+    return mapper().readValue(json, ListNamespacesResponse.class).validate();
+  }
+}
+

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestListTablesResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestListTablesResponse.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest.responses;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.List;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.rest.RequestResponseTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestListTablesResponse extends RequestResponseTestBase<ListTablesResponse> {
+
+  private static final List<TableIdentifier> IDENTIFIERS = ImmutableList.of(
+      TableIdentifier.of(Namespace.of("accounting", "tax"), "paid"));
+
+  @Test
+  public void testRoundTripSerDe() throws JsonProcessingException {
+    String fullJson = "{\"identifiers\":[{\"namespace\":[\"accounting\",\"tax\"],\"name\":\"paid\"}]}";
+    assertRoundTripSerializesEquallyFrom(fullJson, ListTablesResponse.builder().addAll(IDENTIFIERS).build());
+
+    String emptyIdentifiers = "{\"identifiers\":[]}";
+    assertRoundTripSerializesEquallyFrom(emptyIdentifiers, ListTablesResponse.builder().build());
+  }
+
+  @Test
+  public void testDeserializeInvalidResponsesThrows() {
+    String identifiersHasWrongType = "{\"identifiers\":\"accounting%00tax\"}";
+    AssertHelpers.assertThrows(
+        "A JSON response with the incorrect type for the field identifiers should fail to parse",
+        JsonProcessingException.class,
+        () -> deserialize(identifiersHasWrongType));
+
+    String emptyJson = "{}";
+    AssertHelpers.assertThrows(
+        "An empty JSON response should fail to deserialize",
+        IllegalArgumentException.class,
+        "Invalid identifier list: null",
+        () -> deserialize(emptyJson));
+
+    String jsonWithKeysSpelledIncorrectly =
+        "{\"identifyrezzzz\":[{\"namespace\":[\"accounting\",\"tax\"],\"name\":\"paid\"}]}";
+    AssertHelpers.assertThrows(
+        "A JSON response with the keys spelled incorrectly should fail to deserialize",
+        JsonProcessingException.class,
+        () -> deserialize(jsonWithKeysSpelledIncorrectly));
+
+    String jsonWithInvalidIdentifiersInList =
+        "{\"identifiers\":[{\"namespace\":\"accounting.tax\",\"name\":\"paid\"}]}";
+    AssertHelpers.assertThrows(
+        "A JSON response with an invalid identifier in the list of identifiers should fail to parse",
+        JsonProcessingException.class,
+        () -> deserialize(jsonWithInvalidIdentifiersInList)
+    );
+
+    String jsonWithInvalidIdentifiersInList2 =
+        "{\"identifiers\":[{\"namespace\":[\"accounting\",\"tax\"],\"name\":\"paid\"},\"accounting.tax.paid\"]}";
+    AssertHelpers.assertThrows(
+        "A JSON response with an invalid identifier in the list of identifiers should fail to parse",
+        JsonProcessingException.class,
+        () -> deserialize(jsonWithInvalidIdentifiersInList2)
+    );
+
+    String jsonWithInvalidTypeForNamePartOfIdentifier =
+        "{\"identifiers\":[{\"namespace\":[\"accounting\",\"tax\"],\"name\":true}]}";
+    AssertHelpers.assertThrows(
+        "A JSON response with an invalid identifier in the list of identifiers should fail to parse",
+        JsonProcessingException.class,
+        () -> deserialize(jsonWithInvalidTypeForNamePartOfIdentifier)
+    );
+
+    String nullJson = null;
+    AssertHelpers.assertThrows(
+        "A null JSON response should fail to deserialize",
+        IllegalArgumentException.class,
+        () -> deserialize(nullJson)
+    );
+  }
+
+  @Test
+  public void testBuilderDoesNotCreateInvalidObjects() {
+    AssertHelpers.assertThrows(
+        "The builder should not allow using null as a table identifier to add to the list",
+        NullPointerException.class,
+        "Invalid table identifier: null",
+        () -> ListTablesResponse.builder().add(null).build()
+    );
+
+    AssertHelpers.assertThrows(
+        "The builder should not allow passing a null list of table identifiers to add",
+        NullPointerException.class,
+        "Invalid table identifier list: null",
+        () -> ListTablesResponse.builder().addAll(null).build()
+    );
+
+    List<TableIdentifier> listWithNullElement = Lists.newArrayList(
+        TableIdentifier.of(Namespace.of("foo"), "bar"), null);
+    AssertHelpers.assertThrows(
+        "The builder should not allow passing a collection of table identifiers with a null element in it",
+        IllegalArgumentException.class,
+        "Invalid table identifier: null",
+        () -> ListTablesResponse.builder().addAll(listWithNullElement).build()
+    );
+  }
+
+  @Override
+  public String[] allFieldsFromSpec() {
+    return new String[] { "identifiers" };
+  }
+
+  @Override
+  public ListTablesResponse createExampleInstance() {
+    return ListTablesResponse.builder()
+        .addAll(IDENTIFIERS)
+        .build();
+  }
+
+  @Override
+  public void assertEquals(ListTablesResponse actual, ListTablesResponse expected) {
+    Assert.assertTrue("Identifiers should be equal",
+        actual.identifiers().size() == expected.identifiers().size() &&
+            Sets.newHashSet(actual.identifiers()).equals(Sets.newHashSet(expected.identifiers())));
+  }
+
+  @Override
+  public ListTablesResponse deserialize(String json) throws JsonProcessingException {
+    return mapper().readValue(json, ListTablesResponse.class).validate();
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestUpdateNamespacePropertiesResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestUpdateNamespacePropertiesResponse.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest.responses;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.List;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.rest.RequestResponseTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestUpdateNamespacePropertiesResponse extends RequestResponseTestBase<UpdateNamespacePropertiesResponse> {
+
+  /* Values used to fill in response fields */
+  private static final List<String> UPDATED = ImmutableList.of("owner");
+  private static final List<String> REMOVED = ImmutableList.of("foo");
+  private static final List<String> MISSING = ImmutableList.of("bar");
+  private static final List<String> EMPTY_LIST = ImmutableList.of();
+
+  @Test
+  public void testRoundTripSerDe() throws JsonProcessingException {
+    // Full request
+    String fullJson = "{\"removed\":[\"foo\"],\"updated\":[\"owner\"],\"missing\":[\"bar\"]}";
+    assertRoundTripSerializesEquallyFrom(
+        fullJson,
+        UpdateNamespacePropertiesResponse.builder()
+            .addUpdated(UPDATED).addRemoved(REMOVED).addMissing(MISSING).build());
+
+    // Only updated
+    String jsonOnlyUpdated = "{\"removed\":[],\"updated\":[\"owner\"],\"missing\":[]}";
+    assertRoundTripSerializesEquallyFrom(
+        jsonOnlyUpdated, UpdateNamespacePropertiesResponse.builder().addUpdated(UPDATED).build());
+    assertRoundTripSerializesEquallyFrom(
+        jsonOnlyUpdated, UpdateNamespacePropertiesResponse.builder().addUpdated("owner").build());
+
+    assertRoundTripSerializesEquallyFrom(
+        jsonOnlyUpdated,
+        UpdateNamespacePropertiesResponse.builder()
+            .addUpdated(UPDATED).addMissing(EMPTY_LIST).addRemoved(EMPTY_LIST).build());
+
+    // Only removed
+    String jsonOnlyRemoved = "{\"removed\":[\"foo\"],\"updated\":[],\"missing\":[]}";
+    assertRoundTripSerializesEquallyFrom(
+        jsonOnlyRemoved, UpdateNamespacePropertiesResponse.builder().addRemoved(REMOVED).build());
+    assertRoundTripSerializesEquallyFrom(
+        jsonOnlyRemoved, UpdateNamespacePropertiesResponse.builder().addRemoved("foo").build());
+
+    assertRoundTripSerializesEquallyFrom(
+        jsonOnlyRemoved,
+        UpdateNamespacePropertiesResponse.builder()
+            .addRemoved(REMOVED).addUpdated(EMPTY_LIST).addMissing(EMPTY_LIST).build());
+
+    // Only missing
+    String jsonOnlyMissing = "{\"removed\":[],\"updated\":[],\"missing\":[\"bar\"]}";
+    assertRoundTripSerializesEquallyFrom(
+        jsonOnlyMissing, UpdateNamespacePropertiesResponse.builder().addMissing(MISSING).build());
+
+    assertRoundTripSerializesEquallyFrom(
+        jsonOnlyMissing, UpdateNamespacePropertiesResponse.builder().addMissing("bar").build());
+
+    assertRoundTripSerializesEquallyFrom(
+        jsonOnlyMissing,
+        UpdateNamespacePropertiesResponse.builder()
+            .addMissing(MISSING).addUpdated(EMPTY_LIST).addRemoved(EMPTY_LIST).build());
+
+    // All fields are empty
+    String jsonWithAllFieldsAsEmptyList =
+        "{\"removed\":[],\"updated\":[],\"missing\":[]}";
+    assertRoundTripSerializesEquallyFrom(
+        jsonWithAllFieldsAsEmptyList, UpdateNamespacePropertiesResponse.builder().build());
+  }
+
+  @Test
+  // Test cases that can't be constructed with our Builder class e2e but that will parse correctly
+  public void testCanDeserializeWithoutDefaultValues() throws JsonProcessingException {
+    // only updated
+    UpdateNamespacePropertiesResponse onlyUpdated = UpdateNamespacePropertiesResponse.builder()
+            .addUpdated(UPDATED).build();
+    String jsonOnlyUpdatedOthersNull = "{\"removed\":null,\"updated\":[\"owner\"],\"missing\":null}";
+    assertEquals(deserialize(jsonOnlyUpdatedOthersNull), onlyUpdated);
+
+    String jsonOnlyUpdatedOthersMissing = "{\"updated\":[\"owner\"]}";
+    assertEquals(deserialize(jsonOnlyUpdatedOthersMissing), onlyUpdated);
+
+    // Only removed
+    UpdateNamespacePropertiesResponse onlyRemoved = UpdateNamespacePropertiesResponse.builder()
+        .addRemoved(REMOVED).build();
+    String jsonOnlyRemovedOthersNull =  "{\"removed\":[\"foo\"],\"updated\":null,\"missing\":null}";
+    assertEquals(deserialize(jsonOnlyRemovedOthersNull), onlyRemoved);
+
+    String jsonOnlyRemovedOthersMissing =  "{\"removed\":[\"foo\"]}";
+    assertEquals(deserialize(jsonOnlyRemovedOthersMissing), onlyRemoved);
+
+    // Only missing
+    UpdateNamespacePropertiesResponse onlyMissing = UpdateNamespacePropertiesResponse.builder()
+        .addMissing(MISSING).build();
+    String jsonOnlyMissingFieldOthersNull = "{\"removed\":null,\"updated\":null,\"missing\":[\"bar\"]}";
+    assertEquals(deserialize(jsonOnlyMissingFieldOthersNull), onlyMissing);
+
+    String jsonOnlyMissingFieldIsPresent = "{\"missing\":[\"bar\"]}";
+    assertEquals(deserialize(jsonOnlyMissingFieldIsPresent), onlyMissing);
+
+    // all fields are missing
+    UpdateNamespacePropertiesResponse noValues = UpdateNamespacePropertiesResponse.builder().build();
+    String emptyJson = "{}";
+    assertEquals(deserialize(emptyJson), noValues);
+
+  }
+
+  @Test
+  public void testDeserializeInvalidResponse() {
+    // Invalid top-level types
+    String jsonInvalidTypeOnRemovedField =
+        "{\"removed\":{\"foo\":true},\"updated\":[\"owner\"],\"missing\":[\"bar\"]}";
+    AssertHelpers.assertThrows(
+        "A JSON response with an invalid type for one of the fields should fail to parse",
+        JsonProcessingException.class,
+        () -> deserialize(jsonInvalidTypeOnRemovedField)
+    );
+
+    String jsonInvalidTypeOnUpdatedField =
+        "{\"updated\":\"owner\",\"missing\":[\"bar\"]}";
+    AssertHelpers.assertThrows(
+        "A JSON response with an invalid type for one of the fields should fail to parse",
+        JsonProcessingException.class,
+        () -> deserialize(jsonInvalidTypeOnUpdatedField)
+    );
+
+    // Valid top-level (array) types, but at least one entry in the list is not the expected type
+    String jsonInvalidValueOfTypeIntNestedInRemovedList =
+        "{\"removed\":[\"foo\", \"bar\", 123456], ,\"updated\":[\"owner\"],\"missing\":[\"bar\"]}";
+    AssertHelpers.assertThrows(
+        "A JSON response with an invalid type inside one of the list fields should fail to deserialize",
+        JsonProcessingException.class,
+        () -> deserialize(jsonInvalidValueOfTypeIntNestedInRemovedList)
+    );
+
+    // Exception comes from Jackson
+    AssertHelpers.assertThrows(
+        "A null JSON response body should fail to deserialize",
+        IllegalArgumentException.class,
+        () -> deserialize(null)
+    );
+  }
+
+  @Test
+  public void testBuilderDoesNotCreateInvalidObjects() {
+    List<String> listContainingNull = Lists.newArrayList("a", null, null);
+
+    // updated
+    AssertHelpers.assertThrows(
+        "The builder should not allow using null as a property that was updated",
+        NullPointerException.class,
+        "Invalid updated property: null",
+        () -> UpdateNamespacePropertiesResponse.builder().addUpdated((String) null).build()
+    );
+
+    AssertHelpers.assertThrows(
+        "The builder should not allow passing a null list of properties that were removed",
+        NullPointerException.class,
+        "Invalid updated property list: null",
+        () -> UpdateNamespacePropertiesResponse.builder().addUpdated((List<String>) null).build()
+    );
+
+    AssertHelpers.assertThrows(
+        "The builder should not allow passing a list of properties that were removed with a null element",
+        IllegalArgumentException.class,
+        "Invalid updated property: null",
+        () -> UpdateNamespacePropertiesResponse.builder().addUpdated(listContainingNull).build()
+    );
+
+    // removed
+    AssertHelpers.assertThrows(
+        "The builder should not allow using null as a property that was removed",
+        NullPointerException.class,
+        "Invalid removed property: null",
+        () -> UpdateNamespacePropertiesResponse.builder().addRemoved((String) null).build()
+    );
+
+    AssertHelpers.assertThrows(
+        "The builder should not allow passing a null list of properties that were removed",
+        NullPointerException.class,
+        "Invalid removed property list: null",
+        () -> UpdateNamespacePropertiesResponse.builder().addRemoved((List<String>) null).build()
+    );
+
+    AssertHelpers.assertThrows(
+        "The builder should not allow passing a list of properties that were removed with a null element",
+        IllegalArgumentException.class,
+        "Invalid removed property: null",
+        () -> UpdateNamespacePropertiesResponse.builder().addRemoved(listContainingNull).build()
+    );
+
+    // missing
+    AssertHelpers.assertThrows(
+        "The builder should not allow using null as a property that was missing",
+        NullPointerException.class,
+        "Invalid missing property: null",
+        () -> UpdateNamespacePropertiesResponse.builder().addMissing((String) null).build()
+    );
+
+    AssertHelpers.assertThrows(
+        "The builder should not allow passing a null list of properties that were missing",
+        NullPointerException.class,
+        "Invalid missing property list: null",
+        () -> UpdateNamespacePropertiesResponse.builder().addMissing((List<String>) null).build()
+    );
+
+    AssertHelpers.assertThrows(
+        "The builder should not allow passing a list of properties that were missing with a null element",
+        IllegalArgumentException.class,
+        "Invalid missing property: null",
+        () -> UpdateNamespacePropertiesResponse.builder().addMissing(listContainingNull).build()
+    );
+  }
+
+  @Override
+  public String[] allFieldsFromSpec() {
+    return new String[] { "updated", "removed", "missing" };
+  }
+
+  @Override
+  public UpdateNamespacePropertiesResponse createExampleInstance() {
+    return UpdateNamespacePropertiesResponse.builder()
+        .addUpdated(UPDATED)
+        .addMissing(MISSING)
+        .addRemoved(REMOVED)
+        .build();
+  }
+
+  @Override
+  public void assertEquals(UpdateNamespacePropertiesResponse actual, UpdateNamespacePropertiesResponse expected) {
+    Assert.assertEquals("Properties updated should be equal",
+        Sets.newHashSet(actual.updated()), Sets.newHashSet(expected.updated()));
+    Assert.assertEquals("Properties removed should be equal",
+        Sets.newHashSet(actual.removed()), Sets.newHashSet(expected.removed()));
+    Assert.assertEquals("Properties missing should be equal",
+        Sets.newHashSet(actual.missing()), Sets.newHashSet(expected.missing()));
+  }
+
+  @Override
+  public UpdateNamespacePropertiesResponse deserialize(String json) throws JsonProcessingException {
+    return mapper().readValue(json, UpdateNamespacePropertiesResponse.class).validate();
+  }
+}


### PR DESCRIPTION
This PR introduces some of the request and response objects from the REST catalog spec, as well as a set of Jackson based serializers & deserializers that can be used to read and write some of the components as JSON.

Opening this PR to get some initial request / responses that are already defined in the spec under review as well as helping provide some serializers for some components using Jackson, which are needed in the Trino project.

### Added
1. CreateNamespaceRequest / CreateNamespaceResponse
2. UpdateNamespacePropertiesRequest / UpdateNamespacePropertiesResponse
3. DropNamespaceResponse (request relies on only the route and has no request body)
4. GetNamespaceResponse (request has no body)
5. ListNamespacesResponse (request has no body, just the query parameter variables)
6. ListTablesResponse (request has no body)

Test on the above.

Json Parser classes:
1. TableIdentifierParser - adds toJson / fromJson like other objects
~~2. NamespaceParser~~ - This is not presently needed, as I've added a function to JsonUtil `getStringArray` instead.

JsonSerializer / JsonDeserializers, in a Jackson module, for various components needed in this PR:
1. Namespace
2. TableIdentifier
3. Schema
4. PartitionSpec
5. SortOrder