### PR TITLE
Spark : use withNullability rather than creating new AttributeRef and losing ExprId, Qualifiers

### DIFF
--- a/spark/v3.2/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
+++ b/spark/v3.2/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteMergeIntoTable.scala
@@ -264,7 +264,7 @@ object RewriteMergeIntoTable extends RewriteRowLevelCommand {
     }.toMap
 
     attrs.zipWithIndex.map { case (attr, index) =>
-      AttributeReference(attr.name, attr.dataType, nullabilityMap(index))()
+      attr.withNullability(nullabilityMap(index))
     }
   }
 


### PR DESCRIPTION
### About Change
Attribute exposes functions such as withNullability which can be used.
Incase of AttributeRef this is existing impl : [CodePointer](https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/namedExpressions.scala#L306-L312)

```
  /**
   * Returns a copy of this [[AttributeReference]] with changed nullability.
   */
  override def withNullability(newNullability: Boolean): AttributeReference = {
    if (nullable == newNullability) {
      this
    } else {
      AttributeReference(name, dataType, newNullability, metadata)(exprId, qualifier)
    }
  }
```

As per my understanding, our intention was only to change nullablity we should use this rather than creating new AttributeRef obj always and losing exprId's / qualifers in the course 

Note : exprId's were used here to dedupAttributes in buildReadRelation [[CodePointer](https://github.com/apache/iceberg/blob/master/spark/v3.2/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteRowLevelCommand.scala#L63-L73)], losing it can cause issues.

---
### Testing Done

ran TestMerge locally

