### PR TITLE
Spark: Close executor services after action completes in Procedures

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
@@ -175,20 +175,15 @@ abstract class BaseProcedure implements Procedure {
   protected void closeService() {
     if (executorService != null) {
       executorService.shutdown();
-      try {
-        executorService.awaitTermination(1, TimeUnit.SECONDS);
-      } catch (InterruptedException e) {
-        throw new RuntimeException("Internal Error, Procedure closeService was called before all tasks were finished");
-      }
     }
   }
 
-  protected ExecutorService executorService(int concurrentDeletes, String nameFormat) {
+  protected ExecutorService executorService(int threadPoolSize, String nameFormat) {
     Preconditions.checkArgument(executorService == null, "Cannot create a new executor service, one already exists.");
     Preconditions.checkArgument(nameFormat != null, "Cannot create a service with null nameFormat arg");
     executorService = MoreExecutors.getExitingExecutorService(
         (ThreadPoolExecutor) Executors.newFixedThreadPool(
-            concurrentDeletes,
+            threadPoolSize,
             new ThreadFactoryBuilder()
                 .setNameFormat(nameFormat + "-%d")
                 .build()));

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
@@ -19,11 +19,9 @@
 
 package org.apache.iceberg.spark.procedures;
 
-import com.clearspring.analytics.util.Preconditions;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
@@ -22,7 +22,6 @@ package org.apache.iceberg.spark.procedures;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/BaseProcedure.java
@@ -185,6 +185,7 @@ abstract class BaseProcedure implements Procedure {
         (ThreadPoolExecutor) Executors.newFixedThreadPool(
             threadPoolSize,
             new ThreadFactoryBuilder()
+                .setDaemon(true)
                 .setNameFormat(nameFormat + "-%d")
                 .build()));
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
@@ -19,14 +19,9 @@
 
 package org.apache.iceberg.spark.procedures;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadPoolExecutor;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.ExpireSnapshots;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
-import org.apache.iceberg.relocated.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.iceberg.util.DateTimeUtil;
@@ -104,7 +99,7 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
       }
 
       if (maxConcurrentDeletes != null && maxConcurrentDeletes > 0) {
-        action.executeDeleteWith(expireService(maxConcurrentDeletes));
+        action.executeDeleteWith(executorService(maxConcurrentDeletes, "expire-snapshots"));
       }
 
       ExpireSnapshots.Result result = action.execute();
@@ -125,14 +120,5 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
   @Override
   public String description() {
     return "ExpireSnapshotProcedure";
-  }
-
-  private ExecutorService expireService(int concurrentDeletes) {
-    return MoreExecutors.getExitingExecutorService(
-        (ThreadPoolExecutor) Executors.newFixedThreadPool(
-            concurrentDeletes,
-            new ThreadFactoryBuilder()
-                .setNameFormat("expire-snapshots-%d")
-                .build()));
   }
 }


### PR DESCRIPTION
Previously executor services were left to be GC'd, instead now they are
shutdown immediately after the action completes.