### PR TITLE
Infra - Trigger CI using on pull_request, saving push for master branch and tags (releases)

### DIFF
--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -19,13 +19,12 @@
 
 name: "Flink CI"
 on:
+  push:
+    branches:
+    - 'master'
+    tags:
+    - '**'
   pull_request:
-    types:
-    - opened
-    - reopened
-    - ready_for_review
-    # Synchronize represents any kind of change to head ref on an open PR (e.g. push to open PR)
-    - synchronize
     paths-ignore:
     - '.github/workflows/python-ci.yml'
     - '.github/workflows/spark-ci.yml'

--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -19,27 +19,13 @@
 
 name: "Flink CI"
 on:
-  push:
-    paths-ignore:
-    - '.github/workflows/python-ci.yml'
-    - '.github/workflows/spark-ci.yml'
-    - '.github/workflows/hive-ci.yml'
-    - '.github/workflows/cancel-duplicate-workflow-runs.yml'
-    - '.gitignore'
-    - 'dev/**'
-    - 'mr/**'
-    - 'hive3/**'
-    - 'hive3-orc-bundle/**'
-    - 'hive-runtime/**'
-    - 'spark/**'
-    - 'pig/**'
-    - 'python/**'
-    - 'python_legacy/**'
-    - 'docs/**'
-    - '.gitattributes'
-    - 'README.md'
-    - 'CONTRIBUTING.md'
   pull_request:
+    types:
+    - opened
+    - reopened
+    - ready_for_review
+    # Synchronize represents any kind of change to head ref on an open PR (e.g. push to open PR)
+    - synchronize
     paths-ignore:
     - '.github/workflows/python-ci.yml'
     - '.github/workflows/spark-ci.yml'

--- a/.github/workflows/hive-ci.yml
+++ b/.github/workflows/hive-ci.yml
@@ -19,13 +19,12 @@
 
 name: "Hive CI"
 on:
+  push:
+    branches:
+    - 'master'
+    tags:
+    - '**'
   pull_request:
-    types:
-    - opened
-    - reopened
-    - ready_for_review
-    # Synchronize represents any kind of change to head ref on an open PR
-    - synchronize
     paths-ignore:
     - '.github/workflows/python-ci.yml'
     - '.github/workflows/spark-ci.yml'

--- a/.github/workflows/hive-ci.yml
+++ b/.github/workflows/hive-ci.yml
@@ -19,25 +19,13 @@
 
 name: "Hive CI"
 on:
-  push:
-    paths-ignore:
-    - '.github/workflows/python-ci.yml'
-    - '.github/workflows/spark-ci.yml'
-    - '.github/workflows/flink-ci.yml'
-    - '.github/workflows/cancel-duplicate-workflow-runs.yml'
-    - '.gitignore'
-    - 'dev/**'
-    - 'arrow/**'
-    - 'spark/**'
-    - 'flink/**'
-    - 'pig/**'
-    - 'python/**'
-    - 'python_legacy/**'
-    - 'docs/**'
-    - '.gitattributes'
-    - 'README.md'
-    - 'CONTRIBUTING.md'
   pull_request:
+    types:
+    - opened
+    - reopened
+    - ready_for_review
+    # Synchronize represents any kind of change to head ref on an open PR
+    - synchronize
     paths-ignore:
     - '.github/workflows/python-ci.yml'
     - '.github/workflows/spark-ci.yml'

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -19,13 +19,12 @@
 
 name: "Java CI"
 on:
+  push:
+    branches:
+    - 'master'
+    tags:
+    - '**'
   pull_request:
-    types:
-    - opened
-    - reopened
-    - ready_for_review
-    # Synchronize represents any kind of change to head ref on an open PR (e.g. push to open PR)
-    - synchronize
     paths-ignore:
     - '.github/workflows/python-ci.yml'
     - '.github/workflows/spark-ci.yml'

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -19,22 +19,13 @@
 
 name: "Java CI"
 on:
-  push:
-    paths-ignore:
-    - '.github/workflows/python-ci.yml'
-    - '.github/workflows/spark-ci.yml'
-    - '.github/workflows/flink-ci.yml'
-    - '.github/workflows/hive-ci.yml'
-    - '.github/workflows/cancel-duplicate-workflow-runs.yml'
-    - '.gitignore'
-    - 'dev/**'
-    - 'python/**'
-    - 'python_legacy/**'
-    - 'docs/**'
-    - '.gitattributes'
-    - 'README.md'
-    - 'CONTRIBUTING.md'
   pull_request:
