### PR TITLE
Core: Update SnapshotManager to use a transaction

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -216,6 +216,20 @@ class BaseTransaction implements Transaction {
     return expire;
   }
 
+  CherryPickOperation cherryPick() {
+    checkLastOperationCommitted("CherryPick");
+    CherryPickOperation cherrypick = new CherryPickOperation(tableName, transactionOps);
+    updates.add(cherrypick);
+    return cherrypick;
+  }
+
+  SetSnapshotOperation setBranchSnapshot() {
+    checkLastOperationCommitted("SetBranchSnapshot");
+    SetSnapshotOperation set = new SetSnapshotOperation(transactionOps);
+    updates.add(set);
+    return set;
+  }
+
   @Override
   public void commitTransaction() {
     Preconditions.checkState(hasLastOpCommitted,

--- a/core/src/main/java/org/apache/iceberg/CherryPickOperation.java
+++ b/core/src/main/java/org/apache/iceberg/CherryPickOperation.java
@@ -39,7 +39,7 @@ class CherryPickOperation extends MergingSnapshotProducer<CherryPickOperation> {
 
   private final Map<Integer, PartitionSpec> specsById;
   private Snapshot cherrypickSnapshot = null;
-  private boolean isFastForward = false;
+  private boolean requireFastForward = false;
   private PartitionSet replacedPartitions = null;
 
   CherryPickOperation(String tableName, TableOperations ops) {
@@ -118,7 +118,7 @@ class CherryPickOperation extends MergingSnapshotProducer<CherryPickOperation> {
       ValidationException.check(isFastForward(current),
           "Cannot cherry-pick snapshot %s: not append, dynamic overwrite, or fast-forward",
           cherrypickSnapshot.snapshotId());
-      this.isFastForward = true;
+      this.requireFastForward = true;
     }
 
     return this;
@@ -172,8 +172,9 @@ class CherryPickOperation extends MergingSnapshotProducer<CherryPickOperation> {
       return base.currentSnapshot();
     }
 
-    if (isFastForward) {
-      ValidationException.check(isFastForward(base),
+    boolean isFastForward = isFastForward(base);
+    if (requireFastForward || isFastForward) {
+      ValidationException.check(isFastForward,
           "Cannot cherry-pick snapshot %s: not append, dynamic overwrite, or fast-forward",
           cherrypickSnapshot.snapshotId());
       return base.snapshot(cherrypickSnapshot.snapshotId());

--- a/core/src/main/java/org/apache/iceberg/CherryPickOperation.java
+++ b/core/src/main/java/org/apache/iceberg/CherryPickOperation.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.exceptions.CherrypickAncestorCommitException;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.PartitionSet;
+import org.apache.iceberg.util.PropertyUtil;
+import org.apache.iceberg.util.SnapshotUtil;
+import org.apache.iceberg.util.WapUtil;
+
+/**
+ * Cherry-picks or fast-forwards the current state to a snapshot.
+ * <p>
+ * This update is not exposed though the Table API. Instead, it is a package-private part of the Transaction API
+ * intended for use in {@link ManageSnapshots}.
+ */
+class CherryPickOperation extends MergingSnapshotProducer<CherryPickOperation> {
+
+  private final Map<Integer, PartitionSpec> specsById;
+  private Snapshot cherrypickSnapshot = null;
+  private boolean isFastForward = false;
+  private PartitionSet replacedPartitions = null;
+
+  CherryPickOperation(String tableName, TableOperations ops) {
+    super(tableName, ops);
+    this.specsById = ops.current().specsById();
+  }
+
+  @Override
+  protected CherryPickOperation self() {
+    return this;
+  }
+
+  @Override
+  protected String operation() {
+    // snapshotOperation is used by SnapshotProducer when building and writing a new snapshot for cherrypick
+    Preconditions.checkNotNull(cherrypickSnapshot, "[BUG] Detected uninitialized operation");
+    return cherrypickSnapshot.operation();
+  }
+
+  public CherryPickOperation cherrypick(long snapshotId) {
+    TableMetadata current = current();
+    this.cherrypickSnapshot = current.snapshot(snapshotId);
+    ValidationException.check(cherrypickSnapshot != null,
+        "Cannot cherry-pick unknown snapshot ID: %s", snapshotId);
+
+    if (cherrypickSnapshot.operation().equals(DataOperations.APPEND)) {
+      // this property is set on target snapshot that will get published
+      String wapId = WapUtil.validateWapPublish(current, snapshotId);
+      if (wapId != null) {
+        set(SnapshotSummary.PUBLISHED_WAP_ID_PROP, wapId);
+      }
+
+      // link the snapshot about to be published on commit with the picked snapshot
+      set(SnapshotSummary.SOURCE_SNAPSHOT_ID_PROP, String.valueOf(snapshotId));
+
+      // Pick modifications from the snapshot
+      for (DataFile addedFile : cherrypickSnapshot.addedFiles()) {
+        add(addedFile);
+      }
+
+    } else if (cherrypickSnapshot.operation().equals(DataOperations.OVERWRITE) &&
+        PropertyUtil.propertyAsBoolean(cherrypickSnapshot.summary(), SnapshotSummary.REPLACE_PARTITIONS_PROP, false)) {
+      // the operation was ReplacePartitions. this can be cherry-picked iff the partitions have not been modified.
+      // detecting modification requires finding the new files since the parent was committed, so the parent must be an
+      // ancestor of the current state, or null if the overwrite was based on an empty table.
+      ValidationException.check(
+          cherrypickSnapshot.parentId() == null || isCurrentAncestor(current, cherrypickSnapshot.parentId()),
+          "Cannot cherry-pick overwrite not based on an ancestor of the current state: %s", snapshotId);
+
+      // this property is set on target snapshot that will get published
+      String wapId = WapUtil.validateWapPublish(current, snapshotId);
+      if (wapId != null) {
+        set(SnapshotSummary.PUBLISHED_WAP_ID_PROP, wapId);
+      }
+
+      // link the snapshot about to be published on commit with the picked snapshot
+      set(SnapshotSummary.SOURCE_SNAPSHOT_ID_PROP, String.valueOf(snapshotId));
+
+      // check that all deleted files are still in the table
+      failMissingDeletePaths();
+
+      // copy adds from the picked snapshot
+      this.replacedPartitions = PartitionSet.create(specsById);
+      for (DataFile addedFile : cherrypickSnapshot.addedFiles()) {
+        add(addedFile);
+        replacedPartitions.add(addedFile.specId(), addedFile.partition());
+      }
+
+      // copy deletes from the picked snapshot
+      for (DataFile deletedFile : cherrypickSnapshot.deletedFiles()) {
+        delete(deletedFile);
+      }
+
+    } else {
+      // attempt to fast-forward
+      ValidationException.check(isFastForward(current),
+          "Cannot cherry-pick snapshot %s: not append, dynamic overwrite, or fast-forward",
+          cherrypickSnapshot.snapshotId());
+      this.isFastForward = true;
+    }
+
+    return this;
+  }
+
+  @Override
+  public Object updateEvent() {
+    if (cherrypickSnapshot == null) {
+      // NOOP operation, no snapshot created
+      return null;
+    }
+
+    TableMetadata tableMetadata = refresh();
+    long snapshotId = tableMetadata.currentSnapshot().snapshotId();
+    if (cherrypickSnapshot.snapshotId() == snapshotId) {
+      // No new snapshot is created for fast-forward
+      return null;
+    } else {
+      // New snapshot created, we rely on super class to fire a CreateSnapshotEvent
+      return super.updateEvent();
+    }
+  }
+
+  @Override
+  protected void validate(TableMetadata base) {
+    // this is only called after apply() passes off to super, but check fast-forward status just in case
+    if (!isFastForward(base)) {
+      validateNonAncestor(base, cherrypickSnapshot.snapshotId());
+      validateReplacedPartitions(base, cherrypickSnapshot.parentId(), replacedPartitions);
+      WapUtil.validateWapPublish(base, cherrypickSnapshot.snapshotId());
+    }
+  }
+
+  private boolean isFastForward(TableMetadata base) {
+    if (base.currentSnapshot() != null) {
+      // can fast-forward if the cherry-picked snapshot's parent is the current snapshot
+      return cherrypickSnapshot.parentId() != null &&
+          base.currentSnapshot().snapshotId() == cherrypickSnapshot.parentId();
+    } else {
+      // ... or if the parent and current snapshot are both null
+      return cherrypickSnapshot.parentId() == null;
+    }
+  }
+
+  @Override
+  public Snapshot apply() {
+    TableMetadata base = refresh();
+
+    if (cherrypickSnapshot == null) {
+      // if no target snapshot was configured then NOOP by returning current state
+      return base.currentSnapshot();
+    }
+
+    if (isFastForward) {
+      ValidationException.check(isFastForward(base),
+          "Cannot cherry-pick snapshot %s: not append, dynamic overwrite, or fast-forward",
+          cherrypickSnapshot.snapshotId());
+      return base.snapshot(cherrypickSnapshot.snapshotId());
+    } else {
+      // validate(TableMetadata) is called in apply(TableMetadata) after this apply refreshes the table state
+      return super.apply();
+    }
+  }
+
+  private static void validateNonAncestor(TableMetadata meta, long snapshotId) {
+    if (isCurrentAncestor(meta, snapshotId)) {
+      throw new CherrypickAncestorCommitException(snapshotId);
+    }
+
+    Long ancestorId = lookupAncestorBySourceSnapshot(meta, snapshotId);
+    if (ancestorId != null) {
+      throw new CherrypickAncestorCommitException(snapshotId, ancestorId);
+    }
+  }
+
+  private static void validateReplacedPartitions(TableMetadata meta, Long parentId,
+                                                 PartitionSet replacedPartitions) {
+    if (replacedPartitions != null && meta.currentSnapshot() != null) {
+      ValidationException.check(parentId == null || isCurrentAncestor(meta, parentId),
+          "Cannot cherry-pick overwrite, based on non-ancestor of the current state: %s", parentId);
+      List<DataFile> newFiles = SnapshotUtil.newFiles(parentId, meta.currentSnapshot().snapshotId(), meta::snapshot);
+      for (DataFile newFile : newFiles) {
+        ValidationException.check(!replacedPartitions.contains(newFile.specId(), newFile.partition()),
+            "Cannot cherry-pick replace partitions with changed partition: %s",
+            newFile.partition());
+      }
+    }
+  }
+
+  private static Long lookupAncestorBySourceSnapshot(TableMetadata meta, long snapshotId) {
+    String snapshotIdStr = String.valueOf(snapshotId);
+    for (long ancestorId : currentAncestors(meta)) {
+      Map<String, String> summary = meta.snapshot(ancestorId).summary();
+      if (summary != null && snapshotIdStr.equals(summary.get(SnapshotSummary.SOURCE_SNAPSHOT_ID_PROP))) {
+        return ancestorId;
+      }
+    }
+
+    return null;
+  }
+
+  private static List<Long> currentAncestors(TableMetadata meta) {
+    return SnapshotUtil.ancestorIds(meta.currentSnapshot(), meta::snapshot);
+  }
+
+  private static boolean isCurrentAncestor(TableMetadata meta, long snapshotId) {
+    return currentAncestors(meta).contains(snapshotId);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/SetSnapshotOperation.java
+++ b/core/src/main/java/org/apache/iceberg/SetSnapshotOperation.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.List;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.SnapshotUtil;
+import org.apache.iceberg.util.Tasks;
+
+import static org.apache.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS;
+import static org.apache.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS_DEFAULT;
+import static org.apache.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS;
+import static org.apache.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS_DEFAULT;
+import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
+import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES_DEFAULT;
+import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS;
+import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT;
+
+/**
+ * Sets the current snapshot directly or by rolling back.
+ * <p>
+ * This update is not exposed though the Table API. Instead, it is a package-private part of the Transaction API
+ * intended for use in {@link ManageSnapshots}.
+ */
+class SetSnapshotOperation implements PendingUpdate<Snapshot> {
+
+  private final TableOperations ops;
+  private TableMetadata base;
+  private Long targetSnapshotId = null;
+  private boolean isRollback = false;
+
+  SetSnapshotOperation(TableOperations ops) {
+    this.ops = ops;
+    this.base = ops.current();
+  }
+
+
+  public SetSnapshotOperation setCurrentSnapshot(long snapshotId) {
+    ValidationException.check(base.snapshot(snapshotId) != null,
+        "Cannot roll back to unknown snapshot id: %s", snapshotId);
+
+    this.targetSnapshotId = snapshotId;
+
+    return this;
+  }
+
+  public SetSnapshotOperation rollbackToTime(long timestampMillis) {
+    // find the latest snapshot by timestamp older than timestampMillis
+    Snapshot snapshot = findLatestAncestorOlderThan(base, timestampMillis);
+    Preconditions.checkArgument(snapshot != null,
+        "Cannot roll back, no valid snapshot older than: %s", timestampMillis);
+
+    this.targetSnapshotId = snapshot.snapshotId();
+    this.isRollback = true;
+
+    return this;
+  }
+
+  public SetSnapshotOperation rollbackTo(long snapshotId) {
+    TableMetadata current = base;
+    ValidationException.check(current.snapshot(snapshotId) != null,
+        "Cannot roll back to unknown snapshot id: %s", snapshotId);
+    ValidationException.check(
+        isCurrentAncestor(current, snapshotId),
+        "Cannot roll back to snapshot, not an ancestor of the current state: %s", snapshotId);
+    return setCurrentSnapshot(snapshotId);
+  }
+
+  protected void validate(TableMetadata base) {
+    ValidationException.check(!isRollback || isCurrentAncestor(base, targetSnapshotId),
+        "Cannot roll back to %s: not an ancestor of the current table state", targetSnapshotId);
+  }
+
+  @Override
+  public Snapshot apply() {
+    this.base = ops.refresh();
+
+    if (targetSnapshotId == null) {
+      // if no target snapshot was configured then NOOP by returning current state
+      return base.currentSnapshot();
+    }
+
+    // call validate directly because this overrides apply
+    validate(base);
+
+    return base.snapshot(targetSnapshotId);
+  }
+
+  @Override
+  public void commit() {
+    Tasks.foreach(ops)
+        .retry(base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
+        .exponentialBackoff(
+            base.propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+            base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+            base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
+            2.0 /* exponential */)
+        .onlyRetryOn(CommitFailedException.class)
+        .run(taskOps -> {
+          Snapshot snapshot = apply();
+          TableMetadata updated = TableMetadata.buildFrom(base)
+              .setCurrentSnapshot(snapshot.snapshotId())
+              .build();
+
+          if (updated.changes().isEmpty()) {
+            // do not commit if the metadata has not changed. for example, this may happen when setting the current
+            // snapshot to an ID that is already current. note that this check uses identity.
+            return;
+          }
+
+          // if the table UUID is missing, add it here. the UUID will be re-created each time this operation retries
+          // to ensure that if a concurrent operation assigns the UUID, this operation will not fail.
+          taskOps.commit(base, updated.withUUID());
+        });
+  }
+
+  /**
+   * Return the latest snapshot whose timestamp is before the provided timestamp.
+   *
+   * @param meta {@link TableMetadata} for a table
+   * @param timestampMillis lookup snapshots before this timestamp
+   * @return the ID of the snapshot that was current at the given timestamp, or null
+   */
+  private static Snapshot findLatestAncestorOlderThan(TableMetadata meta, long timestampMillis) {
+    long snapshotTimestamp = 0;
+    Snapshot result = null;
+    for (Long snapshotId : currentAncestors(meta)) {
+      Snapshot snapshot = meta.snapshot(snapshotId);
+      if (snapshot.timestampMillis() < timestampMillis &&
+          snapshot.timestampMillis() > snapshotTimestamp) {
+        result = snapshot;
+        snapshotTimestamp = snapshot.timestampMillis();
+      }
+    }
+    return result;
+  }
+
+  private static List<Long> currentAncestors(TableMetadata meta) {
+    return SnapshotUtil.ancestorIds(meta.currentSnapshot(), meta::snapshot);
+  }
+
+  private static boolean isCurrentAncestor(TableMetadata meta, long snapshotId) {
+    return currentAncestors(meta).contains(snapshotId);
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/SetSnapshotOperation.java
+++ b/core/src/main/java/org/apache/iceberg/SetSnapshotOperation.java
@@ -85,11 +85,6 @@ class SetSnapshotOperation implements PendingUpdate<Snapshot> {
     return setCurrentSnapshot(snapshotId);
   }
 
-  protected void validate(TableMetadata base) {
-    ValidationException.check(!isRollback || isCurrentAncestor(base, targetSnapshotId),
-        "Cannot roll back to %s: not an ancestor of the current table state", targetSnapshotId);
-  }
-
   @Override
   public Snapshot apply() {
     this.base = ops.refresh();
@@ -99,8 +94,8 @@ class SetSnapshotOperation implements PendingUpdate<Snapshot> {
       return base.currentSnapshot();
     }
 
-    // call validate directly because this overrides apply
-    validate(base);
+    ValidationException.check(!isRollback || isCurrentAncestor(base, targetSnapshotId),
+        "Cannot roll back to %s: not an ancestor of the current table state", targetSnapshotId);
 
     return base.snapshot(targetSnapshotId);
   }

--- a/core/src/main/java/org/apache/iceberg/SnapshotManager.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotManager.java
@@ -19,292 +19,48 @@
 
 package org.apache.iceberg;
 
-import java.util.List;
-import java.util.Map;
-import org.apache.iceberg.exceptions.CherrypickAncestorCommitException;
-import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.util.PartitionSet;
-import org.apache.iceberg.util.PropertyUtil;
-import org.apache.iceberg.util.SnapshotUtil;
-import org.apache.iceberg.util.WapUtil;
 
-public class SnapshotManager extends MergingSnapshotProducer<ManageSnapshots> implements ManageSnapshots {
+public class SnapshotManager implements ManageSnapshots {
 
-  private enum SnapshotManagerOperation {
-    CHERRYPICK,
-    ROLLBACK
-  }
-
-  private final Map<Integer, PartitionSpec> specsById;
-  private SnapshotManagerOperation managerOperation = null;
-  private Long targetSnapshotId = null;
-  private String snapshotOperation = null;
-  private Long requiredCurrentSnapshotId = null;
-  private Long overwriteParentId = null;
-  private PartitionSet replacedPartitions = null;
+  private final BaseTransaction transaction;
 
   SnapshotManager(String tableName, TableOperations ops) {
-    super(tableName, ops);
-    this.specsById = ops.current().specsById();
-  }
-
-  @Override
-  protected ManageSnapshots self() {
-    return this;
-  }
-
-  @Override
-  protected String operation() {
-    // snapshotOperation is used by SnapshotProducer when building and writing a new snapshot for cherrypick
-    Preconditions.checkNotNull(snapshotOperation, "[BUG] Detected uninitialized operation");
-    return snapshotOperation;
+    Preconditions.checkState(ops.current() != null, "Cannot manage snapshots: table %s does not exist", tableName);
+    this.transaction = new BaseTransaction(tableName, ops, BaseTransaction.TransactionType.SIMPLE, ops.refresh());
   }
 
   @Override
   public ManageSnapshots cherrypick(long snapshotId) {
-    TableMetadata current = current();
-    ValidationException.check(current.snapshot(snapshotId) != null,
-        "Cannot cherry pick unknown snapshot id: %s", snapshotId);
-
-    Snapshot cherryPickSnapshot = current.snapshot(snapshotId);
-    // only append operations are currently supported
-    if (cherryPickSnapshot.operation().equals(DataOperations.APPEND)) {
-      this.managerOperation = SnapshotManagerOperation.CHERRYPICK;
-      this.targetSnapshotId = snapshotId;
-      this.snapshotOperation = cherryPickSnapshot.operation();
-
-      // Pick modifications from the snapshot
-      for (DataFile addedFile : cherryPickSnapshot.addedFiles()) {
-        add(addedFile);
-      }
-
-      // this property is set on target snapshot that will get published
-      String wapId = WapUtil.validateWapPublish(current, targetSnapshotId);
-      if (wapId != null) {
-        set(SnapshotSummary.PUBLISHED_WAP_ID_PROP, wapId);
-      }
-
-      // link the snapshot about to be published on commit with the picked snapshot
-      set(SnapshotSummary.SOURCE_SNAPSHOT_ID_PROP, String.valueOf(targetSnapshotId));
-
-    } else if (cherryPickSnapshot.operation().equals(DataOperations.OVERWRITE) &&
-        PropertyUtil.propertyAsBoolean(cherryPickSnapshot.summary(), SnapshotSummary.REPLACE_PARTITIONS_PROP, false)) {
-      // the operation was ReplacePartitions. this can be cherry-picked iff the partitions have not been modified.
-      // detecting modification requires finding the new files since the parent was committed, so the parent must be an
-      // ancestor of the current state, or null if the overwrite was based on an empty table.
-      this.overwriteParentId = cherryPickSnapshot.parentId();
-      ValidationException.check(overwriteParentId == null || isCurrentAncestor(current, overwriteParentId),
-          "Cannot cherry-pick overwrite not based on an ancestor of the current state: %s", snapshotId);
-
-      this.managerOperation = SnapshotManagerOperation.CHERRYPICK;
-      this.targetSnapshotId = snapshotId;
-      this.snapshotOperation = cherryPickSnapshot.operation();
-      this.replacedPartitions = PartitionSet.create(specsById);
-
-      // check that all deleted files are still in the table
-      failMissingDeletePaths();
-
-      // copy adds from the picked snapshot
-      for (DataFile addedFile : cherryPickSnapshot.addedFiles()) {
-        add(addedFile);
-        replacedPartitions.add(addedFile.specId(), addedFile.partition());
-      }
-
-      // copy deletes from the picked snapshot
-      for (DataFile deletedFile : cherryPickSnapshot.deletedFiles()) {
-        delete(deletedFile);
-      }
-
-      // this property is set on target snapshot that will get published
-      String overwriteWapId = WapUtil.validateWapPublish(current, targetSnapshotId);
-      if (overwriteWapId != null) {
-        set(SnapshotSummary.PUBLISHED_WAP_ID_PROP, overwriteWapId);
-      }
-
-      // link the snapshot about to be published on commit with the picked snapshot
-      set(SnapshotSummary.SOURCE_SNAPSHOT_ID_PROP, String.valueOf(targetSnapshotId));
-
-    } else {
-      // cherry-pick should work if the table can be fast-forwarded
-      this.managerOperation = SnapshotManagerOperation.ROLLBACK;
-      this.requiredCurrentSnapshotId = cherryPickSnapshot.parentId();
-      this.targetSnapshotId = snapshotId;
-      validateCurrentSnapshot(current, requiredCurrentSnapshotId);
-    }
-
+    transaction.cherryPick().cherrypick(snapshotId).commit();
     return this;
   }
 
   @Override
   public ManageSnapshots setCurrentSnapshot(long snapshotId) {
-    ValidationException.check(current().snapshot(snapshotId) != null,
-        "Cannot roll back to unknown snapshot id: %s", snapshotId);
-
-    this.managerOperation = SnapshotManagerOperation.ROLLBACK;
-    this.targetSnapshotId = snapshotId;
-
+    transaction.setBranchSnapshot().setCurrentSnapshot(snapshotId).commit();
     return this;
   }
 
   @Override
   public ManageSnapshots rollbackToTime(long timestampMillis) {
-    // find the latest snapshot by timestamp older than timestampMillis
-    Snapshot snapshot = findLatestAncestorOlderThan(current(), timestampMillis);
-    Preconditions.checkArgument(snapshot != null,
-        "Cannot roll back, no valid snapshot older than: %s", timestampMillis);
-
-    this.managerOperation = SnapshotManagerOperation.ROLLBACK;
-    this.targetSnapshotId = snapshot.snapshotId();
-
+    transaction.setBranchSnapshot().rollbackToTime(timestampMillis).commit();
     return this;
   }
 
   @Override
   public ManageSnapshots rollbackTo(long snapshotId) {
-    TableMetadata current = current();
-    ValidationException.check(current.snapshot(snapshotId) != null,
-        "Cannot roll back to unknown snapshot id: %s", snapshotId);
-    ValidationException.check(
-        isCurrentAncestor(current, snapshotId),
-        "Cannot roll back to snapshot, not an ancestor of the current state: %s", snapshotId);
-    return setCurrentSnapshot(snapshotId);
-  }
-
-  @Override
-  public Object updateEvent() {
-    if (targetSnapshotId == null) {
-      // NOOP operation, no snapshot created
-      return null;
-    }
-
-    switch (managerOperation) {
-      case ROLLBACK:
-        // rollback does not create a new snapshot
-        return null;
-      case CHERRYPICK:
-        TableMetadata tableMetadata = refresh();
-        long snapshotId = tableMetadata.currentSnapshot().snapshotId();
-        if (targetSnapshotId == snapshotId) {
-          // No new snapshot is created for fast-forward
-          return null;
-        } else {
-          // New snapshot created, we rely on super class to fire a CreateSnapshotEvent
-          return super.updateEvent();
-        }
-      default:
-        throw new UnsupportedOperationException(managerOperation + " is not supported");
-    }
-  }
-
-  @Override
-  protected void validate(TableMetadata base) {
-    validateCurrentSnapshot(base, requiredCurrentSnapshotId);
-    validateNonAncestor(base, targetSnapshotId);
-    validateReplacedPartitions(base, overwriteParentId, replacedPartitions);
-    WapUtil.validateWapPublish(base, targetSnapshotId);
+    transaction.setBranchSnapshot().rollbackTo(snapshotId).commit();
+    return this;
   }
 
   @Override
   public Snapshot apply() {
-    TableMetadata base = refresh();
-
-    if (targetSnapshotId == null) {
-      // if no target snapshot was configured then NOOP by returning current state
-      return base.currentSnapshot();
-    }
-
-    switch (managerOperation) {
-      case CHERRYPICK:
-        if (base.snapshot(targetSnapshotId).parentId() != null &&
-            base.currentSnapshot().snapshotId() == base.snapshot(targetSnapshotId).parentId()) {
-          // the snapshot to cherrypick is already based on the current state: fast-forward
-          validate(base);
-          return base.snapshot(targetSnapshotId);
-        } else {
-          // validate(TableMetadata) is called in apply(TableMetadata) after this apply refreshes the table state
-          return super.apply();
-        }
-
-      case ROLLBACK:
-        return base.snapshot(targetSnapshotId);
-
-      default:
-        throw new ValidationException("Invalid SnapshotManagerOperation: only cherrypick, rollback are supported");
-    }
+    return transaction.table().currentSnapshot();
   }
 
-  private static void validateCurrentSnapshot(TableMetadata meta, Long requiredSnapshotId) {
-    if (requiredSnapshotId != null && meta.currentSnapshot() != null) {
-      ValidationException.check(meta.currentSnapshot().snapshotId() == requiredSnapshotId,
-          "Cannot fast-forward to non-append snapshot; current has changed: current=%s != required=%s",
-          meta.currentSnapshot().snapshotId(), requiredSnapshotId);
-    }
-  }
-
-  private static void validateNonAncestor(TableMetadata meta, long snapshotId) {
-    if (isCurrentAncestor(meta, snapshotId)) {
-      throw new CherrypickAncestorCommitException(snapshotId);
-    }
-
-    Long ancestorId = lookupAncestorBySourceSnapshot(meta, snapshotId);
-    if (ancestorId != null) {
-      throw new CherrypickAncestorCommitException(snapshotId, ancestorId);
-    }
-  }
-
-  private static void validateReplacedPartitions(TableMetadata meta, Long parentId,
-                                                 PartitionSet replacedPartitions) {
-    if (replacedPartitions != null && meta.currentSnapshot() != null) {
-      ValidationException.check(parentId == null || isCurrentAncestor(meta, parentId),
-          "Cannot cherry-pick overwrite, based on non-ancestor of the current state: %s", parentId);
-      List<DataFile> newFiles = SnapshotUtil.newFiles(parentId, meta.currentSnapshot().snapshotId(), meta::snapshot);
-      for (DataFile newFile : newFiles) {
-        ValidationException.check(!replacedPartitions.contains(newFile.specId(), newFile.partition()),
-            "Cannot cherry-pick replace partitions with changed partition: %s",
-            newFile.partition());
-      }
-    }
-  }
-
-  private static Long lookupAncestorBySourceSnapshot(TableMetadata meta, long snapshotId) {
-    String snapshotIdStr = String.valueOf(snapshotId);
-    for (long ancestorId : currentAncestors(meta)) {
-      Map<String, String> summary = meta.snapshot(ancestorId).summary();
-      if (summary != null && snapshotIdStr.equals(summary.get(SnapshotSummary.SOURCE_SNAPSHOT_ID_PROP))) {
-        return ancestorId;
-      }
-    }
-
-    return null;
-  }
-
-  /**
-   * Return the latest snapshot whose timestamp is before the provided timestamp.
-   *
-   * @param meta {@link TableMetadata} for a table
-   * @param timestampMillis lookup snapshots before this timestamp
-   * @return the ID of the snapshot that was current at the given timestamp, or null
-   */
-  private static Snapshot findLatestAncestorOlderThan(TableMetadata meta, long timestampMillis) {
-    long snapshotTimestamp = 0;
-    Snapshot result = null;
-    for (Long snapshotId : currentAncestors(meta)) {
-      Snapshot snapshot = meta.snapshot(snapshotId);
-      if (snapshot.timestampMillis() < timestampMillis &&
-          snapshot.timestampMillis() > snapshotTimestamp) {
-        result = snapshot;
-        snapshotTimestamp = snapshot.timestampMillis();
-      }
-    }
-    return result;
-  }
-
-  private static List<Long> currentAncestors(TableMetadata meta) {
-    return SnapshotUtil.ancestorIds(meta.currentSnapshot(), meta::snapshot);
-  }
-
-  private static boolean isCurrentAncestor(TableMetadata meta, long snapshotId) {
-    return currentAncestors(meta).contains(snapshotId);
+  @Override
+  public void commit() {
+    transaction.commitTransaction();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotManager.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotManager.java
@@ -241,7 +241,7 @@ public class TestSnapshotManager extends TableTestBase {
 
     // pick the snapshot into the current state
     AssertHelpers.assertThrows("Should reject partition replacement when a partition has been modified",
-        ValidationException.class, "Cannot fast-forward to non-append snapshot",
+        ValidationException.class, "not append, dynamic overwrite, or fast-forward",
         () -> table.manageSnapshots()
             .cherrypick(staged.snapshotId())
             .commit());

--- a/core/src/test/java/org/apache/iceberg/TestWapWorkflow.java
+++ b/core/src/test/java/org/apache/iceberg/TestWapWorkflow.java
@@ -100,7 +100,7 @@ public class TestWapWorkflow extends TableTestBase {
 
     // try to cherry-pick, which should fail because the overwrite's parent is no longer current
     AssertHelpers.assertThrows("Should reject overwrite that is not a fast-forward commit",
-        ValidationException.class, "Cannot fast-forward to non-append snapshot",
+        ValidationException.class, "not append, dynamic overwrite, or fast-forward",
         () -> table.manageSnapshots().cherrypick(overwrite.snapshotId()).commit());
 
     // the table state should not have changed

--- a/spark/v3.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCherrypickSnapshotProcedure.java
+++ b/spark/v3.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCherrypickSnapshotProcedure.java
@@ -151,7 +151,7 @@ public class TestCherrypickSnapshotProcedure extends SparkExtensionsTestBase {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
 
     AssertHelpers.assertThrows("Should reject invalid snapshot id",
-        ValidationException.class, "Cannot cherry pick unknown snapshot id",
+        ValidationException.class, "Cannot cherry-pick unknown snapshot ID",
         () -> sql("CALL %s.system.cherrypick_snapshot('%s', -1L)", catalogName, tableIdent));
   }
 

--- a/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCherrypickSnapshotProcedure.java
+++ b/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCherrypickSnapshotProcedure.java
@@ -151,7 +151,7 @@ public class TestCherrypickSnapshotProcedure extends SparkExtensionsTestBase {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
 
     AssertHelpers.assertThrows("Should reject invalid snapshot id",
-        ValidationException.class, "Cannot cherry pick unknown snapshot id",
+        ValidationException.class, "Cannot cherry-pick unknown snapshot ID",
         () -> sql("CALL %s.system.cherrypick_snapshot('%s', -1L)", catalogName, tableIdent));
   }
 

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCherrypickSnapshotProcedure.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCherrypickSnapshotProcedure.java
@@ -151,7 +151,7 @@ public class TestCherrypickSnapshotProcedure extends SparkExtensionsTestBase {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
 
     AssertHelpers.assertThrows("Should reject invalid snapshot id",
-        ValidationException.class, "Cannot cherry pick unknown snapshot id",
+        ValidationException.class, "Cannot cherry-pick unknown snapshot ID",
         () -> sql("CALL %s.system.cherrypick_snapshot('%s', -1L)", catalogName, tableIdent));
   }
 


### PR DESCRIPTION
This updates the implementation of `ManageSnapshots` to internally use a `Transaction`. Using `Transaction` as a base allows the API to make multiple changes in a single commit. For example, picking more than one snapshot into the current branch is now supported.

The previous implementation of `ManageSnapshots` supported setting the current snapshot, rolling back to a previous snapshot, and cherry picking a commit. Cherry picking is now handled by `CherryPickOperation` and the other operations that update the current snapshot are handled by `SetSnapshotOperation`. These are split because the set snapshot operation is much simpler and doesn't need to be mixed with cherry picking. Cherry picking is mostly unchanged.

The two new operations make a single change to the table state and are exposed as package-private operations on `Transaction`. The `ManageSnapshots` implementation, `SnapshotManager`, now creates one change at a time on the transaction using one of the two new operation classes.