### PR TITLE
enable stream-results option to avoid spark driver oom

### DIFF
--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
@@ -300,14 +300,12 @@ public class TestExpireSnapshotsProcedure extends SparkExtensionsTestBase {
     Timestamp currentTimestamp = Timestamp.from(Instant.ofEpochMilli(System.currentTimeMillis()));
 
     List<Object[]> output = sql(
-            "CALL %s.system.expire_snapshots(" +
-                    "older_than => TIMESTAMP '%s'," +
-                    "table => '%s'," +
-                    "retain_last => 1, " +
-                    "stream_results => true)",
-            catalogName, currentTimestamp, tableIdent);
-    assertEquals("Procedure output must match",
-            ImmutableList.of(row(0L, 0L, 1L)),
-            output);
+        "CALL %s.system.expire_snapshots(" +
+            "older_than => TIMESTAMP '%s'," +
+            "table => '%s'," +
+            "retain_last => 1, " +
+            "stream_results => true)",
+        catalogName, currentTimestamp, tableIdent);
+    assertEquals("Procedure output must match", ImmutableList.of(row(0L, 0L, 1L)), output);
   }
 }

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
@@ -283,4 +283,31 @@ public class TestExpireSnapshotsProcedure extends SparkExtensionsTestBase {
     Assert.assertFalse("Delete manifest should be removed", localFs.exists(deleteManifestPath));
     Assert.assertFalse("Delete file should be removed", localFs.exists(deleteFilePath));
   }
+
+  @Test
+  public void testExpireSnapshotWithStreamResultsEnabled() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Assert.assertEquals("Should be 2 snapshots", 2, Iterables.size(table.snapshots()));
+
+    waitUntilAfter(table.currentSnapshot().timestampMillis());
+
+    Timestamp currentTimestamp = Timestamp.from(Instant.ofEpochMilli(System.currentTimeMillis()));
+
+    List<Object[]> output = sql(
+            "CALL %s.system.expire_snapshots(" +
+                    "older_than => TIMESTAMP '%s'," +
+                    "table => '%s'," +
+                    "retain_last => 1, " +
+                    "stream_results => true)",
+            catalogName, currentTimestamp, tableIdent);
+    assertEquals("Procedure output must match",
+            ImmutableList.of(row(0L, 0L, 1L)),
+            output);
+  }
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseExpireSnapshotsSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseExpireSnapshotsSparkAction.java
@@ -70,11 +70,12 @@ public class BaseExpireSnapshotsSparkAction
     extends BaseSparkAction<ExpireSnapshots, ExpireSnapshots.Result> implements ExpireSnapshots {
   private static final Logger LOG = LoggerFactory.getLogger(BaseExpireSnapshotsSparkAction.class);
 
+  public static final String STREAM_RESULTS = "stream-results";
+
   private static final String CONTENT_FILE = "Content File";
+
   private static final String MANIFEST = "Manifest";
   private static final String MANIFEST_LIST = "Manifest List";
-
-  private static final String STREAM_RESULTS = "stream-results";
 
   // Creates an executor service that runs each task in the thread that invokes execute/submit.
   private static final ExecutorService DEFAULT_DELETE_EXECUTOR_SERVICE = null;

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseExpireSnapshotsSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseExpireSnapshotsSparkAction.java
@@ -73,7 +73,6 @@ public class BaseExpireSnapshotsSparkAction
   public static final String STREAM_RESULTS = "stream-results";
 
   private static final String CONTENT_FILE = "Content File";
-
   private static final String MANIFEST = "Manifest";
   private static final String MANIFEST_LIST = "Manifest List";
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
@@ -84,7 +84,7 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
     Long olderThanMillis = args.isNullAt(1) ? null : DateTimeUtil.microsToMillis(args.getLong(1));
     Integer retainLastNum = args.isNullAt(2) ? null : args.getInt(2);
     Integer maxConcurrentDeletes = args.isNullAt(3) ? null : args.getInt(3);
-    Boolean streamResult = args.isNullAt(4) ? false : args.getBoolean(4);
+    boolean streamResult = args.isNullAt(4) ? false : args.getBoolean(4);
 
     Preconditions.checkArgument(maxConcurrentDeletes == null || maxConcurrentDeletes > 0,
         "max_concurrent_deletes should have value > 0,  value: " + maxConcurrentDeletes);
@@ -104,9 +104,7 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
         action.executeDeleteWith(executorService(maxConcurrentDeletes, "expire-snapshots"));
       }
 
