### PR TITLE
AWS: Add http client config for AWS clients

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
@@ -25,7 +25,6 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.PropertyUtil;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
 import software.amazon.awssdk.awscore.client.builder.AwsSyncClientBuilder;
-import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.glue.GlueClient;
@@ -35,7 +34,7 @@ import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
-public class AssumeRoleAwsClientFactory implements AwsClientFactory {
+public class AssumeRoleAwsClientFactory extends BaseAwsClientFactory {
 
   private String roleArn;
   private String externalId;
@@ -79,6 +78,7 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
     Preconditions.checkNotNull(region, "Cannot initialize AssumeRoleClientConfigFactory with null region");
 
     this.s3Endpoint = properties.get(AwsProperties.S3FILEIO_ENDPOINT);
+    setHttpClientConfig(properties);
   }
 
   private <T extends AwsClientBuilder & AwsSyncClientBuilder> T configure(T clientBuilder) {
@@ -91,12 +91,12 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
 
     clientBuilder.credentialsProvider(
         StsAssumeRoleCredentialsProvider.builder()
-            .stsClient(StsClient.builder().httpClientBuilder(UrlConnectionHttpClient.builder()).build())
+            .stsClient(StsClient.builder().httpClientBuilder(getHttpClientBuilder()).build())
             .refreshRequest(request)
             .build());
 
     clientBuilder.region(Region.of(region));
-    clientBuilder.httpClientBuilder(UrlConnectionHttpClient.builder());
+    clientBuilder.httpClientBuilder(getHttpClientBuilder());
 
     return clientBuilder;
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactory.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.aws;
 
 import java.io.Serializable;
 import java.util.Map;
+import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.glue.GlueClient;
 import software.amazon.awssdk.services.kms.KmsClient;
@@ -61,5 +62,15 @@ public interface AwsClientFactory extends Serializable {
    * @param properties catalog properties
    */
   void initialize(Map<String, String> properties);
+
+  /**
+   * Get http client config
+   */
+  String getHttpClientConfig();
+
+  /**
+   * Get http client builder based on http client config
+   */
+  SdkHttpClient.Builder getHttpClientBuilder();
 
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/BaseAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/BaseAwsClientFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.aws;
+
+import java.util.Map;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.util.PropertyUtil;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+
+abstract class BaseAwsClientFactory implements AwsClientFactory {
+  private String httpClientConfig;
+
+  /**
+   * Set http client config from properties map
+   *
+   * @param properties catalog properties
+   */
+  protected void setHttpClientConfig(Map<String, String> properties) {
+    httpClientConfig = PropertyUtil.propertyAsString(
+        properties, TableProperties.HTTP_CLIENT_TYPE, TableProperties.HTTP_CLIENT_TYPE_DEFAULT);
+
+    ValidationException.check(
+        (httpClientConfig.equalsIgnoreCase(TableProperties.URL_HTTP_CLIENT) ||
+            httpClientConfig.equalsIgnoreCase(TableProperties.APACHE_HTTP_CLIENT)),
+        "HTTP client can be either url or apache");
+  }
+
+  /**
+   * Create a http client builder based on client config
+   */
+  public SdkHttpClient.Builder getHttpClientBuilder() {
+    if (getHttpClientConfig().equalsIgnoreCase(TableProperties.APACHE_HTTP_CLIENT)) {
+      return ApacheHttpClient.builder();
+    } else {
+      return UrlConnectionHttpClient.builder();
+    }
+  }
+
+  /**
+   * Get http client config
+   */
+  public String getHttpClientConfig() {
+    return this.httpClientConfig;
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -312,6 +312,7 @@ project(':iceberg-aws') {
     implementation project(':iceberg-core')
 
     compileOnly 'software.amazon.awssdk:url-connection-client'
+    compileOnly 'software.amazon.awssdk:apache-client'
     compileOnly 'software.amazon.awssdk:s3'
     compileOnly 'software.amazon.awssdk:kms'
     compileOnly 'software.amazon.awssdk:glue'

--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -280,4 +280,9 @@ public class TableProperties {
 
   public static final String UPSERT_ENABLED = "write.upsert.enabled";
   public static final boolean UPSERT_ENABLED_DEFAULT = false;
+
+  public static final String HTTP_CLIENT_TYPE = "http-client.type";
+  public static final String APACHE_HTTP_CLIENT = "apache";
+  public static final String URL_HTTP_CLIENT = "url";
+  public static final String HTTP_CLIENT_TYPE_DEFAULT = URL_HTTP_CLIENT;
 }


### PR DESCRIPTION
This change adds support for choosing the preferred http client for creating the AWS clients. 

Currently URL and Apache clients are supported:
`http-client.type`: `url` or `apache`