### PR TITLE
Test: Use murmur3_32_fixed in unit test

### DIFF
--- a/api/src/test/java/org/apache/iceberg/transforms/TestBucketing.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestBucketing.java
@@ -39,7 +39,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class TestBucketing {
-  private static final HashFunction MURMUR3 = Hashing.murmur3_32();
+  private static final HashFunction MURMUR3 = Hashing.murmur3_32_fixed();
   private static Constructor<UUID> uuidBytesConstructor;
 
   @BeforeClass


### PR DESCRIPTION
In PR https://github.com/apache/iceberg/pull/3815, I made a mistake and left out the fix for the unit test. `murmur3_32` should be replaced with `murmur3_32_fixed`.

