### PR TITLE
Python: Serialization/Deserialization for types and partition values (port of conversions.py from python_legacy)

### DIFF
--- a/python/src/iceberg/conversions.py
+++ b/python/src/iceberg/conversions.py
@@ -78,7 +78,8 @@ def decimal_to_unscaled(value: Decimal) -> int:
     Returns:
         int: The unscaled value
     """
-    return int(value.to_integral_value())
+    sign, digits, _ = value.as_tuple()
+    return int(Decimal((sign, digits, 0)).to_integral_value())
 
 
 def unscaled_to_decimal(unscaled: int, scale: int) -> Decimal:
@@ -92,7 +93,7 @@ def unscaled_to_decimal(unscaled: int, scale: int) -> Decimal:
         Decimal: A scaled Decimal instance
     """
     sign, digits, _ = Decimal(unscaled).as_tuple()
-    return Decimal((sign, digits, scale))
+    return Decimal((sign, digits, -scale))
 
 
 @singledispatch
@@ -315,4 +316,4 @@ def _(primitive_type, b: bytes) -> bytes:
 @from_bytes.register(DecimalType)
 def _(primitive_type, buf: bytes) -> Decimal:
     unscaled = int.from_bytes(buf, "big", signed=True)
-    return unscaled_to_decimal(unscaled, -primitive_type.scale)
+    return unscaled_to_decimal(unscaled, primitive_type.scale)

--- a/python/src/iceberg/conversions.py
+++ b/python/src/iceberg/conversions.py
@@ -155,6 +155,10 @@ def _(primitive_type, value: int) -> bytes:
 
 @to_bytes.register(FloatType)
 def _(primitive_type, value: float) -> bytes:
+    """
+    Note: float in python is implemented using a double in C. Therefore this involves a conversion of a 32-bit (single precision)
+    float to a 64-bit (double precision) float which introduces some imprecision.
+    """
     return struct.pack("<f", value)
 
 
@@ -231,10 +235,6 @@ def _(primitive_type, b: bytes):
 
 @from_bytes.register(FloatType)
 def _(primitive_type, b: bytes):
-    """
-    Note: float in python is implemented using a double in C. Therefore this involves a conversion of a 32-bit (single precision)
-    float to a 64-bit (double precision) float which introduces some imprecision.
-    """
     return struct.unpack("<f", b)[0]
 
 

--- a/python/src/iceberg/conversions.py
+++ b/python/src/iceberg/conversions.py
@@ -231,6 +231,10 @@ def _(primitive_type, b: bytes):
 
 @from_bytes.register(FloatType)
 def _(primitive_type, b: bytes):
+    """
+    Note: float in python is implemented using a double in C. Therefore this involves a conversion of a 32-bit (single precision)
+    float to a 64-bit (double precision) float which introduces some imprecision.
+    """
     return struct.unpack("<f", b)[0]
 
 

--- a/python/src/iceberg/conversions.py
+++ b/python/src/iceberg/conversions.py
@@ -258,4 +258,4 @@ def _(primitive_type, b: bytes):
     integer_representation = int.from_bytes(b, "big", signed=True)
     with localcontext() as ctx:
         ctx.prec = primitive_type.precision
-        return Decimal(integer_representation) * Decimal(10) ** Decimal(-primitive_type.scale)
+        return Decimal(integer_representation) * (Decimal(10) ** Decimal(-primitive_type.scale))

--- a/python/src/iceberg/conversions.py
+++ b/python/src/iceberg/conversions.py
@@ -63,8 +63,6 @@ from iceberg.types import (
     UUIDType,
 )
 
-HIVE_NULL = "__HIVE_DEFAULT_PARTITION__"
-
 
 @singledispatch
 def from_partition_value_to_py(primitive_type, partition_value_as_str: str):
@@ -74,7 +72,7 @@ def from_partition_value_to_py(primitive_type, partition_value_as_str: str):
         primitive_type(PrimitiveType): An implementation of the PrimitiveType base class
         partition_value_as_str(str): A string representation of a partition value
     """
-    if partition_value_as_str is None or partition_value_as_str == HIVE_NULL:
+    if partition_value_as_str is None:
         return None
     raise TypeError(
         f"Cannot convert partition string to python built-in, type {primitive_type} not supported: '{partition_value_as_str}'"

--- a/python/src/iceberg/conversions.py
+++ b/python/src/iceberg/conversions.py
@@ -187,8 +187,10 @@ def _(primitive_type, value: Decimal) -> bytes:
 
     if value_scale != primitive_type.scale:
         raise ValueError(f"Cannot serialize value, scale of value does not match type {primitive_type}: {value_scale}")
-    elif value_precision != primitive_type.precision:
-        raise ValueError(f"Cannot serialize value, precision of value does not match type {primitive_type}: {value_precision}")
+    elif value_precision > primitive_type.precision:
+        raise ValueError(
+            f"Cannot serialize value, precision of value is greater than precision of type {primitive_type}: {value_precision}"
+        )
 
     with localcontext() as ctx:
         ctx.prec = primitive_type.precision

--- a/python/src/iceberg/conversions.py
+++ b/python/src/iceberg/conversions.py
@@ -26,19 +26,6 @@ Note:
     are defined here as generic functions using the @singledispatch decorator. For each PrimitiveType
     implementation, a concrete function is registered for each generic conversion function. For PrimitiveType
     implementations that share the same conversion logic, registrations can be stacked.
-
-Example (registering `from_partition_to_py` logic for BooleanType):
-    >>> @from_partition_value_to_py.register(BooleanType)
-    >>> def _(primitive_type, partition_value_as_str: str):
-            if partition_value_as_str is None:
-                return None
-            return partition_value_as_str.lower() == "true"
-
-Example (stacking registrations):
-   >>> @from_partition_value_to_py.register(FloatType)
-   >>> @from_partition_value_to_py.register(DoubleType)
-   >>> def _(primitive_type, partition_value_as_str: str):
-           return float(partition_value_as_str)
 """
 import struct
 import uuid

--- a/python/src/iceberg/conversions.py
+++ b/python/src/iceberg/conversions.py
@@ -1,0 +1,251 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Utility module for various conversions around PrimitiveType implementations
+
+This module enables:
+    - Converting partition strings to built-in python objects
+    - Converting a value to a byte buffer
+    - Converting a byte buffer to a value
+
+Note:
+    Conversion logic varies based on the PrimitiveType implementation. Therefore conversion functions
+    are defined here as generic functions using the @singledispatch decorator. For each PrimitiveType
+    implementation, a concrete function is registered for each generic conversion function. For PrimitiveType
+    implementations that share the same conversion logic, registrations can be stacked.
+
+Example (registering `from_partition_to_py` logic for BooleanType):
+    >>> @from_partition_value_to_py.register(BooleanType)
+    >>> def _(type_, partition_value_as_str: str):
+            if partition_value_as_str is None:
+                return False
+            return partition_value_as_str.lower() == "true"
+
+Example (stacking registrations):
+   >>> @from_partition_value_to_py.register(FloatType)
+   >>> @from_partition_value_to_py.register(DoubleType)
+   >>> def _(type_, partition_value_as_str: str):
+           return float(partition_value_as_str)
+"""
+import struct
+import uuid
+from decimal import ROUND_HALF_UP, Decimal
+from functools import singledispatch
+from typing import Any
+
+from iceberg.types import (
+    BinaryType,
+    BooleanType,
+    DateType,
+    DecimalType,
+    DoubleType,
+    FixedType,
+    FloatType,
+    IntegerType,
+    LongType,
+    StringType,
+    TimestampType,
+    TimestamptzType,
+    TimeType,
+    UUIDType,
+)
+
+HIVE_NULL = "__HIVE_DEFAULT_PARTITION__"
+
+
+@singledispatch
+def from_partition_value_to_py(type_, partition_value_as_str: str):
+    """A generic function function which converts a partition string to a python built-in
+
+    Args:
+        type_(PrimitiveType): An implementation of the PrimitiveType base class
+        partition_value_as_str(str): A string representation of a partition value
+    """
+    if partition_value_as_str is None or partition_value_as_str == HIVE_NULL:
+        return None
+    raise TypeError(f"Cannot convert partition string to python built-in, type {type_} not supported: '{partition_value_as_str}'")
+
+
+@from_partition_value_to_py.register(BooleanType)
+def _(type_, partition_value_as_str: str):
+    if partition_value_as_str is None:
+        return False
+    return partition_value_as_str.lower() == "true"
+
+
+@from_partition_value_to_py.register(IntegerType)
+@from_partition_value_to_py.register(LongType)
+def _(type_, partition_value_as_str: str):
+    return int(float(partition_value_as_str))
+
+
+@from_partition_value_to_py.register(FloatType)
+@from_partition_value_to_py.register(DoubleType)
+def _(type_, partition_value_as_str: str):
+    return float(partition_value_as_str)
+
+
+@from_partition_value_to_py.register(StringType)
+def _(type_, partition_value_as_str: str):
+    return partition_value_as_str
+
+
+@from_partition_value_to_py.register(UUIDType)
+def _(type_, partition_value_as_str: str):
+    return uuid.UUID(partition_value_as_str)
+
+
+@from_partition_value_to_py.register(FixedType)
+def _(type_, partition_value_as_str: str):
+    return bytearray(bytes(partition_value_as_str, "UTF-8"))
+
+
+@from_partition_value_to_py.register(BinaryType)
+def _(type_, partition_value_as_str: str):
+    return bytes(partition_value_as_str, "UTF-8")
+
+
+@from_partition_value_to_py.register(DecimalType)
+def _(type_, partition_value_as_str: str):
+    return Decimal(partition_value_as_str)
+
+
+@singledispatch
+def to_bytes(type_, value: Any) -> bytes:
+    """A generic function which converts a built-in python value to bytes
+
+    Args:
+        type_(PrimitiveType): An implementation of the PrimitiveType base class
+        value(Any): The value to convert to bytes
+    """
+    raise TypeError(f"Cannot serialize value, type {type_} not supported: '{value}'")
+
+
+@to_bytes.register(BooleanType)
+def _(type_, value: Any) -> bytes:
+    return struct.pack("<?", 1 if value else 0)
+
+
+@to_bytes.register(IntegerType)
+@to_bytes.register(DateType)
+def _(type_, value: Any) -> bytes:
+    return struct.pack("<i", value)
+
+
+@to_bytes.register(LongType)
+@to_bytes.register(TimeType)
+@to_bytes.register(TimestampType)
+@to_bytes.register(TimestamptzType)
+def _(type_, value: Any) -> bytes:
+    return struct.pack("<q", value)
+
+
+@to_bytes.register(FloatType)
+def _(type_, value: Any) -> bytes:
+    return struct.pack("<f", value)
+
+
+@to_bytes.register(DoubleType)
+def _(type_, value: Any) -> bytes:
+    return struct.pack("<d", value)
+
+
+@to_bytes.register(StringType)
+def _(type_, value: Any) -> bytes:
+    return value.encode("UTF-8")
+
+
+@to_bytes.register(UUIDType)
+def _(type_, value: Any) -> bytes:
+    return struct.pack(">QQ", (value.int >> 64) & 0xFFFFFFFFFFFFFFFF, value.int & 0xFFFFFFFFFFFFFFFF)
+
+
+@to_bytes.register(BinaryType)
+@to_bytes.register(FixedType)
+def _(type_, value: Any) -> bytes:
+    return value
+
+
+@to_bytes.register(DecimalType)
+def _(type_, value: Any) -> bytes:
+    scale = abs(value.as_tuple().exponent)
+    quantized_value = value.quantize(Decimal("10") ** -scale)
+    unscaled_value = int((quantized_value * 10**scale).to_integral_value())
+    min_num_bytes = (unscaled_value.bit_length() + 7) // 8
+    return unscaled_value.to_bytes(min_num_bytes, "big", signed=True)
+
+
+@singledispatch
+def from_bytes(type_, b: bytes):
+    """A generic function which converts bytes to a built-in python value
+
+    Args:
+        type_(PrimitiveType): An implementation of the PrimitiveType base class
+        b(bytes): The bytes to convert
+    """
+    raise TypeError(f"Cannot deserialize bytes, type {type_} not supported: {str(b)}")
+
+
+@from_bytes.register(BooleanType)
+def _(type_, b: bytes):
+    return struct.unpack("<?", b)[0] != 0
+
+
+@from_bytes.register(IntegerType)
+@from_bytes.register(DateType)
+def _(type_, b: bytes):
+    return struct.unpack("<i", b)[0]
+
+
+@from_bytes.register(LongType)
+@from_bytes.register(TimeType)
+@from_bytes.register(TimestampType)
+@from_bytes.register(TimestamptzType)
+def _(type_, b: bytes):
+    return struct.unpack("<q", b)[0]
+
+
+@from_bytes.register(FloatType)
+def _(type_, b: bytes):
+    return struct.unpack("<f", b)[0]
+
+
+@from_bytes.register(DoubleType)
+def _(type_, b: bytes):
+    return struct.unpack("<d", b)[0]
+
+
+@from_bytes.register(StringType)
+def _(type_, b: bytes):
+    return bytes(b).decode("utf-8")
+
+
+@from_bytes.register(UUIDType)
+def _(type_, b: bytes):
+    return uuid.UUID(int=struct.unpack(">QQ", b)[0] << 64 | struct.unpack(">QQ", b)[1])
+
+
+@from_bytes.register(BinaryType)
+@from_bytes.register(FixedType)
+def _(type_, b: bytes):
+    return b
+
+
+@from_bytes.register(DecimalType)
+def _(type_, b: bytes):
+    return Decimal(int.from_bytes(b, "big", signed=True) * 10**-type_.scale).quantize(
+        Decimal("." + "".join(["0" for i in range(1, type_.scale)]) + "1"), rounding=ROUND_HALF_UP
+    )

--- a/python/src/iceberg/conversions.py
+++ b/python/src/iceberg/conversions.py
@@ -31,7 +31,7 @@ Example (registering `from_partition_to_py` logic for BooleanType):
     >>> @from_partition_value_to_py.register(BooleanType)
     >>> def _(primitive_type, partition_value_as_str: str):
             if partition_value_as_str is None:
-                return False
+                return None
             return partition_value_as_str.lower() == "true"
 
 Example (stacking registrations):
@@ -42,8 +42,9 @@ Example (stacking registrations):
 """
 import struct
 import uuid
