### PR TITLE
Tests: Replace DataWriter::add with DataWriter::write in tests

### DIFF
--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroDataWriter.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroDataWriter.java
@@ -85,7 +85,7 @@ public class TestAvroDataWriter {
 
     try {
       for (Record record : records) {
-        dataWriter.add(record);
+        dataWriter.write(record);
       }
     } finally {
       dataWriter.close();

--- a/data/src/test/java/org/apache/iceberg/data/orc/TestOrcDataWriter.java
+++ b/data/src/test/java/org/apache/iceberg/data/orc/TestOrcDataWriter.java
@@ -87,7 +87,7 @@ public class TestOrcDataWriter {
 
     try {
       for (Record record : records) {
-        dataWriter.add(record);
+        dataWriter.write(record);
       }
     } finally {
       dataWriter.close();

--- a/data/src/test/java/org/apache/iceberg/io/TestAppenderFactory.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestAppenderFactory.java
@@ -155,7 +155,7 @@ public abstract class TestAppenderFactory<T> extends TableTestBase {
     DataWriter<T> writer = appenderFactory.newDataWriter(createEncryptedOutputFile(), format, partition);
     try (DataWriter<T> closeableWriter = writer) {
       for (T row : rowSet) {
-        closeableWriter.add(row);
+        closeableWriter.write(row);
       }
     }
 

--- a/data/src/test/java/org/apache/iceberg/io/TestFileWriterFactory.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestFileWriterFactory.java
@@ -339,7 +339,7 @@ public abstract class TestFileWriterFactory<T> extends WriterTestBase<T> {
 
     try (DataWriter<T> closeableWriter = writer) {
       for (T row : rows) {
-        closeableWriter.add(row);
+        closeableWriter.write(row);
       }
     }
 

--- a/data/src/test/java/org/apache/iceberg/io/TestGenericSortedPosDeleteWriter.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestGenericSortedPosDeleteWriter.java
@@ -100,7 +100,7 @@ public class TestGenericSortedPosDeleteWriter extends TableTestBase {
     DataWriter<Record> writer = appenderFactory.newDataWriter(createEncryptedOutputFile(), format, null);
     try (DataWriter<Record> closeableWriter = writer) {
       for (Record record : rowSet) {
-        closeableWriter.add(record);
+        closeableWriter.write(record);
       }
     }
 

--- a/data/src/test/java/org/apache/iceberg/io/TestWriterMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestWriterMetrics.java
@@ -134,7 +134,7 @@ public abstract class TestWriterMetrics<T> {
         PartitionSpec.unpartitioned(),
         null
     );
-    dataWriter.add(row);
+    dataWriter.write(row);
     dataWriter.close();
     DataFile dataFile = dataWriter.toDataFile();
 

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetDataWriter.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetDataWriter.java
@@ -94,7 +94,7 @@ public class TestParquetDataWriter {
 
     try {
       for (Record record : records) {
-        dataWriter.add(record);
+        dataWriter.write(record);
       }
     } finally {
       dataWriter.close();
@@ -152,7 +152,7 @@ public class TestParquetDataWriter {
 
     try {
       for (Record record : overflowRecords) {
-        dataWriter.add(record);
+        dataWriter.write(record);
       }
     } finally {
       dataWriter.close();
@@ -214,7 +214,7 @@ public class TestParquetDataWriter {
 
     try {
       for (Record record : overflowRecords) {
-        dataWriter.add(record);
+        dataWriter.write(record);
       }
     } finally {
       dataWriter.close();


### PR DESCRIPTION
This is a follow-up change of #4048

I searched from IntelliJ and did not find any other usages of the deprecated `DataWriter::add` method.