### PR TITLE
Core: Clean up JDBC implementation, add catalog namespace tests

### DIFF
--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -414,7 +414,7 @@ public class JdbcCatalog extends BaseMetastoreCatalog
   }
 
   private int execute(String sql, String... args) {
-    return execute(err -> {}, sql, args);
+    return execute(err -> { }, sql, args);
   }
 
   private int execute(Consumer<SQLException> sqlErrorHandler, String sql, String... args) {
@@ -436,6 +436,7 @@ public class JdbcCatalog extends BaseMetastoreCatalog
     }
   }
 
+  @SuppressWarnings("checkstyle:NestedTryDepth")
   private boolean exists(String sql, String... args) {
     try {
       return connections.run(conn -> {
@@ -466,6 +467,7 @@ public class JdbcCatalog extends BaseMetastoreCatalog
     R apply(ResultSet result) throws SQLException;
   }
 
+  @SuppressWarnings("checkstyle:NestedTryDepth")
   private <R> List<R> fetch(RowProducer<R> toRow, String sql, String... args) {
     try {
       return connections.run(conn -> {

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcUtil.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcUtil.java
@@ -69,6 +69,9 @@ final class JdbcUtil {
   protected static final String LIST_NAMESPACES_SQL = "SELECT DISTINCT " + TABLE_NAMESPACE +
       " FROM " + CATALOG_TABLE_NAME +
       " WHERE " + CATALOG_NAME + " = ? AND " + TABLE_NAMESPACE + " LIKE ?";
+  protected static final String LIST_ALL_TABLE_NAMESPACES_SQL = "SELECT DISTINCT " + TABLE_NAMESPACE +
+      " FROM " + CATALOG_TABLE_NAME +
+      " WHERE " + CATALOG_NAME + " = ?";
   protected static final String DO_COMMIT_CREATE_TABLE_SQL = "INSERT INTO " + CATALOG_TABLE_NAME +
       " (" + CATALOG_NAME + ", " + TABLE_NAMESPACE + ", " + TABLE_NAME +
       ", " + METADATA_LOCATION + ", " + PREVIOUS_METADATA_LOCATION + ") " +
@@ -103,6 +106,12 @@ final class JdbcUtil {
   protected static final String DELETE_ALL_NAMESPACE_PROPERTIES_SQL =
       "DELETE FROM " + NAMESPACE_PROPERTIES_TABLE_NAME +
       " WHERE " + CATALOG_NAME + " = ? AND " + NAMESPACE_NAME + " = ?";
+  protected static final String LIST_PROPERTY_NAMESPACES_SQL = "SELECT DISTINCT " + NAMESPACE_NAME +
+      " FROM " + NAMESPACE_PROPERTIES_TABLE_NAME +
+      " WHERE " + CATALOG_NAME + " = ? AND " + NAMESPACE_NAME + " LIKE ?";
+  protected static final String LIST_ALL_PROPERTY_NAMESPACES_SQL = "SELECT DISTINCT " + NAMESPACE_NAME +
+      " FROM " + NAMESPACE_PROPERTIES_TABLE_NAME +
+      " WHERE " + CATALOG_NAME + " = ?";
 
   // Utilities
   private static final Joiner JOINER_DOT = Joiner.on('.');

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -1,15 +1,20 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.iceberg.catalog;
@@ -32,7 +37,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.Assume;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.apache.iceberg.types.Types.NestedField.required;

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.catalog;
 
-import com.google.common.collect.Sets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +33,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.Assume;

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -1,0 +1,324 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.catalog;
+
+import com.google.common.collect.Sets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.NoSuchNamespaceException;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
+  private static final Namespace NS = Namespace.of("newdb");
+  // Schema passed to create tables
+  static final Schema SCHEMA = new Schema(
+      required(3, "id", Types.IntegerType.get(), "unique ID"),
+      required(4, "data", Types.StringType.get())
+  );
+
+  // This is the actual schema for the table, with column IDs reassigned
+  static final Schema TABLE_SCHEMA = new Schema(
+      required(1, "id", Types.IntegerType.get(), "unique ID"),
+      required(2, "data", Types.StringType.get())
+  );
+
+  // Partition spec used to create tables
+  static final PartitionSpec SPEC = PartitionSpec.builderFor(SCHEMA)
+      .bucket("data", 16)
+      .build();
+
+  static final DataFile FILE_A = DataFiles.builder(SPEC)
+      .withPath("/path/to/data-a.parquet")
+      .withFileSizeInBytes(0)
+      .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+      .withRecordCount(2) // needs at least one record or else metrics will filter it out
+      .build();
+
+  protected abstract C catalog();
+  protected abstract boolean supportsNamespaceProperties();
+
+  @Test
+  public void testCreateNamespace() {
+    C catalog = catalog();
+
+    Assert.assertFalse("Namespace should not exist", catalog.namespaceExists(NS));
+
+    catalog.createNamespace(NS);
+    Assert.assertEquals("Catalog should have the created namespace", ImmutableList.of(NS), catalog.listNamespaces());
+    Assert.assertTrue("Namespace should exist", catalog.namespaceExists(NS));
+  }
+
+  @Test
+  public void testCreateExistingNamespace() {
+    C catalog = catalog();
+
+    Assert.assertFalse("Namespace should not exist", catalog.namespaceExists(NS));
+
+    catalog.createNamespace(NS);
+    Assert.assertTrue("Namespace should exist", catalog.namespaceExists(NS));
+
+    AssertHelpers.assertThrows("Should fail to create an existing database",
+        AlreadyExistsException.class, "newdb", () -> catalog.createNamespace(NS));
+    Assert.assertTrue("Namespace should still exist", catalog.namespaceExists(NS));
+  }
+
+  @Test
+  public void testCreateNamespaceWithProperties() {
+    Assume.assumeTrue(supportsNamespaceProperties());
+
+    C catalog = catalog();
+
+    Assert.assertFalse("Namespace should not exist", catalog.namespaceExists(NS));
+
+    Map<String, String> createProps = ImmutableMap.of("prop", "val");
+    catalog.createNamespace(NS, createProps);
+    Assert.assertTrue("Namespace should exist", catalog.namespaceExists(NS));
+
+    Map<String, String> props = catalog.loadNamespaceMetadata(NS);
+    Assert.assertEquals("Create properties should be a subset of returned properties",
+        createProps.entrySet(),
+        Sets.intersection(createProps.entrySet(), props.entrySet()));
+  }
+
+  @Test
+  public void testLoadNamespaceMetadata() {
+    C catalog = catalog();
+
+    Assert.assertFalse("Namespace should not exist", catalog.namespaceExists(NS));
+
+    AssertHelpers.assertThrows("Should fail to load nonexistent namespace metadata",
+        NoSuchNamespaceException.class, "newdb",
+        () -> catalog.loadNamespaceMetadata(NS));
+
+    catalog.createNamespace(NS);
+    Assert.assertTrue("Namespace should exist", catalog.namespaceExists(NS));
+
+    Map<String, String> props = catalog.loadNamespaceMetadata(NS);
+    Assert.assertNotNull("Should return non-null property map", props);
+    // note that there are no requirements for the properties returned by the catalog
+  }
+
+  @Test
+  public void testSetNamespaceProperties() {
+    Assume.assumeTrue(supportsNamespaceProperties());
+
+    C catalog = catalog();
+
+    Map<String, String> properties = ImmutableMap.of("owner", "user", "created-at", "sometime");
+
+    catalog.createNamespace(NS);
+    catalog.setProperties(NS, properties);
+
+    Map<String, String> actualProperties = catalog.loadNamespaceMetadata(NS);
+    Assert.assertEquals("Set properties should be a subset of returned properties",
+        properties.entrySet(),
+        Sets.intersection(properties.entrySet(), actualProperties.entrySet()));
+  }
+
+  @Test
+  public void testUpdateNamespaceProperties() {
+    Assume.assumeTrue(supportsNamespaceProperties());
+
+    C catalog = catalog();
+
+    Map<String, String> initialProperties = ImmutableMap.of("owner", "user");
+
+    catalog.createNamespace(NS);
+    catalog.setProperties(NS, initialProperties);
+
+    Map<String, String> actualProperties = catalog.loadNamespaceMetadata(NS);
+    Assert.assertEquals("Set properties should be a subset of returned properties",
+        initialProperties.entrySet(),
+        Sets.intersection(initialProperties.entrySet(), actualProperties.entrySet()));
+
+    Map<String, String> updatedProperties = ImmutableMap.of("owner", "newuser");
+
+    catalog.setProperties(NS, updatedProperties);
+
+    Map<String, String> finalProperties = catalog.loadNamespaceMetadata(NS);
+    Assert.assertEquals("Updated properties should be a subset of returned properties",
+        updatedProperties.entrySet(),
+        Sets.intersection(updatedProperties.entrySet(), finalProperties.entrySet()));
+  }
+
+  @Test
+  public void testUpdateAndSetNamespaceProperties() {
+    Assume.assumeTrue(supportsNamespaceProperties());
+
+    C catalog = catalog();
+
+    Map<String, String> initialProperties = ImmutableMap.of("owner", "user");
+
+    catalog.createNamespace(NS);
+    catalog.setProperties(NS, initialProperties);
+
+    Map<String, String> actualProperties = catalog.loadNamespaceMetadata(NS);
+    Assert.assertEquals("Set properties should be a subset of returned properties",
+        initialProperties.entrySet(),
+        Sets.intersection(initialProperties.entrySet(), actualProperties.entrySet()));
+
+    Map<String, String> updatedProperties = ImmutableMap.of("owner", "newuser", "last-modified-at", "now");
+
+    catalog.setProperties(NS, updatedProperties);
+
+    Map<String, String> finalProperties = catalog.loadNamespaceMetadata(NS);
+    Assert.assertEquals("Updated properties should be a subset of returned properties",
+        updatedProperties.entrySet(),
+        Sets.intersection(updatedProperties.entrySet(), finalProperties.entrySet()));
+  }
+
+  @Test
+  public void testSetNamespacePropertiesNamespaceDoesNotExist() {
+    Assume.assumeTrue(supportsNamespaceProperties());
+
+    C catalog = catalog();
+
+    AssertHelpers.assertThrows("setProperties should fail if the namespace does not exist",
+        NoSuchNamespaceException.class, "does not exist",
+        () -> catalog.setProperties(NS, ImmutableMap.of("test", "value")));
+  }
+
+  @Test
+  public void testRemoveNamespaceProperties() {
+    Assume.assumeTrue(supportsNamespaceProperties());
+
+    C catalog = catalog();
+
+    Map<String, String> properties = ImmutableMap.of("owner", "user", "created-at", "sometime");
+
+    catalog.createNamespace(NS);
+    catalog.setProperties(NS, properties);
+    catalog.removeProperties(NS, ImmutableSet.of("created-at"));
+
+    Map<String, String> actualProperties = catalog.loadNamespaceMetadata(NS);
+    Assert.assertFalse("Should not contain deleted property key", actualProperties.containsKey("created-at"));
+    Assert.assertEquals("Expected properties should be a subset of returned properties",
+        ImmutableMap.of("owner", "user").entrySet(),
+        Sets.intersection(properties.entrySet(), actualProperties.entrySet()));
+  }
+
+  @Test
+  public void testRemoveNamespacePropertiesNamespaceDoesNotExist() {
+    Assume.assumeTrue(supportsNamespaceProperties());
+
+    C catalog = catalog();
+
+    AssertHelpers.assertThrows("setProperties should fail if the namespace does not exist",
+        NoSuchNamespaceException.class, "does not exist",
+        () -> catalog.removeProperties(NS, ImmutableSet.of("a", "b")));
+  }
+
+  @Test
+  public void testDropNamespace() {
+    C catalog = catalog();
+
+    Assert.assertFalse("Namespace should not exist", catalog.namespaceExists(NS));
+
+    catalog.createNamespace(NS);
+    Assert.assertTrue("Namespace should exist", catalog.namespaceExists(NS));
+
+    Assert.assertTrue("Dropping an existing namespace should return true", catalog.dropNamespace(NS));
+    Assert.assertFalse("Namespace should not exist", catalog.namespaceExists(NS));
+  }
+
+  @Test
+  public void testDropNonexistentNamespace() {
+    C catalog = catalog();
+
+    Assert.assertFalse("Dropping a nonexistent namespace should return false", catalog.dropNamespace(NS));
+  }
+
+  @Test
+  public void testListNamespaces() {
+    C catalog = catalog();
+    // the catalog may automatically create a default namespace
+    List<Namespace> starting = catalog.listNamespaces();
+
+    Namespace ns1 = Namespace.of("newdb_1");
+    Namespace ns2 = Namespace.of("newdb_2");
+
+    catalog.createNamespace(ns1);
+    Assert.assertEquals("Should include newdb_1", concat(starting, ns1), catalog.listNamespaces());
+
+    catalog.createNamespace(ns2);
+    Assert.assertEquals("Should include newdb_1 and newdb_2", concat(starting, ns1, ns2), catalog.listNamespaces());
+
+    catalog.dropNamespace(ns1);
+    Assert.assertEquals("Should include newdb_2, not newdb_1", concat(starting, ns2), catalog.listNamespaces());
+
+    catalog.dropNamespace(ns2);
+    Assert.assertEquals("Should include only starting namespaces", starting, catalog.listNamespaces());
+  }
+
+  @Test
+  public void testNamespaceWithSlash() {
+    C catalog = catalog();
+
+    Namespace withSlash = Namespace.of("new/db");
+
+    Assert.assertFalse("Namespace should not exist", catalog.namespaceExists(withSlash));
+
+    catalog.createNamespace(withSlash);
+    Assert.assertTrue("Namespace should exist", catalog.namespaceExists(withSlash));
+
+    Map<String, String> properties = catalog.loadNamespaceMetadata(withSlash);
+    Assert.assertNotNull("Properties should be accessible", properties);
+
+    Assert.assertTrue("Dropping the namespace should succeed", catalog.dropNamespace(withSlash));
+    Assert.assertFalse("Namespace should not exist", catalog.namespaceExists(withSlash));
+  }
+
+  @Test
+  public void testNamespaceWithDot() {
+    C catalog = catalog();
+
+    Namespace withDot = Namespace.of("new.db");
+
+    Assert.assertFalse("Namespace should not exist", catalog.namespaceExists(withDot));
+
+    catalog.createNamespace(withDot);
+    Assert.assertTrue("Namespace should exist", catalog.namespaceExists(withDot));
+
+    Map<String, String> properties = catalog.loadNamespaceMetadata(withDot);
+    Assert.assertNotNull("Properties should be accessible", properties);
+
+    Assert.assertTrue("Dropping the namespace should succeed", catalog.dropNamespace(withDot));
+    Assert.assertFalse("Namespace should not exist", catalog.namespaceExists(withDot));
+  }
+
+  private List<Namespace> concat(List<Namespace> starting, Namespace... additional) {
+    List<Namespace> namespaces = Lists.newArrayList();
+    namespaces.addAll(starting);
+    namespaces.addAll(Arrays.asList(additional));
+    return namespaces;
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
@@ -42,6 +42,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.Transaction;
+import org.apache.iceberg.catalog.CatalogTests;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
@@ -67,7 +68,7 @@ import static org.apache.iceberg.NullOrder.NULLS_FIRST;
 import static org.apache.iceberg.SortDirection.ASC;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
-public class TestJdbcCatalog {
+public class TestJdbcCatalog extends CatalogTests<JdbcCatalog>  {
 
   static final Schema SCHEMA = new Schema(
       required(1, "id", Types.IntegerType.get(), "unique ID"),
@@ -80,9 +81,20 @@ public class TestJdbcCatalog {
   static Configuration conf = new Configuration();
   private static JdbcCatalog catalog;
   private static String warehouseLocation;
+
   @Rule
   public TemporaryFolder temp = new TemporaryFolder();
   File tableDir = null;
+
+  @Override
+  protected JdbcCatalog catalog() {
+    return catalog;
+  }
+
+  @Override
+  protected boolean supportsNamespaceProperties() {
+    return true;
+  }
 
   protected List<String> metadataVersionFiles(String location) {
     return Stream.of(new File(location).listFiles())

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
@@ -378,7 +378,7 @@ public class TestJdbcCatalog {
     TableIdentifier from2 = TableIdentifier.of("db", "tbl2");
     catalog.createTable(from2, SCHEMA, PartitionSpec.unpartitioned());
     AssertHelpers.assertThrows("should throw exception", UncheckedSQLException.class,
-        "Failed to rename db.tbl2 to db.tbl2-newtable", () -> catalog.renameTable(from2, to)
+        "Failed to execute", () -> catalog.renameTable(from2, to)
     );
   }
 


### PR DESCRIPTION
This continues cleaning up the JDBC implementation after #4220 and adds namespace tests to validate the behavior of the JDBC catalog and other catalogs that support namespace properties.

* Creates a base set of catalog tests that check namespace behavior
* Consolidates JDBC exception handling by combining logic in `fetch`, `exists`, and `execute` helper methods
* Fixes namespace listing that needs to combine namespaces that exist from properties or tables