### PR TITLE
Docs: Sync back markdown updates which were done directly in iceberg-docs

### DIFF
--- a/docs/common/community/contribute.md
+++ b/docs/common/community/contribute.md
@@ -72,6 +72,15 @@ This project Iceberg also has modules for adding Iceberg support to processing e
 * `iceberg-mr` contains an InputFormat and other classes for integrating with Apache Hive
 * `iceberg-pig` is an implementation of Pig's LoadFunc API for Iceberg
 
+## Setting up IDE and Code Style
+
+### Configuring Code Formatter for IntelliJ IDEA
+
+In the **Settings/Preferences** dialog go to **Editor > Code Style > Java**. Click on the gear wheel and select **Import Scheme** to import IntelliJ IDEA XML code style settings.
+Point to [intellij-java-palantir-style.xml](https://github.com/apache/iceberg/blob/master/.baseline/idea/intellij-java-palantir-style.xml) and hit **OK** (you might need to enable **Show Hidden Files and Directories** in the dialog). The code itself can then be formatted via **Code > Reformat Code**.
+
+See also the IntelliJ [Code Style docs](https://www.jetbrains.com/help/idea/copying-code-style-settings.html) and [Reformat Code docs](https://www.jetbrains.com/help/idea/reformat-and-rearrange-code.html) for additional details.
+
 ## Iceberg Code Contribution Guidelines
 
 ### Style
@@ -162,6 +171,13 @@ When passing boolean arguments to existing or external methods, use inline comme
     * For example, preferred convection `access-key-id` rather than `access.key.id`
 2. Use `.` to create a hierarchy of config groups
     * For example, `s3` in `s3.access-key-id`, `s3.secret-access-key`
+
+## Running Benchmarks
+Some PRs/changesets might require running benchmarks to determine whether they are affecting the baseline performance. Currently there is 
+no "push a single button to get a performance comparison" solution available, therefore one has to run JMH performance tests on their local machine and
+post the results on the PR.
+
+See [Benchmarks](../benchmarks) for a summary of available benchmarks and how to run them.
 
 ## Website and Documentation Updates
 

--- a/docs/common/community/join.md
+++ b/docs/common/community/join.md
@@ -24,6 +24,10 @@ Apache Iceberg tracks issues in GitHub and prefers to receive contributions as p
 
 Community discussions happen primarily on the dev mailing list, on apache-iceberg Slack workspace, and on specific GitHub issues.
 
+## Contribute
+
+See [Contributing](../../../contribute) for more details on how to contribute to Iceberg.
+
 ## Issues
 
 Issues are tracked in GitHub:
@@ -58,20 +62,3 @@ Iceberg has four mailing lists:
     - [Archive](https://lists.apache.org/list.html?issues@iceberg.apache.org)
 * **Private**: <private@iceberg.apache.org> -- private list for the PMC to discuss sensitive issues related to the health of the project
     - [Archive](https://lists.apache.org/list.html?private@iceberg.apache.org)
-
-
-## Setting up IDE and Code Style
-
-### Configuring Code Formatter for IntelliJ IDEA
-
-In the **Settings/Preferences** dialog go to **Editor > Code Style > Java**. Click on the gear wheel and select **Import Scheme** to import IntelliJ IDEA XML code style settings.
-Point to [intellij-java-palantir-style.xml](https://github.com/apache/iceberg/blob/master/.baseline/idea/intellij-java-palantir-style.xml) and hit **OK** (you might need to enable **Show Hidden Files and Directories** in the dialog). The code itself can then be formatted via **Code > Reformat Code**.
-
-See also the IntelliJ [Code Style docs](https://www.jetbrains.com/help/idea/copying-code-style-settings.html) and [Reformat Code docs](https://www.jetbrains.com/help/idea/reformat-and-rearrange-code.html) for additional details.
-
-## Running Benchmarks
-Some PRs/changesets might require running benchmarks to determine whether they are affecting the baseline performance. Currently there is 
-no "push a single button to get a performance comparison" solution available, therefore one has to run JMH performance tests on their local machine and
-post the results on the PR.
-
-See [Benchmarks](../benchmarks) for a summary of available benchmarks and how to run them.

--- a/docs/common/format/spec.md
+++ b/docs/common/format/spec.md
@@ -34,7 +34,7 @@ The format version number is incremented when new features are added that will b
 
 Version 1 of the Iceberg spec defines how to manage large analytic tables using immutable file formats: Parquet, Avro, and ORC.
 
-All version 1 data and metadata files are valid after upgrading a table to version 2. [Appendix E](#version-2) documents how to default version 2 fields when reading version 1 metadata.
+All version 1 data and metadata files are valid after upgrading a table to version 2. [Appendix E](spec/#version-2) documents how to default version 2 fields when reading version 1 metadata.
 
 #### Version 2: Row-level Deletes
 
@@ -42,7 +42,7 @@ Version 2 of the Iceberg spec adds row-level updates and deletes for analytic ta
 
 The primary change in version 2 adds delete files to encode that rows that are deleted in existing data files. This version can be used to delete or replace individual rows in immutable data files without rewriting the files.
 
-In addition to row-level deletes, version 2 makes some requirements stricter for writers. The full set of changes are listed in [Appendix E](#version-2).
+In addition to row-level deletes, version 2 makes some requirements stricter for writers. The full set of changes are listed in [Appendix E](spec/#version-2).
 
 
 ## Goals
@@ -837,7 +837,7 @@ Note that the string map case is for maps where the key type is a string. Using 
 
 Values should be stored in Parquet using the types and logical type annotations in the table below. Column IDs are required.
 
-Lists must use the [3-level representation](https://github.com/apache/parquet-format/blob/master/LogicalTypes#lists).
+Lists must use the [3-level representation](https://github.com/apache/parquet-format/blob/master/LogicalTypes,md#lists).
 
 | Type               | Parquet physical type                                              | Logical type                                | Notes                                                          |
 |--------------------|--------------------------------------------------------------------|---------------------------------------------|----------------------------------------------------------------|

--- a/docs/versioned/community/contribute.md
+++ b/docs/versioned/community/contribute.md
@@ -1,0 +1,21 @@
+---
+title: "Contribute"
+weight: 400
+bookUrlFromBaseURL: /../../contribute
+---
+<!--
+ - Licensed to the Apache Software Foundation (ASF) under one or more
+ - contributor license agreements.  See the NOTICE file distributed with
+ - this work for additional information regarding copyright ownership.
+ - The ASF licenses this file to You under the Apache License, Version 2.0
+ - (the "License"); you may not use this file except in compliance with
+ - the License.  You may obtain a copy of the License at
+ -
+ -   http://www.apache.org/licenses/LICENSE-2.0
+ -
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -->

--- a/docs/versioned/integrations/aws.md
+++ b/docs/versioned/integrations/aws.md
@@ -436,7 +436,7 @@ The Glue, S3 and DynamoDB clients are then initialized with the assume-role cred
 Here is an example to start Spark shell with this client factory:
 
 ```shell
-spark-sql --packages org.apache.iceberg:iceberg-spark3-runtime:{{% icebergVersion %}},software.amazon.awssdk:bundle:2.17.131 \
+spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-3.2_2.12:{{% icebergVersion %}},software.amazon.awssdk:bundle:2.17.131 \
     --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCatalog \
     --conf spark.sql.catalog.my_catalog.warehouse=s3://my-bucket/my/key/prefix \    
     --conf spark.sql.catalog.my_catalog.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog \
@@ -480,7 +480,7 @@ AWS_PACKAGES=(
 )
 
 ICEBERG_PACKAGES=(
-  "iceberg-spark3-runtime"
+  "iceberg-spark-runtime-3.2_2.12"
   "iceberg-flink-runtime"
 )
 

--- a/docs/versioned/spark/spark-getting-started.md
+++ b/docs/versioned/spark/spark-getting-started.md
@@ -39,10 +39,9 @@ spark-shell --packages org.apache.iceberg:iceberg-spark-runtime-3.2_2.12:{{% ice
 ```
 
 {{< hint info >}}
-If you want to include Iceberg in your Spark installation, add the [`iceberg-spark-runtime-3.2_2.12` Jar](spark-runtime-jar) to Spark's `jars` folder.
+If you want to include Iceberg in your Spark installation, add the 
+[`iceberg-spark-runtime-3.2_2.12` Jar](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-3.2_2.12/{{% icebergVersion %}}/iceberg-spark-runtime-3.2_2.12-{{% icebergVersion %}}.jar) to Spark's `jars` folder.
 {{< /hint >}}
-
-[spark-runtime-jar]: https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-3.2_2.12/{{% icebergVersion %}}/iceberg-spark-runtime-3.2_2.12-{{% icebergVersion %}}.jar
 
 ### Adding catalogs
 


### PR DESCRIPTION
As part of 0.13.1 release, some markdown changes in this PR https://github.com/apache/iceberg-docs/pull/55#issuecomment-1040921523 and this change https://github.com/apache/iceberg-docs/pull/56 were done directly on iceberg-docs. They should be synced back here. This also corrects some links which are incorrect in some of iceberg's docs, but are correct in the iceberg-docs page.

To keep this in sync I copied over iceberg-docs files back to iceberg, and identified which markdown files in iceberg are up to date and do not need to be updated. The remainder are markdown files in Iceberg which need some updates (for correcting broken links etc)