### PR TITLE
Core: bugfix add initial offset when using parquet format

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
@@ -59,7 +59,7 @@ public abstract class BaseRewriteDataFilesAction<ThisT>
     extends BaseSnapshotUpdateAction<ThisT, RewriteDataFilesActionResult> {
 
   private static final Logger LOG = LoggerFactory.getLogger(BaseRewriteDataFilesAction.class);
-  private static final int PARQUET_MAGIC_BYTES = 4;
+  private static final int PARQUET_MAGIC_LEN = 4;
 
   private final Table table;
   private final FileIO fileIO;
@@ -304,7 +304,7 @@ public abstract class BaseRewriteDataFilesAction<ThisT>
       FileScanTask fileScanTask = task.files().iterator().next();
       if (fileScanTask.file().format() == FileFormat.PARQUET) {
         // in parquet format, there is an initial offset of 4 bytes
-        return fileScanTask.file().fileSizeInBytes() != (fileScanTask.length() + PARQUET_MAGIC_BYTES);
+        return fileScanTask.file().fileSizeInBytes() != (fileScanTask.length() + PARQUET_MAGIC_LEN);
       }
       return fileScanTask.file().fileSizeInBytes() != fileScanTask.length();
     } else {

--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
@@ -59,6 +59,7 @@ public abstract class BaseRewriteDataFilesAction<ThisT>
     extends BaseSnapshotUpdateAction<ThisT, RewriteDataFilesActionResult> {
 
   private static final Logger LOG = LoggerFactory.getLogger(BaseRewriteDataFilesAction.class);
+  private static final int PARQUET_MAGIC_BYTES = 4;
 
   private final Table table;
   private final FileIO fileIO;
@@ -303,8 +304,7 @@ public abstract class BaseRewriteDataFilesAction<ThisT>
       FileScanTask fileScanTask = task.files().iterator().next();
       if (fileScanTask.file().format() == FileFormat.PARQUET) {
         // in parquet format, there is an initial offset of 4 bytes
-        return fileScanTask.file().fileSizeInBytes() !=
-                (fileScanTask.length() + fileScanTask.file().splitOffsets().get(0));
+        return fileScanTask.file().fileSizeInBytes() != (fileScanTask.length() + PARQUET_MAGIC_BYTES);
       }
       return fileScanTask.file().fileSizeInBytes() != fileScanTask.length();
     } else {

--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RewriteFiles;
@@ -300,6 +301,11 @@ public abstract class BaseRewriteDataFilesAction<ThisT>
   private boolean isPartialFileScan(CombinedScanTask task) {
     if (task.files().size() == 1) {
       FileScanTask fileScanTask = task.files().iterator().next();
+      if (fileScanTask.file().format() == FileFormat.PARQUET) {
+        // in parquet format, there is an initial offset of 4 bytes
+        return fileScanTask.file().fileSizeInBytes() !=
+                (fileScanTask.length() + fileScanTask.file().splitOffsets().get(0));
+      }
       return fileScanTask.file().fileSizeInBytes() != fileScanTask.length();
     } else {
       return false;

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
@@ -309,7 +309,7 @@ public class TestRewriteDataFilesAction extends FlinkCatalogTestBase {
   }
 
   /**
-   * a test case to test avoid repeate compress
+   * a test case to test avoid repeat compress
    * <p>
    * If datafile cannot be combined to CombinedScanTask with other DataFiles, the size of the CombinedScanTask list size
    * is 1, so we remove these CombinedScanTasks to avoid compressed repeatedly.
@@ -321,20 +321,23 @@ public class TestRewriteDataFilesAction extends FlinkCatalogTestBase {
    * @throws IOException IOException
    */
   @Test
-  public void testRewriteAvoidRepeateCompress() throws IOException {
+  public void testRewriteAvoidRepeatCompress() throws IOException {
     Assume.assumeFalse("ORC does not support getting length when file is opening", format.equals(FileFormat.ORC));
     List<Record> expected = Lists.newArrayList();
     Schema schema = icebergTableUnPartitioned.schema();
     GenericAppenderFactory genericAppenderFactory = new GenericAppenderFactory(schema);
     File file = temp.newFile();
     int count = 0;
+    List<Long> offsets;
     try (FileAppender<Record> fileAppender = genericAppenderFactory.newAppender(Files.localOutput(file), format)) {
-      long filesize = 20000;
-      for (; fileAppender.length() < filesize; count++) {
+      long fileSize = 20000;
+      for (; fileAppender.length() < fileSize; count++) {
         Record record = SimpleDataUtil.createRecord(count, "iceberg");
         fileAppender.add(record);
         expected.add(record);
       }
+      fileAppender.close();
+      offsets = fileAppender.splitOffsets();
     }
 
     DataFile dataFile = DataFiles.builder(icebergTableUnPartitioned.spec())
@@ -342,6 +345,7 @@ public class TestRewriteDataFilesAction extends FlinkCatalogTestBase {
         .withFileSizeInBytes(file.length())
         .withFormat(format)
         .withRecordCount(count)
+        .withSplitOffsets(offsets)
         .build();
 
     icebergTableUnPartitioned.newAppend()

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
@@ -309,7 +309,7 @@ public class TestRewriteDataFilesAction extends FlinkCatalogTestBase {
   }
 
   /**
-   * a test case to test avoid repeate compress
+   * a test case to test avoid repeat compress
    * <p>
    * If datafile cannot be combined to CombinedScanTask with other DataFiles, the size of the CombinedScanTask list size
    * is 1, so we remove these CombinedScanTasks to avoid compressed repeatedly.
@@ -321,20 +321,23 @@ public class TestRewriteDataFilesAction extends FlinkCatalogTestBase {
    * @throws IOException IOException
    */
   @Test
-  public void testRewriteAvoidRepeateCompress() throws IOException {
+  public void testRewriteAvoidRepeatCompress() throws IOException {
     Assume.assumeFalse("ORC does not support getting length when file is opening", format.equals(FileFormat.ORC));
     List<Record> expected = Lists.newArrayList();
     Schema schema = icebergTableUnPartitioned.schema();
     GenericAppenderFactory genericAppenderFactory = new GenericAppenderFactory(schema);
     File file = temp.newFile();
     int count = 0;
+    List<Long> offsets;
     try (FileAppender<Record> fileAppender = genericAppenderFactory.newAppender(Files.localOutput(file), format)) {
-      long filesize = 20000;
-      for (; fileAppender.length() < filesize; count++) {
+      long fileSize = 20000;
+      for (; fileAppender.length() < fileSize; count++) {
         Record record = SimpleDataUtil.createRecord(count, "iceberg");
         fileAppender.add(record);
         expected.add(record);
       }
+      fileAppender.close();
+      offsets = fileAppender.splitOffsets();
     }
 
     DataFile dataFile = DataFiles.builder(icebergTableUnPartitioned.spec())
@@ -342,6 +345,7 @@ public class TestRewriteDataFilesAction extends FlinkCatalogTestBase {
         .withFileSizeInBytes(file.length())
         .withFormat(format)
         .withRecordCount(count)
+        .withSplitOffsets(offsets)
         .build();
 
     icebergTableUnPartitioned.newAppend()

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/actions/TestRewriteDataFilesAction.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/actions/TestRewriteDataFilesAction.java
@@ -354,8 +354,10 @@ public class TestRewriteDataFilesAction extends SparkTestBase {
         .splitOpenFileCost(1)
         .execute();
 
-    Assert.assertEquals("Action should delete 3 data files", 3, result.deletedDataFiles().size());
-    Assert.assertEquals("Action should add 2 data files", 2, result.addedDataFiles().size());
+    // largest files will not be rewritten,
+    // two small files will be merged into one large file
+    Assert.assertEquals("Action should delete 2 data files", 2, result.deletedDataFiles().size());
+    Assert.assertEquals("Action should add 1 data files", 1, result.addedDataFiles().size());
 
     spark.read().format("iceberg").load(tableLocation).createTempView("postRewrite");
     long postRewriteNumRecords = spark.read().format("iceberg").load(tableLocation).count();


### PR DESCRIPTION
when using data files in parquet format, there's going to be a problem here because the initial state of the parquet file itself has a 4-byte offset.
Closes #4070 