### PR TITLE
Core: Implement table refs in TableMetadataParser

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -733,15 +733,17 @@ public class TableMetadata implements Serializable {
                                                        Map<Long, Snapshot> snapshotsById) {
     for (SnapshotRef ref : inputRefs.values()) {
       Preconditions.checkArgument(snapshotsById.containsKey(ref.snapshotId()),
-          "Snapshot reference %s does not exist in the existing snapshots list", ref);
+          "Snapshot for reference %s does not exist in the existing snapshots list", ref);
     }
 
+    SnapshotRef main = inputRefs.get(SnapshotRef.MAIN_BRANCH);
     if (currentSnapshotId != -1) {
-      SnapshotRef main = inputRefs.get(SnapshotRef.MAIN_BRANCH);
-      Preconditions.checkArgument(inputRefs.get(SnapshotRef.MAIN_BRANCH) != null,
-          "Current snapshot ID is set, but main branch is missing");
-      Preconditions.checkArgument(currentSnapshotId == main.snapshotId(),
-          "Current snapshot ID does not match main branch (%s != %s)", currentSnapshotId, main.snapshotId());
+      Preconditions.checkArgument(main == null || currentSnapshotId == main.snapshotId(),
+          "Current snapshot ID does not match main branch (%s != %s)",
+          currentSnapshotId, main != null ? main.snapshotId() : null);
+    } else {
+      Preconditions.checkArgument(main == null,
+          "Current snapshot is not set, but main branch exists: %s", main);
     }
 
     return inputRefs;

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -428,22 +428,24 @@ public class TableMetadataParser {
     long lastUpdatedMillis = JsonUtil.getLong(LAST_UPDATED_MILLIS, node);
 
     ImmutableMap.Builder<String, SnapshotRef> refsBuilder = ImmutableMap.builder();
-    JsonNode refMap = node.get(REFS);
-    Preconditions.checkArgument(refMap.isObject(), "Cannot parse refs from non-object: %s", refMap);
-    Iterator<String> refNames = refMap.fieldNames();
-    while (refNames.hasNext()) {
-      String refName = refNames.next();
-      JsonNode refNode = refMap.get(refName);
-      Preconditions.checkArgument(refNode.isObject(), "Cannot parse ref %s from non-object: %s", refName, refMap);
-      SnapshotRef ref = SnapshotRef
-          .builderFor(
-              JsonUtil.getLong(SNAPSHOT_ID, refNode),
-              SnapshotRefType.valueOf(JsonUtil.getString(TYPE, refNode).toUpperCase(Locale.ROOT)))
-          .maxSnapshotAgeMs(JsonUtil.getLongOrNull(MAX_SNAPSHOT_AGE_MS, refNode))
-          .minSnapshotsToKeep(JsonUtil.getIntOrNull(MIN_SNAPSHOTS_TO_KEEP, refNode))
-          .maxRefAgeMs(JsonUtil.getLongOrNull(MAX_REF_AGE_MS, refNode))
-          .build();
-      refsBuilder.put(refName, ref);
+    if (node.has(REFS)) {
+      JsonNode refMap = node.get(REFS);
+      Preconditions.checkArgument(refMap.isObject(), "Cannot parse refs from non-object: %s", refMap);
+      Iterator<String> refNames = refMap.fieldNames();
+      while (refNames.hasNext()) {
+        String refName = refNames.next();
+        JsonNode refNode = refMap.get(refName);
+        Preconditions.checkArgument(refNode.isObject(), "Cannot parse ref %s from non-object: %s", refName, refMap);
+        SnapshotRef ref = SnapshotRef
+            .builderFor(
+                JsonUtil.getLong(SNAPSHOT_ID, refNode),
+                SnapshotRefType.valueOf(JsonUtil.getString(TYPE, refNode).toUpperCase(Locale.ROOT)))
+            .maxSnapshotAgeMs(JsonUtil.getLongOrNull(MAX_SNAPSHOT_AGE_MS, refNode))
+            .minSnapshotsToKeep(JsonUtil.getIntOrNull(MIN_SNAPSHOTS_TO_KEEP, refNode))
+            .maxRefAgeMs(JsonUtil.getLongOrNull(MAX_REF_AGE_MS, refNode))
+            .build();
+        refsBuilder.put(refName, ref);
+      }
     }
 
     JsonNode snapshotArray = node.get(SNAPSHOTS);

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -319,7 +319,7 @@ public class TableMetadataParser {
     return fromJson(io, file.location(), node);
   }
 
-  @SuppressWarnings("checkstyle:CyclomaticComplexity")
+  @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:MethodLength"})
   static TableMetadata fromJson(FileIO io, String metadataLocation, JsonNode node) {
     Preconditions.checkArgument(node.isObject(),
         "Cannot parse metadata from a non-object: %s", node);

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -249,12 +249,12 @@ public class TestTableMetadata {
   public void testInvalidMainBranch() {
     long previousSnapshotId = System.currentTimeMillis() - new Random(1234).nextInt(3600);
     Snapshot previousSnapshot = new BaseSnapshot(
-        ops.io(), previousSnapshotId, null, previousSnapshotId, null, null, null, ImmutableList.of(
-        new GenericManifestFile(localInput("file:/tmp/manfiest.1.avro"), SPEC_5.specId())));
+        ops.io(), previousSnapshotId, null, previousSnapshotId, null, null, null,
+        ImmutableList.of(new GenericManifestFile(localInput("file:/tmp/manfiest.1.avro"), SPEC_5.specId())));
     long currentSnapshotId = System.currentTimeMillis();
     Snapshot currentSnapshot = new BaseSnapshot(
-        ops.io(), currentSnapshotId, previousSnapshotId, currentSnapshotId, null, null, 7, ImmutableList.of(
-        new GenericManifestFile(localInput("file:/tmp/manfiest.2.avro"), SPEC_5.specId())));
+        ops.io(), currentSnapshotId, previousSnapshotId, currentSnapshotId, null, null, 7,
+        ImmutableList.of(new GenericManifestFile(localInput("file:/tmp/manfiest.2.avro"), SPEC_5.specId())));
 
     List<HistoryEntry> snapshotLog = ImmutableList.<HistoryEntry>builder()
         .add(new SnapshotLogEntry(previousSnapshot.timestampMillis(), previousSnapshot.snapshotId()))
@@ -283,8 +283,8 @@ public class TestTableMetadata {
   public void testMainWithoutCurrent() {
     long snapshotId = System.currentTimeMillis() - new Random(1234).nextInt(3600);
     Snapshot snapshot = new BaseSnapshot(
-        ops.io(), snapshotId, null, snapshotId, null, null, null, ImmutableList.of(
-        new GenericManifestFile(localInput("file:/tmp/manfiest.1.avro"), SPEC_5.specId())));
+        ops.io(), snapshotId, null, snapshotId, null, null, null,
+        ImmutableList.of(new GenericManifestFile(localInput("file:/tmp/manfiest.1.avro"), SPEC_5.specId())));
 
     Schema schema = new Schema(6,
         Types.NestedField.required(10, "x", Types.StringType.get()));


### PR DESCRIPTION
This updates TableMetadataParser to read and write the [refs map](https://iceberg.apache.org/spec/#snapshot-reference).