### PR TITLE
PyArrowFileIO Implementation

### DIFF
--- a/python/src/iceberg/io/base.py
+++ b/python/src/iceberg/io/base.py
@@ -106,7 +106,11 @@ class InputFile(ABC):
     def open(self) -> InputStream:
         """This method should return an object that matches the InputStream protocol
 
-        If a file does not exist at `self.location`, this should raise a FileNotFoundError.
+        Returns:
+            InputStream: An object that matches the InputStream protocol
+        
+        Raises:
+            FileNotFoundError: If the file at self.location does not exist
         """
 
 
@@ -148,6 +152,12 @@ class OutputFile(ABC):
         Args:
             overwrite(bool): If the file already exists at `self.location`
             and `overwrite` is False a FileExistsError should be raised
+        
+        Returns:
+            OutputStream: An object that matches the OutputStream protocol
+        
+        Raises:
+            FileExistsError: If the file at self.location already exists and `overwrite=False`
         """
 
 

--- a/python/src/iceberg/io/base.py
+++ b/python/src/iceberg/io/base.py
@@ -100,7 +100,7 @@ class InputFile(ABC):
 
     @abstractmethod
     def exists(self) -> bool:
-        """Checks whether the file exists"""
+        """Checks whether the location exists"""
 
     @abstractmethod
     def open(self) -> InputStream:
@@ -135,7 +135,7 @@ class OutputFile(ABC):
 
     @abstractmethod
     def exists(self) -> bool:
-        """Checks whether the file exists"""
+        """Checks whether the location exists"""
 
     @abstractmethod
     def to_input_file(self) -> InputFile:

--- a/python/src/iceberg/io/base.py
+++ b/python/src/iceberg/io/base.py
@@ -76,7 +76,15 @@ class OutputStream(Protocol):  # pragma: no cover
 
 
 class InputFile(ABC):
-    """A base class for InputFile implementations"""
+    """A base class for InputFile implementations
+
+    Args:
+        location(str): The URI to the file
+
+    Attributes:
+        location(str): The URI to the file
+        exists(bool): Whether the file exists or not
+    """
 
     def __init__(self, location: str):
         self._location = location
@@ -104,7 +112,15 @@ class InputFile(ABC):
 
 
 class OutputFile(ABC):
-    """A base class for OutputFile implementations"""
+    """A base class for OutputFile implementations
+
+    Args:
+        location(str): The URI to the file
+
+    Attributes:
+        location(str): The URI to the file
+        exists(bool): Whether the file exists or not
+    """
 
     def __init__(self, location: str):
         self._location = location
@@ -133,7 +149,7 @@ class OutputFile(ABC):
 
         Args:
             overwrite(bool): If the file already exists at `self.location`
-            and `overwrite` is False a FileExistsError should be raised.
+            and `overwrite` is False a FileExistsError should be raised
         """
 
 
@@ -142,12 +158,25 @@ class FileIO(ABC):
 
     @abstractmethod
     def new_input(self, location: str) -> InputFile:
-        """Get an InputFile instance to read bytes from the file at the given location"""
+        """Get an InputFile instance to read bytes from the file at the given location
+
+        Args:
+            location(str): The URI to the file
+        """
 
     @abstractmethod
     def new_output(self, location: str) -> OutputFile:
-        """Get an OutputFile instance to write bytes to the file at the given location"""
+        """Get an OutputFile instance to write bytes to the file at the given location
+
+        Args:
+            location(str): The URI to the file
+        """
 
     @abstractmethod
     def delete(self, location: Union[str, InputFile, OutputFile]) -> None:
-        """Delete the file at the given path"""
+        """Delete the file at the given path
+
+        Args:
+            location(str, InputFile, OutputFile): The URI to the file--if an InputFile instance or an OutputFile instance
+            is provided, the location attribute for that instance is used as the URI to delete
+        """

--- a/python/src/iceberg/io/base.py
+++ b/python/src/iceberg/io/base.py
@@ -98,7 +98,6 @@ class InputFile(ABC):
         """The fully-qualified location of the input file"""
         return self._location
 
-    @property
     @abstractmethod
     def exists(self) -> bool:
         """Checks whether the file exists"""
@@ -134,7 +133,6 @@ class OutputFile(ABC):
         """The fully-qualified location of the output file"""
         return self._location
 
-    @property
     @abstractmethod
     def exists(self) -> bool:
         """Checks whether the file exists"""

--- a/python/src/iceberg/io/base.py
+++ b/python/src/iceberg/io/base.py
@@ -108,7 +108,7 @@ class InputFile(ABC):
 
         Returns:
             InputStream: An object that matches the InputStream protocol
-        
+
         Raises:
             FileNotFoundError: If the file at self.location does not exist
         """
@@ -152,10 +152,10 @@ class OutputFile(ABC):
         Args:
             overwrite(bool): If the file already exists at `self.location`
             and `overwrite` is False a FileExistsError should be raised
-        
+
         Returns:
             OutputStream: An object that matches the OutputStream protocol
-        
+
         Raises:
             FileExistsError: If the file at self.location already exists and `overwrite=False`
         """

--- a/python/src/iceberg/io/base.py
+++ b/python/src/iceberg/io/base.py
@@ -79,10 +79,10 @@ class InputFile(ABC):
     """A base class for InputFile implementations
 
     Args:
-        location(str): The URI to the file
+        location(str): A URI or a path to a local file
 
     Attributes:
-        location(str): The URI to the file
+        location(str): The URI or path to a local file for an InputFile instance
         exists(bool): Whether the file exists or not
     """
 
@@ -115,10 +115,10 @@ class OutputFile(ABC):
     """A base class for OutputFile implementations
 
     Args:
-        location(str): The URI to the file
+        location(str): A URI or a path to a local file
 
     Attributes:
-        location(str): The URI to the file
+        location(str): The URI or path to a local file for an OutputFile instance
         exists(bool): Whether the file exists or not
     """
 
@@ -161,7 +161,7 @@ class FileIO(ABC):
         """Get an InputFile instance to read bytes from the file at the given location
 
         Args:
-            location(str): The URI to the file
+            location(str): A URI or a path to a local file
         """
 
     @abstractmethod
@@ -169,7 +169,7 @@ class FileIO(ABC):
         """Get an OutputFile instance to write bytes to the file at the given location
 
         Args:
-            location(str): The URI to the file
+            location(str): A URI or a path to a local file
         """
 
     @abstractmethod
@@ -177,6 +177,6 @@ class FileIO(ABC):
         """Delete the file at the given path
 
         Args:
-            location(str, InputFile, OutputFile): The URI to the file--if an InputFile instance or an OutputFile instance
-            is provided, the location attribute for that instance is used as the URI to delete
+            location(str, InputFile, OutputFile): A URI or a path to a local file--if an InputFile instance or
+            an OutputFile instance is provided, the location attribute for that instance is used as the URI to delete
         """

--- a/python/src/iceberg/io/base.py
+++ b/python/src/iceberg/io/base.py
@@ -100,7 +100,12 @@ class InputFile(ABC):
 
     @abstractmethod
     def exists(self) -> bool:
-        """Checks whether the location exists"""
+        """Checks whether the location exists
+
+
+        Raises:
+            PermissionError: If the file at self.location cannot be accessed due to a permission error
+        """
 
     @abstractmethod
     def open(self) -> InputStream:
@@ -110,6 +115,7 @@ class InputFile(ABC):
             InputStream: An object that matches the InputStream protocol
 
         Raises:
+            PermissionError: If the file at self.location cannot be accessed due to a permission error
             FileNotFoundError: If the file at self.location does not exist
         """
 
@@ -139,7 +145,12 @@ class OutputFile(ABC):
 
     @abstractmethod
     def exists(self) -> bool:
-        """Checks whether the location exists"""
+        """Checks whether the location exists
+
+
+        Raises:
+            PermissionError: If the file at self.location cannot be accessed due to a permission error
+        """
 
     @abstractmethod
     def to_input_file(self) -> InputFile:
@@ -157,6 +168,7 @@ class OutputFile(ABC):
             OutputStream: An object that matches the OutputStream protocol
 
         Raises:
+            PermissionError: If the file at self.location cannot be accessed due to a permission error
             FileExistsError: If the file at self.location already exists and `overwrite=False`
         """
 
@@ -187,4 +199,8 @@ class FileIO(ABC):
         Args:
             location(str, InputFile, OutputFile): A URI or a path to a local file--if an InputFile instance or
             an OutputFile instance is provided, the location attribute for that instance is used as the URI to delete
+
+        Raises:
+            PermissionError: If the file at location cannot be accessed due to a permission error
+            FileNotFoundError: When the file at the provided location does not exist
         """

--- a/python/src/iceberg/io/pyarrow.py
+++ b/python/src/iceberg/io/pyarrow.py
@@ -35,11 +35,12 @@ class PyArrowInputFile(InputFile):
     """An InputFile implementation that uses a pyarrow filesystem to generate pyarrow.lib.NativeFile instances for reading
 
     Args:
-        location(str): The URI to the file
+        location(str): A URI or a path to a local file
 
     Attributes:
-        location(str): The URI to the file
-        parsed_location(urllib.parse.ParseResult): The parsed location URI
+        location(str): The URI or path to a local file for a PyArrowInputFile instance
+        parsed_location(urllib.parse.ParseResult): The parsed location with attributes `scheme`, `netloc`, `path`, `params`,
+          `query`, and `fragment`
         exists(bool): Whether the file exists or not
 
     Examples:
@@ -51,7 +52,7 @@ class PyArrowInputFile(InputFile):
     def __init__(self, location: str):
         parsed_location = urlparse(location)  # Create a ParseResult from the uri
 
