### PR TITLE
Hive: Known exception should not become CommitStateUnknownException

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
+import org.apache.hadoop.hive.metastore.api.InvalidObjectException;
 import org.apache.hadoop.hive.metastore.api.LockComponent;
 import org.apache.hadoop.hive.metastore.api.LockLevel;
 import org.apache.hadoop.hive.metastore.api.LockRequest;
@@ -61,6 +62,7 @@ import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.NoSuchIcebergTableException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.hadoop.ConfigProperties;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
@@ -271,29 +273,32 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
       try {
         persistTable(tbl, updateHiveTable);
         commitStatus = CommitStatus.SUCCESS;
-      } catch (Throwable persistFailure) {
+      } catch (org.apache.hadoop.hive.metastore.api.AlreadyExistsException e) {
+        throw new AlreadyExistsException(e, "Table already exists: %s.%s", database, tableName);
+
+      } catch (InvalidObjectException e) {
+        throw new ValidationException(e, "Invalid table name for %s.%s", database, tableName);
+
+      } catch (Throwable e) {
+        if (e.getMessage() != null && e.getMessage().contains("Table/View 'HIVE_LOCKS' does not exist")) {
+          throw new RuntimeException("Failed to acquire locks from metastore because 'HIVE_LOCKS' doesn't " +
+              "exist, this probably happened when using embedded metastore or doesn't create a " +
+              "transactional meta table. To fix this, use an alternative metastore", e);
+        }
+
         LOG.error("Cannot tell if commit to {}.{} succeeded, attempting to reconnect and check.",
-            database, tableName, persistFailure);
+            database, tableName, e);
         commitStatus = checkCommitStatus(newMetadataLocation, metadata);
         switch (commitStatus) {
           case SUCCESS:
             break;
           case FAILURE:
-            throw persistFailure;
+            throw e;
           case UNKNOWN:
-            throw new CommitStateUnknownException(persistFailure);
+            throw new CommitStateUnknownException(e);
         }
       }
-    } catch (org.apache.hadoop.hive.metastore.api.AlreadyExistsException e) {
-      throw new AlreadyExistsException("Table already exists: %s.%s", database, tableName);
-
     } catch (TException | UnknownHostException e) {
-      if (e.getMessage() != null && e.getMessage().contains("Table/View 'HIVE_LOCKS' does not exist")) {
-        throw new RuntimeException("Failed to acquire locks from metastore because 'HIVE_LOCKS' doesn't " +
-            "exist, this probably happened when using embedded metastore or doesn't create a " +
-            "transactional meta table. To fix this, use an alternative metastore", e);
-      }
-
       throw new RuntimeException(String.format("Metastore operation failed for %s.%s", database, tableName), e);
 
     } catch (InterruptedException e) {

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -277,13 +277,13 @@ public class HiveTableOperations extends BaseMetastoreTableOperations {
         throw new AlreadyExistsException(e, "Table already exists: %s.%s", database, tableName);
 
       } catch (InvalidObjectException e) {
-        throw new ValidationException(e, "Invalid table name for %s.%s", database, tableName);
+        throw new ValidationException(e, "Invalid Hive object for %s.%s", database, tableName);
 
       } catch (Throwable e) {
         if (e.getMessage() != null && e.getMessage().contains("Table/View 'HIVE_LOCKS' does not exist")) {
-          throw new RuntimeException("Failed to acquire locks from metastore because 'HIVE_LOCKS' doesn't " +
-              "exist, this probably happened when using embedded metastore or doesn't create a " +
-              "transactional meta table. To fix this, use an alternative metastore", e);
+          throw new RuntimeException("Failed to acquire locks from metastore because the underlying metastore " +
+              "table 'HIVE_LOCKS' does not exist. This can occur when using an embedded metastore which does not " +
+              "support transactions. To fix this use an alternative metastore.", e);
         }
 
         LOG.error("Cannot tell if commit to {}.{} succeeded, attempting to reconnect and check.",


### PR DESCRIPTION
After #3717 all HIve exceptions become CommitStateUnknownException.  That is because checkCommitStatus stops returning FAILURE mode and always either SUCCESS or UNKNOWN, and subsequent specific error-handling blocks [specific catch blocks](https://github.com/apache/iceberg/blob/master/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java#L287) never get run.

For instance, doing a create table statement with invalid character in name:  
```CREATE TABLE `tbl` (id INT) USING ICEBERG```

Gets this kind of confusing and alarming error message for user:

```
org.apache.iceberg.exceptions.CommitStateUnknownException: `tbl` is not a valid object name
Cannot determine whether the commit was successful or not, the underlying data files may or may not be needed. Manual intervention via the Remove Orphan Files Action can remove these files when a connection to the Catalog can be re-established if the commit was actually unsuccessful.
Please check to see whether or not your commit was successful before retrying this commit. Retrying an already successful operation will result in duplicate records or unintentional modifications.
At this time no files will be deleted including possibly unused manifest lists.
```

Also, another side effect is there is a NPE in checkCommitStatus() code, which was not designed for when table is first being created.

```
java.lang.NullPointerException
	at org.apache.iceberg.BaseMetastoreTableOperations.lambda$checkCommitStatus$4(BaseMetastoreTableOperations.java:302)
	at org.apache.iceberg.util.Tasks$Builder.runTaskWithRetry(Tasks.java:404)
	at org.apache.iceberg.util.Tasks$Builder.runSingleThreaded(Tasks.java:214)
	at org.apache.iceberg.util.Tasks$Builder.run(Tasks.java:198)
	at org.apache.iceberg.util.Tasks$Builder.run(Tasks.java:190)
	at org.apache.iceberg.BaseMetastoreTableOperations.checkCommitStatus(BaseMetastoreTableOperations.java:300)
	at org.apache.iceberg.hive.HiveTableOperations.doCommit(HiveTableOperations.java:285)
	at org.apache.iceberg.BaseMetastoreTableOperations.commit(BaseMetastoreTableOperations.java:127)
	at org.apache.iceberg.BaseMetastoreCatalog$BaseMetastoreCatalogTableBuilder.create(BaseMetastoreCatalog.java:165)
	at org.apache.iceberg.catalog.Catalog.createTable(Catalog.java:78)
	at org.apache.iceberg.catalog.Catalog.createTable(Catalog.java:112)
```

This change just pushes down the original Hive known error handling for user-errors, and skips the CommitStateUnknown handling for those.  A new handling InvalidObjectException is added to catch the common user-error of invalid table names.
