### PR TITLE
Core - Add in RESTUtil class for encoding namespace as URL variable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -203,6 +203,10 @@ project(':iceberg-common') {
 }
 
 project(':iceberg-core') {
+  test {
+    useJUnitPlatform()
+  }
+
   dependencies {
     api project(':iceberg-api')
     implementation project(':iceberg-common')

--- a/build.gradle
+++ b/build.gradle
@@ -203,10 +203,6 @@ project(':iceberg-common') {
 }
 
 project(':iceberg-core') {
-  test {
-    useJUnitPlatform()
-  }
-
   dependencies {
     api project(':iceberg-api')
     implementation project(':iceberg-common')

--- a/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
@@ -27,6 +27,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
@@ -46,7 +47,8 @@ class RESTUtil {
     return path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
   }
 
-  public static Map<String, String> filterAndRemovePrefix(Map<String, String> properties, String prefix) {
+  public static Map<String, String> filterByPrefix(Map<String, String> properties, String prefix) {
+    Preconditions.checkNotNull(properties, "Invalid properties map: null");
     Map<String, String> result = Maps.newHashMap();
     properties.forEach((key, value) -> {
       if (key.startsWith(prefix)) {

--- a/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
@@ -59,7 +59,17 @@ class RESTUtil {
     return result;
   }
 
-  public static String asURLVariable(Namespace ns) {
+  /**
+   * Returns a String representation of a namespace that is suitable for use in a URL / URI.
+   * <p>
+   * This function needs to be called when a namespace is used as a path variable (or query parameter etc.),
+   * to format the namespace per the spec.
+   * <p>
+   * {@link #urlDecode} should be used to parse the namespace from a URL parameter.
+   * @param ns namespace to encode
+   * @return UTF-8 encoded string representing the namespace, suitable for use as a URL parameter
+   */
+  public static String urlEncode(Namespace ns) {
     String[] levels = ns.levels();
     String[] encodedLevels = new String[levels.length];
 
@@ -75,7 +85,13 @@ class RESTUtil {
     return NULL_JOINER.join(encodedLevels);
   }
 
-  public static Namespace fromURLVariable(String encodedNs) {
+  /**
+   * Takes in a string representation of a namespace as used for a URL parameter
+   * and returns the corresponding namespace.
+   * <p>
+   * See also {@link #urlEncode} for generating correctly formatted URLs.
+   */
+  public static Namespace urlDecode(String encodedNs) {
     Iterable<String> encodedLevels = NULL_SPLITTER.split(encodedNs);
     String[] decodedLevels =
         Streams

--- a/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
@@ -48,8 +48,8 @@ class RESTUtil {
   }
 
   /**
-   * Takes in a set of properties, and returns all properties begin with the designated prefix with the prefix
-   * stripped off.
+   * Takes in a map, and returns a copy with entries with keys beginning with the designated prefix
+   * with the prefix removed. Any entries whose keys don't begin with the prefix are not returned.
    * <p>
    * This can be used to get a subset of the configuration related to the REST catalog, such as all
    * properties from a prefix of `spark.sql.catalog.my_catalog.rest.` to get REST catalog specific properties
@@ -59,7 +59,7 @@ class RESTUtil {
     Preconditions.checkNotNull(properties, "Invalid properties map: null");
     Map<String, String> result = Maps.newHashMap();
     properties.forEach((key, value) -> {
-      if (key.startsWith(prefix)) {
+      if (key != null && key.startsWith(prefix)) {
         result.put(key.substring(prefix.length()), value);
       }
     });

--- a/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
@@ -31,7 +31,6 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 
 class RESTUtil {
   private static final Joiner NULL_JOINER = Joiner.on('\u0000');
@@ -53,14 +52,16 @@ class RESTUtil {
   }
 
   /**
-   * Takes in a map, and returns a copy with entries with keys beginning with the designated prefix
-   * with the prefix removed. Any entries whose keys don't begin with the prefix are not returned.
+   * Takes in a map, and returns a copy filtered on the entries with keys beginning with the designated prefix.
+   * The keys are returned with the prefix removed.
+   * <p>
+   * Any entries whose keys don't begin with the prefix are not returned.
    * <p>
    * This can be used to get a subset of the configuration related to the REST catalog, such as all
    * properties from a prefix of `spark.sql.catalog.my_catalog.rest.` to get REST catalog specific properties
    * from the spark configuration.
    */
-  public static Map<String, String> filterByPrefix(Map<String, String> properties, String prefix) {
+  public static Map<String, String> extractPrefixMap(Map<String, String> properties, String prefix) {
     Preconditions.checkNotNull(properties, "Invalid properties map: null");
     Map<String, String> result = Maps.newHashMap();
     properties.forEach((key, value) -> {

--- a/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest;
+
+import java.io.UncheckedIOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.relocated.com.google.common.base.Joiner;
+import org.apache.iceberg.relocated.com.google.common.base.Splitter;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Streams;
+
+class RESTUtil {
+  private static final Joiner NULL_JOINER = Joiner.on('\u0000');
+  private static final Splitter NULL_SPLITTER = Splitter.on('\u0000');
+
+  private RESTUtil() {
+  }
+
+  public static String stripTrailingSlash(String path) {
+    if (path == null) {
+      return null;
+    }
+
+    return path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
+  }
+
+  public static Map<String, String> filterAndRemovePrefix(Map<String, String> properties, String prefix) {
+    Map<String, String> result = Maps.newHashMap();
+    properties.forEach((key, value) -> {
+      if (key.startsWith(prefix)) {
+        result.put(key.substring(prefix.length()), value);
+      }
+    });
+
+    return result;
+  }
+
+  public static String asURLVariable(Namespace ns) {
+    String[] levels = ns.levels();
+    String[] encodedLevels = new String[levels.length];
+
+    for (int i = 0; i < levels.length; i++) {
+      try {
+        encodedLevels[i] = URLEncoder.encode(levels[i], StandardCharsets.UTF_8.name());
+      } catch (UnsupportedEncodingException e) {
+        throw new UncheckedIOException(
+            String.format("Failed to URL encode namespace as UTF-8 encoding is not supported: %s", ns), e);
+      }
+    }
+
+    return NULL_JOINER.join(encodedLevels);
+  }
+
+  public static Namespace fromURLVariable(String encodedNs) {
+    Iterable<String> encodedLevels = NULL_SPLITTER.split(encodedNs);
+    String[] decodedLevels =
+        Streams
+            .stream(encodedLevels)
+            .map(encodedLevel -> {
+              try {
+                return URLDecoder.decode(encodedLevel, StandardCharsets.UTF_8.name());
+              } catch (UnsupportedEncodingException e) {
+                throw new UncheckedIOException(
+                    String.format("Failed to decode namespace as UTF-8 encoding is not supported: %s", encodedNs), e);
+              }
+            })
+            .toArray(String[]::new);
+    return Namespace.of(decodedLevels);
+  }
+
+}

--- a/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
@@ -78,7 +78,7 @@ class RESTUtil {
         encodedLevels[i] = URLEncoder.encode(levels[i], StandardCharsets.UTF_8.name());
       } catch (UnsupportedEncodingException e) {
         throw new UncheckedIOException(
-            String.format("Failed to URL encode namespace as UTF-8 encoding is not supported: %s", ns), e);
+            String.format("Failed to URL encode namespace '%s' as UTF-8 encoding is not supported", ns), e);
       }
     }
 
@@ -100,8 +100,9 @@ class RESTUtil {
               try {
                 return URLDecoder.decode(encodedLevel, StandardCharsets.UTF_8.name());
               } catch (UnsupportedEncodingException e) {
-                throw new UncheckedIOException(
-                    String.format("Failed to decode namespace as UTF-8 encoding is not supported: %s", encodedNs), e);
+                String exceptionMessage = String.format(
+                    "Failed to URL decode namespace '%s' as UTF-8 encoding is not supported", encodedNs);
+                throw new UncheckedIOException(exceptionMessage, e);
               }
             })
             .toArray(String[]::new);

--- a/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
@@ -47,6 +47,14 @@ class RESTUtil {
     return path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
   }
 
+  /**
+   * Takes in a set of properties, and returns all properties begin with the designated prefix with the prefix
+   * stripped off.
+   * <p>
+   * This can be used to get a subset of the configuration related to the REST catalog, such as all
+   * properties from a prefix of `spark.sql.catalog.my_catalog.rest.` to get REST catalog specific properties
+   * from the spark configuration.
+   */
   public static Map<String, String> filterByPrefix(Map<String, String> properties, String prefix) {
     Preconditions.checkNotNull(properties, "Invalid properties map: null");
     Map<String, String> result = Maps.newHashMap();

--- a/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
@@ -78,6 +78,7 @@ class RESTUtil {
    * @return UTF-8 encoded string representing the namespace, suitable for use as a URL parameter
    */
   public static String urlEncode(Namespace ns) {
+    Preconditions.checkArgument(ns != null, "Invalid namespace: null");
     String[] levels = ns.levels();
     String[] encodedLevels = new String[levels.length];
 
@@ -100,6 +101,7 @@ class RESTUtil {
    * See also {@link #urlEncode} for generating correctly formatted URLs.
    */
   public static Namespace urlDecode(String encodedNs) {
+    Preconditions.checkArgument(encodedNs != null, "Invalid namespace: null");
     Iterable<String> encodedLevels = NULL_SPLITTER.split(encodedNs);
     String[] decodedLevels =
         Streams

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
@@ -66,7 +66,7 @@ public class TestRESTUtil {
     );
 
     testCaseAndExpectedAnswer.forEach((input, expected) ->
-      Assertions.assertThat(RESTUtil.stripTrailingSlash(input)).isEqualTo(expected)
+        Assertions.assertThat(RESTUtil.stripTrailingSlash(input)).isEqualTo(expected)
     );
   }
 

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
@@ -95,11 +95,11 @@ public class TestRESTUtil {
       Namespace namespace = Namespace.of(levels);
 
       // To be placed into a URL path as query parameter or path variable
-      Assertions.assertThat(RESTUtil.asURLVariable(namespace))
+      Assertions.assertThat(RESTUtil.urlEncode(namespace))
           .isEqualTo(nsEncodedForURLVariable);
 
       // Decoded (after pulling as String) from URL
-      Namespace asNamespace = RESTUtil.fromURLVariable(nsEncodedForURLVariable);
+      Namespace asNamespace = RESTUtil.urlDecode(nsEncodedForURLVariable);
       Assertions.assertThat(asNamespace).isEqualTo(namespace);
     }
   }

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
@@ -72,6 +72,8 @@ public class TestRESTUtil {
     testCaseAndExpectedAnswer.forEach((input, expected) ->
         Assertions.assertThat(RESTUtil.stripTrailingSlash(input)).isEqualTo(expected)
     );
+
+    Assertions.assertThat(RESTUtil.stripTrailingSlash(null)).isNull();
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class TestRESTUtil {
+
+  static class LevelsAndURLEncodedString {
+    public String[] levels;
+    public String parameterEncodedForUrlUsage;
+
+    LevelsAndURLEncodedString(String[] levels, String parameterEncodedForUrlUsage) {
+      this.levels = levels;
+      this.parameterEncodedForUrlUsage = parameterEncodedForUrlUsage;
+    }
+  }
+
+  @Test
+  public void testFilterAndRemovePrefix() {
+    Map<String, String> input = ImmutableMap.of(
+        "warehouse", "/tmp/warehouse",
+        "rest.prefix", "/ws/ralphs_catalog",
+        "rest.token", "YnVybiBhZnRlciByZWFkaW5nIC0gYWxzbyBoYW5rIGFuZCByYXVsIDQgZXZlcgo=",
+        "rest.rest.uri", "https://localhost:1080/");
+
+    Map<String, String> expected = ImmutableMap.of(
+        "prefix", "/ws/ralphs_catalog",
+        "token", "YnVybiBhZnRlciByZWFkaW5nIC0gYWxzbyBoYW5rIGFuZCByYXVsIDQgZXZlcgo=",
+        "rest.uri", "https://localhost:1080/"
+    );
+
+    Map<String, String> actual = RESTUtil.filterAndRemovePrefix(input, "rest.");
+
+    Assertions.assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void testStripTrailingSlash() {
+    Map<String, String> testCaseAndExpectedAnswer = ImmutableMap.of(
+        "https://foo/", "https://foo",
+        "https://foo////", "https://foo///"
+    );
+
+    testCaseAndExpectedAnswer.forEach((input, expected) ->
+      Assertions.assertThat(RESTUtil.stripTrailingSlash(input)).isEqualTo(expected)
+    );
+  }
+
+  @Test
+  public void testAsURLVariable() {
+    List<LevelsAndURLEncodedString> testCases = ImmutableList.of(
+        new LevelsAndURLEncodedString(new String[] {"dogs"}, "dogs"),
+        new LevelsAndURLEncodedString(new String[] {"dogs.named.hank"}, "dogs.named.hank"),
+        new LevelsAndURLEncodedString(new String[] {"dogs/named/hank"}, "dogs%2Fnamed%2Fhank"),
+        new LevelsAndURLEncodedString(
+            new String[] {"dogs", "named", "hank"},
+            "dogs\u0000named\u0000hank"),
+        new LevelsAndURLEncodedString(
+            new String[] {"dogs.and.cats", "named", "hank.or.james-westfall"},
+            "dogs.and.cats\u0000named\u0000hank.or.james-westfall"));
+
+    for (LevelsAndURLEncodedString testCase : testCases) {
+      String[] levels = testCase.levels;
+      String nsEncodedForURLVariable = testCase.parameterEncodedForUrlUsage;
+      Namespace namespace = Namespace.of(levels);
+
+      // To be placed into a URL path as query parameter or path variable
+      Assertions.assertThat(RESTUtil.asURLVariable(namespace))
+          .isEqualTo(nsEncodedForURLVariable);
+
+      // Decoded (after pulling as String) from URL
+      Namespace asNamespace = RESTUtil.fromURLVariable(nsEncodedForURLVariable);
+      Assertions.assertThat(asNamespace).isEqualTo(namespace);
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
@@ -77,7 +77,7 @@ public class TestRESTUtil {
   }
 
   @Test
-  public void testAsURLVariable() {
+  public void testNamespaceUrlEncodeDecode() {
     List<LevelsAndURLEncodedString> testCases = ImmutableList.of(
         new LevelsAndURLEncodedString(new String[] {"dogs"}, "dogs"),
         new LevelsAndURLEncodedString(new String[] {"dogs.named.hank"}, "dogs.named.hank"),
@@ -102,5 +102,16 @@ public class TestRESTUtil {
       Namespace asNamespace = RESTUtil.urlDecode(nsEncodedForURLVariable);
       Assertions.assertThat(asNamespace).isEqualTo(namespace);
     }
+  }
+
+  @Test
+  public void testNamespaceUrlDoesNotAllowNull() {
+    Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> RESTUtil.urlEncode(null))
+        .withMessage("Invalid namespace: null");
+
+    Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> RESTUtil.urlDecode(null))
+        .withMessage("Invalid namespace: null");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
@@ -56,12 +56,12 @@ public class TestRESTUtil {
     return Stream.of(
         new String[] {"https://foo", "https://foo"},
         new String[] {"https://foo/", "https://foo"},
-        new String[] {"https://foo////", "https://foo///"},
+        new String[] {"https://foo////", "https://foo"},
         new String[] {null, null}
     );
   }
 
-  @DisplayName("Should remove at most one slash from the end of the input string")
+  @DisplayName("Should remove all slash characters from the end of the input string")
   @ParameterizedTest(name = "{index} => input={0}, expected={1}")
   @MethodSource("stripTrailingSlashTestCases")
   public void testStripTrailingSlash(String input, String expected) {

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
@@ -45,7 +45,9 @@ public class TestRESTUtil {
         "warehouse", "/tmp/warehouse",
         "rest.prefix", "/ws/ralphs_catalog",
         "rest.token", "YnVybiBhZnRlciByZWFkaW5nIC0gYWxzbyBoYW5rIGFuZCByYXVsIDQgZXZlcgo=",
-        "rest.rest.uri", "https://localhost:1080/");
+        "rest.rest.uri", "https://localhost:1080/",
+        ".rest", "",
+        "", "");
 
     Map<String, String> expected = ImmutableMap.of(
         "prefix", "/ws/ralphs_catalog",
@@ -53,7 +55,7 @@ public class TestRESTUtil {
         "rest.uri", "https://localhost:1080/"
     );
 
-    Map<String, String> actual = RESTUtil.filterAndRemovePrefix(input, "rest.");
+    Map<String, String> actual = RESTUtil.filterByPrefix(input, "rest.");
 
     Assertions.assertThat(actual).isEqualTo(expected);
   }
@@ -61,6 +63,8 @@ public class TestRESTUtil {
   @Test
   public void testStripTrailingSlash() {
     Map<String, String> testCaseAndExpectedAnswer = ImmutableMap.of(
+        "", "",
+        "https://foo", "https://foo",
         "https://foo/", "https://foo",
         "https://foo////", "https://foo///"
     );


### PR DESCRIPTION
The REST Catalog uses the string value of a namespace in URLs.

Per the spec, the levels of a multi-level namespace are joined by the NULL byte character (`'\0'` or more correctly `'\u0000'`).

This adds a utility class which can:
1) Properly URL encode a `Namespace` for use as either a path or query parameter
2) Function for decoding the namespace string from a path variable into a Namespace
3) Some helpers for use with REST catalog configuration (function to get all config values that start with a specific prefix, and function to strip the trailing slash from a path if need be).

The items from (3) can likely be put into a shared `CatalogUtil` class as they occur in a few places, but to cause minimal disruption I'm declaring them separately. They can be merged together as a follow up.

This PR is to help unblock concurrent work on the REST catalog.