-        if parsed_location.scheme not in (
+        if parsed_location.scheme and parsed_location.scheme not in (
             "file",
             "mock",
             "s3fs",
@@ -103,11 +104,12 @@ class PyArrowOutputFile(OutputFile):
     """An OutputFile implementation that uses a pyarrow filesystem to generate pyarrow.lib.NativeFile instances for writing
 
     Args:
-        location(str): The URI to the file
+        location(str): A URI or a path to a local file
 
     Attributes:
-        location(str): The URI to the file
-        parsed_location(urllib.parse.ParseResult): The parsed location URI
+        location(str): The URI or path to a local file for a PyArrowOutputFile instance
+        parsed_location(urllib.parse.ParseResult): The parsed location with attributes `scheme`, `netloc`, `path`, `params`,
+          `query`, and `fragment`
         exists(bool): Whether the file exists or not
 
     Examples:
@@ -119,7 +121,7 @@ class PyArrowOutputFile(OutputFile):
     def __init__(self, location: str):
         parsed_location = urlparse(location)  # Create a ParseResult from the uri
 
-        if parsed_location.scheme not in (
+        if parsed_location.scheme and parsed_location.scheme not in (
             "file",
             "mock",
             "s3fs",
@@ -186,7 +188,7 @@ class PyArrowFileIO(FileIO):
         """Get a PyArrowInputFile instance to read bytes from the file at the given location
 
         Args:
-            location(str): The URI to the file
+            location(str): A URI or a path to a local file
         """
         return PyArrowInputFile(location)
 
@@ -194,7 +196,7 @@ class PyArrowFileIO(FileIO):
         """Get a PyArrowOutputFile instance to write bytes to the file at the given location
 
         Args:
-            location(str): The URI to the file
+            location(str): A URI or a path to a local file
         """
         return PyArrowOutputFile(location)
 

--- a/python/src/iceberg/io/pyarrow.py
+++ b/python/src/iceberg/io/pyarrow.py
@@ -34,6 +34,23 @@ _FILESYSTEM_INSTANCES: dict = {}
 
 
 def get_filesystem(location: str):
+    """Retrieve a pyarrow.fs.FileSystem instance
+    
+    This method checks _FILESYSTEM_INSTANCES for an existing filesystem based on the location's
+    scheme, i.e. s3, hdfs, viewfs. If an existing filesystem has not been cached, it instantiates a new
+    filesystem using `pyarrow.fs.FileSystem.from_uri(location)`, caches the returned filesystem, and
+    also returns that filesystem. If a path with no scheme is provided, it's assumed to be a path to
+    a local file.
+
+    Args:
+        location(str): The location of the file
+    
+    Returns:
+        pyarrow.fs.FileSystem: An implementation of the FileSystem base class inferred from the location
+    
+    Raises:
+        ArrowInvalid: A suitable FileSystem implementation cannot be found based on the location provided
+    """
     parsed_location = urlparse(location)  # Create a ParseResult from the uri
     if not parsed_location.scheme:  # If no scheme, assume the path is to a local file
         if _FILESYSTEM_INSTANCES.get("local"):

--- a/python/src/iceberg/io/pyarrow.py
+++ b/python/src/iceberg/io/pyarrow.py
@@ -193,6 +193,8 @@ class PyArrowFileIO(FileIO):
         filesystem, path = FileSystem.from_uri(str_path)  # Infer the proper filesystem
         try:
             filesystem.delete_file(path)
+        except FileNotFoundError:
+            raise
         except PermissionError:
             raise
         except OSError as e:

--- a/python/src/iceberg/io/pyarrow.py
+++ b/python/src/iceberg/io/pyarrow.py
@@ -75,10 +75,6 @@ class PyArrowFile(InputFile, OutputFile):
             pyarrow.lib.NativeFile: A NativeFile instance for the file located at `self.location`
         """
         input_file = self._filesystem.open_input_file(self._path)
-        if not isinstance(input_file, InputStream):
-            raise TypeError(
-                f"Object of type {type(input_file)} returned from PyArrowFile.open does not match the InputStream protocol."
-            )
         return input_file
 
     def create(self, overwrite: bool = False) -> OutputStream:
@@ -98,10 +94,6 @@ class PyArrowFile(InputFile, OutputFile):
                 f"A file already exists at this location. If you would like to overwrite it, set `overwrite=True`: {self.location}"
             )
         output_file = self._filesystem.open_output_stream(self._path)
-        if not isinstance(output_file, OutputStream):
-            raise TypeError(
-                f"Object of type {type(output_file)} returned from PyArrowFile.create(...) does not match the OutputStream protocol."
-            )
         return output_file
 
     def to_input_file(self) -> "PyArrowFile":

--- a/python/src/iceberg/io/pyarrow.py
+++ b/python/src/iceberg/io/pyarrow.py
@@ -161,6 +161,9 @@ class PyArrowFileIO(FileIO):
             location(str, InputFile, OutputFile): The URI to the file--if an InputFile instance or an
             OutputFile instance is provided, the location attribute for that instance is used as the location
             to delete
+
+        Raises:
+            FileNotFoundError: When the file at the provided location does not exist
         """
         str_path = location.location if isinstance(location, (InputFile, OutputFile)) else location
         filesystem, path = FileSystem.from_uri(str_path)  # Infer the proper filesystem

--- a/python/src/iceberg/io/pyarrow.py
+++ b/python/src/iceberg/io/pyarrow.py
@@ -1,0 +1,165 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""FileIO implementation for reading and writing table files that uses pyarrow.fs
+
+This file contains a FileIO implementation that relies on the filesystem interface provided
+by PyArrow. It relies on PyArrow's `from_uri` method that infers the correct filesytem
+type to use. Theoretically, this allows the supported storage types to grow naturally
+with the pyarrow library.
+"""
+
+from typing import Union
+
+from pyarrow import NativeFile
+from pyarrow.fs import FileSystem, FileType
+
+from iceberg.io.base import FileIO, InputFile, OutputFile
+
+
+class PyArrowInputFile(InputFile):
+    """An InputFile implementation that uses a pyarrow filesystem to generate pyarrow.lib.NativeFile instances for reading
+
+    Args:
+        location(str): The URI to the file
+
+    Attributes:
+        location(str): The URI to the file
+        exists(bool): Whether the file exists or not
+
+    Examples:
+        >>> from iceberg.io.pyarrow import PyArrowInputFile
+        >>> input_file = PyArrowInputFile("s3://foo/bar.txt")
+        >>> file_content = input_file.open().read()
+    """
+
+    def __init__(self, location: str):
+        self._location = location
+
+    def __len__(self) -> int:
+        """Returns the total length of the file, in bytes"""
+        filesytem, path = FileSystem.from_uri(self.location)  # Infer the proper filesystem
+        file = filesytem.open_input_file(path)
+        return file.size()
+
+    @property
+    def location(self) -> str:
+        """The fully-qualified location of the input file"""
+        return self._location
+
+    @property
+    def exists(self) -> bool:
+        """Checks whether the file exists"""
+        filesytem, path = FileSystem.from_uri(self.location)  # Infer the proper filesystem
+        file_info = filesytem.get_file_info(path)
+        return False if file_info.type() == FileType.NotFound else True
+
+    def open(self) -> NativeFile:
+        """This method should return an instance of a seekable input stream"""
+        filesytem, path = FileSystem.from_uri(self.location)  # Infer the proper filesystem
+        file = filesytem.open_input_file(path)
+        return file
+
+
+class PyArrowOutputFile(OutputFile):
+    """An OutputFile implementation that uses a pyarrow filesystem to generate pyarrow.lib.NativeFile instances for writing
+
+    Args:
+        location(str): The URI to the file
+
+    Attributes:
+        location(str): The URI to the file
+        exists(bool): Whether the file exists or not
+
+    Examples:
+        >>> from iceberg.io.pyarrow import PyArrowOutputFile
+        >>> output_file = PyArrowOutputFile("s3://foo/bar.txt")
+        >>> output_file.create().write(b'baz')
+    """
+
+    def __init__(self, location: str):
+        self._location = location
+
+    def __len__(self) -> int:
+        """Returns the total length of the file, in bytes"""
+        filesytem, path = FileSystem.from_uri(self.location)  # Infer the proper filesystem
+        file = filesytem.open_input_file(path)
+        return file.size()
+
+    @property
+    def location(self) -> str:
+        """The fully-qualified location of the output file"""
+        return self._location
+
+    @property
+    def exists(self) -> bool:
+        """Checks whether the file exists"""
+        filesytem, path = FileSystem.from_uri(self.location)  # Infer the proper filesystem
+        file_info = filesytem.get_file_info(path)
+        return False if file_info.type == FileType.NotFound else True
+
+    def to_input_file(self) -> PyArrowInputFile:
+        """Returns a PyArrowInputFile for the location of this PyArrowOutputFile instance"""
+        return PyArrowInputFile(self.location)
+
+    def create(self, overwrite: bool = False) -> NativeFile:
+        """Creates a writable pyarrow.lib.NativeFile for this PyArrowOutputFile's location
+
+        Args:
+            overwrite(bool): Whether to overwrite the file if it already exists
+
+        Raises:
+            FileExistsError: If the file already exists at `self.location` and `overwrite` is False
+        """
+        if not overwrite and self.exists:
+            raise FileExistsError(
+                f"A file already exists at this location. If you would like to overwrite it, set `overwrite=True`: {self.location}"
+            )
+        filesytem, path = FileSystem.from_uri(self.location)  # Infer the proper filesystem
+        file = filesytem.open_output_stream(path)
+        return file
+
+
+class PyArrowFileIO(FileIO):
+    def new_input(self, location: str) -> PyArrowInputFile:
+        """Get a PyArrowInputFile instance to read bytes from the file at the given location
+
+        Args:
+            overwrite(bool): Whether to overwrite the file if it already exists
+        """
+        return PyArrowInputFile(location)
+
+    def new_output(self, location: str) -> PyArrowOutputFile:
+        """Get a PyArrowOutputFile instance to write bytes to the file at the given location
+
+        Args:
+            location(str): The URI to the file
+        """
+        return PyArrowOutputFile(location)
+
+    def delete(self, location: Union[str, InputFile, OutputFile]) -> None:
+        """Delete the file at the given path
+
+        Args:
+            location(str, PyArrowInputFile, PyArrowOutputFile): The URI to the file--if a PyArrowInputFile instance or
+            PyArrowOutputFile instance is provided, the location attribute for that instance is used as the URI to delete
+        """
+        str_path = location.location if isinstance(location, (InputFile, OutputFile)) else location
+        filesytem, path = FileSystem.from_uri(str_path)  # Infer the proper filesystem
+        try:
+            filesytem.delete_file(path)
+        except OSError:
+            raise FileNotFoundError(f"File could not be deleted because it does not exist: {str_path}")

--- a/python/src/iceberg/io/pyarrow.py
+++ b/python/src/iceberg/io/pyarrow.py
@@ -64,7 +64,7 @@ class PyArrowFile(InputFile, OutputFile):
         return file_info.size
 
     def exists(self) -> bool:
-        """Checks whether the file exists"""
+        """Checks whether the location exists"""
         file_info = self._filesystem.get_file_info(self._path)
         return False if file_info.type == FileType.NotFound else True
 

--- a/python/src/iceberg/io/pyarrow.py
+++ b/python/src/iceberg/io/pyarrow.py
@@ -39,6 +39,7 @@ class PyArrowInputFile(InputFile):
 
     Attributes:
         location(str): The URI to the file
+        parsed_location(urllib.parse.ParseResult): The parsed location URI
         exists(bool): Whether the file exists or not
 
     Examples:
@@ -87,7 +88,7 @@ class PyArrowInputFile(InputFile):
 
     def open(self) -> NativeFile:
         """Opens the location using a PyArrow FileSystem inferred from the scheme
-        
+
         Returns:
             pyarrow.lib.NativeFile: A NativeFile instance for the file located at self.location
         """
@@ -106,6 +107,7 @@ class PyArrowOutputFile(OutputFile):
 
     Attributes:
         location(str): The URI to the file
+        parsed_location(urllib.parse.ParseResult): The parsed location URI
         exists(bool): Whether the file exists or not
 
     Examples:
@@ -123,7 +125,7 @@ class PyArrowOutputFile(OutputFile):
             "s3fs",
             "hdfs",
             "viewfs",
-        ):  # Validate that a uri is provided with a scheme of `file`
+        ):  # Validate that a scheme supported by PyArrow is provided
             raise ValueError("PyArrowOutputFile location must have a scheme of `file`, `mock`, `s3fs`, `hdfs`, or `viewfs`")
 
         super().__init__(location=location)