+    types:
+    - opened
+    - reopened
+    - ready_for_review
+    # Synchronize represents any kind of change to head ref on an open PR (e.g. push to open PR)
+    - synchronize
     paths-ignore:
     - '.github/workflows/python-ci.yml'
     - '.github/workflows/spark-ci.yml'

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -19,11 +19,13 @@
 
 name: "Python CI"
 on:
-  push:
-    paths:
-    - '.github/workflows/python-ci.yml'
-    - 'python/**'
   pull_request:
+    types:
+    - opened
+    - reopened
+    - ready_for_review
+    # Synchronize represents any kind of change to head ref on an open PR
+    - synchronize
     paths:
     - '.github/workflows/python-ci.yml'
     - 'python/**'

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -19,13 +19,12 @@
 
 name: "Python CI"
 on:
+  push:
+    branches:
+    - 'master'
+    tags:
+    - '**'
   pull_request:
-    types:
-    - opened
-    - reopened
-    - ready_for_review
-    # Synchronize represents any kind of change to head ref on an open PR
-    - synchronize
     paths:
     - '.github/workflows/python-ci.yml'
     - 'python/**'

--- a/.github/workflows/python-legacy-ci.yml
+++ b/.github/workflows/python-legacy-ci.yml
@@ -19,11 +19,13 @@
 
 name: "Python Legacy CI"
 on:
-  push:
-    paths:
-    - '.github/workflows/python-legacy-ci.yml'
-    - 'python_legacy/**'
   pull_request:
+    types:
+    - opened
+    - reopened
+    - ready_for_review
+    # Synchronize represents any kind of change to head ref on an open PR
+    - synchronize
     paths:
     - '.github/workflows/python-legacy-ci.yml'
     - 'python_legacy/**'

--- a/.github/workflows/python-legacy-ci.yml
+++ b/.github/workflows/python-legacy-ci.yml
@@ -19,13 +19,12 @@
 
 name: "Python Legacy CI"
 on:
+  push:
+    branches:
+    - 'master'
+    tags:
+    - '**'
   pull_request:
-    types:
-    - opened
-    - reopened
-    - ready_for_review
-    # Synchronize represents any kind of change to head ref on an open PR
-    - synchronize
     paths:
     - '.github/workflows/python-legacy-ci.yml'
     - 'python_legacy/**'

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -19,27 +19,13 @@
 
 name: "Spark CI"
 on:
-  push:
-    paths-ignore:
-    - '.github/workflows/python-ci.yml'
-    - '.github/workflows/flink-ci.yml'
-    - '.github/workflows/hive-ci.yml'
-    - '.github/workflows/cancel-duplicate-workflow-runs.yml'
-    - '.gitignore'
-    - 'dev/**'
-    - 'mr/**'
-    - 'hive3/**'
-    - 'hive3-orc-bundle/**'
-    - 'hive-runtime/**'
-    - 'flink/**'
-    - 'pig/**'
-    - 'python/**'
-    - 'python_legacy/**'
-    - 'docs/**'
-    - '.gitattributes'
-    - 'README.md'
-    - 'CONTRIBUTING.md'
   pull_request:
+    types:
+    - opened
+    - reopened
+    - ready_for_review
+    # Synchronize represents any kind of change to head ref on an open PR
+    - synchronize
     paths-ignore:
     - '.github/workflows/python-ci.yml'
     - '.github/workflows/flink-ci.yml'

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -19,13 +19,12 @@
 
 name: "Spark CI"
 on:
+  push:
+    branches:
+    - 'master'
+    tags:
+    - '**'
   pull_request:
-    types:
-    - opened
-    - reopened
-    - ready_for_review
-    # Synchronize represents any kind of change to head ref on an open PR
-    - synchronize
     paths-ignore:
     - '.github/workflows/python-ci.yml'
     - '.github/workflows/flink-ci.yml'


### PR DESCRIPTION
Right now, we use both `push` and `pull_request` event to trigger our github actions.

This causes us to duplicate our `paths-ignore` in every file.

Additionally, as we start to use more github action features, such as in https://github.com/apache/iceberg/pull/4207, it would be good to reduce the number of events that trigger workflows so that the `github` context has consistent fields. For example, `github.head_ref` is only defined for `pull_request` and not `push` or any other trigger.

Another quirk of using `push` is that it causes CI to run in forks etc when people push to their branch.

I've updated the CI workflows to only run on `pull_request`, which will retrigger every time it's pushed.

I also left `on: push` in, but only for the `'master'` branch, so that CI will run to completion for every merge into master (when combined with @snazy's work in https://github.com/apache/iceberg/pull/4207).

cc @snazy @nastra @rdblue 