-from decimal import ROUND_HALF_DOWN, Decimal, localcontext
+from decimal import Decimal, localcontext
 from functools import singledispatch
+from typing import Union
 
 from iceberg.types import (
     BinaryType,
@@ -55,12 +56,44 @@ from iceberg.types import (
     FloatType,
     IntegerType,
     LongType,
+    PrimitiveType,
     StringType,
     TimestampType,
     TimestamptzType,
     TimeType,
     UUIDType,
 )
+
+
+def convert_decimal_to_unscaled_value(decimal_type_var: DecimalType, value: Decimal) -> int:
+    """Get an unscaled value given a Decimal value and a DecimalType instance with defined precision and scale
+
+    Args:
+        decimal_type_var (DecimalType): A DecimalType instance with precision and scale
+        value (Decimal): A Decimal instance
+
+    Raises:
+        ValueError: If either the scale or precision of `value` does not match that defined in the DecimalType instance provided as `decimal_type_var`
+
+    Returns:
+        int: The unscaled value
+    """
+    value_as_tuple = value.as_tuple()
+    value_precision = len(value_as_tuple.digits)
+    value_scale = -value_as_tuple.exponent
+
+    if value_scale != decimal_type_var.scale:
+        raise ValueError(f"Cannot serialize value, scale of value does not match type {decimal_type_var}: {value_scale}")
+    elif value_precision > decimal_type_var.precision:
+        raise ValueError(
+            f"Cannot serialize value, precision of value is greater than precision of type {decimal_type_var}: {value_precision}"
+        )
+
+    with localcontext() as ctx:
+        ctx.prec = decimal_type_var.precision
+        sign, digits, exponent = value.as_tuple()
+        value_w_adjusted_scale = Decimal((sign, digits, exponent + decimal_type_var.scale))
+        return int(value_w_adjusted_scale.to_integral_value())
 
 
 @singledispatch
@@ -81,57 +114,76 @@ def from_partition_value_to_py(primitive_type, partition_value_as_str: str):
 @from_partition_value_to_py.register(BooleanType)
 def _(primitive_type, partition_value_as_str: str):
     if partition_value_as_str is None:
-        return False
+        return None
     return partition_value_as_str.lower() == "true"
 
 
 @from_partition_value_to_py.register(IntegerType)
 @from_partition_value_to_py.register(LongType)
 def _(primitive_type, partition_value_as_str: str):
+    """
+    Note: Before attempting to cast the value to string, a validation happens to ensure that there are no fractional digits. For
+    example, an invalid value such as "123.45" will be converted to a decimal with digits (1, 2, 3, 4, 5) with an exponent of -2 and the last
+    2 digits will be inspected for non-zero values. An example of a valid value is "123.00".
+    """
+    if partition_value_as_str is None:
+        return None
+    _, digits, exponent = Decimal(partition_value_as_str).as_tuple()
+    if exponent != 0 and any(digits[exponent:]):  # If there are digits to the right of the exponent, raise if any are not 0
+        raise ValueError(f"Cannot convert partition value, value cannot have fractional digits for {primitive_type} partition")
     return int(float(partition_value_as_str))
 
 
 @from_partition_value_to_py.register(FloatType)
 @from_partition_value_to_py.register(DoubleType)
 def _(primitive_type, partition_value_as_str: str):
+    if partition_value_as_str is None:
+        return None
     return float(partition_value_as_str)
 
 
 @from_partition_value_to_py.register(StringType)
 def _(primitive_type, partition_value_as_str: str):
+    if partition_value_as_str is None:
+        return None
     return partition_value_as_str
 
 
 @from_partition_value_to_py.register(UUIDType)
 def _(primitive_type, partition_value_as_str: str):
+    if partition_value_as_str is None:
+        return None
     return uuid.UUID(partition_value_as_str)
 
 
 @from_partition_value_to_py.register(FixedType)
-def _(primitive_type, partition_value_as_str: str):
-    return bytearray(bytes(partition_value_as_str, "UTF-8"))
-
-
 @from_partition_value_to_py.register(BinaryType)
 def _(primitive_type, partition_value_as_str: str):
+    if partition_value_as_str is None:
+        return None
     return bytes(partition_value_as_str, "UTF-8")
 
 
 @from_partition_value_to_py.register(DecimalType)
 def _(primitive_type, partition_value_as_str: str):
+    if partition_value_as_str is None:
+        return None
     return Decimal(partition_value_as_str)
 
 
 @singledispatch
-def to_bytes(primitive_type, value) -> bytes:
+def to_bytes(primitive_type: PrimitiveType, value: Union[bool, bytes, Decimal, float, int, str, uuid.UUID]) -> bytes:
     """A generic function which converts a built-in python value to bytes
+
+    This conversion follows the serialization scheme for storing single values as individual binary values defined in the Iceberg specification that
+    can be found at https://iceberg.apache.org/spec/#appendix-d-single-value-serialization
 
     Args:
         primitive_type(PrimitiveType): An implementation of the PrimitiveType base class
         value: The value to convert to bytes (The type of this value depends on which dispatched function is
             used--check dispatchable functions for typehints)
     """
-    raise TypeError(f"Cannot serialize value, type {primitive_type} not supported: '{value}'")
+    raise TypeError(f"Cannot serialize value, type {primitive_type} not supported: '{str(value)}'")
 
 
 @to_bytes.register(BooleanType)
@@ -185,26 +237,13 @@ def _(primitive_type, value: bytes) -> bytes:
 
 @to_bytes.register(DecimalType)
 def _(primitive_type, value: Decimal) -> bytes:
-    value_as_tuple = value.as_tuple()
-    value_precision = len(value_as_tuple.digits)
-    value_scale = -value_as_tuple.exponent
-
-    if value_scale != primitive_type.scale:
-        raise ValueError(f"Cannot serialize value, scale of value does not match type {primitive_type}: {value_scale}")
-    elif value_precision > primitive_type.precision:
-        raise ValueError(
-            f"Cannot serialize value, precision of value is greater than precision of type {primitive_type}: {value_precision}"
-        )
-
-    with localcontext() as ctx:
-        ctx.prec = primitive_type.precision
-        unscaled_value = int((value * 10**primitive_type.scale).to_integral_value(rounding=ROUND_HALF_DOWN))
-        min_num_bytes = ((unscaled_value).bit_length() + 7) // 8
-        return unscaled_value.to_bytes(min_num_bytes, "big", signed=True)
+    unscaled_value = convert_decimal_to_unscaled_value(decimal_type_var=primitive_type, value=value)
+    min_num_bytes = ((unscaled_value).bit_length() + 7) // 8
+    return unscaled_value.to_bytes(min_num_bytes, "big", signed=True)
 
 
 @singledispatch
-def from_bytes(primitive_type, b: bytes):
+def from_bytes(primitive_type: PrimitiveType, b: bytes) -> Union[bool, bytes, Decimal, float, int, str, uuid.UUID]:
     """A generic function which converts bytes to a built-in python value
 
     Args:
@@ -215,13 +254,13 @@ def from_bytes(primitive_type, b: bytes):
 
 
 @from_bytes.register(BooleanType)
-def _(primitive_type, b: bytes):
+def _(primitive_type, b: bytes) -> bool:
     return struct.unpack("<?", b)[0] != 0
 
 
 @from_bytes.register(IntegerType)
 @from_bytes.register(DateType)
-def _(primitive_type, b: bytes):
+def _(primitive_type, b: bytes) -> int:
     return struct.unpack("<i", b)[0]
 
 
@@ -229,7 +268,7 @@ def _(primitive_type, b: bytes):
 @from_bytes.register(TimeType)
 @from_bytes.register(TimestampType)
 @from_bytes.register(TimestamptzType)
-def _(primitive_type, b: bytes):
+def _(primitive_type, b: bytes) -> int:
     return struct.unpack("<q", b)[0]
 
 
@@ -239,29 +278,30 @@ def _(primitive_type, b: bytes):
 
 
 @from_bytes.register(DoubleType)
-def _(primitive_type, b: bytes):
+def _(primitive_type, b: bytes) -> float:
     return struct.unpack("<d", b)[0]
 
 
 @from_bytes.register(StringType)
-def _(primitive_type, b: bytes):
+def _(primitive_type: PrimitiveType, b: bytes) -> str:
     return bytes(b).decode("utf-8")
 
 
 @from_bytes.register(UUIDType)
-def _(primitive_type, b: bytes):
-    return uuid.UUID(int=struct.unpack(">QQ", b)[0] << 64 | struct.unpack(">QQ", b)[1])
+def _(primitive_type, b: bytes) -> uuid.UUID:
+    unpacked_bytes = struct.unpack(">QQ", b)
+    return uuid.UUID(int=unpacked_bytes[0] << 64 | unpacked_bytes[1])
 
 
 @from_bytes.register(BinaryType)
 @from_bytes.register(FixedType)
-def _(primitive_type, b: bytes):
+def _(primitive_type, b: bytes) -> bytes:
     return b
 
 
 @from_bytes.register(DecimalType)
-def _(primitive_type, b: bytes):
+def _(primitive_type, b: bytes) -> Decimal:
     integer_representation = int.from_bytes(b, "big", signed=True)
     with localcontext() as ctx:
         ctx.prec = primitive_type.precision
-        return Decimal(integer_representation) * (Decimal(10) ** Decimal(-primitive_type.scale))
+        return Decimal(integer_representation) * Decimal((0, (1,), -primitive_type.scale))

--- a/python/src/iceberg/conversions.py
+++ b/python/src/iceberg/conversions.py
@@ -29,7 +29,7 @@ Note:
 
 Example (registering `from_partition_to_py` logic for BooleanType):
     >>> @from_partition_value_to_py.register(BooleanType)
-    >>> def _(type_, partition_value_as_str: str):
+    >>> def _(primitive_type, partition_value_as_str: str):
             if partition_value_as_str is None:
                 return False
             return partition_value_as_str.lower() == "true"
@@ -37,7 +37,7 @@ Example (registering `from_partition_to_py` logic for BooleanType):
 Example (stacking registrations):
    >>> @from_partition_value_to_py.register(FloatType)
    >>> @from_partition_value_to_py.register(DoubleType)
-   >>> def _(type_, partition_value_as_str: str):
+   >>> def _(primitive_type, partition_value_as_str: str):
            return float(partition_value_as_str)
 """
 import struct
@@ -67,20 +67,22 @@ HIVE_NULL = "__HIVE_DEFAULT_PARTITION__"
 
 
 @singledispatch
-def from_partition_value_to_py(type_, partition_value_as_str: str):
+def from_partition_value_to_py(primitive_type, partition_value_as_str: str):
     """A generic function function which converts a partition string to a python built-in
 
     Args:
-        type_(PrimitiveType): An implementation of the PrimitiveType base class
+        primitive_type(PrimitiveType): An implementation of the PrimitiveType base class
         partition_value_as_str(str): A string representation of a partition value
     """
     if partition_value_as_str is None or partition_value_as_str == HIVE_NULL:
         return None
-    raise TypeError(f"Cannot convert partition string to python built-in, type {type_} not supported: '{partition_value_as_str}'")
+    raise TypeError(
+        f"Cannot convert partition string to python built-in, type {primitive_type} not supported: '{partition_value_as_str}'"
+    )
 
 
 @from_partition_value_to_py.register(BooleanType)
-def _(type_, partition_value_as_str: str):
+def _(primitive_type, partition_value_as_str: str):
     if partition_value_as_str is None:
         return False
     return partition_value_as_str.lower() == "true"
@@ -88,60 +90,60 @@ def _(type_, partition_value_as_str: str):
 
 @from_partition_value_to_py.register(IntegerType)
 @from_partition_value_to_py.register(LongType)
-def _(type_, partition_value_as_str: str):
+def _(primitive_type, partition_value_as_str: str):
     return int(float(partition_value_as_str))
 
 
 @from_partition_value_to_py.register(FloatType)
 @from_partition_value_to_py.register(DoubleType)
-def _(type_, partition_value_as_str: str):
+def _(primitive_type, partition_value_as_str: str):
     return float(partition_value_as_str)
 
 
 @from_partition_value_to_py.register(StringType)
-def _(type_, partition_value_as_str: str):
+def _(primitive_type, partition_value_as_str: str):
     return partition_value_as_str
 
 
 @from_partition_value_to_py.register(UUIDType)
-def _(type_, partition_value_as_str: str):
+def _(primitive_type, partition_value_as_str: str):
     return uuid.UUID(partition_value_as_str)
 
 
 @from_partition_value_to_py.register(FixedType)
-def _(type_, partition_value_as_str: str):
+def _(primitive_type, partition_value_as_str: str):
     return bytearray(bytes(partition_value_as_str, "UTF-8"))
 
 
 @from_partition_value_to_py.register(BinaryType)
-def _(type_, partition_value_as_str: str):
+def _(primitive_type, partition_value_as_str: str):
     return bytes(partition_value_as_str, "UTF-8")
 
 
 @from_partition_value_to_py.register(DecimalType)
-def _(type_, partition_value_as_str: str):
+def _(primitive_type, partition_value_as_str: str):
     return Decimal(partition_value_as_str)
 
 
 @singledispatch
-def to_bytes(type_, value: Any) -> bytes:
+def to_bytes(primitive_type, value: Any) -> bytes:
     """A generic function which converts a built-in python value to bytes
 
     Args:
-        type_(PrimitiveType): An implementation of the PrimitiveType base class
+        primitive_type(PrimitiveType): An implementation of the PrimitiveType base class
         value(Any): The value to convert to bytes
     """
-    raise TypeError(f"Cannot serialize value, type {type_} not supported: '{value}'")
+    raise TypeError(f"Cannot serialize value, type {primitive_type} not supported: '{value}'")
 
 
 @to_bytes.register(BooleanType)
-def _(type_, value: Any) -> bytes:
+def _(primitive_type, value: Any) -> bytes:
     return struct.pack("<?", 1 if value else 0)
 
 
 @to_bytes.register(IntegerType)
 @to_bytes.register(DateType)
-def _(type_, value: Any) -> bytes:
+def _(primitive_type, value: Any) -> bytes:
     return struct.pack("<i", value)
 
 
@@ -149,73 +151,73 @@ def _(type_, value: Any) -> bytes:
 @to_bytes.register(TimeType)
 @to_bytes.register(TimestampType)
 @to_bytes.register(TimestamptzType)
-def _(type_, value: Any) -> bytes:
+def _(primitive_type, value: Any) -> bytes:
     return struct.pack("<q", value)
 
 
 @to_bytes.register(FloatType)
-def _(type_, value: Any) -> bytes:
+def _(primitive_type, value: Any) -> bytes:
     return struct.pack("<f", value)
 
 
 @to_bytes.register(DoubleType)
-def _(type_, value: Any) -> bytes:
+def _(primitive_type, value: Any) -> bytes:
     return struct.pack("<d", value)
 
 
 @to_bytes.register(StringType)
-def _(type_, value: Any) -> bytes:
+def _(primitive_type, value: Any) -> bytes:
     return value.encode("UTF-8")
 
 
 @to_bytes.register(UUIDType)
-def _(type_, value: Any) -> bytes:
+def _(primitive_type, value: Any) -> bytes:
     return struct.pack(">QQ", (value.int >> 64) & 0xFFFFFFFFFFFFFFFF, value.int & 0xFFFFFFFFFFFFFFFF)
 
 
 @to_bytes.register(BinaryType)
 @to_bytes.register(FixedType)
-def _(type_, value: Any) -> bytes:
+def _(primitive_type, value: Any) -> bytes:
     return value
 
 
 @to_bytes.register(DecimalType)
-def _(type_, value: Any) -> bytes:
+def _(primitive_type, value: Any) -> bytes:
     value_as_tuple = value.as_tuple()
     value_precision = len(value_as_tuple.digits)
     value_scale = -value_as_tuple.exponent
 
-    if value_scale != type_.scale:
-        raise ValueError(f"Cannot serialize value, scale of value does not match type {type_}: {value_scale}")
-    elif value_precision != type_.precision:
-        raise ValueError(f"Cannot serialize value, precision of value does not match type {type_}: {value_precision}")
+    if value_scale != primitive_type.scale:
+        raise ValueError(f"Cannot serialize value, scale of value does not match type {primitive_type}: {value_scale}")
+    elif value_precision != primitive_type.precision:
+        raise ValueError(f"Cannot serialize value, precision of value does not match type {primitive_type}: {value_precision}")
 
     with localcontext() as ctx:
-        ctx.prec = type_.precision
-        unscaled_value = int((value * 10**type_.scale).to_integral_value(rounding=ROUND_HALF_DOWN))
+        ctx.prec = primitive_type.precision
+        unscaled_value = int((value * 10**primitive_type.scale).to_integral_value(rounding=ROUND_HALF_DOWN))
         min_num_bytes = ((unscaled_value).bit_length() + 7) // 8
         return unscaled_value.to_bytes(min_num_bytes, "big", signed=True)
 
 
 @singledispatch
-def from_bytes(type_, b: bytes):
+def from_bytes(primitive_type, b: bytes):
     """A generic function which converts bytes to a built-in python value
 
     Args:
-        type_(PrimitiveType): An implementation of the PrimitiveType base class
+        primitive_type(PrimitiveType): An implementation of the PrimitiveType base class
         b(bytes): The bytes to convert
     """
-    raise TypeError(f"Cannot deserialize bytes, type {type_} not supported: {str(b)}")
+    raise TypeError(f"Cannot deserialize bytes, type {primitive_type} not supported: {str(b)}")
 
 
 @from_bytes.register(BooleanType)
-def _(type_, b: bytes):
+def _(primitive_type, b: bytes):
     return struct.unpack("<?", b)[0] != 0
 
 
 @from_bytes.register(IntegerType)
 @from_bytes.register(DateType)
-def _(type_, b: bytes):
+def _(primitive_type, b: bytes):
     return struct.unpack("<i", b)[0]
 
 
@@ -223,39 +225,39 @@ def _(type_, b: bytes):
 @from_bytes.register(TimeType)
 @from_bytes.register(TimestampType)
 @from_bytes.register(TimestamptzType)
-def _(type_, b: bytes):
+def _(primitive_type, b: bytes):
     return struct.unpack("<q", b)[0]
 
 
 @from_bytes.register(FloatType)
-def _(type_, b: bytes):
+def _(primitive_type, b: bytes):
     return struct.unpack("<f", b)[0]
 
 
 @from_bytes.register(DoubleType)
-def _(type_, b: bytes):
+def _(primitive_type, b: bytes):
     return struct.unpack("<d", b)[0]
 
 
 @from_bytes.register(StringType)
-def _(type_, b: bytes):
+def _(primitive_type, b: bytes):
     return bytes(b).decode("utf-8")
 
 
 @from_bytes.register(UUIDType)
-def _(type_, b: bytes):
+def _(primitive_type, b: bytes):
     return uuid.UUID(int=struct.unpack(">QQ", b)[0] << 64 | struct.unpack(">QQ", b)[1])
 
 
 @from_bytes.register(BinaryType)
 @from_bytes.register(FixedType)
-def _(type_, b: bytes):
+def _(primitive_type, b: bytes):
     return b
 
 
 @from_bytes.register(DecimalType)
-def _(type_, b: bytes):
+def _(primitive_type, b: bytes):
     integer_representation = int.from_bytes(b, "big", signed=True)
     with localcontext() as ctx:
-        ctx.prec = type_.precision
-        return Decimal(integer_representation) * Decimal(10) ** Decimal(-type_.scale)
+        ctx.prec = primitive_type.precision
+        return Decimal(integer_representation) * Decimal(10) ** Decimal(-primitive_type.scale)

--- a/python/tests/test_conversions.py
+++ b/python/tests/test_conversions.py
@@ -266,18 +266,18 @@ def test_raise_on_unregistered_type():
         ),
         (
             DecimalType(7, 2),
-            Decimal("1234.56"),
-            "Cannot serialize value, precision of value does not match type decimal(7, 2): 6",
+            Decimal("1234567.89"),
+            "Cannot serialize value, precision of value is greater than precision of type decimal(7, 2): 9",
         ),
         (
             DecimalType(17, 9),
             Decimal("123456789.123456789"),
-            "Cannot serialize value, precision of value does not match type decimal(17, 9): 18",
+            "Cannot serialize value, precision of value is greater than precision of type decimal(17, 9): 18",
         ),
         (
-            DecimalType(37, 35),
+            DecimalType(35, 35),
             Decimal("1.23456789123456789123456789123456789"),
-            "Cannot serialize value, precision of value does not match type decimal(37, 35): 36",
+            "Cannot serialize value, precision of value is greater than precision of type decimal(35, 35): 36",
         ),
     ],
 )

