### PR TITLE
Core: Add methods to RESTClient interface with no error handler in signature

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTClient.java
@@ -27,9 +27,15 @@ import org.apache.iceberg.rest.responses.ErrorResponse;
  * Interface for a basic HTTP Client for interfacing with the REST catalog.
  */
 public interface RESTClient extends Closeable {
+  <T> T delete(String path, Class<T> responseType);
   <T> T delete(String path, Class<T> responseType, Consumer<ErrorResponse> errorHandler);
-  <T> T post(String path, Object body, Class<T> responseType, Consumer<ErrorResponse> errorHandler);
-  <T> T get(String path, Class<T> responseType, Consumer<ErrorResponse> errorHandler);
-  <T> T head(String path, Consumer<ErrorResponse> errorHandler);
-}
 
+  <T> T post(String path, Object body, Class<T> responseType);
+  <T> T post(String path, Object body, Class<T> responseType, Consumer<ErrorResponse> errorHandler);
+
+  <T> T get(String path, Class<T> responseType);
+  <T> T get(String path, Class<T> responseType, Consumer<ErrorResponse> errorHandler);
+
+  void head(String path, Consumer<ErrorResponse> errorHandler);
+  void head(String path);
+}


### PR DESCRIPTION
The RESTClient will be configurable with a default error handler.

To that end, this updates the `RESTClient` interface to have method signatures with no `Consumer<ErrorResponse>` (to fall back to the default).

I have tests and an implementation of this coming in https://github.com/apache/iceberg/pull/4235, but this unblocks others from working on things in parallel that use this interface.