### PR TITLE
AWS: Add S3 Tagging

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -218,9 +218,10 @@ public class AwsProperties implements Serializable {
 
   /**
    * Used by {@link S3FileIO} to tag objects when writing. To set, we can pass a catalog property.
-   * Example in Spark: --conf spark.sql.catalog.my_catalog.s3.write.tags.my_key=my_val
    * <p>
    * For more details, see https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html
+   * <p>
+   * Example in Spark: --conf spark.sql.catalog.my_catalog.s3.write.tags.my_key=my_val
    */
   public static final String S3_WRITE_TAGS_PREFIX = "s3.write.tags.";
 

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.aws;
 import java.io.Serializable;
 import java.util.Map;
 import org.apache.iceberg.aws.dynamodb.DynamoDbCatalog;
+import org.apache.iceberg.aws.s3.S3FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.PropertyUtil;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
@@ -214,6 +215,14 @@ public class AwsProperties implements Serializable {
    * For more details, see https://docs.aws.amazon.com/general/latest/gr/rande.html
    */
   public static final String CLIENT_ASSUME_ROLE_REGION = "client.assume-role.region";
+
+  /**
+   * Used by {@link S3FileIO} to tag objects when writing. To set, we can pass a catalog property.
+   * Example in Spark: --conf spark.sql.catalog.my_catalog.s3.write.tags.my_key=my_val
+   * <p>
+   * For more details, see https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html
+   */
+  public static final String S3_WRITE_TAGS_PREFIX = "s3.write.tags.";
 
   /**
    * @deprecated will be removed at 0.15.0, please use {@link #S3_CHECKSUM_ENABLED_DEFAULT} instead

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/BaseS3File.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/BaseS3File.java
@@ -19,13 +19,16 @@
 
 package org.apache.iceberg.aws.s3;
 
+import java.util.Set;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.metrics.MetricsContext;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import software.amazon.awssdk.http.HttpStatusCode;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.model.Tag;
 
 abstract class BaseS3File {
   private final S3Client client;
@@ -33,12 +36,23 @@ abstract class BaseS3File {
   private final AwsProperties awsProperties;
   private HeadObjectResponse metadata;
   private final MetricsContext metrics;
+  private final Set<Tag> writeTags;
 
   BaseS3File(S3Client client, S3URI uri, AwsProperties awsProperties, MetricsContext metrics) {
     this.client = client;
     this.uri = uri;
     this.awsProperties = awsProperties;
     this.metrics = metrics;
+    this.writeTags = Sets.newHashSet();
+  }
+
+  BaseS3File(S3Client client, S3URI uri, AwsProperties awsProperties, MetricsContext metrics,
+      Set<Tag> writeTags) {
+    this.client = client;
+    this.uri = uri;
+    this.awsProperties = awsProperties;
+    this.metrics = metrics;
+    this.writeTags = writeTags;
   }
 
   public String location() {
@@ -59,6 +73,10 @@ abstract class BaseS3File {
 
   protected MetricsContext metrics() {
     return metrics;
+  }
+
+  public Set<Tag> writeTags() {
+    return writeTags;
   }
 
   /**

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -115,8 +115,7 @@ public class S3FileIO implements FileIO {
   @Override
   public void initialize(Map<String, String> properties) {
     this.awsProperties = new AwsProperties(properties);
-    this.writeTags = toTags(
-        PropertyUtil.propertiesWithPrefix(properties, AwsProperties.S3_WRITE_TAGS_PREFIX));
+    this.writeTags = toTags(properties);
 
     // Do not override s3 client if it was provided
     if (s3 == null) {
@@ -145,8 +144,9 @@ public class S3FileIO implements FileIO {
     }
   }
 
-  private Set<Tag> toTags(Map<String, String> tagKeyToTagValue) {
-    return tagKeyToTagValue.entrySet().stream()
+  private Set<Tag> toTags(Map<String, String> properties) {
+    return PropertyUtil.propertiesWithPrefix(properties, AwsProperties.S3_WRITE_TAGS_PREFIX)
+        .entrySet().stream()
         .map(e -> Tag.builder().key(e.getKey()).value(e.getValue()).build())
         .collect(Collectors.toSet());
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -20,7 +20,9 @@
 package org.apache.iceberg.aws.s3;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 import org.apache.iceberg.aws.AwsClientFactories;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.common.DynConstructors;
@@ -28,11 +30,13 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.metrics.MetricsContext;
+import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.SerializableSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.Tag;
 
 /**
  * FileIO implementation backed by S3.
@@ -50,6 +54,7 @@ public class S3FileIO implements FileIO {
   private transient S3Client client;
   private MetricsContext metrics = MetricsContext.nullMetrics();
   private final AtomicBoolean isResourceClosed = new AtomicBoolean(false);
+  private Set<Tag> writeTags;
 
   /**
    * No-arg constructor to load the FileIO dynamically.
@@ -88,7 +93,7 @@ public class S3FileIO implements FileIO {
 
   @Override
   public OutputFile newOutputFile(String path) {
-    return S3OutputFile.fromLocation(path, client(), awsProperties, metrics);
+    return S3OutputFile.fromLocation(path, client(), awsProperties, metrics, writeTags);
   }
 
   @Override
@@ -110,6 +115,8 @@ public class S3FileIO implements FileIO {
   @Override
   public void initialize(Map<String, String> properties) {
     this.awsProperties = new AwsProperties(properties);
+    this.writeTags = toTags(
+        PropertyUtil.propertiesWithPrefix(properties, AwsProperties.S3_WRITE_TAGS_PREFIX));
 
     // Do not override s3 client if it was provided
     if (s3 == null) {
@@ -136,5 +143,11 @@ public class S3FileIO implements FileIO {
         client.close();
       }
     }
+  }
+
+  private Set<Tag> toTags(Map<String, String> tagKeyToTagValue) {
+    return tagKeyToTagValue.entrySet().stream()
+        .map(e -> Tag.builder().key(e.getKey()).value(e.getValue()).build())
+        .collect(Collectors.toSet());
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
@@ -28,10 +28,16 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.PositionOutputStream;
 import org.apache.iceberg.metrics.MetricsContext;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.Tag;
 
 public class S3OutputFile extends BaseS3File implements OutputFile {
+  public static S3OutputFile fromLocation(String location, S3Client client, AwsProperties awsProperties,
+      MetricsContext metrics) {
+    return new S3OutputFile(client, new S3URI(location), awsProperties, metrics, Sets.newHashSet());
+  }
+
   public static S3OutputFile fromLocation(String location, S3Client client, AwsProperties awsProperties,
       MetricsContext metrics, Set<Tag> writeTags) {
     return new S3OutputFile(client, new S3URI(location), awsProperties, metrics, writeTags);

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.aws.s3;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Set;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.io.InputFile;
@@ -28,15 +29,16 @@ import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.PositionOutputStream;
 import org.apache.iceberg.metrics.MetricsContext;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.Tag;
 
 public class S3OutputFile extends BaseS3File implements OutputFile {
   public static S3OutputFile fromLocation(String location, S3Client client, AwsProperties awsProperties,
-      MetricsContext metrics) {
-    return new S3OutputFile(client, new S3URI(location), awsProperties, metrics);
+      MetricsContext metrics, Set<Tag> writeTags) {
+    return new S3OutputFile(client, new S3URI(location), awsProperties, metrics, writeTags);
   }
 
-  S3OutputFile(S3Client client, S3URI uri, AwsProperties awsProperties, MetricsContext metrics) {
-    super(client, uri, awsProperties, metrics);
+  S3OutputFile(S3Client client, S3URI uri, AwsProperties awsProperties, MetricsContext metrics, Set<Tag> writeTags) {
+    super(client, uri, awsProperties, metrics, writeTags);
   }
 
   /**
@@ -57,7 +59,7 @@ public class S3OutputFile extends BaseS3File implements OutputFile {
   @Override
   public PositionOutputStream createOrOverwrite() {
     try {
-      return new S3OutputStream(client(), uri(), awsProperties(), metrics());
+      return new S3OutputStream(client(), uri(), awsProperties(), metrics(), writeTags());
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to create output stream for location: " + uri(), e);
     }

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
@@ -94,8 +94,8 @@ public class TestGlueCatalog {
   @Test
   public void testConstructorWarehousePathWithEndSlash() {
     GlueCatalog catalogWithSlash = new GlueCatalog();
-    catalogWithSlash.initialize(
-        CATALOG_NAME, WAREHOUSE_PATH + "/", new AwsProperties(), glue, LockManagers.defaultLockManager(), null);
+    catalogWithSlash.initialize(CATALOG_NAME, WAREHOUSE_PATH + "/", new AwsProperties(), glue,
+        LockManagers.defaultLockManager(), null);
     Mockito.doReturn(GetDatabaseResponse.builder()
         .database(Database.builder().name("db").build()).build())
         .when(glue).getDatabase(Mockito.any(GetDatabaseRequest.class));

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
@@ -30,11 +30,13 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -54,6 +56,7 @@ import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.Tag;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 import software.amazon.awssdk.utils.BinaryUtils;
 
@@ -85,6 +88,9 @@ public class TestS3OutputStream {
   private final Random random = new Random(1);
   private final Path tmpDir = Files.createTempDirectory("s3fileio-test-");
   private final String newTmpDirectory = "/tmp/newStagingDirectory";
+  private final Set<Tag> tags = ImmutableSet.of(
+      Tag.builder().key("abc").value("123").build(),
+      Tag.builder().key("def").value("789").build());
 
   private final AwsProperties properties = new AwsProperties(ImmutableMap.of(
       AwsProperties.S3FILEIO_MULTIPART_SIZE, Integer.toString(5 * 1024 * 1024),
@@ -116,7 +122,8 @@ public class TestS3OutputStream {
   public void testAbortAfterFailedPartUpload() {
     doThrow(new RuntimeException()).when(s3mock).uploadPart((UploadPartRequest) any(), (RequestBody) any());
 
-    try (S3OutputStream stream = new S3OutputStream(s3mock, randomURI(), properties, nullMetrics())) {
+    try (S3OutputStream stream = new S3OutputStream(s3mock, randomURI(), properties, nullMetrics(),
+        tags)) {
       stream.write(randomData(10 * 1024 * 1024));
     } catch (Exception e) {
       verify(s3mock, atLeastOnce()).abortMultipartUpload((AbortMultipartUploadRequest) any());
@@ -127,7 +134,8 @@ public class TestS3OutputStream {
   public void testAbortMultipart() {
     doThrow(new RuntimeException()).when(s3mock).completeMultipartUpload((CompleteMultipartUploadRequest) any());
 
-    try (S3OutputStream stream = new S3OutputStream(s3mock, randomURI(), properties, nullMetrics())) {
+    try (S3OutputStream stream = new S3OutputStream(s3mock, randomURI(), properties, nullMetrics(),
+        tags)) {
       stream.write(randomData(10 * 1024 * 1024));
     } catch (Exception e) {
       verify(s3mock).abortMultipartUpload((AbortMultipartUploadRequest) any());
@@ -136,7 +144,7 @@ public class TestS3OutputStream {
 
   @Test
   public void testMultipleClose() throws IOException {
-    S3OutputStream stream = new S3OutputStream(s3, randomURI(), properties, nullMetrics());
+    S3OutputStream stream = new S3OutputStream(s3, randomURI(), properties, nullMetrics(), tags);
     stream.close();
     stream.close();
   }
@@ -145,7 +153,8 @@ public class TestS3OutputStream {
   public void testStagingDirectoryCreation() throws IOException {
     AwsProperties newStagingDirectoryAwsProperties = new AwsProperties(ImmutableMap.of(
         AwsProperties.S3FILEIO_STAGING_DIRECTORY, newTmpDirectory));
-    S3OutputStream stream = new S3OutputStream(s3, randomURI(), newStagingDirectoryAwsProperties, nullMetrics());
+    S3OutputStream stream = new S3OutputStream(s3, randomURI(), newStagingDirectoryAwsProperties,
+        nullMetrics(), tags);
     stream.close();
   }
 
@@ -166,6 +175,7 @@ public class TestS3OutputStream {
       verify(s3mock, times(1)).putObject(putObjectRequestArgumentCaptor.capture(),
           (RequestBody) any());
       checkPutObjectRequestContent(data, putObjectRequestArgumentCaptor);
+      checkTags(putObjectRequestArgumentCaptor);
       reset(s3mock);
 
       // Test file larger than part size but less than multipart threshold
@@ -175,6 +185,7 @@ public class TestS3OutputStream {
       verify(s3mock, times(1)).putObject(putObjectRequestArgumentCaptor.capture(),
           (RequestBody) any());
       checkPutObjectRequestContent(data, putObjectRequestArgumentCaptor);
+      checkTags(putObjectRequestArgumentCaptor);
       reset(s3mock);
 
       // Test file large enough to trigger multipart upload
@@ -224,6 +235,20 @@ public class TestS3OutputStream {
     }
   }
 
+  private void checkTags(ArgumentCaptor<PutObjectRequest> putObjectRequestArgumentCaptor) {
+    if (properties.isS3ChecksumEnabled()) {
+      List<PutObjectRequest> putObjectRequests = putObjectRequestArgumentCaptor.getAllValues();
+      String tagging = putObjectRequests.get(0).tagging();
+      assertEquals(getTags(tags), tagging);
+    }
+  }
+
+  private String getTags(Set<Tag> objectTags) {
+    return objectTags.stream()
+        .map(e -> e.key() + "=" + e.value())
+        .collect(Collectors.joining("&"));
+  }
+
   private String getDigest(byte[] data, int offset, int length) {
     try {
       MessageDigest md5 = MessageDigest.getInstance("MD5");
@@ -236,7 +261,7 @@ public class TestS3OutputStream {
   }
 
   private void writeAndVerify(S3Client client, S3URI uri, byte [] data, boolean arrayWrite) {
-    try (S3OutputStream stream = new S3OutputStream(client, uri, properties, nullMetrics())) {
+    try (S3OutputStream stream = new S3OutputStream(client, uri, properties, nullMetrics(), tags)) {
       if (arrayWrite) {
         stream.write(data);
         assertEquals(data.length, stream.getPos());

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
@@ -122,8 +122,8 @@ public class TestS3OutputStream {
   public void testAbortAfterFailedPartUpload() {
     doThrow(new RuntimeException()).when(s3mock).uploadPart((UploadPartRequest) any(), (RequestBody) any());
 
-    try (S3OutputStream stream = new S3OutputStream(s3mock, randomURI(), properties, nullMetrics(),
-        tags)) {
+    try (S3OutputStream stream = new S3OutputStream(
+        s3mock, randomURI(), properties, nullMetrics(), tags)) {
       stream.write(randomData(10 * 1024 * 1024));
     } catch (Exception e) {
       verify(s3mock, atLeastOnce()).abortMultipartUpload((AbortMultipartUploadRequest) any());
@@ -134,8 +134,8 @@ public class TestS3OutputStream {
   public void testAbortMultipart() {
     doThrow(new RuntimeException()).when(s3mock).completeMultipartUpload((CompleteMultipartUploadRequest) any());
 
-    try (S3OutputStream stream = new S3OutputStream(s3mock, randomURI(), properties, nullMetrics(),
-        tags)) {
+    try (S3OutputStream stream = new S3OutputStream(
+        s3mock, randomURI(), properties, nullMetrics(), tags)) {
       stream.write(randomData(10 * 1024 * 1024));
     } catch (Exception e) {
       verify(s3mock).abortMultipartUpload((AbortMultipartUploadRequest) any());
@@ -153,8 +153,8 @@ public class TestS3OutputStream {
   public void testStagingDirectoryCreation() throws IOException {
     AwsProperties newStagingDirectoryAwsProperties = new AwsProperties(ImmutableMap.of(
         AwsProperties.S3FILEIO_STAGING_DIRECTORY, newTmpDirectory));
-    S3OutputStream stream = new S3OutputStream(s3, randomURI(), newStagingDirectoryAwsProperties,
-        nullMetrics(), tags);
+    S3OutputStream stream = new S3OutputStream(
+        s3, randomURI(), newStagingDirectoryAwsProperties, nullMetrics(), tags);
     stream.close();
   }
 

--- a/core/src/main/java/org/apache/iceberg/util/PropertyUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/PropertyUtil.java
@@ -82,13 +82,13 @@ public class PropertyUtil {
    * @param prefix prefix to choose keys from input map
    * @return subset of input map with keys starting with provided prefix and prefix trimmed out
    */
-  public static Map<String, String> propertiesWithPrefix(Map<String, String> properties,
-      String prefix) {
+  public static Map<String, String> propertiesWithPrefix(
+      Map<String, String> properties, String prefix) {
     if (properties == null || properties.isEmpty()) {
       return ImmutableMap.of();
     }
 
-    Preconditions.checkState(prefix != null, "prefix can't be null.");
+    Preconditions.checkArgument(prefix != null, "prefix can't be null.");
 
     return properties.entrySet().stream()
         .filter(e -> e.getKey().startsWith(prefix))

--- a/core/src/main/java/org/apache/iceberg/util/PropertyUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/PropertyUtil.java
@@ -20,6 +20,9 @@
 package org.apache.iceberg.util;
 
 import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 
 public class PropertyUtil {
 
@@ -69,5 +72,27 @@ public class PropertyUtil {
       return value;
     }
     return defaultValue;
+  }
+
+  /**
+   * Returns subset of provided map with keys matching the provided prefix. Matching is case-sensitive and the matching
+   * prefix is removed from the keys in returned map.
+   *
+   * @param properties input map
+   * @param prefix prefix to choose keys from input map
+   * @return subset of input map with keys starting with provided prefix and prefix trimmed out
+   */
+  public static Map<String, String> propertiesWithPrefix(Map<String, String> properties,
+      String prefix) {
+    if (properties == null || properties.isEmpty()) {
+      return ImmutableMap.of();
+    }
+
+    Preconditions.checkState(prefix != null, "prefix can't be null.");
+
+    return properties.entrySet().stream()
+        .filter(e -> e.getKey().startsWith(prefix))
+        .collect(Collectors.toMap(
+            e -> e.getKey().replaceFirst(prefix, ""), Map.Entry::getValue));
   }
 }


### PR DESCRIPTION
This change adds [S3 Tags](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html) to the objects while writing using `S3FileIO`. Users can pass their custom tags as part of the catalog properties.

Spark SQL launch command:
```
sh spark-sql --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCatalog \
    --conf spark.sql.catalog.my_catalog.warehouse=s3://iceberg-warehouse/s3-tagging \
    --conf spark.sql.catalog.my_catalog.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog \
    --conf spark.sql.catalog.my_catalog.io-impl=org.apache.iceberg.aws.s3.S3FileIO \
    --conf spark.sql.catalog.my_catalog.s3.write.tags.my_key=my_val \
    --conf spark.sql.catalog.my_catalog.s3.write.tags.my_key2=my_val2
```

Tags added in S3:

```
aws s3api get-object-tagging --bucket iceberg-warehouse --key s3-tagging/data/00000-0-593dfa9d-872f-4683-986f-ea220b7c875d-00001.parquet
{
    "TagSet": [
        {
            "Key": "my_key2",
            "Value": "my_val2"
        },
        {
            "Key": "my_key",
            "Value": "my_val"
        }
    ]
}
```
----

cc: @jackye1995 @arminnajafi @singhpk234 @amogh-jahagirdar @xiaoxuandev @yyanyy