### PR TITLE
Core: Update JDBC catalog namespaces

### DIFF
--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcUtil.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcUtil.java
@@ -100,6 +100,9 @@ final class JdbcUtil {
       " FROM " + NAMESPACE_PROPERTIES_TABLE_NAME + " WHERE " + CATALOG_NAME + " = ? AND " + NAMESPACE_NAME + " = ? ";
   protected static final String DELETE_NAMESPACE_PROPERTIES_SQL = "DELETE FROM " + NAMESPACE_PROPERTIES_TABLE_NAME +
       " WHERE " + CATALOG_NAME + " = ? AND " + NAMESPACE_NAME + " = ? AND " + NAMESPACE_PROPERTY_KEY + " IN ";
+  protected static final String DELETE_ALL_NAMESPACE_PROPERTIES_SQL =
+      "DELETE FROM " + NAMESPACE_PROPERTIES_TABLE_NAME +
+      " WHERE " + CATALOG_NAME + " = ? AND " + NAMESPACE_NAME + " = ?";
 
   // Utilities
   private static final Joiner JOINER_DOT = Joiner.on('.');


### PR DESCRIPTION
This fixes a few issues with the JDBC catalog's namespace implementation:
* Uses a default "exists" property to allow creating a database without custom metadata
* Implements `loadNamespaceMetadata`
* Fixes incorrect `NoSuchNamespaceException` thrown in `dropNamespace` (return `false` instead)
* Fixes `dropNamespace` when the namespace exists because properties are set (will remove all properties)
* Allows an empty map or set of properties in `removeProperties` and `setProperties` as noops
* Moves private helper methods to the end of the JDBCCatalog class
* Update tests for behavior fixes and to use `loadNamespaceMetadata` rather than directly using the `fetchProperties` helper method