### PR TITLE
Update release scripts to support publishing Spark 3.2 with Scala 2.13 support to Maven

### DIFF
--- a/dev/stage-binaries.sh
+++ b/dev/stage-binaries.sh
@@ -18,9 +18,14 @@
 # under the License.
 #
 
+SCALA_VERSION=2.12
 FLINK_VERSIONS=1.13,1.14,1.15
 SPARK_VERSIONS=2.4,3.0,3.1,3.2
 HIVE_VERSIONS=2,3
 
-./gradlew -Prelease -DflinkVersions=$FLINK_VERSIONS -DsparkVersions=$SPARK_VERSIONS -DhiveVersions=$HIVE_VERSIONS publishApachePublicationToMavenRepository
+./gradlew -Prelease -DscalaVersion=$SCALA_VERSION -DflinkVersions=$FLINK_VERSIONS -DsparkVersions=$SPARK_VERSIONS -DhiveVersions=$HIVE_VERSIONS publishApachePublicationToMavenRepository
+
+# Also publish Scala 2.13 Artifacts for versions that support it.
+# Flink does not yet support 2.13 (and is largely dropping a user-facing dependency on Scala). Hive doesn't need a Scala specification.
+./gradlew -P release -DscalaVersion=2.13 :iceberg-spark:iceberg-spark-3.2_2.13:publishApachePublicationToMavenRepository :iceberg-spark:iceberg-spark-extensions-3.2_2.13:publishApachePublicationToMavenRepository :iceberg-spark:iceberg-spark-runtime-3.2_2.13:publishApachePublicationToMavenRepository
 

--- a/dev/stage-binaries.sh
+++ b/dev/stage-binaries.sh
@@ -27,5 +27,5 @@ HIVE_VERSIONS=2,3
 
 # Also publish Scala 2.13 Artifacts for versions that support it.
 # Flink does not yet support 2.13 (and is largely dropping a user-facing dependency on Scala). Hive doesn't need a Scala specification.
-./gradlew -P release -DscalaVersion=2.13 :iceberg-spark:iceberg-spark-3.2_2.13:publishApachePublicationToMavenRepository :iceberg-spark:iceberg-spark-extensions-3.2_2.13:publishApachePublicationToMavenRepository :iceberg-spark:iceberg-spark-runtime-3.2_2.13:publishApachePublicationToMavenRepository
+./gradlew -Prelease -DscalaVersion=2.13 :iceberg-spark:iceberg-spark-3.2_2.13:publishApachePublicationToMavenRepository :iceberg-spark:iceberg-spark-extensions-3.2_2.13:publishApachePublicationToMavenRepository :iceberg-spark:iceberg-spark-runtime-3.2_2.13:publishApachePublicationToMavenRepository
 


### PR DESCRIPTION
Noticed we added support for Scala 2.13 with Spark 3.2 recently, but the release scripts have not been updated to reflect that. The nightly release workflow has been updated to publish Scala 2.13 artifacts: https://github.com/apache/iceberg/pull/4009

This came up as a result of this discussion: https://github.com/apache/iceberg/pull/4157#discussion_r809710633. There's probably more work to do, and I can covert this to an issue if somebody else wants to take over.