### PR TITLE
Fix Typo in Spark-writes sample code

### DIFF
--- a/docs/versioned/spark/spark-writes.md
+++ b/docs/versioned/spark/spark-writes.md
@@ -295,7 +295,7 @@ Create and replace operations support table configuration methods, like `partiti
 ```scala
 data.writeTo("prod.db.table")
     .tableProperty("write.format.default", "orc")
-    .partitionBy($"level", days($"ts"))
+    .partitionedBy($"level", days($"ts"))
     .createOrReplace()
 ```
 


### PR DESCRIPTION
We should use `partitionedBy` rather than `partitionBy` as mentioned before the sample code.