### PR TITLE
SPEC - Update the REST catalog's CreateNamespaceResponse to provide more useful info

### DIFF
--- a/rest_docs/rest-catalog-open-api.yaml
+++ b/rest_docs/rest-catalog-open-api.yaml
@@ -1384,7 +1384,7 @@ components:
       description:
         Represents a successful call to create a namespace.
         Returns the namespace created, as well as any properties that were stored for the namespace,
-        including those the server might have added. Implemenations are not required to support namespace
+        including those the server might have added. Implementations are not required to support namespace
         properties.
       content:
         application/json:
@@ -1401,11 +1401,8 @@ components:
                   type: string
                 description:
                   Properties stored on the namespace, if supported by the server.
-                  If the server does not support namespace properties, it should return null for this field.
-                  If namespace properties are supported, but none are set, it should return an empty object.
                 example: { "owner": "Ralph", "created_at": "1452120468" }
                 default: { }
-                nullable: true
           example: {
             "namespace": ["accounting", "tax"],
             "properties": { "owner": "Ralph", "created_at": "1452120468" }

--- a/rest_docs/rest-catalog-open-api.yaml
+++ b/rest_docs/rest-catalog-open-api.yaml
@@ -1381,15 +1381,35 @@ components:
               } }
 
     CreateNamespaceResponse:
-      description: A succesful call to create a namespace
+      description:
+        Represents a successful call to create a namespace.
+        Returns the namespace created, as well as any properties that were stored for the namespace,
+        including those the server might have added. Implemenations are not required to support namespace
+        properties.
       content:
         application/json:
           schema:
             type: object
+            required:
+              - namespace
             properties:
-              created:
-                type: boolean
-                description: true if the namespace was added to the catalog
+              namespace:
+                $ref: '#/components/schemas/Namespace'
+              properties:
+                type: object
+                additionalProperties:
+                  type: string
+                description:
+                  Properties stored on the namespace, if supported by the server.
+                  If the server does not support namespace properties, it should return null for this field.
+                  If namespace properties are supported, but none are set, it should return an empty object.
+                example: { "owner": "Ralph", "created_at": "1452120468" }
+                default: { }
+                nullable: true
+          example: {
+            "namespace": ["accounting", "tax"],
+            "properties": { "owner": "Ralph", "created_at": "1452120468" }
+          }
 
     DropTableResponse:
       description: A successful call to drop a table


### PR DESCRIPTION
The current 200 response to create a namespace, is simply `{ "created": true }`. This doesn't provide much useful information.

Updating the spec to instead return the name of the namespace that was created, as well as any properties that were stored on the namespace (including any the server might have added).

Returning the namespace and actual properties means the caller doesn't have to immediately send a GET request to access this information.

The new 200 response will look like the following (in this situation we can assume `created_at` was added by the server).
`{ "namespace": ["accounting"], "properties": {"owner": "Hank", "created_at": "1452120468" }`

This still passes parsing according to a variety of openapi tools.
```bash
$ openapi-spec-validator rest_docs/rest-catalog-open-api.yaml
OK
```