### PR TITLE
Avro: Fix BuildAvroProjection list and map handling to preserve field IDs

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -93,7 +93,7 @@ public class AvroSchemaUtil {
   /**
    * Check if any of the nodes in a given avro schema is missing an ID
    * <p>
-   * To have an ID recognizable by Iceberg core API:
+   * To have an ID for a node:
    * <ul>
    *   <li>a field node under struct (record) schema should have {@link FIELD_ID_PROP} property
    *   <li>an element node under list (array) schema should have {@link ELEMENT_ID_PROP} property

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -90,6 +90,10 @@ public class AvroSchemaUtil {
     return AvroCustomOrderSchemaVisitor.visit(schema, new HasIds());
   }
 
+  static boolean missingIds(Schema schema) {
+    return AvroCustomOrderSchemaVisitor.visit(schema, new MissingIds());
+  }
+
   public static Map<Type, Schema> convertTypes(Types.StructType type, String name) {
     TypeToSchema converter = new TypeToSchema(ImmutableMap.of(type, name));
     TypeUtil.visit(type, converter);
@@ -354,6 +358,26 @@ public class AvroSchemaUtil {
       copy.addAlias(field.name());
     }
 
+    return copy;
+  }
+
+  static Schema copyArray(Schema array, Schema elementSchema) {
+    Preconditions.checkArgument(array.getType() == org.apache.avro.Schema.Type.ARRAY,
+        "Cannot invoke copyArray on non array schema");
+    Schema copy = Schema.createArray(elementSchema);
+    for (Map.Entry<String, Object> prop : array.getObjectProps().entrySet()) {
+      copy.addProp(prop.getKey(), prop.getValue());
+    }
+    return copy;
+  }
+
+  static Schema copyMap(Schema map, Schema valueSchema) {
+    Preconditions.checkArgument(map.getType() == org.apache.avro.Schema.Type.MAP,
+        "Cannot invoke copyMap on non map schema");
+    Schema copy = Schema.createMap(valueSchema);
+    for (Map.Entry<String, Object> prop : map.getObjectProps().entrySet()) {
+      copy.addProp(prop.getKey(), prop.getValue());
+    }
     return copy;
   }
 

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -91,8 +91,8 @@ public class AvroSchemaUtil {
   }
 
   /**
-   * Check if any of the nodes in a given avro schema is missing an ID recognizable by Iceberg core API
-   *
+   * Check if any of the nodes in a given avro schema is missing an ID
+   * <p>
    * To have an ID recognizable by Iceberg core API:
    * <ul>
    *   <li>a field node under struct (record) schema should have {@link FIELD_ID_PROP} property
@@ -101,7 +101,7 @@ public class AvroSchemaUtil {
    *   {@link VALUE_ID_PROP} respectively
    *   <li>a primitive node is not assigned any ID properties
    * </ul>
-   *
+   * <p>
    * @param schema an Avro Schema
    * @return true if any of the nodes of the given Avro Schema is missing an ID property, false otherwise
    */

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -91,7 +91,7 @@ public class AvroSchemaUtil {
   }
 
   /**
-   * Check if any of the nodes on a given avro schema is missing ID property recognizable by Iceberg core API
+   * Check if any of the nodes in a given avro schema is missing an ID recognizable by Iceberg core API
    *
    * To have an ID recognizable by Iceberg core API:
    * <ul>

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -90,6 +90,19 @@ public class AvroSchemaUtil {
     return AvroCustomOrderSchemaVisitor.visit(schema, new HasIds());
   }
 
+  /**
+   * @param schema an Avro Schema
+   * @return true/false based on whether any of the nodes in the provided schema is missing an
+   * ID property recognizable by Iceberg core API. To have an ID recognizable by Iceberg core API:
+   * <ul>
+   *   <li>a field node under struct (record) schema should have {@link FIELD_ID_PROP} property
+   *   <li>an element node under list (array) schema should have {@link ELEMENT_ID_PROP} property
+   *   <li>a pair of key and value node under map schema should have {@link KEY_ID_PROP} and
+   *   {@link VALUE_ID_PROP} respectively
+   *   <li>a primitive node is not assigned any ID related properties
+   * </ul>
+   * @implNote see {@link MissingIds} for more details
+   */
   static boolean missingIds(Schema schema) {
     return AvroCustomOrderSchemaVisitor.visit(schema, new MissingIds());
   }
@@ -361,9 +374,9 @@ public class AvroSchemaUtil {
     return copy;
   }
 
-  static Schema copyArray(Schema array, Schema elementSchema) {
+  static Schema replaceElement(Schema array, Schema elementSchema) {
     Preconditions.checkArgument(array.getType() == org.apache.avro.Schema.Type.ARRAY,
-        "Cannot invoke copyArray on non array schema");
+        "Cannot invoke replaceElement on non array schema: %s", array);
     Schema copy = Schema.createArray(elementSchema);
     for (Map.Entry<String, Object> prop : array.getObjectProps().entrySet()) {
       copy.addProp(prop.getKey(), prop.getValue());
@@ -371,9 +384,9 @@ public class AvroSchemaUtil {
     return copy;
   }
 
-  static Schema copyMap(Schema map, Schema valueSchema) {
+  static Schema replaceValue(Schema map, Schema valueSchema) {
     Preconditions.checkArgument(map.getType() == org.apache.avro.Schema.Type.MAP,
-        "Cannot invoke copyMap on non map schema");
+        "Cannot invoke replaceValue on non map schema: %s", map);
     Schema copy = Schema.createMap(valueSchema);
     for (Map.Entry<String, Object> prop : map.getObjectProps().entrySet()) {
       copy.addProp(prop.getKey(), prop.getValue());

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -91,17 +91,19 @@ public class AvroSchemaUtil {
   }
 
   /**
-   * @param schema an Avro Schema
-   * @return true/false based on whether any of the nodes in the provided schema is missing an
-   * ID property recognizable by Iceberg core API. To have an ID recognizable by Iceberg core API:
+   * Check if any of the nodes on a given avro schema is missing ID property recognizable by Iceberg core API
+   *
+   * To have an ID recognizable by Iceberg core API:
    * <ul>
    *   <li>a field node under struct (record) schema should have {@link FIELD_ID_PROP} property
    *   <li>an element node under list (array) schema should have {@link ELEMENT_ID_PROP} property
    *   <li>a pair of key and value node under map schema should have {@link KEY_ID_PROP} and
    *   {@link VALUE_ID_PROP} respectively
-   *   <li>a primitive node is not assigned any ID related properties
+   *   <li>a primitive node is not assigned any ID properties
    * </ul>
-   * @implNote see {@link MissingIds} for more details
+   *
+   * @param schema an Avro Schema
+   * @return true if any of the nodes of the given Avro Schema is missing an ID property, false otherwise
    */
   static boolean missingIds(Schema schema) {
     return AvroCustomOrderSchemaVisitor.visit(schema, new MissingIds());

--- a/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
+++ b/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
@@ -206,7 +206,7 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
 
         // element was changed, create a new array
         if (!Objects.equals(elementSchema, array.getElementType())) {
-          return AvroSchemaUtil.copyArray(array, elementSchema);
+          return AvroSchemaUtil.replaceElement(array, elementSchema);
         }
 
         return array;
@@ -230,7 +230,7 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
 
       // element was changed, create a new map
       if (!Objects.equals(valueSchema, map.getValueType())) {
-        return AvroSchemaUtil.copyMap(map, valueSchema);
+        return AvroSchemaUtil.replaceValue(map, valueSchema);
       }
 
       return map;

--- a/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
+++ b/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
@@ -49,6 +49,11 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
     this.current = expectedSchema.asStruct();
   }
 
+  BuildAvroProjection(org.apache.iceberg.types.Type expectedType, Map<String, String> renames) {
+    this.renames = renames;
+    this.current = expectedType;
+  }
+
   @Override
   @SuppressWarnings("checkstyle:CyclomaticComplexity")
   public Schema record(Schema record, List<String> names, Iterable<Schema.Field> schemaIterable) {
@@ -201,7 +206,7 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
 
         // element was changed, create a new array
         if (!Objects.equals(elementSchema, array.getElementType())) {
-          return Schema.createArray(elementSchema);
+          return AvroSchemaUtil.copyArray(array, elementSchema);
         }
 
         return array;
@@ -225,7 +230,7 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
 
       // element was changed, create a new map
       if (!Objects.equals(valueSchema, map.getValueType())) {
-        return Schema.createMap(valueSchema);
+        return AvroSchemaUtil.copyMap(map, valueSchema);
       }
 
       return map;

--- a/core/src/main/java/org/apache/iceberg/avro/HasIds.java
+++ b/core/src/main/java/org/apache/iceberg/avro/HasIds.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.avro;
 import java.util.List;
 import java.util.function.Supplier;
 import org.apache.avro.Schema;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 
 /**
  * Lazily evaluates the schema to see if any field ids are set.
@@ -30,12 +31,7 @@ import org.apache.avro.Schema;
 class HasIds extends AvroCustomOrderSchemaVisitor<Boolean, Boolean> {
   @Override
   public Boolean record(Schema record, List<String> names, Iterable<Boolean> fields) {
-    for (Boolean field : fields) {
-      if (field) {
-        return true;
-      }
-    }
-    return false;
+    return Iterables.any(fields, Boolean.TRUE::equals);
   }
 
   @Override
@@ -58,12 +54,7 @@ class HasIds extends AvroCustomOrderSchemaVisitor<Boolean, Boolean> {
 
   @Override
   public Boolean union(Schema union, Iterable<Boolean> options) {
-    for (Boolean option : options) {
-      if (option) {
-        return true;
-      }
-    }
-    return false;
+    return Iterables.any(options, Boolean.TRUE::equals);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/avro/MissingIds.java
+++ b/core/src/main/java/org/apache/iceberg/avro/MissingIds.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.avro;
 import java.util.List;
 import java.util.function.Supplier;
 import org.apache.avro.Schema;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 
 /**
  * Returns true once the first node is found with ID property missing. Reverse of {@link HasIds}
@@ -34,12 +35,7 @@ import org.apache.avro.Schema;
 class MissingIds extends AvroCustomOrderSchemaVisitor<Boolean, Boolean> {
   @Override
   public Boolean record(Schema record, List<String> names, Iterable<Boolean> fields) {
-    for (Boolean field : fields) {
-      if (field) {
-        return true;
-      }
-    }
-    return false;
+    return Iterables.any(fields, Boolean.TRUE::equals);
   }
 
   @Override
@@ -64,12 +60,7 @@ class MissingIds extends AvroCustomOrderSchemaVisitor<Boolean, Boolean> {
 
   @Override
   public Boolean union(Schema union, Iterable<Boolean> options) {
-    for (Boolean option : options) {
-      if (option) {
-        return true;
-      }
-    }
-    return false;
+    return Iterables.any(options, Boolean.TRUE::equals);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/avro/MissingIds.java
+++ b/core/src/main/java/org/apache/iceberg/avro/MissingIds.java
@@ -31,7 +31,7 @@ import org.apache.avro.Schema;
  * that the schema has at least one ID, and not sufficient condition for invoking
  * {@link AvroSchemaUtil#toIceberg(Schema)} on the schema.
  */
-public class MissingIds extends AvroCustomOrderSchemaVisitor<Boolean, Boolean> {
+class MissingIds extends AvroCustomOrderSchemaVisitor<Boolean, Boolean> {
   @Override
   public Boolean record(Schema record, List<String> names, Iterable<Boolean> fields) {
     for (Boolean field : fields) {

--- a/core/src/main/java/org/apache/iceberg/avro/MissingIds.java
+++ b/core/src/main/java/org/apache/iceberg/avro/MissingIds.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.avro;
+
+import java.util.List;
+import java.util.function.Supplier;
+import org.apache.avro.Schema;
+
+/**
+ * Returns true once the first node is found with ID property missing. Reverse of {@link HasIds}
+ * <p>
+ * Note: To use {@link AvroSchemaUtil#toIceberg(Schema)} on an avro schema, the avro schema need to be either
+ * have IDs on every node or not have IDs at all. Invoke {@link AvroSchemaUtil#hasIds(Schema)} only proves
+ * that the schema has at least one ID, and not sufficient condition for invoking
+ * {@link AvroSchemaUtil#toIceberg(Schema)} on the schema.
+ */
+public class MissingIds extends AvroCustomOrderSchemaVisitor<Boolean, Boolean> {
+  @Override
+  public Boolean record(Schema record, List<String> names, Iterable<Boolean> fields) {
+    for (Boolean field : fields) {
+      if (field) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public Boolean field(Schema.Field field, Supplier<Boolean> fieldResult) {
+    // either this field is missing ID, or the subtree is missing ID somewhere
+    return !AvroSchemaUtil.hasFieldId(field) || fieldResult.get();
+  }
+
+  @Override
+  public Boolean map(Schema map, Supplier<Boolean> value) {
+    // either this map node is missing (key/value) ID, or the subtree is missing ID somewhere
+    return !AvroSchemaUtil.hasProperty(map, AvroSchemaUtil.KEY_ID_PROP) ||
+        !AvroSchemaUtil.hasProperty(map, AvroSchemaUtil.VALUE_ID_PROP) ||
+        value.get();
+  }
+
+  @Override
+  public Boolean array(Schema array, Supplier<Boolean> element) {
+    // either this list node is missing (elem) ID, or the subtree is missing ID somewhere
+    return !AvroSchemaUtil.hasProperty(array, AvroSchemaUtil.ELEMENT_ID_PROP) || element.get();
+  }
+
+  @Override
+  public Boolean union(Schema union, Iterable<Boolean> options) {
+    for (Boolean option : options) {
+      if (option) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public Boolean primitive(Schema primitive) {
+    // primitive node cannot be missing ID as Iceberg do not assign primitive node IDs in the first place
+    return false;
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroSchemaProjection.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroSchemaProjection.java
@@ -53,7 +53,8 @@ public class TestAvroSchemaProjection {
     final org.apache.avro.Schema projectedAvroSchema =
         AvroSchemaUtil.buildAvroProjection(idAllocatedUpdatedAvroSchema, currentIcebergSchema, Collections.emptyMap());
 
-    assertFalse(AvroSchemaUtil.missingIds(projectedAvroSchema));
+    assertFalse("Result of buildAvroProjection is missing some IDs",
+        AvroSchemaUtil.missingIds(projectedAvroSchema));
   }
 
 
@@ -82,7 +83,8 @@ public class TestAvroSchemaProjection {
     final org.apache.avro.Schema projectedAvroSchema =
         AvroSchemaUtil.buildAvroProjection(idAllocatedUpdatedAvroSchema, currentIcebergSchema, Collections.emptyMap());
 
-    assertFalse(AvroSchemaUtil.missingIds(projectedAvroSchema));
+    assertFalse("Result of buildAvroProjection is missing some IDs",
+        AvroSchemaUtil.missingIds(projectedAvroSchema));
   }
 
 }

--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroSchemaProjection.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroSchemaProjection.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.avro;
+
+import java.util.Collections;
+import org.apache.avro.SchemaBuilder;
+import org.apache.iceberg.Schema;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+
+public class TestAvroSchemaProjection {
+
+  @Test
+  public void projectWithListSchemaChanged() {
+    final org.apache.avro.Schema currentAvroSchema = SchemaBuilder.record("myrecord").namespace("unit.test").fields()
+        .name("f1").type().nullable().array().items(
+            SchemaBuilder.record("elem").fields()
+                .name("f11").type().nullable().intType().noDefault().endRecord())
+        .noDefault().endRecord();
+
+    final org.apache.avro.Schema updatedAvroSchema = SchemaBuilder.record("myrecord").namespace("unit.test").fields()
+        .name("f1").type().nullable().array().items(
+            SchemaBuilder.record("elem").fields()
+                .name("f11").type().nullable().intType().noDefault()
+                .name("f12").type().nullable().stringType().noDefault()
+                .endRecord())
+        .noDefault().endRecord();
+
+    final Schema currentIcebergSchema = AvroSchemaUtil.toIceberg(currentAvroSchema);
+
+    // Getting the node ID in updatedAvroSchema allocated by converting into iceberg schema and back
+    final org.apache.avro.Schema idAllocatedUpdatedAvroSchema =
+        AvroSchemaUtil.convert(AvroSchemaUtil.toIceberg(updatedAvroSchema).asStruct());
+
+    final org.apache.avro.Schema projectedAvroSchema =
+        AvroSchemaUtil.buildAvroProjection(idAllocatedUpdatedAvroSchema, currentIcebergSchema, Collections.emptyMap());
+
+    assertFalse(AvroSchemaUtil.missingIds(projectedAvroSchema));
+  }
+
+
+  @Test
+  public void projectWithMapSchemaChanged() {
+    final org.apache.avro.Schema currentAvroSchema = SchemaBuilder.record("myrecord").namespace("unit.test").fields()
+        .name("f1").type().nullable().map().values(
+            SchemaBuilder.record("elem").fields()
+                .name("f11").type().nullable().intType().noDefault().endRecord())
+        .noDefault().endRecord();
+
+    final org.apache.avro.Schema updatedAvroSchema = SchemaBuilder.record("myrecord").namespace("unit.test").fields()
+        .name("f1").type().nullable().map().values(
+            SchemaBuilder.record("elem").fields()
+                .name("f11").type().nullable().intType().noDefault()
+                .name("f12").type().nullable().stringType().noDefault()
+                .endRecord())
+        .noDefault().endRecord();
+
+    final Schema currentIcebergSchema = AvroSchemaUtil.toIceberg(currentAvroSchema);
+
+    // Getting the node ID in updatedAvroSchema allocated by converting into iceberg schema and back
+    final org.apache.avro.Schema idAllocatedUpdatedAvroSchema =
+        AvroSchemaUtil.convert(AvroSchemaUtil.toIceberg(updatedAvroSchema).asStruct());
+
+    final org.apache.avro.Schema projectedAvroSchema =
+        AvroSchemaUtil.buildAvroProjection(idAllocatedUpdatedAvroSchema, currentIcebergSchema, Collections.emptyMap());
+
+    assertFalse(AvroSchemaUtil.missingIds(projectedAvroSchema));
+  }
+
+}

--- a/core/src/test/java/org/apache/iceberg/avro/TestBuildAvroProjection.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestBuildAvroProjection.java
@@ -54,8 +54,10 @@ public class TestBuildAvroProjection {
 
     final org.apache.avro.Schema actual = testSubject.array(expected, supplier);
 
-    assertEquals(expected, actual);
-    assertEquals(0, Integer.valueOf(actual.getProp(AvroSchemaUtil.ELEMENT_ID_PROP)).intValue());
+    assertEquals("Array projection produced undesired array schema",
+        expected, actual);
+    assertEquals("Unexpected element ID discovered on the projected array schema",
+        0, Integer.valueOf(actual.getProp(AvroSchemaUtil.ELEMENT_ID_PROP)).intValue());
   }
 
   @Test
@@ -90,8 +92,10 @@ public class TestBuildAvroProjection {
 
     final org.apache.avro.Schema actual = testSubject.array(extraField, supplier);
 
-    assertEquals(expected, actual);
-    assertEquals(0, Integer.valueOf(actual.getProp(AvroSchemaUtil.ELEMENT_ID_PROP)).intValue());
+    assertEquals("Array projection produced undesired array schema",
+        expected, actual);
+    assertEquals("Unexpected element ID discovered on the projected array schema",
+        0, Integer.valueOf(actual.getProp(AvroSchemaUtil.ELEMENT_ID_PROP)).intValue());
   }
 
   @Test
@@ -124,8 +128,10 @@ public class TestBuildAvroProjection {
 
     final org.apache.avro.Schema actual = testSubject.array(lessField, supplier);
 
-    assertEquals(expected, actual);
-    assertEquals(0, Integer.valueOf(actual.getProp(AvroSchemaUtil.ELEMENT_ID_PROP)).intValue());
+    assertEquals("Array projection produced undesired array schema",
+        expected, actual);
+    assertEquals("Unexpected element ID discovered on the projected array schema",
+        0, Integer.valueOf(actual.getProp(AvroSchemaUtil.ELEMENT_ID_PROP)).intValue());
   }
 
   @Test
@@ -154,9 +160,12 @@ public class TestBuildAvroProjection {
 
     final org.apache.avro.Schema actual = testSubject.map(expected, supplier);
 
-    assertEquals(expected, actual);
-    assertEquals(0, Integer.valueOf(actual.getProp(AvroSchemaUtil.KEY_ID_PROP)).intValue());
-    assertEquals(1, Integer.valueOf(actual.getProp(AvroSchemaUtil.VALUE_ID_PROP)).intValue());
+    assertEquals("Map projection produced undesired map schema",
+        expected, actual);
+    assertEquals("Unexpected key ID discovered on the projected map schema",
+        0, Integer.valueOf(actual.getProp(AvroSchemaUtil.KEY_ID_PROP)).intValue());
+    assertEquals("Unexpected value ID discovered on the projected map schema",
+        1, Integer.valueOf(actual.getProp(AvroSchemaUtil.VALUE_ID_PROP)).intValue());
   }
 
   @Test
@@ -196,9 +205,12 @@ public class TestBuildAvroProjection {
 
     final org.apache.avro.Schema actual = testSubject.map(extraField, supplier);
 
-    assertEquals(expected, actual);
-    assertEquals(0, Integer.valueOf(actual.getProp(AvroSchemaUtil.KEY_ID_PROP)).intValue());
-    assertEquals(1, Integer.valueOf(actual.getProp(AvroSchemaUtil.VALUE_ID_PROP)).intValue());
+    assertEquals("Map projection produced undesired map schema",
+        expected, actual);
+    assertEquals("Unexpected key ID discovered on the projected map schema",
+        0, Integer.valueOf(actual.getProp(AvroSchemaUtil.KEY_ID_PROP)).intValue());
+    assertEquals("Unexpected value ID discovered on the projected map schema",
+        1, Integer.valueOf(actual.getProp(AvroSchemaUtil.VALUE_ID_PROP)).intValue());
   }
 
 
@@ -237,8 +249,11 @@ public class TestBuildAvroProjection {
 
     final org.apache.avro.Schema actual = testSubject.map(lessField, supplier);
 
-    assertEquals(expected, actual);
-    assertEquals(0, Integer.valueOf(actual.getProp(AvroSchemaUtil.KEY_ID_PROP)).intValue());
-    assertEquals(1, Integer.valueOf(actual.getProp(AvroSchemaUtil.VALUE_ID_PROP)).intValue());
+    assertEquals("Map projection produced undesired map schema",
+        expected, actual);
+    assertEquals("Unexpected key ID discovered on the projected map schema",
+        0, Integer.valueOf(actual.getProp(AvroSchemaUtil.KEY_ID_PROP)).intValue());
+    assertEquals("Unexpected value ID discovered on the projected map schema",
+        1, Integer.valueOf(actual.getProp(AvroSchemaUtil.VALUE_ID_PROP)).intValue());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/avro/TestBuildAvroProjection.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestBuildAvroProjection.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.avro;
+
+import java.util.Collections;
+import java.util.function.Supplier;
+import org.apache.avro.SchemaBuilder;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.junit.Test;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.junit.Assert.assertEquals;
+
+public class TestBuildAvroProjection {
+
+  @Test
+  public void projectArrayWithElementSchemaUnchanged() {
+
+    final Type icebergType = Types.ListType.ofRequired(0,
+        Types.StructType.of(
+            optional(1, "int1", Types.IntegerType.get()),
+            optional(2, "string1", Types.StringType.get())
+        )
+    );
+
+    final org.apache.avro.Schema expected = SchemaBuilder.array().prop(AvroSchemaUtil.ELEMENT_ID_PROP, "0")
+        .items(
+            SchemaBuilder.record("elem").namespace("unit.test").fields()
+                .name("int1").prop(AvroSchemaUtil.FIELD_ID_PROP, "1").type().nullable().intType().noDefault()
+                .name("string1").prop(AvroSchemaUtil.FIELD_ID_PROP, "2").type().nullable().stringType().noDefault()
+                .endRecord());
+
+    final BuildAvroProjection testSubject = new BuildAvroProjection(icebergType, Collections.emptyMap());
+
+    final Supplier<org.apache.avro.Schema> supplier = expected::getElementType;
+
+    final org.apache.avro.Schema actual = testSubject.array(expected, supplier);
+
+    assertEquals(expected, actual);
+    assertEquals(0, Integer.valueOf(actual.getProp(AvroSchemaUtil.ELEMENT_ID_PROP)).intValue());
+  }
+
+  @Test
+  public void projectArrayWithExtraFieldInElementSchema() {
+
+    final Type icebergType = Types.ListType.ofRequired(0,
+        Types.StructType.of(
+            optional(1, "int1", Types.IntegerType.get()),
+            optional(2, "string1", Types.StringType.get())
+        )
+    );
+
+    final org.apache.avro.Schema extraField = SchemaBuilder.array().prop(AvroSchemaUtil.ELEMENT_ID_PROP, "0")
+        .items(
+            SchemaBuilder.record("elem").namespace("unit.test").fields()
+                .name("int1").prop(AvroSchemaUtil.FIELD_ID_PROP, "1").type().nullable().intType().noDefault()
+                .name("string1").prop(AvroSchemaUtil.FIELD_ID_PROP, "2").type().nullable().stringType().noDefault()
+                .name("float1").prop(AvroSchemaUtil.FIELD_ID_PROP, "3").type().nullable().floatType().noDefault()
+                .endRecord());
+
+    // once projected onto iceberg schema, the avro schema will lose the extra float field
+    final org.apache.avro.Schema expected = SchemaBuilder.array().prop(AvroSchemaUtil.ELEMENT_ID_PROP, "0")
+        .items(
+            SchemaBuilder.record("elem").namespace("unit.test").fields()
+                .name("int1").prop(AvroSchemaUtil.FIELD_ID_PROP, "1").type().nullable().intType().noDefault()
+                .name("string1").prop(AvroSchemaUtil.FIELD_ID_PROP, "2").type().nullable().stringType().noDefault()
+                .endRecord());
+
+    final BuildAvroProjection testSubject = new BuildAvroProjection(icebergType, Collections.emptyMap());
+
+    final Supplier<org.apache.avro.Schema> supplier = expected::getElementType;
+
+    final org.apache.avro.Schema actual = testSubject.array(extraField, supplier);
+
+    assertEquals(expected, actual);
+    assertEquals(0, Integer.valueOf(actual.getProp(AvroSchemaUtil.ELEMENT_ID_PROP)).intValue());
+  }
+
+  @Test
+  public void projectArrayWithLessFieldInElementSchema() {
+
+    final Type icebergType = Types.ListType.ofRequired(0,
+        Types.StructType.of(
+            optional(1, "int1", Types.IntegerType.get()),
+            optional(2, "string1", Types.StringType.get())
+        )
+    );
+
+    final org.apache.avro.Schema lessField = SchemaBuilder.array().prop(AvroSchemaUtil.ELEMENT_ID_PROP, "0")
+        .items(
+            SchemaBuilder.record("elem").namespace("unit.test").fields()
+                .name("int1").prop(AvroSchemaUtil.FIELD_ID_PROP, "1").type().nullable().intType().noDefault()
+                .endRecord());
+
+    // once projected onto iceberg schema, the avro schema will have an extra string column
+    final org.apache.avro.Schema expected = SchemaBuilder.array().prop(AvroSchemaUtil.ELEMENT_ID_PROP, "0")
+        .items(
+            SchemaBuilder.record("elem").namespace("unit.test").fields()
+                .name("int1").prop(AvroSchemaUtil.FIELD_ID_PROP, "1").type().nullable().intType().noDefault()
+                .name("string1_r").prop(AvroSchemaUtil.FIELD_ID_PROP, "2").type().nullable().stringType().noDefault()
+                .endRecord());
+
+    final BuildAvroProjection testSubject = new BuildAvroProjection(icebergType, Collections.emptyMap());
+
+    final Supplier<org.apache.avro.Schema> supplier = expected::getElementType;
+
+    final org.apache.avro.Schema actual = testSubject.array(lessField, supplier);
+
+    assertEquals(expected, actual);
+    assertEquals(0, Integer.valueOf(actual.getProp(AvroSchemaUtil.ELEMENT_ID_PROP)).intValue());
+  }
+
+  @Test
+  public void projectMapWithValueSchemaUnchanged() {
+
+    final Type icebergType = Types.MapType.ofRequired(0, 1,
+        Types.StringType.get(),
+        Types.StructType.of(
+            optional(2, "int1", Types.IntegerType.get()),
+            optional(3, "string1", Types.StringType.get())
+        )
+    );
+
+    final org.apache.avro.Schema expected = SchemaBuilder.map()
+        .prop(AvroSchemaUtil.KEY_ID_PROP, "0")
+        .prop(AvroSchemaUtil.VALUE_ID_PROP, "1")
+        .values(
+            SchemaBuilder.record("value").namespace("unit.test").fields()
+                .name("int1").prop(AvroSchemaUtil.FIELD_ID_PROP, "1").type().nullable().intType().noDefault()
+                .name("string1").prop(AvroSchemaUtil.FIELD_ID_PROP, "2").type().nullable().stringType().noDefault()
+                .endRecord());
+
+    final BuildAvroProjection testSubject = new BuildAvroProjection(icebergType, Collections.emptyMap());
+
+    final Supplier<org.apache.avro.Schema> supplier = expected::getValueType;
+
+    final org.apache.avro.Schema actual = testSubject.map(expected, supplier);
+
+    assertEquals(expected, actual);
+    assertEquals(0, Integer.valueOf(actual.getProp(AvroSchemaUtil.KEY_ID_PROP)).intValue());
+    assertEquals(1, Integer.valueOf(actual.getProp(AvroSchemaUtil.VALUE_ID_PROP)).intValue());
+  }
+
+  @Test
+  public void projectMapWithExtraFieldInValueSchema() {
+
+    final Type icebergType = Types.MapType.ofRequired(0, 1,
+        Types.StringType.get(),
+        Types.StructType.of(
+            optional(2, "int1", Types.IntegerType.get()),
+            optional(3, "string1", Types.StringType.get())
+        )
+    );
+
+    final org.apache.avro.Schema extraField = SchemaBuilder.map()
+        .prop(AvroSchemaUtil.KEY_ID_PROP, "0")
+        .prop(AvroSchemaUtil.VALUE_ID_PROP, "1")
+        .values(
+            SchemaBuilder.record("value").namespace("unit.test").fields()
+                .name("int1").prop(AvroSchemaUtil.FIELD_ID_PROP, "1").type().nullable().intType().noDefault()
+                .name("string1").prop(AvroSchemaUtil.FIELD_ID_PROP, "2").type().nullable().stringType().noDefault()
+                .name("float1").prop(AvroSchemaUtil.FIELD_ID_PROP, "3").type().nullable().floatType().noDefault()
+                .endRecord());
+
+    // once projected onto iceberg schema, the avro schema will lose the extra float field
+    final org.apache.avro.Schema expected = SchemaBuilder.map()
+        .prop(AvroSchemaUtil.KEY_ID_PROP, "0")
+        .prop(AvroSchemaUtil.VALUE_ID_PROP, "1")
+        .values(
+            SchemaBuilder.record("value").namespace("unit.test").fields()
+                .name("int1").prop(AvroSchemaUtil.FIELD_ID_PROP, "1").type().nullable().intType().noDefault()
+                .name("string1").prop(AvroSchemaUtil.FIELD_ID_PROP, "2").type().nullable().stringType().noDefault()
+                .endRecord());
+
+    final BuildAvroProjection testSubject = new BuildAvroProjection(icebergType, Collections.emptyMap());
+
+    final Supplier<org.apache.avro.Schema> supplier = expected::getValueType;
+
+    final org.apache.avro.Schema actual = testSubject.map(extraField, supplier);
+
+    assertEquals(expected, actual);
+    assertEquals(0, Integer.valueOf(actual.getProp(AvroSchemaUtil.KEY_ID_PROP)).intValue());
+    assertEquals(1, Integer.valueOf(actual.getProp(AvroSchemaUtil.VALUE_ID_PROP)).intValue());
+  }
+
+
+  @Test
+  public void projectMapWithLessFieldInValueSchema() {
+
+    final Type icebergType = Types.MapType.ofRequired(0, 1,
+        Types.StringType.get(),
+        Types.StructType.of(
+            optional(2, "int1", Types.IntegerType.get()),
+            optional(3, "string1", Types.StringType.get())
+        )
+    );
+
+    final org.apache.avro.Schema lessField = SchemaBuilder.map()
+        .prop(AvroSchemaUtil.KEY_ID_PROP, "0")
+        .prop(AvroSchemaUtil.VALUE_ID_PROP, "1")
+        .values(
+            SchemaBuilder.record("value").namespace("unit.test").fields()
+                .name("int1").prop(AvroSchemaUtil.FIELD_ID_PROP, "1").type().nullable().intType().noDefault()
+                .endRecord());
+
+    // once projected onto iceberg schema, the avro schema will have an extra string column
+    final org.apache.avro.Schema expected = SchemaBuilder.map()
+        .prop(AvroSchemaUtil.KEY_ID_PROP, "0")
+        .prop(AvroSchemaUtil.VALUE_ID_PROP, "1")
+        .values(
+            SchemaBuilder.record("value").namespace("unit.test").fields()
+                .name("int1").prop(AvroSchemaUtil.FIELD_ID_PROP, "1").type().nullable().intType().noDefault()
+                .name("string1_r2").prop(AvroSchemaUtil.FIELD_ID_PROP, "2").type().nullable().stringType().noDefault()
+                .endRecord());
+
+    final BuildAvroProjection testSubject = new BuildAvroProjection(icebergType, Collections.emptyMap());
+
+    final Supplier<org.apache.avro.Schema> supplier = expected::getValueType;
+
+    final org.apache.avro.Schema actual = testSubject.map(lessField, supplier);
+
+    assertEquals(expected, actual);
+    assertEquals(0, Integer.valueOf(actual.getProp(AvroSchemaUtil.KEY_ID_PROP)).intValue());
+    assertEquals(1, Integer.valueOf(actual.getProp(AvroSchemaUtil.VALUE_ID_PROP)).intValue());
+  }
+}


### PR DESCRIPTION
https://github.com/apache/iceberg/issues/4072

Purpose: Keeping the ID properties for list and map node when projecting

@RussellSpitzer 