-      if (streamResult) {
-        action.option("stream-results", streamResult.toString());
-      }
+      action.option("stream-results", Boolean.toString(streamResult));
 
       ExpireSnapshots.Result result = action.execute();
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
@@ -45,7 +45,8 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
       ProcedureParameter.required("table", DataTypes.StringType),
       ProcedureParameter.optional("older_than", DataTypes.TimestampType),
       ProcedureParameter.optional("retain_last", DataTypes.IntegerType),
-      ProcedureParameter.optional("max_concurrent_deletes", DataTypes.IntegerType)
+      ProcedureParameter.optional("max_concurrent_deletes", DataTypes.IntegerType),
+      ProcedureParameter.optional("stream_results", DataTypes.BooleanType)
   };
 
   private static final StructType OUTPUT_TYPE = new StructType(new StructField[]{
@@ -83,6 +84,7 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
     Long olderThanMillis = args.isNullAt(1) ? null : DateTimeUtil.microsToMillis(args.getLong(1));
     Integer retainLastNum = args.isNullAt(2) ? null : args.getInt(2);
     Integer maxConcurrentDeletes = args.isNullAt(3) ? null : args.getInt(3);
+    Boolean streamResult = args.isNullAt(4) ? false : args.getBoolean(4);
 
     Preconditions.checkArgument(maxConcurrentDeletes == null || maxConcurrentDeletes > 0,
         "max_concurrent_deletes should have value > 0,  value: " + maxConcurrentDeletes);
@@ -100,6 +102,10 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
 
       if (maxConcurrentDeletes != null && maxConcurrentDeletes > 0) {
         action.executeDeleteWith(executorService(maxConcurrentDeletes, "expire-snapshots"));
+      }
+
+      if (streamResult) {
+        action.option("stream-results", streamResult.toString());
       }
 
       ExpireSnapshots.Result result = action.execute();

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.spark.procedures;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.ExpireSnapshots;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.spark.actions.BaseExpireSnapshotsSparkAction;
 import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.iceberg.util.DateTimeUtil;
@@ -104,7 +105,7 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
         action.executeDeleteWith(executorService(maxConcurrentDeletes, "expire-snapshots"));
       }
 
-      action.option("stream-results", Boolean.toString(streamResult));
+      action.option(BaseExpireSnapshotsSparkAction.STREAM_RESULTS, Boolean.toString(streamResult));
 
       ExpireSnapshots.Result result = action.execute();
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
@@ -85,7 +85,7 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
     Long olderThanMillis = args.isNullAt(1) ? null : DateTimeUtil.microsToMillis(args.getLong(1));
     Integer retainLastNum = args.isNullAt(2) ? null : args.getInt(2);
     Integer maxConcurrentDeletes = args.isNullAt(3) ? null : args.getInt(3);
-    boolean streamResult = args.isNullAt(4) ? false : args.getBoolean(4);
+    Boolean streamResult = args.isNullAt(4) ? null : args.getBoolean(4);
 
     Preconditions.checkArgument(maxConcurrentDeletes == null || maxConcurrentDeletes > 0,
         "max_concurrent_deletes should have value > 0,  value: " + maxConcurrentDeletes);
@@ -105,7 +105,9 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
         action.executeDeleteWith(executorService(maxConcurrentDeletes, "expire-snapshots"));
       }
 
-      action.option(BaseExpireSnapshotsSparkAction.STREAM_RESULTS, Boolean.toString(streamResult));
+      if (streamResult != null) {
+        action.option(BaseExpireSnapshotsSparkAction.STREAM_RESULTS, Boolean.toString(streamResult));
+      }
 
       ExpireSnapshots.Result result = action.execute();
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -26,7 +26,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.BaseTable;

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -1049,7 +1049,8 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
       ExpireSnapshots.Result results =
               SparkActions.get().expireSnapshots(table).expireOlderThan(end).execute();
 
