### PR TITLE
chore: commenting invalid typo `commited` in base_transaction.py and fix invalid typos in test_cases

### DIFF
--- a/python_legacy/iceberg/core/base_transaction.py
+++ b/python_legacy/iceberg/core/base_transaction.py
@@ -60,13 +60,14 @@ class BaseTransaction(Transaction):
     def table(self):
         return self.transaction_table
 
-    def check_last_operation_committed(self, operation):
+    # NOTE: function name has typo in the word `comitted`. Kept for backwards compatability in legacy python API.
+    def check_last_operation_commited(self, operation):
         if self.last_base == self.current:
             raise RuntimeError("Cannot create new %s: last operation has not committed" % operation)
         self.last_base = self.current
 
     def update_schema(self):
-        self.check_last_operation_committed("UpdateSchema")
+        self.check_last_operation_commited("UpdateSchema")
 
     @staticmethod
     def current_id(meta):

--- a/python_legacy/iceberg/core/base_transaction.py
+++ b/python_legacy/iceberg/core/base_transaction.py
@@ -60,13 +60,13 @@ class BaseTransaction(Transaction):
     def table(self):
         return self.transaction_table
 
-    def check_last_operation_commited(self, operation):
+    def check_last_operation_committed(self, operation):
         if self.last_base == self.current:
             raise RuntimeError("Cannot create new %s: last operation has not committed" % operation)
         self.last_base = self.current
 
     def update_schema(self):
-        self.check_last_operation_commited("UpdateSchema")
+        self.check_last_operation_committed("UpdateSchema")
 
     @staticmethod
     def current_id(meta):

--- a/python_legacy/tests/api/expressions/test_predicate_binding.py
+++ b/python_legacy/tests/api/expressions/test_predicate_binding.py
@@ -64,7 +64,7 @@ def test_comparison_predicate_binding(op, assert_and_unwrap):
     assert op == bound.op
 
 
-def test_literal_converison(op, assert_and_unwrap):
+def test_literal_conversion(op, assert_and_unwrap):
     struct = StructType.of([NestedField.required(15, "d", DecimalType.of(9, 2))])
     unbound = UnboundPredicate(op, Expressions.ref("d"), "12.40")
     bound = assert_and_unwrap(unbound.bind(struct))

--- a/python_legacy/tests/api/test_conversions.py
+++ b/python_legacy/tests/api/test_conversions.py
@@ -235,7 +235,7 @@ class TestConversions(unittest.TestCase):
             bytes([11]),
             Literal.of(0.011).to(DecimalType.of(10, 3)).to_byte_buffer())
 
-    def assertConversion(self, value, type, expectedBinary):
-        byteBuffer = Conversions.to_byte_buffer(type.type_id, value)
-        self.assertEqual(expectedBinary, byteBuffer)
-        self.assertEqual(value, Conversions.from_byte_buffer(type, byteBuffer))
+    def assertConversion(self, value, type, expected_binary):
+        byte_buffer = Conversions.to_byte_buffer(type.type_id, value)
+        self.assertEqual(expected_binary, byte_buffer)
+        self.assertEqual(value, Conversions.from_byte_buffer(type, byte_buffer))


### PR DESCRIPTION
fix: change invalid typo `commited` to `committed`