### PR TITLE
Spark 3.2: Rename variables referring to RowLevelOperationTable

### DIFF
--- a/spark/v3.2/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
+++ b/spark/v3.2/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
@@ -157,17 +157,17 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand {
   // build a rewrite plan for sources that support replacing groups of data (e.g. files, partitions)
   private def buildReplaceDataPlan(
       relation: DataSourceV2Relation,
-      table: RowLevelOperationTable,
+      operationTable: RowLevelOperationTable,
       source: LogicalPlan,
       cond: Expression,
       matchedActions: Seq[MergeAction],
       notMatchedActions: Seq[MergeAction]): ReplaceData = {
 
     // resolve all needed attrs (e.g. metadata attrs for grouping data on write)
-    val metadataAttrs = resolveRequiredMetadataAttrs(relation, table.operation)
+    val metadataAttrs = resolveRequiredMetadataAttrs(relation, operationTable.operation)
 
     // construct a scan relation and include all required metadata columns
-    val readRelation = buildReadRelation(relation, table, metadataAttrs)
+    val readRelation = buildReadRelation(relation, operationTable, metadataAttrs)
     val readAttrs = readRelation.output
 
     // project an extra column to check if a target row exists after the join
@@ -222,7 +222,7 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand {
       joinPlan)
 
     // build a plan to replace read groups in the table
-    val writeRelation = relation.copy(table = table)
+    val writeRelation = relation.copy(table = operationTable)
     ReplaceData(writeRelation, mergeRows, relation)
   }
 

--- a/spark/v3.2/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
+++ b/spark/v3.2/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteUpdateTable.scala
@@ -78,21 +78,21 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
   // if the condition does NOT contain a subquery
   private def buildReplaceDataPlan(
       relation: DataSourceV2Relation,
-      table: RowLevelOperationTable,
+      operationTable: RowLevelOperationTable,
       assignments: Seq[Assignment],
       cond: Expression): ReplaceData = {
 
     // resolve all needed attrs (e.g. metadata attrs for grouping data on write)
-    val metadataAttrs = resolveRequiredMetadataAttrs(relation, table.operation)
+    val metadataAttrs = resolveRequiredMetadataAttrs(relation, operationTable.operation)
 
     // construct a read relation and include all required metadata columns
-    val readRelation = buildReadRelation(relation, table, metadataAttrs)
+    val readRelation = buildReadRelation(relation, operationTable, metadataAttrs)
 
     // build a plan with updated and copied over records
     val updatedAndRemainingRowsPlan = buildUpdateProjection(readRelation, assignments, cond)
 
     // build a plan to replace read groups in the table
-    val writeRelation = relation.copy(table = table)
+    val writeRelation = relation.copy(table = operationTable)
     ReplaceData(writeRelation, updatedAndRemainingRowsPlan, relation)
   }
 
@@ -100,17 +100,17 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
   // if the condition contains a subquery
   private def buildReplaceDataWithUnionPlan(
       relation: DataSourceV2Relation,
-      table: RowLevelOperationTable,
+      operationTable: RowLevelOperationTable,
       assignments: Seq[Assignment],
       cond: Expression): ReplaceData = {
 
     // resolve all needed attrs (e.g. metadata attrs for grouping data on write)
-    val metadataAttrs = resolveRequiredMetadataAttrs(relation, table.operation)
+    val metadataAttrs = resolveRequiredMetadataAttrs(relation, operationTable.operation)
 
     // construct a read relation and include all required metadata columns
     // the same read relation will be used to read records that must be updated and be copied over
     // DeduplicateRelations will take care of duplicated attr IDs
-    val readRelation = buildReadRelation(relation, table, metadataAttrs)
+    val readRelation = buildReadRelation(relation, operationTable, metadataAttrs)
 
     // build a plan for records that match the cond and should be updated
     val matchedRowsPlan = Filter(cond, readRelation)
@@ -124,24 +124,24 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
     val updatedAndRemainingRowsPlan = Union(updatedRowsPlan, remainingRowsPlan)
 
     // build a plan to replace read groups in the table
-    val writeRelation = relation.copy(table = table)
+    val writeRelation = relation.copy(table = operationTable)
     ReplaceData(writeRelation, updatedAndRemainingRowsPlan, relation)
   }
 
   // build a rewrite plan for sources that support row deltas
   private def buildWriteDeltaPlan(
       relation: DataSourceV2Relation,
-      table: RowLevelOperationTable,
+      operationTable: RowLevelOperationTable,
       assignments: Seq[Assignment],
       cond: Expression): WriteDelta = {
 
     // resolve all needed attrs (e.g. row ID and any required metadata attrs)
     val rowAttrs = relation.output
-    val rowIdAttrs = resolveRowIdAttrs(relation, table.operation)
-    val metadataAttrs = resolveRequiredMetadataAttrs(relation, table.operation)
+    val rowIdAttrs = resolveRowIdAttrs(relation, operationTable.operation)
+    val metadataAttrs = resolveRequiredMetadataAttrs(relation, operationTable.operation)
 
     // construct a scan relation and include all required metadata columns
-    val readRelation = buildReadRelation(relation, table, metadataAttrs, rowIdAttrs)
+    val readRelation = buildReadRelation(relation, operationTable, metadataAttrs, rowIdAttrs)
 
     // build a plan for updated records that match the cond
     val matchedRowsPlan = Filter(cond, readRelation)
@@ -150,7 +150,7 @@ object RewriteUpdateTable extends RewriteRowLevelCommand {
     val project = Project(operationType +: updatedRowsPlan.output, updatedRowsPlan)
 
     // build a plan to write the row delta to the table
-    val writeRelation = relation.copy(table = table)
+    val writeRelation = relation.copy(table = operationTable)
     val projections = buildWriteDeltaProjections(project, rowAttrs, rowIdAttrs, metadataAttrs)
     WriteDelta(writeRelation, project, relation, projections)
   }


### PR DESCRIPTION
As mentioned [here](https://github.com/apache/iceberg/pull/3984/files#r798156043), certain `RowLevelOperationTable` usages are a bit confusing. This PR attempts to rename some vars to avoid the ambiguity.