### PR TITLE
AWS: Use independent http client for AWS clients

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/TestAssumeRoleAwsClientFactory.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/TestAssumeRoleAwsClientFactory.java
@@ -32,7 +32,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.glue.model.AccessDeniedException;
 import software.amazon.awssdk.services.glue.model.GlueException;
@@ -47,6 +48,7 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 public class TestAssumeRoleAwsClientFactory {
 
   private static final Logger LOG = LoggerFactory.getLogger(TestAssumeRoleAwsClientFactory.class);
+  private static final SdkHttpClient.Builder HTTP_CLIENT_BUILDER_DEFAULT = ApacheHttpClient.builder();
 
   private IamClient iam;
   private String roleName;
@@ -58,7 +60,7 @@ public class TestAssumeRoleAwsClientFactory {
     roleName = UUID.randomUUID().toString();
     iam = IamClient.builder()
         .region(Region.AWS_GLOBAL)
-        .httpClient(UrlConnectionHttpClient.create())
+        .httpClientBuilder(HTTP_CLIENT_BUILDER_DEFAULT)
         .build();
     CreateRoleResponse response = iam.createRole(CreateRoleRequest.builder()
         .roleName(roleName)

--- a/aws/src/integration/java/org/apache/iceberg/aws/TestAssumeRoleAwsClientFactory.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/TestAssumeRoleAwsClientFactory.java
@@ -32,8 +32,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.http.SdkHttpClient;
-import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.glue.model.AccessDeniedException;
 import software.amazon.awssdk.services.glue.model.GlueException;
@@ -48,7 +47,6 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 public class TestAssumeRoleAwsClientFactory {
 
   private static final Logger LOG = LoggerFactory.getLogger(TestAssumeRoleAwsClientFactory.class);
-  private static final SdkHttpClient.Builder HTTP_CLIENT_BUILDER_DEFAULT = ApacheHttpClient.builder();
 
   private IamClient iam;
   private String roleName;
@@ -60,7 +58,7 @@ public class TestAssumeRoleAwsClientFactory {
     roleName = UUID.randomUUID().toString();
     iam = IamClient.builder()
         .region(Region.AWS_GLOBAL)
-        .httpClientBuilder(HTTP_CLIENT_BUILDER_DEFAULT)
+        .httpClientBuilder(UrlConnectionHttpClient.builder())
         .build();
     CreateRoleResponse response = iam.createRole(CreateRoleRequest.builder()
         .roleName(roleName)

--- a/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
@@ -25,7 +25,8 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.PropertyUtil;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
 import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
-import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.glue.GlueClient;
@@ -36,6 +37,8 @@ import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 public class AssumeRoleAwsClientFactory implements AwsClientFactory {
+
+  private static final SdkHttpClient.Builder HTTP_CLIENT_BUILDER_DEFAULT = ApacheHttpClient.builder();
 
   private String roleArn;
   private String externalId;
@@ -91,12 +94,12 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
 
     clientBuilder.credentialsProvider(
         StsAssumeRoleCredentialsProvider.builder()
-            .stsClient(StsClient.builder().httpClient(UrlConnectionHttpClient.create()).build())
+            .stsClient(StsClient.builder().httpClientBuilder(HTTP_CLIENT_BUILDER_DEFAULT).build())
             .refreshRequest(request)
             .build());
 
     clientBuilder.region(Region.of(region));
-    clientBuilder.httpClient(UrlConnectionHttpClient.create());
+    clientBuilder.httpClientBuilder(HTTP_CLIENT_BUILDER_DEFAULT);
 
     return clientBuilder;
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
@@ -25,7 +25,6 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.PropertyUtil;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
 import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
-import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -37,8 +36,6 @@ import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 public class AssumeRoleAwsClientFactory implements AwsClientFactory {
-
-  private static final SdkHttpClient HTTP_CLIENT_DEFAULT = UrlConnectionHttpClient.create();
 
   private String roleArn;
   private String externalId;
@@ -94,12 +91,12 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
 
     clientBuilder.credentialsProvider(
         StsAssumeRoleCredentialsProvider.builder()
-            .stsClient(StsClient.builder().httpClient(HTTP_CLIENT_DEFAULT).build())
+            .stsClient(StsClient.builder().httpClient(UrlConnectionHttpClient.create()).build())
             .refreshRequest(request)
             .build());
 
     clientBuilder.region(Region.of(region));
-    clientBuilder.httpClient(HTTP_CLIENT_DEFAULT);
+    clientBuilder.httpClient(UrlConnectionHttpClient.create());
 
     return clientBuilder;
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
@@ -25,8 +25,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.PropertyUtil;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
 import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
-import software.amazon.awssdk.http.SdkHttpClient;
-import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.glue.GlueClient;
@@ -37,8 +36,6 @@ import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 public class AssumeRoleAwsClientFactory implements AwsClientFactory {
-
-  private static final SdkHttpClient.Builder HTTP_CLIENT_BUILDER_DEFAULT = ApacheHttpClient.builder();
 
   private String roleArn;
   private String externalId;
@@ -94,12 +91,12 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
 
     clientBuilder.credentialsProvider(
         StsAssumeRoleCredentialsProvider.builder()
-            .stsClient(StsClient.builder().httpClientBuilder(HTTP_CLIENT_BUILDER_DEFAULT).build())
+            .stsClient(StsClient.builder().httpClientBuilder(UrlConnectionHttpClient.builder()).build())
             .refreshRequest(request)
             .build());
 
     clientBuilder.region(Region.of(region));
-    clientBuilder.httpClientBuilder(HTTP_CLIENT_BUILDER_DEFAULT);
+    clientBuilder.httpClientBuilder(UrlConnectionHttpClient.builder());
 
     return clientBuilder;
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
@@ -30,8 +30,7 @@ import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.client.builder.SdkClientBuilder;
-import software.amazon.awssdk.http.SdkHttpClient;
-import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.glue.GlueClient;
 import software.amazon.awssdk.services.kms.KmsClient;
@@ -40,7 +39,6 @@ import software.amazon.awssdk.services.s3.S3Client;
 public class AwsClientFactories {
 
   private static final DefaultAwsClientFactory AWS_CLIENT_FACTORY_DEFAULT = new DefaultAwsClientFactory();
-  private static final SdkHttpClient.Builder HTTP_CLIENT_BUILDER_DEFAULT = ApacheHttpClient.builder();
 
   private AwsClientFactories() {
   }
@@ -89,7 +87,7 @@ public class AwsClientFactories {
     @Override
     public S3Client s3() {
       return S3Client.builder()
-          .httpClientBuilder(HTTP_CLIENT_BUILDER_DEFAULT)
+          .httpClientBuilder(UrlConnectionHttpClient.builder())
           .applyMutation(builder -> configureEndpoint(builder, s3Endpoint))
           .credentialsProvider(credentialsProvider(s3AccessKeyId, s3SecretAccessKey, s3SessionToken))
           .build();
@@ -97,17 +95,17 @@ public class AwsClientFactories {
 
     @Override
     public GlueClient glue() {
-      return GlueClient.builder().httpClientBuilder(HTTP_CLIENT_BUILDER_DEFAULT).build();
+      return GlueClient.builder().httpClientBuilder(UrlConnectionHttpClient.builder()).build();
     }
 
     @Override
     public KmsClient kms() {
-      return KmsClient.builder().httpClientBuilder(HTTP_CLIENT_BUILDER_DEFAULT).build();
+      return KmsClient.builder().httpClientBuilder(UrlConnectionHttpClient.builder()).build();
     }
 
     @Override
     public DynamoDbClient dynamo() {
-      return DynamoDbClient.builder().httpClientBuilder(HTTP_CLIENT_BUILDER_DEFAULT).build();
+      return DynamoDbClient.builder().httpClientBuilder(UrlConnectionHttpClient.builder()).build();
     }
 
     @Override

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
@@ -30,7 +30,8 @@ import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.client.builder.SdkClientBuilder;
-import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.glue.GlueClient;
 import software.amazon.awssdk.services.kms.KmsClient;
@@ -39,6 +40,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 public class AwsClientFactories {
 
   private static final DefaultAwsClientFactory AWS_CLIENT_FACTORY_DEFAULT = new DefaultAwsClientFactory();
+  private static final SdkHttpClient.Builder HTTP_CLIENT_BUILDER_DEFAULT = ApacheHttpClient.builder();
 
   private AwsClientFactories() {
   }
@@ -87,7 +89,7 @@ public class AwsClientFactories {
     @Override
     public S3Client s3() {
       return S3Client.builder()
-          .httpClient(UrlConnectionHttpClient.create())
+          .httpClientBuilder(HTTP_CLIENT_BUILDER_DEFAULT)
           .applyMutation(builder -> configureEndpoint(builder, s3Endpoint))
           .credentialsProvider(credentialsProvider(s3AccessKeyId, s3SecretAccessKey, s3SessionToken))
           .build();
@@ -95,17 +97,17 @@ public class AwsClientFactories {
 
     @Override
     public GlueClient glue() {
-      return GlueClient.builder().httpClient(UrlConnectionHttpClient.create()).build();
+      return GlueClient.builder().httpClientBuilder(HTTP_CLIENT_BUILDER_DEFAULT).build();
     }
 
     @Override
     public KmsClient kms() {
-      return KmsClient.builder().httpClient(UrlConnectionHttpClient.create()).build();
+      return KmsClient.builder().httpClientBuilder(HTTP_CLIENT_BUILDER_DEFAULT).build();
     }
 
     @Override
     public DynamoDbClient dynamo() {
-      return DynamoDbClient.builder().httpClient(UrlConnectionHttpClient.create()).build();
+      return DynamoDbClient.builder().httpClientBuilder(HTTP_CLIENT_BUILDER_DEFAULT).build();
     }
 
     @Override

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
@@ -30,7 +30,6 @@ import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.client.builder.SdkClientBuilder;
-import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.glue.GlueClient;
@@ -39,7 +38,6 @@ import software.amazon.awssdk.services.s3.S3Client;
 
 public class AwsClientFactories {
 
-  private static final SdkHttpClient HTTP_CLIENT_DEFAULT = UrlConnectionHttpClient.create();
   private static final DefaultAwsClientFactory AWS_CLIENT_FACTORY_DEFAULT = new DefaultAwsClientFactory();
 
   private AwsClientFactories() {
@@ -89,7 +87,7 @@ public class AwsClientFactories {
     @Override
     public S3Client s3() {
       return S3Client.builder()
-          .httpClient(HTTP_CLIENT_DEFAULT)
+          .httpClient(UrlConnectionHttpClient.create())
           .applyMutation(builder -> configureEndpoint(builder, s3Endpoint))
           .credentialsProvider(credentialsProvider(s3AccessKeyId, s3SecretAccessKey, s3SessionToken))
           .build();
@@ -97,17 +95,17 @@ public class AwsClientFactories {
 
     @Override
     public GlueClient glue() {
-      return GlueClient.builder().httpClient(HTTP_CLIENT_DEFAULT).build();
+      return GlueClient.builder().httpClient(UrlConnectionHttpClient.create()).build();
     }
 
     @Override
     public KmsClient kms() {
-      return KmsClient.builder().httpClient(HTTP_CLIENT_DEFAULT).build();
+      return KmsClient.builder().httpClient(UrlConnectionHttpClient.create()).build();
     }
 
     @Override
     public DynamoDbClient dynamo() {
-      return DynamoDbClient.builder().httpClient(HTTP_CLIENT_DEFAULT).build();
+      return DynamoDbClient.builder().httpClient(UrlConnectionHttpClient.create()).build();
     }
 
     @Override

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
@@ -87,7 +87,7 @@ public class TestS3FileIO {
   @Test
   public void testSerializeClient() {
     SerializableSupplier<S3Client> pre =
-        () -> S3Client.builder().httpClient(UrlConnectionHttpClient.builder().build()).region(Region.US_EAST_1).build();
+        () -> S3Client.builder().httpClientBuilder(UrlConnectionHttpClient.builder()).region(Region.US_EAST_1).build();
 
     byte [] data = SerializationUtils.serialize(pre);
     SerializableSupplier<S3Client> post = SerializationUtils.deserialize(data);

--- a/build.gradle
+++ b/build.gradle
@@ -312,7 +312,6 @@ project(':iceberg-aws') {
     implementation project(':iceberg-core')
 
     compileOnly 'software.amazon.awssdk:url-connection-client'
-    compileOnly 'software.amazon.awssdk:apache-client'
     compileOnly 'software.amazon.awssdk:s3'
     compileOnly 'software.amazon.awssdk:kms'
     compileOnly 'software.amazon.awssdk:glue'

--- a/build.gradle
+++ b/build.gradle
@@ -312,6 +312,7 @@ project(':iceberg-aws') {
     implementation project(':iceberg-core')
 
     compileOnly 'software.amazon.awssdk:url-connection-client'
+    compileOnly 'software.amazon.awssdk:apache-client'
     compileOnly 'software.amazon.awssdk:s3'
     compileOnly 'software.amazon.awssdk:kms'
     compileOnly 'software.amazon.awssdk:glue'


### PR DESCRIPTION
Currently one http client instance is shared among AWS clients. This change enables users to independently close AWS clients and their associated http client without affecting other clients.