-      Assert.assertEquals("Table does not have 1 snapshot after expiration", 1, Iterables.size(table.snapshots()));
+      Assert.assertEquals("Table does not have 1 snapshot after expiration",
+              1, Iterables.size(table.snapshots()));
 
       int jobsAfter = spark.sparkContext().dagScheduler().nextJobId().get();
       int totalJobsRun = jobsAfter - jobsBefore;
@@ -1058,7 +1059,8 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
 
       // expire() in BaseExpireSnapshotsSparkAction contains two dataframe operations
       Assert.assertEquals(
-              String.format("Expected more than %d jobs when using local iterator, ran %d", SHUFFLE_PARTITIONS, totalJobsRun),
+              String.format("Expected more than %d jobs when using local iterator, ran %d",
+                      SHUFFLE_PARTITIONS, totalJobsRun),
               totalJobsRun, SHUFFLE_PARTITIONS * 2);
     });
   }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -1027,45 +1027,6 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
   }
 
   @Test
-  public void testUseCollectAsList() {
-    table.newFastAppend()
-        .appendFile(FILE_A)
-        .commit();
-
-    table.newOverwrite()
-        .deleteFile(FILE_A)
-        .addFile(FILE_B)
-        .commit();
-
-    table.newFastAppend()
-        .appendFile(FILE_C)
-        .commit();
-
-    long end = rightAfterSnapshot();
-
-    int jobsBefore = spark.sparkContext().dagScheduler().nextJobId().get();
-
-    withSQLConf(ImmutableMap.of("spark.sql.adaptive.enabled", "false"), () -> {
-      ExpireSnapshots.Result results =
-              SparkActions.get().expireSnapshots(table).expireOlderThan(end).execute();
-
-      Assert.assertEquals("Table does not have 1 snapshot after expiration",
-              1, Iterables.size(table.snapshots()));
-
-      int jobsAfter = spark.sparkContext().dagScheduler().nextJobId().get();
-      int totalJobsRun = jobsAfter - jobsBefore;
-
-      checkExpirationResults(1L, 1L, 2L, results);
-
-      // expire() in BaseExpireSnapshotsSparkAction contains two dataframe operations
-      Assert.assertEquals(
-              String.format("Expected more than %d jobs when using local iterator, ran %d",
-                      SHUFFLE_PARTITIONS, totalJobsRun),
-              totalJobsRun, SHUFFLE_PARTITIONS * 2);
-    });
-  }
-
-  @Test
   public void testUseLocalIterator() {
     table.newFastAppend()
             .appendFile(FILE_A)

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -1064,7 +1064,7 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
 
     long endBeforeStreamResults = rightAfterSnapshot();
 
-    int JobsBeforeStreamResults = spark.sparkContext().dagScheduler().nextJobId().get();
+    int jobsBeforeStreamResults = spark.sparkContext().dagScheduler().nextJobId().get();
 
     AtomicReference<Integer> jobsRunDuringStreamResults = new AtomicReference<>();
 
@@ -1072,8 +1072,8 @@ public class TestExpireSnapshotsAction extends SparkTestBase {
       ExpireSnapshots.Result results = SparkActions.get().expireSnapshots(table).expireOlderThan(endBeforeStreamResults)
           .option("stream-results", "true").execute();
 
-      int JobsAfterStreamResults = spark.sparkContext().dagScheduler().nextJobId().get();
-      jobsRunDuringStreamResults.set(JobsAfterStreamResults - JobsBeforeStreamResults);
+      int jobsAfterStreamResults = spark.sparkContext().dagScheduler().nextJobId().get();
+      jobsRunDuringStreamResults.set(jobsAfterStreamResults - jobsBeforeStreamResults);
 
       checkExpirationResults(1L, 2L, 1L, results);
     });


### PR DESCRIPTION
When we try to run expire_snapshots procedure on the iceberg table for the first time, it often makes the driver OOM due to a big list of files to delete, which requires to increase the driver memory a lot. The iceberg table in our case contained more than ~2M data files and ~70K snapshots before we executed the expire_snapshots procedure. 

We can allow the user to choose whether to use `stream_results` as a procedure option to avoid this case.