### PR TITLE
Core: Call the replaceCurrentSnapshot with snapshotId for rollback operations

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -283,7 +283,9 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
             Snapshot newSnapshot = apply();
             newSnapshotId.set(newSnapshot.snapshotId());
             TableMetadata updated;
-            if (stageOnly) {
+            if (base.snapshot(newSnapshot.snapshotId()) != null) {
+              updated = base.replaceCurrentSnapshot(newSnapshot.snapshotId());
+            } else if (stageOnly) {
               updated = base.addStagedSnapshot(newSnapshot);
             } else {
               updated = base.replaceCurrentSnapshot(newSnapshot);

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -284,6 +284,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
             newSnapshotId.set(newSnapshot.snapshotId());
             TableMetadata updated;
             if (base.snapshot(newSnapshot.snapshotId()) != null) {
+              // this is a rollback operation
               updated = base.replaceCurrentSnapshot(newSnapshot.snapshotId());
             } else if (stageOnly) {
               updated = base.addStagedSnapshot(newSnapshot);

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -501,6 +501,10 @@ public class TableMetadata implements Serializable {
     return new Builder(this).setCurrentSnapshot(snapshot).build();
   }
 
+  public TableMetadata replaceCurrentSnapshot(long snapshotId) {
+    return new Builder(this).setCurrentSnapshot(snapshotId).build();
+  }
+
   public TableMetadata removeSnapshotsIf(Predicate<Snapshot> removeIf) {
     List<Snapshot> toRemove = snapshots.stream().filter(removeIf).collect(Collectors.toList());
     return new Builder(this).removeSnapshots(toRemove).build();


### PR DESCRIPTION
While testing rollback_to_snaphot feature, we found that this is feature is failing in some cases.

In the setSetCurrentSnapshot method '[null](https://github.com/apache/iceberg/blob/apache-iceberg-0.13.0/core/src/main/java/org/apache/iceberg/TableMetadata.java#L924)' is being passed for timestamp which eventually causes the failure of the following [precondition check](https://github.com/apache/iceberg/blob/apache-iceberg-0.13.0/core/src/main/java/org/apache/iceberg/TableMetadata.java#L306).  The timeStamp should also be passed along with the Snapshot just like [here](https://github.com/apache/iceberg/blob/apache-iceberg-0.13.0/core/src/main/java/org/apache/iceberg/TableMetadata.java#L938 )

This PR fixes this bug in 0.13.x. I tested this with our internal tests and also by running the unit tests in Iceberg. This issue no longer exists in master because of [4089](https://github.com/apache/iceberg/pull/4089). The current fix is ported from [here](https://github.com/apache/iceberg/pull/4089#discussion_r806331672)

Steps to reproduce the rollback_to_snapshot bug in spark.

Each insert operation below is done separately in its own spark app. 
  


    sql("INSERT INTO %s VALUES (3, 'zzz', 1)" % table1)    
    sql("INSERT INTO %s VALUES (6, 'www', 1)" % table1)
    sql("INSERT INTO %s VALUES (9, 'zyz', 1)" % table1)
    sql("INSERT INTO %s VALUES (2, 'yy', 2)" % table1)
    sql("INSERT INTO %s VALUES (4, 'xx', 2)" % table1)
    sql("INSERT INTO %s VALUES (1, 'x', 3)" % table1)`
    
   # launch a new spark shell and follow the following steps
    results, _ = sql("select id, data, id2 from %s order by id2, id" % table1) # some internal code to get the results.
    results, _ = sql("select snapshot_id from %s.%s.snapshots" % (DATABASE, table1))
    snapshots = self.get_rows(results) # some internal code to get snapshots in a python list.
    sql("CALL spark_catalog.system.rollback_to_snapshot('%s', %s)" % (table1, str(snapshots[2][0])))`
