### PR TITLE
Flink: The Data Skew Problem on FlinkSink

### DIFF
--- a/api/src/main/java/org/apache/iceberg/PartitionKey.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionKey.java
@@ -136,4 +136,8 @@ public class PartitionKey implements StructLike, Serializable {
   public int hashCode() {
     return Arrays.hashCode(partitionTuple);
   }
+
+  public PartitionSpec getSpec() {
+    return this.spec;
+  }
 }

--- a/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -418,7 +418,16 @@ public class FlinkSink {
           if (partitionSpec.isUnpartitioned()) {
             return input;
           } else {
-            return input.keyBy(new PartitionKeySelector(partitionSpec, iSchema, flinkRowType));
+            if (partitionSpec.isBucketPartiton()) {
+              return input.partitionCustom(new Partitioner<String>() {
+                @Override
+                public int partition(String key, int numPartitions) {
+                  return Integer.parseInt(key) % numPartitions;
+                }
+              }, new PartitionKeySelector(partitionSpec, iSchema, flinkRowType));
+            } else {
+              return input.keyBy(new PartitionKeySelector(partitionSpec, iSchema, flinkRowType));
+            }
           }
 
         case RANGE:


### PR DESCRIPTION
Hi,

I tried to load 1TB data from TiDB to Iceberg by Flink. Iceberg table consists of 128 buckets partition. 

I found data skew problem on FlinkSQL IcebergWriter stage. We set parrallism 128 on this stage, there are only 49 taskmanagers has data processing tasks, others are finished so quickly. 

The data partition operator for a bucket partition table in Flink is 'keyby', a hash policy may  occur the data skew. I make a 
custom partition function which can distribute a task for a table partition data to a taskmanager evenly。

![image](https://user-images.githubusercontent.com/58673451/155674884-440e1b1b-0c6c-4c53-a7c5-0be80d3aca2b.png)

According to my testing, on batch mode without deletion process, this function can make every tm has task to process and cut down data load time from 96 min to 38 min with 64 parallism.
