### PR TITLE
Core: Make REST response builders public

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/responses/CreateNamespaceResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/CreateNamespaceResponse.java
@@ -70,7 +70,7 @@ public class CreateNamespaceResponse {
     return new Builder();
   }
 
-  static class Builder {
+  public static class Builder {
     private Namespace namespace;
     private final ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
 

--- a/core/src/main/java/org/apache/iceberg/rest/responses/GetNamespaceResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/GetNamespaceResponse.java
@@ -70,7 +70,7 @@ public class GetNamespaceResponse {
     return new Builder();
   }
 
-  static class Builder {
+  public static class Builder {
     private Namespace namespace;
     private final ImmutableMap.Builder<String, String> properties =  ImmutableMap.builder();
 

--- a/core/src/main/java/org/apache/iceberg/rest/responses/ListNamespacesResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/ListNamespacesResponse.java
@@ -61,7 +61,7 @@ public class ListNamespacesResponse {
     return new Builder();
   }
 
-  static class Builder {
+  public static class Builder {
     private final ImmutableList.Builder<Namespace> namespaces = ImmutableList.builder();
 
     private Builder() {

--- a/core/src/main/java/org/apache/iceberg/rest/responses/ListTablesResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/ListTablesResponse.java
@@ -63,7 +63,7 @@ public class ListTablesResponse {
     return new Builder();
   }
 
-  static class Builder {
+  public static class Builder {
     private final ImmutableList.Builder<TableIdentifier> identifiers = ImmutableList.builder();
 
     private Builder() {


### PR DESCRIPTION
The builders can only be used outside of the `responses` package if the builders are public.