--- a/python/tests/test_conversions.py
+++ b/python/tests/test_conversions.py
@@ -72,6 +72,7 @@ def test_from_partition_value_to_py(primitive_type, partition_value_as_str, expe
         (BooleanType(), b"\x01", True),
         (IntegerType(), b"\xd2\x04\x00\x00", 1234),
         (LongType(), b"\xd2\x04\x00\x00\x00\x00\x00\x00", 1234),
+        (DoubleType(), b"\x8d\x97\x6e\x12\x83\xc0\xf3\x3f", 1.2345),
         (DateType(), b"\xd2\x04\x00\x00", 1234),
         (TimeType(), b"\x00\xe8vH\x17\x00\x00\x00", 100000000000),
         (TimestamptzType(), b"\x00\xe8vH\x17\x00\x00\x00", 100000000000),
@@ -94,7 +95,6 @@ def test_from_bytes(primitive_type, b, result):
     "primitive_type, b, approximate_result, approximation",
     [
         (FloatType(), b"\x19\x04\x9e?", 1.2345, 5),
-        (DoubleType(), b"\x8d\x97\x6e\x12\x83\xc0\xf3\x3f", 1.2345, 1e-6),
     ],
 )
 def test_from_bytes_approximately(primitive_type, b, approximate_result, approximation):

