### PR TITLE
Fix random test failure of testDeleteWithSerializableIsolation

### DIFF
--- a/spark/v3.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -593,6 +593,17 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
 
     sql("ALTER TABLE %s SET TBLPROPERTIES('%s' '%s')", tableName, DELETE_ISOLATION_LEVEL, "serializable");
 
+    // Pre-populate the table to force it to use the DeltaWriter instead of Metadata-Only Delete
+    List<Integer> initialIds = ImmutableList.of(1, 2);
+    Dataset<Row> initialInputDf = spark.createDataset(initialIds, Encoders.INT())
+        .withColumnRenamed("value", "id")
+        .withColumn("dep", lit("hr"));
+    try {
+      initialInputDf.coalesce(1).writeTo(tableName).append();
+    } catch (NoSuchTableException e) {
+      throw new RuntimeException(e);
+    }
+
     ExecutorService executorService = MoreExecutors.getExitingExecutorService(
         (ThreadPoolExecutor) Executors.newFixedThreadPool(2));
 

--- a/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -593,6 +593,17 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
 
     sql("ALTER TABLE %s SET TBLPROPERTIES('%s' '%s')", tableName, DELETE_ISOLATION_LEVEL, "serializable");
 
+    // Pre-populate the table to force it to use the DeltaWriter instead of Metadata-Only Delete
+    List<Integer> initialIds = ImmutableList.of(1, 2);
+    Dataset<Row> initialInputDf = spark.createDataset(initialIds, Encoders.INT())
+        .withColumnRenamed("value", "id")
+        .withColumn("dep", lit("hr"));
+    try {
+      initialInputDf.coalesce(1).writeTo(tableName).append();
+    } catch (NoSuchTableException e) {
+      throw new RuntimeException(e);
+    }
+
     ExecutorService executorService = MoreExecutors.getExitingExecutorService(
         (ThreadPoolExecutor) Executors.newFixedThreadPool(2));
 

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -621,13 +621,14 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
 
     sql("ALTER TABLE %s SET TBLPROPERTIES('%s' '%s')", tableName, DELETE_ISOLATION_LEVEL, "serializable");
 
-    // Pre-populate the table to force it to use the DeltaWriter instead of Metadata-Only Delete
-    List<Integer> initialIds = ImmutableList.of(1, 2);
-    Dataset<Row> initialInputDf = spark.createDataset(initialIds, Encoders.INT())
+    // Pre-populate the table to force it to use the Spark Writers instead of Metadata-Only Delete
+    // for more consistent exception stack
+    List<Integer> ids = ImmutableList.of(1, 2);
+    Dataset<Row> inputDF = spark.createDataset(ids, Encoders.INT())
         .withColumnRenamed("value", "id")
         .withColumn("dep", lit("hr"));
     try {
-      initialInputDf.coalesce(1).writeTo(tableName).append();
+      inputDF.coalesce(1).writeTo(tableName).append();
     } catch (NoSuchTableException e) {
       throw new RuntimeException(e);
     }
@@ -650,11 +651,6 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
 
     // append thread
     Future<?> appendFuture = executorService.submit(() -> {
-      List<Integer> ids = ImmutableList.of(1, 2);
-      Dataset<Row> inputDF = spark.createDataset(ids, Encoders.INT())
-          .withColumnRenamed("value", "id")
-          .withColumn("dep", lit("hr"));
-
       for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
         while (barrier.get() < numOperations * 2) {
           sleep(10);


### PR DESCRIPTION
Tries to fix #4090 

(Copied from my comment there)

From the log, the expected exception seems still a validationException, just not from the distributed Spark delta-writer job as is expected but rather from the non-distributed metadata-only version.  Ref:

Expected: an instance of org.apache.spark.SparkException
     but: <java.lang.IllegalArgumentException: Failed to cleanly delete data files matching: ref(name="id") == 1> is a java.lang.IllegalArgumentException
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)

That's from here (the metadata-only version):
https://github.com/apache/iceberg/blob/master/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java#L271

Although most of the time it will hit the distributed delta delete, there is a chance here it will fall to this metadata version. This is if the optimizer (OptimizeMetadataOnlyDeleteFromTable in particular) believes that the delete can be handled with just metadata. The appendFuture tries to avert this by constructing a file of two elements (1,2) and each time the deleteFuture hits only (1) so it decides it cannot use metadata, but if the appendTable has not run yet then the table is empty the deleteFuture decides it proceed with metadata-only delete.  In most of those times, that delete goes through fine as there is nothing to do and the test gets another try to get the right exception, but a very smaller percentage of time it may find the appendFuture has landed right before the commit and then fails in the above code path.

One fix is to try to add expected checks this potential failure. Another fix is to make sure that there is some pre-existing data to force it always to use the distributed delta delete, which is done here.