### PR TITLE
Core: Add InMemory FileIO/Catalog and extract common catalog tests from HadoopCatalog into a common test

### DIFF
--- a/core/src/main/java/org/apache/iceberg/io/inmemory/InMemoryCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/io/inmemory/InMemoryCatalog.java
@@ -1,0 +1,374 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io.inmemory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+import org.apache.iceberg.BaseMetastoreCatalog;
+import org.apache.iceberg.BaseMetastoreTableOperations;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
+import org.apache.iceberg.exceptions.NoSuchNamespaceException;
+import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.base.Joiner;
+import org.apache.iceberg.relocated.com.google.common.base.Objects;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Catalog implementation that uses in-memory data-structures to
+ * store the namespaces and tables.
+ * This class doesn't touch external resources and
+ * can be utilized to write unit tests without side effects.
+ * It uses {@link InMemoryFileIO}.
+ * <p>
+ * This catalog supports namespaces.
+ * This catalog automatically creates namespaces if needed during table creation.
+ */
+public class InMemoryCatalog extends BaseMetastoreCatalog implements SupportsNamespaces, Closeable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(InMemoryCatalog.class);
+  private static final Joiner SLASH = Joiner.on("/");
+  private static final Joiner DOT = Joiner.on(".");
+
+  private final ConcurrentMap<Namespace, Map<String, String>> namespaceDb;
+  private final ConcurrentMap<TableIdentifier, String> tableDb;
+  private FileIO io;
+  private String catalogName;
+  private String warehouseLocation;
+
+  public InMemoryCatalog() {
+    namespaceDb = new ConcurrentHashMap<>();
+    tableDb = new ConcurrentHashMap<>();
+  }
+
+  @Override
+  public String name() {
+    return catalogName;
+  }
+
+  @Override
+  public void initialize(String name, Map<String, String> properties) {
+    this.catalogName = name != null ? name : InMemoryCatalog.class.getSimpleName();
+
+    String warehouse = properties.getOrDefault(CatalogProperties.WAREHOUSE_LOCATION, "");
+    this.warehouseLocation = warehouse.replaceAll("/*$", "");
+
+    this.io = new InMemoryFileIO();
+  }
+
+  @Override
+  protected TableOperations newTableOps(TableIdentifier tableIdentifier) {
+    return new InMemoryTableOperations(io, tableIdentifier);
+  }
+
+  @Override
+  protected String defaultWarehouseLocation(TableIdentifier tableIdentifier) {
+    return SLASH.join(defaultNamespaceLocation(tableIdentifier.namespace()), tableIdentifier.name());
+  }
+
+  private String defaultNamespaceLocation(Namespace namespace) {
+    if (namespace.isEmpty()) {
+      return warehouseLocation;
+    } else {
+      return SLASH.join(warehouseLocation, SLASH.join(namespace.levels()));
+    }
+  }
+
+  @Override
+  public Table createTable(
+      TableIdentifier tableIdentifier,
+      Schema schema,
+      PartitionSpec spec,
+      String location,
+      Map<String, String> properties) {
+
+    // Create namespace automatically if it does not exist.
+    if (!namespaceExists(tableIdentifier.namespace())) {
+      createNamespace(tableIdentifier.namespace());
+    }
+
+    return super.createTable(tableIdentifier, schema, spec, location, properties);
+  }
+
+  @Override
+  public boolean dropTable(TableIdentifier tableIdentifier, boolean purge) {
+    TableOperations ops = newTableOps(tableIdentifier);
+    TableMetadata lastMetadata;
+    if (purge && ops.current() != null) {
+      lastMetadata = ops.current();
+    } else {
+      lastMetadata = null;
+    }
+
+    if (tableDb.remove(tableIdentifier) == null) {
+      LOG.info("Table does not exist: cannot drop table {}", tableIdentifier);
+      return false;
+    }
+
+    if (purge && lastMetadata != null) {
+      CatalogUtil.dropTableData(ops.io(), lastMetadata);
+    }
+
+    return true;
+  }
+
+  @Override
+  public List<TableIdentifier> listTables(Namespace namespace) {
+    if (!namespaceExists(namespace) && !namespace.isEmpty()) {
+      throw new NoSuchNamespaceException(
+          "Namespace does not exist: cannot list tables for namespace %s", namespace);
+    }
+
+    return tableDb.keySet().stream()
+        .filter(t -> namespace.isEmpty() || t.namespace().equals(namespace))
+        .sorted(Comparator.comparing(TableIdentifier::toString))
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public void renameTable(TableIdentifier fromTableIdentifier, TableIdentifier toTableIdentifier) {
+    if (fromTableIdentifier.equals(toTableIdentifier)) {
+      return;
+    }
+
+    if (!namespaceExists(toTableIdentifier.namespace())) {
+      throw new NoSuchNamespaceException("Cannot rename %s to %s because the namespace %s does not exist",
+          fromTableIdentifier, toTableIdentifier, toTableIdentifier.namespace());
+    }
+
+    if (!tableDb.containsKey(fromTableIdentifier)) {
+      throw new NoSuchTableException("Cannot rename %s to %s because the table %s does not exist",
+          fromTableIdentifier, toTableIdentifier, fromTableIdentifier);
+    }
+
+    if (tableDb.containsKey(toTableIdentifier)) {
+      throw new AlreadyExistsException("Cannot rename %s to %s because the table %s already exists",
+          fromTableIdentifier, toTableIdentifier, toTableIdentifier);
+    }
+
+    String fromLocation = tableDb.remove(fromTableIdentifier);
+    if (fromLocation != null) {
+      tableDb.put(toTableIdentifier, fromLocation);
+    } else {
+      throw new IllegalStateException(String.format(
+          "Cannot rename from %s to %s because source table does not exist",
+          fromTableIdentifier, toTableIdentifier));
+    }
+  }
+
+  @Override
+  public void createNamespace(Namespace namespace) {
+    createNamespace(namespace, Collections.emptyMap());
+  }
+
+  @Override
+  public void createNamespace(Namespace namespace, Map<String, String> metadata) {
+    if (namespaceExists(namespace)) {
+      throw new AlreadyExistsException("Namespace already exists: %s. Cannot create namespace", namespace);
+    }
+
+    namespaceDb.put(namespace, ImmutableMap.copyOf(metadata));
+  }
+
+  @Override
+  public boolean namespaceExists(Namespace namespace) {
+    return namespaceDb.containsKey(namespace);
+  }
+
+  @Override
+  public boolean dropNamespace(Namespace namespace) throws NamespaceNotEmptyException {
+    if (!namespaceExists(namespace)) {
+      return false;
+    }
+
+    List<TableIdentifier> tableIdentifiers = listTables(namespace);
+    if (!tableIdentifiers.isEmpty()) {
+      throw new NamespaceNotEmptyException(
+          "Namespace %s is not empty. Contains %d table(s).", namespace, tableIdentifiers.size());
+    }
+
+    return namespaceDb.remove(namespace) != null;
+  }
+
+  @Override
+  public boolean setProperties(Namespace namespace, Map<String, String> properties) throws NoSuchNamespaceException {
+    if (!namespaceExists(namespace)) {
+      throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);
+    }
+
+    namespaceDb.compute(namespace, (k, v) -> {
+      if (v == null) {
+        throw new IllegalStateException("Namespace does not exist: " + namespace);
+      } else {
+        Map<String, String> newProperties = Maps.newHashMap(v);
+        newProperties.putAll(properties);
+        return newProperties;
+      }
+    });
+
+    return true;
+  }
+
+  @Override
+  public boolean removeProperties(Namespace namespace, Set<String> properties) throws NoSuchNamespaceException {
+    if (!namespaceExists(namespace)) {
+      throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);
+    }
+
+    namespaceDb.compute(namespace, (k, v) -> {
+      if (v == null) {
+        throw new IllegalStateException("Namespace does not exist: " + namespace);
+      } else {
+        Map<String, String> newProperties = Maps.newHashMap(v);
+        properties.forEach(newProperties::remove);
+        return newProperties;
+      }
+    });
+
+    return true;
+  }
+
+  @Override
+  public Map<String, String> loadNamespaceMetadata(Namespace namespace) throws NoSuchNamespaceException {
+    Map<String, String> properties = namespaceDb.get(namespace);
+    if (properties == null) {
+      throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);
+    }
+
+    return Maps.newHashMap(properties);
+  }
+
+  @Override
+  public List<Namespace> listNamespaces() {
+    return namespaceDb.keySet().stream()
+        .filter(n -> !n.isEmpty())
+        .map(n -> n.level(0))
+        .distinct()
+        .sorted()
+        .map(Namespace::of)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<Namespace> listNamespaces(Namespace namespace) throws NoSuchNamespaceException {
+    final String searchNamespaceString = namespace.isEmpty() ? "" : DOT.join(namespace.levels()) + ".";
+    final int searchNumberOfLevels = namespace.levels().length;
+
+    List<Namespace> filteredNamespaces = namespaceDb.keySet().stream()
+        .filter(n -> DOT.join(n.levels()).startsWith(searchNamespaceString))
+        .collect(Collectors.toList());
+
+    // If the namespace does not exist and the namespace is not a prefix of another namespace,
+    // throw an exception.
+    if (!namespaceDb.containsKey(namespace) && filteredNamespaces.isEmpty()) {
+      throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);
+    }
+
+    return filteredNamespaces.stream()
+        // List only the child-namespaces roots.
+        .map(n -> Namespace.of(Arrays.copyOf(n.levels(), searchNumberOfLevels + 1)))
+        .distinct()
+        .sorted(Comparator.comparing(n -> DOT.join(n.levels())))
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public void close() throws IOException {
+    namespaceDb.clear();
+    tableDb.clear();
+  }
+
+  private class InMemoryTableOperations extends BaseMetastoreTableOperations {
+
+    private final FileIO fileIO;
+    private final TableIdentifier tableIdentifier;
+
+    InMemoryTableOperations(FileIO fileIO, TableIdentifier tableIdentifier) {
+      this.fileIO = fileIO;
+      this.tableIdentifier = tableIdentifier;
+    }
+
+    @Override
+    public void doRefresh() {
+      String latestLocation = tableDb.get(tableIdentifier);
+      if (latestLocation == null) {
+        disableRefresh();
+      } else {
+        refreshFromMetadataLocation(latestLocation);
+      }
+    }
+
+    @Override
+    public void doCommit(TableMetadata base, TableMetadata metadata) {
+      // Create namespace automatically if it does not exist.
+      // This is needed to handle transactions.
+      if (!namespaceExists(tableIdentifier.namespace())) {
+        createNamespace(tableIdentifier.namespace());
+      }
+
+      // Commit the table.
+      String newLocation = writeNewMetadata(metadata, currentVersion() + 1);
+      String oldLocation = base == null ? null : base.metadataFileLocation();
+
+      tableDb.compute(tableIdentifier, (k, existingLocation) -> {
+        if (!Objects.equal(existingLocation, oldLocation)) {
+          throw new CommitFailedException("Cannot create/update table %s metadata location from %s to %s" +
+              " because it has been concurrently modified to %s",
+              tableIdentifier, oldLocation, newLocation, existingLocation);
+        }
+        return newLocation;
+      });
+    }
+
+    @Override
+    public FileIO io() {
+      return fileIO;
+    }
+
+    @Override
+    protected String tableName() {
+      return tableIdentifier.toString();
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/io/inmemory/InMemoryFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/io/inmemory/InMemoryFileIO.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io.inmemory;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.EOFException;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.PositionOutputStream;
+import org.apache.iceberg.io.SeekableInputStream;
+
+/**
+ * FileIO implementation backed by in-memory data-structures.
+ * This class doesn't touch external resources and
+ * can be utilized to write unit tests without side effects.
+ * Locations can any string supported by the {@link InMemoryFileStore}.
+ */
+public final class InMemoryFileIO implements FileIO {
+
+  private final InMemoryFileStore store;
+
+  public InMemoryFileIO() {
+    store = new InMemoryFileStore();
+  }
+
+  InMemoryFileStore getStore() {
+    return store;
+  }
+
+  @Override
+  public InputFile newInputFile(String path) {
+    return new InMemoryInputFile(path);
+  }
+
+  @Override
+  public OutputFile newOutputFile(String path) {
+    return new InMemoryOutputFile(path);
+  }
+
+  @Override
+  public void deleteFile(String path) {
+    if (!store.remove(path)) {
+      throw new IllegalArgumentException("Location: " + path + " does not exist!");
+    }
+  }
+
+  private class InMemoryInputFile implements InputFile {
+
+    private final String location;
+
+    InMemoryInputFile(String location) {
+      this.location = location;
+    }
+
+    @Override
+    public long getLength() {
+      return getDataOrThrow().remaining();
+    }
+
+    @Override
+    public SeekableInputStream newStream() {
+      return new InMemoryInputStream(getDataOrThrow().duplicate());
+    }
+
+    private ByteBuffer getDataOrThrow() {
+      return store.get(location).orElseThrow(
+        () -> new UncheckedIOException(new FileNotFoundException("Cannot find file, does not exist: " + location))
+      );
+    }
+
+    @Override
+    public String location() {
+      return location;
+    }
+
+    @Override
+    public boolean exists() {
+      return store.exists(location);
+    }
+  }
+
+  private class InMemoryOutputFile implements OutputFile {
+
+    private final String location;
+
+    InMemoryOutputFile(String location) {
+      this.location = location;
+    }
+
+    @Override
+    public PositionOutputStream create() {
+      if (store.exists(location)) {
+        throw new UncheckedIOException(new IOException("Cannot create file, already exists: " + location));
+      }
+
+      return new InMemoryOutputStream(location);
+    }
+
+    @Override
+    public PositionOutputStream createOrOverwrite() {
+      return new InMemoryOutputStream(location);
+    }
+
+    @Override
+    public String location() {
+      return location;
+    }
+
+    @Override
+    public InputFile toInputFile() {
+      return new InMemoryInputFile(location);
+    }
+  }
+
+  private static class SeekableByteArrayInputStream extends ByteArrayInputStream {
+
+    SeekableByteArrayInputStream(byte[] buf) {
+      super(buf);
+    }
+
+    void seek(long newPos) {
+      reset();
+      long actuallySkipped = skip(newPos);
+      if (actuallySkipped < newPos) {
+        throw new UncheckedIOException(new EOFException("Cannot seek to position: " + newPos + ", EOF reached"));
+      }
+    }
+
+    @Override
+    public void mark(int readAheadLimit) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean markSupported() {
+      return false;
+    }
+
+    long position() {
+      return pos;
+    }
+  }
+
+  private static class InMemoryInputStream extends SeekableInputStream {
+
+    private final SeekableByteArrayInputStream inputStream;
+
+    InMemoryInputStream(ByteBuffer buffer) {
+      byte[] bytes = new byte[buffer.remaining()];
+      buffer.get(bytes);
+      this.inputStream = new SeekableByteArrayInputStream(bytes);
+    }
+
+    @Override
+    public long getPos() throws IOException {
+      return inputStream.position();
+    }
+
+    @Override
+    public void seek(long newPos) {
+      inputStream.seek(newPos);
+    }
+
+    @Override
+    public int read() throws IOException {
+      return inputStream.read();
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+      return inputStream.read(b, off, len);
+    }
+
+    @Override
+    public void close() throws IOException {
+      inputStream.close();
+    }
+  }
+
+  private class InMemoryOutputStream extends PositionOutputStream {
+
+    private final String location;
+    private final ByteArrayOutputStream outputStream;
+
+    InMemoryOutputStream(String location) {
+      this.location = location;
+      this.outputStream = new ByteArrayOutputStream();
+    }
+
+    @Override
+    public long getPos() throws IOException {
+      return outputStream.size();
+    }
+
+    @Override
+    public void flush() throws IOException {
+    }
+
+    @Override
+    public void write(int i) throws IOException {
+      outputStream.write(i);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+      outputStream.write(b, off, len);
+    }
+
+    @Override
+    public void close() throws IOException {
+      outputStream.close();
+      store.put(location, ByteBuffer.wrap(outputStream.toByteArray()));
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/io/inmemory/InMemoryFileStore.java
+++ b/core/src/main/java/org/apache/iceberg/io/inmemory/InMemoryFileStore.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io.inmemory;
+
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * An in-memory collection based storage for file contents
+ * keyed by a string location.
+ */
+class InMemoryFileStore {
+
+  private final ConcurrentMap<String, byte[]> store;
+
+  InMemoryFileStore() {
+    this.store = new ConcurrentHashMap<>();
+  }
+
+  /**
+   * Put the file contents at the given location, overwrite if it already exists.
+   */
+  public void put(String location, ByteBuffer data) {
+    // Copy the contents and store it.
+    byte[] bytes = new byte[data.remaining()];
+    data.get(bytes);
+    store.put(location, bytes);
+  }
+
+  /**
+   * Get the file contents for the given location.
+   */
+  public Optional<ByteBuffer> get(String location) {
+    return Optional.ofNullable(store.get(location)).map(bytes -> {
+      // Copy the contents and return it.
+      byte[] copy = new byte[bytes.length];
+      System.arraycopy(bytes, 0, copy, 0, bytes.length);
+      return ByteBuffer.wrap(copy);
+    });
+  }
+
+  /**
+   * Remove the given location and its contents.
+   */
+  public boolean remove(String location) {
+    return store.remove(location) != null;
+  }
+
+  /**
+   * Check whether the location exists.
+   */
+  public boolean exists(String location) {
+    return store.containsKey(location);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/hadoop/CommonCatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/CommonCatalogTests.java
@@ -1,0 +1,443 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.hadoop;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.Transaction;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
+import org.apache.iceberg.exceptions.NoSuchNamespaceException;
+import org.apache.iceberg.io.inmemory.InMemoryCatalog;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.transforms.Transform;
+import org.apache.iceberg.transforms.Transforms;
+import org.apache.iceberg.types.Types;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.apache.iceberg.NullOrder.NULLS_FIRST;
+import static org.apache.iceberg.SortDirection.ASC;
+
+/**
+ * Common tests for the Iceberg catalog.
+ * The tests expect the catalog to support namespaces.
+ * <p>
+ * Currently, the following catalogs are tested:
+ * <ol>
+ *   <li>{@link HadoopCatalog}</li>
+ *   <li>{@link InMemoryCatalog}</li>
+ * </ol>
+ * Catalog specific tests should be tested in a separate test,
+ * e.g. {@link TestHadoopCatalog}.
+ */
+@RunWith(Parameterized.class)
+public class CommonCatalogTests extends HadoopTableTestBase {
+
+  private enum CatalogFactory {
+    HADOOP("hadoop"),
+    IN_MEMORY("mem");
+
+    private final String catalogName;
+
+    CatalogFactory(String catalogName) {
+      this.catalogName = catalogName;
+    }
+
+    public String catalogName() {
+      return catalogName;
+    }
+  }
+
+  @Parameterized.Parameters(name = "catalogFactory = {0}")
+  public static Object[][] parameters() {
+    return new Object[][] { {CatalogFactory.HADOOP}, {CatalogFactory.IN_MEMORY} };
+  }
+
+  private final CatalogFactory catalogFactory;
+
+  public CommonCatalogTests(CatalogFactory catalogFactory) {
+    this.catalogFactory = catalogFactory;
+  }
+
+  private Catalog catalog() throws IOException {
+    switch (catalogFactory) {
+      case HADOOP: return hadoopCatalog();
+      case IN_MEMORY: {
+        Catalog catalog = new InMemoryCatalog();
+        catalog.initialize("mem", ImmutableMap.of(CatalogProperties.WAREHOUSE_LOCATION,
+            temp.newFolder().getAbsolutePath()));
+        return catalog;
+      }
+      default:
+        throw new IllegalStateException("Unsupported catalog factory: " + catalogFactory);
+    }
+  }
+
+  @Test
+  public void testCreateTableBuilder() throws Exception {
+    TableIdentifier tableIdent = TableIdentifier.of("db", "ns1", "ns2", "tbl");
+    Table table = catalog().buildTable(tableIdent, SCHEMA)
+        .withPartitionSpec(SPEC)
+        .withProperties(null)
+        .withProperty("key1", "value1")
+        .withProperties(ImmutableMap.of("key2", "value2"))
+        .create();
+
+    Assert.assertEquals(TABLE_SCHEMA.toString(), table.schema().toString());
+    Assert.assertEquals(1, table.spec().fields().size());
+    Assert.assertEquals("value1", table.properties().get("key1"));
+    Assert.assertEquals("value2", table.properties().get("key2"));
+  }
+
+  @Test
+  public void testCreateTableTxnBuilder() throws Exception {
+    Catalog catalog = catalog();
+    TableIdentifier tableIdent = TableIdentifier.of("db", "ns1", "ns2", "tbl");
+    Transaction txn = catalog.buildTable(tableIdent, SCHEMA)
+        .withPartitionSpec(null)
+        .createTransaction();
+    txn.commitTransaction();
+    Table table = catalog.loadTable(tableIdent);
+
+    Assert.assertEquals(TABLE_SCHEMA.toString(), table.schema().toString());
+    Assert.assertTrue(table.spec().isUnpartitioned());
+  }
+
+  @Test
+  public void testReplaceTxnBuilder() throws Exception {
+    Catalog catalog = catalog();
+    TableIdentifier tableIdent = TableIdentifier.of("db", "ns1", "ns2", "tbl");
+
+    Transaction createTxn = catalog.buildTable(tableIdent, SCHEMA)
+        .withPartitionSpec(SPEC)
+        .withProperty("key1", "value1")
+        .createOrReplaceTransaction();
+
+    createTxn.newAppend()
+        .appendFile(FILE_A)
+        .commit();
+
+    createTxn.commitTransaction();
+
+    Table table = catalog.loadTable(tableIdent);
+    Assert.assertNotNull(table.currentSnapshot());
+
+    Transaction replaceTxn = catalog.buildTable(tableIdent, SCHEMA)
+        .withProperty("key2", "value2")
+        .replaceTransaction();
+    replaceTxn.commitTransaction();
+
+    table = catalog.loadTable(tableIdent);
+    Assert.assertNull(table.currentSnapshot());
+    PartitionSpec v1Expected = PartitionSpec.builderFor(table.schema())
+        .alwaysNull("data", "data_bucket")
+        .withSpecId(1)
+        .build();
+    Assert.assertEquals("Table should have a spec with one void field",
+        v1Expected, table.spec());
+
+    Assert.assertEquals("value1", table.properties().get("key1"));
+    Assert.assertEquals("value2", table.properties().get("key2"));
+  }
+
+  @Test
+  public void testCreateTableDefaultSortOrder() throws Exception {
+    TableIdentifier tableIdent = TableIdentifier.of("db", "ns1", "ns2", "tbl");
+    Table table = catalog().createTable(tableIdent, SCHEMA, SPEC);
+
+    SortOrder sortOrder = table.sortOrder();
+    Assert.assertEquals("Order ID must match", 0, sortOrder.orderId());
+    Assert.assertTrue("Order must unsorted", sortOrder.isUnsorted());
+  }
+
+  @Test
+  public void testCreateTableCustomSortOrder() throws Exception {
+    TableIdentifier tableIdent = TableIdentifier.of("db", "ns1", "ns2", "tbl");
+    SortOrder order = SortOrder.builderFor(SCHEMA)
+        .asc("id", NULLS_FIRST)
+        .build();
+    Table table = catalog().buildTable(tableIdent, SCHEMA)
+        .withPartitionSpec(SPEC)
+        .withSortOrder(order)
+        .create();
+
+    SortOrder sortOrder = table.sortOrder();
+    Assert.assertEquals("Order ID must match", 1, sortOrder.orderId());
+    Assert.assertEquals("Order must have 1 field", 1, sortOrder.fields().size());
+    Assert.assertEquals("Direction must match ", ASC, sortOrder.fields().get(0).direction());
+    Assert.assertEquals("Null order must match ", NULLS_FIRST, sortOrder.fields().get(0).nullOrder());
+    Transform<?, ?> transform = Transforms.identity(Types.IntegerType.get());
+    Assert.assertEquals("Transform must match", transform, sortOrder.fields().get(0).transform());
+  }
+
+  @Test
+  public void testBasicCatalog() throws Exception {
+    Catalog catalog = catalog();
+    TableIdentifier testTable = TableIdentifier.of("db", "ns1", "ns2", "tbl");
+    catalog.createTable(testTable, SCHEMA, PartitionSpec.unpartitioned());
+    Assert.assertTrue(catalog.tableExists(testTable));
+  }
+
+  @Test
+  public void testCreateAndDropTableWithoutNamespace() throws Exception {
+    Catalog catalog = catalog();
+
+    TableIdentifier testTable = TableIdentifier.of("tbl");
+    Table table = catalog.createTable(testTable, SCHEMA, PartitionSpec.unpartitioned());
+
+    Assert.assertEquals(table.schema().toString(), TABLE_SCHEMA.toString());
+    Assert.assertEquals(catalogFactory.catalogName() + ".tbl", table.name());
+    Assert.assertTrue(catalog.tableExists(testTable));
+
+    catalog.dropTable(testTable);
+    Assert.assertFalse(catalog.tableExists(testTable));
+  }
+
+  @Test
+  public void testDropTable() throws Exception {
+    Catalog catalog = catalog();
+    TableIdentifier testTable = TableIdentifier.of("db", "ns1", "ns2", "tbl");
+    catalog.createTable(testTable, SCHEMA, PartitionSpec.unpartitioned());
+    Assert.assertTrue(catalog.tableExists(testTable));
+
+    catalog.dropTable(testTable);
+    Assert.assertFalse(catalog.tableExists(testTable));
+  }
+
+  @Test
+  public void testDropNonIcebergTable() throws Exception {
+    Catalog catalog = catalog();
+    TableIdentifier testTable = TableIdentifier.of("db", "ns1", "ns2", "tbl");
+    Assert.assertFalse(catalog.dropTable(testTable));
+  }
+
+  @Test
+  public void testListTables() throws Exception {
+    Catalog catalog = catalog();
+
+    TableIdentifier tbl1 = TableIdentifier.of("db", "tbl1");
+    TableIdentifier tbl2 = TableIdentifier.of("db", "tbl2");
+    TableIdentifier tbl3 = TableIdentifier.of("db", "ns1", "tbl3");
+    TableIdentifier tbl4 = TableIdentifier.of("db", "metadata", "metadata");
+
+    Lists.newArrayList(tbl1, tbl2, tbl3, tbl4).forEach(t ->
+        catalog.createTable(t, SCHEMA, PartitionSpec.unpartitioned())
+    );
+
+    List<TableIdentifier> tbls1 = catalog.listTables(Namespace.of("db"));
+    Set<String> tblSet = Sets.newHashSet(tbls1.stream().map(t -> t.name()).iterator());
+    Assert.assertEquals(2, tblSet.size());
+    Assert.assertTrue(tblSet.contains("tbl1"));
+    Assert.assertTrue(tblSet.contains("tbl2"));
+
+    List<TableIdentifier> tbls2 = catalog.listTables(Namespace.of("db", "ns1"));
+    Assert.assertEquals("table identifiers", 1, tbls2.size());
+    Assert.assertEquals("table name", "tbl3", tbls2.get(0).name());
+
+    AssertHelpers.assertThrows("should throw exception", NoSuchNamespaceException.class,
+        "Namespace does not exist: ", () -> {
+        catalog.listTables(Namespace.of("db", "ns1", "ns2"));
+      });
+  }
+
+  @Test
+  public void testCallingLocationProviderWhenNoCurrentMetadata() throws IOException {
+    Catalog catalog = catalog();
+
+    TableIdentifier tableIdent = TableIdentifier.of("ns1", "ns2", "table1");
+    Transaction create = catalog.newCreateTableTransaction(tableIdent, SCHEMA);
+    create.table().locationProvider();  // NPE triggered if not handled appropriately
+    create.commitTransaction();
+
+    Assert.assertEquals("1 table expected", 1, catalog.listTables(Namespace.of("ns1", "ns2")).size());
+    catalog.dropTable(tableIdent, true);
+  }
+
+  @Test
+  public void testCreateNamespace() throws Exception {
+    Catalog catalog = catalog();
+    SupportsNamespaces catalogWithNamespaceSupport = castToSupportsNamespaces(catalog);
+
+    TableIdentifier tbl1 = TableIdentifier.of("db", "ns1", "ns2", "metadata");
+    TableIdentifier tbl2 = TableIdentifier.of("db", "ns2", "ns3", "tbl2");
+
+    Lists.newArrayList(tbl1, tbl2).forEach(t ->
+        catalogWithNamespaceSupport.createNamespace(t.namespace(), ImmutableMap.of())
+    );
+
+    Assert.assertTrue(catalogWithNamespaceSupport.namespaceExists(tbl1.namespace()));
+
+    AssertHelpers.assertThrows("Should fail to create when namespace already exist: " + tbl1.namespace(),
+        org.apache.iceberg.exceptions.AlreadyExistsException.class,
+        "Namespace already exists: " + tbl1.namespace(), () -> {
+          catalogWithNamespaceSupport.createNamespace(tbl1.namespace());
+        });
+  }
+
+  @Test
+  public void testListNamespace() throws Exception {
+    Catalog catalog = catalog();
+    SupportsNamespaces catalogWithNamespaceSupport = castToSupportsNamespaces(catalog);
+
+    TableIdentifier tbl1 = TableIdentifier.of("db", "ns1", "ns2", "metadata");
+    TableIdentifier tbl2 = TableIdentifier.of("db", "ns2", "ns3", "tbl2");
+    TableIdentifier tbl3 = TableIdentifier.of("db", "ns3", "tbl4");
+    TableIdentifier tbl4 = TableIdentifier.of("db", "metadata");
+    TableIdentifier tbl5 = TableIdentifier.of("db2", "metadata");
+
+    Lists.newArrayList(tbl1, tbl2, tbl3, tbl4, tbl5).forEach(t ->
+        catalog.createTable(t, SCHEMA, PartitionSpec.unpartitioned())
+    );
+
+    List<Namespace> nsp1 = catalogWithNamespaceSupport.listNamespaces(Namespace.of("db"));
+    Set<String> tblSet = Sets.newHashSet(nsp1.stream().map(t -> t.toString()).iterator());
+    Assert.assertEquals(3, tblSet.size());
+    Assert.assertTrue(tblSet.contains("db.ns1"));
+    Assert.assertTrue(tblSet.contains("db.ns2"));
+    Assert.assertTrue(tblSet.contains("db.ns3"));
+
+    List<Namespace> nsp2 = catalogWithNamespaceSupport.listNamespaces(Namespace.of("db", "ns1"));
+    Assert.assertEquals(1, nsp2.size());
+    Assert.assertTrue(nsp2.get(0).toString().equals("db.ns1.ns2"));
+
+    List<Namespace> nsp3 = catalogWithNamespaceSupport.listNamespaces();
+    Set<String> tblSet2 = Sets.newHashSet(nsp3.stream().map(t -> t.toString()).iterator());
+    Assert.assertEquals(2, tblSet2.size());
+    Assert.assertTrue(tblSet2.contains("db"));
+    Assert.assertTrue(tblSet2.contains("db2"));
+
+    List<Namespace> nsp4 = catalogWithNamespaceSupport.listNamespaces();
+    Set<String> tblSet3 = Sets.newHashSet(nsp4.stream().map(t -> t.toString()).iterator());
+    Assert.assertEquals(2, tblSet3.size());
+    Assert.assertTrue(tblSet3.contains("db"));
+    Assert.assertTrue(tblSet3.contains("db2"));
+
+    AssertHelpers.assertThrows("Should fail to list namespace doesn't exist", NoSuchNamespaceException.class,
+        "Namespace does not exist: ", () -> {
+          catalogWithNamespaceSupport.listNamespaces(Namespace.of("db", "db2", "ns2"));
+        });
+  }
+
+  @Test
+  public void testLoadNamespaceMeta() throws IOException {
+    Catalog catalog = catalog();
+    SupportsNamespaces catalogWithNamespaceSupport = castToSupportsNamespaces(catalog);
+
+    TableIdentifier tbl1 = TableIdentifier.of("db", "ns1", "ns2", "metadata");
+    TableIdentifier tbl2 = TableIdentifier.of("db", "ns2", "ns3", "tbl2");
+    TableIdentifier tbl3 = TableIdentifier.of("db", "ns3", "tbl4");
+    TableIdentifier tbl4 = TableIdentifier.of("db", "metadata");
+
+    Lists.newArrayList(tbl1, tbl2, tbl3, tbl4).forEach(t ->
+        catalog.createTable(t, SCHEMA, PartitionSpec.unpartitioned())
+    );
+    catalogWithNamespaceSupport.loadNamespaceMetadata(Namespace.of("db"));
+
+    AssertHelpers.assertThrows("Should fail to load namespace doesn't exist", NoSuchNamespaceException.class,
+        "Namespace does not exist: ", () -> {
+          catalogWithNamespaceSupport.loadNamespaceMetadata(Namespace.of("db", "db2", "ns2"));
+        });
+  }
+
+  @Test
+  public void testNamespaceExists() throws IOException {
+    Catalog catalog = catalog();
+    SupportsNamespaces catalogWithNamespaceSupport = castToSupportsNamespaces(catalog);
+
+    TableIdentifier tbl1 = TableIdentifier.of("db", "ns1", "ns2", "metadata");
+    TableIdentifier tbl2 = TableIdentifier.of("db", "ns2", "ns3", "tbl2");
+    TableIdentifier tbl3 = TableIdentifier.of("db", "ns3", "tbl4");
+    TableIdentifier tbl4 = TableIdentifier.of("db", "metadata");
+
+    Lists.newArrayList(tbl1, tbl2, tbl3, tbl4).forEach(t ->
+        catalog.createTable(t, SCHEMA, PartitionSpec.unpartitioned())
+    );
+    Assert.assertTrue("Should true to namespace exist",
+        catalogWithNamespaceSupport.namespaceExists(Namespace.of("db", "ns1", "ns2")));
+    Assert.assertTrue("Should false to namespace doesn't exist",
+        !catalogWithNamespaceSupport.namespaceExists(Namespace.of("db", "db2", "ns2")));
+  }
+
+  @Test
+  public void testDropNamespace() throws IOException {
+    Catalog catalog = catalog();
+    SupportsNamespaces catalogWithNamespaceSupport = castToSupportsNamespaces(catalog);
+    Namespace namespace1 = Namespace.of("db");
+    Namespace namespace2 = Namespace.of("db", "ns1");
+
+    TableIdentifier tbl1 = TableIdentifier.of(namespace1, "tbl1");
+    TableIdentifier tbl2 = TableIdentifier.of(namespace2, "tbl1");
+
+    Lists.newArrayList(tbl1, tbl2).forEach(t ->
+        catalog.createTable(t, SCHEMA, PartitionSpec.unpartitioned())
+    );
+
+    AssertHelpers.assertThrows("Should fail to drop namespace is not empty " + namespace1,
+        NamespaceNotEmptyException.class,
+        "Namespace " + namespace1 + " is not empty.", () -> {
+          catalogWithNamespaceSupport.dropNamespace(Namespace.of("db"));
+        });
+    Assert.assertFalse("Should fail to drop namespace doesn't exist",
+          catalogWithNamespaceSupport.dropNamespace(Namespace.of("db2")));
+    Assert.assertTrue(catalog.dropTable(tbl1));
+    Assert.assertTrue(catalog.dropTable(tbl2));
+    Assert.assertTrue(catalogWithNamespaceSupport.dropNamespace(namespace2));
+    Assert.assertTrue(catalogWithNamespaceSupport.dropNamespace(namespace1));
+  }
+
+  @Test
+  public void testTableName() throws Exception {
+    Catalog catalog = catalog();
+    TableIdentifier tableIdent = TableIdentifier.of("db", "ns1", "ns2", "tbl");
+    catalog.buildTable(tableIdent, SCHEMA)
+        .withPartitionSpec(SPEC)
+        .create();
+
+    Table table = catalog.loadTable(tableIdent);
+    Assert.assertEquals("Name must match", catalogFactory.catalogName() + ".db.ns1.ns2.tbl", table.name());
+
+    TableIdentifier snapshotsTableIdent = TableIdentifier.of("db", "ns1", "ns2", "tbl", "snapshots");
+    Table snapshotsTable = catalog.loadTable(snapshotsTableIdent);
+    Assert.assertEquals("Name must match",
+        catalogFactory.catalogName() + ".db.ns1.ns2.tbl.snapshots", snapshotsTable.name());
+  }
+
+  private SupportsNamespaces castToSupportsNamespaces(Catalog catalog) {
+    if (!(catalog instanceof SupportsNamespaces)) {
+      throw new IllegalArgumentException(
+          String.format("Catalog %s does not implement SupportsNamespaces", catalog.getClass()));
+    }
+    return (SupportsNamespaces) catalog;
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/io/inmemory/InMemoryCatalogTest.java
+++ b/core/src/test/java/org/apache/iceberg/io/inmemory/InMemoryCatalogTest.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io.inmemory;
+
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.hadoop.CommonCatalogTests;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.types.Types.IntegerType;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests specific to {@link InMemoryCatalog}, e.g. rename table, alter namespace properties, etc.
+ * Common catalog tests can be found in {@link CommonCatalogTests}.
+ */
+public class InMemoryCatalogTest {
+
+  private InMemoryCatalog catalog;
+
+  @Before
+  public void before() {
+    catalog = new InMemoryCatalog();
+    catalog.initialize("in-memory-catalog", ImmutableMap.of());
+  }
+
+  @Test
+  public void testSetProperties() {
+    Namespace namespace = Namespace.of("a");
+
+    // Create a namespace with properties: {'k1': 'v1', 'k2': 'v2'}
+    catalog.createNamespace(namespace, ImmutableMap.of("k1", "v1", "k2", "v2"));
+    // Verify the properties
+    assertEquals(ImmutableMap.of("k1", "v1", "k2", "v2"), catalog.loadNamespaceMetadata(namespace));
+
+    // Set properties such that 'k1' is overwritten and a new key 'k3' is added.
+    catalog.setProperties(namespace, ImmutableMap.of("k1", "v1'", "k3", "v3"));
+    // Verify the result of set properties.
+    assertEquals(ImmutableMap.of("k1", "v1'", "k2", "v2", "k3", "v3"), catalog.loadNamespaceMetadata(namespace));
+  }
+
+  @Test
+  public void testRemoveProperties() {
+    Namespace namespace = Namespace.of("a");
+
+    // Create a namespace with properties: {'k1': 'v1', 'k2': 'v2'}
+    catalog.createNamespace(namespace, ImmutableMap.of("k1", "v1", "k2", "v2"));
+    // Verify the properties
+    assertEquals(ImmutableMap.of("k1", "v1", "k2", "v2"), catalog.loadNamespaceMetadata(namespace));
+
+    // Remove properties 'k1'
+    catalog.removeProperties(namespace, ImmutableSet.of("k1", "k3"));
+    // Verify the result of set properties.
+    assertEquals(ImmutableMap.of("k2", "v2"), catalog.loadNamespaceMetadata(namespace));
+  }
+
+  @Test
+  public void testCreateTable() {
+    TableIdentifier tableIdentifier = TableIdentifier.of("db1", "table1");
+
+    // Verify table does not already exist
+    assertFalse(catalog.tableExists(tableIdentifier));
+
+    // Create table
+    catalog.createTable(tableIdentifier, new Schema());
+
+    // Verify table exists now and can be loaded
+    assertTrue(catalog.tableExists(tableIdentifier));
+    assertNotNull(catalog.loadTable(tableIdentifier));
+  }
+
+  @Test
+  public void testAlterTable() {
+    TableIdentifier tableIdentifier = TableIdentifier.of("db1", "table1");
+
+    // Create table
+    catalog.createTable(tableIdentifier, new Schema());
+    Table table = catalog.loadTable(tableIdentifier);
+    assertTrue(table.schema().columns().isEmpty());
+
+    // Alter the schema and verify updated schema
+    table.updateSchema().addColumn("column", IntegerType.get()).commit();
+    Table alteredTable = catalog.loadTable(tableIdentifier);
+    assertEquals(1, alteredTable.schema().columns().size());
+    assertEquals(ImmutableList.of(Types.NestedField.of(1, true, "column", IntegerType.get())),
+        alteredTable.schema().columns());
+  }
+
+  @Test
+  public void testDropTable_doesNotExist() {
+    assertFalse(catalog.dropTable(TableIdentifier.of("db1", "table1"), false));
+    assertFalse(catalog.dropTable(TableIdentifier.of("db1", "table1"), true));
+  }
+
+  @Test
+  public void testRenameTable() {
+    TableIdentifier fromTableIdentifier = TableIdentifier.of("db1", "table1");
+    TableIdentifier toTableIdentifier = TableIdentifier.of("db1", "table2");
+
+    // Verify that either table does not exist
+    assertFalse(catalog.tableExists(fromTableIdentifier));
+    assertFalse(catalog.tableExists(toTableIdentifier));
+
+    // Create table 'from'
+    catalog.createTable(fromTableIdentifier, new Schema());
+
+    // Verify that 'db1.table1' exists and 'db1.table2' does not
+    assertTrue(catalog.tableExists(fromTableIdentifier));
+    assertFalse(catalog.tableExists(toTableIdentifier));
+
+    // Rename table 'db1.table1' -> 'db1.table2'
+    catalog.renameTable(fromTableIdentifier, toTableIdentifier);
+
+    // Verify that rename worked
+    assertFalse(catalog.tableExists(fromTableIdentifier));
+    assertTrue(catalog.tableExists(toTableIdentifier));
+  }
+
+  @Test
+  public void testRenameTable_fromDoesNotExist() {
+    TableIdentifier fromTableIdentifier = TableIdentifier.of("db1", "table1");
+    TableIdentifier toTableIdentifier = TableIdentifier.of("db2", "table2");
+
+    catalog.createNamespace(Namespace.of("db2"));
+
+    // Rename should fail because 'db1.table1' does not exist
+    AssertHelpers.assertThrows(
+        "Renaming a table that does not exist should fail",
+        NoSuchTableException.class,
+        "Cannot rename db1.table1 to db2.table2 because the table db1.table1 does not exist",
+        () -> catalog.renameTable(fromTableIdentifier, toTableIdentifier));
+  }
+
+  @Test
+  public void testRenameTable_toAlreadyExists() {
+    TableIdentifier fromTableIdentifier = TableIdentifier.of("db1", "table1");
+    TableIdentifier toTableIdentifier = TableIdentifier.of("db2", "table2");
+
+    // Create both 'db1.table1' and 'db1.table2'
+    catalog.createTable(fromTableIdentifier, new Schema());
+    catalog.createTable(toTableIdentifier, new Schema());
+
+    // Rename should fail because 'db2.table2' already exists
+    AssertHelpers.assertThrows(
+        "Renaming a table to an existing table should fail",
+        AlreadyExistsException.class,
+        "Cannot rename db1.table1 to db2.table2 because the table db2.table2 already exists",
+        () -> catalog.renameTable(fromTableIdentifier, toTableIdentifier));
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/io/inmemory/InMemoryFileIOTest.java
+++ b/core/src/test/java/org/apache/iceberg/io/inmemory/InMemoryFileIOTest.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.io.inmemory;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.stream.IntStream;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.PositionOutputStream;
+import org.apache.iceberg.io.SeekableInputStream;
+import org.junit.Before;
+import org.junit.Test;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class InMemoryFileIOTest {
+
+  private InMemoryFileIO fileIO;
+  private InMemoryFileStore store;
+
+  @Before
+  public void before() {
+    fileIO = new InMemoryFileIO();
+    store = fileIO.getStore();
+  }
+
+  @Test
+  public void testGetStore() {
+    assertNotNull(store);
+  }
+
+  @Test
+  public void testDeleteFile() {
+    assertFalse(store.exists("file1"));
+
+    // Create the file
+    store.put("file1", ByteBuffer.wrap(new byte[0]));
+    assertTrue(store.exists("file1"));
+
+    // Delete the file
+    fileIO.deleteFile("file1");
+    // Verify that the file has been deleted
+    assertFalse(store.exists("file1"));
+  }
+
+  @Test
+  public void testNewInputFile() throws IOException {
+    String fileName = "file1";
+
+    store.put(fileName, ByteBuffer.wrap("data1".getBytes(UTF_8)));
+
+    InputFile inputFile = fileIO.newInputFile(fileName);
+    assertNotNull(inputFile);
+
+    assertTrue(inputFile.exists());
+    assertEquals(fileName, inputFile.location());
+    assertEquals(5, inputFile.getLength());
+
+    SeekableInputStream inputStream = inputFile.newStream();
+    assertNotNull(inputStream);
+
+    // Test read()
+    assertEquals(0, inputStream.getPos());
+    assertEquals('d', inputStream.read());
+
+    // Test read(byte[], index, len)
+    byte[] dataRead = new byte[3];
+    assertEquals(2, inputStream.read(dataRead, 0, 2));
+    assertEquals("at", new String(dataRead, 0, 2, UTF_8));
+
+    inputStream.close();
+  }
+
+  @Test
+  public void testSeek() throws IOException {
+    String fileName = "file1";
+
+    // Number of rows
+    int numRowsInChunk = 10;
+
+    // Emulate parquet file structure
+    ByteBuffer buffer = ByteBuffer.allocate(1024);
+    // Add magic number
+    buffer.put("par1".getBytes(UTF_8));
+    // Add column chunk 1 for int32
+    IntStream.range(0, numRowsInChunk).forEach(buffer::putInt);
+    // Add column chunk 2 for float64
+    IntStream.range(0, numRowsInChunk).forEach(buffer::putDouble);
+    // Add metadata footer (index to the start of chunks)
+    buffer.putInt(4);
+    buffer.putInt(4 + numRowsInChunk * 4);
+    // Add footer size
+    buffer.putInt(8);
+    // Add magic number
+    buffer.put("par1".getBytes(UTF_8));
+
+    // Put the data in the store
+    buffer.flip();
+    store.put(fileName, buffer);
+
+    // magic number, chunk1, chunk2, footer, footer size, magic number
+    int expectedFileSize = 4 + numRowsInChunk * 4 + numRowsInChunk * 8 + 8 + 4 + 4;
+
+    InputFile inputFile = fileIO.newInputFile(fileName);
+    assertNotNull(inputFile);
+
+    // Check file size
+    assertTrue(inputFile.exists());
+    assertEquals(fileName, inputFile.location());
+    assertEquals(expectedFileSize, inputFile.getLength());
+
+    SeekableInputStream inputStream = inputFile.newStream();
+    assertNotNull(inputStream);
+
+    // Seek to footer length
+    inputStream.seek(expectedFileSize - 8);
+
+    // Read and check the footer size
+    byte[] footerSizeBytes = new byte[4];
+    assertEquals(footerSizeBytes.length, inputStream.read(footerSizeBytes));
+    ByteBuffer footerSizeBuffer = ByteBuffer.wrap(footerSizeBytes);
+    int footerSize = footerSizeBuffer.getInt();
+    assertEquals(8, footerSize);
+
+    // Read and check the footer
+    inputStream.seek(expectedFileSize - 8 - footerSize);
+    byte[] footerBytes = new byte[footerSize];
+    assertEquals(footerBytes.length, inputStream.read(footerBytes));
+    ByteBuffer footerBuffer = ByteBuffer.wrap(footerBytes);
+    int chunk1Offset = footerBuffer.getInt();
+    int chunk2Offset = footerBuffer.getInt();
+    assertEquals(4, chunk1Offset);
+    assertEquals(4 + numRowsInChunk * 4, chunk2Offset);
+
+    // Read and check the chunk2
+    inputStream.seek(chunk2Offset);
+    byte[] chunk2Bytes = new byte[8 * numRowsInChunk];
+    assertEquals(chunk2Bytes.length, inputStream.read(chunk2Bytes));
+    ByteBuffer chunk2Buffer = ByteBuffer.wrap(chunk2Bytes);
+    IntStream.range(0, numRowsInChunk).forEach(i -> assertEquals(i, chunk2Buffer.getDouble(), 1e-15));
+
+    // Read and check the chunk1
+    inputStream.seek(chunk1Offset);
+    byte[] chunk1Bytes = new byte[4 * numRowsInChunk];
+    assertEquals(chunk1Bytes.length, inputStream.read(chunk1Bytes));
+    ByteBuffer chunk1Buffer = ByteBuffer.wrap(chunk1Bytes);
+    IntStream.range(0, numRowsInChunk).forEach(i -> assertEquals(i, chunk1Buffer.getInt()));
+
+    inputStream.close();
+  }
+
+  @Test
+  public void testNewOutputFile() throws IOException {
+    String fileName = "file1";
+
+    // Create output file
+    OutputFile outputFile = fileIO.newOutputFile(fileName);
+    assertNotNull(outputFile);
+    assertEquals(fileName, outputFile.location());
+
+    // Create output stream
+    PositionOutputStream outputStream = outputFile.create();
+    assertNotNull(outputStream);
+
+    // Write data to the output stream
+    outputStream.write("data1".getBytes(UTF_8));
+    outputStream.close();
+
+    // Read the data back to check whether it was written.
+    byte[] dataRead = new byte[5];
+    assertEquals(5, outputFile.toInputFile().newStream().read(dataRead));
+    assertEquals("data1", new String(dataRead, UTF_8));
+  }
+}


### PR DESCRIPTION
The purpose of this pr is to create pure in-memory implementations of FileIO and Catalog+SupportsNamespace that can be utilized to write unit tests that don't use external resources such local disk, databases, etc.

The FileIO implementation is backed by in-memory data-structures, specifically, InMemoryFileStore which uses ConcurrentHashMap.
The Catalog implementation uses in-memory data-structures to store the namespaces and tables, specifically InMemoryCatalogDb which uses ConcurrentHashMaps. The InMemoryCatalog uses InMemoryFileIO.

There was an old corrupted (closed) pr ([commit](https://github.com/apache/iceberg/pull/3294/commits/31cab1d7f06cf3439c3ed1fc8a40ae9e1ef36f96)) with this same change.

@rdblue apologies for messing up the old pr. I've created this new pr with the same changes in the commit mentioned above. Could you please take a look again?

@nastra this is the new inmemory catalog pr.

Thanks,
Mayur