### PR TITLE
AWS: Use Glue optimistic locking while updating table

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -39,6 +39,7 @@ import org.apache.iceberg.aws.s3.S3FileIO;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.common.DynMethods;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
@@ -87,6 +88,12 @@ public class GlueCatalog extends BaseMetastoreCatalog
   private LockManager lockManager;
   private CloseableGroup closeableGroup;
 
+  // Attempt to set versionId if available on the path
+  private static final DynMethods.UnboundMethod SET_VERSION_ID = DynMethods.builder("versionId")
+      .hiddenImpl("software.amazon.awssdk.services.glue.model.UpdateTableRequest$Builder", String.class)
+      .orNoop()
+      .build();
+
   /**
    * No-arg constructor to load the catalog dynamically.
    * <p>
@@ -102,7 +109,7 @@ public class GlueCatalog extends BaseMetastoreCatalog
         properties.get(CatalogProperties.WAREHOUSE_LOCATION),
         new AwsProperties(properties),
         AwsClientFactories.from(properties).glue(),
-        LockManagers.from(properties),
+        LockManagers.from(SET_VERSION_ID, properties),
         initializeFileIO(properties));
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -109,8 +109,17 @@ public class GlueCatalog extends BaseMetastoreCatalog
         properties.get(CatalogProperties.WAREHOUSE_LOCATION),
         new AwsProperties(properties),
         AwsClientFactories.from(properties).glue(),
-        LockManagers.from(SET_VERSION_ID, properties),
+        initializeLockManager(properties),
         initializeFileIO(properties));
+  }
+
+  private LockManager initializeLockManager(Map<String, String> properties) {
+    if (properties.containsKey(CatalogProperties.LOCK_IMPL)) {
+      return LockManagers.from(properties);
+    } else if (SET_VERSION_ID.isNoop()) {
+      return LockManagers.LOCK_MANAGER_DEFAULT;
+    }
+    return null;
   }
 
   private FileIO initializeFileIO(Map<String, String> properties) {

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -117,7 +117,7 @@ public class GlueCatalog extends BaseMetastoreCatalog
     if (properties.containsKey(CatalogProperties.LOCK_IMPL)) {
       return LockManagers.from(properties);
     } else if (SET_VERSION_ID.isNoop()) {
-      return LockManagers.LOCK_MANAGER_DEFAULT;
+      return LockManagers.defaultLockManager();
     }
     return null;
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -203,7 +203,7 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
               .parameters(parameters)
               .build());
       // Use Optimistic locking with table version id while updating table
-      if (!SET_VERSION_ID.isNoop()) {
+      if (!SET_VERSION_ID.isNoop() && lockManager == null) {
         SET_VERSION_ID.invoke(updateTableRequest, glueTable.versionId());
       }
 

--- a/core/src/main/java/org/apache/iceberg/util/LockManagers.java
+++ b/core/src/main/java/org/apache/iceberg/util/LockManagers.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
 
 public class LockManagers {
 
-  public static final LockManager LOCK_MANAGER_DEFAULT = new InMemoryLockManager(Maps.newHashMap());
+  private static final LockManager LOCK_MANAGER_DEFAULT = new InMemoryLockManager(Maps.newHashMap());
 
   private LockManagers() {
   }

--- a/core/src/main/java/org/apache/iceberg/util/LockManagers.java
+++ b/core/src/main/java/org/apache/iceberg/util/LockManagers.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.LockManager;
 import org.apache.iceberg.common.DynConstructors;
+import org.apache.iceberg.common.DynMethods;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
@@ -52,6 +53,15 @@ public class LockManagers {
     } else {
       return defaultLockManager();
     }
+  }
+
+  public static LockManager from(DynMethods.UnboundMethod setVersionId, Map<String, String> properties) {
+    if (properties.containsKey(CatalogProperties.LOCK_IMPL)) {
+      return LockManagers.from(properties);
+    } else if (setVersionId.isNoop()) {
+      return LOCK_MANAGER_DEFAULT;
+    }
+    return null;
   }
 
   private static LockManager loadLockManager(String impl, Map<String, String> properties) {

--- a/core/src/main/java/org/apache/iceberg/util/LockManagers.java
+++ b/core/src/main/java/org/apache/iceberg/util/LockManagers.java
@@ -28,7 +28,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.LockManager;
 import org.apache.iceberg.common.DynConstructors;
-import org.apache.iceberg.common.DynMethods;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
@@ -38,7 +37,7 @@ import org.slf4j.LoggerFactory;
 
 public class LockManagers {
 
-  private static final LockManager LOCK_MANAGER_DEFAULT = new InMemoryLockManager(Maps.newHashMap());
+  public static final LockManager LOCK_MANAGER_DEFAULT = new InMemoryLockManager(Maps.newHashMap());
 
   private LockManagers() {
   }
@@ -53,15 +52,6 @@ public class LockManagers {
     } else {
       return defaultLockManager();
     }
-  }
-
-  public static LockManager from(DynMethods.UnboundMethod setVersionId, Map<String, String> properties) {
-    if (properties.containsKey(CatalogProperties.LOCK_IMPL)) {
-      return LockManagers.from(properties);
-    } else if (setVersionId.isNoop()) {
-      return LOCK_MANAGER_DEFAULT;
-    }
-    return null;
   }
 
   private static LockManager loadLockManager(String impl, Map<String, String> properties) {


### PR DESCRIPTION
Use Glue optimistic locking while updating table.

Retry logs in case of concurrent updates:
```
22/02/21 15:37:10 WARN Tasks: Retrying task after failure: Cannot commit my_catalog.db_iceberg.table because Glue detected concurrent update
org.apache.iceberg.exceptions.CommitFailedException: Cannot commit my_catalog.db_iceberg.table because Glue detected concurrent update
	at org.apache.iceberg.aws.glue.GlueTableOperations.doCommit(GlueTableOperations.java:127)
	at org.apache.iceberg.BaseMetastoreTableOperations.commit(BaseMetastoreTableOperations.java:127)
	at org.apache.iceberg.BaseTransaction.lambda$commitSimpleTransaction$5(BaseTransaction.java:377)
	at org.apache.iceberg.util.Tasks$Builder.runTaskWithRetry(Tasks.java:404)
	at org.apache.iceberg.util.Tasks$Builder.runSingleThreaded(Tasks.java:214)
	at org.apache.iceberg.util.Tasks$Builder.run(Tasks.java:198)
	at org.apache.iceberg.util.Tasks$Builder.run(Tasks.java:190)
	at org.apache.iceberg.BaseTransaction.commitSimpleTransaction(BaseTransaction.java:362)
```