### PR TITLE
Docs: refer to multi-engine-support page for engine compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,24 +77,7 @@ This project Iceberg also has modules for adding Iceberg support to processing e
 * `iceberg-mr` contains an InputFormat and other classes for integrating with Apache Hive
 * `iceberg-pig` is an implementation of Pig's LoadFunc API for Iceberg
 
-### Compatibility
+### Engine Compatibility
 
-Iceberg's Spark integration is compatible with Spark using the modules in the following table:
-
-| Iceberg version | Spark 2.4.x           | Spark 3.0.x            | Spark 3.1.x                    | Spark 3.2.x                    |
-| --------------- | --------------------- | ---------------------- | ------------------------------ | ------------------------------ |
-| master branch   | iceberg-spark-runtime | iceberg-spark3-runtime | iceberg-spark-runtime-3.1_2.12 | iceberg-spark-runtime-3.2_2.12 |
-| 0.12.x          | iceberg-spark-runtime | iceberg-spark3-runtime | iceberg-spark-runtime-3.1_2.12 |                                |
-| 0.11.x          | iceberg-spark-runtime | iceberg-spark3-runtime |                                |                                |
-| 0.10.x          | iceberg-spark-runtime | iceberg-spark3-runtime |                                |                                |
-| 0.9.x           | iceberg-spark-runtime | iceberg-spark3-runtime |                                |                                |
-
-Iceberg's Flink integration is compatible with Flink using the modules in the following table:
-
-| Iceberg version | Flink 1.11.x          | Flink 1.12.x               | Flink 1.13.x               | Flink 1.14.x               |
-| --------------- | --------------------- | -------------------------- | -------------------------- | -------------------------- |
-| master branch   |                       | iceberg-flink-runtime-1.12 | iceberg-flink-runtime-1.13 | iceberg-flink-runtime-1.14 |
-| 0.12.x          |                       | iceberg-flink-runtime      |                            |                            |
-| 0.11.x          | iceberg-flink-runtime |                            |                            |                            |
-| 0.10.x          | iceberg-flink-runtime |                            |                            |                            |
-
+See [Multi-Engine Support](https://iceberg.apache.org/multi-engine-support/) page in the Iceberg website to know about Iceberg compatibility with different Spark, Flink and Trino versions.
+For other engines such as Presto and Trino, please visit their websites for Iceberg integration details.


### PR DESCRIPTION
@samredai @rdblue 

Given that we have a page for engine compatibility now in the website, I think it's better to refer to that in README instead of updating different places.