@@ -184,7 +186,7 @@ class PyArrowFileIO(FileIO):
         """Get a PyArrowInputFile instance to read bytes from the file at the given location
 
         Args:
-            overwrite(bool): Whether to overwrite the file if it already exists
+            location(str): The URI to the file
         """
         return PyArrowInputFile(location)
 
@@ -200,8 +202,8 @@ class PyArrowFileIO(FileIO):
         """Delete the file at the given path
 
         Args:
-            location(str, PyArrowInputFile, PyArrowOutputFile): The URI to the file--if a PyArrowInputFile instance or
-            PyArrowOutputFile instance is provided, the location attribute for that instance is used as the URI to delete
+            location(str, InputFile, OutputFile): The URI to the file--if an InputFile instance or an
+            OutputFile instance is provided, the location attribute for that instance is used as the URI to delete
         """
         str_path = location.location if isinstance(location, (InputFile, OutputFile)) else location
         filesytem, path = FileSystem.from_uri(str_path)  # Infer the proper filesystem

--- a/python/src/iceberg/io/pyarrow.py
+++ b/python/src/iceberg/io/pyarrow.py
@@ -47,7 +47,7 @@ class PyArrowFile(InputFile, OutputFile):
         >>> input_file = PyArrowFile("s3://foo/bar.txt")
         >>> file_content = input_file.open().read()  # Read the contents of the PyArrowFile instance
         >>> output_file = PyArrowFile("s3://baz/qux.txt")
-        >>> output_file.create().write(b'foobytes')  # Write bytes to the PyarrowFile instance
+        >>> output_file.create().write(b'foobytes')  # Write bytes to the PyArrowFile instance
     """
 
     def __init__(self, location: str):

--- a/python/src/iceberg/io/pyarrow.py
+++ b/python/src/iceberg/io/pyarrow.py
@@ -99,7 +99,9 @@ class PyArrowFile(InputFile, OutputFile):
         filesytem, path = FileSystem.from_uri(self.location)  # Infer the proper filesystem
         input_file = filesytem.open_input_file(path)
         if not isinstance(input_file, InputStream):
-            raise TypeError(f"Object of type {type(input_file)} returned from PyArrowFile.open does not match the InputStream protocol.")
+            raise TypeError(
+                f"Object of type {type(input_file)} returned from PyArrowFile.open does not match the InputStream protocol."
+            )
         return input_file
 
     def create(self, overwrite: bool = False) -> OutputStream:
@@ -121,7 +123,9 @@ class PyArrowFile(InputFile, OutputFile):
         filesytem, path = FileSystem.from_uri(self.location)  # Infer the proper filesystem
         output_file = filesytem.open_output_stream(path)
         if not isinstance(output_file, OutputStream):
-            raise TypeError(f"Object of type {type(output_file)} returned from PyArrowFile.create does not match the OutputStream protocol.")
+            raise TypeError(
+                f"Object of type {type(output_file)} returned from PyArrowFile.create does not match the OutputStream protocol."
+            )
         return output_file
 
     def to_input_file(self) -> "PyArrowFile":

--- a/python/src/iceberg/io/pyarrow.py
+++ b/python/src/iceberg/io/pyarrow.py
@@ -25,7 +25,6 @@ with the pyarrow library.
 from typing import Union
 from urllib.parse import ParseResult, urlparse
 
-from pyarrow import NativeFile
 from pyarrow.fs import FileSystem, FileType
 
 from iceberg.io.base import FileIO, InputFile, InputStream, OutputFile, OutputStream
@@ -87,7 +86,7 @@ class PyArrowInputFile(InputFile):
         file_info = filesytem.get_file_info(path)
         return False if file_info.type == FileType.NotFound else True
 
-    def open(self) -> NativeFile:
+    def open(self) -> InputStream:
         """Opens the location using a PyArrow FileSystem inferred from the scheme
 
         Returns:
@@ -160,7 +159,7 @@ class PyArrowOutputFile(OutputFile):
         """Returns a PyArrowInputFile for the location of this PyArrowOutputFile instance"""
         return PyArrowInputFile(self.location)
 
-    def create(self, overwrite: bool = False) -> NativeFile:
+    def create(self, overwrite: bool = False) -> OutputStream:
         """Creates a writable pyarrow.lib.NativeFile for this PyArrowOutputFile's location
 
         Args:

--- a/python/src/iceberg/io/pyarrow.py
+++ b/python/src/iceberg/io/pyarrow.py
@@ -35,7 +35,7 @@ _FILESYSTEM_INSTANCES: dict = {}
 
 def get_filesystem(location: str):
     """Retrieve a pyarrow.fs.FileSystem instance
-    
+
     This method checks _FILESYSTEM_INSTANCES for an existing filesystem based on the location's
     scheme, i.e. s3, hdfs, viewfs. If an existing filesystem has not been cached, it instantiates a new
     filesystem using `pyarrow.fs.FileSystem.from_uri(location)`, caches the returned filesystem, and
@@ -44,10 +44,10 @@ def get_filesystem(location: str):
 
     Args:
         location(str): The location of the file
-    
+
     Returns:
         pyarrow.fs.FileSystem: An implementation of the FileSystem base class inferred from the location
-    
+
     Raises:
         ArrowInvalid: A suitable FileSystem implementation cannot be found based on the location provided
     """
@@ -86,9 +86,8 @@ class PyArrowFile(InputFile, OutputFile):
     """
 
     def __init__(self, location: str):
-        filesystem = get_filesystem(location)  # Checks for cached filesystem for this location's scheme
+        self._filesystem = get_filesystem(location)  # Checks for cached filesystem for this location's scheme
         super().__init__(location=location)
-        self._filesystem = filesystem
 
     def __len__(self) -> int:
         """Returns the total length of the file, in bytes"""

--- a/python/src/iceberg/io/pyarrow.py
+++ b/python/src/iceberg/io/pyarrow.py
@@ -60,8 +60,8 @@ class PyArrowFile(InputFile, OutputFile):
 
     def __len__(self) -> int:
         """Returns the total length of the file, in bytes"""
-        file = self._filesystem.open_input_file(self._path)
-        return file.size()
+        file_info = self._filesystem.get_file_info(self._path)
+        return file_info.size
 
     def exists(self) -> bool:
         """Checks whether the file exists"""

--- a/python/src/iceberg/io/pyarrow.py
+++ b/python/src/iceberg/io/pyarrow.py
@@ -67,7 +67,7 @@ class PyArrowFile(InputFile, OutputFile):
             file_info = self._filesystem.get_file_info(self._path)
         except OSError as e:
             if e.errno == 13 or "AWS Error [code 15]" in str(e):
-                raise PermissionError(f"Cannot check if file exists, access denied: {self.location}")
+                raise PermissionError(f"Cannot get file info, access denied: {self.location}")
             raise  # pragma: no cover - If some other kind of OSError, raise the raw error
         return file_info
 
@@ -180,9 +180,11 @@ class PyArrowFileIO(FileIO):
         filesystem, path = FileSystem.from_uri(str_path)  # Infer the proper filesystem
         try:
             filesystem.delete_file(path)
+        except PermissionError:
+            raise
         except OSError as e:
             if e.errno == 2 or "Path does not exist" in str(e):
                 raise FileNotFoundError(f"Cannot delete file, does not exist: {location}")
-            elif e.errno == 13 or "AWS Error [code 15]" in str(e) or isinstance(e, PermissionError):
+            elif e.errno == 13 or "AWS Error [code 15]" in str(e):
                 raise PermissionError(f"Cannot delete file, access denied: {location}")
             raise  # pragma: no cover - If some other kind of OSError, raise the raw error

--- a/python/src/iceberg/io/pyarrow.py
+++ b/python/src/iceberg/io/pyarrow.py
@@ -70,10 +70,10 @@ class PyArrowFile(InputFile, OutputFile):
         return False if file_info.type == FileType.NotFound else True
 
     def open(self) -> InputStream:
-        """Opens the location using a PyArrow FileSystem inferred from the scheme
+        """Opens the location using a PyArrow FileSystem inferred from the location
 
         Returns:
-            pyarrow.lib.NativeFile: A NativeFile instance for the file located at self.location
+            pyarrow.lib.NativeFile: A NativeFile instance for the file located at `self.location`
         """
         input_file = self._filesystem.open_input_file(self._path)
         if not isinstance(input_file, InputStream):
@@ -101,7 +101,7 @@ class PyArrowFile(InputFile, OutputFile):
         output_file = self._filesystem.open_output_stream(self._path)
         if not isinstance(output_file, OutputStream):
             raise TypeError(
-                f"Object of type {type(output_file)} returned from PyArrowFile.create does not match the OutputStream protocol."
+                f"Object of type {type(output_file)} returned from PyArrowFile.create(...) does not match the OutputStream protocol."
             )
         return output_file
 
@@ -121,6 +121,9 @@ class PyArrowFileIO(FileIO):
 
         Args:
             location(str): A URI or a path to a local file
+
+        Returns:
+            PyArrowFile: A PyArrowFile instance for the given location
         """
         return PyArrowFile(location)
 
@@ -129,15 +132,19 @@ class PyArrowFileIO(FileIO):
 
         Args:
             location(str): A URI or a path to a local file
+
+        Returns:
+            PyArrowFile: A PyArrowFile instance for the given location
         """
         return PyArrowFile(location)
 
     def delete(self, location: Union[str, InputFile, OutputFile]) -> None:
-        """Delete the file at the given path
+        """Delete the file at the given location
 
         Args:
             location(str, InputFile, OutputFile): The URI to the file--if an InputFile instance or an
-            OutputFile instance is provided, the location attribute for that instance is used as the URI to delete
+            OutputFile instance is provided, the location attribute for that instance is used as the location
+            to delete
         """
         str_path = location.location if isinstance(location, (InputFile, OutputFile)) else location
         filesystem, path = FileSystem.from_uri(str_path)  # Infer the proper filesystem

