### PR TITLE
Flink: Support configurable Scala version.

### DIFF
--- a/flink/v1.12/build.gradle
+++ b/flink/v1.12/build.gradle
@@ -17,18 +17,11 @@
  * under the License.
  */
 
-def flinkProjects = [
-    project(':iceberg-flink:iceberg-flink-1.12'),
-    project(':iceberg-flink:iceberg-flink-runtime-1.12')
-]
+String flinkVersion = '1.12.5'
+String flinkMajorVersion = '1.12'
+String scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
 
-configure(flinkProjects) {
-  project.ext {
-    flinkVersion = '1.12.5'
-  }
-}
-
-project(':iceberg-flink:iceberg-flink-1.12') {
+project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}_${scalaVersion}") {
 
   dependencies {
     implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
@@ -40,11 +33,11 @@ project(':iceberg-flink:iceberg-flink-1.12') {
     implementation project(':iceberg-parquet')
     implementation project(':iceberg-hive-metastore')
 
-    compileOnly "org.apache.flink:flink-streaming-java_2.12:${flinkVersion}"
-    compileOnly "org.apache.flink:flink-streaming-java_2.12:${flinkVersion}:tests"
-    compileOnly "org.apache.flink:flink-table-api-java-bridge_2.12:${flinkVersion}"
-    compileOnly "org.apache.flink:flink-table-planner-blink_2.12:${flinkVersion}"
-    compileOnly "org.apache.flink:flink-table-planner_2.12:${flinkVersion}"
+    compileOnly "org.apache.flink:flink-streaming-java_${scalaVersion}:${flinkVersion}"
+    compileOnly "org.apache.flink:flink-streaming-java_${scalaVersion}:${flinkVersion}:tests"
+    compileOnly "org.apache.flink:flink-table-api-java-bridge_${scalaVersion}:${flinkVersion}"
+    compileOnly "org.apache.flink:flink-table-planner-blink_${scalaVersion}:${flinkVersion}"
+    compileOnly "org.apache.flink:flink-table-planner_${scalaVersion}:${flinkVersion}"
     compileOnly "org.apache.hadoop:hadoop-hdfs"
     compileOnly "org.apache.hadoop:hadoop-common"
     compileOnly("org.apache.hadoop:hadoop-minicluster") {
@@ -69,12 +62,12 @@ project(':iceberg-flink:iceberg-flink-1.12') {
     }
 
     testImplementation "org.apache.flink:flink-core:${flinkVersion}"
-    testImplementation "org.apache.flink:flink-runtime_2.12:${flinkVersion}"
-    testImplementation "org.apache.flink:flink-table-planner-blink_2.12:${flinkVersion}"
+    testImplementation "org.apache.flink:flink-runtime_${scalaVersion}:${flinkVersion}"
+    testImplementation "org.apache.flink:flink-table-planner-blink_${scalaVersion}:${flinkVersion}"
     testImplementation("org.apache.flink:flink-test-utils-junit:${flinkVersion}") {
       exclude group: 'junit'
     }
-    testImplementation("org.apache.flink:flink-test-utils_2.12:${flinkVersion}") {
+    testImplementation("org.apache.flink:flink-test-utils_${scalaVersion}:${flinkVersion}") {
       exclude group: "org.apache.curator", module: 'curator-test'
       exclude group: 'junit'
     }
@@ -118,7 +111,7 @@ project(':iceberg-flink:iceberg-flink-1.12') {
   }
 }
 
-project(':iceberg-flink:iceberg-flink-runtime-1.12') {
+project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}_${scalaVersion}") {
   apply plugin: 'com.github.johnrengelman.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
@@ -138,7 +131,7 @@ project(':iceberg-flink:iceberg-flink-runtime-1.12') {
   }
 
   dependencies {
-    implementation project(':iceberg-flink:iceberg-flink-1.12')
+    implementation project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}_${scalaVersion}")
     implementation project(':iceberg-aws')
     implementation(project(':iceberg-aliyun')) {
       exclude group: 'edu.umd.cs.findbugs', module: 'findbugs'

--- a/flink/v1.13/build.gradle
+++ b/flink/v1.13/build.gradle
@@ -17,18 +17,11 @@
  * under the License.
  */
 
-def flinkProjects = [
-  project(':iceberg-flink:iceberg-flink-1.13'),
-  project(':iceberg-flink:iceberg-flink-runtime-1.13')
-]
+String flinkVersion = '1.13.2'
+String flinkMajorVersion = '1.13'
+String scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
 
-configure(flinkProjects) {
-  project.ext {
-    flinkVersion = '1.13.2'
-  }
-}
-
-project(':iceberg-flink:iceberg-flink-1.13') {
+project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}_${scalaVersion}") {
 
   dependencies {
     implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
@@ -40,11 +33,11 @@ project(':iceberg-flink:iceberg-flink-1.13') {
     implementation project(':iceberg-parquet')
     implementation project(':iceberg-hive-metastore')
 
-    compileOnly "org.apache.flink:flink-streaming-java_2.12:${flinkVersion}"
-    compileOnly "org.apache.flink:flink-streaming-java_2.12:${flinkVersion}:tests"
-    compileOnly "org.apache.flink:flink-table-api-java-bridge_2.12:${flinkVersion}"
-    compileOnly "org.apache.flink:flink-table-planner-blink_2.12:${flinkVersion}"
-    compileOnly "org.apache.flink:flink-table-planner_2.12:${flinkVersion}"
+    compileOnly "org.apache.flink:flink-streaming-java_${scalaVersion}:${flinkVersion}"
+    compileOnly "org.apache.flink:flink-streaming-java_${scalaVersion}:${flinkVersion}:tests"
+    compileOnly "org.apache.flink:flink-table-api-java-bridge_${scalaVersion}:${flinkVersion}"
+    compileOnly "org.apache.flink:flink-table-planner-blink_${scalaVersion}:${flinkVersion}"
+    compileOnly "org.apache.flink:flink-table-planner_${scalaVersion}:${flinkVersion}"
     compileOnly "org.apache.hadoop:hadoop-hdfs"
     compileOnly "org.apache.hadoop:hadoop-common"
     compileOnly("org.apache.hadoop:hadoop-minicluster") {
@@ -69,12 +62,12 @@ project(':iceberg-flink:iceberg-flink-1.13') {
     }
 
     testImplementation "org.apache.flink:flink-core:${flinkVersion}"
-    testImplementation "org.apache.flink:flink-runtime_2.12:${flinkVersion}"
-    testImplementation "org.apache.flink:flink-table-planner-blink_2.12:${flinkVersion}"
+    testImplementation "org.apache.flink:flink-runtime_${scalaVersion}:${flinkVersion}"
+    testImplementation "org.apache.flink:flink-table-planner-blink_${scalaVersion}:${flinkVersion}"
     testImplementation ("org.apache.flink:flink-test-utils-junit:${flinkVersion}") {
       exclude group: 'junit'
     }
-    testImplementation("org.apache.flink:flink-test-utils_2.12:${flinkVersion}") {
+    testImplementation("org.apache.flink:flink-test-utils_${scalaVersion}:${flinkVersion}") {
       exclude group: "org.apache.curator", module: 'curator-test'
       exclude group: 'junit'
     }
@@ -118,7 +111,7 @@ project(':iceberg-flink:iceberg-flink-1.13') {
   }
 }
 
-project(':iceberg-flink:iceberg-flink-runtime-1.13') {
+project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}_${scalaVersion}") {
   apply plugin: 'com.github.johnrengelman.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
@@ -138,7 +131,7 @@ project(':iceberg-flink:iceberg-flink-runtime-1.13') {
   }
 
   dependencies {
-    implementation project(':iceberg-flink:iceberg-flink-1.13')
+    implementation project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}_${scalaVersion}")
     implementation project(':iceberg-aws')
     implementation(project(':iceberg-aliyun')) {
       exclude group: 'edu.umd.cs.findbugs', module: 'findbugs'

--- a/flink/v1.14/build.gradle
+++ b/flink/v1.14/build.gradle
@@ -17,18 +17,11 @@
  * under the License.
  */
 
-def flinkProjects = [
-  project(':iceberg-flink:iceberg-flink-1.14'),
-  project(':iceberg-flink:iceberg-flink-runtime-1.14')
-]
+String flinkVersion = '1.14.0'
+String flinkMajorVersion = '1.14'
+String scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
 
-configure(flinkProjects) {
-  project.ext {
-    flinkVersion = '1.14.0'
-  }
-}
-
-project(':iceberg-flink:iceberg-flink-1.14') {
+project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}_${scalaVersion}") {
 
   dependencies {
     implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
@@ -40,10 +33,10 @@ project(':iceberg-flink:iceberg-flink-1.14') {
     implementation project(':iceberg-parquet')
     implementation project(':iceberg-hive-metastore')
 
-    compileOnly "org.apache.flink:flink-streaming-java_2.12:${flinkVersion}"
-    compileOnly "org.apache.flink:flink-streaming-java_2.12:${flinkVersion}:tests"
-    compileOnly "org.apache.flink:flink-table-api-java-bridge_2.12:${flinkVersion}"
-    compileOnly "org.apache.flink:flink-table-planner_2.12:${flinkVersion}"
+    compileOnly "org.apache.flink:flink-streaming-java_${scalaVersion}:${flinkVersion}"
+    compileOnly "org.apache.flink:flink-streaming-java_${scalaVersion}:${flinkVersion}:tests"
+    compileOnly "org.apache.flink:flink-table-api-java-bridge_${scalaVersion}:${flinkVersion}"
+    compileOnly "org.apache.flink:flink-table-planner_${scalaVersion}:${flinkVersion}"
     compileOnly "org.apache.hadoop:hadoop-hdfs"
     compileOnly "org.apache.hadoop:hadoop-common"
     compileOnly("org.apache.hadoop:hadoop-minicluster") {
@@ -72,7 +65,7 @@ project(':iceberg-flink:iceberg-flink-1.14') {
     testImplementation ("org.apache.flink:flink-test-utils-junit:${flinkVersion}") {
       exclude group: 'junit'
     }
-    testImplementation("org.apache.flink:flink-test-utils_2.12:${flinkVersion}") {
+    testImplementation("org.apache.flink:flink-test-utils_${scalaVersion}:${flinkVersion}") {
       exclude group: "org.apache.curator", module: 'curator-test'
       exclude group: 'junit'
     }
@@ -116,7 +109,7 @@ project(':iceberg-flink:iceberg-flink-1.14') {
   }
 }
 
-project(':iceberg-flink:iceberg-flink-runtime-1.14') {
+project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}_${scalaVersion}") {
   apply plugin: 'com.github.johnrengelman.shadow'
 
   tasks.jar.dependsOn tasks.shadowJar
@@ -136,7 +129,7 @@ project(':iceberg-flink:iceberg-flink-runtime-1.14') {
   }
 
   dependencies {
-    implementation project(':iceberg-flink:iceberg-flink-1.14')
+    implementation project(":iceberg-flink:iceberg-flink-${flinkMajorVersion}_${scalaVersion}")
     implementation project(':iceberg-aws')
     implementation(project(':iceberg-aliyun')) {
       exclude group: 'edu.umd.cs.findbugs', module: 'findbugs'

--- a/settings.gradle
+++ b/settings.gradle
@@ -87,30 +87,30 @@ if (!flinkVersions.isEmpty()) {
 }
 
 if (flinkVersions.contains("1.12")) {
-  include ':iceberg-flink:flink-1.12'
-  include ':iceberg-flink:flink-runtime-1.12'
-  project(':iceberg-flink:flink-1.12').projectDir = file('flink/v1.12/flink')
-  project(':iceberg-flink:flink-1.12').name = 'iceberg-flink-1.12'
-  project(':iceberg-flink:flink-runtime-1.12').projectDir = file('flink/v1.12/flink-runtime')
-  project(':iceberg-flink:flink-runtime-1.12').name = 'iceberg-flink-runtime-1.12'
+  include ":iceberg-flink:flink-1.12_${scalaVersion}"
+  include ":iceberg-flink:flink-runtime-1.12_${scalaVersion}"
+  project(":iceberg-flink:flink-1.12_${scalaVersion}").projectDir = file('flink/v1.12/flink')
+  project(":iceberg-flink:flink-1.12_${scalaVersion}").name = "iceberg-flink-1.12_${scalaVersion}"
+  project(":iceberg-flink:flink-runtime-1.12_${scalaVersion}").projectDir = file('flink/v1.12/flink-runtime')
+  project(":iceberg-flink:flink-runtime-1.12_${scalaVersion}").name = "iceberg-flink-runtime-1.12_${scalaVersion}"
 }
 
 if (flinkVersions.contains("1.13")) {
-  include ':iceberg-flink:flink-1.13'
-  include ':iceberg-flink:flink-runtime-1.13'
-  project(':iceberg-flink:flink-1.13').projectDir = file('flink/v1.13/flink')
-  project(':iceberg-flink:flink-1.13').name = 'iceberg-flink-1.13'
-  project(':iceberg-flink:flink-runtime-1.13').projectDir = file('flink/v1.13/flink-runtime')
-  project(':iceberg-flink:flink-runtime-1.13').name = 'iceberg-flink-runtime-1.13'
+  include ":iceberg-flink:flink-1.13_${scalaVersion}"
+  include ":iceberg-flink:flink-runtime-1.13_${scalaVersion}"
+  project(":iceberg-flink:flink-1.13_${scalaVersion}").projectDir = file('flink/v1.13/flink')
+  project(":iceberg-flink:flink-1.13_${scalaVersion}").name = "iceberg-flink-1.13_${scalaVersion}"
+  project(":iceberg-flink:flink-runtime-1.13_${scalaVersion}").projectDir = file('flink/v1.13/flink-runtime')
+  project(":iceberg-flink:flink-runtime-1.13_${scalaVersion}").name = "iceberg-flink-runtime-1.13_${scalaVersion}"
 }
 
 if (flinkVersions.contains("1.14")) {
-  include ':iceberg-flink:flink-1.14'
-  include ':iceberg-flink:flink-runtime-1.14'
-  project(':iceberg-flink:flink-1.14').projectDir = file('flink/v1.14/flink')
-  project(':iceberg-flink:flink-1.14').name = 'iceberg-flink-1.14'
-  project(':iceberg-flink:flink-runtime-1.14').projectDir = file('flink/v1.14/flink-runtime')
-  project(':iceberg-flink:flink-runtime-1.14').name = 'iceberg-flink-runtime-1.14'
+  include ":iceberg-flink:flink-1.14_${scalaVersion}"
+  include ":iceberg-flink:flink-runtime-1.14_${scalaVersion}"
+  project(":iceberg-flink:flink-1.14_${scalaVersion}").projectDir = file('flink/v1.14/flink')
+  project(":iceberg-flink:flink-1.14_${scalaVersion}").name = "iceberg-flink-1.14_${scalaVersion}"
+  project(":iceberg-flink:flink-runtime-1.14_${scalaVersion}").projectDir = file('flink/v1.14/flink-runtime')
+  project(":iceberg-flink:flink-runtime-1.14_${scalaVersion}").name = "iceberg-flink-runtime-1.14_${scalaVersion}"
 }
 
 if (sparkVersions.contains("3.0")) {


### PR DESCRIPTION
As apache flink usually will release a version with two scala version, but we apache iceberg only support scala 2.12 now. So here I publish a PR to support configurable scala version for building flink iceberg module.

We can use the following command to build flink runtime modules for scala 2.12: 

```bash
./gradlew clean build -x test -DflinkVersions=1.12,1.13,1.14 \
  -DscalaVersion=2.12 \
  -DknownScalaVersions=2.12 \
  -x javadoc -Pquick \
  -DsparkVersions= -DhiveVersions=
```

Their packaged jar are looks like:

```
➜  iceberg git:(add-flink-scala-version) find  flink/ | grep jar | grep v1                                                                                                                             
flink//v1.12/flink/build/libs/iceberg-flink-1.12_2.11-0.13.0-SNAPSHOT-tests.jar
flink//v1.12/flink/build/libs/iceberg-flink-1.12_2.11-0.13.0-SNAPSHOT.jar
flink//v1.12/flink/build/libs/iceberg-flink-1.12_2.11-0.13.0-SNAPSHOT-javadoc.jar
flink//v1.12/flink/build/libs/iceberg-flink-1.12_2.11-0.13.0-SNAPSHOT-sources.jar
flink//v1.12/flink/build/tmp/jar
flink//v1.12/flink/build/tmp/jar/MANIFEST.MF
flink//v1.12/flink-runtime/build/libs/iceberg-flink-runtime-1.12_2.11-0.13.0-SNAPSHOT.jar
flink//v1.12/flink-runtime/build/libs/iceberg-flink-runtime-1.12_2.11-0.13.0-SNAPSHOT-javadoc.jar
flink//v1.12/flink-runtime/build/libs/iceberg-flink-runtime-1.12_2.11-0.13.0-SNAPSHOT-tests.jar
flink//v1.12/flink-runtime/build/libs/iceberg-flink-runtime-1.12_2.11-0.13.0-SNAPSHOT-sources.jar
flink//v1.14/flink/build/libs/iceberg-flink-1.14_2.11-0.13.0-SNAPSHOT-tests.jar
flink//v1.14/flink/build/libs/iceberg-flink-1.14_2.11-0.13.0-SNAPSHOT-javadoc.jar
flink//v1.14/flink/build/libs/iceberg-flink-1.14_2.11-0.13.0-SNAPSHOT-sources.jar
flink//v1.14/flink/build/libs/iceberg-flink-1.14_2.11-0.13.0-SNAPSHOT.jar
flink//v1.14/flink/build/tmp/jar
flink//v1.14/flink/build/tmp/jar/MANIFEST.MF
flink//v1.14/flink-runtime/build/libs/iceberg-flink-runtime-1.14_2.11-0.13.0-SNAPSHOT-tests.jar
flink//v1.14/flink-runtime/build/libs/iceberg-flink-runtime-1.14_2.11-0.13.0-SNAPSHOT-javadoc.jar
flink//v1.14/flink-runtime/build/libs/iceberg-flink-runtime-1.14_2.11-0.13.0-SNAPSHOT-sources.jar
flink//v1.14/flink-runtime/build/libs/iceberg-flink-runtime-1.14_2.11-0.13.0-SNAPSHOT.jar
flink//v1.13/flink/build/libs/iceberg-flink-1.13_2.11-0.13.0-SNAPSHOT-sources.jar
flink//v1.13/flink/build/libs/iceberg-flink-1.13_2.11-0.13.0-SNAPSHOT-javadoc.jar
flink//v1.13/flink/build/libs/iceberg-flink-1.13_2.11-0.13.0-SNAPSHOT-tests.jar
flink//v1.13/flink/build/libs/iceberg-flink-1.13_2.11-0.13.0-SNAPSHOT.jar
flink//v1.13/flink/build/tmp/jar
flink//v1.13/flink/build/tmp/jar/MANIFEST.MF
flink//v1.13/flink-runtime/build/libs/iceberg-flink-runtime-1.13_2.11-0.13.0-SNAPSHOT-tests.jar
flink//v1.13/flink-runtime/build/libs/iceberg-flink-runtime-1.13_2.11-0.13.0-SNAPSHOT.jar
flink//v1.13/flink-runtime/build/libs/iceberg-flink-runtime-1.13_2.11-0.13.0-SNAPSHOT-sources.jar
flink//v1.13/flink-runtime/build/libs/iceberg-flink-runtime-1.13_2.11-0.13.0-SNAPSHOT-javadoc.jar
```


And use the following command to build flink runtime modules for scala 2.11:

```bash
./gradlew clean build -x test -DflinkVersions=1.12,1.13,1.14 \
  -DscalaVersion=2.11 \
  -DknownScalaVersions=2.11 \
  -x javadoc -Pquick \
  -DsparkVersions= -DhiveVersions=
```

The build jars are similar to the above context.

