### PR TITLE
Add delete_files metadata table

### DIFF
--- a/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
@@ -118,7 +118,8 @@ public class AllDataFilesTable extends BaseMetadataTable {
       ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(filter);
 
       return CloseableIterable.transform(manifests, manifest ->
-          new DataFilesTable.ManifestReadTask(ops.io(), manifest, schema(), schemaString, specString, residuals));
+          new BaseFilesTable.ManifestReadTask(ops.io(), ops.current().specsById(), manifest, schema(),
+              schemaString, specString, residuals));
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
@@ -22,6 +22,7 @@ package org.apache.iceberg;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+import org.apache.iceberg.BaseFilesTable.ManifestReadTask;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
@@ -118,7 +119,7 @@ public class AllDataFilesTable extends BaseMetadataTable {
       ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(filter);
 
       return CloseableIterable.transform(manifests, manifest ->
-          new BaseFilesTable.ManifestReadTask(ops.io(), ops.current().specsById(), manifest, schema(),
+          new ManifestReadTask(ops.io(), ops.current().specsById(), manifest, schema(),
               schemaString, specString, residuals));
     }
   }

--- a/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
@@ -51,28 +51,31 @@ abstract class BaseFilesTable extends BaseMetadataTable {
 
   abstract static class BaseFilesTableScan extends BaseMetadataTableScan {
     private final Schema fileSchema;
+    private final MetadataTableType type;
 
-    protected BaseFilesTableScan(TableOperations ops, Table table, Schema fileSchema) {
+    protected BaseFilesTableScan(TableOperations ops, Table table, Schema fileSchema, MetadataTableType type) {
       super(ops, table, fileSchema);
       this.fileSchema = fileSchema;
+      this.type = type;
     }
 
     protected BaseFilesTableScan(TableOperations ops, Table table, Schema schema, Schema fileSchema,
-                           TableScanContext context) {
+                           TableScanContext context, MetadataTableType type) {
       super(ops, table, schema, context);
       this.fileSchema = fileSchema;
+      this.type = type;
     }
 
     @Override
     public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
       throw new UnsupportedOperationException(
-          String.format("Cannot incrementally scan table of type %s", MetadataTableType.FILES.name()));
+          String.format("Cannot incrementally scan table of type %s", type.name()));
     }
 
     @Override
     public TableScan appendsAfter(long fromSnapshotId) {
       throw new UnsupportedOperationException(
-          String.format("Cannot incrementally scan table of type %s", MetadataTableType.FILES.name()));
+          String.format("Cannot incrementally scan table of type %s", type.name()));
     }
 
     protected CloseableIterable<ManifestFile> filterManifests(List<ManifestFile> manifests,

--- a/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
@@ -89,8 +89,7 @@ abstract class BaseFilesTable extends BaseMetadataTable {
     }
 
     @Override
-    protected CloseableIterable<FileScanTask> planFiles(
-        TableOperations ops, Snapshot snapshot, Expression rowFilter,
+    protected CloseableIterable<FileScanTask> planFiles(TableOperations ops, Snapshot snapshot, Expression rowFilter,
         boolean ignoreResiduals, boolean caseSensitive, boolean colStats) {
       CloseableIterable<ManifestFile> filtered = filterManifests(manifests(), rowFilter, caseSensitive);
 

--- a/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.List;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.ManifestEvaluator;
+import org.apache.iceberg.expressions.Projections;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types.StructType;
+
+/**
+ * Base class logic for files metadata tables
+ */
+abstract class BaseFilesTable extends BaseMetadataTable {
+
+  BaseFilesTable(TableOperations ops, Table table, String name) {
+    super(ops, table, name);
+  }
+
+  @Override
+  public Schema schema() {
+    StructType partitionType = Partitioning.partitionType(table());
+    Schema schema = new Schema(DataFile.getType(partitionType).fields());
+    if (partitionType.fields().size() < 1) {
+      // avoid returning an empty struct, which is not always supported. instead, drop the partition field
+      return TypeUtil.selectNot(schema, Sets.newHashSet(DataFile.PARTITION_ID));
+    } else {
+      return schema;
+    }
+  }
+
+  abstract static class BaseFilesTableScan extends BaseMetadataTableScan {
+    private final Schema fileSchema;
+
+    protected BaseFilesTableScan(TableOperations ops, Table table, Schema fileSchema) {
+      super(ops, table, fileSchema);
+      this.fileSchema = fileSchema;
+    }
+
+    protected BaseFilesTableScan(TableOperations ops, Table table, Schema schema, Schema fileSchema,
+                           TableScanContext context) {
+      super(ops, table, schema, context);
+      this.fileSchema = fileSchema;
+    }
+
+    @Override
+    public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
+      throw new UnsupportedOperationException(
+          String.format("Cannot incrementally scan table of type %s", MetadataTableType.FILES.name()));
+    }
+
+    @Override
+    public TableScan appendsAfter(long fromSnapshotId) {
+      throw new UnsupportedOperationException(
+          String.format("Cannot incrementally scan table of type %s", MetadataTableType.FILES.name()));
+    }
+
+    protected CloseableIterable<ManifestFile> filterManifests(List<ManifestFile> manifests,
+                                                              Expression rowFilter,
+                                                              boolean caseSensitive) {
+      CloseableIterable<ManifestFile> manifestIterable = CloseableIterable.withNoopClose(manifests);
+
+      // use an inclusive projection to remove the partition name prefix and filter out any non-partition expressions
+      Expression partitionFilter = Projections
+          .inclusive(
+              transformSpec(fileSchema, table().spec(), PARTITION_FIELD_PREFIX),
+              caseSensitive)
+          .project(rowFilter);
+
+      ManifestEvaluator manifestEval = ManifestEvaluator.forPartitionFilter(
+          partitionFilter, table().spec(), caseSensitive);
+
+      return CloseableIterable.filter(manifestIterable, manifestEval::eval);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
@@ -55,7 +55,7 @@ abstract class BaseFilesTable extends BaseMetadataTable {
     }
   }
 
-  abstract static class BaseFilesTableScan extends BaseMetadataTableScan {
+  abstract static class BaseFilesTableScan<T extends BaseFile<?>> extends BaseMetadataTableScan {
     private final Schema fileSchema;
     private final MetadataTableType type;
 
@@ -104,7 +104,7 @@ abstract class BaseFilesTable extends BaseMetadataTable {
       // empty struct in the schema for unpartitioned tables. Some engines, like Spark, can't handle empty structs in
       // all cases.
       return CloseableIterable.transform(filtered, manifest ->
-          new ManifestReadTask(ops.io(), ops.current().specsById(),
+          new ManifestReadTask<T>(ops.io(), ops.current().specsById(),
               manifest, schema(), schemaString, specString, residuals));
     }
 
@@ -131,7 +131,7 @@ abstract class BaseFilesTable extends BaseMetadataTable {
     }
   }
 
-  static class ManifestReadTask extends BaseFileScanTask implements DataTask {
+  static class ManifestReadTask<T extends BaseFile<?>> extends BaseFileScanTask implements DataTask {
     private final FileIO io;
     private final Map<Integer, PartitionSpec> specsById;
     private final ManifestFile manifest;
@@ -148,7 +148,7 @@ abstract class BaseFilesTable extends BaseMetadataTable {
 
     @Override
     public CloseableIterable<StructLike> rows() {
-      return CloseableIterable.transform(manifestEntries(), file -> (GenericDeleteFile) file);
+      return CloseableIterable.transform(manifestEntries(), file -> (T) file);
     }
 
     private CloseableIterable<? extends ContentFile<?>> manifestEntries() {

--- a/core/src/main/java/org/apache/iceberg/DataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DataFilesTable.java
@@ -54,13 +54,13 @@ public class DataFilesTable extends BaseFilesTable {
     private final Schema fileSchema;
 
     DataFilesTableScan(TableOperations ops, Table table, Schema fileSchema) {
-      super(ops, table, fileSchema);
+      super(ops, table, fileSchema, MetadataTableType.FILES);
       this.fileSchema = fileSchema;
     }
 
     DataFilesTableScan(TableOperations ops, Table table, Schema schema, Schema fileSchema,
                            TableScanContext context) {
-      super(ops, table, schema, fileSchema, context);
+      super(ops, table, schema, fileSchema, context, MetadataTableType.FILES);
       this.fileSchema = fileSchema;
     }
 

--- a/core/src/main/java/org/apache/iceberg/DataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DataFilesTable.java
@@ -44,7 +44,7 @@ public class DataFilesTable extends BaseFilesTable {
     return MetadataTableType.FILES;
   }
 
-  public static class DataFilesTableScan extends BaseFilesTableScan {
+  public static class DataFilesTableScan extends BaseFilesTableScan<GenericDataFile> {
 
     DataFilesTableScan(TableOperations ops, Table table, Schema fileSchema) {
       super(ops, table, fileSchema, MetadataTableType.FILES);

--- a/core/src/main/java/org/apache/iceberg/DataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DataFilesTable.java
@@ -44,7 +44,7 @@ public class DataFilesTable extends BaseFilesTable {
     return MetadataTableType.FILES;
   }
 
-  public static class DataFilesTableScan extends BaseFilesTableScan<GenericDataFile> {
+  public static class DataFilesTableScan extends BaseFilesTableScan {
 
     DataFilesTableScan(TableOperations ops, Table table, Schema fileSchema) {
       super(ops, table, fileSchema, MetadataTableType.FILES);

--- a/core/src/main/java/org/apache/iceberg/DataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DataFilesTable.java
@@ -56,7 +56,7 @@ public class DataFilesTable extends BaseFilesTable {
 
     @Override
     protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      return new DataFilesTableScan(ops, table, schema, this.fileSchema(), context);
+      return new DataFilesTableScan(ops, table, schema, fileSchema(), context);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/DeleteFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFilesTable.java
@@ -55,13 +55,13 @@ public class DeleteFilesTable extends BaseFilesTable {
     private final Schema fileSchema;
 
     DeleteFilesTableScan(TableOperations ops, Table table, Schema fileSchema) {
-      super(ops, table, fileSchema);
+      super(ops, table, fileSchema, MetadataTableType.DELETE_FILES);
       this.fileSchema = fileSchema;
     }
 
     private DeleteFilesTableScan(TableOperations ops, Table table, Schema schema, Schema fileSchema,
                            TableScanContext context) {
-      super(ops, table, schema, fileSchema, context);
+      super(ops, table, schema, fileSchema, context, MetadataTableType.DELETE_FILES);
       this.fileSchema = fileSchema;
     }
 

--- a/core/src/main/java/org/apache/iceberg/DeleteFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFilesTable.java
@@ -44,14 +44,13 @@ public class DeleteFilesTable extends BaseFilesTable {
     return MetadataTableType.DELETE_FILES;
   }
 
-  public static class DeleteFilesTableScan extends BaseFilesTableScan<GenericDeleteFile> {
+  public static class DeleteFilesTableScan extends BaseFilesTableScan {
 
     DeleteFilesTableScan(TableOperations ops, Table table, Schema fileSchema) {
       super(ops, table, fileSchema, MetadataTableType.DELETE_FILES);
     }
 
-    private DeleteFilesTableScan(TableOperations ops, Table table, Schema schema, Schema fileSchema,
-                                 TableScanContext context) {
+    DeleteFilesTableScan(TableOperations ops, Table table, Schema schema, Schema fileSchema, TableScanContext context) {
       super(ops, table, schema, fileSchema, context, MetadataTableType.DELETE_FILES);
     }
 

--- a/core/src/main/java/org/apache/iceberg/DeleteFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFilesTable.java
@@ -44,7 +44,7 @@ public class DeleteFilesTable extends BaseFilesTable {
     return MetadataTableType.DELETE_FILES;
   }
 
-  public static class DeleteFilesTableScan extends BaseFilesTableScan {
+  public static class DeleteFilesTableScan extends BaseFilesTableScan<GenericDeleteFile> {
 
     DeleteFilesTableScan(TableOperations ops, Table table, Schema fileSchema) {
       super(ops, table, fileSchema, MetadataTableType.DELETE_FILES);

--- a/core/src/main/java/org/apache/iceberg/DeleteFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFilesTable.java
@@ -19,14 +19,7 @@
 
 package org.apache.iceberg;
 
-import java.util.Map;
-import org.apache.iceberg.expressions.Expression;
-import org.apache.iceberg.expressions.Expressions;
-import org.apache.iceberg.expressions.ResidualEvaluator;
-import org.apache.iceberg.io.CloseableIterable;
-import org.apache.iceberg.io.FileIO;
-import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import java.util.List;
 
 /**
  * A {@link Table} implementation that exposes a table's delete files as rows.
@@ -52,75 +45,24 @@ public class DeleteFilesTable extends BaseFilesTable {
   }
 
   public static class DeleteFilesTableScan extends BaseFilesTableScan {
-    private final Schema fileSchema;
 
     DeleteFilesTableScan(TableOperations ops, Table table, Schema fileSchema) {
       super(ops, table, fileSchema, MetadataTableType.DELETE_FILES);
-      this.fileSchema = fileSchema;
     }
 
     private DeleteFilesTableScan(TableOperations ops, Table table, Schema schema, Schema fileSchema,
-                           TableScanContext context) {
+                                 TableScanContext context) {
       super(ops, table, schema, fileSchema, context, MetadataTableType.DELETE_FILES);
-      this.fileSchema = fileSchema;
     }
 
     @Override
     protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      return new DeleteFilesTableScan(ops, table, schema, fileSchema, context);
+      return new DeleteFilesTableScan(ops, table, schema, fileSchema(), context);
     }
 
     @Override
-    protected CloseableIterable<FileScanTask> planFiles(
-        TableOperations ops, Snapshot snapshot, Expression rowFilter,
-        boolean ignoreResiduals, boolean caseSensitive, boolean colStats) {
-      CloseableIterable<ManifestFile> filtered = filterManifests(snapshot.deleteManifests(), rowFilter, caseSensitive);
-
-      String schemaString = SchemaParser.toJson(schema());
-      String specString = PartitionSpecParser.toJson(PartitionSpec.unpartitioned());
-      Expression filter = ignoreResiduals ? Expressions.alwaysTrue() : rowFilter;
-      ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(filter);
-
-      // Data tasks produce the table schema, not the projection schema and projection is done by processing engines.
-      // This data task needs to use the table schema, which may not include a partition schema to avoid having an
-      // empty struct in the schema for unpartitioned tables. Some engines, like Spark, can't handle empty structs in
-      // all cases.
-      return CloseableIterable.transform(filtered, manifest ->
-          new DeleteManifestReadTask(ops.io(), ops.current().specsById(),
-              manifest, schema(), schemaString, specString, residuals));
-    }
-  }
-
-  static class DeleteManifestReadTask extends BaseFileScanTask implements DataTask {
-    private final FileIO io;
-    private final Map<Integer, PartitionSpec> specsById;
-    private final ManifestFile manifest;
-    private final Schema schema;
-
-    DeleteManifestReadTask(FileIO io, Map<Integer, PartitionSpec> specsById, ManifestFile manifest,
-                           Schema schema, String schemaString, String specString, ResidualEvaluator residuals) {
-      super(DataFiles.fromManifest(manifest), null, schemaString, specString, residuals);
-      this.io = io;
-      this.specsById = specsById;
-      this.manifest = manifest;
-      this.schema = schema;
-    }
-
-    @Override
-    public CloseableIterable<StructLike> rows() {
-      return CloseableIterable.transform(
-          ManifestFiles.readDeleteManifest(manifest, io, specsById).project(schema),
-          file -> (GenericDeleteFile) file);
-    }
-
-    @Override
-    public Iterable<FileScanTask> split(long splitSize) {
-      return ImmutableList.of(this); // don't split
-    }
-
-    @VisibleForTesting
-    ManifestFile manifest() {
-      return manifest;
+    protected List<ManifestFile> manifests() {
+      return snapshot().deleteManifests();
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/MetadataTableType.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataTableType.java
@@ -24,6 +24,7 @@ import java.util.Locale;
 public enum MetadataTableType {
   ENTRIES,
   FILES,
+  DELETE_FILES,
   HISTORY,
   SNAPSHOTS,
   MANIFESTS,

--- a/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
@@ -55,6 +55,8 @@ public class MetadataTableUtils {
         return new ManifestEntriesTable(ops, baseTable, metadataTableName);
       case FILES:
         return new DataFilesTable(ops, baseTable, metadataTableName);
+      case DELETE_FILES:
+        return new DeleteFilesTable(ops, baseTable, metadataTableName);
       case HISTORY:
         return new HistoryTable(ops, baseTable, metadataTableName);
       case SNAPSHOTS:

--- a/core/src/test/java/org/apache/iceberg/TableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/TableTestBase.java
@@ -107,34 +107,24 @@ public class TableTestBase {
       .withPartitionPath("data_bucket=2") // easy way to set partition data for now
       .withRecordCount(1)
       .build();
+  static final DeleteFile FILE_C2_DELETES = FileMetadata.deleteFileBuilder(SPEC)
+      .ofEqualityDeletes(1)
+      .withPath("/path/to/data-c-deletes.parquet")
+      .withFileSizeInBytes(10)
+      .withPartitionPath("data_bucket=2") // easy way to set partition data for now
+      .withRecordCount(1)
+      .build();
   static final DataFile FILE_D = DataFiles.builder(SPEC)
       .withPath("/path/to/data-d.parquet")
       .withFileSizeInBytes(10)
       .withPartitionPath("data_bucket=3") // easy way to set partition data for now
       .withRecordCount(1)
       .build();
-  static final DataFile FILE_PARTITION_0 = DataFiles.builder(SPEC)
-      .withPath("/path/to/data-0.parquet")
+  static final DeleteFile FILE_D2_DELETES = FileMetadata.deleteFileBuilder(SPEC)
+      .ofEqualityDeletes(1)
+      .withPath("/path/to/data-d-deletes.parquet")
       .withFileSizeInBytes(10)
-      .withPartition(TestHelpers.Row.of(0))
-      .withRecordCount(1)
-      .build();
-  static final DataFile FILE_PARTITION_1 = DataFiles.builder(SPEC)
-      .withPath("/path/to/data-1.parquet")
-      .withFileSizeInBytes(10)
-      .withPartition(TestHelpers.Row.of(1))
-      .withRecordCount(1)
-      .build();
-  static final DataFile FILE_PARTITION_2 = DataFiles.builder(SPEC)
-      .withPath("/path/to/data-2.parquet")
-      .withFileSizeInBytes(10)
-      .withPartition(TestHelpers.Row.of(2))
-      .withRecordCount(1)
-      .build();
-  static final DataFile FILE_PARTITION_3 = DataFiles.builder(SPEC)
-      .withPath("/path/to/data-3.parquet")
-      .withFileSizeInBytes(10)
-      .withPartition(TestHelpers.Row.of(3))
+      .withPartitionPath("data_bucket=3") // easy way to set partition data for now
       .withRecordCount(1)
       .build();
   static final DataFile FILE_WITH_STATS = DataFiles.builder(SPEC)

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -495,10 +495,10 @@ public class TestMetadataTableScans extends TableTestBase {
     CloseableIterable<FileScanTask> tasksAndEq = scanNoFilter.planFiles();
 
     Assert.assertEquals(4, Iterables.size(tasksAndEq));
-    validateDeleteFileScanTasks(tasksAndEq, 0);
-    validateDeleteFileScanTasks(tasksAndEq, 1);
-    validateDeleteFileScanTasks(tasksAndEq, 2);
-    validateDeleteFileScanTasks(tasksAndEq, 3);
+    validateFileScanTasks(tasksAndEq, 0);
+    validateFileScanTasks(tasksAndEq, 1);
+    validateFileScanTasks(tasksAndEq, 2);
+    validateFileScanTasks(tasksAndEq, 3);
   }
 
   @Test
@@ -515,7 +515,7 @@ public class TestMetadataTableScans extends TableTestBase {
     TableScan scanAndEq = deleteFilesTable.newScan().filter(andEquals);
     CloseableIterable<FileScanTask> tasksAndEq = scanAndEq.planFiles();
     Assert.assertEquals(1, Iterables.size(tasksAndEq));
-    validateDeleteFileScanTasks(tasksAndEq, 0);
+    validateFileScanTasks(tasksAndEq, 0);
   }
 
   @Test
@@ -532,7 +532,7 @@ public class TestMetadataTableScans extends TableTestBase {
     TableScan scanAndEq = deleteFilesTable.newScan().filter(andEquals);
     CloseableIterable<CombinedScanTask> tasksAndEq = scanAndEq.planTasks();
     Assert.assertEquals(1, Iterables.size(tasksAndEq));
-    validateDeleteFilesCombinedScanTasks(tasksAndEq, 0);
+    validateCombinedScanTasks(tasksAndEq, 0);
   }
 
   @Test
@@ -547,8 +547,8 @@ public class TestMetadataTableScans extends TableTestBase {
     TableScan scan = deleteFilesTable.newScan().filter(lt);
     CloseableIterable<FileScanTask> tasksLt = scan.planFiles();
     Assert.assertEquals(2, Iterables.size(tasksLt));
-    validateDeleteFileScanTasks(tasksLt, 0);
-    validateDeleteFileScanTasks(tasksLt, 1);
+    validateFileScanTasks(tasksLt, 0);
+    validateFileScanTasks(tasksLt, 1);
   }
 
   @Test
@@ -566,10 +566,10 @@ public class TestMetadataTableScans extends TableTestBase {
         .filter(or);
     CloseableIterable<FileScanTask> tasksOr = scan.planFiles();
     Assert.assertEquals(4, Iterables.size(tasksOr));
-    validateDeleteFileScanTasks(tasksOr, 0);
-    validateDeleteFileScanTasks(tasksOr, 1);
-    validateDeleteFileScanTasks(tasksOr, 2);
-    validateDeleteFileScanTasks(tasksOr, 3);
+    validateFileScanTasks(tasksOr, 0);
+    validateFileScanTasks(tasksOr, 1);
+    validateFileScanTasks(tasksOr, 2);
+    validateFileScanTasks(tasksOr, 3);
   }
 
   @Test
@@ -602,8 +602,8 @@ public class TestMetadataTableScans extends TableTestBase {
     CloseableIterable<FileScanTask> tasksNot = scan.planFiles();
     Assert.assertEquals(2, Iterables.size(tasksNot));
 
-    validateDeleteFileScanTasks(tasksNot, 2);
-    validateDeleteFileScanTasks(tasksNot, 3);
+    validateFileScanTasks(tasksNot, 2);
+    validateFileScanTasks(tasksNot, 3);
   }
 
   @Test
@@ -619,10 +619,10 @@ public class TestMetadataTableScans extends TableTestBase {
     CloseableIterable<FileScanTask> tasksUnary = scan.planFiles();
     Assert.assertEquals(4, Iterables.size(tasksUnary));
 
-    validateDeleteFileScanTasks(tasksUnary, 0);
-    validateDeleteFileScanTasks(tasksUnary, 1);
-    validateDeleteFileScanTasks(tasksUnary, 2);
-    validateDeleteFileScanTasks(tasksUnary, 3);
+    validateFileScanTasks(tasksUnary, 0);
+    validateFileScanTasks(tasksUnary, 1);
+    validateFileScanTasks(tasksUnary, 2);
+    validateFileScanTasks(tasksUnary, 3);
   }
 
   @Test
@@ -791,28 +791,14 @@ public class TestMetadataTableScans extends TableTestBase {
   private void validateFileScanTasks(CloseableIterable<FileScanTask> fileScanTasks, int partValue) {
     Assert.assertTrue("File scan tasks do not include correct file",
         StreamSupport.stream(fileScanTasks.spliterator(), false).anyMatch(t -> {
-          ManifestFile mf = ((DataFilesTable.ManifestReadTask) t).manifest();
+          ManifestFile mf = ((BaseFilesTable.ManifestReadTask) t).manifest();
           return manifestHasPartition(mf, partValue);
         }));
   }
 
   private void validateCombinedScanTasks(CloseableIterable<CombinedScanTask> tasks, int partValue) {
     StreamSupport.stream(tasks.spliterator(), false)
-        .flatMap(c -> c.files().stream().map(t -> ((DataFilesTable.ManifestReadTask) t).manifest()))
-        .anyMatch(m -> manifestHasPartition(m, partValue));
-  }
-
-  private void validateDeleteFileScanTasks(CloseableIterable<FileScanTask> fileScanTasks, int partValue) {
-    Assert.assertTrue("File scan tasks do not include correct file",
-        StreamSupport.stream(fileScanTasks.spliterator(), false).anyMatch(t -> {
-          ManifestFile mf = ((DeleteFilesTable.DeleteManifestReadTask) t).manifest();
-          return manifestHasPartition(mf, partValue);
-        }));
-  }
-
-  private void validateDeleteFilesCombinedScanTasks(CloseableIterable<CombinedScanTask> tasks, int partValue) {
-    StreamSupport.stream(tasks.spliterator(), false)
-        .flatMap(c -> c.files().stream().map(t -> ((DeleteFilesTable.DeleteManifestReadTask) t).manifest()))
+        .flatMap(c -> c.files().stream().map(t -> ((BaseFilesTable.ManifestReadTask) t).manifest()))
         .anyMatch(m -> manifestHasPartition(m, partValue));
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -493,13 +493,13 @@ public class TestMetadataTableScans extends TableTestBase {
 
     TableScan scanNoFilter = deleteFilesTable.newScan().select("partition.data_bucket");
     Assert.assertEquals(expected, scanNoFilter.schema().asStruct());
-    CloseableIterable<FileScanTask> tasksAndEq = scanNoFilter.planFiles();
+    CloseableIterable<FileScanTask> tasks = scanNoFilter.planFiles();
 
-    Assert.assertEquals(4, Iterables.size(tasksAndEq));
-    validateFileScanTasks(tasksAndEq, 0);
-    validateFileScanTasks(tasksAndEq, 1);
-    validateFileScanTasks(tasksAndEq, 2);
-    validateFileScanTasks(tasksAndEq, 3);
+    Assert.assertEquals(4, Iterables.size(tasks));
+    validateFileScanTasks(tasks, 0);
+    validateFileScanTasks(tasks, 1);
+    validateFileScanTasks(tasks, 2);
+    validateFileScanTasks(tasks, 3);
   }
 
   @Test
@@ -513,10 +513,10 @@ public class TestMetadataTableScans extends TableTestBase {
     Expression andEquals = Expressions.and(
         Expressions.equal("partition.data_bucket", 0),
         Expressions.greaterThan("record_count", 0));
-    TableScan scanAndEq = deleteFilesTable.newScan().filter(andEquals);
-    CloseableIterable<FileScanTask> tasksAndEq = scanAndEq.planFiles();
-    Assert.assertEquals(1, Iterables.size(tasksAndEq));
-    validateFileScanTasks(tasksAndEq, 0);
+    TableScan scan = deleteFilesTable.newScan().filter(andEquals);
+    CloseableIterable<FileScanTask> tasks = scan.planFiles();
+    Assert.assertEquals(1, Iterables.size(tasks));
+    validateFileScanTasks(tasks, 0);
   }
 
   @Test
@@ -530,10 +530,10 @@ public class TestMetadataTableScans extends TableTestBase {
     Expression andEquals = Expressions.and(
         Expressions.equal("partition.data_bucket", 0),
         Expressions.greaterThan("record_count", 0));
-    TableScan scanAndEq = deleteFilesTable.newScan().filter(andEquals);
-    CloseableIterable<CombinedScanTask> tasksAndEq = scanAndEq.planTasks();
-    Assert.assertEquals(1, Iterables.size(tasksAndEq));
-    validateCombinedScanTasks(tasksAndEq, 0);
+    TableScan scan = deleteFilesTable.newScan().filter(andEquals);
+    CloseableIterable<CombinedScanTask> tasks = scan.planTasks();
+    Assert.assertEquals(1, Iterables.size(tasks));
+    validateCombinedScanTasks(tasks, 0);
   }
 
   @Test
@@ -600,11 +600,11 @@ public class TestMetadataTableScans extends TableTestBase {
     Expression set = Expressions.in("partition.data_bucket", 2, 3);
     TableScan scan = deleteFilesTable.newScan()
         .filter(set);
-    CloseableIterable<FileScanTask> tasksNot = scan.planFiles();
-    Assert.assertEquals(2, Iterables.size(tasksNot));
+    CloseableIterable<FileScanTask> tasksIn = scan.planFiles();
+    Assert.assertEquals(2, Iterables.size(tasksIn));
 
-    validateFileScanTasks(tasksNot, 2);
-    validateFileScanTasks(tasksNot, 3);
+    validateFileScanTasks(tasksIn, 2);
+    validateFileScanTasks(tasksIn, 3);
   }
 
   @Test
@@ -614,16 +614,16 @@ public class TestMetadataTableScans extends TableTestBase {
     preparePartitionedTable();
 
     Table deleteFilesTable = new DeleteFilesTable(table.ops(), table);
-    Expression unary = Expressions.notNull("partition.data_bucket");
+    Expression notNull = Expressions.notNull("partition.data_bucket");
     TableScan scan = deleteFilesTable.newScan()
-        .filter(unary);
-    CloseableIterable<FileScanTask> tasksUnary = scan.planFiles();
-    Assert.assertEquals(4, Iterables.size(tasksUnary));
+        .filter(notNull);
+    CloseableIterable<FileScanTask> tasksNotNull = scan.planFiles();
+    Assert.assertEquals(4, Iterables.size(tasksNotNull));
 
-    validateFileScanTasks(tasksUnary, 0);
-    validateFileScanTasks(tasksUnary, 1);
-    validateFileScanTasks(tasksUnary, 2);
-    validateFileScanTasks(tasksUnary, 3);
+    validateFileScanTasks(tasksNotNull, 0);
+    validateFileScanTasks(tasksNotNull, 1);
+    validateFileScanTasks(tasksNotNull, 2);
+    validateFileScanTasks(tasksNotNull, 3);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.StreamSupport;
+import org.apache.iceberg.BaseFilesTable.ManifestReadTask;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
@@ -791,14 +792,14 @@ public class TestMetadataTableScans extends TableTestBase {
   private void validateFileScanTasks(CloseableIterable<FileScanTask> fileScanTasks, int partValue) {
     Assert.assertTrue("File scan tasks do not include correct file",
         StreamSupport.stream(fileScanTasks.spliterator(), false).anyMatch(t -> {
-          ManifestFile mf = ((BaseFilesTable.ManifestReadTask) t).manifest();
+          ManifestFile mf = ((ManifestReadTask) t).manifest();
           return manifestHasPartition(mf, partValue);
         }));
   }
 
   private void validateCombinedScanTasks(CloseableIterable<CombinedScanTask> tasks, int partValue) {
     StreamSupport.stream(tasks.spliterator(), false)
-        .flatMap(c -> c.files().stream().map(t -> ((BaseFilesTable.ManifestReadTask) t).manifest()))
+        .flatMap(c -> c.files().stream().map(t -> ((ManifestReadTask) t).manifest()))
         .anyMatch(m -> manifestHasPartition(m, partValue));
   }
 

--- a/core/src/test/java/org/apache/iceberg/hadoop/HadoopTableTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/HadoopTableTestBase.java
@@ -30,6 +30,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileMetadata;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -86,6 +88,13 @@ public class HadoopTableTestBase {
       .withFileSizeInBytes(0)
       .withPartitionPath("data_bucket=1") // easy way to set partition data for now
       .withRecordCount(2) // needs at least one record or else metrics will filter it out
+      .build();
+  static final DeleteFile FILE_B_DELETES = FileMetadata.deleteFileBuilder(SPEC)
+      .ofPositionDeletes()
+      .withPath("/path/to/data-b-deletes.parquet")
+      .withFileSizeInBytes(0)
+      .withPartitionPath("data_bucket=1")
+      .withRecordCount(1)
       .build();
   static final DataFile FILE_C = DataFiles.builder(SPEC)
       .withPath("/path/to/data-a.parquet")

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestTableSerialization.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestTableSerialization.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.io.CloseableIterable;
@@ -120,6 +121,10 @@ public class TestTableSerialization extends HadoopTableTestBase {
 
   @Test
   public void testSerializableMetadataTablesPlanning() throws IOException {
+    table.updateProperties()
+        .set(TableProperties.FORMAT_VERSION, "2")
+        .commit();
+
     table.newAppend()
         .appendFile(FILE_A)
         .commit();
@@ -138,8 +143,12 @@ public class TestTableSerialization extends HadoopTableTestBase {
     table.newAppend()
         .appendFile(FILE_B)
         .commit();
+    table.newRowDelta()
+        .addDeletes(FILE_B_DELETES)
+        .commit();
 
     for (MetadataTableType type : MetadataTableType.values()) {
+
       // Collect the deserialized data
       Set<CharSequence> deserializedFiles = getFiles(deserializeFromBytes(serialized.get(type)));
 

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestTableSerialization.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestTableSerialization.java
@@ -148,7 +148,6 @@ public class TestTableSerialization extends HadoopTableTestBase {
         .commit();
 
     for (MetadataTableType type : MetadataTableType.values()) {
-
       // Collect the deserialized data
       Set<CharSequence> deserializedFiles = getFiles(deserializeFromBytes(serialized.get(type)));
 

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
@@ -77,7 +77,7 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     Schema entriesTableSchema = Spark3Util.loadIcebergTable(spark, tableName + ".entries").schema();
     Schema filesTableSchema = Spark3Util.loadIcebergTable(spark, tableName + ".delete_files").schema();
 
-    List<Row> actual = spark.sql("SELECT * FROM "+ tableName + ".delete_files").collectAsList();
+    List<Row> actual = spark.sql("SELECT * FROM " + tableName + ".delete_files").collectAsList();
 
     List<GenericData.Record> expected = expectedEntries(table, entriesTableSchema, expectedManifests, null);
 
@@ -120,7 +120,7 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     List<ManifestFile> expectedManifests = TestHelpers.deleteManifests(table);
     Assert.assertEquals("Should have 2 delete files", 2, expectedManifests.size());
 
-    List<Row> actual = spark.sql("SELECT * FROM "+ tableName + ".delete_files " +
+    List<Row> actual = spark.sql("SELECT * FROM " + tableName + ".delete_files " +
         "WHERE partition.data='a'").collectAsList();
 
     Schema entriesTableSchema = Spark3Util.loadIcebergTable(spark, tableName + ".entries").schema();

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.extensions;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.apache.avro.generic.GenericData;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.avro.Avro;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.Spark3Util;
+import org.apache.iceberg.spark.data.TestHelpers;
+import org.apache.iceberg.spark.source.SimpleRecord;
+import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.Row;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class TestMetadataTables extends SparkExtensionsTestBase {
+
+  public TestMetadataTables(String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
+  }
+
+  @After
+  public void removeTables() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @Test
+  public void testDeleteFilesTable() throws Exception {
+    sql("CREATE TABLE %s (id bigint, data string) USING iceberg TBLPROPERTIES" +
+        "('format-version'='2', 'write.delete.mode'='merge-on-read')", tableName);
+
+    List<SimpleRecord> records = Lists.newArrayList(
+        new SimpleRecord(1, "a"),
+        new SimpleRecord(2, "b"),
+        new SimpleRecord(3, "c"),
+        new SimpleRecord(4, "d")
+    );
+    spark.createDataset(records, Encoders.bean(SimpleRecord.class))
+        .coalesce(1)
+        .writeTo(tableName)
+        .append();
+
+    sql("DELETE FROM %s WHERE id=1", tableName);
+
+    Table table = Spark3Util.loadIcebergTable(spark, tableName);
+    List<ManifestFile> expectedManifests = TestHelpers.deleteManifests(table);
+    Assert.assertEquals("Should have 1 delete file", 1, expectedManifests.size());
+
+    Schema entriesTableSchema = Spark3Util.loadIcebergTable(spark, tableName + ".entries").schema();
+    Schema filesTableSchema = Spark3Util.loadIcebergTable(spark, tableName + ".delete_files").schema();
+
+    List<Row> actual = spark.sql("SELECT * FROM "+ tableName + ".delete_files").collectAsList();
+
+    List<GenericData.Record> expected = expectedEntries(table, entriesTableSchema, expectedManifests, null);
+
+    Assert.assertEquals("Should be one delete file manifest entry", 1, expected.size());
+    Assert.assertEquals("Metadata table should return one delete file", 1, actual.size());
+
+    TestHelpers.assertEqualsSafe(filesTableSchema.asStruct(), expected.get(0), actual.get(0));
+  }
+
+  @Test
+  public void testDeleteFilesTablePartitioned() throws Exception {
+    sql("CREATE TABLE %s (id bigint, data string) " +
+        "USING iceberg " +
+        "PARTITIONED BY (data) " +
+        "TBLPROPERTIES" +
+        "('format-version'='2', 'write.delete.mode'='merge-on-read')", tableName);
+
+    List<SimpleRecord> recordsA = Lists.newArrayList(
+        new SimpleRecord(1, "a"),
+        new SimpleRecord(2, "a")
+    );
+    spark.createDataset(recordsA, Encoders.bean(SimpleRecord.class))
+        .coalesce(1)
+        .writeTo(tableName)
+        .append();
+
+    List<SimpleRecord> recordsB = Lists.newArrayList(
+        new SimpleRecord(1, "b"),
+        new SimpleRecord(2, "b")
+        );
+    spark.createDataset(recordsB, Encoders.bean(SimpleRecord.class))
+        .coalesce(1)
+        .writeTo(tableName)
+        .append();
+
+    sql("DELETE FROM %s WHERE id=1 AND data='a'", tableName);
+    sql("DELETE FROM %s WHERE id=1 AND data='b'", tableName);
+
+    Table table = Spark3Util.loadIcebergTable(spark, tableName);
+    List<ManifestFile> expectedManifests = TestHelpers.deleteManifests(table);
+    Assert.assertEquals("Should have 2 delete files", 2, expectedManifests.size());
+
+    List<Row> actual = spark.sql("SELECT * FROM "+ tableName + ".delete_files " +
+        "WHERE partition.data='a'").collectAsList();
+
+    Schema entriesTableSchema = Spark3Util.loadIcebergTable(spark, tableName + ".entries").schema();
+    Schema filesTableSchema = Spark3Util.loadIcebergTable(spark, tableName + ".delete_files").schema();
+
+    List<GenericData.Record> expected = expectedEntries(table, entriesTableSchema, expectedManifests, "a");
+
+    Assert.assertEquals("Should be one delete file manifest entry", 1, expected.size());
+    Assert.assertEquals("Metadata table should return one delete file", 1, actual.size());
+
+    TestHelpers.assertEqualsSafe(filesTableSchema.asStruct(), expected.get(0), actual.get(0));
+  }
+
+  /**
+   * Find matching manifest entries of an Iceberg table
+   * @param table iceberg table
+   * @param entriesTableSchema schema of Manifest entries
+   * @param manifestsToExplore manifests to explore of the table
+   * @param partValue partition value that manifest entries must match, or null to skip filtering
+   */
+  private List<GenericData.Record> expectedEntries(Table table, Schema entriesTableSchema,
+                                                   List<ManifestFile> manifestsToExplore, String partValue)
+      throws IOException {
+    List<GenericData.Record> expected = Lists.newArrayList();
+    for (ManifestFile manifest : manifestsToExplore) {
+      InputFile in = table.io().newInputFile(manifest.path());
+      try (CloseableIterable<GenericData.Record> rows = Avro.read(in).project(
+          entriesTableSchema).build()) {
+        for (GenericData.Record record : rows) {
+          if ((Integer) record.get("status") < 2 /* added or existing */) {
+            GenericData.Record file = (GenericData.Record) record.get("data_file");
+            if (partitionMatch(file, partValue)) {
+              asDeleteRecords(file);
+              expected.add(file);
+            }
+          }
+        }
+      }
+    }
+    return expected;
+  }
+
+  // Populate certain fields derived in the metadata tables
+  private void asDeleteRecords(GenericData.Record file) {
+    file.put(0, FileContent.POSITION_DELETES.id());
+    file.put(3, 0); // specId
+  }
+
+  private boolean partitionMatch(GenericData.Record file, String partValue) {
+    if (partValue == null) {
+      return true;
+    }
+    GenericData.Record partition = (GenericData.Record) file.get(4);
+    return partValue.equals(partition.get(0).toString());
+  }
+}

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
@@ -72,7 +72,7 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
 
     Table table = Spark3Util.loadIcebergTable(spark, tableName);
     List<ManifestFile> expectedManifests = TestHelpers.deleteManifests(table);
-    Assert.assertEquals("Should have 1 delete file", 1, expectedManifests.size());
+    Assert.assertEquals("Should have 1 delete manifest", 1, expectedManifests.size());
 
     Schema entriesTableSchema = Spark3Util.loadIcebergTable(spark, tableName + ".entries").schema();
     Schema filesTableSchema = Spark3Util.loadIcebergTable(spark, tableName + ".delete_files").schema();
@@ -146,8 +146,7 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     List<Record> expected = Lists.newArrayList();
     for (ManifestFile manifest : manifestsToExplore) {
       InputFile in = table.io().newInputFile(manifest.path());
-      try (CloseableIterable<Record> rows = Avro.read(in).project(
-          entriesTableSchema).build()) {
+      try (CloseableIterable<Record> rows = Avro.read(in).project(entriesTableSchema).build()) {
         for (Record record : rows) {
           if ((Integer) record.get("status") < 2 /* added or existing */) {
             Record file = (Record) record.get("data_file");


### PR DESCRIPTION
Closes #4139 

It was decided there to make it into a separate table.

This change refactors some of the DataFilesTable logic (like schema, partition pruning) into a base class and re-uses it for DeleteFilesTable.