### PR TITLE
AWS: Add SupportBulkOperation interface. S3FileIO implementation will perform a batch deletion using RemoveObjects API

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/BulkDeletionFailureException.java
+++ b/api/src/main/java/org/apache/iceberg/io/BulkDeletionFailureException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io;
+
+public class BulkDeletionFailureException extends RuntimeException {
+  private final int numberFailedObjects;
+
+  public BulkDeletionFailureException(int numberFailedObjects) {
+    super(String.format("Failed to delete %d files", numberFailedObjects));
+    this.numberFailedObjects = numberFailedObjects;
+  }
+
+  public int numberFailedObjects() {
+    return numberFailedObjects;
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/io/SupportsBulkOperations.java
+++ b/api/src/main/java/org/apache/iceberg/io/SupportsBulkOperations.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io;
+
+public interface SupportsBulkOperations {
+  /**
+   * Delete the files at the given paths.
+   *
+   * @param pathsToDelete The paths to delete
+   * @throws BulkDeletionFailureException in
+   */
+  void deleteFiles(Iterable<String> pathsToDelete) throws BulkDeletionFailureException;
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -173,6 +173,25 @@ public class AwsProperties implements Serializable {
   public static final boolean S3_CHECKSUM_ENABLED_DEFAULT = false;
 
   /**
+   * Configure the batch size used when deleting multiple files from a given S3 bucket
+   */
+  public static final String S3FILEIO_DELETE_BATCH_SIZE = "s3.delete.batch-size";
+
+  /**
+   * Default batch size used when deleting files.
+   * <p>
+   * Refer to https://github.com/apache/hadoop/commit/56dee667707926f3796c7757be1a133a362f05c9
+   * for more details on why this value was chosen.
+   */
+  public static final int S3FILEIO_DELETE_BATCH_SIZE_DEFAULT = 250;
+
+  /**
+   * Max possible batch size for deletion. Currently, a max of 1000 keys can be deleted in one batch.
+   * https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html
+   */
+  public static final int S3FILEIO_DELETE_BATCH_SIZE_MAX = 1000;
+
+  /**
    * DynamoDB table name for {@link DynamoDbCatalog}
    */
   public static final String DYNAMODB_TABLE_NAME = "dynamodb.table-name";
@@ -236,6 +255,7 @@ public class AwsProperties implements Serializable {
   private String s3FileIoSseMd5;
   private int s3FileIoMultipartUploadThreads;
   private int s3FileIoMultiPartSize;
+  private int s3FileIoDeleteBatchSize;
   private double s3FileIoMultipartThresholdFactor;
   private String s3fileIoStagingDirectory;
   private ObjectCannedACL s3FileIoAcl;
@@ -256,6 +276,7 @@ public class AwsProperties implements Serializable {
     this.s3FileIoMultipartUploadThreads = Runtime.getRuntime().availableProcessors();
     this.s3FileIoMultiPartSize = S3FILEIO_MULTIPART_SIZE_DEFAULT;
     this.s3FileIoMultipartThresholdFactor = S3FILEIO_MULTIPART_THRESHOLD_FACTOR_DEFAULT;
+    this.s3FileIoDeleteBatchSize = S3FILEIO_DELETE_BATCH_SIZE_DEFAULT;
     this.s3fileIoStagingDirectory = System.getProperty("java.io.tmpdir");
     this.isS3ChecksumEnabled = S3_CHECKSUM_ENABLED_DEFAULT;
 
@@ -310,6 +331,12 @@ public class AwsProperties implements Serializable {
     this.isS3ChecksumEnabled = PropertyUtil.propertyAsBoolean(properties, S3_CHECKSUM_ENABLED,
         S3_CHECKSUM_ENABLED_DEFAULT);
 
+    this.s3FileIoDeleteBatchSize = PropertyUtil.propertyAsInt(properties, S3FILEIO_DELETE_BATCH_SIZE,
+        S3FILEIO_DELETE_BATCH_SIZE_DEFAULT);
+    Preconditions.checkArgument(s3FileIoDeleteBatchSize > 0 &&
+        s3FileIoDeleteBatchSize <= S3FILEIO_DELETE_BATCH_SIZE_MAX,
+        String.format("Deletion batch size must be between 1 and %s", S3FILEIO_DELETE_BATCH_SIZE_MAX));
+
     this.dynamoDbTableName = PropertyUtil.propertyAsString(properties, DYNAMODB_TABLE_NAME,
         DYNAMODB_TABLE_NAME_DEFAULT);
   }
@@ -324,6 +351,14 @@ public class AwsProperties implements Serializable {
 
   public String s3FileIoSseKey() {
     return s3FileIoSseKey;
+  }
+
+  public int s3FileIoDeleteBatchSize() {
+    return s3FileIoDeleteBatchSize;
+  }
+
+  public void setS3FileIoDeleteBatchSize(int deleteBatchSize) {
+    this.s3FileIoDeleteBatchSize = deleteBatchSize;
   }
 
   public void setS3FileIoSseKey(String sseKey) {

--- a/aws/src/test/java/org/apache/iceberg/aws/TestAwsProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestAwsProperties.java
@@ -97,4 +97,24 @@ public class TestAwsProperties {
         () -> new AwsProperties(map));
   }
 
+  @Test
+  public void testS3FileIoDeleteBatchSizeTooLarge() {
+    Map<String, String> map = Maps.newHashMap();
+    map.put(AwsProperties.S3FILEIO_DELETE_BATCH_SIZE, "2000");
+    AssertHelpers.assertThrows("should not accept batch size greater than 1000",
+        IllegalArgumentException.class,
+        "Deletion batch size must be between 1 and 1000",
+        () -> new AwsProperties(map));
+  }
+
+  @Test
+  public void testS3FileIoDeleteBatchSizeTooSmall() {
+    Map<String, String> map = Maps.newHashMap();
+    map.put(AwsProperties.S3FILEIO_DELETE_BATCH_SIZE, "0");
+    AssertHelpers.assertThrows("should not accept batch size less than 1",
+        IllegalArgumentException.class,
+        "Deletion batch size must be between 1 and 1000",
+        () -> new AwsProperties(map));
+  }
+
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
@@ -23,44 +23,69 @@ import com.adobe.testing.s3mock.junit4.S3MockRule;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.SerializationUtils;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.io.BulkDeletionFailureException;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.SerializableSupplier;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
+import software.amazon.awssdk.services.s3.model.S3Error;
 import software.amazon.awssdk.services.s3.model.Tag;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
+@RunWith(MockitoJUnitRunner.class)
 public class TestS3FileIO {
   @ClassRule
   public static final S3MockRule S3_MOCK_RULE = S3MockRule.builder().silent().build();
   public SerializableSupplier<S3Client> s3 = S3_MOCK_RULE::createS3ClientV2;
+  private final S3Client s3mock = mock(S3Client.class, delegatesTo(s3.get()));
   private final Random random = new Random(1);
-
+  private final int numBucketsForBatchDeletion = 3;
+  private final String batchDeletionBucketPrefix = "batch-delete-";
+  private final int batchDeletionSize = 5;
   private S3FileIO s3FileIO;
   private final Map<String, String> properties = ImmutableMap.of(
-      "s3.write.tags.tagKey1", "TagValue1");
+      "s3.write.tags.tagKey1", "TagValue1",
+      "s3.delete.batch-size", Integer.toString(batchDeletionSize));
 
   @Before
   public void before() {
-    s3FileIO = new S3FileIO(s3);
+    s3FileIO = new S3FileIO(() -> s3mock);
     s3FileIO.initialize(properties);
     s3.get().createBucket(CreateBucketRequest.builder().bucket("bucket").build());
+    for (int i = 1; i <= numBucketsForBatchDeletion; i++) {
+      s3.get().createBucket(CreateBucketRequest.builder().bucket(batchDeletionBucketPrefix + i).build());
+    }
   }
 
   @Test
@@ -92,6 +117,72 @@ public class TestS3FileIO {
   }
 
   @Test
+  public void testDeleteFilesMultipleBatches() {
+    testBatchDelete(batchDeletionSize * 2);
+  }
+
+  @Test
+  public void testDeleteFilesLessThanBatchSize() {
+    testBatchDelete(batchDeletionSize - 1);
+  }
+
+  @Test
+  public void testDeleteFilesSingleBatchWithRemainder() {
+    testBatchDelete(batchDeletionSize + 1);
+  }
+
+  @Test
+  public void testDeleteEmptyList() throws IOException {
+    String location = "s3://bucket/path/to/file.txt";
+    InputFile in = s3FileIO.newInputFile(location);
+    assertFalse(in.exists());
+    OutputFile out = s3FileIO.newOutputFile(location);
+    try (OutputStream os = out.createOrOverwrite()) {
+      IOUtils.write(new byte[1024 * 1024], os);
+    }
+
+    s3FileIO.deleteFiles(Lists.newArrayList());
+
+    Assert.assertTrue(s3FileIO.newInputFile(location).exists());
+    s3FileIO.deleteFile(in);
+    assertFalse(s3FileIO.newInputFile(location).exists());
+  }
+
+  @Test
+  public void testDeleteFilesS3ReturnsError() {
+    String location = "s3://bucket/path/to/file-to-delete.txt";
+    DeleteObjectsResponse deleteObjectsResponse = DeleteObjectsResponse.builder()
+        .errors(ImmutableList.of(S3Error.builder().key("path/to/file.txt").build()))
+        .build();
+    doReturn(deleteObjectsResponse).when(s3mock).deleteObjects((DeleteObjectsRequest) any());
+
+    AssertHelpers.assertThrows("A failure during S3 DeleteObjects call should result in FileIODeleteException",
+        BulkDeletionFailureException.class,
+        "Failed to delete 1 file",
+        () -> s3FileIO.deleteFiles(Lists.newArrayList(location)));
+  }
+
+  private void testBatchDelete(int numObjects) {
+    List<String> paths = Lists.newArrayList();
+    for (int i = 1; i <= numBucketsForBatchDeletion; i++) {
+      String bucketName = batchDeletionBucketPrefix + i;
+      for (int j = 1; j <= numObjects; j++) {
+        String key = "object-" + j;
+        paths.add("s3://" + bucketName + "/" + key);
+      }
+    }
+    s3FileIO.deleteFiles(paths);
+
+    int expectedNumberOfBatchesPerBucket =
+        (numObjects / batchDeletionSize) + (numObjects % batchDeletionSize == 0 ? 0 : 1);
+    int expectedDeleteRequests = expectedNumberOfBatchesPerBucket * numBucketsForBatchDeletion;
+    verify(s3mock, times(expectedDeleteRequests)).deleteObjects((DeleteObjectsRequest) any());
+    for (String path : paths) {
+      Assert.assertFalse(s3FileIO.newInputFile(path).exists());
+    }
+  }
+
+  @Test
   public void testSerializeClient() {
     SerializableSupplier<S3Client> pre =
         () -> S3Client.builder().httpClientBuilder(UrlConnectionHttpClient.builder()).region(Region.US_EAST_1).build();
@@ -120,7 +211,7 @@ public class TestS3FileIO {
 
     // Assert for writeTags
     assertTrue(((S3InputFile) in).writeTags().isEmpty());
-    assertEquals(((S3OutputFile) out).writeTags().size(), properties.size());
+    assertEquals(((S3OutputFile) out).writeTags().size(), 1);
     assertEquals(((S3OutputFile) out).writeTags(), ImmutableSet.of(
         Tag.builder().key("tagKey1").value("TagValue1").build()));
 


### PR DESCRIPTION
Starting a draft PR for performing batch deletion for S3 objects. Related issue: https://github.com/apache/iceberg/issues/4012

This can be useful for the expire snapshots and remove orphan files operations. In this PR we update the FileIO interface and add a S3 implementation to perform the batch removal. Leaving it in draft until I add some unit tests for the batch removal implementation for S3, wanted to get some initial feedback on the code.

In other PRs we can tackle updating the actions for expiring snapshots and removing orphan files. My thoughts there are we do have a separate batching mechanism within the action implementation (for an action a user would specify a batch size (defaulting to 1). Tasks looks like it is generic and for the parameter we could partition the given input list into batches, and then we could pass in a function which accepts a list of strings for performing the batch deletion. This would only be done in the case the batch size is greater than 1. Any thoughts?

@szehon-ho @dramaticlly @jackye1995 