### PR TITLE
Docs: Update section on inspecting tables

### DIFF
--- a/docs/spark/spark-queries.md
+++ b/docs/spark/spark-queries.md
@@ -170,7 +170,7 @@ Metadata tables are identified by adding the metadata table name after the origi
 {{< hint info >}}
 For Spark 2.4, use the `DataFrameReader` API to [inspect tables](#inspecting-with-dataframes).
 
-For Spark 3, prior to 3.2, the Spark session catalog (`spark_catalog`) does not support table names with multipart identifiers such as `catalog.database.table.metadata`. To work around this, for querying metadata tables, configure a different catalog that uses the Iceberg `SparkCatalog` class, or use the Spark `DataFrameReader` API. From Spark 3.2 onwards, the session catalog supports table names with multipart identifiers.
+For Spark 3, prior to 3.2, the Spark [session catalog](../spark-configuration#replacing-the-session-catalog) does not support table names with multipart identifiers such as `catalog.database.table.metadata`. As a workaround, configure a catalog that uses `org.apache.iceberg.spark.SparkCatalog`, or use the Spark `DataFrameReader` API.
 {{< /hint >}}
 
 ### History

--- a/docs/spark/spark-queries.md
+++ b/docs/spark/spark-queries.md
@@ -168,7 +168,7 @@ To inspect a table's history, snapshots, and other metadata, Iceberg supports me
 Metadata tables are identified by adding the metadata table name after the original table name. For example, history for `db.table` is read using `db.table.history`.
 
 {{< hint info >}}
-In Spark 3.0 and 3.1, if you have replaced Spark's default catalog (`spark_catalog`) with Iceberg's `SparkSessionCatalog`, you cannot use it to query metadata tables, as the form of the metadata table name (`catalog.database.table.metadata`) is not accepted by Spark. This is fixed in Spark 3.2 by [SPARK-34209](https://issues.apache.org/jira/browse/SPARK-34209). For Spark 3.0 and 3.1, you can configure a different catalog (implemented by `SparkCatalog`) to query metadata tables, or you can use the `DataFrameReader` API.
+In Spark 3.0 and 3.1, the Spark session catalog (`spark_catalog`) does not support table names with multipart identifiers such as `catalog.database.table.metadata`. To work around this, for querying metadata tables, configure a different catalog that uses the Iceberg `SparkCatalog` class, or use the Spark `DataFrameReader` API. From Spark 3.2 onwards, the session catalog supports table names with multipart identifiers.
 {{< /hint >}}
 
 ### History

--- a/docs/spark/spark-queries.md
+++ b/docs/spark/spark-queries.md
@@ -170,7 +170,7 @@ Metadata tables are identified by adding the metadata table name after the origi
 {{< hint info >}}
 For Spark 2.4, use the `DataFrameReader` API to [inspect tables](#inspecting-with-dataframes).
 
-For Spark 3, prior to 3.2, the Spark [session catalog](../spark-configuration#replacing-the-session-catalog) does not support table names with multipart identifiers such as `catalog.database.table.metadata`. As a workaround, configure a catalog that uses `org.apache.iceberg.spark.SparkCatalog`, or use the Spark `DataFrameReader` API.
+For Spark 3, prior to 3.2, the Spark [session catalog](../spark-configuration#replacing-the-session-catalog) does not support table names with multipart identifiers such as `catalog.database.table.metadata`. As a workaround, configure an `org.apache.iceberg.spark.SparkCatalog`, or use the Spark `DataFrameReader` API.
 {{< /hint >}}
 
 ### History

--- a/docs/spark/spark-queries.md
+++ b/docs/spark/spark-queries.md
@@ -168,7 +168,7 @@ To inspect a table's history, snapshots, and other metadata, Iceberg supports me
 Metadata tables are identified by adding the metadata table name after the original table name. For example, history for `db.table` is read using `db.table.history`.
 
 {{< hint info >}}
-As of Spark 3.0, the format of the table name for inspection (`catalog.database.table.metadata`) doesn't work with Spark's default catalog (`spark_catalog`). If you've replaced the default catalog, you may want to use `DataFrameReader` API to inspect the table. 
+In Spark 3.0 and 3.1, if you have replaced Spark's default catalog (`spark_catalog`) with Iceberg's `SparkSessionCatalog`, you cannot use it to query metadata tables, as the form of the metadata table name (`catalog.database.table.metadata`) is not accepted by Spark. This is fixed in Spark 3.2 by [SPARK-34209](https://issues.apache.org/jira/browse/SPARK-34209). For Spark 3.0 and 3.1, you can configure a different catalog (implemented by `SparkCatalog`) to query metadata tables, or you can use the `DataFrameReader` API.
 {{< /hint >}}
 
 ### History

--- a/docs/spark/spark-queries.md
+++ b/docs/spark/spark-queries.md
@@ -168,7 +168,9 @@ To inspect a table's history, snapshots, and other metadata, Iceberg supports me
 Metadata tables are identified by adding the metadata table name after the original table name. For example, history for `db.table` is read using `db.table.history`.
 
 {{< hint info >}}
-In Spark 3.0 and 3.1, the Spark session catalog (`spark_catalog`) does not support table names with multipart identifiers such as `catalog.database.table.metadata`. To work around this, for querying metadata tables, configure a different catalog that uses the Iceberg `SparkCatalog` class, or use the Spark `DataFrameReader` API. From Spark 3.2 onwards, the session catalog supports table names with multipart identifiers.
+For Spark 2.4, use the `DataFrameReader` API to [inspect tables](#inspecting-with-dataframes).
+
+For Spark 3, prior to 3.2, the Spark session catalog (`spark_catalog`) does not support table names with multipart identifiers such as `catalog.database.table.metadata`. To work around this, for querying metadata tables, configure a different catalog that uses the Iceberg `SparkCatalog` class, or use the Spark `DataFrameReader` API. From Spark 3.2 onwards, the session catalog supports table names with multipart identifiers.
 {{< /hint >}}
 
 ### History


### PR DESCRIPTION
Using the SparkSessionCatalog to query metadata tables is possible in Spark 3.2.