### PR TITLE
Core: Add REST catalog adapter and tests

### DIFF
--- a/api/src/main/java/org/apache/iceberg/util/CharSequenceSet.java
+++ b/api/src/main/java/org/apache/iceberg/util/CharSequenceSet.java
@@ -20,13 +20,17 @@
 package org.apache.iceberg.util;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 
 public class CharSequenceSet implements Set<CharSequence>, Serializable {
   private static final ThreadLocal<CharSequenceWrapper> wrappers = ThreadLocal.withInitial(
@@ -151,5 +155,29 @@ public class CharSequenceSet implements Set<CharSequence>, Serializable {
   @Override
   public void clear() {
     wrapperSet.clear();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    CharSequenceSet that = (CharSequenceSet) o;
+    return wrapperSet.equals(that.wrapperSet);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(wrapperSet);
+  }
+
+  @Override
+  public String toString() {
+    return "CharSequenceSet({" + Streams.stream(iterator()).collect(Collectors.joining(", ")) + "})";
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -196,7 +196,7 @@ public abstract class BaseMetastoreCatalog implements Catalog {
     private Transaction newReplaceTableTransaction(boolean orCreate) {
       TableOperations ops = newTableOps(identifier);
       if (!orCreate && ops.current() == null) {
-        throw new NoSuchTableException("No such table: %s", identifier);
+        throw new NoSuchTableException("Table does not exist: %s", identifier);
       }
 
       TableMetadata metadata;

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.io.FileIO;
@@ -115,7 +116,11 @@ public abstract class BaseMetastoreTableOperations implements TableOperations {
   public void commit(TableMetadata base, TableMetadata metadata) {
     // if the metadata is already out of date, reject it
     if (base != current()) {
-      throw new CommitFailedException("Cannot commit: stale table metadata");
+      if (base != null) {
+        throw new CommitFailedException("Cannot commit: stale table metadata");
+      } else {
+        throw new AlreadyExistsException("Table already exists: %s", tableName());
+      }
     }
     // if the metadata is not changed, return early
     if (base == metadata) {

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -49,7 +49,7 @@ import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES_DEFAULT;
 import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS;
 import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT;
 
-class BaseTransaction implements Transaction {
+public class BaseTransaction implements Transaction {
   private static final Logger LOG = LoggerFactory.getLogger(BaseTransaction.class);
 
   enum TransactionType {
@@ -88,6 +88,14 @@ class BaseTransaction implements Transaction {
   @Override
   public Table table() {
     return transactionTable;
+  }
+
+  public TableMetadata startMetadata() {
+    return current;
+  }
+
+  public TableOperations underyingOps() {
+    return ops;
   }
 
   private void checkLastOperationCommitted(String operation) {

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
@@ -22,11 +22,14 @@ package org.apache.iceberg;
 import java.io.Serializable;
 import java.util.Map;
 import java.util.Set;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 
 /**
  * Represents a change to table metadata.
  */
 public interface MetadataUpdate extends Serializable {
+  void applyTo(TableMetadata.Builder metadataBuilder);
+
   class AssignUUID implements MetadataUpdate {
     private final String uuid;
 
@@ -36,6 +39,11 @@ public interface MetadataUpdate extends Serializable {
 
     public String uuid() {
       return uuid;
+    }
+
+    @Override
+    public void applyTo(TableMetadata.Builder metadataBuilder) {
+      throw new UnsupportedOperationException("Not implemented");
     }
   }
 
@@ -48,6 +56,11 @@ public interface MetadataUpdate extends Serializable {
 
     public int formatVersion() {
       return formatVersion;
+    }
+
+    @Override
+    public void applyTo(TableMetadata.Builder metadataBuilder) {
+      metadataBuilder.upgradeFormatVersion(formatVersion);
     }
   }
 
@@ -67,6 +80,11 @@ public interface MetadataUpdate extends Serializable {
     public int lastColumnId() {
       return lastColumnId;
     }
+
+    @Override
+    public void applyTo(TableMetadata.Builder metadataBuilder) {
+      metadataBuilder.addSchema(schema, lastColumnId);
+    }
   }
 
   class SetCurrentSchema implements MetadataUpdate {
@@ -78,6 +96,11 @@ public interface MetadataUpdate extends Serializable {
 
     public int schemaId() {
       return schemaId;
+    }
+
+    @Override
+    public void applyTo(TableMetadata.Builder metadataBuilder) {
+      metadataBuilder.setCurrentSchema(schemaId);
     }
   }
 
@@ -91,6 +114,11 @@ public interface MetadataUpdate extends Serializable {
     public PartitionSpec spec() {
       return spec;
     }
+
+    @Override
+    public void applyTo(TableMetadata.Builder metadataBuilder) {
+      metadataBuilder.addPartitionSpec(spec);
+    }
   }
 
   class SetDefaultPartitionSpec implements MetadataUpdate {
@@ -103,6 +131,11 @@ public interface MetadataUpdate extends Serializable {
     public int specId() {
       return specId;
     }
+
+    @Override
+    public void applyTo(TableMetadata.Builder metadataBuilder) {
+      metadataBuilder.setDefaultPartitionSpec(specId);
+    }
   }
 
   class AddSortOrder implements MetadataUpdate {
@@ -112,8 +145,13 @@ public interface MetadataUpdate extends Serializable {
       this.sortOrder = sortOrder;
     }
 
-    public SortOrder spec() {
+    public SortOrder sortOrder() {
       return sortOrder;
+    }
+
+    @Override
+    public void applyTo(TableMetadata.Builder metadataBuilder) {
+      metadataBuilder.addSortOrder(sortOrder);
     }
   }
 
@@ -127,6 +165,11 @@ public interface MetadataUpdate extends Serializable {
     public int sortOrderId() {
       return sortOrderId;
     }
+
+    @Override
+    public void applyTo(TableMetadata.Builder metadataBuilder) {
+      metadataBuilder.setDefaultSortOrder(sortOrderId);
+    }
   }
 
   class AddSnapshot implements MetadataUpdate {
@@ -138,6 +181,11 @@ public interface MetadataUpdate extends Serializable {
 
     public Snapshot snapshot() {
       return snapshot;
+    }
+
+    @Override
+    public void applyTo(TableMetadata.Builder metadataBuilder) {
+      metadataBuilder.addSnapshot(snapshot);
     }
   }
 
@@ -151,6 +199,11 @@ public interface MetadataUpdate extends Serializable {
     public long snapshotId() {
       return snapshotId;
     }
+
+    @Override
+    public void applyTo(TableMetadata.Builder metadataBuilder) {
+      metadataBuilder.removeSnapshots(ImmutableSet.of(snapshotId));
+    }
   }
 
   class RemoveSnapshotRef implements MetadataUpdate {
@@ -162,6 +215,12 @@ public interface MetadataUpdate extends Serializable {
 
     public String name() {
       return name;
+    }
+
+    @Override
+    public void applyTo(TableMetadata.Builder metadataBuilder) {
+      // TODO: this should be generalized when tagging is supported
+      metadataBuilder.removeBranch(name);
     }
   }
 
@@ -181,6 +240,11 @@ public interface MetadataUpdate extends Serializable {
     public long snapshotId() {
       return snapshotId;
     }
+
+    @Override
+    public void applyTo(TableMetadata.Builder metadataBuilder) {
+      metadataBuilder.setBranchSnapshot(snapshotId, name);
+    }
   }
 
   class SetProperties implements MetadataUpdate {
@@ -192,6 +256,11 @@ public interface MetadataUpdate extends Serializable {
 
     public Map<String, String> updated() {
       return updated;
+    }
+
+    @Override
+    public void applyTo(TableMetadata.Builder metadataBuilder) {
+      metadataBuilder.setProperties(updated);
     }
   }
 
@@ -205,6 +274,11 @@ public interface MetadataUpdate extends Serializable {
     public Set<String> removed() {
       return removed;
     }
+
+    @Override
+    public void applyTo(TableMetadata.Builder metadataBuilder) {
+      metadataBuilder.removeProperties(removed);
+    }
   }
 
   class SetLocation implements MetadataUpdate {
@@ -216,6 +290,11 @@ public interface MetadataUpdate extends Serializable {
 
     public String location() {
       return location;
+    }
+
+    @Override
+    public void applyTo(TableMetadata.Builder metadataBuilder) {
+      metadataBuilder.setLocation(location);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -409,7 +409,7 @@ public class TableMetadata implements Serializable {
     return specsById;
   }
 
-  int lastAssignedPartitionId() {
+  public int lastAssignedPartitionId() {
     return lastAssignedPartitionId;
   }
 
@@ -1146,6 +1146,7 @@ public class TableMetadata implements Serializable {
       boolean schemaFound = schemasById.containsKey(newSchemaId);
       if (schemaFound && newLastColumnId == lastColumnId) {
         // the new spec and last column id is already current and no change is needed
+        this.lastAddedSchemaId = newSchemaId;
         return newSchemaId;
       }
 
@@ -1186,6 +1187,7 @@ public class TableMetadata implements Serializable {
     private int addPartitionSpecInternal(PartitionSpec spec) {
       int newSpecId = reuseOrCreateNewSpecId(spec);
       if (specsById.containsKey(newSpecId)) {
+        this.lastAddedSpecId = newSpecId;
         return newSpecId;
       }
 
@@ -1223,6 +1225,7 @@ public class TableMetadata implements Serializable {
     private int addSortOrderInternal(SortOrder order) {
       int newOrderId = reuseOrCreateNewSortOrderId(order);
       if (sortOrdersById.containsKey(newOrderId)) {
+        this.lastAddedOrderId = newOrderId;
         return newOrderId;
       }
 

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg;
 
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -28,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
@@ -755,6 +757,7 @@ public class TableMetadata implements Serializable {
 
   public static class Builder {
     private final TableMetadata base;
+    private String metadataLocation;
     private int formatVersion;
     private String uuid;
     private Long lastUpdatedMillis;
@@ -771,12 +774,15 @@ public class TableMetadata implements Serializable {
     private final Map<String, String> properties;
     private long currentSnapshotId;
     private List<Snapshot> snapshots;
-    private Map<String, SnapshotRef> refs;
+    private final Map<String, SnapshotRef> refs;
 
     // change tracking
     private final List<MetadataUpdate> changes;
     private final int startingChangeCount;
     private boolean discardChanges = false;
+    private Integer lastAddedSchemaId = null;
+    private Integer lastAddedSpecId = null;
+    private Integer lastAddedOrderId = null;
 
     // handled in build
     private final List<HistoryEntry> snapshotLog;
@@ -821,6 +827,12 @@ public class TableMetadata implements Serializable {
       this.sortOrdersById = Maps.newHashMap(base.sortOrdersById);
     }
 
+    public Builder withMetadataLocation(String location) {
+      this.metadataLocation = location;
+      this.discardChanges = true;
+      return this;
+    }
+
     public Builder assignUUID() {
       if (uuid == null) {
         this.uuid = UUID.randomUUID().toString();
@@ -853,6 +865,12 @@ public class TableMetadata implements Serializable {
     }
 
     public Builder setCurrentSchema(int schemaId) {
+      if (schemaId == -1) {
+        ValidationException.check(lastAddedSchemaId != null,
+            "Cannot set last added schema: no schema has been added");
+        return setCurrentSchema(lastAddedSchemaId);
+      }
+
       if (currentSchemaId == schemaId) {
         return this;
       }
@@ -873,12 +891,18 @@ public class TableMetadata implements Serializable {
 
       this.currentSchemaId = schemaId;
 
-      changes.add(new MetadataUpdate.SetCurrentSchema(schemaId));
+      if (lastAddedSchemaId != null && lastAddedSchemaId == schemaId) {
+        // use -1 to signal that current was set to the last added schema
+        changes.add(new MetadataUpdate.SetCurrentSchema(-1));
+      } else {
+        changes.add(new MetadataUpdate.SetCurrentSchema(schemaId));
+      }
 
       return this;
     }
 
     public Builder addSchema(Schema schema, int newLastColumnId) {
+      // TODO: remove requirement for newLastColumnId
       addSchemaInternal(schema, newLastColumnId);
       return this;
     }
@@ -889,13 +913,23 @@ public class TableMetadata implements Serializable {
     }
 
     public Builder setDefaultPartitionSpec(int specId) {
+      if (specId == -1) {
+        ValidationException.check(lastAddedSpecId != null, "Cannot set last added spec: no spec has been added");
+        return setDefaultPartitionSpec(lastAddedSpecId);
+      }
+
       if (defaultSpecId == specId) {
         // the new spec is already current and no change is needed
         return this;
       }
 
       this.defaultSpecId = specId;
-      changes.add(new MetadataUpdate.SetDefaultPartitionSpec(specId));
+      if (lastAddedSpecId != null && lastAddedSpecId == specId) {
+        // use -1 to signal that current was set to the last added schema
+        changes.add(new MetadataUpdate.SetDefaultPartitionSpec(-1));
+      } else {
+        changes.add(new MetadataUpdate.SetDefaultPartitionSpec(specId));
+      }
 
       return this;
     }
@@ -911,12 +945,23 @@ public class TableMetadata implements Serializable {
     }
 
     public Builder setDefaultSortOrder(int sortOrderId) {
+      if (sortOrderId == -1) {
+        ValidationException.check(lastAddedOrderId != null,
+            "Cannot set last added sort order: no sort order has been added");
+        return setDefaultSortOrder(lastAddedOrderId);
+      }
+
       if (sortOrderId == defaultSortOrderId) {
         return this;
       }
 
       this.defaultSortOrderId = sortOrderId;
-      changes.add(new MetadataUpdate.SetDefaultSortOrder(sortOrderId));
+      if (lastAddedOrderId != null && lastAddedOrderId == sortOrderId) {
+        // use -1 to signal that current was set to the last added schema
+        changes.add(new MetadataUpdate.SetDefaultSortOrder(-1));
+      } else {
+        changes.add(new MetadataUpdate.SetDefaultSortOrder(sortOrderId));
+      }
 
       return this;
     }
@@ -947,7 +992,7 @@ public class TableMetadata implements Serializable {
 
     public Builder setBranchSnapshot(Snapshot snapshot, String branch) {
       addSnapshot(snapshot);
-      setBranchSnapshot(snapshot, branch, null);
+      setBranchSnapshotInternal(snapshot, branch);
       return this;
     }
 
@@ -961,7 +1006,7 @@ public class TableMetadata implements Serializable {
       Snapshot snapshot = snapshotsById.get(snapshotId);
       ValidationException.check(snapshot != null, "Cannot set %s to unknown snapshot: %s", branch, snapshotId);
 
-      setBranchSnapshot(snapshot, branch, System.currentTimeMillis());
+      setBranchSnapshotInternal(snapshot, branch);
 
       return this;
     }
@@ -983,7 +1028,10 @@ public class TableMetadata implements Serializable {
 
     public Builder removeSnapshots(List<Snapshot> snapshotsToRemove) {
       Set<Long> idsToRemove = snapshotsToRemove.stream().map(Snapshot::snapshotId).collect(Collectors.toSet());
+      return removeSnapshots(idsToRemove);
+    }
 
+    public Builder removeSnapshots(Collection<Long> idsToRemove) {
       List<Snapshot> retainedSnapshots = Lists.newArrayListWithExpectedSize(snapshots.size() - idsToRemove.size());
       for (Snapshot snapshot : snapshots) {
         long snapshotId = snapshot.snapshotId();
@@ -1066,7 +1114,7 @@ public class TableMetadata implements Serializable {
       List<HistoryEntry> newSnapshotLog = updateSnapshotLog(snapshotLog, snapshotsById, currentSnapshotId, changes);
 
       return new TableMetadata(
-          null,
+          metadataLocation,
           formatVersion,
           uuid,
           location,
@@ -1117,6 +1165,8 @@ public class TableMetadata implements Serializable {
 
       changes.add(new MetadataUpdate.AddSchema(newSchema, lastColumnId));
 
+      this.lastAddedSchemaId = newSchemaId;
+
       return newSchemaId;
     }
 
@@ -1150,6 +1200,8 @@ public class TableMetadata implements Serializable {
       specsById.put(newSpecId, newSpec);
 
       changes.add(new MetadataUpdate.AddPartitionSpec(newSpec));
+
+      this.lastAddedSpecId = newSpecId;
 
       return newSpecId;
     }
@@ -1190,6 +1242,8 @@ public class TableMetadata implements Serializable {
 
       changes.add(new MetadataUpdate.AddSortOrder(newOrder));
 
+      this.lastAddedOrderId = newOrderId;
+
       return newOrderId;
     }
 
@@ -1211,7 +1265,7 @@ public class TableMetadata implements Serializable {
       return newOrderId;
     }
 
-    private void setBranchSnapshot(Snapshot snapshot, String branch, Long currentTimestampMillis) {
+    private void setBranchSnapshotInternal(Snapshot snapshot, String branch) {
       long replacementSnapshotId = snapshot.snapshotId();
       SnapshotRef ref = refs.get(branch);
       if (ref != null) {
@@ -1225,7 +1279,9 @@ public class TableMetadata implements Serializable {
           "Last sequence number %s is less than existing snapshot sequence number %s",
           lastSequenceNumber, snapshot.sequenceNumber());
 
-      this.lastUpdatedMillis = currentTimestampMillis != null ? currentTimestampMillis : snapshot.timestampMillis();
+      // if the snapshot was added in this change set, use its timestamp
+      this.lastUpdatedMillis = isAddedSnapshot(snapshot.snapshotId()) ?
+          snapshot.timestampMillis() : System.currentTimeMillis();
 
       if (SnapshotRef.MAIN_BRANCH.equals(branch)) {
         this.currentSnapshotId = replacementSnapshotId;
@@ -1327,6 +1383,17 @@ public class TableMetadata implements Serializable {
       }
 
       return newSnapshotLog;
+    }
+
+    private boolean isAddedSnapshot(long snapshotId) {
+      return changes(MetadataUpdate.AddSnapshot.class)
+          .anyMatch(add -> add.snapshot().snapshotId() == snapshotId);
+    }
+
+    private <U extends MetadataUpdate> Stream<U> changes(Class<U> updateClass) {
+      return changes.stream()
+          .filter(updateClass::isInstance)
+          .map(updateClass::cast);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcTableOperations.java
@@ -94,7 +94,7 @@ class JdbcTableOperations extends BaseMetastoreTableOperations {
     try {
       Map<String, String> table = getTable();
 
-      if (!table.isEmpty()) {
+      if (base != null) {
         validateMetadataLocation(table, base);
         String oldMetadataLocation = base.metadataFileLocation();
         // Start atomic update
@@ -123,6 +123,9 @@ class JdbcTableOperations extends BaseMetastoreTableOperations {
     } catch (SQLWarning e) {
       throw new UncheckedSQLException(e, "Database warning");
     } catch (SQLException e) {
+      if (e.getMessage().contains("constraint failed")) {
+        throw new CommitFailedException("Table already exists: %s", tableIdentifier);
+      }
       throw new UncheckedSQLException(e, "Unknown failure");
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -19,19 +19,29 @@
 
 package org.apache.iceberg.rest;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.BaseTransaction;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.Transaction;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
@@ -53,12 +63,23 @@ import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES_DEFAULT;
 import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT;
 
 public class CatalogHandlers {
+  private static Schema EMPTY_SCHEMA = new Schema();
+
   private CatalogHandlers() {
   }
 
   static class UnprocessableEntityException extends RuntimeException {
     public UnprocessableEntityException(Set<String> commonKeys) {
       super(String.format("Invalid namespace update, cannot set and remove keys: %s", commonKeys));
+    }
+  }
+
+  private static class ValidationFailureException extends RuntimeException {
+    CommitFailedException wrapped;
+
+    public ValidationFailureException(CommitFailedException cause) {
+      super(cause);
+      this.wrapped = cause;
     }
   }
 
@@ -131,6 +152,30 @@ public class CatalogHandlers {
     return ListTablesResponse.builder().addAll(idents).build();
   }
 
+  public static LoadTableResponse stageTableCreate(Catalog catalog, Namespace namespace, CreateTableRequest request) {
+    request.validate();
+
+    TableIdentifier ident = TableIdentifier.of(namespace, request.name());
+    if (catalog.tableExists(ident)) {
+      throw new AlreadyExistsException("Table already exists: %s", ident);
+    }
+
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("created-at", OffsetDateTime.now().toString());
+    properties.putAll(request.properties());
+
+    TableMetadata metadata = TableMetadata.newTableMetadata(
+        request.schema(),
+        request.spec() != null ? request.spec() : PartitionSpec.unpartitioned(),
+        request.writeOrder() != null ? request.writeOrder() : SortOrder.unsorted(),
+        request.location(),
+        properties);
+
+    return LoadTableResponse.builder()
+        .withTableMetadata(metadata)
+        .build();
+  }
+
   public static LoadTableResponse createTable(Catalog catalog, Namespace namespace, CreateTableRequest request) {
     request.validate();
 
@@ -168,65 +213,99 @@ public class CatalogHandlers {
     throw new IllegalStateException("Cannot wrap catalog that does not produce BaseTable");
   }
 
-  private static class ValidationFailureException extends RuntimeException {
-    CommitFailedException wrapped;
-
-    public ValidationFailureException(CommitFailedException cause) {
-      super(cause);
-      this.wrapped = cause;
-    }
-  }
-
   public static LoadTableResponse updateTable(Catalog catalog, TableIdentifier ident, UpdateTableRequest request) {
-    Table table = catalog.loadTable(ident);
-
-    if (table instanceof BaseTable) {
-      TableOperations ops = ((BaseTable) table).operations();
-
-      AtomicBoolean isRetry = new AtomicBoolean(false);
-      try {
-        Tasks.foreach(ops)
-            .retry(COMMIT_NUM_RETRIES_DEFAULT)
-            .exponentialBackoff(
-                COMMIT_MIN_RETRY_WAIT_MS_DEFAULT, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT,
-                COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT, 2.0 /* exponential */)
-            .onlyRetryOn(CommitFailedException.class)
-            .run(taskOps -> {
-              TableMetadata base = isRetry.get() ? taskOps.refresh() : taskOps.current();
-              isRetry.set(true);
-
-              // validate requirements
-              try {
-                request.requirements().forEach(requirement -> requirement.validate(base));
-              } catch (CommitFailedException e) {
-                // wrap and rethrow outside of tasks to avoid unnecessary retry
-                throw new ValidationFailureException(e);
-              }
-
-              // apply changes
-              TableMetadata.Builder metadataBuilder = TableMetadata.buildFrom(base);
-              request.updates().forEach(update -> update.applyTo(metadataBuilder));
-
-              TableMetadata updated = metadataBuilder.build();
-              if (updated.changes().isEmpty()) {
-                // do not commit if the metadata has not changed
-                return;
-              }
-
-              // commit
-              taskOps.commit(base, updated);
-            });
-
-      } catch (ValidationFailureException e) {
-        throw e.wrapped;
+    TableMetadata finalMetadata;
+    if (isCreate(request)) {
+      // this is a hacky way to get TableOperations for an uncommitted table
+      Transaction transaction = catalog.buildTable(ident, EMPTY_SCHEMA).createOrReplaceTransaction();
+      if (transaction instanceof BaseTransaction) {
+        BaseTransaction baseTransaction = (BaseTransaction) transaction;
+        finalMetadata = create(baseTransaction.underyingOps(), baseTransaction.startMetadata(), request);
+      } else {
+        throw new IllegalStateException("Cannot wrap catalog that does not produce BaseTransaction");
       }
 
-      return LoadTableResponse.builder()
-          .withTableMetadata(ops.current())
-          .build();
+    } else {
+      Table table = catalog.loadTable(ident);
+      if (table instanceof BaseTable) {
+        TableOperations ops = ((BaseTable) table).operations();
+        finalMetadata = commit(ops, request);
+      } else {
+        throw new IllegalStateException("Cannot wrap catalog that does not produce BaseTable");
+      }
     }
 
-    throw new IllegalStateException("Cannot wrap catalog that does not produce BaseTable");
+    return LoadTableResponse.builder()
+        .withTableMetadata(finalMetadata)
+        .build();
   }
 
+  private static boolean isCreate(UpdateTableRequest request) {
+    boolean isCreate = request.requirements().stream()
+        .anyMatch(UpdateTableRequest.UpdateRequirement.AssertTableDoesNotExist.class::isInstance);
+
+    if (isCreate) {
+      List<UpdateTableRequest.UpdateRequirement> invalidRequirements = request.requirements().stream()
+          .filter(req -> !(req instanceof UpdateTableRequest.UpdateRequirement.AssertTableDoesNotExist))
+          .collect(Collectors.toList());
+      Preconditions.checkArgument(invalidRequirements.isEmpty(),
+          "Invalid create requirements: %s", invalidRequirements);
+    }
+
+    return isCreate;
+  }
+
+  private static TableMetadata create(TableOperations ops, TableMetadata start, UpdateTableRequest request) {
+    TableMetadata.Builder builder = TableMetadata.buildFrom(start);
+
+    // the only valid requirement is that the table will be created
+    request.updates().forEach(update -> update.applyTo(builder));
+
+    // create transactions do not retry. if the table exists, retrying is not a solution
+    ops.commit(null, builder.build());
+
+    return ops.current();
+  }
+
+  private static TableMetadata commit(TableOperations ops, UpdateTableRequest request) {
+    AtomicBoolean isRetry = new AtomicBoolean(false);
+    try {
+      Tasks.foreach(ops)
+          .retry(COMMIT_NUM_RETRIES_DEFAULT)
+          .exponentialBackoff(
+              COMMIT_MIN_RETRY_WAIT_MS_DEFAULT, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT,
+              COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT, 2.0 /* exponential */)
+          .onlyRetryOn(CommitFailedException.class)
+          .run(taskOps -> {
+            TableMetadata base = isRetry.get() ? taskOps.refresh() : taskOps.current();
+            isRetry.set(true);
+
+            // validate requirements
+            try {
+              request.requirements().forEach(requirement -> requirement.validate(base));
+            } catch (CommitFailedException e) {
+              // wrap and rethrow outside of tasks to avoid unnecessary retry
+              throw new ValidationFailureException(e);
+            }
+
+            // apply changes
+            TableMetadata.Builder metadataBuilder = TableMetadata.buildFrom(base);
+            request.updates().forEach(update -> update.applyTo(metadataBuilder));
+
+            TableMetadata updated = metadataBuilder.build();
+            if (updated.changes().isEmpty()) {
+              // do not commit if the metadata has not changed
+              return;
+            }
+
+            // commit
+            taskOps.commit(base, updated);
+          });
+
+    } catch (ValidationFailureException e) {
+      throw e.wrapped;
+    }
+
+    return ops.current();
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.rest;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
+import org.apache.iceberg.rest.requests.CreateTableRequest;
+import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
+import org.apache.iceberg.rest.responses.CreateNamespaceResponse;
+import org.apache.iceberg.rest.responses.DropNamespaceResponse;
+import org.apache.iceberg.rest.responses.GetNamespaceResponse;
+import org.apache.iceberg.rest.responses.ListNamespacesResponse;
+import org.apache.iceberg.rest.responses.ListTablesResponse;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
+
+public class CatalogHandlers {
+  private CatalogHandlers() {
+  }
+
+  static class UnprocessableEntityException extends RuntimeException {
+    public UnprocessableEntityException(Set<String> commonKeys) {
+      super(String.format("Invalid namespace update, cannot set and remove keys: %s", commonKeys));
+    }
+  }
+
+  public static ListNamespacesResponse listNamespaces(SupportsNamespaces catalog, Namespace parent) {
+    List<Namespace> results;
+    if (parent.isEmpty()) {
+      results = catalog.listNamespaces();
+    } else {
+      results = catalog.listNamespaces(parent);
+    }
+
+    return ListNamespacesResponse.builder().addAll(results).build();
+  }
+
+  public static CreateNamespaceResponse createNamespace(SupportsNamespaces catalog, CreateNamespaceRequest request) {
+    Namespace namespace = request.namespace();
+    catalog.createNamespace(namespace, request.properties());
+    return CreateNamespaceResponse.builder()
+        .withNamespace(namespace)
+        .setProperties(catalog.loadNamespaceMetadata(namespace))
+        .build();
+  }
+
+  public static GetNamespaceResponse loadNamespace(SupportsNamespaces catalog, Namespace namespace) {
+    Map<String, String> properties = catalog.loadNamespaceMetadata(namespace);
+    return GetNamespaceResponse.builder()
+        .withNamespace(namespace)
+        .setProperties(properties)
+        .build();
+  }
+
+  public static DropNamespaceResponse dropNamespace(SupportsNamespaces catalog, Namespace namespace) {
+    boolean dropped = catalog.dropNamespace(namespace);
+    return DropNamespaceResponse.builder()
+        .dropped(dropped)
+        .build();
+  }
+
+  public static UpdateNamespacePropertiesResponse updateNamespaceProperties(
+      SupportsNamespaces catalog, Namespace namespace, UpdateNamespacePropertiesRequest request) {
+    Set<String> removals = Sets.newHashSet(request.removals());
+    Map<String, String> updates = request.updates();
+
+    Set<String> commonKeys = Sets.intersection(updates.keySet(), removals);
+    if (!commonKeys.isEmpty()) {
+      throw new UnprocessableEntityException(commonKeys);
+    }
+
+    Map<String, String> startProperties = catalog.loadNamespaceMetadata(namespace);
+    Set<String> missing = Sets.difference(removals, startProperties.keySet());
+
+    if (!updates.isEmpty()) {
+      catalog.setProperties(namespace, updates);
+    }
+
+    if (!removals.isEmpty()) {
+      // remove the original set just in case there was an update just after loading properties
+      catalog.removeProperties(namespace, removals);
+    }
+
+    return UpdateNamespacePropertiesResponse.builder()
+            .addMissing(missing)
+            .addUpdated(updates.keySet())
+            .addRemoved(Sets.difference(removals, missing))
+            .build();
+  }
+
+  public static ListTablesResponse listTables(Catalog catalog, Namespace namespace) {
+    List<TableIdentifier> idents = catalog.listTables(namespace);
+    return ListTablesResponse.builder().addAll(idents).build();
+  }
+
+  public static LoadTableResponse createTable(Catalog catalog, Namespace namespace, CreateTableRequest request) {
+    request.validate();
+
+    TableIdentifier ident = TableIdentifier.of(namespace, request.name());
+    Table table = catalog.buildTable(ident, request.schema())
+        .withLocation(request.location())
+        .withPartitionSpec(request.spec())
+        .withSortOrder(request.writeOrder())
+        .withProperties(request.properties())
+        .create();
+
+    if (table instanceof BaseTable) {
+      return LoadTableResponse.builder()
+          .withTableMetadata(((BaseTable) table).operations().current())
+          .build();
+    }
+
+    throw new IllegalStateException("Cannot wrap catalog that does not produce BaseTable");
+  }
+
+  public static LoadTableResponse loadTable(Catalog catalog, TableIdentifier ident) {
+    Table table = catalog.loadTable(ident);
+
+    if (table instanceof BaseTable) {
+      return LoadTableResponse.builder()
+          .withTableMetadata(((BaseTable) table).operations().current())
+          .build();
+    }
+
+    throw new IllegalStateException("Cannot wrap catalog that does not produce BaseTable");
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -1,15 +1,20 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.iceberg.rest;
@@ -17,23 +22,35 @@ package org.apache.iceberg.rest;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
 import org.apache.iceberg.rest.requests.CreateTableRequest;
 import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
+import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.rest.responses.CreateNamespaceResponse;
 import org.apache.iceberg.rest.responses.DropNamespaceResponse;
+import org.apache.iceberg.rest.responses.DropTableResponse;
 import org.apache.iceberg.rest.responses.GetNamespaceResponse;
 import org.apache.iceberg.rest.responses.ListNamespacesResponse;
 import org.apache.iceberg.rest.responses.ListTablesResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
+import org.apache.iceberg.util.Tasks;
+
+import static org.apache.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS_DEFAULT;
+import static org.apache.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS_DEFAULT;
+import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES_DEFAULT;
+import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT;
 
 public class CatalogHandlers {
   private CatalogHandlers() {
@@ -134,6 +151,11 @@ public class CatalogHandlers {
     throw new IllegalStateException("Cannot wrap catalog that does not produce BaseTable");
   }
 
+  public static DropTableResponse dropTable(Catalog catalog, TableIdentifier ident) {
+    boolean dropped = catalog.dropTable(ident);
+    return DropTableResponse.builder().dropped(dropped).build();
+  }
+
   public static LoadTableResponse loadTable(Catalog catalog, TableIdentifier ident) {
     Table table = catalog.loadTable(ident);
 
@@ -145,4 +167,66 @@ public class CatalogHandlers {
 
     throw new IllegalStateException("Cannot wrap catalog that does not produce BaseTable");
   }
+
+  private static class ValidationFailureException extends RuntimeException {
+    CommitFailedException wrapped;
+
+    public ValidationFailureException(CommitFailedException cause) {
+      super(cause);
+      this.wrapped = cause;
+    }
+  }
+
+  public static LoadTableResponse updateTable(Catalog catalog, TableIdentifier ident, UpdateTableRequest request) {
+    Table table = catalog.loadTable(ident);
+
+    if (table instanceof BaseTable) {
+      TableOperations ops = ((BaseTable) table).operations();
+
+      AtomicBoolean isRetry = new AtomicBoolean(false);
+      try {
+        Tasks.foreach(ops)
+            .retry(COMMIT_NUM_RETRIES_DEFAULT)
+            .exponentialBackoff(
+                COMMIT_MIN_RETRY_WAIT_MS_DEFAULT, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT,
+                COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT, 2.0 /* exponential */)
+            .onlyRetryOn(CommitFailedException.class)
+            .run(taskOps -> {
+              TableMetadata base = isRetry.get() ? taskOps.refresh() : taskOps.current();
+              isRetry.set(true);
+
+              // validate requirements
+              try {
+                request.requirements().forEach(requirement -> requirement.validate(base));
+              } catch (CommitFailedException e) {
+                // wrap and rethrow outside of tasks to avoid unnecessary retry
+                throw new ValidationFailureException(e);
+              }
+
+              // apply changes
+              TableMetadata.Builder metadataBuilder = TableMetadata.buildFrom(base);
+              request.updates().forEach(update -> update.applyTo(metadataBuilder));
+
+              TableMetadata updated = metadataBuilder.build();
+              if (updated.changes().isEmpty()) {
+                // do not commit if the metadata has not changed
+                return;
+              }
+
+              // commit
+              taskOps.commit(base, updated);
+            });
+
+      } catch (ValidationFailureException e) {
+        throw e.wrapped;
+      }
+
+      return LoadTableResponse.builder()
+          .withTableMetadata(ops.current())
+          .build();
+    }
+
+    throw new IllegalStateException("Cannot wrap catalog that does not produce BaseTable");
+  }
+
 }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java
@@ -1,0 +1,287 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.rest;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.Transaction;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
+import org.apache.iceberg.exceptions.NoSuchNamespaceException;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.LocationProvider;
+import org.apache.iceberg.relocated.com.google.common.base.Joiner;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
+import org.apache.iceberg.rest.requests.CreateTableRequest;
+import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
+import org.apache.iceberg.rest.responses.CreateNamespaceResponse;
+import org.apache.iceberg.rest.responses.DropNamespaceResponse;
+import org.apache.iceberg.rest.responses.GetNamespaceResponse;
+import org.apache.iceberg.rest.responses.ListNamespacesResponse;
+import org.apache.iceberg.rest.responses.ListTablesResponse;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
+
+public class RESTCatalog implements Catalog, SupportsNamespaces {
+  private static final Joiner NULL = Joiner.on('\0');
+  private final RESTClient client;
+  private String catalogName = null;
+
+  RESTCatalog(RESTClient client) {
+    this.client = client;
+  }
+
+  @Override
+  public void initialize(String name, Map<String, String> properties) {
+    this.catalogName = name;
+  }
+
+  @Override
+  public String name() {
+    return catalogName;
+  }
+
+  private String fullTableName(TableIdentifier ident) {
+    return String.format("%s.%s", catalogName, ident);
+  }
+
+  @Override
+  public List<TableIdentifier> listTables(Namespace namespace) {
+    String joined = NULL.join(namespace.levels());
+    // TODO: URL-encode joined and add tests for / in the namespace name
+    ListTablesResponse response = client
+        .get("v1/namespaces/" + joined + "/tables", ListTablesResponse.class, ErrorHandlers.namespaceErrorHandler());
+    return response.identifiers();
+  }
+
+  @Override
+  public boolean dropTable(TableIdentifier identifier, boolean purge) {
+    return false;
+  }
+
+  @Override
+  public void renameTable(TableIdentifier from, TableIdentifier to) {
+
+  }
+
+  @Override
+  public Table loadTable(TableIdentifier identifier) {
+    String joined = NULL.join(identifier.namespace().levels());
+    LoadTableResponse response = client.get(
+        "v1/namespaces/" + joined + "/tables/" + identifier.name(),
+        LoadTableResponse.class, ErrorHandlers.tableErrorHandler());
+
+    // TODO: implement initialize and fixup the name reported by the table
+    return new BaseTable(new RESTTableOperations(response.tableMetadata()), fullTableName(identifier));
+  }
+
+  @Override
+  public void createNamespace(Namespace namespace, Map<String, String> metadata) {
+    CreateNamespaceRequest request = CreateNamespaceRequest.builder()
+        .withNamespace(namespace)
+        .setProperties(metadata)
+        .build();
+
+    // for now, ignore the response because there is no way to return it
+    client.post("v1/namespaces", request, CreateNamespaceResponse.class, ErrorHandlers.namespaceErrorHandler());
+  }
+
+  @Override
+  public List<Namespace> listNamespaces(Namespace namespace) throws NoSuchNamespaceException {
+    Preconditions.checkArgument(namespace.isEmpty(), "Cannot list namespaces under parent: %s", namespace);
+    // String joined = NULL.join(namespace.levels());
+    ListNamespacesResponse response = client
+        .get("v1/namespaces", ListNamespacesResponse.class, ErrorHandlers.namespaceErrorHandler());
+    return response.namespaces();
+  }
+
+  @Override
+  public Map<String, String> loadNamespaceMetadata(Namespace namespace) throws NoSuchNamespaceException {
+    String joined = NULL.join(namespace.levels());
+    // TODO: rename to LoadNamespaceResponse?
+    GetNamespaceResponse response = client
+        .get("v1/namespaces/" + joined, GetNamespaceResponse.class, ErrorHandlers.namespaceErrorHandler());
+    return response.properties();
+  }
+
+  @Override
+  public boolean dropNamespace(Namespace namespace) throws NamespaceNotEmptyException {
+    String joined = NULL.join(namespace.levels());
+    DropNamespaceResponse response = client
+        .delete("v1/namespaces/" + joined, DropNamespaceResponse.class, ErrorHandlers.namespaceErrorHandler());
+    return response.isDropped();
+  }
+
+  @Override
+  public boolean setProperties(Namespace namespace, Map<String, String> properties) throws NoSuchNamespaceException {
+    String joined = NULL.join(namespace.levels());
+    UpdateNamespacePropertiesRequest request = UpdateNamespacePropertiesRequest.builder()
+        .updateAll(properties)
+        .build();
+
+    UpdateNamespacePropertiesResponse response = client.post(
+        "v1/namespaces/" + joined + "/properties", request, UpdateNamespacePropertiesResponse.class,
+        ErrorHandlers.namespaceErrorHandler());
+
+    return !response.updated().isEmpty();
+  }
+
+  @Override
+  public boolean removeProperties(Namespace namespace, Set<String> properties) throws NoSuchNamespaceException {
+    String joined = NULL.join(namespace.levels());
+    UpdateNamespacePropertiesRequest request = UpdateNamespacePropertiesRequest.builder()
+        .removeAll(properties)
+        .build();
+
+    UpdateNamespacePropertiesResponse response = client.post(
+        "v1/namespaces/" + joined + "/properties", request, UpdateNamespacePropertiesResponse.class,
+        ErrorHandlers.namespaceErrorHandler());
+
+    return !response.removed().isEmpty();
+  }
+
+  @Override
+  public TableBuilder buildTable(TableIdentifier identifier, Schema schema) {
+    return new Builder(identifier, schema);
+  }
+
+  private class Builder implements TableBuilder {
+    private final TableIdentifier ident;
+    private final Schema schema;
+    private final ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.builder();
+    private PartitionSpec spec = null;
+    private SortOrder writeOrder = null;
+    private String location = null;
+
+    private Builder(TableIdentifier ident, Schema schema) {
+      this.ident = ident;
+      this.schema = schema;
+    }
+
+    @Override
+    public TableBuilder withPartitionSpec(PartitionSpec tableSpec) {
+      this.spec = tableSpec;
+      return this;
+    }
+
+    @Override
+    public TableBuilder withSortOrder(SortOrder tableWriteOrder) {
+      this.writeOrder = tableWriteOrder;
+      return this;
+    }
+
+    @Override
+    public TableBuilder withLocation(String location) {
+      this.location = location;
+      return this;
+    }
+
+    @Override
+    public TableBuilder withProperties(Map<String, String> properties) {
+      this.propertiesBuilder.putAll(properties);
+      return this;
+    }
+
+    @Override
+    public TableBuilder withProperty(String key, String value) {
+      this.propertiesBuilder.put(key, value);
+      return this;
+    }
+
+    @Override
+    public Table create() {
+      String joined = NULL.join(ident.namespace().levels());
+      CreateTableRequest request = CreateTableRequest.builder()
+          .withName(ident.name())
+          .withSchema(schema)
+          .withPartitionSpec(spec)
+          .withWriteOrder(writeOrder)
+          .withLocation(location)
+          .setProperties(propertiesBuilder.build())
+          .build();
+
+      LoadTableResponse response = client.post(
+          "v1/namespaces/" + joined + "/tables", request, LoadTableResponse.class, ErrorHandlers.tableErrorHandler());
+
+      return new BaseTable(new RESTTableOperations(response.tableMetadata()), fullTableName(ident));
+    }
+
+    @Override
+    public Transaction createTransaction() {
+      throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public Transaction replaceTransaction() {
+      throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public Transaction createOrReplaceTransaction() {
+      throw new UnsupportedOperationException("Not implemented yet");
+    }
+  }
+
+  private static class RESTTableOperations implements TableOperations {
+    private final TableMetadata current;
+
+    private RESTTableOperations(TableMetadata current) {
+      this.current = current;
+    }
+
+    @Override
+    public TableMetadata current() {
+      return current;
+    }
+
+    @Override
+    public TableMetadata refresh() {
+      return current;
+    }
+
+    @Override
+    public void commit(TableMetadata base, TableMetadata metadata) {
+      throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public FileIO io() {
+      throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public String metadataFileLocation(String fileName) {
+      throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public LocationProvider locationProvider() {
+      throw new UnsupportedOperationException("Not implemented yet");
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -92,6 +92,7 @@ public class RESTCatalogAdapter implements RESTClient {
     UPDATE_NAMESPACE(HTTPMethod.POST, "v1/namespaces/{namespace}/properties"),
     LIST_TABLES(HTTPMethod.GET, "v1/namespaces/{namespace}/tables"),
     CREATE_TABLE(HTTPMethod.POST, "v1/namespaces/{namespace}/tables"),
+    STAGE_CREATE_TABLE(HTTPMethod.POST, "v1/namespaces/{namespace}/stageCreate"),
     LOAD_TABLE(HTTPMethod.GET, "v1/namespaces/{namespace}/tables/{table}"),
     UPDATE_TABLE(HTTPMethod.POST, "v1/namespaces/{namespace}/tables/{table}"),
     DROP_TABLE(HTTPMethod.DELETE, "v1/namespaces/{namespace}/tables/{table}");
@@ -199,6 +200,12 @@ public class RESTCatalogAdapter implements RESTClient {
         Namespace namespace = namespaceFromPathVars(vars);
         CreateTableRequest request = castRequest(CreateTableRequest.class, body);
         return castResponse(responseType, CatalogHandlers.createTable(catalog, namespace, request));
+      }
+
+      case STAGE_CREATE_TABLE: {
+        Namespace namespace = namespaceFromPathVars(vars);
+        CreateTableRequest request = castRequest(CreateTableRequest.class, body);
+        return castResponse(responseType, CatalogHandlers.stageTableCreate(catalog, namespace, request));
       }
 
       case DROP_TABLE: {

--- a/core/src/main/java/org/apache/iceberg/rest/RESTCatalogAdaptor.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTCatalogAdaptor.java
@@ -1,0 +1,340 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.rest;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.SupportsNamespaces;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
+import org.apache.iceberg.exceptions.ForbiddenException;
+import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
+import org.apache.iceberg.exceptions.NoSuchIcebergTableException;
+import org.apache.iceberg.exceptions.NoSuchNamespaceException;
+import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.exceptions.NotAuthorizedException;
+import org.apache.iceberg.exceptions.RESTException;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.base.Splitter;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
+import org.apache.iceberg.rest.requests.CreateTableRequest;
+import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.iceberg.util.Pair;
+
+/**
+ * Adaptor class to translate REST requests into {@link Catalog} API calls.
+ */
+public class RESTCatalogAdaptor implements RESTClient {
+  private static final Splitter SLASH = Splitter.on('/');
+  private static final Splitter NULL = Splitter.on('\0');
+
+  private static final Map<Class<? extends Exception>, Integer> EXCEPTION_ERROR_CODES = ImmutableMap
+      .<Class<? extends Exception>, Integer>builder()
+      .put(IllegalArgumentException.class, 400)
+      .put(ValidationException.class, 400)
+      .put(NamespaceNotEmptyException.class, 400) // TODO: should this be more specific?
+      .put(NotAuthorizedException.class, 401)
+      .put(ForbiddenException.class, 403)
+      .put(NoSuchNamespaceException.class, 404)
+      .put(NoSuchTableException.class, 404)
+      .put(NoSuchIcebergTableException.class, 404)
+      .put(UnsupportedOperationException.class, 406)
+      .put(AlreadyExistsException.class, 409)
+      .put(CommitFailedException.class, 409)
+      .put(CatalogHandlers.UnprocessableEntityException.class, 422)
+      .put(CommitStateUnknownException.class, 500)
+      .build();
+
+  private final Catalog catalog;
+  private final SupportsNamespaces asNamespaceCatalog;
+  private final Consumer<ErrorResponse> defaultErrorHandler;
+
+  public RESTCatalogAdaptor(Catalog catalog, Consumer<ErrorResponse> defaultErrorHandler) {
+    this.catalog = catalog;
+    this.asNamespaceCatalog = catalog instanceof SupportsNamespaces ? (SupportsNamespaces) catalog : null;
+    this.defaultErrorHandler = defaultErrorHandler;
+  }
+
+  private enum HTTPMethod {
+    GET,
+    HEAD,
+    POST,
+    DELETE
+  }
+
+  private enum Route {
+    CONFIG(HTTPMethod.GET, "v1/config"),
+    LIST_NAMESPACES(HTTPMethod.GET, "v1/namespaces"),
+    CREATE_NAMESPACE(HTTPMethod.POST, "v1/namespaces"),
+    LOAD_NAMESPACE(HTTPMethod.GET, "v1/namespaces/{namespace}"),
+    DROP_NAMESPACE(HTTPMethod.DELETE, "v1/namespaces/{namespace}"),
+    UPDATE_NAMESPACE(HTTPMethod.POST, "v1/namespaces/{namespace}/properties"),
+    LIST_TABLES(HTTPMethod.GET, "v1/namespaces/{namespace}/tables"),
+    CREATE_TABLE(HTTPMethod.POST, "v1/namespaces/{namespace}/tables"),
+    LOAD_TABLE(HTTPMethod.GET, "v1/namespaces/{namespace}/tables/{table}"),
+    UPDATE_TABLE(HTTPMethod.POST, "v1/namespaces/{namespace}/tables/{table}"),
+    DROP_TABLE(HTTPMethod.DELETE, "v1/namespaces/{namespace}/tables/{table}");
+
+    private final HTTPMethod method;
+    private final int requriedLength;
+    private final Map<Integer, String> requirements;
+    private final Map<Integer, String> variables;
+
+    Route(HTTPMethod method, String pattern) {
+      this.method = method;
+
+      // parse the pattern into requirements and variables
+      List<String> parts = SLASH.splitToList(pattern);
+      ImmutableMap.Builder<Integer, String> requirementsBuilder = ImmutableMap.builder();
+      ImmutableMap.Builder<Integer, String> variablesBuilder = ImmutableMap.builder();
+      for (int pos = 0; pos < parts.size(); pos += 1) {
+        String part = parts.get(pos);
+        if (part.startsWith("{") && part.endsWith("}")) {
+          variablesBuilder.put(pos, part.substring(1, part.length() - 1));
+        } else {
+          requirementsBuilder.put(pos, part);
+        }
+      }
+
+      this.requriedLength = parts.size();
+      this.requirements = requirementsBuilder.build();
+      this.variables = variablesBuilder.build();
+    }
+
+    private boolean matches(HTTPMethod requestMethod, List<String> requestPath) {
+      return method == requestMethod && requriedLength == requestPath.size() &&
+          requirements.entrySet().stream().allMatch(
+              requirement -> requirement.getValue().equalsIgnoreCase(requestPath.get(requirement.getKey())));
+    }
+
+    private Map<String, String> variables(List<String> requestPath) {
+      ImmutableMap.Builder<String, String> vars = ImmutableMap.builder();
+      variables.forEach((key, value) -> vars.put(value, requestPath.get(key)));
+      return vars.build();
+    }
+
+    public static Pair<Route, Map<String, String>> from(HTTPMethod method, String path) {
+      List<String> parts = SLASH.splitToList(path);
+      for (Route candidate : Route.values()) {
+        if (candidate.matches(method, parts)) {
+          return Pair.of(candidate, candidate.variables(parts));
+        }
+      }
+
+      return null;
+    }
+  }
+
+  public <T> T handleRequest(Route route, Map<String, String> vars, Object body, Class<T> responseType) {
+    switch (route) {
+      case CONFIG:
+        // TODO: use the correct response object
+        return castResponse(responseType, ImmutableMap.of());
+
+      case LIST_NAMESPACES:
+        if (asNamespaceCatalog != null) {
+          // TODO: support parent namespace from query params
+          return castResponse(responseType, CatalogHandlers.listNamespaces(asNamespaceCatalog, Namespace.empty()));
+        }
+        break;
+
+      case CREATE_NAMESPACE:
+        if (asNamespaceCatalog != null) {
+          CreateNamespaceRequest request = castRequest(CreateNamespaceRequest.class, body);
+          return castResponse(responseType, CatalogHandlers.createNamespace(asNamespaceCatalog, request));
+        }
+        break;
+
+      case LOAD_NAMESPACE:
+        if (asNamespaceCatalog != null) {
+          Namespace namespace = namespaceFromPathVars(vars);
+          return castResponse(responseType, CatalogHandlers.loadNamespace(asNamespaceCatalog, namespace));
+        }
+        break;
+
+      case DROP_NAMESPACE:
+        if (asNamespaceCatalog != null) {
+          Namespace namespace = namespaceFromPathVars(vars);
+          return castResponse(responseType, CatalogHandlers.dropNamespace(asNamespaceCatalog, namespace));
+        }
+        break;
+
+      case UPDATE_NAMESPACE:
+        if (asNamespaceCatalog != null) {
+          Namespace namespace = namespaceFromPathVars(vars);
+          UpdateNamespacePropertiesRequest request = castRequest(UpdateNamespacePropertiesRequest.class, body);
+          return castResponse(responseType,
+              CatalogHandlers.updateNamespaceProperties(asNamespaceCatalog, namespace, request));
+        }
+        break;
+
+      case LIST_TABLES: {
+        // TODO: how is the empty namespace passed?
+        Namespace namespace = namespaceFromPathVars(vars);
+        return castResponse(responseType, CatalogHandlers.listTables(catalog, namespace));
+      }
+
+      case CREATE_TABLE: {
+        Namespace namespace = namespaceFromPathVars(vars);
+        CreateTableRequest request = castRequest(CreateTableRequest.class, body);
+        return castResponse(responseType, CatalogHandlers.createTable(catalog, namespace, request));
+      }
+
+      case LOAD_TABLE: {
+        TableIdentifier ident = identFromPathVars(vars);
+        return castResponse(responseType, CatalogHandlers.loadTable(catalog, ident));
+      }
+
+      default:
+    }
+
+    return null; // will be converted to a 400
+  }
+
+  public <T> T execute(HTTPMethod method, String path, Object body, Class<T> responseType,
+                       Consumer<ErrorResponse> errorHandler) {
+    ErrorResponse.Builder errorBuilder = ErrorResponse.builder();
+    Pair<Route, Map<String, String>> routeAndVars = Route.from(method, path);
+    if (routeAndVars != null) {
+      try {
+        T response = handleRequest(routeAndVars.first(), routeAndVars.second(), body, responseType);
+        if (response != null) {
+          return response;
+        }
+
+        // TODO: should this be more specific and state that namespaces aren't supported?
+        // if a response was not returned, there was no handler for the route
+        errorBuilder
+            .responseCode(400)
+            .withType("BadRequestException")
+            .withMessage(String.format("No handler for request: %s %s", method, path));
+
+      } catch (RuntimeException e) {
+        configureResponseFromException(e, errorBuilder);
+      }
+
+    } else {
+      errorBuilder
+          .responseCode(400)
+          .withType("BadRequestException")
+          .withMessage(String.format("No route for request: %s %s", method, path));
+    }
+
+    ErrorResponse error = errorBuilder.build();
+    errorHandler.accept(error);
+
+    // if the error handler doesn't throw an exception, throw a generic one
+    throw new RESTException("Unhandled error: %s", error);
+  }
+
+  @Override
+  public <T> T delete(String path, Class<T> responseType, Consumer<ErrorResponse> errorHandler) {
+    return execute(HTTPMethod.DELETE, path, null, responseType, errorHandler);
+  }
+
+//  @Override
+//  public <T> T delete(String path, Class<T> responseType) {
+//    return execute(HTTPMethod.DELETE, path, null, responseType, defaultErrorHandler);
+//  }
+
+  @Override
+  public <T> T post(String path, Object body, Class<T> responseType, Consumer<ErrorResponse> errorHandler) {
+    return execute(HTTPMethod.POST, path, body, responseType, errorHandler);
+  }
+
+//  @Override
+//  public <T> T post(String path, Object body, Class<T> responseType) {
+//    return execute(HTTPMethod.POST, path, body, responseType, defaultErrorHandler);
+//  }
+
+  @Override
+  public <T> T get(String path, Class<T> responseType, Consumer<ErrorResponse> errorHandler) {
+    return execute(HTTPMethod.GET, path, null, responseType, errorHandler);
+  }
+
+//  @Override
+//  public <T> T get(String path, Class<T> responseType) {
+//    return execute(HTTPMethod.GET, path, null, responseType, defaultErrorHandler);
+//  }
+
+  @Override
+  public <T> T head(String path, Consumer<ErrorResponse> errorHandler) {
+    return execute(HTTPMethod.HEAD, path, null, null, errorHandler);
+  }
+
+//  @Override
+//  public <T> T head(String path) {
+//    return execute(HTTPMethod.HEAD, path, null, null, defaultErrorHandler);
+//  }
+
+  @Override
+  public void close() throws IOException {
+    if (catalog instanceof Closeable) {
+      ((Closeable) catalog).close();
+    }
+  }
+
+  private static class BadResponseType extends RuntimeException {
+    public BadResponseType(Class<?> responseType, Object response) {
+      super(String.format("Invalid response object, not a %s: %s", responseType.getName(), response));
+    }
+  }
+
+  private static class BadRequestType extends RuntimeException {
+    public BadRequestType(Class<?> requestType, Object request) {
+      super(String.format("Invalid request object, not a %s: %s", requestType.getName(), request));
+    }
+  }
+
+  public static <T> T castRequest(Class<T> requestType, Object request) {
+    if (requestType.isInstance(request)) {
+      return requestType.cast(request);
+    }
+
+    throw new BadRequestType(requestType, request);
+  }
+
+  public static <T> T castResponse(Class<T> responseType, Object response) {
+    if (responseType.isInstance(response)) {
+      return responseType.cast(response);
+    }
+
+    throw new BadResponseType(responseType, response);
+  }
+
+  public static void configureResponseFromException(Exception exc, ErrorResponse.Builder errorBuilder) {
+    errorBuilder
+        .responseCode(EXCEPTION_ERROR_CODES.getOrDefault(exc.getClass(), 500))
+        .withType(exc.getClass().getSimpleName())
+        .withMessage(exc.getMessage());
+  }
+
+  private static Namespace namespaceFromPathVars(Map<String, String> pathVars) {
+    return Namespace.of(NULL.splitToList(pathVars.get("namespace")).toArray(new String[0]));
+  }
+
+  private static TableIdentifier identFromPathVars(Map<String, String> pathVars) {
+    return TableIdentifier.of(namespaceFromPathVars(pathVars), pathVars.get("table"));
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Objects;
+import org.apache.iceberg.LocationProviders;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.LocationProvider;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.rest.requests.UpdateTableRequest;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+
+class RESTTableOperations implements TableOperations {
+  private static final String METADATA_FOLDER_NAME = "metadata";
+  private static final ObjectMapper MAPPER = new ObjectMapper(new JsonFactory());
+  static {
+    RESTSerializers.registerAll(MAPPER);
+  }
+
+  private final RESTClient client;
+  private final String path;
+  private final FileIO io;
+  private TableMetadata current;
+
+  RESTTableOperations(RESTClient client, String path, FileIO io, TableMetadata current) {
+    this.client = client;
+    this.path = path;
+    this.current = current;
+    this.io = io;
+  }
+
+  @Override
+  public TableMetadata current() {
+    return current;
+  }
+
+  @Override
+  public TableMetadata refresh() {
+    // TODO: what if config changes?
+    LoadTableResponse response = client.get(path, LoadTableResponse.class, ErrorHandlers.tableErrorHandler());
+    if (!Objects.equals(current.metadataFileLocation(), response.metadataLocation())) {
+      this.current = response.tableMetadata();
+    }
+
+    return current;
+  }
+
+  @Override
+  public void commit(TableMetadata base, TableMetadata metadata) {
+    // TODO: handle transactions
+    // REST validation for transactions can probably be done with requirements:
+    // Create table transaction: assert-table-not-exists
+    // Replace table transaction: assert-uuid-equals
+    // Create or replace transaction: no assert
+
+    Preconditions.checkState(base != null, "Invalid base metadata: null");
+
+    UpdateTableRequest.Builder requestBuilder = UpdateTableRequest.builderFor(base);
+    metadata.changes().forEach(requestBuilder::update);
+    UpdateTableRequest request = requestBuilder.build();
+
+    // the error handler will throw necessary exceptions like CommitFailedException and UnknownCommitStateException
+    // TODO: ensure that the HTTP client lib passes HTTP client errors to the error handler
+    LoadTableResponse response = client.post(
+        path, request, LoadTableResponse.class, ErrorHandlers.tableCommitHandler());
+
+    this.current = response.tableMetadata();
+  }
+
+  @Override
+  public FileIO io() {
+    return io;
+  }
+
+  private static String metadataFileLocation(TableMetadata metadata, String filename) {
+    String metadataLocation = metadata.properties()
+        .get(TableProperties.WRITE_METADATA_LOCATION);
+
+    if (metadataLocation != null) {
+      return String.format("%s/%s", metadataLocation, filename);
+    } else {
+      return String.format("%s/%s/%s", metadata.location(), METADATA_FOLDER_NAME, filename);
+    }
+  }
+
+  @Override
+  public String metadataFileLocation(String filename) {
+    return metadataFileLocation(current(), filename);
+  }
+
+  @Override
+  public LocationProvider locationProvider() {
+    return LocationProviders.locationsFor(current().location(), current().properties());
+  }
+
+  @Override
+  public TableOperations temp(TableMetadata uncommittedMetadata) {
+    return new TableOperations() {
+      @Override
+      public TableMetadata current() {
+        return uncommittedMetadata;
+      }
+
+      @Override
+      public TableMetadata refresh() {
+        throw new UnsupportedOperationException("Cannot call refresh on temporary table operations");
+      }
+
+      @Override
+      public void commit(TableMetadata base, TableMetadata metadata) {
+        throw new UnsupportedOperationException("Cannot call commit on temporary table operations");
+      }
+
+      @Override
+      public String metadataFileLocation(String fileName) {
+        return RESTTableOperations.metadataFileLocation(uncommittedMetadata, fileName);
+      }
+
+      @Override
+      public LocationProvider locationProvider() {
+        return LocationProviders.locationsFor(uncommittedMetadata.location(), uncommittedMetadata.properties());
+      }
+
+      @Override
+      public FileIO io() {
+        return RESTTableOperations.this.io();
+      }
+
+      @Override
+      public EncryptionManager encryption() {
+        return RESTTableOperations.this.encryption();
+      }
+
+      @Override
+      public long newSnapshotId() {
+        return RESTTableOperations.this.newSnapshotId();
+      }
+    };
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/requests/CreateTableRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/CreateTableRequest.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest.requests;
+
+import java.util.Map;
+import java.util.Objects;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+
+/**
+ * A REST request to create a namespace, with an optional set of properties.
+ */
+public class CreateTableRequest {
+
+  private String name;
+  private String location;
+  private Schema schema;
+  private PartitionSpec spec;
+  private SortOrder order;
+  private Map<String, String> properties;
+
+  public CreateTableRequest() {
+    // Needed for Jackson Deserialization.
+  }
+
+  private CreateTableRequest(String name, String location, Schema schema, PartitionSpec spec, SortOrder order,
+                             Map<String, String> properties) {
+    this.name = name;
+    this.location = location;
+    this.schema = schema;
+    this.spec = spec;
+    this.order = order;
+    this.properties = properties;
+    validate();
+  }
+
+  public CreateTableRequest validate() {
+    Preconditions.checkArgument(name != null, "Invalid table name: null");
+    Preconditions.checkArgument(schema != null, "Invalid schema: null");
+    return this;
+  }
+
+  public String name() {
+    return name;
+  }
+
+  public String location() {
+    return location;
+  }
+
+  public Schema schema() {
+    return schema;
+  }
+
+  public PartitionSpec spec() {
+    return spec;
+  }
+
+  public SortOrder writeOrder() {
+    return order;
+  }
+
+  public Map<String, String> properties() {
+    return properties != null ? properties : ImmutableMap.of();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("name", name)
+        .add("location", location)
+        .add("properties", properties)
+        .add("schema", schema)
+        .add("spec", spec)
+        .add("order", order)
+        .toString();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String name;
+    private String location;
+    private Schema schema;
+    private PartitionSpec spec;
+    private SortOrder order;
+    private final ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
+
+    private Builder() {
+    }
+
+    public Builder withName(String tableName) {
+      Preconditions.checkNotNull(tableName, "Invalid name: null");
+      this.name = tableName;
+      return this;
+    }
+
+    public Builder withLocation(String location) {
+      this.location = location;
+      return this;
+    }
+
+    public Builder setProperty(String name, String value) {
+      Preconditions.checkArgument(name != null, "Invalid property: null");
+      Preconditions.checkArgument(value != null, "Invalid value for property %s: null", name);
+      properties.put(name, value);
+      return this;
+    }
+
+    public Builder setProperties(Map<String, String> props) {
+      Preconditions.checkNotNull(props, "Invalid collection of properties: null");
+      Preconditions.checkArgument(!props.containsKey(null), "Invalid property: null");
+      Preconditions.checkArgument(!props.containsValue(null),
+          "Invalid value for properties %s: null", Maps.filterValues(props, Objects::isNull).keySet());
+      properties.putAll(props);
+      return this;
+    }
+
+    public Builder withSchema(Schema tableSchema) {
+      Preconditions.checkNotNull(tableSchema, "Invalid schema: null");
+      this.schema = tableSchema;
+      return this;
+    }
+
+    public Builder withPartitionSpec(PartitionSpec tableSpec) {
+      this.spec = tableSpec;
+      return this;
+    }
+
+    public Builder withWriteOrder(SortOrder writeOrder) {
+      this.order = writeOrder;
+      return this;
+    }
+
+    public CreateTableRequest build() {
+      return new CreateTableRequest(name, location, schema, spec, order, properties.build());
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateTableRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateTableRequest.java
@@ -1,0 +1,275 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest.requests;
+
+import java.util.List;
+import java.util.Set;
+import org.apache.commons.compress.utils.Lists;
+import org.apache.commons.compress.utils.Sets;
+import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+
+public class UpdateTableRequest {
+
+  private List<UpdateRequirement> requirements;
+  private List<MetadataUpdate> updates;
+
+  public UpdateTableRequest() {
+    // needed for Jackson deserialization
+  }
+
+  public UpdateTableRequest(List<UpdateRequirement> requirements, List<MetadataUpdate> updates) {
+    this.requirements = requirements;
+    this.updates = updates;
+  }
+
+  public List<UpdateRequirement> requirements() {
+    return requirements != null ? requirements : ImmutableList.of();
+  }
+
+  public List<MetadataUpdate> updates() {
+    return updates != null ? updates : ImmutableList.of();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("requirements", requirements)
+        .add("updates", updates)
+        .toString();
+  }
+
+  public static Builder builderFor(TableMetadata base) {
+    return new Builder(base);
+  }
+
+  public static class Builder {
+    private final TableMetadata base;
+    private final ImmutableList.Builder<UpdateRequirement> requirements = ImmutableList.builder();
+    private final List<MetadataUpdate> updates = Lists.newArrayList();
+    private final Set<String> changedRefs = Sets.newHashSet();
+    private boolean changedSchema = false;
+    private boolean changedSpec = false;
+    private boolean changedOrder = false;
+
+    public Builder(TableMetadata base) {
+      this.base = base;
+      requireTableUUID(base.uuid());
+    }
+
+
+    private Builder require(UpdateRequirement requirement) {
+      Preconditions.checkArgument(requirement != null, "Invalid requirement: null");
+      requirements.add(requirement);
+      return this;
+    }
+
+    private Builder requireTableUUID(String uuid) {
+      Preconditions.checkArgument(uuid != null, "Invalid required UUID: null");
+      return require(new UpdateRequirement.AssertTableUUID(uuid));
+    }
+
+    private Builder requireRefSnapshotId(String ref, Long snapshotId) {
+      return require(new UpdateRequirement.AssertRefSnapshotID(ref, snapshotId));
+    }
+
+    private Builder requireCurrentSchemaId(int schemaId) {
+      return require(new UpdateRequirement.AssertCurrentSchemaID(schemaId));
+    }
+
+    private Builder requireDefaultSpecId(int specId) {
+      return require(new UpdateRequirement.AssertDefaultSpecID(specId));
+    }
+
+    private Builder requireDefaultSortOrderId(int orderId) {
+      return require(new UpdateRequirement.AssertDefaultSortOrderID(orderId));
+    }
+
+    public Builder update(MetadataUpdate update) {
+      Preconditions.checkArgument(update != null, "Invalid update: null");
+      updates.add(update);
+
+      // add requirements based on the change
+      if (update instanceof MetadataUpdate.SetSnapshotRef) {
+        // require that the ref is unchanged from the base
+        MetadataUpdate.SetSnapshotRef setRef = (MetadataUpdate.SetSnapshotRef) update;
+        String name = setRef.name();
+        // add returns true the first time the ref name is added
+        if (changedRefs.add(name)) {
+          SnapshotRef baseRef = base.ref(name);
+          // require that the ref does not exist (null) or is the same as the base snapshot
+          requireRefSnapshotId(name, baseRef != null ? baseRef.snapshotId() : null);
+        }
+
+      } else if (update instanceof MetadataUpdate.SetCurrentSchema) {
+        if (!changedSchema) {
+          // require that the current schema has not changed
+          requireCurrentSchemaId(base.currentSchemaId());
+          changedSchema = true;
+        }
+
+      } else if (update instanceof MetadataUpdate.SetDefaultPartitionSpec) {
+        if (!changedSpec) {
+          // require that the default spec has not changed
+          requireDefaultSpecId(base.defaultSpecId());
+          changedSpec = true;
+        }
+
+      } else if (update instanceof MetadataUpdate.SetDefaultSortOrder) {
+        if (!changedOrder) {
+          // require that the default write order has not changed
+          requireDefaultSortOrderId(base.defaultSortOrderId());
+          changedOrder = true;
+        }
+      }
+
+      return this;
+    }
+
+    public UpdateTableRequest build() {
+      return new UpdateTableRequest(requirements.build(), ImmutableList.copyOf(updates));
+    }
+  }
+
+  public interface UpdateRequirement {
+    void validate(TableMetadata base);
+
+    class AssertTableUUID implements UpdateRequirement {
+      private final String uuid;
+
+      private AssertTableUUID(String uuid) {
+        this.uuid = uuid;
+      }
+
+      public String uuid() {
+        return uuid;
+      }
+
+      @Override
+      public void validate(TableMetadata base) {
+        if (!uuid.equalsIgnoreCase(base.uuid())) {
+          throw new CommitFailedException("Requirement failed: UUID does not match (%s != %s)", base.uuid(), uuid);
+        }
+      }
+    }
+
+    class AssertRefSnapshotID implements UpdateRequirement {
+      private final String name;
+      private final Long snapshotId;
+
+      private AssertRefSnapshotID(String name, Long snapshotId) {
+        this.name = name;
+        this.snapshotId = snapshotId;
+      }
+
+      public String refName() {
+        return name;
+      }
+
+      public Long snapshotId() {
+        return snapshotId;
+      }
+
+      @Override
+      public void validate(TableMetadata base) {
+        SnapshotRef ref = base.ref(name);
+        if (ref != null) {
+          String type = ref.isBranch() ? "branch" : "tag";
+          if (snapshotId == null) {
+            // a null snapshot ID means the ref should not exist already
+            throw new CommitFailedException("Requirement failed: %s %s was created concurrently", type, name);
+          } else if (snapshotId != ref.snapshotId()) {
+            throw new CommitFailedException(
+                "Requirement failed: %s %s has changed (%s != %s)", type, name, snapshotId, ref.snapshotId());
+          }
+        } else if (snapshotId != null) {
+          throw new CommitFailedException(
+              "Requirement failed: branch or tag %s is missing, expected %s", name, snapshotId);
+        }
+      }
+    }
+
+    class AssertCurrentSchemaID implements UpdateRequirement {
+      private final int schemaId;
+
+      private AssertCurrentSchemaID(int schemaId) {
+        this.schemaId = schemaId;
+      }
+
+      public int schemaId() {
+        return schemaId;
+      }
+
+      @Override
+      public void validate(TableMetadata base) {
+        if (schemaId != base.currentSchemaId()) {
+          throw new CommitFailedException(
+              "Requirement failed: current schema changed (id %s != %s)", schemaId, base.currentSchemaId());
+        }
+      }
+    }
+
+    class AssertDefaultSpecID implements UpdateRequirement {
+      private final int specId;
+
+      private AssertDefaultSpecID(int specId) {
+        this.specId = specId;
+      }
+
+      public int specId() {
+        return specId;
+      }
+
+      @Override
+      public void validate(TableMetadata base) {
+        if (specId != base.defaultSpecId()) {
+          throw new CommitFailedException(
+              "Requirement failed: default partition spec changed (id %s != %s)", specId, base.defaultSpecId());
+        }
+      }
+    }
+
+    class AssertDefaultSortOrderID implements UpdateRequirement {
+      private final int sortOrderId;
+
+      private AssertDefaultSortOrderID(int sortOrderId) {
+        this.sortOrderId = sortOrderId;
+      }
+
+      public int sortOrderId() {
+        return sortOrderId;
+      }
+
+      @Override
+      public void validate(TableMetadata base) {
+        if (sortOrderId != base.defaultSortOrderId()) {
+          throw new CommitFailedException(
+              "Requirement failed: default sort order changed (id %s != %s)", sortOrderId, base.defaultSortOrderId());
+        }
+      }
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/DropTableResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/DropTableResponse.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest.responses;
+
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+/**
+ * Represents a REST response to drop a table.
+ */
+public class DropTableResponse {
+
+  // For Jackson to properly fail when deserializing, this needs to be boxed.
+  // Otherwise, the boolean is parsed according to "loose" javascript JSON rules.
+  private Boolean dropped;
+
+  public DropTableResponse() {
+    // Required for Jackson deserialization
+  }
+
+  private DropTableResponse(boolean dropped) {
+    this.dropped = dropped;
+    validate();
+  }
+
+  DropTableResponse validate() {
+    Preconditions.checkArgument(dropped != null, "Invalid response, missing field: dropped");
+    return this;
+  }
+
+  public boolean isDropped() {
+    return dropped;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("dropped", dropped)
+        .toString();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private Boolean dropped;
+
+    private Builder() {
+    }
+
+    public Builder dropped(boolean isDropped) {
+      this.dropped = isDropped;
+      return this;
+    }
+
+    public DropTableResponse build() {
+      Preconditions.checkArgument(dropped != null, "Invalid response, missing field: dropped");
+      return new DropTableResponse(dropped);
+    }
+  }
+}
+

--- a/core/src/main/java/org/apache/iceberg/rest/responses/LoadTableResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/LoadTableResponse.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.rest.responses;
 import java.util.Map;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
@@ -30,6 +31,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
  */
 public class LoadTableResponse {
 
+  private String metadataLocation;
   private TableMetadata meta;
   private Map<String, String> config;
 
@@ -37,13 +39,18 @@ public class LoadTableResponse {
     // Required for Jackson deserialization
   }
 
-  private LoadTableResponse(TableMetadata meta, Map<String, String> config) {
+  private LoadTableResponse(String metadataLocation, TableMetadata meta, Map<String, String> config) {
+    this.metadataLocation = metadataLocation;
     this.meta = meta;
     this.config = config;
   }
 
+  public String metadataLocation() {
+    return metadataLocation;
+  }
+
   public TableMetadata tableMetadata() {
-    return meta;
+    return TableMetadata.buildFrom(meta).withMetadataLocation(metadataLocation).build();
   }
 
   public Map<String, String> config() {
@@ -63,6 +70,7 @@ public class LoadTableResponse {
   }
   
   public static class Builder {
+    private String metadataLocation;
     private TableMetadata meta;
     private Map<String, String> config = Maps.newHashMap();
     
@@ -70,6 +78,7 @@ public class LoadTableResponse {
     }
 
     public Builder withTableMetadata(TableMetadata metadata) {
+      this.metadataLocation = metadata.metadataFileLocation();
       this.meta = metadata;
       return this;
     }
@@ -85,7 +94,8 @@ public class LoadTableResponse {
     }
 
     public LoadTableResponse build() {
-      return new LoadTableResponse(meta, config);
+      Preconditions.checkNotNull(meta, "Invalid metadata: null");
+      return new LoadTableResponse(metadataLocation, meta, config);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/responses/LoadTableResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/LoadTableResponse.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest.responses;
+
+import java.util.Map;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+
+/**
+ *
+ */
+public class LoadTableResponse {
+
+  private TableMetadata meta;
+  private Map<String, String> config;
+
+  public LoadTableResponse() {
+    // Required for Jackson deserialization
+  }
+
+  private LoadTableResponse(TableMetadata meta, Map<String, String> config) {
+    this.meta = meta;
+    this.config = config;
+  }
+
+  public TableMetadata tableMetadata() {
+    return meta;
+  }
+
+  public Map<String, String> config() {
+    return config != null ? config : ImmutableMap.of();
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("metadata", meta)
+        .add("config", config)
+        .toString();
+  }
+  
+  public static Builder builder() {
+    return new Builder();
+  }
+  
+  public static class Builder {
+    private TableMetadata meta;
+    private Map<String, String> config = Maps.newHashMap();
+    
+    private Builder() {
+    }
+
+    public Builder withTableMetadata(TableMetadata metadata) {
+      this.meta = metadata;
+      return this;
+    }
+
+    public Builder addConfig(String property, String value) {
+      config.put(property, value);
+      return this;
+    }
+
+    public Builder addAllConfig(Map<String, String> properties) {
+      config.putAll(properties);
+      return this;
+    }
+
+    public LoadTableResponse build() {
+      return new LoadTableResponse(meta, config);
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -36,9 +36,10 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
   @Before
   public void createCatalog() throws IOException {
     File warehouse = temp.newFolder();
+    Configuration conf = new Configuration();
 
     JdbcCatalog backendCatalog = new JdbcCatalog();
-    backendCatalog.setConf(new Configuration());
+    backendCatalog.setConf(conf);
     Map<String, String> backendCatalogProperties = ImmutableMap.of(
         CatalogProperties.WAREHOUSE_LOCATION, warehouse.getAbsolutePath(),
         CatalogProperties.URI, "jdbc:sqlite:file::memory:?ic" + UUID.randomUUID().toString().replace("-", ""),
@@ -46,9 +47,10 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
         JdbcCatalog.PROPERTY_PREFIX + "password", "password");
     backendCatalog.initialize("backend", backendCatalogProperties);
 
-    RESTCatalogAdaptor adaptor = new RESTCatalogAdaptor(backendCatalog, ErrorHandlers.defaultErrorHandler());
+    RESTCatalogAdapter adaptor = new RESTCatalogAdapter(backendCatalog, ErrorHandlers.defaultErrorHandler());
 
     this.restCatalog = new RESTCatalog(adaptor);
+    restCatalog.setConf(conf);
     restCatalog.initialize("prod", ImmutableMap.of());
   }
 
@@ -59,6 +61,11 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
 
   @Override
   protected boolean supportsNamespaceProperties() {
+    return true;
+  }
+
+  @Override
+  protected boolean supportsServerSideRetry() {
     return true;
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.rest;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.catalog.CatalogTests;
+import org.apache.iceberg.jdbc.JdbcCatalog;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  private RESTCatalog restCatalog;
+
+  @Before
+  public void createCatalog() throws IOException {
+    File warehouse = temp.newFolder();
+
+    JdbcCatalog backendCatalog = new JdbcCatalog();
+    backendCatalog.setConf(new Configuration());
+    Map<String, String> backendCatalogProperties = ImmutableMap.of(
+        CatalogProperties.WAREHOUSE_LOCATION, warehouse.getAbsolutePath(),
+        CatalogProperties.URI, "jdbc:sqlite:file::memory:?ic" + UUID.randomUUID().toString().replace("-", ""),
+        JdbcCatalog.PROPERTY_PREFIX + "username", "user",
+        JdbcCatalog.PROPERTY_PREFIX + "password", "password");
+    backendCatalog.initialize("backend", backendCatalogProperties);
+
+    RESTCatalogAdaptor adaptor = new RESTCatalogAdaptor(backendCatalog, ErrorHandlers.defaultErrorHandler());
+
+    this.restCatalog = new RESTCatalog(adaptor);
+    restCatalog.initialize("prod", ImmutableMap.of());
+  }
+
+  @Override
+  protected RESTCatalog catalog() {
+    return restCatalog;
+  }
+
+  @Override
+  protected boolean supportsNamespaceProperties() {
+    return true;
+  }
+}


### PR DESCRIPTION
This adds an implementation of `RESTClient` that translates REST protocol requests to the `Catalog` API. This makes it possible to test the `RESTCatalog` implementation like any other catalog. These tests do not exercise serialization; request and response objects are passed between methods directly.

* `RESTCatalogAdaptor` is a simple translation from `RESTClient` routes to catalog handlers
* `CatalogHandlers` accepts request objects, makes the appropriate calls to a catalog, and produces response objects
* `RESTCatalog` is a `Catalog` implementation that translates to calls to `RESTClient`
* `TestRESTCatalog` runs `CatalogTests` against the `RESTCatalog`

This also implements load table and update table routes, with new tests in `CatalogTests` that are passing for REST and JDBC.

To get tests working, this PR includes a few other changes and fixes:

* Adds `equals` to `CharSequenceSet` for assertions
* Updates `TableMetadataParser` to handle `refs`
* Supports `-1` to signal "last added" in schema, partition spec, and sort order changes
* Fixes `TableMetadata` history timestamps by detecting whether a snapshot was added
* Adds `applyTo(TableMetadata.Builder)` to `MetadataUpdate` to apply changes from the REST protocol on the server side
* Adds requirements classes and validations that are used server side to check the loaded metadata
