### PR TITLE
Parquet: Enable vectorized reads by default

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -148,7 +148,7 @@ public class TableProperties {
   public static final long SPLIT_OPEN_FILE_COST_DEFAULT = 4 * 1024 * 1024; // 4MB
 
   public static final String PARQUET_VECTORIZATION_ENABLED = "read.parquet.vectorization.enabled";
-  public static final boolean PARQUET_VECTORIZATION_ENABLED_DEFAULT = false;
+  public static final boolean PARQUET_VECTORIZATION_ENABLED_DEFAULT = true;
 
   public static final String PARQUET_BATCH_SIZE = "read.parquet.vectorization.batch-size";
   public static final int PARQUET_BATCH_SIZE_DEFAULT = 5000;

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTableUtilWithInMemoryCatalog.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkTableUtilWithInMemoryCatalog.java
@@ -451,9 +451,10 @@ public class TestSparkTableUtilWithInMemoryCatalog {
       );
       Table table = TABLES.create(schema, PartitionSpec.unpartitioned(), tableLocation);
 
-      // assign a custom metrics config
+      // assign a custom metrics config and disable vectorized reads
       table.updateProperties()
           .set(TableProperties.DEFAULT_WRITE_METRICS_MODE, "full")
+          .set(TableProperties.PARQUET_VECTORIZATION_ENABLED, "false")
           .commit();
 
       File stagingDir = temp.newFolder("staging-dir");


### PR DESCRIPTION
This PR enables vectorized Parquet reads by default. This feature has been available for quite some time and being used by multiple companies in prod. I do anticipate more bugs to be found when we enable this by default but I think there is sufficient confidence it will perform reasonably well in most cases.