### PR TITLE
Core: Update GenericManifestFile toString

### DIFF
--- a/core/src/main/java/org/apache/iceberg/GenericManifestFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericManifestFile.java
@@ -404,6 +404,7 @@ public class GenericManifestFile
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
+        .add("content", content)
         .add("path", manifestPath)
         .add("length", length)
         .add("partition_spec_id", specId)
@@ -416,6 +417,8 @@ public class GenericManifestFile
         .add("deleted_rows_count", deletedRowsCount)
         .add("partitions", partitions)
         .add("key_metadata", keyMetadata == null ? "null" : "(redacted)")
+        .add("sequence_number", sequenceNumber)
+        .add("min_sequence_number", minSequenceNumber)
         .toString();
   }
 


### PR DESCRIPTION
Split out GenericManifestFile::toString changes of #4142, as per https://github.com/apache/iceberg/pull/4142#discussion_r808414246 .  This changes adds to toString method some certain missed fields of GenericManifestFile.