### PR TITLE
Spark 3.1: Support update/delete with NOT IN condition in subquery

### DIFF
--- a/spark/v3.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RowLevelOperationsPredicateCheck.scala
+++ b/spark/v3.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RowLevelOperationsPredicateCheck.scala
@@ -37,21 +37,6 @@ object RowLevelOperationsPredicateCheck extends (LogicalPlan => Unit) {
 
   override def apply(plan: LogicalPlan): Unit = {
     plan foreach {
-      case DeleteFromTable(r, Some(condition)) if hasNullAwarePredicateWithinNot(condition) && isIcebergRelation(r) =>
-        // this limitation is present since SPARK-25154 fix is not yet available
-        // we use Not(EqualsNullSafe(cond, true)) when deciding which records to keep
-        // such conditions are rewritten by Spark as an existential join and currently Spark
-        // does not handle correctly NOT IN subqueries nested into other expressions
-        failAnalysis("Null-aware predicate subqueries are not currently supported in DELETE")
-
-      case UpdateTable(r, _, Some(condition)) if hasNullAwarePredicateWithinNot(condition) && isIcebergRelation(r) =>
-        // this limitation is present since SPARK-25154 fix is not yet available
-        // we use Not(EqualsNullSafe(cond, true)) when processing records that did not match
-        // the update condition but were present in files we are overwriting
-        // such conditions are rewritten by Spark as an existential join and currently Spark
-        // does not handle correctly NOT IN subqueries nested into other expressions
-        failAnalysis("Null-aware predicate subqueries are not currently supported in UPDATE")
-
       case merge: MergeIntoTable if isIcebergRelation(merge.targetTable) =>
         validateMergeIntoConditions(merge)
 

--- a/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -420,7 +420,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", tableName));
   }
 
-  @Ignore // TODO: not supported since SPARK-25154 fix is not yet available
+  @Test
   public void testDeleteWithNotInSubquery() throws NoSuchTableException {
     createAndInitUnpartitionedTable();
 
@@ -463,19 +463,6 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     assertEquals("Should have expected rows",
         ImmutableList.of(),
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", tableName));
-  }
-
-  @Test
-  public void testDeleteWithNotInSubqueryNotSupported() throws NoSuchTableException {
-    createAndInitUnpartitionedTable();
-
-    append(new Employee(1, "hr"), new Employee(2, "hardware"));
-
-    createOrReplaceView("deleted_id", Arrays.asList(-1, -2, null), Encoders.INT());
-
-    AssertHelpers.assertThrows("Should complain about NOT IN subquery",
-        AnalysisException.class, "Null-aware predicate subqueries are not currently supported",
-        () -> sql("DELETE FROM %s WHERE id NOT IN (SELECT * FROM deleted_id)", tableName));
   }
 
   @Test

--- a/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -633,7 +633,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST", tableName));
   }
 
-  @Ignore // TODO: not supported since SPARK-25154 fix is not yet available
+  @Test
   public void testUpdateWithNotInSubquery() {
     createAndInitTable("id INT, dep STRING");
 
@@ -660,17 +660,6 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     assertEquals("Should have expected rows",
         ImmutableList.of(row(-1, "hardware"), row(5, "hr"), row(5, "hr")),
         sql("SELECT * FROM %s ORDER BY id ASC NULLS LAST, dep", tableName));
-  }
-
-  @Test
-  public void testUpdateWithNotInSubqueryNotSupported() {
-    createAndInitTable("id INT, dep STRING");
-
-    createOrReplaceView("updated_id", Arrays.asList(-1, -2, null), Encoders.INT());
-
-    AssertHelpers.assertThrows("Should complain about NOT IN subquery",
-        AnalysisException.class, "Null-aware predicate subqueries are not currently supported",
-        () -> sql("UPDATE %s SET id = -1 WHERE id NOT IN (SELECT * FROM updated_id)", tableName));
   }
 
   @Test


### PR DESCRIPTION
Since [SPARK-25154](https://issues.apache.org/jira/browse/SPARK-25154) has been addressed in Spark 3.1.0, we should support update/delete with NOT IN condition in subquery in spark 3.1 module.