--- a/python/tests/test_conversions.py
+++ b/python/tests/test_conversions.py
@@ -174,7 +174,7 @@ def test_none_partition_values(primitive_type):
         (BinaryType(), bytearray("Z", "utf8"), bytes([90])),
         (BinaryType(), b"foo", b"foo"),
         (DecimalType(5, 2), b"\x30\x39", Decimal("123.45")),
-        (DecimalType(7, 4), b"\x00\x12\xd6\x87", Decimal("123.4567")),
+        (DecimalType(7, 4), b"\x12\xd6\x87", Decimal("123.4567")),
         (DecimalType(7, 4), b"\xff\xed\x29\x79", Decimal("-123.4567")),
     ],
 )
@@ -218,11 +218,11 @@ def test_from_bytes(primitive_type, b, result):
         # decimal on 3-bytes to test that we use the minimum number of bytes and not a power of 2
         # 1234567 is 00010010|11010110|10000111 in binary
         # 00010010 -> 18, 11010110 -> 214, 10000111 -> 135
-        (DecimalType(7, 4), bytes([18, 214, 135]), Decimal("123.4567")),
+        (DecimalType(7, 4), b"\x12\xd6\x87", Decimal("123.4567")),
         # negative decimal to test two's complement
         # -1234567 is 11101101|00101001|01111001 in binary
         # 11101101 -> 237, 00101001 -> 41, 01111001 -> 121
-        (DecimalType(7, 4), bytes([237, 41, 121]), Decimal("-123.4567")),
+        (DecimalType(7, 4), b"\xed)y", Decimal("-123.4567")),
         # test empty byte in decimal
         # 11 is 00001011 in binary
         # 00001011 -> 11

