### PR TITLE
Add MetricsContext to enable metrics tracking with initial S3FileIO implementation

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/FileIOMetricsContext.java
+++ b/api/src/main/java/org/apache/iceberg/io/FileIOMetricsContext.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io;
+
+import org.apache.iceberg.metrics.MetricsContext;
+
+/**
+ * Extension of MetricsContext for use with FileIO to define standard metrics
+ * that should be reported.
+ */
+public interface FileIOMetricsContext extends MetricsContext {
+  String READ_BYTES = "read.bytes";
+  String READ_OPERATIONS = "read.operations";
+  String WRITE_BYTES = "write.bytes";
+  String WRITE_OPERATIONS = "write.operations";
+}

--- a/api/src/main/java/org/apache/iceberg/metrics/MetricsContext.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/MetricsContext.java
@@ -32,7 +32,7 @@ public interface MetricsContext extends Serializable {
   enum Unit {
     UNDEFINED("undefined"),
     BYTES("bytes"),
-    SCALAR("scalar");
+    COUNT("count");
 
     private final String displayName;
 
@@ -85,15 +85,7 @@ public interface MetricsContext extends Serializable {
    * @return a counter implementation
    */
   default <T extends Number> Counter<T> counter(String name, Class<T> type, Unit unit) {
-    return new Counter<T>() {
-      @Override
-      public void increment() {
-      }
-
-      @Override
-      public void increment(T amount) {
-      }
-    };
+    throw new UnsupportedOperationException("Counter is not supported.");
   }
 
   /**
@@ -102,6 +94,19 @@ public interface MetricsContext extends Serializable {
    * @return a non-recording metrics context
    */
   static MetricsContext nullMetrics() {
-    return new MetricsContext() {};
+    return new MetricsContext() {
+      @Override
+      public <T extends Number> Counter<T> counter(String name, Class<T> type, Unit unit) {
+        return new Counter<T>() {
+          @Override
+          public void increment() {
+          }
+
+          @Override
+          public void increment(T amount) {
+          }
+        };
+      }
+    };
   }
 }

--- a/api/src/main/java/org/apache/iceberg/metrics/MetricsContext.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/MetricsContext.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.metrics;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Generalized interface for creating telemetry related instances for tracking
+ * operations.  Implementations must take into account usage considerations
+ * like thread safety and serialization.
+ */
+public interface MetricsContext extends Serializable {
+  enum Unit {
+    UNDEFINED("undefined"),
+    BYTES("bytes"),
+    SCALAR("scalar");
+
+    private final String displayName;
+
+    Unit(String displayName) {
+      this.displayName = displayName;
+    }
+
+    public String displayName() {
+      return displayName;
+    }
+  }
+
+  default void initialize(Map<String,String> properties) {
+  }
+
+  interface Counter<T extends Number> {
+    /**
+     * Increment the counter by a single whole number value (i.e. 1).
+     */
+    void increment();
+
+    /**
+     * Increment the counter by the provided amount.
+     *
+     * @param amount to be incremented
+     */
+    void increment(T amount);
+
+    /**
+     * Reporting count is optional if the counter is reporting externally.
+     *
+     * @return
+     */
+    default Optional<T> count() {
+      return Optional.empty();
+    }
+
+    default Unit unit() { return Unit.UNDEFINED; };
+  }
+
+  /**
+   * Get a named counter of a specific type.  Metric implementations may impose
+   * restrictions on what types are supported for specific counters.
+   *
+   * @param name name of the metric
+   * @param type numeric type of the counter value
+   * @param unit the unit designation of the metric
+   * @return a counter implementation
+   */
+  default <T extends Number> Counter<T> counter(String name, Class<T> type, Unit unit) {
+    return new Counter<T>() {
+      @Override
+      public void increment() {
+      }
+
+      @Override
+      public void increment(T amount) {
+      }
+    };
+  }
+
+  /**
+   * Utility method for producing no metrics.
+   *
+   * @return a non-recording metrics context
+   */
+  static MetricsContext nullMetrics() {
+      return new MetricsContext() {};
+    }
+}

--- a/api/src/main/java/org/apache/iceberg/metrics/MetricsContext.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/MetricsContext.java
@@ -45,7 +45,7 @@ public interface MetricsContext extends Serializable {
     }
   }
 
-  default void initialize(Map<String,String> properties) {
+  default void initialize(Map<String, String> properties) {
   }
 
   interface Counter<T extends Number> {
@@ -64,13 +64,15 @@ public interface MetricsContext extends Serializable {
     /**
      * Reporting count is optional if the counter is reporting externally.
      *
-     * @return
+     * @return current count if available
      */
     default Optional<T> count() {
       return Optional.empty();
     }
 
-    default Unit unit() { return Unit.UNDEFINED; };
+    default Unit unit() {
+      return Unit.UNDEFINED;
+    }
   }
 
   /**
@@ -100,6 +102,6 @@ public interface MetricsContext extends Serializable {
    * @return a non-recording metrics context
    */
   static MetricsContext nullMetrics() {
-      return new MetricsContext() {};
-    }
+    return new MetricsContext() {};
+  }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/BaseS3File.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/BaseS3File.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.aws.s3;
 
 import org.apache.iceberg.aws.AwsProperties;
+import org.apache.iceberg.metrics.MetricsContext;
 import software.amazon.awssdk.http.HttpStatusCode;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
@@ -31,15 +32,13 @@ abstract class BaseS3File {
   private final S3URI uri;
   private final AwsProperties awsProperties;
   private HeadObjectResponse metadata;
+  private final MetricsContext metrics;
 
-  BaseS3File(S3Client client, S3URI uri) {
-    this(client, uri, new AwsProperties());
-  }
-
-  BaseS3File(S3Client client, S3URI uri, AwsProperties awsProperties) {
+  BaseS3File(S3Client client, S3URI uri, AwsProperties awsProperties, MetricsContext metrics) {
     this.client = client;
     this.uri = uri;
     this.awsProperties = awsProperties;
+    this.metrics = metrics;
   }
 
   public String location() {
@@ -56,6 +55,10 @@ abstract class BaseS3File {
 
   public AwsProperties awsProperties() {
     return awsProperties;
+  }
+
+  protected MetricsContext metrics() {
+    return metrics;
   }
 
   /**

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -26,9 +26,9 @@ import org.apache.iceberg.aws.AwsClientFactories;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.common.DynClasses;
 import org.apache.iceberg.io.FileIO;
-import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.util.SerializableSupplier;
 import org.slf4j.Logger;
@@ -114,7 +114,7 @@ public class S3FileIO implements FileIO {
     this.awsProperties = new AwsProperties(properties);
 
     // Do not override s3 client if it was provided
-    if(s3 != null) {
+    if (s3 != null) {
       this.s3 = AwsClientFactories.from(properties)::s3;
     }
 
@@ -126,8 +126,7 @@ public class S3FileIO implements FileIO {
       metrics.initialize(ImmutableMap.of("fileio.scheme", "s3"));
     } catch (ClassNotFoundException e) {
       LOG.warn("Metrics class not found: '{}', falling back to null metrics", DEFAULT_METRICS_IMPL, e);
-    } catch (NoSuchMethodException | InstantiationException
-        | IllegalAccessException | InvocationTargetException e) {
+    } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
       LOG.warn("Failed to instantiate metrics: '{}', falling back to null metrics", DEFAULT_METRICS_IMPL, e);
     }
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -114,7 +114,7 @@ public class S3FileIO implements FileIO {
     this.awsProperties = new AwsProperties(properties);
 
     // Do not override s3 client if it was provided
-    if (s3 != null) {
+    if (s3 == null) {
       this.s3 = AwsClientFactories.from(properties)::s3;
     }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputFile.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputFile.java
@@ -20,9 +20,9 @@
 package org.apache.iceberg.aws.s3;
 
 import org.apache.iceberg.aws.AwsProperties;
-import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.SeekableInputStream;
+import org.apache.iceberg.metrics.MetricsContext;
 import software.amazon.awssdk.services.s3.S3Client;
 
 public class S3InputFile extends BaseS3File implements InputFile {

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputFile.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputFile.java
@@ -20,21 +20,19 @@
 package org.apache.iceberg.aws.s3;
 
 import org.apache.iceberg.aws.AwsProperties;
+import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.SeekableInputStream;
 import software.amazon.awssdk.services.s3.S3Client;
 
 public class S3InputFile extends BaseS3File implements InputFile {
-  public static S3InputFile fromLocation(String location, S3Client client) {
-    return new S3InputFile(client, new S3URI(location), new AwsProperties());
+  public static S3InputFile fromLocation(String location, S3Client client, AwsProperties awsProperties,
+      MetricsContext metrics) {
+    return new S3InputFile(client, new S3URI(location), awsProperties, metrics);
   }
 
-  public static S3InputFile fromLocation(String location, S3Client client, AwsProperties awsProperties) {
-    return new S3InputFile(client, new S3URI(location), awsProperties);
-  }
-
-  S3InputFile(S3Client client, S3URI uri, AwsProperties awsProperties) {
-    super(client, uri, awsProperties);
+  S3InputFile(S3Client client, S3URI uri, AwsProperties awsProperties, MetricsContext metrics) {
+    super(client, uri, awsProperties, metrics);
   }
 
   /**
@@ -49,7 +47,6 @@ public class S3InputFile extends BaseS3File implements InputFile {
 
   @Override
   public SeekableInputStream newStream() {
-    return new S3InputStream(client(), uri(), awsProperties());
+    return new S3InputStream(client(), uri(), awsProperties(), metrics());
   }
-
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
@@ -66,10 +66,10 @@ class S3InputStream extends SeekableInputStream {
     this.location = location;
     this.awsProperties = awsProperties;
 
-    readBytes = metrics.counter(FileIOMetricsContext.READ_BYTES, Long.class, BYTES);
-    readOperations = metrics.counter(FileIOMetricsContext.READ_OPERATIONS, Integer.class, SCALAR);
+    this.readBytes = metrics.counter(FileIOMetricsContext.READ_BYTES, Long.class, BYTES);
+    this.readOperations = metrics.counter(FileIOMetricsContext.READ_OPERATIONS, Integer.class, SCALAR);
 
-    createStack = Thread.currentThread().getStackTrace();
+    this.createStack = Thread.currentThread().getStackTrace();
   }
 
   @Override

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
@@ -24,9 +24,10 @@ import java.io.InputStream;
 import java.util.Arrays;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.io.FileIOMetricsContext;
+import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.metrics.MetricsContext.Counter;
-import org.apache.iceberg.io.SeekableInputStream;
+import org.apache.iceberg.metrics.MetricsContext.Unit;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
@@ -35,9 +36,6 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
-
-import static org.apache.iceberg.metrics.MetricsContext.Unit.BYTES;
-import static org.apache.iceberg.metrics.MetricsContext.Unit.SCALAR;
 
 class S3InputStream extends SeekableInputStream {
   private static final Logger LOG = LoggerFactory.getLogger(S3InputStream.class);
@@ -66,8 +64,8 @@ class S3InputStream extends SeekableInputStream {
     this.location = location;
     this.awsProperties = awsProperties;
 
-    this.readBytes = metrics.counter(FileIOMetricsContext.READ_BYTES, Long.class, BYTES);
-    this.readOperations = metrics.counter(FileIOMetricsContext.READ_OPERATIONS, Integer.class, SCALAR);
+    this.readBytes = metrics.counter(FileIOMetricsContext.READ_BYTES, Long.class, Unit.BYTES);
+    this.readOperations = metrics.counter(FileIOMetricsContext.READ_OPERATIONS, Integer.class, Unit.SCALAR);
 
     this.createStack = Thread.currentThread().getStackTrace();
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputStream.java
@@ -65,7 +65,7 @@ class S3InputStream extends SeekableInputStream {
     this.awsProperties = awsProperties;
 
     this.readBytes = metrics.counter(FileIOMetricsContext.READ_BYTES, Long.class, Unit.BYTES);
-    this.readOperations = metrics.counter(FileIOMetricsContext.READ_OPERATIONS, Integer.class, Unit.SCALAR);
+    this.readOperations = metrics.counter(FileIOMetricsContext.READ_OPERATIONS, Integer.class, Unit.COUNT);
 
     this.createStack = Thread.currentThread().getStackTrace();
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
@@ -23,22 +23,20 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.PositionOutputStream;
 import software.amazon.awssdk.services.s3.S3Client;
 
 public class S3OutputFile extends BaseS3File implements OutputFile {
-  public static S3OutputFile fromLocation(String location, S3Client client) {
-    return new S3OutputFile(client, new S3URI(location), new AwsProperties());
+  public static S3OutputFile fromLocation(String location, S3Client client, AwsProperties awsProperties,
+      MetricsContext metrics) {
+    return new S3OutputFile(client, new S3URI(location), awsProperties, metrics);
   }
 
-  public static S3OutputFile fromLocation(String location, S3Client client, AwsProperties awsProperties) {
-    return new S3OutputFile(client, new S3URI(location), awsProperties);
-  }
-
-  S3OutputFile(S3Client client, S3URI uri, AwsProperties awsProperties) {
-    super(client, uri, awsProperties);
+  S3OutputFile(S3Client client, S3URI uri, AwsProperties awsProperties, MetricsContext metrics) {
+    super(client, uri, awsProperties, metrics);
   }
 
   /**
@@ -59,7 +57,7 @@ public class S3OutputFile extends BaseS3File implements OutputFile {
   @Override
   public PositionOutputStream createOrOverwrite() {
     try {
-      return new S3OutputStream(client(), uri(), awsProperties());
+      return new S3OutputStream(client(), uri(), awsProperties(), metrics());
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to create output stream for location: " + uri(), e);
     }
@@ -67,6 +65,6 @@ public class S3OutputFile extends BaseS3File implements OutputFile {
 
   @Override
   public InputFile toInputFile() {
-    return new S3InputFile(client(), uri(), awsProperties());
+    return new S3InputFile(client(), uri(), awsProperties(), metrics());
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
@@ -23,10 +23,10 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
-import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.PositionOutputStream;
+import org.apache.iceberg.metrics.MetricsContext;
 import software.amazon.awssdk.services.s3.S3Client;
 
 public class S3OutputFile extends BaseS3File implements OutputFile {

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -47,6 +47,7 @@ import org.apache.iceberg.io.FileIOMetricsContext;
 import org.apache.iceberg.io.PositionOutputStream;
 import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.metrics.MetricsContext.Counter;
+import org.apache.iceberg.metrics.MetricsContext.Unit;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Predicates;
@@ -69,8 +70,6 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 import software.amazon.awssdk.utils.BinaryUtils;
-
-import static org.apache.iceberg.metrics.MetricsContext.Unit.*;
 
 class S3OutputStream extends PositionOutputStream {
   private static final Logger LOG = LoggerFactory.getLogger(S3OutputStream.class);
@@ -133,8 +132,8 @@ class S3OutputStream extends PositionOutputStream {
       throw new RuntimeException("Failed to create message digest needed for s3 checksum checks", e);
     }
 
-    this.writeBytes = metrics.counter(FileIOMetricsContext.WRITE_BYTES, Long.class, BYTES);
-    this.writeOperations = metrics.counter(FileIOMetricsContext.WRITE_OPERATIONS, Integer.class, SCALAR);
+    this.writeBytes = metrics.counter(FileIOMetricsContext.WRITE_BYTES, Long.class, Unit.BYTES);
+    this.writeOperations = metrics.counter(FileIOMetricsContext.WRITE_OPERATIONS, Integer.class, Unit.SCALAR);
 
     newStream();
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -133,7 +133,7 @@ class S3OutputStream extends PositionOutputStream {
     }
 
     this.writeBytes = metrics.counter(FileIOMetricsContext.WRITE_BYTES, Long.class, Unit.BYTES);
-    this.writeOperations = metrics.counter(FileIOMetricsContext.WRITE_OPERATIONS, Integer.class, Unit.SCALAR);
+    this.writeOperations = metrics.counter(FileIOMetricsContext.WRITE_OPERATIONS, Integer.class, Unit.COUNT);
 
     newStream();
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -43,7 +43,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.stream.Collectors;
 import org.apache.iceberg.aws.AwsProperties;
+import org.apache.iceberg.io.FileIOMetricsContext;
 import org.apache.iceberg.io.PositionOutputStream;
+import org.apache.iceberg.metrics.MetricsContext;
+import org.apache.iceberg.metrics.MetricsContext.Counter;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Predicates;
@@ -66,6 +69,8 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 import software.amazon.awssdk.utils.BinaryUtils;
+
+import static org.apache.iceberg.metrics.MetricsContext.Unit.*;
 
 class S3OutputStream extends PositionOutputStream {
   private static final Logger LOG = LoggerFactory.getLogger(S3OutputStream.class);
@@ -90,11 +95,14 @@ class S3OutputStream extends PositionOutputStream {
   private final MessageDigest completeMessageDigest;
   private MessageDigest currentPartMessageDigest;
 
+  private final Counter<Long> writeBytes;
+  private final Counter<Integer> writeOperations;
+
   private long pos = 0;
   private boolean closed = false;
 
   @SuppressWarnings("StaticAssignmentInConstructor")
-  S3OutputStream(S3Client s3, S3URI location, AwsProperties awsProperties) throws IOException {
+  S3OutputStream(S3Client s3, S3URI location, AwsProperties awsProperties, MetricsContext metrics) throws IOException {
     if (executorService == null) {
       synchronized (S3OutputStream.class) {
         if (executorService == null) {
@@ -113,17 +121,20 @@ class S3OutputStream extends PositionOutputStream {
     this.location = location;
     this.awsProperties = awsProperties;
 
-    createStack = Thread.currentThread().getStackTrace();
+    this.createStack = Thread.currentThread().getStackTrace();
 
-    multiPartSize = awsProperties.s3FileIoMultiPartSize();
-    multiPartThresholdSize =  (int) (multiPartSize * awsProperties.s3FileIOMultipartThresholdFactor());
-    stagingDirectory = new File(awsProperties.s3fileIoStagingDirectory());
-    isChecksumEnabled = awsProperties.isS3ChecksumEnabled();
+    this.multiPartSize = awsProperties.s3FileIoMultiPartSize();
+    this.multiPartThresholdSize =  (int) (multiPartSize * awsProperties.s3FileIOMultipartThresholdFactor());
+    this.stagingDirectory = new File(awsProperties.s3fileIoStagingDirectory());
+    this.isChecksumEnabled = awsProperties.isS3ChecksumEnabled();
     try {
-      completeMessageDigest = isChecksumEnabled ? MessageDigest.getInstance(digestAlgorithm) : null;
+      this.completeMessageDigest = isChecksumEnabled ? MessageDigest.getInstance(digestAlgorithm) : null;
     } catch (NoSuchAlgorithmException e) {
       throw new RuntimeException("Failed to create message digest needed for s3 checksum checks", e);
     }
+
+    this.writeBytes = metrics.counter(FileIOMetricsContext.WRITE_BYTES, Long.class, BYTES);
+    this.writeOperations = metrics.counter(FileIOMetricsContext.WRITE_OPERATIONS, Integer.class, SCALAR);
 
     newStream();
   }
@@ -147,6 +158,8 @@ class S3OutputStream extends PositionOutputStream {
 
     stream.write(b);
     pos += 1;
+    writeBytes.increment();
+    writeOperations.increment();
 
     // switch to multipart upload
     if (multipartUploadId == null && pos >= multiPartThresholdSize) {
@@ -176,6 +189,8 @@ class S3OutputStream extends PositionOutputStream {
 
     stream.write(b, relativeOffset, remaining);
     pos += len;
+    writeBytes.increment((long) len);
+    writeOperations.increment();
 
     // switch to multipart upload
     if (multipartUploadId == null && pos >= multiPartThresholdSize) {

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
@@ -66,16 +66,16 @@ public class HadoopMetricsContext implements FileIOMetricsContext {
   public <T extends Number> Counter<T> counter(String name, Class<T> type, Unit unit) {
     switch (name) {
       case READ_BYTES:
-        ValidationException.check(type != Long.class, "'%s' requires Long type", READ_BYTES);
+        ValidationException.check(type == Long.class, "'%s' requires Long type", READ_BYTES);
         return (Counter<T>) longCounter(statistics::incrementBytesRead);
       case READ_OPERATIONS:
-        ValidationException.check(type != Integer.class, "'%s' requires Integer type", READ_OPERATIONS);
+        ValidationException.check(type == Integer.class, "'%s' requires Integer type", READ_OPERATIONS);
         return (Counter<T>) integerCounter(statistics::incrementReadOps);
       case WRITE_BYTES:
-        ValidationException.check(type != Long.class, "'%s' requires Long type", WRITE_BYTES);
+        ValidationException.check(type == Long.class, "'%s' requires Long type", WRITE_BYTES);
         return (Counter<T>) longCounter(statistics::incrementBytesWritten);
       case WRITE_OPERATIONS:
-        ValidationException.check(type != Integer.class, "'%s' requires Integer type", WRITE_OPERATIONS);
+        ValidationException.check(type == Integer.class, "'%s' requires Integer type", WRITE_OPERATIONS);
         return (Counter<T>) integerCounter(statistics::incrementWriteOps);
       default:
         throw new IllegalArgumentException(String.format("Unsupported counter: '%s'", name));

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.hadoop;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.io.FileIOMetricsContext;
+
+import static java.lang.String.format;
+
+/**
+ * FileIO Metrics implementation that delegates to Hadoop FileSystem
+ * statistics implementation using the provided scheme.
+ */
+public class HadoopMetricsContext implements FileIOMetricsContext {
+  public static final String SCHEME = "fileio.scheme";
+
+  private String scheme;
+  private transient FileSystem.Statistics statistics;
+
+  @Override
+  public void initialize(Map<String, String> properties) {
+    ValidationException.check(properties.containsKey(SCHEME),
+        "Scheme is required for Hadoop FileSystem metrics reporting");
+
+    // FileIO has no specific implementation class, but Hadoop will
+    // still track and report for the provided scheme.
+    this.scheme = properties.get(SCHEME);
+    this.statistics = FileSystem.getStatistics(scheme, null);
+  }
+
+  /**
+   * The Hadoop implementation delegates to the Hadoop delegates to the
+   * FileSystem.Statistics implementation and therefore does not require
+   * support for operations like unit() and count() as the counter
+   * values are not directly consumed.
+   *
+   * @param name name of the metric
+   * @param type numeric type of the counter value
+   * @param unit ignored
+   * @param <T> Counter numeric type
+   * @return counter
+   */
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T extends Number> Counter<T> counter(String name, Class<T> type, Unit unit) {
+    switch (name) {
+      case READ_BYTES:
+        ValidationException.check(type != Long.class, "'%s' requires Long type", READ_BYTES);
+        return (Counter<T>) longCounter(statistics::incrementBytesRead);
+      case READ_OPERATIONS:
+        ValidationException.check(type != Integer.class, "'%s' requires Integer type", READ_OPERATIONS);
+        return (Counter<T>) integerCounter(statistics::incrementReadOps);
+      case WRITE_BYTES:
+        ValidationException.check(type != Long.class, "'%s' requires Long type", WRITE_BYTES);
+        return (Counter<T>) longCounter(statistics::incrementBytesWritten);
+      case WRITE_OPERATIONS:
+        ValidationException.check(type != Integer.class, "'%s' requires Integer type", WRITE_OPERATIONS);
+        return (Counter<T>) integerCounter(statistics::incrementWriteOps);
+      default:
+        throw new IllegalArgumentException(format("Unsupported counter: '%s'", name));
+    }
+  }
+
+  private Counter<Long> longCounter(Consumer<Long> consumer) {
+    return  new Counter<Long>() {
+      @Override
+      public void increment() {
+        increment(1L);
+      }
+      @Override
+      public void increment(Long amount) {
+        consumer.accept(amount);
+      }
+    };
+  }
+
+  private Counter<Integer> integerCounter(Consumer<Integer> consumer) {
+    return new Counter<Integer>() {
+      @Override
+      public void increment() {
+        increment(1);
+      }
+
+      @Override
+      public void increment(Integer amount) {
+        consumer.accept(amount);
+      }
+    };
+  }
+
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    out.defaultWriteObject();
+  }
+
+  private void readObject(ObjectInputStream in) throws ClassNotFoundException, IOException {
+    in.defaultReadObject();
+    statistics = FileSystem.getStatistics(scheme, null);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
@@ -28,8 +28,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.io.FileIOMetricsContext;
 
-import static java.lang.String.format;
-
 /**
  * FileIO Metrics implementation that delegates to Hadoop FileSystem
  * statistics implementation using the provided scheme.
@@ -80,7 +78,7 @@ public class HadoopMetricsContext implements FileIOMetricsContext {
         ValidationException.check(type != Integer.class, "'%s' requires Integer type", WRITE_OPERATIONS);
         return (Counter<T>) integerCounter(statistics::incrementWriteOps);
       default:
-        throw new IllegalArgumentException(format("Unsupported counter: '%s'", name));
+        throw new IllegalArgumentException(String.format("Unsupported counter: '%s'", name));
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
@@ -33,7 +33,7 @@ import org.apache.iceberg.io.FileIOMetricsContext;
  * statistics implementation using the provided scheme.
  */
 public class HadoopMetricsContext implements FileIOMetricsContext {
-  public static final String SCHEME = "fileio.scheme";
+  public static final String SCHEME = "io.metrics-scheme";
 
   private String scheme;
   private transient FileSystem.Statistics statistics;

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
@@ -38,14 +38,18 @@ public class HadoopMetricsContext implements FileIOMetricsContext {
   private String scheme;
   private transient FileSystem.Statistics statistics;
 
-  @Override
-  public void initialize(Map<String, String> properties) {
-    ValidationException.check(properties.containsKey(SCHEME),
+  public HadoopMetricsContext(String scheme) {
+    ValidationException.check(scheme != null,
         "Scheme is required for Hadoop FileSystem metrics reporting");
 
+    this.scheme = scheme;
+  }
+
+  @Override
+  public void initialize(Map<String, String> properties) {
     // FileIO has no specific implementation class, but Hadoop will
     // still track and report for the provided scheme.
-    this.scheme = properties.get(SCHEME);
+    this.scheme = properties.getOrDefault(SCHEME, scheme);
     this.statistics = FileSystem.getStatistics(scheme, null);
   }
 
@@ -88,6 +92,7 @@ public class HadoopMetricsContext implements FileIOMetricsContext {
       public void increment() {
         increment(1L);
       }
+
       @Override
       public void increment(Long amount) {
         consumer.accept(amount);


### PR DESCRIPTION
This PR adds a basic interface for reporting FileIO metrics and a shim implementation for reporting IO metrics via the Hadoop `FileSystem.Statistics` to be compatible with how Spark/Flink gather and report task metrics.