### PR TITLE
Docs: add multi-engine support redirect page in versioned doc project section

### DIFF
--- a/docs/versioned/project/multi-engine-support.md
+++ b/docs/versioned/project/multi-engine-support.md
@@ -1,0 +1,20 @@
+---
+title: "Multi-Engine Support"
+bookUrlFromBaseURL: /../../multi-engine-support
+---
+<!--
+ - Licensed to the Apache Software Foundation (ASF) under one or more
+ - contributor license agreements.  See the NOTICE file distributed with
+ - this work for additional information regarding copyright ownership.
+ - The ASF licenses this file to You under the Apache License, Version 2.0
+ - (the "License"); you may not use this file except in compliance with
+ - the License.  You may obtain a copy of the License at
+ -
+ -   http://www.apache.org/licenses/LICENSE-2.0
+ -
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -->


### PR DESCRIPTION
As discussed in https://apache-iceberg.slack.com/archives/C025PH0G1D4/p1644497009853909, add a redirect in versioned doc so people can have a way of finding the multi-version support page from the versioned doc part.

I think it would be good to also make it a section in the landing home, that change will go to the iceberg-docs repo in HTML.

@amogh-jahagirdar @nastra @samredai 