### PR TITLE
Remove the publish directive from .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -48,6 +48,3 @@ notifications:
     issues:       issues@iceberg.apache.org
     pullrequests: issues@iceberg.apache.org
     jira_options: link label link label
-
-publish:
-    whoami:  asf-site


### PR DESCRIPTION
This PR removes the publish directive from `.asf.yaml`. This should be merged before merging [PR #36](https://github.com/apache/iceberg-docs/pull/36) in apache/iceberg-docs which adds the publish directive there.