### PR TITLE
Flink: Add support for ResolvedSchema

### DIFF
--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -23,19 +23,17 @@ import java.util.Set;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogDatabaseImpl;
-import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.factories.DynamicTableSinkFactory;
 import org.apache.flink.table.factories.DynamicTableSourceFactory;
-import org.apache.flink.table.utils.TableSchemaUtils;
 import org.apache.flink.util.Preconditions;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
@@ -84,9 +82,9 @@ public class FlinkDynamicTableFactory
   @Override
   public DynamicTableSource createDynamicTableSource(Context context) {
     ObjectIdentifier objectIdentifier = context.getObjectIdentifier();
-    CatalogTable catalogTable = context.getCatalogTable();
+    ResolvedCatalogTable catalogTable = context.getCatalogTable();
     Map<String, String> tableProps = catalogTable.getOptions();
-    TableSchema tableSchema = TableSchemaUtils.getPhysicalSchema(catalogTable.getSchema());
+    ResolvedSchema tableSchema = catalogTable.getResolvedSchema();
 
     TableLoader tableLoader;
     if (catalog != null) {
@@ -106,9 +104,9 @@ public class FlinkDynamicTableFactory
   @Override
   public DynamicTableSink createDynamicTableSink(Context context) {
     ObjectPath objectPath = context.getObjectIdentifier().toObjectPath();
-    CatalogTable catalogTable = context.getCatalogTable();
+    ResolvedCatalogTable catalogTable = context.getCatalogTable();
     Map<String, String> writeProps = catalogTable.getOptions();
-    TableSchema tableSchema = TableSchemaUtils.getPhysicalSchema(catalogTable.getSchema());
+    ResolvedSchema tableSchema = catalogTable.getResolvedSchema();
 
     TableLoader tableLoader;
     if (catalog != null) {
@@ -144,7 +142,7 @@ public class FlinkDynamicTableFactory
   }
 
   private static TableLoader createTableLoader(
-      CatalogBaseTable catalogBaseTable,
+      ResolvedCatalogTable catalogBaseTable,
       Map<String, String> tableProps,
       String databaseName,
       String tableName) {

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSink.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSink.java
@@ -21,8 +21,8 @@ package org.apache.iceberg.flink;
 import java.util.List;
 import java.util.Map;
 import org.apache.flink.configuration.ReadableConfig;
-import org.apache.flink.table.api.TableSchema;
-import org.apache.flink.table.api.constraints.UniqueConstraint;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.UniqueConstraint;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.sink.DataStreamSinkProvider;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
@@ -35,7 +35,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 
 public class IcebergTableSink implements DynamicTableSink, SupportsPartitioning, SupportsOverwrite {
   private final TableLoader tableLoader;
-  private final TableSchema tableSchema;
+  private final ResolvedSchema tableSchema;
   private final ReadableConfig readableConfig;
   private final Map<String, String> writeProps;
 
@@ -51,7 +51,7 @@ public class IcebergTableSink implements DynamicTableSink, SupportsPartitioning,
 
   public IcebergTableSink(
       TableLoader tableLoader,
-      TableSchema tableSchema,
+      ResolvedSchema tableSchema,
       ReadableConfig readableConfig,
       Map<String, String> writeProps) {
     this.tableLoader = tableLoader;

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -36,6 +36,7 @@ import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.util.DataFormatConverters;
 import org.apache.flink.table.types.DataType;
@@ -125,6 +126,7 @@ public class FlinkSink {
     private TableLoader tableLoader;
     private Table table;
     private TableSchema tableSchema;
+    private ResolvedSchema resolvedTableSchema;
     private Integer writeParallelism = null;
     private List<String> equalityFieldColumns = null;
     private String uidPrefix = null;
@@ -204,6 +206,11 @@ public class FlinkSink {
 
     public Builder tableSchema(TableSchema newTableSchema) {
       this.tableSchema = newTableSchema;
+      return this;
+    }
+
+    public Builder tableSchema(ResolvedSchema newTableSchema) {
+      this.resolvedTableSchema = newTableSchema;
       return this;
     }
 
@@ -333,7 +340,7 @@ public class FlinkSink {
       List<Integer> equalityFieldIds = checkAndGetEqualityFieldIds();
 
       // Convert the requested flink table schema to flink row type.
-      RowType flinkRowType = toFlinkRowType(table.schema(), tableSchema);
+      RowType flinkRowType = toFlinkRowType(table.schema(), tableSchema, resolvedTableSchema);
 
       // Distribute the records from input data stream based on the write.distribution-mode and
       // equality fields.
@@ -537,10 +544,16 @@ public class FlinkSink {
   }
 
   static RowType toFlinkRowType(Schema schema, TableSchema requestedSchema) {
-    if (requestedSchema != null) {
+    return toFlinkRowType(schema, requestedSchema, null);
+  }
+
+  static RowType toFlinkRowType(
+      Schema schema, TableSchema tableSchema, ResolvedSchema resolvedTableSchema) {
+    if (resolvedTableSchema != null) {
       // Convert the flink schema to iceberg schema firstly, then reassign ids to match the existing
       // iceberg schema.
-      Schema writeSchema = TypeUtil.reassignIds(FlinkSchemaUtil.convert(requestedSchema), schema);
+      Schema writeSchema =
+          TypeUtil.reassignIds(FlinkSchemaUtil.convert(resolvedTableSchema), schema);
       TypeUtil.validateWriteSchema(schema, writeSchema, true, true);
 
       // We use this flink schema to read values from RowData. The flink's TINYINT and SMALLINT will
@@ -550,10 +563,14 @@ public class FlinkSink {
       // read 4 bytes rather than 1 byte, it will mess up the byte array in BinaryRowData. So here
       // we must use flink
       // schema.
-      return (RowType) requestedSchema.toRowDataType().getLogicalType();
-    } else {
-      return FlinkSchemaUtil.convert(schema);
+      return (RowType) resolvedTableSchema.toPhysicalRowDataType().getLogicalType();
+    } else if (tableSchema != null) {
+      Schema writeSchema = TypeUtil.reassignIds(FlinkSchemaUtil.convert(tableSchema), schema);
+      TypeUtil.validateWriteSchema(schema, writeSchema, true, true);
+
+      return (RowType) tableSchema.toRowDataType().getLogicalType();
     }
+    return FlinkSchemaUtil.convert(schema);
   }
 
   static IcebergStreamWriter<RowData> createStreamWriter(

--- a/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/IcebergTableSource.java
+++ b/flink/v1.15/flink/src/main/java/org/apache/iceberg/flink/source/IcebergTableSource.java
@@ -29,7 +29,7 @@ import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.ProviderContext;
 import org.apache.flink.table.connector.source.DataStreamScanProvider;
@@ -63,7 +63,7 @@ public class IcebergTableSource
   private List<Expression> filters;
 
   private final TableLoader loader;
-  private final TableSchema schema;
+  private final ResolvedSchema schema;
   private final Map<String, String> properties;
   private final boolean isLimitPushDown;
   private final ReadableConfig readableConfig;
@@ -81,7 +81,7 @@ public class IcebergTableSource
 
   public IcebergTableSource(
       TableLoader loader,
-      TableSchema schema,
+      ResolvedSchema schema,
       Map<String, String> properties,
       ReadableConfig readableConfig) {
     this(loader, schema, properties, null, false, -1, ImmutableList.of(), readableConfig);
@@ -89,7 +89,7 @@ public class IcebergTableSource
 
   private IcebergTableSource(
       TableLoader loader,
-      TableSchema schema,
+      ResolvedSchema schema,
       Map<String, String> properties,
       int[] projectedFields,
       boolean isLimitPushDown,
@@ -150,17 +150,16 @@ public class IcebergTableSource
     return stream;
   }
 
-  private TableSchema getProjectedSchema() {
+  private ResolvedSchema getProjectedSchema() {
     if (projectedFields == null) {
       return schema;
     } else {
-      String[] fullNames = schema.getFieldNames();
-      DataType[] fullTypes = schema.getFieldDataTypes();
-      return TableSchema.builder()
-          .fields(
-              Arrays.stream(projectedFields).mapToObj(i -> fullNames[i]).toArray(String[]::new),
-              Arrays.stream(projectedFields).mapToObj(i -> fullTypes[i]).toArray(DataType[]::new))
-          .build();
+      List<String> fullNames = schema.getColumnNames();
+      List<DataType> fullTypes = schema.getColumnDataTypes();
+
+      return ResolvedSchema.physical(
+          Arrays.stream(projectedFields).mapToObj(fullNames::get).toArray(String[]::new),
+          Arrays.stream(projectedFields).mapToObj(fullTypes::get).toArray(DataType[]::new));
     }
   }
 

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
@@ -28,6 +28,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
@@ -83,6 +85,10 @@ public class SimpleDataUtil {
       TableSchema.builder().field("id", DataTypes.INT()).field("data", DataTypes.STRING()).build();
 
   public static final RowType ROW_TYPE = (RowType) FLINK_SCHEMA.toRowDataType().getLogicalType();
+
+  public static final ResolvedSchema FLINK_RESOLVED_SCHEMA =
+      ResolvedSchema.of(
+          Column.physical("id", DataTypes.INT()), Column.physical("data", DataTypes.STRING()));
 
   public static final Record RECORD = GenericRecord.create(SCHEMA);
 

--- a/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
+++ b/flink/v1.15/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java
@@ -198,6 +198,25 @@ public class TestFlinkIcebergSink {
   }
 
   @Test
+  public void testWriteRowWithResolvedTableSchema() throws Exception {
+    List<Row> rows = createRows("");
+    DataStream<Row> dataStream = env.addSource(createBoundedSource(rows), ROW_TYPE_INFO);
+
+    FlinkSink.forRow(dataStream, SimpleDataUtil.FLINK_SCHEMA)
+        .table(table)
+        .tableLoader(tableLoader)
+        .tableSchema(SimpleDataUtil.FLINK_RESOLVED_SCHEMA)
+        .writeParallelism(parallelism)
+        .distributionMode(DistributionMode.NONE)
+        .append();
+
+    // Execute the program.
+    env.execute("Test Iceberg DataStream.");
+
+    SimpleDataUtil.assertTableRows(table, convertToRowData(rows));
+  }
+
+  @Test
   public void testJobNoneDistributeMode() throws Exception {
     table
         .updateProperties()


### PR DESCRIPTION
Some tasks in our production environment have been migrated to Schema/ResolvedSchema. This PR is mainly used to add support for ResolvedSchema.
1. Add the following `project` to the source:
```java
public Builder project(ResolvedSchema schema) {
  this.projectedResolvedSchema = schema;
  return this;
}
```
2. Add the following `tableSchema` to the sink:
```java
public Builder tableSchema(ResolvedSchema newTableSchema) {
  this.resolvedTableSchema = newTableSchema;
  return this;
}
```
3. FlinkDynamicTableFactory replaces CatalogTable with ResolvedCatalogTable and uses it to get `ResolvedSchema`, then pass `ResolvedSchema` in `IcebergTableSource`and `IcebergTableSink`. 
4. Add a tool class for ResolvedSchema: FlinkResolvedSchemaUtil. Convert the flink table schema to apache iceberg schema.
5. Add simple test cases.
https://github.com/apache/iceberg/blob/a08dff6a780f9d6154564f70c7d660f091dd5ec3/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSink.java#L203
https://github.com/apache/iceberg/blob/a08dff6a780f9d6154564f70c7d660f091dd5ec3/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkInputFormat.java#L132