### PR TITLE
Core: Replace setCurrentSnapshot with setBranchSnapshot in metadata builder

### DIFF
--- a/api/src/main/java/org/apache/iceberg/SnapshotRef.java
+++ b/api/src/main/java/org/apache/iceberg/SnapshotRef.java
@@ -55,6 +55,14 @@ public class SnapshotRef implements Serializable {
     return type;
   }
 
+  public boolean isBranch() {
+    return type == SnapshotRefType.BRANCH;
+  }
+
+  public boolean isTag() {
+    return type == SnapshotRefType.TAG;
+  }
+
   public Integer minSnapshotsToKeep() {
     return minSnapshotsToKeep;
   }

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
@@ -153,14 +153,32 @@ public interface MetadataUpdate extends Serializable {
     }
   }
 
-  class SetCurrentSnapshot implements MetadataUpdate {
-    private final Long snapshotId;
+  class RemoveSnapshotRef implements MetadataUpdate {
+    private final String name;
 
-    public SetCurrentSnapshot(Long snapshotId) {
+    public RemoveSnapshotRef(String name) {
+      this.name = name;
+    }
+
+    public String name() {
+      return name;
+    }
+  }
+
+  class SetSnapshotRef implements MetadataUpdate {
+    private final String name;
+    private final long snapshotId;
+
+    public SetSnapshotRef(String name, long snapshotId) {
+      this.name = name;
       this.snapshotId = snapshotId;
     }
 
-    public Long snapshotId() {
+    public String name() {
+      return name;
+    }
+
+    public long snapshotId() {
       return snapshotId;
     }
   }

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -930,7 +930,7 @@ public class TableMetadata implements Serializable {
 
     public Builder setBranchSnapshot(Snapshot snapshot, String branch) {
       addSnapshot(snapshot);
-      setBranchSnapshot(snapshot.snapshotId(), branch);
+      setBranchSnapshot(snapshot, branch, null);
       return this;
     }
 

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -496,14 +496,6 @@ public class TableMetadata implements Serializable {
     return new Builder(this).setDefaultSortOrder(newOrder).build();
   }
 
-  public TableMetadata addStagedSnapshot(Snapshot snapshot) {
-    return new Builder(this).addSnapshot(snapshot).build();
-  }
-
-  public TableMetadata replaceCurrentSnapshot(Snapshot snapshot) {
-    return new Builder(this).setBranchSnapshot(snapshot, SnapshotRef.MAIN_BRANCH).build();
-  }
-
   public TableMetadata removeSnapshotsIf(Predicate<Snapshot> removeIf) {
     List<Snapshot> toRemove = snapshots.stream().filter(removeIf).collect(Collectors.toList());
     return new Builder(this).removeSnapshots(toRemove).build();

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1271,9 +1271,9 @@ public class TableMetadata implements Serializable {
           addedSnapshotIds.add(addSnapshot.snapshot().snapshotId());
         } else if (update instanceof MetadataUpdate.SetSnapshotRef) {
           MetadataUpdate.SetSnapshotRef setRef = (MetadataUpdate.SetSnapshotRef) update;
-          Long snapshotId = setRef.snapshotId();
-          if (snapshotId != null && addedSnapshotIds.contains(snapshotId) &&
-              "main".equals(setRef.name()) && snapshotId != currentSnapshotId) {
+          long snapshotId = setRef.snapshotId();
+          if (addedSnapshotIds.contains(snapshotId) &&
+              SnapshotRef.MAIN_BRANCH.equals(setRef.name()) && snapshotId != currentSnapshotId) {
             intermediateSnapshotIds.add(snapshotId);
           }
         }

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
@@ -86,13 +86,15 @@ public class NessieTableOperations extends BaseMetastoreTableOperations {
 
   private TableMetadata loadTableMetadata(String metadataLocation) {
     // Update the TableMetadata with the Content of NessieTableState.
-    return TableMetadata.buildFrom(TableMetadataParser.read(io(), metadataLocation))
-        .setBranchSnapshot(table.getSnapshotId(), SnapshotRef.MAIN_BRANCH)
+    TableMetadata.Builder builder = TableMetadata.buildFrom(TableMetadataParser.read(io(), metadataLocation))
         .setCurrentSchema(table.getSchemaId())
         .setDefaultSortOrder(table.getSortOrderId())
-        .setDefaultPartitionSpec(table.getSpecId())
-        .discardChanges()
-        .build();
+        .setDefaultPartitionSpec(table.getSpecId());
+    if (table.getSnapshotId() != -1) {
+      builder.setBranchSnapshot(table.getSnapshotId(), SnapshotRef.MAIN_BRANCH);
+    }
+
+    return builder.discardChanges().build();
   }
 
   @Override

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieTableOperations.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.function.Predicate;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.exceptions.CommitFailedException;
@@ -86,7 +87,7 @@ public class NessieTableOperations extends BaseMetastoreTableOperations {
   private TableMetadata loadTableMetadata(String metadataLocation) {
     // Update the TableMetadata with the Content of NessieTableState.
     return TableMetadata.buildFrom(TableMetadataParser.read(io(), metadataLocation))
-        .setCurrentSnapshot(table.getSnapshotId())
+        .setBranchSnapshot(table.getSnapshotId(), SnapshotRef.MAIN_BRANCH)
         .setCurrentSchema(table.getSchemaId())
         .setDefaultSortOrder(table.getSortOrderId())
         .setDefaultPartitionSpec(table.getSpecId())

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -737,6 +737,7 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
     TestHelpers.assertEqualsSafe(historyTable.schema().asStruct(), expected.get(0), actual.get(0));
     TestHelpers.assertEqualsSafe(historyTable.schema().asStruct(), expected.get(1), actual.get(1));
     TestHelpers.assertEqualsSafe(historyTable.schema().asStruct(), expected.get(2), actual.get(2));
+    TestHelpers.assertEqualsSafe(historyTable.schema().asStruct(), expected.get(3), actual.get(3));
   }
 
   @Test


### PR DESCRIPTION
This updates the `TableMetadata.Builder` methods and replaces the previous `setCurrentSnapshot` with a branch-aware `setBranchSnapshot`.

I'm posting this for early feedback. This is the most straight-forward change, but it doesn't support modifying the ref settings like max age and it doesn't support creating/removing tags. We may want to change the builder API to be more generic and if so this is a step toward that API.