### PR TITLE
[Spark] Preserves the original table format when migrating from hive to Iceberg #4226

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseMigrateTableSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseMigrateTableSparkAction.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.actions.BaseMigrateTableActionResult;
 import org.apache.iceberg.actions.MigrateTable;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
@@ -159,6 +160,16 @@ public class BaseMigrateTableSparkAction
     // copy over relevant source table props
     properties.putAll(JavaConverters.mapAsJavaMapConverter(v1SourceTable().properties()).asJava());
     EXCLUDED_PROPERTIES.forEach(properties::remove);
+
+    // inherit the source table format
+    String format = v1SourceTable().storage().serde().get();
+    if (format.contains("avro")) {
+      properties.put(TableProperties.DEFAULT_FILE_FORMAT, "avro");
+    } else if (format.contains("parquet")) {
+      properties.put(TableProperties.DEFAULT_FILE_FORMAT, "parquet");
+    } else if (format.contains("orc")) {
+      properties.put(TableProperties.DEFAULT_FILE_FORMAT, "orc");
+    }
 
     // set default and user-provided props
     properties.put(TableCatalog.PROP_PROVIDER, "iceberg");


### PR DESCRIPTION
Run the following command to migrate the Hive table. The default table format is `parquet` even if the original table format is `orc`. This patch will preserves the format of the original hive table if no table format is specified.
```
CALL spark_catalog.system.migrate('db.tbl');
```