### PR TITLE
Core: Convert REST request classes to Immutables

### DIFF
--- a/baseline.gradle
+++ b/baseline.gradle
@@ -62,8 +62,8 @@ subprojects {
   pluginManager.withPlugin('com.palantir.baseline-error-prone') {
     tasks.withType(JavaCompile).configureEach {
       options.errorprone.errorproneArgs.addAll (
-          // error-prone is slow, don't run on tests and generated src
-          '-XepExcludedPaths:.*/(test|generated-src)/.*',
+          // error-prone is slow, don't run on tests/generated-src/generated
+          '-XepExcludedPaths:.*/(test|generated-src|generated)/.*',
           // specific to Palantir
           '-Xep:ConsistentLoggerName:OFF',  // Uses name `log` but we use name `LOG`
           '-Xep:FinalClass:OFF',

--- a/build.gradle
+++ b/build.gradle
@@ -207,6 +207,8 @@ project(':iceberg-core') {
     api project(':iceberg-api')
     implementation project(':iceberg-common')
     implementation project(path: ':iceberg-bundled-guava', configuration: 'shadow')
+    annotationProcessor "org.immutables:value"
+    implementation "org.immutables:value"
 
     implementation("org.apache.avro:avro") {
       exclude group: 'org.tukaani' // xz compression is not supported

--- a/core/src/main/java/org/apache/iceberg/rest/requests/CreateNamespaceRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/CreateNamespaceRequest.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.Map;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.immutables.value.Value;
 
 /**
@@ -48,11 +47,7 @@ public abstract class CreateNamespaceRequest {
   }
 
   public static CreateNamespaceRequest of(Namespace namespace, Map<String, String> properties) {
-    Map<String, String> props = properties;
-    if (null == props) {
-      props = ImmutableMap.of();
-    }
-    return ImmutableCreateNamespaceRequest.builder().namespace(namespace).properties(props).build();
+    return ImmutableCreateNamespaceRequest.builder().namespace(namespace).properties(properties).build();
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateNamespacePropertiesRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateNamespacePropertiesRequest.java
@@ -19,109 +19,35 @@
 
 package org.apache.iceberg.rest.requests;
 
-import java.util.Collection;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
-import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.immutables.value.Value;
 
 /**
  * A REST request to set and/or remove properties on a namespace.
+ *
+ * Note that Immutable classes by definition don't have a default no-arg constructor (which is required for Jackson),
+ *  therefore the @{@link JsonSerialize}/@{@link JsonDeserialize} annotations on the class will generate what's
+ *  necessary for Jackson-binding to properly work with this class.
  */
-public class UpdateNamespacePropertiesRequest {
+@Value.Immutable
+@JsonSerialize(as = ImmutableUpdateNamespacePropertiesRequest.class)
+@JsonDeserialize(as = ImmutableUpdateNamespacePropertiesRequest.class)
+public abstract class UpdateNamespacePropertiesRequest {
 
-  private List<String> removals;
-  private Map<String, String> updates;
+  public abstract List<String> removals();
 
-  public UpdateNamespacePropertiesRequest() {
-    // Required for Jackson deserialization.
-  }
-
-  private UpdateNamespacePropertiesRequest(List<String> removals, Map<String, String> updates) {
-    this.removals = removals;
-    this.updates = updates;
-    validate();
-  }
-
-  UpdateNamespacePropertiesRequest validate() {
-    return this;
-  }
-
-  public List<String> removals() {
-    return removals == null ? ImmutableList.of() : removals;
-  }
-
-  public Map<String, String> updates() {
-    return updates == null ? ImmutableMap.of() : updates;
-  }
+  public abstract Map<String, String> updates();
 
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
-        .add("removals", removals)
-        .add("updates", updates)
+        .add("removals", removals())
+        .add("updates", updates())
         .toString();
-  }
-
-  public static Builder builder() {
-    return new Builder();
-  }
-
-  public static class Builder {
-    private final ImmutableSet.Builder<String> removalsBuilder = ImmutableSet.builder();
-    private final ImmutableMap.Builder<String, String> updatesBuilder = ImmutableMap.builder();
-
-    private Builder() {
-    }
-
-    public Builder remove(String removal) {
-      Preconditions.checkNotNull(removal,
-          "Invalid property to remove: null");
-      removalsBuilder.add(removal);
-      return this;
-    }
-
-    public Builder removeAll(Collection<String> removals) {
-      Preconditions.checkNotNull(removals,
-          "Invalid list of properties to remove: null");
-      Preconditions.checkArgument(!removals.contains(null),
-          "Invalid property to remove: null");
-      removalsBuilder.addAll(removals);
-      return this;
-    }
-
-    public Builder update(String key, String value) {
-      Preconditions.checkNotNull(key,
-          "Invalid property to update: null");
-      Preconditions.checkNotNull(value,
-          "Invalid value to update for key [%s]: null. Use remove instead", key);
-      updatesBuilder.put(key, value);
-      return this;
-    }
-
-    public Builder updateAll(Map<String, String> updates) {
-      Preconditions.checkNotNull(updates,
-          "Invalid collection of properties to update: null");
-      Preconditions.checkArgument(!updates.containsKey(null),
-          "Invalid property to update: null");
-      Preconditions.checkArgument(!updates.containsValue(null),
-          "Invalid value to update for properties %s: null. Use remove instead",
-          Maps.filterValues(updates, Objects::isNull).keySet());
-      updatesBuilder.putAll(updates);
-      return this;
-    }
-
-    public UpdateNamespacePropertiesRequest build() {
-      List<String> removals = removalsBuilder.build().asList();
-      Map<String, String> updates = updatesBuilder.build();
-
-      return new UpdateNamespacePropertiesRequest(removals, updates);
-    }
   }
 }
 

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestCreateNamespaceRequest.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestCreateNamespaceRequest.java
@@ -104,9 +104,8 @@ public class TestCreateNamespaceRequest extends RequestResponseTestBase<CreateNa
         .isInstanceOf(NullPointerException.class)
         .hasMessage("namespace");
 
-    Assertions.assertThat(CreateNamespaceRequest.of(NAMESPACE, null))
-        .extracting("properties")
-        .isEqualTo(ImmutableMap.of());
+    Assertions.assertThatThrownBy(() -> CreateNamespaceRequest.of(NAMESPACE, null))
+        .isInstanceOf(NullPointerException.class);
 
     Map<String, String> mapWithNullKey = Maps.newHashMap();
     mapWithNullKey.put(null, "hello");

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateNamespacePropertiesRequest.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateNamespacePropertiesRequest.java
@@ -22,13 +22,13 @@ package org.apache.iceberg.rest.requests;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.List;
 import java.util.Map;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.rest.RequestResponseTestBase;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -45,35 +45,38 @@ public class TestUpdateNamespacePropertiesRequest extends RequestResponseTestBas
     // Full request
     String fullJson = "{\"removals\":[\"foo\",\"bar\"],\"updates\":{\"owner\":\"Hank\"}}";
     assertRoundTripSerializesEquallyFrom(
-        fullJson, UpdateNamespacePropertiesRequest.builder().updateAll(UPDATES).removeAll(REMOVALS).build());
+        fullJson, ImmutableUpdateNamespacePropertiesRequest.builder().updates(UPDATES).removals(REMOVALS).build());
 
     // Only updates
     String emptyRemoval = "{\"removals\":[],\"updates\":{\"owner\":\"Hank\"}}";
     assertRoundTripSerializesEquallyFrom(
-        emptyRemoval, UpdateNamespacePropertiesRequest.builder().updateAll(UPDATES).removeAll(EMPTY_REMOVALS).build());
+        emptyRemoval, ImmutableUpdateNamespacePropertiesRequest.builder()
+            .updates(UPDATES).removals(EMPTY_REMOVALS).build());
 
     assertRoundTripSerializesEquallyFrom(
-        emptyRemoval, UpdateNamespacePropertiesRequest.builder().update("owner", "Hank").build());
+        emptyRemoval, ImmutableUpdateNamespacePropertiesRequest.builder().putUpdates("owner", "Hank").build());
 
     // Only removals
     String emptyUpdates = "{\"removals\":[\"foo\",\"bar\"],\"updates\":{}}";
     assertRoundTripSerializesEquallyFrom(
-        emptyUpdates, UpdateNamespacePropertiesRequest.builder().removeAll(REMOVALS).updateAll(EMPTY_UPDATES).build());
+        emptyUpdates, ImmutableUpdateNamespacePropertiesRequest.builder()
+            .removals(REMOVALS).updates(EMPTY_UPDATES).build());
 
     assertRoundTripSerializesEquallyFrom(
-        emptyUpdates, UpdateNamespacePropertiesRequest.builder().remove("foo").remove("bar").build());
+        emptyUpdates, ImmutableUpdateNamespacePropertiesRequest.builder().addRemovals("foo", "bar").build());
 
     // All empty
     String jsonAllFieldsEmpty = "{\"removals\":[],\"updates\":{}}";
     assertRoundTripSerializesEquallyFrom(
-        jsonAllFieldsEmpty, UpdateNamespacePropertiesRequest.builder().build());
+        jsonAllFieldsEmpty, ImmutableUpdateNamespacePropertiesRequest.builder().build());
   }
 
   @Test
   // Test cases that can't be constructed with our Builder class e2e but that will parse correctly
   public void testCanDeserializeWithoutDefaultValues() throws JsonProcessingException {
     // `removals` is null
-    UpdateNamespacePropertiesRequest noRemovals = UpdateNamespacePropertiesRequest.builder().updateAll(UPDATES).build();
+    UpdateNamespacePropertiesRequest noRemovals = ImmutableUpdateNamespacePropertiesRequest.builder()
+        .updates(UPDATES).build();
     String jsonWithNullRemovals = "{\"removals\":null,\"updates\":{\"owner\":\"Hank\"}}";
     UpdateNamespacePropertiesRequest parsed = deserialize(jsonWithNullRemovals);
     assertEquals(parsed, noRemovals);
@@ -83,7 +86,8 @@ public class TestUpdateNamespacePropertiesRequest extends RequestResponseTestBas
     assertEquals(deserialize(jsonWithMissingRemovals), noRemovals);
 
     // `updates` is null
-    UpdateNamespacePropertiesRequest noUpdates = UpdateNamespacePropertiesRequest.builder().removeAll(REMOVALS).build();
+    UpdateNamespacePropertiesRequest noUpdates = ImmutableUpdateNamespacePropertiesRequest.builder()
+        .removals(REMOVALS).build();
     String jsonWithNullUpdates = "{\"removals\":[\"foo\",\"bar\"],\"updates\":null}";
     assertEquals(deserialize(jsonWithNullUpdates), noUpdates);
 
@@ -92,7 +96,7 @@ public class TestUpdateNamespacePropertiesRequest extends RequestResponseTestBas
     assertEquals(deserialize(jsonWithMissingUpdates), noUpdates);
 
     // all null / no values set
-    UpdateNamespacePropertiesRequest allMissing = UpdateNamespacePropertiesRequest.builder().build();
+    UpdateNamespacePropertiesRequest allMissing = ImmutableUpdateNamespacePropertiesRequest.builder().build();
     String jsonAllNull = "{\"removals\":null,\"updates\":null}";
     assertEquals(deserialize(jsonAllNull), allMissing);
 
@@ -105,103 +109,73 @@ public class TestUpdateNamespacePropertiesRequest extends RequestResponseTestBas
     // Invalid top-level types
     String jsonInvalidTypeOnRemovalField =
         "{\"removals\":{\"foo\":\"bar\"},\"updates\":{\"owner\":\"Hank\"}}";
-    AssertHelpers.assertThrows(
-        "A JSON request with an invalid type for one of the fields should fail to parse",
-        JsonProcessingException.class,
-        () -> deserialize(jsonInvalidTypeOnRemovalField)
-    );
+    Assertions.assertThatThrownBy(() -> deserialize(jsonInvalidTypeOnRemovalField))
+        .isInstanceOf(JsonProcessingException.class);
 
     String jsonInvalidTypeOnUpdatesField =
         "{\"removals\":[\"foo\":\"bar\"],\"updates\":[\"owner\"]}";
-    AssertHelpers.assertThrows(
-        "A JSON value with an invalid type for one of the fields should fail to parse",
-        JsonProcessingException.class,
-        () -> deserialize(jsonInvalidTypeOnUpdatesField)
-    );
+    Assertions.assertThatThrownBy(() -> deserialize(jsonInvalidTypeOnUpdatesField))
+        .isInstanceOf(JsonProcessingException.class);
 
     // Valid top-level (array) types, but at least one entry in the list is not the expected type
     // NOTE: non-string values that are integral types will still parse into a string list.
     //    e.g. { removals: [ "foo", "bar", 1234 ] } will parse correctly.
     String invalidJsonWrongTypeInRemovalsList =
         "{\"removals\":[\"foo\",\"bar\", {\"owner\": \"Hank\"}],\"updates\":{\"owner\":\"Hank\"}}";
-    AssertHelpers.assertThrows(
-        "A JSON value with an invalid type inside one of the list fields should fail to parse",
-        JsonProcessingException.class,
-        () -> deserialize(invalidJsonWrongTypeInRemovalsList)
-    );
+    Assertions.assertThatThrownBy(() -> deserialize(invalidJsonWrongTypeInRemovalsList))
+        .isInstanceOf(JsonProcessingException.class);
 
     String nullJson = null;
-    AssertHelpers.assertThrows(
-        "A null JSON should fail to parse",
-        IllegalArgumentException.class,
-        "argument \"content\" is null",
-        () -> deserialize(nullJson)
-    );
+    Assertions.assertThatThrownBy(() -> deserialize(nullJson))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("argument \"content\" is null");
   }
 
   @Test
   public void testBuilderDoesNotCreateInvalidObjects() {
-    AssertHelpers.assertThrows(
-        "The builder should not allow using null as a key to remove",
-        NullPointerException.class,
-        "Invalid property to remove: null",
-        () -> UpdateNamespacePropertiesRequest.builder().remove(null).build()
-    );
+    Assertions.assertThatThrownBy(() ->
+            ImmutableUpdateNamespacePropertiesRequest.builder().addRemovals((String) null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("removals element");
 
-    AssertHelpers.assertThrows(
-        "The builder should not allow passing a null list of properties to remove",
-        NullPointerException.class,
-        "Invalid list of properties to remove: null",
-        () -> UpdateNamespacePropertiesRequest.builder().removeAll(null).build()
-    );
+    Assertions.assertThatThrownBy(() ->
+            ImmutableUpdateNamespacePropertiesRequest.builder().removals(null).build())
+        .isInstanceOf(NullPointerException.class);
 
     List<String> listWithNull = Lists.newArrayList("a", null, null);
-    AssertHelpers.assertThrows(
-        "The builder should not allow passing a list of properties to remove with a null element",
-        IllegalArgumentException.class,
-        "Invalid property to remove: null",
-        () -> UpdateNamespacePropertiesRequest.builder().removeAll(listWithNull).build()
-    );
+    Assertions.assertThatThrownBy(() ->
+            ImmutableUpdateNamespacePropertiesRequest.builder().removals(listWithNull).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("removals element");
 
-    AssertHelpers.assertThrows(
-        "The builder should not allow using null as a key to update",
-        NullPointerException.class,
-        "Invalid property to update: null",
-        () -> UpdateNamespacePropertiesRequest.builder().update(null, "100").build()
-    );
+    Assertions.assertThatThrownBy(() ->
+            ImmutableUpdateNamespacePropertiesRequest.builder().putUpdates(null, "100").build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("updates key");
 
-    AssertHelpers.assertThrows(
-        "The builder should not allow using null as a value to update",
-        NullPointerException.class,
-        "Invalid value to update for key [owner]: null. Use remove instead",
-        () -> UpdateNamespacePropertiesRequest.builder().update("owner", null).build()
-    );
+    Assertions.assertThatThrownBy(() ->
+            ImmutableUpdateNamespacePropertiesRequest.builder().putUpdates("owner", null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("updates value");
 
-    AssertHelpers.assertThrows(
-        "The builder should not allow passing a null collection of properties to update",
-        NullPointerException.class,
-        "Invalid collection of properties to update: null",
-        () -> UpdateNamespacePropertiesRequest.builder().updateAll(null).build()
-    );
+    Assertions.assertThatThrownBy(() ->
+            ImmutableUpdateNamespacePropertiesRequest.builder().updates(null).build())
+        .isInstanceOf(NullPointerException.class);
 
     Map<String, String> mapWithNullKey = Maps.newHashMap();
     mapWithNullKey.put(null, "hello");
-    AssertHelpers.assertThrows(
-        "The builder should not allow using null as a key to update from a collection of updates",
-        IllegalArgumentException.class,
-        "Invalid property to update: null",
-        () -> UpdateNamespacePropertiesRequest.builder().updateAll(mapWithNullKey).build()
-    );
+    Assertions.assertThatThrownBy(() ->
+            ImmutableUpdateNamespacePropertiesRequest.builder().updates(mapWithNullKey).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("updates key");
 
     Map<String, String> mapWithMultipleNullValues = Maps.newHashMap();
     mapWithMultipleNullValues.put("a", null);
     mapWithMultipleNullValues.put("b", "b");
-    AssertHelpers.assertThrows(
-        "The builder should not allow using null as a value to update from a collection of updates",
-        IllegalArgumentException.class,
-        "Invalid value to update for properties [a]: null. Use remove instead",
-        () -> UpdateNamespacePropertiesRequest.builder().updateAll(mapWithMultipleNullValues).build()
-    );
+    Assertions.assertThatThrownBy(() ->
+            ImmutableUpdateNamespacePropertiesRequest.builder().updates(mapWithMultipleNullValues).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("updates value");
   }
 
   @Override
@@ -211,9 +185,9 @@ public class TestUpdateNamespacePropertiesRequest extends RequestResponseTestBas
 
   @Override
   public UpdateNamespacePropertiesRequest createExampleInstance() {
-    return UpdateNamespacePropertiesRequest.builder()
-        .updateAll(UPDATES)
-        .removeAll(REMOVALS)
+    return ImmutableUpdateNamespacePropertiesRequest.builder()
+        .updates(UPDATES)
+        .removals(REMOVALS)
         .build();
   }
 
@@ -226,6 +200,6 @@ public class TestUpdateNamespacePropertiesRequest extends RequestResponseTestBas
 
   @Override
   public UpdateNamespacePropertiesRequest deserialize(String json) throws JsonProcessingException {
-    return mapper().readValue(json, UpdateNamespacePropertiesRequest.class).validate();
+    return mapper().readValue(json, ImmutableUpdateNamespacePropertiesRequest.class);
   }
 }

--- a/versions.props
+++ b/versions.props
@@ -28,6 +28,7 @@ com.google.cloud:libraries-bom = 24.1.0
 org.scala-lang.modules:scala-collection-compat_2.12 = 2.6.0
 org.scala-lang.modules:scala-collection-compat_2.13 = 2.6.0
 com.emc.ecs:object-client-bundle = 3.3.2
+org.immutables:value = 2.8.8
 
 # test deps
 org.junit.vintage:junit-vintage-engine = 5.7.2


### PR DESCRIPTION
@rdblue @kbendick this simplifies/reduces the code in the REST request classes (`CreateNamespaceRequest` / `UpdateNamespacePropertiesRequest`). I figured we first start with those classes before applying similar changes to the [response classes](https://github.com/apache/iceberg/tree/master/core/src/main/java/org/apache/iceberg/rest/responses).

In terms of reviewing I think it makes the most sense to look at the final content of those classes (since the diff is rather noisy because a bunch of stuff is being removed)