### PR TITLE
Core: support dynamic MetricsContext initialization

### DIFF
--- a/api/src/main/java/org/apache/iceberg/metrics/MetricsContext.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/MetricsContext.java
@@ -29,6 +29,21 @@ import java.util.Optional;
  * like thread safety and serialization.
  */
 public interface MetricsContext extends Serializable {
+  MetricsContext NULL_METRICS = new MetricsContext() {
+    @Override
+    public <T extends Number> Counter<T> counter(String name, Class<T> type, Unit unit) {
+      return new Counter<T>() {
+        @Override
+        public void increment() {
+        }
+
+        @Override
+        public void increment(T amount) {
+        }
+      };
+    }
+  };
+
   enum Unit {
     UNDEFINED("undefined"),
     BYTES("bytes"),
@@ -94,19 +109,6 @@ public interface MetricsContext extends Serializable {
    * @return a non-recording metrics context
    */
   static MetricsContext nullMetrics() {
-    return new MetricsContext() {
-      @Override
-      public <T extends Number> Counter<T> counter(String name, Class<T> type, Unit unit) {
-        return new Counter<T>() {
-          @Override
-          public void increment() {
-          }
-
-          @Override
-          public void increment(T amount) {
-          }
-        };
-      }
-    };
+    return NULL_METRICS;
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -45,14 +45,13 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
  */
 public class S3FileIO implements FileIO {
   private static final Logger LOG = LoggerFactory.getLogger(S3FileIO.class);
+  private static final String IO_METRICS_SCHEME_S3 = "s3";
 
   private SerializableSupplier<S3Client> s3;
   private AwsProperties awsProperties;
   private transient S3Client client;
   private MetricsContext metrics = MetricsContext.nullMetrics();
   private final AtomicBoolean isResourceClosed = new AtomicBoolean(false);
-
-  private static final String IO_METRICS_SCHEME_S3 = "s3";
 
   /**
    * No-arg constructor to load the FileIO dynamically.
@@ -123,7 +122,7 @@ public class S3FileIO implements FileIO {
     String metricsImpl = properties.getOrDefault(
             CatalogProperties.IO_METRICS_IMPL, CatalogProperties.IO_METRICS_IMPL_DEFAULT);
 
-    ImmutableMap<String, String> metricContextProperties = ImmutableMap.copyOf(properties);
+    Map<String, String> metricContextProperties = properties;
     if (!properties.containsKey(CatalogProperties.IO_METRICS_SCHEME)) {
       metricContextProperties = ImmutableMap.<String, String>builder()
               .putAll(properties)
@@ -131,7 +130,8 @@ public class S3FileIO implements FileIO {
               .build();
     }
 
-    this.metrics = CatalogUtil.loadFileIOMetricsContext(metricsImpl, metricContextProperties, null);
+    this.metrics = CatalogUtil.loadFileIOMetricsContext(
+            metricsImpl, metricContextProperties, null /* no Hadoop config */);
   }
 
   @Override

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -118,7 +118,6 @@ public class S3FileIO implements FileIO {
       this.s3 = AwsClientFactories.from(properties)::s3;
     }
 
-    // Report Hadoop metrics if Hadoop is available
     String metricsImpl = properties.getOrDefault(
             CatalogProperties.IO_METRICS_IMPL, CatalogProperties.IO_METRICS_IMPL_DEFAULT);
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -117,18 +117,16 @@ public class S3FileIO implements FileIO {
     }
 
     // Report Hadoop metrics if Hadoop is available
+    String metricsImpl = properties.getOrDefault(
+            CatalogProperties.IO_METRICS_IMPL, CatalogProperties.DEFAULT_METRICS_IMPL);
     try {
       DynConstructors.Ctor<MetricsContext> ctor =
-              DynConstructors.builder(MetricsContext.class)
-                      .impl(properties.getOrDefault(
-                              CatalogProperties.IO_METRICS_IMPL, CatalogProperties.DEFAULT_METRICS_IMPL))
-                      .buildChecked();
+              DynConstructors.builder(MetricsContext.class).impl(metricsImpl, String.class).buildChecked();
       this.metrics = ctor.newInstance("s3");
 
       metrics.initialize(properties);
     } catch (NoSuchMethodException | ClassCastException e) {
-      LOG.warn("Unable to load metrics class: '{}', falling back to null metrics",
-              CatalogProperties.DEFAULT_METRICS_IMPL, e);
+      LOG.warn("Unable to load metrics class: '{}', falling back to null metrics", metricsImpl, e);
     }
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -52,7 +52,7 @@ public class S3FileIO implements FileIO {
   private MetricsContext metrics = MetricsContext.nullMetrics();
   private final AtomicBoolean isResourceClosed = new AtomicBoolean(false);
 
-  private static final String S3 = "s3";
+  private static final String IO_METRICS_SCHEME_S3 = "s3";
 
   /**
    * No-arg constructor to load the FileIO dynamically.
@@ -123,15 +123,11 @@ public class S3FileIO implements FileIO {
     String metricsImpl = properties.getOrDefault(
             CatalogProperties.IO_METRICS_IMPL, CatalogProperties.IO_METRICS_IMPL_DEFAULT);
 
-    ImmutableMap<String, String> metricContextProperties;
-    if (properties.containsKey(CatalogProperties.IO_METRICS_SCHEME)) {
+    ImmutableMap<String, String> metricContextProperties = ImmutableMap.copyOf(properties);
+    if (!properties.containsKey(CatalogProperties.IO_METRICS_SCHEME)) {
       metricContextProperties = ImmutableMap.<String, String>builder()
               .putAll(properties)
-              .build();
-    } else {
-      metricContextProperties = ImmutableMap.<String, String>builder()
-              .putAll(properties)
-              .put(CatalogProperties.IO_METRICS_SCHEME, S3)
+              .put(CatalogProperties.IO_METRICS_SCHEME, IO_METRICS_SCHEME_S3)
               .build();
     }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -122,10 +122,10 @@ public class S3FileIO implements FileIO {
             CatalogProperties.IO_METRICS_IMPL, CatalogProperties.IO_METRICS_IMPL_DEFAULT);
 
     Map<String, String> metricContextProperties = properties;
-    if (!properties.containsKey(CatalogProperties.IO_METRICS_SCHEME)) {
+    if (!properties.containsKey(CatalogProperties.IO_METRICS_NAMESPACE)) {
       metricContextProperties = ImmutableMap.<String, String>builder()
               .putAll(properties)
-              .put(CatalogProperties.IO_METRICS_SCHEME, IO_METRICS_SCHEME_S3)
+              .put(CatalogProperties.IO_METRICS_NAMESPACE, IO_METRICS_SCHEME_S3)
               .build();
     }
 

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -82,7 +82,7 @@ public class CatalogProperties {
   public static final String USER = "user";
 
   public static final String IO_METRICS_IMPL = "io-metrics-impl";
-  public static final String DEFAULT_METRICS_IMPL = "org.apache.iceberg.hadoop.HadoopMetricsContext";
+  public static final String IO_METRICS_IMPL_DEFAULT = "org.apache.iceberg.hadoop.HadoopMetricsContext";
   public static final String IO_METRICS_SCHEME = "io.metrics-scheme";
 
 }

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -83,6 +83,6 @@ public class CatalogProperties {
 
   public static final String IO_METRICS_IMPL = "io.metrics-impl";
   public static final String IO_METRICS_IMPL_DEFAULT = "org.apache.iceberg.hadoop.HadoopMetricsContext";
-  public static final String IO_METRICS_SCHEME = "io.metrics-scheme";
+  public static final String IO_METRICS_NAMESPACE = "io.metrics.namespace";
 
 }

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -81,7 +81,7 @@ public class CatalogProperties {
   public static final String APP_ID = "app-id";
   public static final String USER = "user";
 
-  public static final String IO_METRICS_IMPL = "io-metrics-impl";
+  public static final String IO_METRICS_IMPL = "io.metrics-impl";
   public static final String IO_METRICS_IMPL_DEFAULT = "org.apache.iceberg.hadoop.HadoopMetricsContext";
   public static final String IO_METRICS_SCHEME = "io.metrics-scheme";
 

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -81,4 +81,8 @@ public class CatalogProperties {
   public static final String APP_ID = "app-id";
   public static final String USER = "user";
 
+  public static final String IO_METRICS_IMPL = "io-metrics-impl";
+  public static final String DEFAULT_METRICS_IMPL = "org.apache.iceberg.hadoop.HadoopMetricsContext";
+  public static final String IO_METRICS_SCHEME = "io.metrics-scheme";
+
 }

--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -278,7 +278,8 @@ public class CatalogUtil {
 
   public static MetricsContext loadFileIOMetricsContext(
       String impl,
-      Map<String, String> properties) {
+      Map<String, String> properties,
+      Object hadoopConf) {
     LOG.info("Loading custom MetricsContext implementation: {}", impl);
     MetricsContext metricsContext;
     try {

--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -297,7 +297,6 @@ public class CatalogUtil {
     return metricsContext;
   }
 
-
   /**
    * Dynamically detects whether an object is a Hadoop Configurable and calls setConf.
    * @param maybeConfigurable an object that may be Configurable

--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -291,6 +291,8 @@ public class CatalogUtil {
       return null;
     }
 
+    configureHadoopConf(metricsContext, hadoopConf);
+
     metricsContext.initialize(properties);
     return metricsContext;
   }

--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -288,7 +288,7 @@ public class CatalogUtil {
       metricsContext = ctor.newInstance();
     } catch (NoSuchMethodException | ClassCastException e) {
       LOG.warn("Unable to load metrics class: '{}', falling back to null metrics", impl, e);
-      return null;
+      metricsContext = MetricsContext.nullMetrics();
     }
 
     configureHadoopConf(metricsContext, hadoopConf);

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
@@ -45,7 +45,7 @@ public class HadoopMetricsContext implements FileIOMetricsContext {
   public void initialize(Map<String, String> properties) {
     // FileIO has no specific implementation class, but Hadoop will
     // still track and report for the provided scheme.
-    this.scheme = properties.get(CatalogProperties.IO_METRICS_SCHEME);
+    this.scheme = properties.get(CatalogProperties.IO_METRICS_NAMESPACE);
     ValidationException.check(this.scheme != null,
             "Scheme is required for Hadoop FileSystem metrics reporting");
 

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
@@ -46,6 +46,9 @@ public class HadoopMetricsContext implements FileIOMetricsContext {
     // FileIO has no specific implementation class, but Hadoop will
     // still track and report for the provided scheme.
     this.scheme = properties.get(CatalogProperties.IO_METRICS_SCHEME);
+    ValidationException.check(this.scheme != null,
+            "Scheme is required for Hadoop FileSystem metrics reporting");
+
     this.statistics = FileSystem.getStatistics(scheme, null);
   }
 

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
@@ -25,6 +25,7 @@ import java.io.ObjectOutputStream;
 import java.util.Map;
 import java.util.function.Consumer;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.io.FileIOMetricsContext;
 
@@ -33,7 +34,6 @@ import org.apache.iceberg.io.FileIOMetricsContext;
  * statistics implementation using the provided scheme.
  */
 public class HadoopMetricsContext implements FileIOMetricsContext {
-  public static final String SCHEME = "io.metrics-scheme";
 
   private String scheme;
   private transient FileSystem.Statistics statistics;
@@ -49,7 +49,7 @@ public class HadoopMetricsContext implements FileIOMetricsContext {
   public void initialize(Map<String, String> properties) {
     // FileIO has no specific implementation class, but Hadoop will
     // still track and report for the provided scheme.
-    this.scheme = properties.getOrDefault(SCHEME, scheme);
+    this.scheme = properties.getOrDefault(CatalogProperties.IO_METRICS_SCHEME, scheme);
     this.statistics = FileSystem.getStatistics(scheme, null);
   }
 

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
@@ -38,18 +38,14 @@ public class HadoopMetricsContext implements FileIOMetricsContext {
   private String scheme;
   private transient FileSystem.Statistics statistics;
 
-  public HadoopMetricsContext(String scheme) {
-    ValidationException.check(scheme != null,
-        "Scheme is required for Hadoop FileSystem metrics reporting");
-
-    this.scheme = scheme;
+  public HadoopMetricsContext() {
   }
 
   @Override
   public void initialize(Map<String, String> properties) {
     // FileIO has no specific implementation class, but Hadoop will
     // still track and report for the provided scheme.
-    this.scheme = properties.getOrDefault(CatalogProperties.IO_METRICS_SCHEME, scheme);
+    this.scheme = properties.get(CatalogProperties.IO_METRICS_SCHEME);
     this.statistics = FileSystem.getStatistics(scheme, null);
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.FileIOMetricsContext;
@@ -425,11 +424,7 @@ public class TestCatalogUtil {
 
     @Override
     public void initialize(Map<String, String> properties) {
-      // FileIO has no specific implementation class, but Hadoop will
-      // still track and report for the provided scheme.
       this.scheme = properties.get(CatalogProperties.IO_METRICS_SCHEME);
-      ValidationException.check(this.scheme != null,
-              "Scheme is required for Hadoop FileSystem metrics reporting");
     }
 
     public String scheme() {

--- a/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
@@ -171,6 +171,15 @@ public class TestCatalogUtil {
     Assert.assertEquals("testScheme", testMetricsContext.scheme());
   }
 
+  @Test public void loadBadFileIOMetricsContext() {
+    Map<String, String> properties = Maps.newHashMap();
+    MetricsContext metricsContext = CatalogUtil.loadFileIOMetricsContext(
+            "BadMetricsContext", properties, null);
+
+    MetricsContext nullMetricsContext = MetricsContext.nullMetrics();
+    Assert.assertEquals(nullMetricsContext, metricsContext);
+  }
+
   @Test
   public void buildCustomCatalog_withTypeSet() {
     Map<String, String> options = Maps.newHashMap();

--- a/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
@@ -162,7 +162,7 @@ public class TestCatalogUtil {
 
   @Test public void loadFileIOMetricsContext() {
     Map<String, String> properties = Maps.newHashMap();
-    properties.put(CatalogProperties.IO_METRICS_SCHEME, "testScheme");
+    properties.put(CatalogProperties.IO_METRICS_NAMESPACE, "testScheme");
     MetricsContext metricsContext = CatalogUtil.loadFileIOMetricsContext(
             TestFileIOMetricsContext.class.getName(), properties, null);
     TestFileIOMetricsContext testMetricsContext = (TestFileIOMetricsContext) metricsContext;
@@ -433,7 +433,7 @@ public class TestCatalogUtil {
 
     @Override
     public void initialize(Map<String, String> properties) {
-      this.scheme = properties.get(CatalogProperties.IO_METRICS_SCHEME);
+      this.scheme = properties.get(CatalogProperties.IO_METRICS_NAMESPACE);
     }
 
     public String scheme() {


### PR DESCRIPTION
With MetricsContext being recently added, it is important to be able to dynamically initialize what implementation of MetricsContext the user prefers. This PR adds that option with the `io.metrics-impl` property for future MetricsContext implementations. Moved `IO_METRICS_IMPL` and `DEFAULT_METRICS_IMPL` to `CatalogProperties`  to keep consistency with the repo.