--- a/python/src/iceberg/io/pyarrow.py
+++ b/python/src/iceberg/io/pyarrow.py
@@ -99,7 +99,7 @@ class PyArrowFile(InputFile, OutputFile):
         filesytem, path = FileSystem.from_uri(self.location)  # Infer the proper filesystem
         input_file = filesytem.open_input_file(path)
         if not isinstance(input_file, InputStream):
-            raise TypeError("""Object returned from PyArrowFile.open does not match the InputStream protocol.""")
+            raise TypeError(f"Object of type {type(input_file)} returned from PyArrowFile.open does not match the InputStream protocol.")
         return input_file
 
     def create(self, overwrite: bool = False) -> OutputStream:
@@ -121,7 +121,7 @@ class PyArrowFile(InputFile, OutputFile):
         filesytem, path = FileSystem.from_uri(self.location)  # Infer the proper filesystem
         output_file = filesytem.open_output_stream(path)
         if not isinstance(output_file, OutputStream):
-            raise TypeError("Object returned from PyArrowFile.create does not match the OutputStream protocol.")
+            raise TypeError(f"Object of type {type(output_file)} returned from PyArrowFile.create does not match the OutputStream protocol.")
         return output_file
 
     def to_input_file(self) -> "PyArrowFile":

--- a/python/src/iceberg/io/pyarrow.py
+++ b/python/src/iceberg/io/pyarrow.py
@@ -90,9 +90,7 @@ class PyArrowFile(InputFile, OutputFile):
             FileExistsError: If the file already exists at `self.location` and `overwrite` is False
         """
         if not overwrite and self.exists():
-            raise FileExistsError(
-                f"A file already exists at this location. If you would like to overwrite it, set `overwrite=True`: {self.location}"
-            )
+            raise FileExistsError(f"Cannot create file, already exists: {self.location}")
         output_file = self._filesystem.open_output_stream(self._path)
         return output_file
 
@@ -141,5 +139,5 @@ class PyArrowFileIO(FileIO):
         filesystem, path = FileSystem.from_uri(str_path)  # Infer the proper filesystem
         try:
             filesystem.delete_file(path)
-        except OSError:
-            raise FileNotFoundError(f"File could not be deleted because it does not exist: {str_path}")
+        except OSError as e:
+            raise FileNotFoundError(f"Cannot delete file, does not exist: {location} - Caused by: " + str(e))

--- a/python/src/iceberg/io/pyarrow.py
+++ b/python/src/iceberg/io/pyarrow.py
@@ -29,6 +29,14 @@ from pyarrow.fs import FileSystem, FileType
 
 from iceberg.io.base import FileIO, InputFile, InputStream, OutputFile, OutputStream
 
+SUPPORTED_SCHEMES = [
+            "file",
+            "mock",
+            "s3fs",
+            "hdfs",
+            "viewfs",
+]
+
 
 class PyArrowInputFile(InputFile):
     """An InputFile implementation that uses a pyarrow filesystem to generate pyarrow.lib.NativeFile instances for reading
@@ -51,14 +59,8 @@ class PyArrowInputFile(InputFile):
     def __init__(self, location: str):
         parsed_location = urlparse(location)  # Create a ParseResult from the uri
 
-        if parsed_location.scheme and parsed_location.scheme not in (
-            "file",
-            "mock",
-            "s3fs",
-            "hdfs",
-            "viewfs",
-        ):  # Validate that a uri is provided with a scheme of `file`
-            raise ValueError("PyArrowInputFile location must have a scheme of `file`, `mock`, `s3fs`, `hdfs`, or `viewfs`")
+        if parsed_location.scheme and parsed_location.scheme not in SUPPORTED_SCHEMES:
+            raise ValueError(f"PyArrowInputFile location must have one of the following schemes: {SUPPORTED_SCHEMES}")
 
         super().__init__(location=location)
         self._parsed_location = parsed_location
@@ -120,14 +122,8 @@ class PyArrowOutputFile(OutputFile):
     def __init__(self, location: str):
         parsed_location = urlparse(location)  # Create a ParseResult from the uri
 
-        if parsed_location.scheme and parsed_location.scheme not in (
-            "file",
-            "mock",
-            "s3fs",
-            "hdfs",
-            "viewfs",
-        ):  # Validate that a scheme supported by PyArrow is provided
-            raise ValueError("PyArrowOutputFile location must have a scheme of `file`, `mock`, `s3fs`, `hdfs`, or `viewfs`")
+        if parsed_location.scheme and parsed_location.scheme not in SUPPORTED_SCHEMES:
+            raise ValueError(f"PyArrowOutputFile location must have one of the following schemes: {SUPPORTED_SCHEMES}")
 
         super().__init__(location=location)
         self._parsed_location = parsed_location

--- a/python/src/iceberg/io/pyarrow.py
+++ b/python/src/iceberg/io/pyarrow.py
@@ -86,7 +86,11 @@ class PyArrowInputFile(InputFile):
         return False if file_info.type == FileType.NotFound else True
 
     def open(self) -> NativeFile:
-        """This method should return an instance of a seekable input stream"""
+        """Opens the location using a PyArrow FileSystem inferred from the scheme
+        
+        Returns:
+            pyarrow.lib.NativeFile: A NativeFile instance for the file located at self.location
+        """
         filesytem, path = FileSystem.from_uri(self.location)  # Infer the proper filesystem
         input_file = filesytem.open_input_file(path)
         if not isinstance(input_file, InputStream):
@@ -157,6 +161,9 @@ class PyArrowOutputFile(OutputFile):
 
         Args:
             overwrite(bool): Whether to overwrite the file if it already exists
+
+        Returns:
+            pyarrow.lib.NativeFile: A NativeFile instance for the file located at self.location
 
         Raises:
             FileExistsError: If the file already exists at `self.location` and `overwrite` is False

--- a/python/src/iceberg/io/pyarrow.py
+++ b/python/src/iceberg/io/pyarrow.py
@@ -123,6 +123,13 @@ class PyArrowFile(InputFile, OutputFile):
 
         Raises:
             FileExistsError: If the file already exists at `self.location` and `overwrite` is False
+
+        Note:
+            This retrieves a pyarrow NativeFile by opening an output stream. If overwrite is set to False,
+            a check is first performed to verify that the file does not exist. This is not thread-safe and
+            a possibility does exist that the file can be created by a concurrent process after the existence
+            check yet before the output stream is created. In such a case, the default pyarrow behavior will
+            truncate the contents of the existing file when opening the output stream.
         """
         try:
             if not overwrite and self.exists() is True:

--- a/python/src/iceberg/io/pyarrow.py
+++ b/python/src/iceberg/io/pyarrow.py
@@ -63,7 +63,6 @@ class PyArrowFile(InputFile, OutputFile):
         file = self._filesystem.open_input_file(self._path)
         return file.size()
 
-    @property
     def exists(self) -> bool:
         """Checks whether the file exists"""
         file_info = self._filesystem.get_file_info(self._path)
@@ -94,7 +93,7 @@ class PyArrowFile(InputFile, OutputFile):
         Raises:
             FileExistsError: If the file already exists at `self.location` and `overwrite` is False
         """
-        if not overwrite and self.exists:
+        if not overwrite and self.exists():
             raise FileExistsError(
                 f"A file already exists at this location. If you would like to overwrite it, set `overwrite=True`: {self.location}"
             )

--- a/python/src/iceberg/io/pyarrow.py
+++ b/python/src/iceberg/io/pyarrow.py
@@ -101,7 +101,7 @@ class PyArrowFile(InputFile, OutputFile):
         PyArrowFile class (as opposed to separate InputFile and OutputFile implementations), this method effectively returns
         a copy of the same instance.
         """
-        return PyArrowFile(self.location)
+        return self
 
 
 class PyArrowFileIO(FileIO):

--- a/python/src/iceberg/io/pyarrow.py
+++ b/python/src/iceberg/io/pyarrow.py
@@ -73,6 +73,9 @@ class PyArrowFile(InputFile, OutputFile):
 
         Returns:
             pyarrow.lib.NativeFile: A NativeFile instance for the file located at `self.location`
+
+        Raises:
+            FileNotFoundError: If the file at self.location does not exist
         """
         input_file = self._filesystem.open_input_file(self._path)
         return input_file

--- a/python/tests/io/test_base.py
+++ b/python/tests/io/test_base.py
@@ -53,7 +53,6 @@ class LocalInputFile(InputFile):
     def __len__(self):
         return os.path.getsize(self.parsed_location.path)
 
-    @property
     def exists(self):
         return os.path.exists(self.parsed_location.path)
 
@@ -91,7 +90,6 @@ class LocalOutputFile(OutputFile):
     def __len__(self):
         return os.path.getsize(self.parsed_location.path)
 
-    @property
     def exists(self):
         return os.path.exists(self.parsed_location.path)
 
@@ -212,8 +210,8 @@ def test_custom_file_exists(CustomFile):
         non_existent_file = CustomFile(location=f"{non_existent_absolute_file_location}")
 
         # Test opening and reading the file
-        assert file.exists
-        assert not non_existent_file.exists
+        assert file.exists()
+        assert not non_existent_file.exists()
 
 
 @pytest.mark.parametrize("CustomOutputFile", [LocalOutputFile, PyArrowFile])

--- a/python/tests/io/test_base.py
+++ b/python/tests/io/test_base.py
@@ -116,8 +116,8 @@ class LocalFileIO(FileIO):
         parsed_location = location.parsed_location if isinstance(location, (InputFile, OutputFile)) else urlparse(location)
         try:
             os.remove(parsed_location.path)
-        except FileNotFoundError:
-            raise FileNotFoundError(f"File could not be deleted because it does not exist: {parsed_location.path}")
+        except FileNotFoundError as e:
+            raise FileNotFoundError(f"Cannot delete file, does not exist: {parsed_location.path} - Caused by: " + str(e))
 
 
 @pytest.mark.parametrize("CustomInputFile", [LocalInputFile, PyArrowFile])
@@ -315,7 +315,7 @@ def test_raise_file_not_found_error_for_fileio_delete(CustomFileIO):
         with pytest.raises(FileNotFoundError) as exc_info:
             file_io.delete(output_file_location)
 
-        assert (f"File could not be deleted because it does not exist:") in str(exc_info.value)
+        assert (f"Cannot delete file, does not exist:") in str(exc_info.value)
 
         # Confirm that the file no longer exists
         assert not os.path.exists(output_file_location)

--- a/python/tests/io/test_base.py
+++ b/python/tests/io/test_base.py
@@ -32,7 +32,7 @@ class LocalInputFile(InputFile):
     def __init__(self, location: str):
 
         parsed_location = urlparse(location)  # Create a ParseResult from the uri
