### PR TITLE
Core: Avoid possible NPE in RESTCatalogConfigResponse#merge

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/responses/RESTCatalogConfigResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/RESTCatalogConfigResponse.java
@@ -88,9 +88,13 @@ public class RESTCatalogConfigResponse {
   public Map<String, String> merge(Map<String, String> clientProperties) {
     Preconditions.checkNotNull(clientProperties,
         "Cannot merge client properties with server-provided properties. Invalid client configuration: null");
-    Map<String, String> merged = Maps.newHashMap(defaults);
+    Map<String, String> merged = defaults != null ? Maps.newHashMap(defaults) : Maps.newHashMap();
     merged.putAll(clientProperties);
-    merged.putAll(overrides);
+
+    if (overrides != null) {
+      merged.putAll(overrides);
+    }
+
     return ImmutableMap.copyOf(Maps.filterValues(merged, Objects::nonNull));
   }
 


### PR DESCRIPTION
Right now, the `RESTCatalogConfigResponse#merge` function is used to merge the server-provided configuration with the initial client provided configuration.

However, if the data is parsed by Jackson and one of `overrides` or `defaults` is null (or wasn't in the original payload), this will hit an NPE.

Updating to avoid the NPE. Will add a unit test for this in my next PR (which makes use of this).

cc @rdblue 