### PR TITLE
Core: BaseRollingWriter to use DataWriter::write instead of DataWriter::add

### DIFF
--- a/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/BaseTaskWriter.java
@@ -320,7 +320,7 @@ public abstract class BaseTaskWriter<T> implements TaskWriter<T> {
 
     @Override
     void write(DataWriter<T> writer, T record) {
-      writer.add(record);
+      writer.write(record);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/io/DataWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/DataWriter.java
@@ -68,7 +68,7 @@ public class DataWriter<T> implements FileWriter<T, DataWriteResult> {
    */
   @Deprecated
   public void add(T row) {
-    appender.add(row);
+    write(row);
   }
 
   @Override


### PR DESCRIPTION
The DataWriter::add is deprecated in 0.13 and will be removed in 0.14.
BaseRollingWriter should stop using the deprecated add() method.
Moreover, if a subclass of BaseRollingWriter only overrides the write()
method, add() should honor that.

In this patch I did not remove all calls to `DataWriter::add` in tests. May update that as well?