### PR TITLE
Spark 3.2: Support mergeSchema option on write

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Schema.java
+++ b/api/src/main/java/org/apache/iceberg/Schema.java
@@ -55,6 +55,7 @@ public class Schema implements Serializable {
   private final StructType struct;
   private final int schemaId;
   private final int[] identifierFieldIds;
+  private final int highestFieldId;
 
   private transient BiMap<String, Integer> aliasToId = null;
   private transient Map<Integer, NestedField> idToField = null;
@@ -102,7 +103,7 @@ public class Schema implements Serializable {
 
     this.identifierFieldIds = identifierFieldIds != null ? Ints.toArray(identifierFieldIds) : new int[0];
 
-    lazyIdToName();
+    this.highestFieldId = lazyIdToName().keySet().stream().mapToInt(i -> i).max().orElse(0);
   }
 
   static void validateIdentifierField(int fieldId, Map<Integer, Types.NestedField> idToField,
@@ -184,6 +185,13 @@ public class Schema implements Serializable {
    */
   public int schemaId() {
     return this.schemaId;
+  }
+
+  /**
+   * Returns the highest field ID in this schema, including nested fields.
+   */
+  public int highestFieldId() {
+    return highestFieldId;
   }
 
   /**

--- a/api/src/main/java/org/apache/iceberg/types/ReassignIds.java
+++ b/api/src/main/java/org/apache/iceberg/types/ReassignIds.java
@@ -46,14 +46,16 @@ class ReassignIds extends TypeUtil.CustomOrderSchemaVisitor<Type> {
   }
 
   private int id(Types.StructType sourceStruct, String name) {
-    if (sourceStruct != null) {
-      Types.NestedField sourceField = sourceStruct.field(name);
-      if (sourceField != null) {
-        return sourceField.fieldId();
-      }
+    Types.NestedField sourceField = sourceStruct.field(name);
+    if (sourceField != null) {
+      return sourceField.fieldId();
     }
 
-    return assignId.get();
+    if (assignId != null) {
+      return assignId.get();
+    }
+
+    throw new IllegalArgumentException("Field " + name + " not found in source schema");
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/types/ReassignIds.java
+++ b/api/src/main/java/org/apache/iceberg/types/ReassignIds.java
@@ -27,10 +27,12 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
 class ReassignIds extends TypeUtil.CustomOrderSchemaVisitor<Type> {
   private final Schema sourceSchema;
+  private final TypeUtil.NextID assignId;
   private Type sourceType;
 
-  ReassignIds(Schema sourceSchema) {
+  ReassignIds(Schema sourceSchema, TypeUtil.NextID nextID) {
     this.sourceSchema = sourceSchema;
+    this.assignId = nextID;
   }
 
   @Override
@@ -41,6 +43,17 @@ class ReassignIds extends TypeUtil.CustomOrderSchemaVisitor<Type> {
     } finally {
       this.sourceType = null;
     }
+  }
+
+  private int id(Types.StructType sourceStruct, String name) {
+    if (sourceStruct != null) {
+      Types.NestedField sourceField = sourceStruct.field(name);
+      if (sourceField != null) {
+        return sourceField.fieldId();
+      }
+    }
+
+    return assignId.get();
   }
 
   @Override
@@ -56,11 +69,11 @@ class ReassignIds extends TypeUtil.CustomOrderSchemaVisitor<Type> {
     List<Types.NestedField> newFields = Lists.newArrayListWithExpectedSize(length);
     for (int i = 0; i < length; i += 1) {
       Types.NestedField field = fields.get(i);
-      int sourceFieldId = sourceStruct.field(field.name()).fieldId();
+      int fieldId = id(sourceStruct, field.name());
       if (field.isRequired()) {
-        newFields.add(Types.NestedField.required(sourceFieldId, field.name(), types.get(i), field.doc()));
+        newFields.add(Types.NestedField.required(fieldId, field.name(), types.get(i), field.doc()));
       } else {
-        newFields.add(Types.NestedField.optional(sourceFieldId, field.name(), types.get(i), field.doc()));
+        newFields.add(Types.NestedField.optional(fieldId, field.name(), types.get(i), field.doc()));
       }
     }
 
@@ -73,15 +86,20 @@ class ReassignIds extends TypeUtil.CustomOrderSchemaVisitor<Type> {
 
     Types.StructType sourceStruct = sourceType.asStructType();
     Types.NestedField sourceField = sourceStruct.field(field.name());
-    if (sourceField == null) {
-      throw new IllegalArgumentException("Field " + field.name() + " not found in source schema");
-    }
+    if (sourceField != null) {
+      this.sourceType = sourceField.type();
+      try {
+        return future.get();
+      } finally {
+        sourceType = sourceStruct;
+      }
 
-    this.sourceType = sourceField.type();
-    try {
-      return future.get();
-    } finally {
-      sourceType = sourceStruct;
+    } else if (assignId != null) {
+      // there is no corresponding field in the id source schema, assign fresh IDs for the type
+      return TypeUtil.assignFreshIds(field.type(), assignId);
+
+    } else {
+      throw new IllegalArgumentException("Field " + field.name() + " not found in source schema");
     }
   }
 

--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -273,7 +273,13 @@ public class TypeUtil {
    * @throws IllegalArgumentException if a field cannot be found (by name) in the source schema
    */
   public static Schema reassignIds(Schema schema, Schema idSourceSchema) {
-    Types.StructType struct = visit(schema, new ReassignIds(idSourceSchema)).asStructType();
+    Types.StructType struct = visit(schema, new ReassignIds(idSourceSchema, null)).asStructType();
+    return new Schema(struct.fields(), refreshIdentifierFields(struct, schema));
+  }
+
+  public static Schema reassignOrRefreshIds(Schema schema, Schema idSourceSchema) {
+    AtomicInteger highest = new AtomicInteger(schema.highestFieldId());
+    Types.StructType struct = visit(schema, new ReassignIds(idSourceSchema, highest::incrementAndGet)).asStructType();
     return new Schema(struct.fields(), refreshIdentifierFields(struct, schema));
   }
 

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -214,6 +214,9 @@ public class TableProperties {
   public static final String SPARK_WRITE_PARTITIONED_FANOUT_ENABLED = "write.spark.fanout.enabled";
   public static final boolean SPARK_WRITE_PARTITIONED_FANOUT_ENABLED_DEFAULT = false;
 
+  public static final String SPARK_WRITE_ACCEPT_ANY_SCHEMA = "write.spark.accept-any-schema";
+  public static final boolean SPARK_WRITE_ACCEPT_ANY_SCHEMA_DEFAULT = false;
+
   public static final String SNAPSHOT_ID_INHERITANCE_ENABLED = "compatibility.snapshot-id-inheritance.enabled";
   public static final boolean SNAPSHOT_ID_INHERITANCE_ENABLED_DEFAULT = false;
 

--- a/core/src/main/java/org/apache/iceberg/types/FixupTypes.java
+++ b/core/src/main/java/org/apache/iceberg/types/FixupTypes.java
@@ -83,11 +83,16 @@ public abstract class FixupTypes extends TypeUtil.CustomOrderSchemaVisitor<Type>
     Preconditions.checkArgument(sourceType.isStructType(), "Not a struct: %s", sourceType);
 
     Types.StructType sourceStruct = sourceType.asStructType();
-    this.sourceType = sourceStruct.field(field.fieldId()).type();
-    try {
-      return future.get();
-    } finally {
-      sourceType = sourceStruct;
+    Types.NestedField sourceField = sourceStruct.field(field.fieldId());
+    if (sourceField != null) {
+      this.sourceType = sourceField.type();
+      try {
+        return future.get();
+      } finally {
+        sourceType = sourceStruct;
+      }
+    } else {
+      return field.type();
     }
   }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkConfParser.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkConfParser.java
@@ -19,13 +19,13 @@
 
 package org.apache.iceberg.spark;
 
-import com.clearspring.analytics.util.Lists;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.spark.sql.RuntimeConfig;
 import org.apache.spark.sql.SparkSession;
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkConfParser.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkConfParser.java
@@ -19,6 +19,8 @@
 
 package org.apache.iceberg.spark;
 
+import com.clearspring.analytics.util.Lists;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
@@ -149,14 +151,14 @@ class SparkConfParser {
   }
 
   abstract class ConfParser<ThisT, T> {
-    private String optionName;
+    private final List<String> optionNames = Lists.newArrayList();
     private String sessionConfName;
     private String tablePropertyName;
 
     protected abstract ThisT self();
 
     public ThisT option(String name) {
-      this.optionName = name;
+      this.optionNames.add(name);
       return self();
     }
 
@@ -171,11 +173,13 @@ class SparkConfParser {
     }
 
     protected T parse(Function<String, T> conversion, T defaultValue) {
-      if (optionName != null) {
-        // use lower case comparison as DataSourceOptions.asMap() in Spark 2 returns a lower case map
-        String optionValue = options.get(optionName.toLowerCase(Locale.ROOT));
-        if (optionValue != null) {
-          return conversion.apply(optionValue);
+      if (!optionNames.isEmpty()) {
+        for (String optionName : optionNames) {
+          // use lower case comparison as DataSourceOptions.asMap() in Spark 2 returns a lower case map
+          String optionValue = options.get(optionName.toLowerCase(Locale.ROOT));
+          if (optionValue != null) {
+            return conversion.apply(optionValue);
+          }
         }
       }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -115,6 +115,14 @@ public class SparkWriteConf {
     return sessionConf.get("spark.wap.id", null);
   }
 
+  public boolean mergeSchema() {
+    return confParser.booleanConf()
+        .option(SparkWriteOptions.MERGE_SCHEMA)
+        .option(SparkWriteOptions.SPARK_MERGE_SCHEMA)
+        .defaultValue(SparkWriteOptions.MERGE_SCHEMA_DEFAULT)
+        .parse();
+  }
+
   public FileFormat dataFileFormat() {
     String valueAsString = confParser.stringConf()
         .option(SparkWriteOptions.WRITE_FORMAT)

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
@@ -68,4 +68,8 @@ public class SparkWriteOptions {
   // Controls whether to take into account the table distribution and sort order during a write operation
   public static final String USE_TABLE_DISTRIBUTION_AND_ORDERING = "use-table-distribution-and-ordering";
   public static final boolean USE_TABLE_DISTRIBUTION_AND_ORDERING_DEFAULT = true;
+
+  public static final String MERGE_SCHEMA = "merge-schema";
+  public static final String SPARK_MERGE_SCHEMA = "mergeSchema";
+  public static final boolean MERGE_SCHEMA_DEFAULT = false;
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkWriteBuilder.java
@@ -132,9 +132,7 @@ class SparkWriteBuilder implements WriteBuilder, SupportsDynamicOverwrite, Suppo
         SparkUtil.TIMESTAMP_WITHOUT_TIMEZONE_ERROR);
 
     Schema writeSchema;
-    boolean mergeSchema = writeInfo.options().getBoolean("mergeSchema",
-        writeInfo.options().getBoolean("merge-schema", false));
-    if (mergeSchema) {
+    if (writeConf.mergeSchema()) {
       // convert the dataset schema and assign fresh ids for new fields
       Schema newSchema = SparkSchemaUtil.convertWithFreshIds(table.schema(), dsSchema);
 

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/SparkTestBase.java
@@ -40,6 +40,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.internal.SQLConf;
@@ -238,6 +240,11 @@ public abstract class SparkTestBase {
         }
       });
     }
+  }
+
+  protected Dataset<Row> jsonToDF(String schema, String... records) {
+    Dataset<String> jsonDF = spark.createDataset(ImmutableList.copyOf(records), Encoders.STRING());
+    return spark.read().schema(schema).json(jsonDF);
   }
 
   @FunctionalInterface

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
@@ -1,15 +1,20 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.iceberg.spark.source;

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
@@ -19,9 +19,9 @@
 
 package org.apache.iceberg.spark.source;
 
-import com.google.common.collect.ImmutableList;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
 import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.spark.source;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.spark.SparkTestBaseWithCatalog;
+import org.apache.spark.sql.AnalysisException;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestDataFrameWriterV2 extends SparkTestBaseWithCatalog {
+  @Before
+  public void createTable() {
+    sql("CREATE TABLE %s (id bigint, data string) USING iceberg", tableName);
+  }
+
+  @After
+  public void removeTables() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @Test
+  public void testMergeSchemaFailsWithoutWriterOption() throws Exception {
+    sql("ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')", tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+
+    Dataset<Row> twoColDF = jsonToDF(
+        "id bigint, data string",
+        "{ \"id\": 1, \"data\": \"a\" }",
+        "{ \"id\": 2, \"data\": \"b\" }");
+
+    twoColDF.writeTo(tableName).append();
+
+    assertEquals("Should have initial 2-column rows",
+        ImmutableList.of(row(1L, "a"), row(2L, "b")),
+        sql("select * from %s order by id", tableName));
+
+    Dataset<Row> threeColDF = jsonToDF(
+        "id bigint, data string, new_col float",
+        "{ \"id\": 3, \"data\": \"c\", \"new_col\": 12.06 }",
+        "{ \"id\": 4, \"data\": \"d\", \"new_col\": 14.41 }");
+
+    // this has a different error message than the case without accept-any-schema because it uses Iceberg checks
+    AssertHelpers.assertThrows("Should fail when merge-schema is not enabled on the writer",
+        IllegalArgumentException.class, "Field new_col not found in source schema",
+        () -> {
+          try {
+            threeColDF.writeTo(tableName).append();
+          } catch (NoSuchTableException e) {
+            // needed because append has checked exceptions
+            throw new RuntimeException(e);
+          }
+        });
+  }
+
+  @Test
+  public void testMergeSchemaWithoutAcceptAnySchema() throws Exception {
+    Dataset<Row> twoColDF = jsonToDF(
+        "id bigint, data string",
+        "{ \"id\": 1, \"data\": \"a\" }",
+        "{ \"id\": 2, \"data\": \"b\" }");
+
+    twoColDF.writeTo(tableName).append();
+
+    assertEquals("Should have initial 2-column rows",
+        ImmutableList.of(row(1L, "a"), row(2L, "b")),
+        sql("select * from %s order by id", tableName));
+
+    Dataset<Row> threeColDF = jsonToDF(
+        "id bigint, data string, new_col float",
+        "{ \"id\": 3, \"data\": \"c\", \"new_col\": 12.06 }",
+        "{ \"id\": 4, \"data\": \"d\", \"new_col\": 14.41 }");
+
+    AssertHelpers.assertThrows("Should fail when accept-any-schema is not enabled on the table",
+        AnalysisException.class, "too many data columns",
+        () -> {
+          try {
+            threeColDF.writeTo(tableName).option("merge-schema", "true").append();
+          } catch (NoSuchTableException e) {
+            // needed because append has checked exceptions
+            throw new RuntimeException(e);
+          }
+        });
+  }
+
+  @Test
+  public void testMergeSchemaSparkProperty() throws Exception {
+    sql("ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')", tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+
+    Dataset<Row> twoColDF = jsonToDF(
+        "id bigint, data string",
+        "{ \"id\": 1, \"data\": \"a\" }",
+        "{ \"id\": 2, \"data\": \"b\" }");
+
+    twoColDF.writeTo(tableName).append();
+
+    assertEquals("Should have initial 2-column rows",
+        ImmutableList.of(row(1L, "a"), row(2L, "b")),
+        sql("select * from %s order by id", tableName));
+
+    Dataset<Row> threeColDF = jsonToDF(
+        "id bigint, data string, new_col float",
+        "{ \"id\": 3, \"data\": \"c\", \"new_col\": 12.06 }",
+        "{ \"id\": 4, \"data\": \"d\", \"new_col\": 14.41 }");
+
+    threeColDF.writeTo(tableName).option("mergeSchema", "true").append();
+
+    assertEquals("Should have 3-column rows",
+        ImmutableList.of(row(1L, "a", null), row(2L, "b", null), row(3L, "c", 12.06F), row(4L, "d", 14.41F)),
+        sql("select * from %s order by id", tableName));
+  }
+
+  @Test
+  public void testMergeSchemaIcebergProperty() throws Exception {
+    sql("ALTER TABLE %s SET TBLPROPERTIES ('%s'='true')", tableName, TableProperties.SPARK_WRITE_ACCEPT_ANY_SCHEMA);
+
+    Dataset<Row> twoColDF = jsonToDF(
+        "id bigint, data string",
+        "{ \"id\": 1, \"data\": \"a\" }",
+        "{ \"id\": 2, \"data\": \"b\" }");
+
+    twoColDF.writeTo(tableName).append();
+
+    assertEquals("Should have initial 2-column rows",
+        ImmutableList.of(row(1L, "a"), row(2L, "b")),
+        sql("select * from %s order by id", tableName));
+
+    Dataset<Row> threeColDF = jsonToDF(
+        "id bigint, data string, new_col float",
+        "{ \"id\": 3, \"data\": \"c\", \"new_col\": 12.06 }",
+        "{ \"id\": 4, \"data\": \"d\", \"new_col\": 14.41 }");
+
+    threeColDF.writeTo(tableName).option("merge-schema", "true").append();
+
+    assertEquals("Should have 3-column rows",
+        ImmutableList.of(row(1L, "a", null), row(2L, "b", null), row(3L, "c", 12.06F), row(4L, "d", 14.41F)),
+        sql("select * from %s order by id", tableName));
+  }
+}


### PR DESCRIPTION
Some Spark tables support an option, `mergeSchema`, that will update the table schema on write if the incoming data has extra columns. This adds support for the `mergeSchema` option as well as an Iceberg alias, `merge-schema`.

In order to add this functionality, this PR adds a new table property, `write.spark.accept-any-schema`. This adds the Spark DSv2 capability `ACCEPT_ANY_SCHEMA` to the Spark table. This will bypass Spark's schema validation checks and use Iceberg's instead. As a result, this fixes #2456.