--- a/python/tests/test_conversions.py
+++ b/python/tests/test_conversions.py
@@ -1,0 +1,181 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import uuid
+from decimal import Decimal
+
+import pytest
+
+from iceberg import conversions
+from iceberg.types import (
+    BinaryType,
+    BooleanType,
+    DateType,
+    DecimalType,
+    DoubleType,
+    FixedType,
+    FloatType,
+    IntegerType,
+    LongType,
+    StringType,
+    TimestampType,
+    TimestamptzType,
+    TimeType,
+    UUIDType,
+)
+
+
+@pytest.mark.parametrize(
+    "type_, partition_value_as_str, expected_result",
+    [
+        (BooleanType(), "true", True),
+        (BooleanType(), "false", False),
+        (BooleanType(), "TRUE", True),
+        (BooleanType(), "FALSE", False),
+        (BooleanType(), None, False),
+        (IntegerType(), "1", 1),
+        (IntegerType(), "9999", 9999),
+        (LongType(), "123456789", 123456789),
+        (FloatType(), "1.1", 1.1),
+        (DoubleType(), "99999.9", 99999.9),
+        (StringType(), "foo", "foo"),
+        (UUIDType(), "f79c3e09-677c-4bbd-a479-3f349cb785e7", uuid.UUID("f79c3e09-677c-4bbd-a479-3f349cb785e7")),
+        (FixedType(3), "foo", bytearray(b"foo")),
+        (BinaryType(), "foo", b"foo"),
+        (None, "__HIVE_DEFAULT_PARTITION__", None),
+        (None, None, None),
+    ],
+)
+def test_from_partition_value_to_py(type_, partition_value_as_str, expected_result):
+    """Test converting a partition value to a python built-in"""
+    assert conversions.from_partition_value_to_py(type_, partition_value_as_str) == expected_result
+
+
+@pytest.mark.parametrize(
+    "type_, partition_value_as_str, expected_result",
+    [
+        (DecimalType(5, 2), "123.45", Decimal(123.45)),
+    ],
+)
+def test_from_partition_value_to_py_approximated(type_, partition_value_as_str, expected_result):
+    """Test approximate equality when converting a partition value to a python built-in"""
+    assert conversions.from_partition_value_to_py(type_, partition_value_as_str) == pytest.approx(expected_result)
+
+
+@pytest.mark.parametrize(
+    "type_, b, result",
+    [
+        (BooleanType(), b"\x00", False),
+        (BooleanType(), b"\x01", True),
+        (IntegerType(), b"\xd2\x04\x00\x00", 1234),
+        (LongType(), b"\xd2\x04\x00\x00\x00\x00\x00\x00", 1234),
+        (DateType(), b"\xd2\x04\x00\x00", 1234),
+        (TimeType(), b"\x00\xe8vH\x17\x00\x00\x00", 100000000000),
+        (TimestamptzType(), b"\x00\xe8vH\x17\x00\x00\x00", 100000000000),
+        (TimestampType(), b"\x00\xe8vH\x17\x00\x00\x00", 100000000000),
+        (StringType(), b"foo", "foo"),
+        (UUIDType(), b"\xf7\x9c>\tg|K\xbd\xa4y?4\x9c\xb7\x85\xe7", uuid.UUID("f79c3e09-677c-4bbd-a479-3f349cb785e7")),
+        (FixedType(3), b"foo", b"foo"),
+        (BinaryType(), b"foo", b"foo"),
+        (DecimalType(5, 2), b"\x30\x39", Decimal(123.45).quantize(Decimal(".01"))),
+        (DecimalType(5, 4), b"\x00\x12\xd6\x87", Decimal(123.4567).quantize(Decimal(".0001"))),
+        (DecimalType(5, 4), b"\xff\xed\x29\x79", Decimal(-123.4567).quantize(Decimal(".0001"))),
+    ],
+)
+def test_from_bytes(type_, b, result):
+    """Test converting from bytes"""
+    assert conversions.from_bytes(type_, b) == result
+
+
+@pytest.mark.parametrize(
+    "type_, b, approximate_result, approximation",
+    [
+        (FloatType(), b"\x19\x04\x9e?", 1.2345, 5),
+        (DoubleType(), b"\x8d\x97\x6e\x12\x83\xc0\xf3\x3f", 1.2345, 1e-6),
+    ],
+)
+def test_from_bytes_approximately(type_, b, approximate_result, approximation):
+    """Test approximate equality when converting from bytes"""
+    assert conversions.from_bytes(type_, b) == pytest.approx(approximate_result, approximation)
+
+
+@pytest.mark.parametrize(
+    "type_, b, result",
+    [
+        (BooleanType(), b"\x00", False),
+        (BooleanType(), b"\x01", True),
+        (IntegerType(), b"\xd2\x04\x00\x00", 1234),
+        (LongType(), b"\xd2\x04\x00\x00\x00\x00\x00\x00", 1234),
+        (DateType(), b"\xd2\x04\x00\x00", 1234),
+        (TimeType(), b"\x00\xe8vH\x17\x00\x00\x00", 100000000000),
+        (TimestamptzType(), b"\x00\xe8vH\x17\x00\x00\x00", 100000000000),
+        (TimestampType(), b"\x00\xe8vH\x17\x00\x00\x00", 100000000000),
+        (StringType(), b"foo", "foo"),
+        (UUIDType(), b"\xf7\x9c>\tg|K\xbd\xa4y?4\x9c\xb7\x85\xe7", uuid.UUID("f79c3e09-677c-4bbd-a479-3f349cb785e7")),
+        (FixedType(3), b"foo", b"foo"),
+        (BinaryType(), b"foo", b"foo"),
+        (DecimalType(5, 2), b"\x30\x39", Decimal(123.45).quantize(Decimal(".01"))),
+        (DecimalType(3, 2), bytes([1, 89]), Decimal(3.45).quantize(Decimal(".01"))),
+        (DecimalType(7, 4), bytes([18, 214, 135]), Decimal(123.4567).quantize(Decimal(".0001"))),
+        (DecimalType(7, 4), bytes([237, 41, 121]), Decimal(-123.4567).quantize(Decimal(".0001"))),
+    ],
+)
+def test_round_trip_conversion(type_, b, result):
+    """Test round trip conversions of calling `conversions.from_bytes` and then `conversions.to_bytes` on the result"""
+    value_from_bytes = conversions.from_bytes(type_, b)
+    assert value_from_bytes == result
+
+    bytes_from_value = conversions.to_bytes(type_, value_from_bytes)
+    assert bytes_from_value == b
+
+
+@pytest.mark.parametrize(
+    "type_, b, result",
+    [
+        (FloatType(), b"\x19\x04\x9e?", 1.2345),
+        (DoubleType(), b"\x8d\x97n\x12\x83\xc0\xf3?", 1.2345),
+    ],
+)
+def test_round_trip_conversion_approximation(type_, b, result):
+    """Test approximate round trip conversions of calling `conversions.from_bytes` and then `conversions.to_bytes` on the result"""
+    value_from_bytes = conversions.from_bytes(type_, b)
+    assert value_from_bytes == pytest.approx(result)
+
+    bytes_from_value = conversions.to_bytes(type_, value_from_bytes)
+    assert bytes_from_value == b
+
+
+def test_raise_on_unregistered_type():
+    """Test raising when a conversion is attempted for a type that has no registered method"""
+
+    class FooUnknownType:
+        def __repr__(self):
+            return "FooUnknownType()"
+
+    with pytest.raises(TypeError) as exc_info:
+        conversions.from_partition_value_to_py(FooUnknownType(), "foo")
+    assert (f"Cannot convert partition string to python built-in, type FooUnknownType() not supported: 'foo'") in str(
+        exc_info.value
+    )
+
+    with pytest.raises(TypeError) as exc_info:
+        conversions.to_bytes(FooUnknownType(), "foo")
+    assert ("Cannot serialize value, type FooUnknownType() not supported: 'foo'") in str(exc_info.value)
+
+    with pytest.raises(TypeError) as exc_info:
+        conversions.from_bytes(FooUnknownType(), b"foo")
+    assert ("Cannot deserialize bytes, type FooUnknownType() not supported: b'foo'") in str(exc_info.value)

--- a/python/tests/test_conversions.py
+++ b/python/tests/test_conversions.py
@@ -52,6 +52,7 @@ from iceberg.types import (
         (LongType(), "123456789", 123456789),
         (FloatType(), "1.1", 1.1),
         (DoubleType(), "99999.9", 99999.9),
+        (DecimalType(5, 2), "123.45", Decimal("123.45")),
         (StringType(), "foo", "foo"),
         (UUIDType(), "f79c3e09-677c-4bbd-a479-3f349cb785e7", uuid.UUID("f79c3e09-677c-4bbd-a479-3f349cb785e7")),
         (FixedType(3), "foo", bytearray(b"foo")),
@@ -63,17 +64,6 @@ from iceberg.types import (
 def test_from_partition_value_to_py(type_, partition_value_as_str, expected_result):
     """Test converting a partition value to a python built-in"""
     assert conversions.from_partition_value_to_py(type_, partition_value_as_str) == expected_result
-
-
-@pytest.mark.parametrize(
-    "type_, partition_value_as_str, expected_result",
-    [
-        (DecimalType(5, 2), "123.45", Decimal(123.45)),
-    ],
-)
-def test_from_partition_value_to_py_approximated(type_, partition_value_as_str, expected_result):
-    """Test approximate equality when converting a partition value to a python built-in"""
-    assert conversions.from_partition_value_to_py(type_, partition_value_as_str) == pytest.approx(expected_result)
 
 
 @pytest.mark.parametrize(
@@ -91,9 +81,9 @@ def test_from_partition_value_to_py_approximated(type_, partition_value_as_str, 
         (UUIDType(), b"\xf7\x9c>\tg|K\xbd\xa4y?4\x9c\xb7\x85\xe7", uuid.UUID("f79c3e09-677c-4bbd-a479-3f349cb785e7")),
         (FixedType(3), b"foo", b"foo"),
         (BinaryType(), b"foo", b"foo"),
-        (DecimalType(5, 2), b"\x30\x39", Decimal(123.45).quantize(Decimal(".01"))),
-        (DecimalType(5, 4), b"\x00\x12\xd6\x87", Decimal(123.4567).quantize(Decimal(".0001"))),
-        (DecimalType(5, 4), b"\xff\xed\x29\x79", Decimal(-123.4567).quantize(Decimal(".0001"))),
+        (DecimalType(5, 2), b"\x30\x39", Decimal("123.45")),
+        (DecimalType(7, 4), b"\x00\x12\xd6\x87", Decimal("123.4567")),
+        (DecimalType(7, 4), b"\xff\xed\x29\x79", Decimal("-123.4567")),
     ],
 )
 def test_from_bytes(type_, b, result):
@@ -128,13 +118,93 @@ def test_from_bytes_approximately(type_, b, approximate_result, approximation):
         (UUIDType(), b"\xf7\x9c>\tg|K\xbd\xa4y?4\x9c\xb7\x85\xe7", uuid.UUID("f79c3e09-677c-4bbd-a479-3f349cb785e7")),
         (FixedType(3), b"foo", b"foo"),
         (BinaryType(), b"foo", b"foo"),
-        (DecimalType(5, 2), b"\x30\x39", Decimal(123.45).quantize(Decimal(".01"))),
-        (DecimalType(3, 2), bytes([1, 89]), Decimal(3.45).quantize(Decimal(".01"))),
-        (DecimalType(7, 4), bytes([18, 214, 135]), Decimal(123.4567).quantize(Decimal(".0001"))),
-        (DecimalType(7, 4), bytes([237, 41, 121]), Decimal(-123.4567).quantize(Decimal(".0001"))),
+        (DecimalType(5, 2), b"\x30\x39", Decimal("123.45")),
+        (DecimalType(3, 2), bytes([1, 89]), Decimal("3.45")),
+        (DecimalType(7, 4), bytes([18, 214, 135]), Decimal("123.4567")),
+        (DecimalType(7, 4), bytes([237, 41, 121]), Decimal("-123.4567")),
     ],
 )
 def test_round_trip_conversion(type_, b, result):
