### PR TITLE
Core: Remove unused method accidentally added to TableMetadata

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -501,10 +501,6 @@ public class TableMetadata implements Serializable {
     return new Builder(this).setCurrentSnapshot(snapshot).build();
   }
 
-  public TableMetadata replaceCurrentSnapshot(long snapshotId) {
-    return new Builder(this).setCurrentSnapshot(snapshotId).build();
-  }
-
   public TableMetadata removeSnapshotsIf(Predicate<Snapshot> removeIf) {
     List<Snapshot> toRemove = snapshots.stream().filter(removeIf).collect(Collectors.toList());
     return new Builder(this).removeSnapshots(toRemove).build();


### PR DESCRIPTION
#4135 fixed a regression in 0.13.x by porting part of #4089, but accidentally added an unused method to `TableMetadata`. We remove it in this follow-up.