-        if parsed_location.scheme != "file":  # Validate that a uri is provided with a scheme of `file`
+        if parsed_location.scheme and parsed_location.scheme != "file":  # Validate that a uri is provided with a scheme of `file`
             raise ValueError("LocalInputFile location must have a scheme of `file`")
         elif parsed_location.netloc:
             raise ValueError(f"Network location is not allowed for LocalInputFile: {parsed_location.netloc}")
@@ -70,7 +70,7 @@ class LocalOutputFile(OutputFile):
     def __init__(self, location: str):
 
         parsed_location = urlparse(location)  # Create a ParseResult from the uri
-        if parsed_location.scheme != "file":  # Validate that a uri is provided with a scheme of `file`
+        if parsed_location.scheme and parsed_location.scheme != "file":  # Validate that a uri is provided with a scheme of `file`
             raise ValueError("LocalOutputFile location must have a scheme of `file`")
         elif parsed_location.netloc:
             raise ValueError(f"Network location is not allowed for LocalOutputFile: {parsed_location.netloc}")
@@ -134,7 +134,7 @@ def test_custom_local_input_file(CustomInputFile):
 
         # Instantiate the input file
         absolute_file_location = os.path.abspath(file_location)
-        input_file = CustomInputFile(location=f"file:{absolute_file_location}")
+        input_file = CustomInputFile(location=f"{absolute_file_location}")
 
         # Test opening and reading the file
         f = input_file.open()
@@ -150,7 +150,7 @@ def test_custom_local_output_file(CustomOutputFile):
 
         # Instantiate the output file
         absolute_file_location = os.path.abspath(file_location)
-        output_file = CustomOutputFile(location=f"file:{absolute_file_location}")
+        output_file = CustomOutputFile(location=f"{absolute_file_location}")
 
         # Create the output file and write to it
         f = output_file.create()
@@ -173,7 +173,7 @@ def test_custom_local_output_file_with_overwrite(CustomOutputFile):
             f.write(b"foo")
 
         # Instantiate an output file
-        output_file = CustomOutputFile(location=f"file://{output_file_location}")
+        output_file = CustomOutputFile(location=f"{output_file_location}")
 
         # Confirm that a FileExistsError is raised when overwrite=False
         with pytest.raises(FileExistsError):
@@ -204,8 +204,8 @@ def test_custom_file_exists(CustomFile):
         non_existent_absolute_file_location = os.path.abspath(nonexistent_file_location)
 
         # Create File instances
-        file = CustomFile(location=f"file:{absolute_file_location}")
-        non_existent_file = CustomFile(location=f"file:{non_existent_absolute_file_location}")
+        file = CustomFile(location=f"{absolute_file_location}")
+        non_existent_file = CustomFile(location=f"{non_existent_absolute_file_location}")
 
         # Test opening and reading the file
         assert file.exists
@@ -218,7 +218,7 @@ def test_output_file_to_input_file(CustomOutputFile):
         output_file_location = os.path.join(tmpdirname, "foo.txt")
 
         # Create an output file instance
-        output_file = CustomOutputFile(location=f"file://{output_file_location}")
+        output_file = CustomOutputFile(location=f"{output_file_location}")
 
         # Create the output file and write to it
         f = output_file.create()