+    """Test round trip conversions of calling `conversions.from_bytes` and then `conversions.to_bytes` on the result"""
+    value_from_bytes = conversions.from_bytes(type_, b)
+    assert value_from_bytes == result
+
+    bytes_from_value = conversions.to_bytes(type_, value_from_bytes)
+    assert bytes_from_value == b
+
+
+@pytest.mark.parametrize(
+    "type_, b, result",
+    [
+        (
+            DecimalType(38, 21),
+            b"\tI\xb0\xf7\x13\xe9\x180s\xb9\x1e~\xa2\xb3j\x83",
+            Decimal("12345678912345678.123456789123456789123"),
+        ),
+        (DecimalType(38, 22), b'\tI\xb0\xf7\x13\xe9\x16\xbb\x01/L\xc3+B)"', Decimal("1234567891234567.1234567891234567891234")),
+        (
+            DecimalType(38, 23),
+            b"\tI\xb0\xf7\x13\xe9\nB\xa1\xad\xe5+3\x15\x9bY",
+            Decimal("123456789123456.12345678912345678912345"),
+        ),
+        (
+            DecimalType(38, 24),
+            b"\tI\xb0\xf7\x13\xe8\xa2\xbb\xe9g\xba\x86w\xd8\x11\x80",
+            Decimal("12345678912345.123456789123456789123456"),
+        ),
+        (
+            DecimalType(38, 25),
+            b"\tI\xb0\xf7\x13\xe5k:\xd2x\xdd\x04\xc8p\xaf\x07",
+            Decimal("1234567891234.1234567891234567891234567"),
+        ),
+        (DecimalType(38, 26), b"\tI\xb0\xf7\x13\xcd\x85\xc5\x0387<8f\xd6N", Decimal("123456789123.12345678912345678912345678")),
+        (DecimalType(38, 27), b"\tI\xb0\xf7\x131F\xfd\xc7y\xca9|\x04_\x15", Decimal("12345678912.123456789123456789123456789")),
+        (
+            DecimalType(38, 28),
+            b"\tI\xb0\xf7\x10R\x01r\x11\xda\x08[\x08+\xb6\xd3",
+            Decimal("1234567891.1234567891234567891234567891"),
+        ),
+        (
+            DecimalType(38, 29),
+            b"\tI\xb0\xf7\x13\xe9\x18[7\xc1x\x0b\x91\xb5$@",
+            Decimal("123456789.12345678912345678912345678912"),
+        ),
+        (
+            DecimalType(38, 30),
+            b"\tI\xb0\xed\x1e\xdf\x80\x03G;\x16\x9b\xf1\x13j\x83",
+            Decimal("12345678.123456789123456789123456789123"),
+        ),
+        (DecimalType(38, 31), b'\tI\xb0\x96+\xac)d(p6)\xea\xc2)"', Decimal("1234567.1234567891234567891234567891234")),
+        (
+            DecimalType(38, 32),
+            b"\tI\xad\xae\xe3h\xe7O\xb5\x14\xbc\xdc+\x95\x9bY",
+            Decimal("123456.12345678912345678912345678912345"),
+        ),
+        (
+            DecimalType(38, 33),
+            b"\tI\x95\x94>5\x93\xde\xb9.\xefS\xb3\xd8\x11\x80",
+            Decimal("12345.123456789123456789123456789123456"),
+        ),
+        (
+            DecimalType(38, 34),
+            b"\tH\xd5\xd7\x90x\xdf\x08\x1a\xf6C\t\x06p\xaf\x07",
+            Decimal("1234.1234567891234567891234567891234567"),
+        ),
+        (DecimalType(38, 35), b"\tCE\x82\x85\xc7Vf$M\x16\x82@f\xd6N", Decimal("123.12345678912345678912345678912345678")),
+        (DecimalType(21, 16), b"\x06\xb1:\xe3\xc4N\x94\xaf\x07", Decimal("12345.1234567891234567")),
+        (DecimalType(22, 17), b"B\xecL\xe5\xab\x11\xce\xd6N", Decimal("12345.12345678912345678")),
+        (DecimalType(23, 18), b"\x02\x9d;\x00\xf8\xae\xb2\x14_\x15", Decimal("12345.123456789123456789")),
+        (DecimalType(24, 19), b"\x1a$N\t\xb6\xd2\xf4\xcb\xb6\xd3", Decimal("12345.1234567891234567891")),
+        (DecimalType(25, 20), b"\x01\x05k\x0ca$=\x8f\xf5$@", Decimal("12345.12345678912345678912")),
+        (DecimalType(26, 21), b"\n6.{\xcbjg\x9f\x93j\x83", Decimal("12345.123456789123456789123")),
+        (DecimalType(27, 22), b'f\x1d\xd0\xd5\xf2(\x0c;\xc2)"', Decimal("12345.1234567891234567891234")),
+        (DecimalType(28, 23), b"\x03\xfd*([u\x90zU\x95\x9bY", Decimal("12345.12345678912345678912345")),
+        (DecimalType(29, 24), b"'\xe3\xa5\x93\x92\x97\xa4\xc7W\xd8\x11\x80", Decimal("12345.123456789123456789123456")),
+        (DecimalType(30, 25), b"\x01\x8e\xe4w\xc3\xb9\xeco\xc9np\xaf\x07", Decimal("12345.1234567891234567891234567")),
+        (DecimalType(31, 26), b"\x0f\x94\xec\xad\xa5C<]\xdePf\xd6N", Decimal("12345.12345678912345678912345678")),
+    ],
+)
+def test_round_trip_conversion_large_decimals(type_, b, result):
     """Test round trip conversions of calling `conversions.from_bytes` and then `conversions.to_bytes` on the result"""
     value_from_bytes = conversions.from_bytes(type_, b)
     assert value_from_bytes == result
@@ -179,3 +249,41 @@ def test_raise_on_unregistered_type():
     with pytest.raises(TypeError) as exc_info:
         conversions.from_bytes(FooUnknownType(), b"foo")
     assert ("Cannot deserialize bytes, type FooUnknownType() not supported: b'foo'") in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "type_, value, expected_error_message",
+    [
+        (DecimalType(7, 3), Decimal("123.4567"), "Cannot serialize value, scale of value does not match type decimal(7, 3): 4"),
+        (
+            DecimalType(18, 8),
+            Decimal("123456789.123456789"),
+            "Cannot serialize value, scale of value does not match type decimal(18, 8): 9",
+        ),
+        (
+            DecimalType(36, 34),
+            Decimal("1.23456789123456789123456789123456789"),
+            "Cannot serialize value, scale of value does not match type decimal(36, 34): 35",
+        ),
+        (
+            DecimalType(7, 2),
+            Decimal("1234.56"),
+            "Cannot serialize value, precision of value does not match type decimal(7, 2): 6",
+        ),
+        (
+            DecimalType(17, 9),
+            Decimal("123456789.123456789"),
+            "Cannot serialize value, precision of value does not match type decimal(17, 9): 18",
+        ),
+        (
+            DecimalType(37, 35),
+            Decimal("1.23456789123456789123456789123456789"),
+            "Cannot serialize value, precision of value does not match type decimal(37, 35): 36",
+        ),
+    ],
+)
+def test_raise_on_incorrect_precision_or_scale(type_, value, expected_error_message):
+    with pytest.raises(ValueError) as exc_info:
+        conversions.to_bytes(type_, value)
+
+    assert expected_error_message in str(exc_info.value)

--- a/python/tests/test_conversions.py
+++ b/python/tests/test_conversions.py
@@ -98,7 +98,12 @@ def test_from_bytes(primitive_type, b, result):
     ],
 )
 def test_from_bytes_approximately(primitive_type, b, approximate_result, approximation):
-    """Test approximate equality when converting from bytes"""
+    """Test approximate equality when converting from bytes
+
+    Note: This tests approximate equality because floating point numbers in python are implemented
+    using a double in C. Therefore a 32-bit (single precision) float is unpacked to 64-bit (double precision)
+    float in python which introduces some imprecision.
+    """
     assert conversions.from_bytes(primitive_type, b) == pytest.approx(approximate_result, approximation)
 
 

--- a/python/tests/test_conversions.py
+++ b/python/tests/test_conversions.py
@@ -247,7 +247,7 @@ def test_max_value_round_trip_conversion(primitive_type, expected_max_value):
 
 
 @pytest.mark.parametrize(
-    "primitive_type, expected_max_value",
+    "primitive_type, expected_min_value",
     [
         (DecimalType(6, 2), Decimal("-9999.99")),
         (DecimalType(10, 10), Decimal("-.9999999999")),
@@ -256,12 +256,12 @@ def test_max_value_round_trip_conversion(primitive_type, expected_max_value):
         (DecimalType(20, 1), Decimal("-9999999999999999999.9")),
     ],
 )
-def test_min_value_round_trip_conversion(primitive_type, expected_max_value):
+def test_min_value_round_trip_conversion(primitive_type, expected_min_value):
     """Test round trip conversions of minimum DecimalType values"""
-    b = conversions.to_bytes(primitive_type, expected_max_value)
+    b = conversions.to_bytes(primitive_type, expected_min_value)
     value_from_bytes = conversions.from_bytes(primitive_type, b)
 
-    assert value_from_bytes == expected_max_value
+    assert value_from_bytes == expected_min_value
 
 
 def test_raise_on_unregistered_type():

