### PR TITLE
[python legacy] skipping required hms host and port when iprot field is presented in conf

### DIFF
--- a/python_legacy/iceberg/hive/hive_tables.py
+++ b/python_legacy/iceberg/hive/hive_tables.py
@@ -71,9 +71,12 @@ class HiveTables(BaseMetastoreTables):
         from urllib.parse import urlparse
         iprot = self.conf.get(HiveTables.IPROT)
         oprot = self.conf.get(HiveTables.OPROT)
-        metastore_uri = urlparse(self.conf[HiveTables.THRIFT_URIS])
-
-        client = hmsclient.HMSClient(iprot=iprot, oprot=oprot, host=metastore_uri.hostname, port=metastore_uri.port)
+        if HiveTables.THRIFT_URIS in self.conf:
+            metastore_uri = urlparse(self.conf[HiveTables.THRIFT_URIS])
+            client = hmsclient.HMSClient(iprot=iprot, oprot=oprot, host=metastore_uri.hostname, port=metastore_uri.port)
+        else:
+            assert iprot is not None, "Error when creating hmsclient, either pass in {} or {}".format(HiveTables.THRIFT_URIS, HiveTables.IPROT)
+            client = hmsclient.HMSClient(iprot=iprot, oprot=oprot, host=None, port=None)
         return client
 
     def drop(self, database: str, table: str, purge: bool = False) -> None:

--- a/python_legacy/iceberg/hive/hive_tables.py
+++ b/python_legacy/iceberg/hive/hive_tables.py
@@ -75,7 +75,8 @@ class HiveTables(BaseMetastoreTables):
             metastore_uri = urlparse(self.conf[HiveTables.THRIFT_URIS])
             client = hmsclient.HMSClient(iprot=iprot, oprot=oprot, host=metastore_uri.hostname, port=metastore_uri.port)
         else:
-            assert iprot is not None, "Error when creating hmsclient, either pass in {} or {}".format(HiveTables.THRIFT_URIS, HiveTables.IPROT)
+            if iprot is None:
+                raise Exception("Error when creating hmsclient, either pass in {} or {}".format(HiveTables.THRIFT_URIS, HiveTables.IPROT))
             client = hmsclient.HMSClient(iprot=iprot, oprot=oprot, host=None, port=None)
         return client
 

--- a/python_legacy/tests/hive/test_hive_tables.py
+++ b/python_legacy/tests/hive/test_hive_tables.py
@@ -28,6 +28,21 @@ from tests.api.test_helpers import MockHMSTable, MockManifest, MockManifestEntry
     MockSnapshot, MockTableOperations
 
 
+@mock.patch("iceberg.hive.hive_tables.hmsclient")
+def test_get_client(mock_hmsclient):
+    conf = {"hive.metastore.uris": 'thrift://hms:123'}
+    tables = HiveTables(conf)
+    tables.get_client()
+    mock_hmsclient.HMSClient.assert_called_with(iprot=None, oprot=None, host="hms", port=123)
+
+    mock_iprot = mock.Mock()
+    mock_oprot = mock.Mock()
+    conf = {HiveTables.IPROT: mock_iprot, HiveTables.OPROT: mock_oprot}
+    tables = HiveTables(conf)
+    tables.get_client()
+    mock_hmsclient.HMSClient.assert_called_with(iprot=mock_iprot, oprot=mock_oprot, host=None, port=None)
+
+
 @mock.patch("iceberg.hive.HiveTableOperations.refresh_from_metadata_location")
 @mock.patch("iceberg.hive.HiveTableOperations.current")
 @mock.patch("iceberg.hive.HiveTables.get_client")


### PR DESCRIPTION
According to https://github.com/gglanzani/hmsclient/blob/master/hmsclient/hmsclient.py#L42 the hms host and port is not used, thus not required, when `iprot` is presented. 

While the current iceberg `get_client()` implementation requires hms host and port to present. This diff is to make such requirement optional when `iprot` is presented in conf. 