@@ -233,8 +233,10 @@ def test_output_file_to_input_file(CustomOutputFile):
 @pytest.mark.parametrize(
     "CustomFileIO,string_uri,scheme,netloc,path",
     [
+        (LocalFileIO, "foo/bar.parquet", "", "", "foo/bar.parquet"),
         (LocalFileIO, "file:///foo/bar.parquet", "file", "", "/foo/bar.parquet"),
         (LocalFileIO, "file:/foo/bar/baz.parquet", "file", "", "/foo/bar/baz.parquet"),
+        (PyArrowFileIO, "foo/bar/baz.parquet", "", "", "foo/bar/baz.parquet"),
         (PyArrowFileIO, "file:/foo/bar/baz.parquet", "file", "", "/foo/bar/baz.parquet"),
         (PyArrowFileIO, "file:/foo/bar/baz.parquet", "file", "", "/foo/bar/baz.parquet"),
     ],
@@ -337,7 +339,7 @@ def test_deleting_local_file_using_file_io_InputFile(CustomFileIO, CustomInputFi
         assert os.path.exists(file_location)
 
         # Instantiate the custom InputFile
-        input_file = CustomInputFile(location=f"file://{file_location}")
+        input_file = CustomInputFile(location=f"{file_location}")
 
         # Delete the file using the file-io implementations delete method
         file_io.delete(input_file)
@@ -362,7 +364,7 @@ def test_deleting_local_file_using_file_io_OutputFile(CustomFileIO, CustomOutput
         assert os.path.exists(file_location)
 
         # Instantiate the custom OutputFile
-        output_file = CustomOutputFile(location=f"file://{file_location}")
+        output_file = CustomOutputFile(location=f"{file_location}")
 
         # Delete the file using the file-io implementations delete method
         file_io.delete(output_file)

--- a/python/tests/io/test_base.py
+++ b/python/tests/io/test_base.py
@@ -236,14 +236,14 @@ def test_output_file_to_input_file(CustomOutputFile):
 
 
 @pytest.mark.parametrize(
-    "CustomFileIO,string_uri,scheme,netloc,path",
+    "CustomFileIO,string_uri",
     [
-        (LocalFileIO, "foo/bar.parquet", "", "", "foo/bar.parquet"),
-        (LocalFileIO, "file:///foo/bar.parquet", "file", "", "/foo/bar.parquet"),
-        (LocalFileIO, "file:/foo/bar/baz.parquet", "file", "", "/foo/bar/baz.parquet"),
-        (PyArrowFileIO, "foo/bar/baz.parquet", "", "", "foo/bar/baz.parquet"),
-        (PyArrowFileIO, "file:/foo/bar/baz.parquet", "file", "", "/foo/bar/baz.parquet"),
-        (PyArrowFileIO, "file:/foo/bar/baz.parquet", "file", "", "/foo/bar/baz.parquet"),
+        (LocalFileIO, "foo/bar.parquet"),
+        (LocalFileIO, "file:///foo/bar.parquet"),
+        (LocalFileIO, "file:/foo/bar/baz.parquet"),
+        (PyArrowFileIO, "foo/bar/baz.parquet"),
+        (PyArrowFileIO, "file:/foo/bar/baz.parquet"),
+        (PyArrowFileIO, "file:/foo/bar/baz.parquet"),
     ],
 )
 def test_custom_file_io_locations(CustomFileIO, string_uri):

--- a/python/tests/io/test_base.py
+++ b/python/tests/io/test_base.py
@@ -60,7 +60,7 @@ class LocalInputFile(InputFile):
     def open(self) -> InputStream:
         input_file = open(self.parsed_location.path, "rb")
         if not isinstance(input_file, InputStream):
-            raise TypeError("""Object returned from LocalInputFile.open does not match the OutputStream protocol.""")
+            raise TypeError("Object returned from LocalInputFile.open does not match the OutputStream protocol.")
         return input_file
 
 
@@ -101,7 +101,7 @@ class LocalOutputFile(OutputFile):
     def create(self, overwrite: bool = False) -> OutputStream:
         output_file = open(self.parsed_location.path, "wb" if overwrite else "xb")
         if not isinstance(output_file, OutputStream):
-            raise TypeError("""Object returned from LocalOutputFile.create does not match the OutputStream protocol.""")
+            raise TypeError("Object returned from LocalOutputFile.create does not match the OutputStream protocol.")
         return output_file
 
 

--- a/python/tests/io/test_base.py
+++ b/python/tests/io/test_base.py
@@ -246,15 +246,9 @@ def test_custom_file_io_locations(CustomFileIO, string_uri, scheme, netloc, path
     file_io = CustomFileIO()
     input_file = file_io.new_input(location=string_uri)
     assert input_file.location == string_uri
-    assert input_file.parsed_location.scheme == scheme
-    assert input_file.parsed_location.netloc == netloc
-    assert input_file.parsed_location.path == path
 
     output_file = file_io.new_output(location=string_uri)
     assert output_file.location == string_uri
-    assert output_file.parsed_location.scheme == scheme
-    assert output_file.parsed_location.netloc == netloc
-    assert output_file.parsed_location.path == path
 
 
 @pytest.mark.parametrize(

--- a/python/tests/io/test_base.py
+++ b/python/tests/io/test_base.py
@@ -23,7 +23,7 @@ from urllib.parse import ParseResult, urlparse
 import pytest
 
 from iceberg.io.base import FileIO, InputFile, InputStream, OutputFile, OutputStream
-from iceberg.io.pyarrow import PyArrowFileIO, PyArrowInputFile, PyArrowOutputFile
+from iceberg.io.pyarrow import PyArrowFile, PyArrowFileIO
 
 
 class LocalInputFile(InputFile):
@@ -122,7 +122,7 @@ class LocalFileIO(FileIO):
             raise FileNotFoundError(f"File could not be deleted because it does not exist: {parsed_location.path}")
 
 
-@pytest.mark.parametrize("CustomInputFile", [LocalInputFile, PyArrowInputFile])
+@pytest.mark.parametrize("CustomInputFile", [LocalInputFile, PyArrowFile])
 def test_custom_local_input_file(CustomInputFile):
     with tempfile.TemporaryDirectory() as tmpdirname:
         file_location = os.path.join(tmpdirname, "foo.txt")
@@ -143,7 +143,7 @@ def test_custom_local_input_file(CustomInputFile):
         assert len(input_file) == 3
 
 
-@pytest.mark.parametrize("CustomOutputFile", [LocalOutputFile, PyArrowOutputFile])
+@pytest.mark.parametrize("CustomOutputFile", [LocalOutputFile, PyArrowFile])
 def test_custom_local_output_file(CustomOutputFile):
     with tempfile.TemporaryDirectory() as tmpdirname:
         file_location = os.path.join(tmpdirname, "foo.txt")
@@ -163,7 +163,7 @@ def test_custom_local_output_file(CustomOutputFile):
         assert len(output_file) == 3
 
 
-@pytest.mark.parametrize("CustomOutputFile", [LocalOutputFile, PyArrowOutputFile])
+@pytest.mark.parametrize("CustomOutputFile", [LocalOutputFile, PyArrowFile])
 def test_custom_local_output_file_with_overwrite(CustomOutputFile):
     with tempfile.TemporaryDirectory() as tmpdirname:
         output_file_location = os.path.join(tmpdirname, "foo.txt")
@@ -187,7 +187,7 @@ def test_custom_local_output_file_with_overwrite(CustomOutputFile):
             assert f.read() == b"bar"
 
 
-@pytest.mark.parametrize("CustomFile", [LocalInputFile, LocalOutputFile, PyArrowInputFile, PyArrowOutputFile])
+@pytest.mark.parametrize("CustomFile", [LocalInputFile, LocalOutputFile, PyArrowFile, PyArrowFile])
 def test_custom_file_exists(CustomFile):
     with tempfile.TemporaryDirectory() as tmpdirname:
         file_location = os.path.join(tmpdirname, "foo.txt")
@@ -212,7 +212,7 @@ def test_custom_file_exists(CustomFile):
         assert not non_existent_file.exists
 
 
-@pytest.mark.parametrize("CustomOutputFile", [LocalOutputFile, PyArrowOutputFile])
+@pytest.mark.parametrize("CustomOutputFile", [LocalOutputFile, PyArrowFile])
 def test_output_file_to_input_file(CustomOutputFile):
     with tempfile.TemporaryDirectory() as tmpdirname:
         output_file_location = os.path.join(tmpdirname, "foo.txt")
@@ -323,7 +323,7 @@ def test_raise_FileNotFoundError_for_fileio_delete(CustomFileIO):
         assert not os.path.exists(output_file_location)
 
 
-@pytest.mark.parametrize("CustomFileIO, CustomInputFile", [(LocalFileIO, LocalInputFile), (PyArrowFileIO, PyArrowInputFile)])
+@pytest.mark.parametrize("CustomFileIO, CustomInputFile", [(LocalFileIO, LocalInputFile), (PyArrowFileIO, PyArrowFile)])
 def test_deleting_local_file_using_file_io_InputFile(CustomFileIO, CustomInputFile):
 
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -348,7 +348,7 @@ def test_deleting_local_file_using_file_io_InputFile(CustomFileIO, CustomInputFi
         assert not os.path.exists(file_location)
 
 
-@pytest.mark.parametrize("CustomFileIO, CustomOutputFile", [(LocalFileIO, LocalOutputFile), (PyArrowFileIO, PyArrowOutputFile)])
+@pytest.mark.parametrize("CustomFileIO, CustomOutputFile", [(LocalFileIO, LocalOutputFile), (PyArrowFileIO, PyArrowFile)])
 def test_deleting_local_file_using_file_io_OutputFile(CustomFileIO, CustomOutputFile):
 
     with tempfile.TemporaryDirectory() as tmpdirname:

--- a/python/tests/io/test_base.py
+++ b/python/tests/io/test_base.py
@@ -315,7 +315,7 @@ def test_raise_file_not_found_error_for_fileio_delete(CustomFileIO):
         with pytest.raises(FileNotFoundError) as exc_info:
             file_io.delete(output_file_location)
 
-        assert (f"Cannot delete file, does not exist:") in str(exc_info.value)
+        assert (f"Cannot delete file") in str(exc_info.value)
 
         # Confirm that the file no longer exists
         assert not os.path.exists(output_file_location)

--- a/python/tests/io/test_base.py
+++ b/python/tests/io/test_base.py
@@ -261,7 +261,7 @@ def test_custom_file_io_locations(CustomFileIO, string_uri, scheme, netloc, path
     "string_uri_w_netloc",
     ["file://localhost:80/foo/bar.parquet", "file://foo/bar.parquet"],
 )
-def test_raise_on_network_location_in_InputFile(string_uri_w_netloc):
+def test_raise_on_network_location_in_input_file(string_uri_w_netloc):
 
     with pytest.raises(ValueError) as exc_info:
         LocalInputFile(location=string_uri_w_netloc)
@@ -273,7 +273,7 @@ def test_raise_on_network_location_in_InputFile(string_uri_w_netloc):
     "string_uri_w_netloc",
     ["file://localhost:80/foo/bar.parquet", "file://foo/bar.parquet"],
 )
-def test_raise_on_network_location_in_OutputFile(string_uri_w_netloc):
+def test_raise_on_network_location_in_output_file(string_uri_w_netloc):
 
     with pytest.raises(ValueError) as exc_info:
         LocalInputFile(location=string_uri_w_netloc)
@@ -304,7 +304,7 @@ def test_deleting_local_file_using_file_io(CustomFileIO):
 
 
 @pytest.mark.parametrize("CustomFileIO", [LocalFileIO, PyArrowFileIO])
-def test_raise_FileNotFoundError_for_fileio_delete(CustomFileIO):
+def test_raise_file_not_found_error_for_fileio_delete(CustomFileIO):
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         # Write to the temporary file
@@ -324,7 +324,7 @@ def test_raise_FileNotFoundError_for_fileio_delete(CustomFileIO):
 
 
 @pytest.mark.parametrize("CustomFileIO, CustomInputFile", [(LocalFileIO, LocalInputFile), (PyArrowFileIO, PyArrowFile)])
-def test_deleting_local_file_using_file_io_InputFile(CustomFileIO, CustomInputFile):
+def test_deleting_local_file_using_file_io_input_file(CustomFileIO, CustomInputFile):
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         # Write to the temporary file
@@ -349,7 +349,7 @@ def test_deleting_local_file_using_file_io_InputFile(CustomFileIO, CustomInputFi
 
 
 @pytest.mark.parametrize("CustomFileIO, CustomOutputFile", [(LocalFileIO, LocalOutputFile), (PyArrowFileIO, PyArrowFile)])
-def test_deleting_local_file_using_file_io_OutputFile(CustomFileIO, CustomOutputFile):
+def test_deleting_local_file_using_file_io_output_file(CustomFileIO, CustomOutputFile):
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         # Write to the temporary file

--- a/python/tests/io/test_base.py
+++ b/python/tests/io/test_base.py
@@ -60,7 +60,7 @@ class LocalInputFile(InputFile):
     def open(self) -> InputStream:
         input_file = open(self.parsed_location.path, "rb")
         if not isinstance(input_file, InputStream):
-            raise TypeError("Object returned from LocalInputFile.open does not match the OutputStream protocol.")
+            raise TypeError("Object returned from LocalInputFile.open() does not match the OutputStream protocol.")
         return input_file
 
 
@@ -101,7 +101,7 @@ class LocalOutputFile(OutputFile):
     def create(self, overwrite: bool = False) -> OutputStream:
         output_file = open(self.parsed_location.path, "wb" if overwrite else "xb")
         if not isinstance(output_file, OutputStream):
-            raise TypeError("Object returned from LocalOutputFile.create does not match the OutputStream protocol.")
+            raise TypeError("Object returned from LocalOutputFile.create(...) does not match the OutputStream protocol.")
         return output_file
 
 
@@ -124,6 +124,7 @@ class LocalFileIO(FileIO):
 
 @pytest.mark.parametrize("CustomInputFile", [LocalInputFile, PyArrowFile])
 def test_custom_local_input_file(CustomInputFile):
+    """Test initializing an InputFile implementation to read a local file"""
     with tempfile.TemporaryDirectory() as tmpdirname:
         file_location = os.path.join(tmpdirname, "foo.txt")
         with open(file_location, "wb") as f:
@@ -145,6 +146,7 @@ def test_custom_local_input_file(CustomInputFile):
 
 @pytest.mark.parametrize("CustomOutputFile", [LocalOutputFile, PyArrowFile])
 def test_custom_local_output_file(CustomOutputFile):
+    """Test initializing an OutputFile implementation to write to a local file"""
     with tempfile.TemporaryDirectory() as tmpdirname:
         file_location = os.path.join(tmpdirname, "foo.txt")
 
@@ -165,6 +167,7 @@ def test_custom_local_output_file(CustomOutputFile):
 
 @pytest.mark.parametrize("CustomOutputFile", [LocalOutputFile, PyArrowFile])
 def test_custom_local_output_file_with_overwrite(CustomOutputFile):
+    """Test initializing an OutputFile implementation to overwrite a local file"""
     with tempfile.TemporaryDirectory() as tmpdirname:
         output_file_location = os.path.join(tmpdirname, "foo.txt")
 
@@ -189,6 +192,7 @@ def test_custom_local_output_file_with_overwrite(CustomOutputFile):
 
 @pytest.mark.parametrize("CustomFile", [LocalInputFile, LocalOutputFile, PyArrowFile, PyArrowFile])
 def test_custom_file_exists(CustomFile):
+    """Test that the exists property returns the proper value for existing and non-existing files"""
     with tempfile.TemporaryDirectory() as tmpdirname:
         file_location = os.path.join(tmpdirname, "foo.txt")
         with open(file_location, "wb") as f:
@@ -214,6 +218,7 @@ def test_custom_file_exists(CustomFile):
 
 @pytest.mark.parametrize("CustomOutputFile", [LocalOutputFile, PyArrowFile])
 def test_output_file_to_input_file(CustomOutputFile):
+    """Test initializing an InputFile using the `to_input_file()` method on an OutputFile instance"""
     with tempfile.TemporaryDirectory() as tmpdirname:
         output_file_location = os.path.join(tmpdirname, "foo.txt")
 
@@ -241,7 +246,8 @@ def test_output_file_to_input_file(CustomOutputFile):
         (PyArrowFileIO, "file:/foo/bar/baz.parquet", "file", "", "/foo/bar/baz.parquet"),
     ],
 )
-def test_custom_file_io_locations(CustomFileIO, string_uri, scheme, netloc, path):
+def test_custom_file_io_locations(CustomFileIO, string_uri):
+    """Test that the location property is maintained as the value of the location argument"""
     # Instantiate the file-io and create a new input and output file
     file_io = CustomFileIO()
     input_file = file_io.new_input(location=string_uri)
@@ -256,7 +262,7 @@ def test_custom_file_io_locations(CustomFileIO, string_uri, scheme, netloc, path
     ["file://localhost:80/foo/bar.parquet", "file://foo/bar.parquet"],
 )
 def test_raise_on_network_location_in_input_file(string_uri_w_netloc):
-
+    """Test raising a ValueError when providing a network location to a LocalInputFile"""
     with pytest.raises(ValueError) as exc_info:
         LocalInputFile(location=string_uri_w_netloc)
 
@@ -268,7 +274,7 @@ def test_raise_on_network_location_in_input_file(string_uri_w_netloc):
     ["file://localhost:80/foo/bar.parquet", "file://foo/bar.parquet"],
 )
 def test_raise_on_network_location_in_output_file(string_uri_w_netloc):
-
+    """Test raising a ValueError when providing a network location to a LocalOutputFile"""
     with pytest.raises(ValueError) as exc_info:
         LocalInputFile(location=string_uri_w_netloc)
 
@@ -277,7 +283,7 @@ def test_raise_on_network_location_in_output_file(string_uri_w_netloc):
 
 @pytest.mark.parametrize("CustomFileIO", [LocalFileIO, PyArrowFileIO])
 def test_deleting_local_file_using_file_io(CustomFileIO):
-
+    """Test deleting a local file using FileIO.delete(...)"""
     with tempfile.TemporaryDirectory() as tmpdirname:
         # Write to the temporary file
         output_file_location = os.path.join(tmpdirname, "foo.txt")
@@ -299,7 +305,7 @@ def test_deleting_local_file_using_file_io(CustomFileIO):
 
 @pytest.mark.parametrize("CustomFileIO", [LocalFileIO, PyArrowFileIO])
 def test_raise_file_not_found_error_for_fileio_delete(CustomFileIO):
-
+    """Test raising a FileNotFound error when trying to delete a non-existent file"""
     with tempfile.TemporaryDirectory() as tmpdirname:
         # Write to the temporary file
         output_file_location = os.path.join(tmpdirname, "foo.txt")
@@ -319,7 +325,7 @@ def test_raise_file_not_found_error_for_fileio_delete(CustomFileIO):
 
 @pytest.mark.parametrize("CustomFileIO, CustomInputFile", [(LocalFileIO, LocalInputFile), (PyArrowFileIO, PyArrowFile)])
 def test_deleting_local_file_using_file_io_input_file(CustomFileIO, CustomInputFile):
-
+    """Test deleting a local file by passing an InputFile instance to FileIO.delete(...)"""
     with tempfile.TemporaryDirectory() as tmpdirname:
         # Write to the temporary file
         file_location = os.path.join(tmpdirname, "foo.txt")
@@ -344,7 +350,7 @@ def test_deleting_local_file_using_file_io_input_file(CustomFileIO, CustomInputF
 
 @pytest.mark.parametrize("CustomFileIO, CustomOutputFile", [(LocalFileIO, LocalOutputFile), (PyArrowFileIO, PyArrowFile)])
 def test_deleting_local_file_using_file_io_output_file(CustomFileIO, CustomOutputFile):
-
+    """Test deleting a local file by passing an OutputFile instance to FileIO.delete(...)"""
     with tempfile.TemporaryDirectory() as tmpdirname:
         # Write to the temporary file
         file_location = os.path.join(tmpdirname, "foo.txt")

--- a/python/tests/io/test_pyarrow.py
+++ b/python/tests/io/test_pyarrow.py
@@ -123,4 +123,4 @@ def test_pyarrow_violating_output_stream_protocol():
         output_file.create()
 
     assert ("Object of type") in str(exc_info.value)
-    assert ("returned from PyArrowFile.create does not match the OutputStream protocol.") in str(exc_info.value)
+    assert ("returned from PyArrowFile.create(...) does not match the OutputStream protocol.") in str(exc_info.value)

--- a/python/tests/io/test_pyarrow.py
+++ b/python/tests/io/test_pyarrow.py
@@ -105,8 +105,8 @@ def test_pyarrow_violating_output_stream_protocol():
     """Test that a TypeError is raised if an output stream is provided that violates the OutputStream protocol"""
 
     # Missing closed, and close
-    output_file_mock = MagicMock(spec=["write"])
-    output_file_mock.exists = False
+    output_file_mock = MagicMock(spec=["write", "exists"])
+    output_file_mock.exists.return_value = False
 
     file_info_mock = MagicMock()
     file_info_mock.type = FileType.NotFound

--- a/python/tests/io/test_pyarrow.py
+++ b/python/tests/io/test_pyarrow.py
@@ -1,0 +1,74 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import tempfile
+
+import pytest
+
+from iceberg.io.pyarrow import PyArrowInputFile, PyArrowOutputFile
+
+
+def test_pyarrow_input_file():
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        file_location = os.path.join(tmpdirname, "foo.txt")
+        with open(file_location, "wb") as f:
+            f.write(b"foo")
+
+        # Confirm that the file initially exists
+        assert os.path.exists(file_location)
+
+        # Instantiate the input file
+        absolute_file_location = os.path.abspath(file_location)
+        input_file = PyArrowInputFile(location=f"file:{absolute_file_location}")
+
+        # Test opening and reading the file
+        f = input_file.open()
+        data = f.read()
+        assert data == b"foo"
+        assert len(input_file) == 3
+
+
+def test_pyarrow_output_file():
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        file_location = os.path.join(tmpdirname, "foo.txt")
+
+        # Instantiate the output file
+        absolute_file_location = os.path.abspath(file_location)
+        output_file = PyArrowOutputFile(location=f"file:{absolute_file_location}")
+
+        # Create the output file and write to it
+        f = output_file.create()
+        f.write(b"foo")
+
+        # Confirm that bytes were written
+        with open(file_location, "rb") as f:
+            assert f.read() == b"foo"
+
+        assert len(output_file) == 3
+
+
+def test_pyarrow_invalid_scheme():
+    with pytest.raises(ValueError) as exc_info:
+        PyArrowInputFile("foo://bar/baz.txt")
+
+    assert ("PyArrowInputFile location must have a scheme of `file`, `mock`, `s3fs`, `hdfs`, or `viewfs`") in str(exc_info.value)
+
+    with pytest.raises(ValueError) as exc_info:
+        PyArrowOutputFile("foo://bar/baz.txt")
+
+    assert ("PyArrowOutputFile location must have a scheme of `file`, `mock`, `s3fs`, `hdfs`, or `viewfs`") in str(exc_info.value)

--- a/python/tests/io/test_pyarrow.py
+++ b/python/tests/io/test_pyarrow.py
@@ -87,7 +87,7 @@ def test_pyarrow_invalid_scheme():
 
 
 @patch("iceberg.io.pyarrow.FileSystem")
-def test_pyarrow_violating_InputStream_protocol(MockedFileSystem):
+def test_pyarrow_violating_input_stream_protocol(MockedFileSystem):
     """Test that a TypeError is raised if an input file is provided that violates the InputStream protocol"""
 
     # Missing seek, tell, closed, and close
@@ -110,7 +110,7 @@ def test_pyarrow_violating_InputStream_protocol(MockedFileSystem):
 
 
 @patch("iceberg.io.pyarrow.FileSystem")
-def test_pyarrow_violating_OutputStream_protocol(MockedFileSystem):
+def test_pyarrow_violating_output_stream_protocol(MockedFileSystem):
     """Test that a TypeError is raised if an output stream is provided that violates the OutputStream protocol"""
 
     # Missing closed, and close

--- a/python/tests/io/test_pyarrow.py
+++ b/python/tests/io/test_pyarrow.py
@@ -22,11 +22,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pyarrow.fs import FileType
 
-from iceberg.io.pyarrow import PyArrowInputFile, PyArrowOutputFile
+from iceberg.io.pyarrow import PyArrowFile
 
 
 def test_pyarrow_input_file():
-    """Test reading a file using PyArrowInputFile"""
+    """Test reading a file using PyArrowFile"""
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         file_location = os.path.join(tmpdirname, "foo.txt")
@@ -38,7 +38,7 @@ def test_pyarrow_input_file():
 
         # Instantiate the input file
         absolute_file_location = os.path.abspath(file_location)
-        input_file = PyArrowInputFile(location=f"{absolute_file_location}")
+        input_file = PyArrowFile(location=f"{absolute_file_location}")
 
         # Test opening and reading the file
         f = input_file.open()
@@ -48,14 +48,14 @@ def test_pyarrow_input_file():
 
 
 def test_pyarrow_output_file():
-    """Test writing a file using PyArrowOutputFile"""
+    """Test writing a file using PyArrowFile"""
 
     with tempfile.TemporaryDirectory() as tmpdirname:
         file_location = os.path.join(tmpdirname, "foo.txt")
 
         # Instantiate the output file
         absolute_file_location = os.path.abspath(file_location)
-        output_file = PyArrowOutputFile(location=f"{absolute_file_location}")
+        output_file = PyArrowFile(location=f"{absolute_file_location}")
 
         # Create the output file and write to it
         f = output_file.create()
@@ -72,14 +72,18 @@ def test_pyarrow_invalid_scheme():
     """Test that a ValueError is raised if a location is provided with an invalid scheme"""
 
     with pytest.raises(ValueError) as exc_info:
-        PyArrowInputFile("foo://bar/baz.txt")
+        PyArrowFile("foo://bar/baz.txt")
 
-    assert ("PyArrowInputFile location must have a scheme of `file`, `mock`, `s3fs`, `hdfs`, or `viewfs`") in str(exc_info.value)
+    assert ("PyArrowFile location must have one of the following schemes: ['file', 'mock', 's3fs', 'hdfs', 'viewfs']") in str(
+        exc_info.value
+    )
 
     with pytest.raises(ValueError) as exc_info:
-        PyArrowOutputFile("foo://bar/baz.txt")
+        PyArrowFile("foo://bar/baz.txt")
 
-    assert ("PyArrowOutputFile location must have a scheme of `file`, `mock`, `s3fs`, `hdfs`, or `viewfs`") in str(exc_info.value)
+    assert ("PyArrowFile location must have one of the following schemes: ['file', 'mock', 's3fs', 'hdfs', 'viewfs']") in str(
+        exc_info.value
+    )
 
 
 @patch("iceberg.io.pyarrow.FileSystem")
@@ -99,9 +103,9 @@ def test_pyarrow_violating_InputStream_protocol(MockedFileSystem):
     )  # Patch the FileSystem.from_uri method to return the mocked filesystem
 
     with pytest.raises(TypeError) as exc_info:
-        PyArrowInputFile("foo.txt").open()
+        PyArrowFile("foo.txt").open()
 
-    assert ("Object returned from PyArrowInputFile.open does not match the InputStream protocol.") in str(exc_info.value)
+    assert ("Object returned from PyArrowFile.open does not match the InputStream protocol.") in str(exc_info.value)
 
 
 @patch("iceberg.io.pyarrow.FileSystem")
@@ -125,6 +129,6 @@ def test_pyarrow_violating_OutputStream_protocol(MockedFileSystem):
     )  # Patch the FileSystem.from_uri method to return the mocked filesystem
 
     with pytest.raises(TypeError) as exc_info:
-        PyArrowOutputFile("foo.txt").create()
+        PyArrowFile("foo.txt").create()
 
-    assert ("Object returned from PyArrowOutputFile.create does not match the OutputStream protocol.") in str(exc_info.value)
+    assert ("Object returned from PyArrowFile.create does not match the OutputStream protocol.") in str(exc_info.value)

--- a/python/tests/io/test_pyarrow.py
+++ b/python/tests/io/test_pyarrow.py
@@ -163,21 +163,7 @@ def test_raise_on_checking_if_local_file_exists_no_permission():
         with pytest.raises(PermissionError) as exc_info:
             f.create()
 
-        assert "Cannot create file, access denied:" in str(exc_info.value)
-
-
-def test_raise_on_checking_if_local_file_exists_no_permission():
-    """Test that the PyArrowFile.exists method, specifically, raises when checking for existence on a file without permission"""
-
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        os.chmod(tmpdirname, 0o600)
-        file_location = os.path.join(tmpdirname, "foo.txt")
-        f = PyArrowFile(file_location)
-
-        with pytest.raises(PermissionError) as exc_info:
-            f.exists()
-
-        assert "Cannot check if file exists, access denied:" in str(exc_info.value)
+        assert "Cannot get file info, access denied:" in str(exc_info.value)
 
 
 def test_raise_on_creating_a_local_file_no_permission():
@@ -191,7 +177,7 @@ def test_raise_on_creating_a_local_file_no_permission():
         with pytest.raises(PermissionError) as exc_info:
             f.create()
 
-        assert "Cannot check if file exists, access denied:" in str(exc_info.value)
+        assert "Cannot get file info, access denied:" in str(exc_info.value)
 
 
 @patch("iceberg.io.pyarrow.PyArrowFile.exists", return_value=False)
@@ -253,7 +239,7 @@ def test_deleting_s3_file_no_permission(filesystem_mock):
     """Test that a PyArrowFile raises a PermissionError when the pyarrow error includes 'AWS Error [code 15]'"""
 
     s3fs_mock = MagicMock()
-    s3fs_mock.delete_file.side_effect = OSError("AWS Error [code 15]")
+    s3fs_mock.delete_file.side_effect = PermissionError("AWS Error [code 15]")
 
     filesystem_mock.from_uri.return_value = (s3fs_mock, "foo.txt")
 
@@ -262,4 +248,21 @@ def test_deleting_s3_file_no_permission(filesystem_mock):
     with pytest.raises(PermissionError) as exc_info:
         file_io.delete("s3://foo/bar.txt")
 
-    assert "Cannot delete file, access denied:" in str(exc_info.value)
+    assert "AWS Error [code 15]" in str(exc_info.value)
+
+
+@patch("iceberg.io.pyarrow.FileSystem")
+def test_deleting_s3_file_not_found(filesystem_mock):
+    """Test that a PyArrowFile raises a PermissionError when the pyarrow error includes 'AWS Error [code 15]'"""
+
+    s3fs_mock = MagicMock()
+    s3fs_mock.delete_file.side_effect = OSError("Path does not exist")
+
+    filesystem_mock.from_uri.return_value = (s3fs_mock, "foo.txt")
+
+    file_io = PyArrowFileIO()
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        file_io.delete("s3://foo/bar.txt")
+
+    assert "Cannot delete file, does not exist:" in str(exc_info.value)

--- a/python/tests/io/test_pyarrow.py
+++ b/python/tests/io/test_pyarrow.py
@@ -17,13 +17,17 @@
 
 import os
 import tempfile
+from unittest.mock import MagicMock, patch
 
 import pytest
+from pyarrow.fs import FileType
 
 from iceberg.io.pyarrow import PyArrowInputFile, PyArrowOutputFile
 
 
 def test_pyarrow_input_file():
+    """Test reading a file using PyArrowInputFile"""
+
     with tempfile.TemporaryDirectory() as tmpdirname:
         file_location = os.path.join(tmpdirname, "foo.txt")
         with open(file_location, "wb") as f:
@@ -44,6 +48,8 @@ def test_pyarrow_input_file():
 
 
 def test_pyarrow_output_file():
+    """Test writing a file using PyArrowOutputFile"""
+
     with tempfile.TemporaryDirectory() as tmpdirname:
         file_location = os.path.join(tmpdirname, "foo.txt")
 
@@ -63,6 +69,8 @@ def test_pyarrow_output_file():
 
 
 def test_pyarrow_invalid_scheme():
+    """Test that a ValueError is raised if a location is provided with an invalid scheme"""
+
     with pytest.raises(ValueError) as exc_info:
         PyArrowInputFile("foo://bar/baz.txt")
 
@@ -72,3 +80,51 @@ def test_pyarrow_invalid_scheme():
         PyArrowOutputFile("foo://bar/baz.txt")
 
     assert ("PyArrowOutputFile location must have a scheme of `file`, `mock`, `s3fs`, `hdfs`, or `viewfs`") in str(exc_info.value)
+
+
+@patch("iceberg.io.pyarrow.FileSystem")
+def test_pyarrow_violating_InputStream_protocol(MockedFileSystem):
+    """Test that a TypeError is raised if an input file is provided that violates the InputStream protocol"""
+
+    # Missing seek, tell, closed, and close
+    input_file_mock = MagicMock(spec=["read"])
+
+    # Create a mocked filesystem that returns input_file_mock
+    filesystem_mock = MagicMock()
+    filesystem_mock.open_input_file.return_value = input_file_mock
+
+    MockedFileSystem.from_uri.return_value = (
+        filesystem_mock,
+        "foo_path",
+    )  # Patch the FileSystem.from_uri method to return the mocked filesystem
+
+    with pytest.raises(TypeError) as exc_info:
+        PyArrowInputFile("file://foo/bar.txt").open()
+
+    assert ("Object returned from PyArrowInputFile.open does not match the InputStream protocol.") in str(exc_info.value)
+
+
+@patch("iceberg.io.pyarrow.FileSystem")
+def test_pyarrow_violating_OutputStream_protocol(MockedFileSystem):
+    """Test that a TypeError is raised if an output stream is provided that violates the OutputStream protocol"""
+
+    # Missing closed, and close
+    output_file_mock = MagicMock(spec=["write"])
+    output_file_mock.exists = False
+
+    file_info_mock = MagicMock
+    file_info_mock.type = FileType.NotFound
+
+    # Create a mocked filesystem that returns output_file_mock
+    filesystem_mock = MagicMock()
+    filesystem_mock.open_output_stream.return_value = output_file_mock
+    filesystem_mock.get_file_info.return_value = file_info_mock
+    MockedFileSystem.from_uri.return_value = (
+        filesystem_mock,
+        "foo_path",
+    )  # Patch the FileSystem.from_uri method to return the mocked filesystem
+
+    with pytest.raises(TypeError) as exc_info:
+        PyArrowOutputFile("file://foo/bar/baz.txt").create()
+
+    assert ("Object returned from PyArrowOutputFile.create does not match the OutputStream protocol.") in str(exc_info.value)

--- a/python/tests/io/test_pyarrow.py
+++ b/python/tests/io/test_pyarrow.py
@@ -105,7 +105,8 @@ def test_pyarrow_violating_InputStream_protocol(MockedFileSystem):
     with pytest.raises(TypeError) as exc_info:
         PyArrowFile("foo.txt").open()
 
-    assert ("Object returned from PyArrowFile.open does not match the InputStream protocol.") in str(exc_info.value)
+    assert ("Object of type") in str(exc_info.value)
+    assert ("returned from PyArrowFile.open does not match the InputStream protocol.") in str(exc_info.value)
 
 
 @patch("iceberg.io.pyarrow.FileSystem")
@@ -131,4 +132,5 @@ def test_pyarrow_violating_OutputStream_protocol(MockedFileSystem):
     with pytest.raises(TypeError) as exc_info:
         PyArrowFile("foo.txt").create()
 
-    assert ("Object returned from PyArrowFile.create does not match the OutputStream protocol.") in str(exc_info.value)
+    assert ("Object of type") in str(exc_info.value)
+    assert ("returned from PyArrowFile.create does not match the OutputStream protocol.") in str(exc_info.value)

--- a/python/tests/io/test_pyarrow.py
+++ b/python/tests/io/test_pyarrow.py
@@ -38,7 +38,7 @@ def test_pyarrow_input_file():
 
         # Instantiate the input file
         absolute_file_location = os.path.abspath(file_location)
-        input_file = PyArrowInputFile(location=f"file:{absolute_file_location}")
+        input_file = PyArrowInputFile(location=f"{absolute_file_location}")
 
         # Test opening and reading the file
         f = input_file.open()
@@ -55,7 +55,7 @@ def test_pyarrow_output_file():
 
         # Instantiate the output file
         absolute_file_location = os.path.abspath(file_location)
-        output_file = PyArrowOutputFile(location=f"file:{absolute_file_location}")
+        output_file = PyArrowOutputFile(location=f"{absolute_file_location}")
 
         # Create the output file and write to it
         f = output_file.create()
@@ -99,7 +99,7 @@ def test_pyarrow_violating_InputStream_protocol(MockedFileSystem):
     )  # Patch the FileSystem.from_uri method to return the mocked filesystem
 
     with pytest.raises(TypeError) as exc_info:
-        PyArrowInputFile("file://foo/bar.txt").open()
+        PyArrowInputFile("foo.txt").open()
 
     assert ("Object returned from PyArrowInputFile.open does not match the InputStream protocol.") in str(exc_info.value)
 
@@ -125,6 +125,6 @@ def test_pyarrow_violating_OutputStream_protocol(MockedFileSystem):
     )  # Patch the FileSystem.from_uri method to return the mocked filesystem
 
     with pytest.raises(TypeError) as exc_info:
-        PyArrowOutputFile("file://foo/bar/baz.txt").create()
+        PyArrowOutputFile("foo.txt").create()
 
     assert ("Object returned from PyArrowOutputFile.create does not match the OutputStream protocol.") in str(exc_info.value)

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -24,6 +24,7 @@ deps =
     coverage
     mock
     pytest
+    pyarrow
 setenv =
     COVERAGE_FILE = test-reports/{envname}/.coverage
     PYTEST_ADDOPTS = --junitxml=test-reports/{envname}/junit.xml -vv

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -65,7 +65,7 @@ commands =
 deps =
     mypy
 commands =
-    mypy --no-implicit-optional src
+    mypy --no-implicit-optional --config tox.ini src
 
 [testenv:docs]
 basepython = python3
@@ -91,3 +91,6 @@ python =
   3.7: py37
   3.8: py38, linters
   3.9: py39
+
+[mypy-pyarrow.*]
+ignore_missing_imports = True


### PR DESCRIPTION
This PR adds the first FileIO implementation. It wraps the PyArrow [FileSystem](https://arrow.apache.org/docs/python/generated/pyarrow.fs.FileSystem.html#pyarrow.fs.FileSystem) class. The locations provided to `PyArrowInputFile` and `PyArrowOutputFile` are used to infer the correct filesystem by passing them to the [FileSystem.from_uri](https://arrow.apache.org/docs/python/generated/pyarrow.fs.FileSystem.html#pyarrow.fs.FileSystem.from_uri) method. The implementations of the `InputFile.open` and `OutputFile.create` methods both return a `pyarrow.lib.NativeFile` instance.