--- a/python/tests/test_conversions.py
+++ b/python/tests/test_conversions.py
@@ -40,7 +40,7 @@ from iceberg.types import (
 
 
 @pytest.mark.parametrize(
-    "type_, partition_value_as_str, expected_result",
+    "primitive_type, partition_value_as_str, expected_result",
     [
         (BooleanType(), "true", True),
         (BooleanType(), "false", False),
@@ -61,13 +61,13 @@ from iceberg.types import (
         (None, None, None),
     ],
 )
-def test_from_partition_value_to_py(type_, partition_value_as_str, expected_result):
+def test_from_partition_value_to_py(primitive_type, partition_value_as_str, expected_result):
     """Test converting a partition value to a python built-in"""
-    assert conversions.from_partition_value_to_py(type_, partition_value_as_str) == expected_result
+    assert conversions.from_partition_value_to_py(primitive_type, partition_value_as_str) == expected_result
 
 
 @pytest.mark.parametrize(
-    "type_, b, result",
+    "primitive_type, b, result",
     [
         (BooleanType(), b"\x00", False),
         (BooleanType(), b"\x01", True),
@@ -86,25 +86,25 @@ def test_from_partition_value_to_py(type_, partition_value_as_str, expected_resu
         (DecimalType(7, 4), b"\xff\xed\x29\x79", Decimal("-123.4567")),
     ],
 )
-def test_from_bytes(type_, b, result):
+def test_from_bytes(primitive_type, b, result):
     """Test converting from bytes"""
-    assert conversions.from_bytes(type_, b) == result
+    assert conversions.from_bytes(primitive_type, b) == result
 
 
 @pytest.mark.parametrize(
-    "type_, b, approximate_result, approximation",
+    "primitive_type, b, approximate_result, approximation",
     [
         (FloatType(), b"\x19\x04\x9e?", 1.2345, 5),
         (DoubleType(), b"\x8d\x97\x6e\x12\x83\xc0\xf3\x3f", 1.2345, 1e-6),
     ],
 )
-def test_from_bytes_approximately(type_, b, approximate_result, approximation):
+def test_from_bytes_approximately(primitive_type, b, approximate_result, approximation):
     """Test approximate equality when converting from bytes"""
-    assert conversions.from_bytes(type_, b) == pytest.approx(approximate_result, approximation)
+    assert conversions.from_bytes(primitive_type, b) == pytest.approx(approximate_result, approximation)
 
 
 @pytest.mark.parametrize(
-    "type_, b, result",
+    "primitive_type, b, result",
     [
         (BooleanType(), b"\x00", False),
         (BooleanType(), b"\x01", True),
@@ -124,17 +124,17 @@ def test_from_bytes_approximately(type_, b, approximate_result, approximation):
         (DecimalType(7, 4), bytes([237, 41, 121]), Decimal("-123.4567")),
     ],
 )
-def test_round_trip_conversion(type_, b, result):
+def test_round_trip_conversion(primitive_type, b, result):
     """Test round trip conversions of calling `conversions.from_bytes` and then `conversions.to_bytes` on the result"""
-    value_from_bytes = conversions.from_bytes(type_, b)
+    value_from_bytes = conversions.from_bytes(primitive_type, b)
     assert value_from_bytes == result
 
-    bytes_from_value = conversions.to_bytes(type_, value_from_bytes)
+    bytes_from_value = conversions.to_bytes(primitive_type, value_from_bytes)
     assert bytes_from_value == b
 
 
 @pytest.mark.parametrize(
-    "type_, b, result",
+    "primitive_type, b, result",
     [
         (
             DecimalType(38, 21),
@@ -204,28 +204,28 @@ def test_round_trip_conversion(type_, b, result):
         (DecimalType(31, 26), b"\x0f\x94\xec\xad\xa5C<]\xdePf\xd6N", Decimal("12345.12345678912345678912345678")),
     ],
 )
-def test_round_trip_conversion_large_decimals(type_, b, result):
+def test_round_trip_conversion_large_decimals(primitive_type, b, result):
     """Test round trip conversions of calling `conversions.from_bytes` and then `conversions.to_bytes` on the result"""
-    value_from_bytes = conversions.from_bytes(type_, b)
+    value_from_bytes = conversions.from_bytes(primitive_type, b)
     assert value_from_bytes == result
 
-    bytes_from_value = conversions.to_bytes(type_, value_from_bytes)
+    bytes_from_value = conversions.to_bytes(primitive_type, value_from_bytes)
     assert bytes_from_value == b
 
 
 @pytest.mark.parametrize(
-    "type_, b, result",
+    "primitive_type, b, result",
     [
         (FloatType(), b"\x19\x04\x9e?", 1.2345),
         (DoubleType(), b"\x8d\x97n\x12\x83\xc0\xf3?", 1.2345),
     ],
 )
-def test_round_trip_conversion_approximation(type_, b, result):
+def test_round_trip_conversion_approximation(primitive_type, b, result):
     """Test approximate round trip conversions of calling `conversions.from_bytes` and then `conversions.to_bytes` on the result"""
-    value_from_bytes = conversions.from_bytes(type_, b)
+    value_from_bytes = conversions.from_bytes(primitive_type, b)
     assert value_from_bytes == pytest.approx(result)
 
-    bytes_from_value = conversions.to_bytes(type_, value_from_bytes)
+    bytes_from_value = conversions.to_bytes(primitive_type, value_from_bytes)
     assert bytes_from_value == b
 
 
@@ -252,7 +252,7 @@ def test_raise_on_unregistered_type():
 
 
 @pytest.mark.parametrize(
-    "type_, value, expected_error_message",
+    "primitive_type, value, expected_error_message",
     [
         (DecimalType(7, 3), Decimal("123.4567"), "Cannot serialize value, scale of value does not match type decimal(7, 3): 4"),
         (
@@ -282,8 +282,8 @@ def test_raise_on_unregistered_type():
         ),
     ],
 )
-def test_raise_on_incorrect_precision_or_scale(type_, value, expected_error_message):
+def test_raise_on_incorrect_precision_or_scale(primitive_type, value, expected_error_message):
     with pytest.raises(ValueError) as exc_info:
-        conversions.to_bytes(type_, value)
+        conversions.to_bytes(primitive_type, value)
 
     assert expected_error_message in str(exc_info.value)

--- a/python/tests/test_conversions.py
+++ b/python/tests/test_conversions.py
@@ -57,7 +57,6 @@ from iceberg.types import (
         (UUIDType(), "f79c3e09-677c-4bbd-a479-3f349cb785e7", uuid.UUID("f79c3e09-677c-4bbd-a479-3f349cb785e7")),
         (FixedType(3), "foo", bytearray(b"foo")),
         (BinaryType(), "foo", b"foo"),
-        (None, "__HIVE_DEFAULT_PARTITION__", None),
         (None, None, None),
     ],
 )

--- a/python/tests/test_conversions.py
+++ b/python/tests/test_conversions.py
@@ -14,7 +14,63 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+"""This test module tests PrimitiveType based conversions of values to/from bytes
 
+Notes:
+    Boolean:
+        - Stored as 0x00 for False and non-zero byte for True
+    Integer:
+        - Stored as 4 bytes in little-endian order
+        - 84202 is 0...01|01001000|11101010 in binary
+    Long:
+        - Stored as 8 bytes in little-endian order
+        - 200L is 0...0|11001000 in binary
+        - 11001000 -> 200 (-56), 00000000 -> 0, ... , 00000000 -> 0
+    Double:
+        - Stored as 8 bytes in little-endian order
+        - floating point numbers are represented as sign * 2ˆexponent * mantissa
+        - 6.0 is 1 * 2ˆ4 * 1.5 and encoded as 01000000|00011000|0...0
+        - 00000000 -> 0, ... , 00011000 -> 24, 01000000 -> 64
+    Date:
+        - Stored as days from 1970-01-01 in a 4-byte little-endian int
+        - 1000 is 0...0|00000011|11101000 in binary
+        - 11101000 -> 232 (-24), 00000011 -> 3, ... , 00000000 -> 0
+    Time:
+        - Stored as microseconds from midnight in an 8-byte little-endian long
+        - 10000L is 0...0|00100111|00010000 in binary
+        - 00010000 -> 16, 00100111 -> 39, ... , 00000000 -> 0
+    Timestamp:
+        - Stored as microseconds from 1970-01-01 00:00:00.000000 in an 8-byte little-endian long
+        - 400000L is 0...110|00011010|10000000 in binary
+        - 10000000 -> 128 (-128), 00011010 -> 26, 00000110 -> 6, ... , 00000000 -> 0
+    String:
+        - Stored as UTF-8 bytes (without length)
+        - 'A' -> 65, 'B' -> 66, 'C' -> 67
+    UUID:
+        - Stored as 16-byte big-endian values
+        - f79c3e09-677c-4bbd-a479-3f349cb785e7 is encoded as F7 9C 3E 09 67 7C 4B BD A4 79 3F 34 9C B7 85 E7
+        - 0xF7 -> 11110111 -> 247 (-9), 0x9C -> 10011100 -> 156 (-100), 0x3E -> 00111110 -> 62,
+        - 0x09 -> 00001001 -> 9, 0x67 -> 01100111 -> 103, 0x7C -> 01111100 -> 124,
+        - 0x4B -> 01001011 -> 75, 0xBD -> 10111101 -> 189 (-67), 0xA4 -> 10100100 -> 164 (-92),
+        - 0x79 -> 01111001 -> 121, 0x3F -> 00111111 -> 63, 0x34 -> 00110100 -> 52,
+        - 0x9C -> 10011100 -> 156 (-100), 0xB7 -> 10110111 -> 183 (-73), 0x85 -> 10000101 -> 133 (-123),
+        - 0xE7 -> 11100111 -> 231 (-25)
+    Fixed:
+        - Stored directly
+        - 'a' -> 97, 'b' -> 98
+    Binary:
+        - Stored directly
+        - 'Z' -> 90
+    Decimal:
+        - Stored as unscaled values in the form of two's-complement big-endian binary using the minimum number of bytes for the values
+        - 345 is 0...1|01011001 in binary
+        - 00000001 -> 1, 01011001 -> 89
+    Float:
+        - Stored as 4 bytes in little-endian order
+        - floating point numbers are represented as sign * 2ˆexponent * mantissa
+        - -4.5F is -1 * 2ˆ2 * 1.125 and encoded as 11000000|10010000|0...0 in binary
+        - 00000000 -> 0, 00000000 -> 0, 10010000 -> 144 (-112), 11000000 -> 192 (-64),
+"""
 import uuid
 from decimal import Decimal
 
@@ -73,13 +129,25 @@ def test_from_partition_value_to_py(primitive_type, partition_value_as_str, expe
         (IntegerType(), b"\xd2\x04\x00\x00", 1234),
         (LongType(), b"\xd2\x04\x00\x00\x00\x00\x00\x00", 1234),
         (DoubleType(), b"\x8d\x97\x6e\x12\x83\xc0\xf3\x3f", 1.2345),
+        (DateType(), bytes([232, 3, 0, 0]), 1000),
         (DateType(), b"\xd2\x04\x00\x00", 1234),
+        (TimeType(), bytes([16, 39, 0, 0, 0, 0, 0, 0]), 10000),
         (TimeType(), b"\x00\xe8vH\x17\x00\x00\x00", 100000000000),
+        (TimestamptzType(), bytes([128, 26, 6, 0, 0, 0, 0, 0]), 400000),
         (TimestamptzType(), b"\x00\xe8vH\x17\x00\x00\x00", 100000000000),
+        (TimestampType(), bytes([128, 26, 6, 0, 0, 0, 0, 0]), 400000),
         (TimestampType(), b"\x00\xe8vH\x17\x00\x00\x00", 100000000000),
+        (StringType(), bytes([65, 66, 67]), "ABC"),
         (StringType(), b"foo", "foo"),
+        (
+            UUIDType(),
+            bytes([247, 156, 62, 9, 103, 124, 75, 189, 164, 121, 63, 52, 156, 183, 133, 231]),
+            uuid.UUID("f79c3e09-677c-4bbd-a479-3f349cb785e7"),
+        ),
         (UUIDType(), b"\xf7\x9c>\tg|K\xbd\xa4y?4\x9c\xb7\x85\xe7", uuid.UUID("f79c3e09-677c-4bbd-a479-3f349cb785e7")),
+        (FixedType(3), bytes([97, 98]), bytes("ab", "utf8")),
         (FixedType(3), b"foo", b"foo"),
+        (BinaryType(), bytearray("Z", "utf8"), bytes([90])),
         (BinaryType(), b"foo", b"foo"),
         (DecimalType(5, 2), b"\x30\x39", Decimal("123.45")),
         (DecimalType(7, 4), b"\x00\x12\xd6\x87", Decimal("123.4567")),
@@ -112,20 +180,45 @@ def test_from_bytes_approximately(primitive_type, b, approximate_result, approxi
     [
         (BooleanType(), b"\x00", False),
         (BooleanType(), b"\x01", True),
+        (IntegerType(), bytes([234, 72, 1, 0]), 84202),
         (IntegerType(), b"\xd2\x04\x00\x00", 1234),
+        (LongType(), bytes([200, 0, 0, 0, 0, 0, 0, 0]), 200),
         (LongType(), b"\xd2\x04\x00\x00\x00\x00\x00\x00", 1234),
+        (DoubleType(), bytes([0, 0, 0, 0, 0, 0, 24, 64]), 6.0),
+        (DoubleType(), b"\x8d\x97n\x12\x83\xc0\xf3?", 1.2345),
+        (DateType(), bytes([232, 3, 0, 0]), 1000),
         (DateType(), b"\xd2\x04\x00\x00", 1234),
+        (TimeType(), bytes([16, 39, 0, 0, 0, 0, 0, 0]), 10000),
         (TimeType(), b"\x00\xe8vH\x17\x00\x00\x00", 100000000000),
+        (TimestamptzType(), bytes([128, 26, 6, 0, 0, 0, 0, 0]), 400000),
         (TimestamptzType(), b"\x00\xe8vH\x17\x00\x00\x00", 100000000000),
         (TimestampType(), b"\x00\xe8vH\x17\x00\x00\x00", 100000000000),
+        (StringType(), bytes([65, 66, 67]), "ABC"),
         (StringType(), b"foo", "foo"),
+        (
+            UUIDType(),
+            bytes([247, 156, 62, 9, 103, 124, 75, 189, 164, 121, 63, 52, 156, 183, 133, 231]),
+            uuid.UUID("f79c3e09-677c-4bbd-a479-3f349cb785e7"),
+        ),
         (UUIDType(), b"\xf7\x9c>\tg|K\xbd\xa4y?4\x9c\xb7\x85\xe7", uuid.UUID("f79c3e09-677c-4bbd-a479-3f349cb785e7")),
+        (FixedType(3), bytes([97, 98]), bytes("ab", "utf8")),
         (FixedType(3), b"foo", b"foo"),
+        (BinaryType(), bytearray("Z", "utf8"), bytes([90])),
         (BinaryType(), b"foo", b"foo"),
         (DecimalType(5, 2), b"\x30\x39", Decimal("123.45")),
         (DecimalType(3, 2), bytes([1, 89]), Decimal("3.45")),
+        # decimal on 3-bytes to test that we use the minimum number of bytes and not a power of 2
+        # 1234567 is 00010010|11010110|10000111 in binary
+        # 00010010 -> 18, 11010110 -> 214, 10000111 -> 135
         (DecimalType(7, 4), bytes([18, 214, 135]), Decimal("123.4567")),
+        # negative decimal to test two's complement
+        # -1234567 is 11101101|00101001|01111001 in binary
+        # 11101101 -> 237, 00101001 -> 41, 01111001 -> 121
         (DecimalType(7, 4), bytes([237, 41, 121]), Decimal("-123.4567")),
+        # test empty byte in decimal
+        # 11 is 00001011 in binary
+        # 00001011 -> 11
+        (DecimalType(10, 3), bytes([11]), Decimal("0.011")),
     ],
 )
 def test_round_trip_conversion(primitive_type, b, result):
@@ -220,8 +313,8 @@ def test_round_trip_conversion_large_decimals(primitive_type, b, result):
 @pytest.mark.parametrize(
     "primitive_type, b, result",
     [
+        (FloatType(), bytes([0, 0, 144, 192]), -4.5),
         (FloatType(), b"\x19\x04\x9e?", 1.2345),
-        (DoubleType(), b"\x8d\x97n\x12\x83\xc0\xf3?", 1.2345),
     ],
 )
 def test_round_trip_conversion_approximation(primitive_type, b, result):

--- a/python/tests/test_conversions.py
+++ b/python/tests/test_conversions.py
@@ -97,6 +97,43 @@ from iceberg.types import (
 
 
 @pytest.mark.parametrize(
+    "value, expected_result",
+    [
+        (Decimal("1.2345"), 12345),
+        (Decimal("12.345"), 12345),
+        (Decimal("1234.5"), 12345),
+        (Decimal("9999999.9999"), 99999999999),
+        (Decimal("1.0"), 10),
+        (Decimal("1"), 1),
+        (Decimal("0.1"), 1),
+        (Decimal("0.12345"), 12345),
+        (Decimal("0.0000001"), 1),
+    ],
+)
+def test_decimal_to_unscaled(value, expected_result):
+    """Test converting a decimal to an unscaled value"""
+    assert conversions.decimal_to_unscaled(value=value) == expected_result
+
+
+@pytest.mark.parametrize(
+    "unscaled, scale, expected_result",
+    [
+        (12345, 4, Decimal("1.2345")),
+        (12345, 3, Decimal("12.345")),
+        (12345, 1, Decimal("1234.5")),
+        (99999999999, 4, Decimal("9999999.9999")),
+        (1, 1, Decimal("0.1")),
+        (1, 0, Decimal("1")),
+        (12345, 5, Decimal("0.12345")),
+        (1, 7, Decimal("0.0000001")),
+    ],
+)
+def test_unscaled_to_decimal(unscaled, scale, expected_result):
+    """Test converting an unscaled value to a decimal with a specified scale"""
+    assert conversions.unscaled_to_decimal(unscaled=unscaled, scale=scale) == expected_result
+
+
+@pytest.mark.parametrize(
     "primitive_type, value_str, expected_result",
     [
         (BooleanType(), "true", True),

--- a/python/tests/test_conversions.py
+++ b/python/tests/test_conversions.py
@@ -228,6 +228,42 @@ def test_round_trip_conversion_approximation(primitive_type, b, result):
     assert bytes_from_value == b
 
 
+@pytest.mark.parametrize(
+    "primitive_type, expected_max_value",
+    [
+        (DecimalType(6, 2), Decimal("9999.99")),
+        (DecimalType(10, 10), Decimal(".9999999999")),
+        (DecimalType(2, 1), Decimal("9.9")),
+        (DecimalType(38, 37), Decimal("9.9999999999999999999999999999999999999")),
+        (DecimalType(20, 1), Decimal("9999999999999999999.9")),
+    ],
+)
+def test_max_value_round_trip_conversion(primitive_type, expected_max_value):
+    """Test round trip conversions of maximum DecimalType values"""
+    b = conversions.to_bytes(primitive_type, expected_max_value)
+    value_from_bytes = conversions.from_bytes(primitive_type, b)
+
+    assert value_from_bytes == expected_max_value
+
+
+@pytest.mark.parametrize(
+    "primitive_type, expected_max_value",
+    [
+        (DecimalType(6, 2), Decimal("-9999.99")),
+        (DecimalType(10, 10), Decimal("-.9999999999")),
+        (DecimalType(2, 1), Decimal("-9.9")),
+        (DecimalType(38, 37), Decimal("-9.9999999999999999999999999999999999999")),
+        (DecimalType(20, 1), Decimal("-9999999999999999999.9")),
+    ],
+)
+def test_min_value_round_trip_conversion(primitive_type, expected_max_value):
+    """Test round trip conversions of minimum DecimalType values"""
+    b = conversions.to_bytes(primitive_type, expected_max_value)
+    value_from_bytes = conversions.from_bytes(primitive_type, b)
+
+    assert value_from_bytes == expected_max_value
+
+
 def test_raise_on_unregistered_type():
     """Test raising when a conversion is attempted for a type that has no registered method"""
 


### PR DESCRIPTION
This adds functionality for converting a value to bytes and vice-versa augmented by the `PrimitiveType` subclass provided.

Functionally this is a direct port of [conversion.py](https://github.com/apache/iceberg/blob/master/python_legacy/iceberg/api/types/conversions.py) in the python legacy library. The main changes are:
1. I replaced the large dictionaries containing `<type>: <lambda function>` pairs with [@singledispatch](https://docs.python.org/3/library/functools.html#functools.singledispatch)
2. I removed the [TypeID](https://github.com/apache/iceberg/blob/master/python_legacy/iceberg/api/types/type.py#L24) enum and instead just used the types directly.

Overall this is more lines of source code but I'll summarize my reasonings for the above two changes:

1. I believe the intention behind the lambda maps was to allow for generic `from_...` and `to_...` functions that contain dynamic logic based on the argument type, similar to constructor overloading in Java. I feel that using `@singledispatch` achieves that more directly by creating a generic function and then registering functions based on the first argument's type. This also allows stacking the register decorators for types that share the same logic (such as `IntegerType` and `DateType`) instead of defining that logic multiple times. Also it's a stable feature added as early as python 3.4 so I believe it's future-proof.
2. The `TypeID` enum in the legacy python client carries some information in the enum value, for example `BOOLEAN = {"java_class": "Boolean.class", "python_class": bool, "id": 1}`. These dictionary values weren't used in `conversions.py` but it looks like they're used in other places such as the partition spec. I removed it because this also felt like it may be adding some unnecessary indirection. If anyone feels this should be put back I'm ok with that but I would suggest that we see where the relationships in these dictionaries are required and localize these mappings to that area of the source code (maybe with a simple `PY_TO_JAVA_CLASS = {...}` object and a `get_class_id(...)` function).