### PR TITLE
[Spark] Delete dataFile on iteration level in SparkParquetWritersFlatDataBenchmark

### DIFF
--- a/spark/v2.4/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersFlatDataBenchmark.java
+++ b/spark/v2.4/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersFlatDataBenchmark.java
@@ -35,6 +35,7 @@ import org.apache.spark.sql.types.StructType;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Scope;
@@ -85,7 +86,7 @@ public class SparkParquetWritersFlatDataBenchmark {
     dataFile.delete();
   }
 
-  @TearDown
+  @TearDown(Level.Iteration)
   public void tearDownBenchmark() {
     if (dataFile != null) {
       dataFile.delete();

--- a/spark/v3.0/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersFlatDataBenchmark.java
+++ b/spark/v3.0/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersFlatDataBenchmark.java
@@ -35,6 +35,7 @@ import org.apache.spark.sql.types.StructType;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Scope;
@@ -85,7 +86,7 @@ public class SparkParquetWritersFlatDataBenchmark {
     dataFile.delete();
   }
 
-  @TearDown
+  @TearDown(Level.Iteration)
   public void tearDownBenchmark() {
     if (dataFile != null) {
       dataFile.delete();

--- a/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersFlatDataBenchmark.java
+++ b/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersFlatDataBenchmark.java
@@ -35,6 +35,7 @@ import org.apache.spark.sql.types.StructType;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Scope;
@@ -85,7 +86,7 @@ public class SparkParquetWritersFlatDataBenchmark {
     dataFile.delete();
   }
 
-  @TearDown
+  @TearDown(Level.Iteration)
   public void tearDownBenchmark() {
     if (dataFile != null) {
       dataFile.delete();

--- a/spark/v3.2/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersFlatDataBenchmark.java
+++ b/spark/v3.2/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersFlatDataBenchmark.java
@@ -35,6 +35,7 @@ import org.apache.spark.sql.types.StructType;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Scope;
@@ -85,7 +86,7 @@ public class SparkParquetWritersFlatDataBenchmark {
     dataFile.delete();
   }
 
-  @TearDown
+  @TearDown(Level.Iteration)
   public void tearDownBenchmark() {
     if (dataFile != null) {
       dataFile.delete();


### PR DESCRIPTION
This PR fixes a minor issue for a jmh test - `SparkParquetWritersFlatDataBenchmark`

The `dataFile` holds mocked outputs now cleaned at `Level.Trial` which will be executed after the set of benchmark iterations. Then, it cause errors like below.

```java
# Warmup Iteration   1: 7.251 s/op
# Warmup Iteration   2: <failure>

org.apache.iceberg.exceptions.AlreadyExistsException: File already exists: /Users/kentyao/iceberg/spark/v3.2/spark/build/tmp/jmh/parquet-flat-data-benchmark3385433263675547096.parquet
	at org.apache.iceberg.Files$LocalOutputFile.create(Files.java:58)
	at org.apache.iceberg.parquet.ParquetIO$ParquetOutputFile.create(ParquetIO.java:148)
```

In this PR, I set the TearDown level to Iteration to make the dataFile be deleted after each iteration.