### PR TITLE
GCP: Add metrics tracking for GCSFileIO

### DIFF
--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/BaseGCSFile.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/BaseGCSFile.java
@@ -24,17 +24,20 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
 import java.net.URI;
 import org.apache.iceberg.gcp.GCPProperties;
+import org.apache.iceberg.metrics.MetricsContext;
 
 abstract class BaseGCSFile {
   private final Storage storage;
   private final GCPProperties gcpProperties;
   private final BlobId blobId;
   private Blob metadata;
+  private final MetricsContext metrics;
 
-  BaseGCSFile(Storage storage, BlobId blobId, GCPProperties gcpProperties) {
+  BaseGCSFile(Storage storage, BlobId blobId, GCPProperties gcpProperties, MetricsContext metrics) {
     this.storage = storage;
     this.blobId = blobId;
     this.gcpProperties = gcpProperties;
+    this.metrics = metrics;
   }
 
   public String location() {
@@ -55,6 +58,10 @@ abstract class BaseGCSFile {
 
   protected GCPProperties gcpProperties() {
     return gcpProperties;
+  }
+
+  protected MetricsContext metrics() {
+    return metrics;
   }
 
   public boolean exists() {

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSFileIO.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSFileIO.java
@@ -24,10 +24,12 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.gcp.GCPProperties;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.util.SerializableSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,10 +45,12 @@ import org.slf4j.LoggerFactory;
  */
 public class GCSFileIO implements FileIO {
   private static final Logger LOG = LoggerFactory.getLogger(GCSFileIO.class);
+  private static final String DEFAULT_METRICS_IMPL = "org.apache.iceberg.hadoop.HadoopMetricsContext";
 
   private SerializableSupplier<Storage> storageSupplier;
   private GCPProperties gcpProperties;
   private transient Storage storage;
+  private MetricsContext metrics = MetricsContext.nullMetrics();
   private final AtomicBoolean isResourceClosed = new AtomicBoolean(false);
 
   /**
@@ -72,12 +76,12 @@ public class GCSFileIO implements FileIO {
 
   @Override
   public InputFile newInputFile(String path) {
-    return GCSInputFile.fromLocation(path, client(), gcpProperties);
+    return GCSInputFile.fromLocation(path, client(), gcpProperties, metrics);
   }
 
   @Override
   public OutputFile newOutputFile(String path) {
-    return GCSOutputFile.fromLocation(path, client(), gcpProperties);
+    return GCSOutputFile.fromLocation(path, client(), gcpProperties, metrics);
   }
 
   @Override
@@ -107,6 +111,17 @@ public class GCSFileIO implements FileIO {
       gcpProperties.projectId().ifPresent(builder::setProjectId);
       gcpProperties.clientLibToken().ifPresent(builder::setClientLibToken);
       gcpProperties.serviceHost().ifPresent(builder::setHost);
+
+      // Report Hadoop metrics if Hadoop is available
+      try {
+        DynConstructors.Ctor<MetricsContext> ctor =
+            DynConstructors.builder(MetricsContext.class).hiddenImpl(DEFAULT_METRICS_IMPL, String.class).buildChecked();
+        this.metrics = ctor.newInstance("gcs");
+
+        metrics.initialize(properties);
+      } catch (NoSuchMethodException | ClassCastException e) {
+        LOG.warn("Unable to load metrics class: '{}', falling back to null metrics", DEFAULT_METRICS_IMPL, e);
+      }
 
       return builder.build().getService();
     };

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputFile.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputFile.java
@@ -24,14 +24,17 @@ import com.google.cloud.storage.Storage;
 import org.apache.iceberg.gcp.GCPProperties;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.SeekableInputStream;
+import org.apache.iceberg.metrics.MetricsContext;
 
 public class GCSInputFile extends BaseGCSFile implements InputFile {
-  public static GCSInputFile fromLocation(String location, Storage storage, GCPProperties gcpProperties) {
-    return new GCSInputFile(storage, BlobId.fromGsUtilUri(location), gcpProperties);
+
+  public static GCSInputFile fromLocation(String location, Storage storage,
+      GCPProperties gcpProperties, MetricsContext metrics) {
+    return new GCSInputFile(storage, BlobId.fromGsUtilUri(location), gcpProperties, metrics);
   }
 
-  GCSInputFile(Storage storage, BlobId blobId, GCPProperties gcpProperties) {
-    super(storage, blobId, gcpProperties);
+  GCSInputFile(Storage storage, BlobId blobId, GCPProperties gcpProperties, MetricsContext metrics) {
+    super(storage, blobId, gcpProperties, metrics);
   }
 
   @Override
@@ -41,6 +44,6 @@ public class GCSInputFile extends BaseGCSFile implements InputFile {
 
   @Override
   public SeekableInputStream newStream() {
-    return new GCSInputStream(storage(), blobId(), gcpProperties());
+    return new GCSInputStream(storage(), blobId(), gcpProperties(), metrics());
   }
 }

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputFile.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputFile.java
@@ -26,9 +26,9 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.metrics.MetricsContext;
 
-public class GCSInputFile extends BaseGCSFile implements InputFile {
+class GCSInputFile extends BaseGCSFile implements InputFile {
 
-  public static GCSInputFile fromLocation(String location, Storage storage,
+  static GCSInputFile fromLocation(String location, Storage storage,
       GCPProperties gcpProperties, MetricsContext metrics) {
     return new GCSInputFile(storage, BlobId.fromGsUtilUri(location), gcpProperties, metrics);
   }

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSOutputFile.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSOutputFile.java
@@ -28,14 +28,17 @@ import org.apache.iceberg.gcp.GCPProperties;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.PositionOutputStream;
+import org.apache.iceberg.metrics.MetricsContext;
 
 public class GCSOutputFile extends BaseGCSFile implements OutputFile {
-  public static GCSOutputFile fromLocation(String location, Storage storage, GCPProperties gcpProperties) {
-    return new GCSOutputFile(storage, BlobId.fromGsUtilUri(location), gcpProperties);
+
+  public static GCSOutputFile fromLocation(String location, Storage storage,
+      GCPProperties gcpProperties, MetricsContext metrics) {
+    return new GCSOutputFile(storage, BlobId.fromGsUtilUri(location), gcpProperties, metrics);
   }
 
-  GCSOutputFile(Storage storage, BlobId blobId, GCPProperties gcpProperties) {
-    super(storage, blobId, gcpProperties);
+  GCSOutputFile(Storage storage, BlobId blobId, GCPProperties gcpProperties, MetricsContext metrics) {
+    super(storage, blobId, gcpProperties, metrics);
   }
 
   /**
@@ -56,7 +59,7 @@ public class GCSOutputFile extends BaseGCSFile implements OutputFile {
   @Override
   public PositionOutputStream createOrOverwrite() {
     try {
-      return new GCSOutputStream(storage(), blobId(), gcpProperties());
+      return new GCSOutputStream(storage(), blobId(), gcpProperties(), metrics());
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to create output stream for location: " + uri(), e);
     }
@@ -64,6 +67,6 @@ public class GCSOutputFile extends BaseGCSFile implements OutputFile {
 
   @Override
   public InputFile toInputFile() {
-    return new GCSInputFile(storage(), blobId(), gcpProperties());
+    return new GCSInputFile(storage(), blobId(), gcpProperties(), metrics());
   }
 }

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSOutputFile.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSOutputFile.java
@@ -30,9 +30,9 @@ import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.PositionOutputStream;
 import org.apache.iceberg.metrics.MetricsContext;
 
-public class GCSOutputFile extends BaseGCSFile implements OutputFile {
+class GCSOutputFile extends BaseGCSFile implements OutputFile {
 
-  public static GCSOutputFile fromLocation(String location, Storage storage,
+  static GCSOutputFile fromLocation(String location, Storage storage,
       GCPProperties gcpProperties, MetricsContext metrics) {
     return new GCSOutputFile(storage, BlobId.fromGsUtilUri(location), gcpProperties, metrics);
   }

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSOutputStream.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSOutputStream.java
@@ -31,7 +31,11 @@ import java.nio.channels.Channels;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.iceberg.gcp.GCPProperties;
+import org.apache.iceberg.io.FileIOMetricsContext;
 import org.apache.iceberg.io.PositionOutputStream;
+import org.apache.iceberg.metrics.MetricsContext;
+import org.apache.iceberg.metrics.MetricsContext.Counter;
+import org.apache.iceberg.metrics.MetricsContext.Unit;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,15 +54,22 @@ class GCSOutputStream extends PositionOutputStream {
 
   private OutputStream stream;
 
+  private final Counter<Long> writeBytes;
+  private final Counter<Integer> writeOperations;
+
   private long pos = 0;
   private boolean closed = false;
 
-  GCSOutputStream(Storage storage, BlobId blobId, GCPProperties gcpProperties) throws IOException {
+  GCSOutputStream(Storage storage, BlobId blobId, GCPProperties gcpProperties,
+      MetricsContext metrics) throws IOException {
     this.storage = storage;
     this.blobId = blobId;
     this.gcpProperties = gcpProperties;
 
     createStack = Thread.currentThread().getStackTrace();
+
+    this.writeBytes = metrics.counter(FileIOMetricsContext.WRITE_BYTES, Long.class, Unit.BYTES);
+    this.writeOperations = metrics.counter(FileIOMetricsContext.WRITE_OPERATIONS, Integer.class, Unit.COUNT);
 
     openStream();
   }
@@ -77,12 +88,16 @@ class GCSOutputStream extends PositionOutputStream {
   public void write(int b) throws IOException {
     stream.write(b);
     pos += 1;
+    writeBytes.increment();
+    writeOperations.increment();
   }
 
   @Override
   public void write(byte[] b, int off, int len) throws IOException {
     stream.write(b, off, len);
     pos += len;
+    writeBytes.increment((long) len);
+    writeOperations.increment();
   }
 
   private void openStream() {

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/GCSInputStreamTest.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/GCSInputStreamTest.java
@@ -30,6 +30,7 @@ import java.util.Random;
 import org.apache.commons.io.IOUtils;
 import org.apache.iceberg.gcp.GCPProperties;
 import org.apache.iceberg.io.SeekableInputStream;
+import org.apache.iceberg.metrics.MetricsContext;
 import org.junit.Test;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -51,7 +52,8 @@ public class GCSInputStreamTest {
 
     writeGCSData(uri, data);
 
-    try (SeekableInputStream in = new GCSInputStream(storage, uri, gcpProperties)) {
+    try (SeekableInputStream in = new GCSInputStream(storage, uri, gcpProperties,
+        MetricsContext.nullMetrics())) {
       int readSize = 1024;
       byte [] actual = new byte[readSize];
 
@@ -102,7 +104,8 @@ public class GCSInputStreamTest {
   @Test
   public void testClose() throws Exception {
     BlobId blobId = BlobId.fromGsUtilUri("gs://bucket/path/to/closed.dat");
-    SeekableInputStream closed = new GCSInputStream(storage, blobId, gcpProperties);
+    SeekableInputStream closed = new GCSInputStream(storage, blobId, gcpProperties,
+        MetricsContext.nullMetrics());
     closed.close();
     assertThrows(IllegalStateException.class, () -> closed.seek(0));
   }
@@ -114,7 +117,8 @@ public class GCSInputStreamTest {
 
     writeGCSData(blobId, data);
 
-    try (SeekableInputStream in = new GCSInputStream(storage, blobId, gcpProperties)) {
+    try (SeekableInputStream in = new GCSInputStream(storage, blobId, gcpProperties,
+        MetricsContext.nullMetrics())) {
       in.seek(data.length / 2);
       byte[] actual = new byte[data.length / 2 ];
 

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/GCSOutputStreamTest.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/GCSOutputStreamTest.java
@@ -58,8 +58,8 @@ public class GCSOutputStreamTest {
 
   @Test
   public void testMultipleClose() throws IOException {
-    GCSOutputStream stream = new GCSOutputStream(storage, randomBlobId(), properties, MetricsContext
-        .nullMetrics());
+    GCSOutputStream stream =
+        new GCSOutputStream(storage, randomBlobId(), properties, MetricsContext.nullMetrics());
     stream.close();
     stream.close();
   }

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/GCSOutputStreamTest.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/GCSOutputStreamTest.java
@@ -28,6 +28,7 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.stream.Stream;
 import org.apache.iceberg.gcp.GCPProperties;
+import org.apache.iceberg.metrics.MetricsContext;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,14 +58,16 @@ public class GCSOutputStreamTest {
 
   @Test
   public void testMultipleClose() throws IOException {
-    GCSOutputStream stream = new GCSOutputStream(storage, randomBlobId(), properties);
+    GCSOutputStream stream = new GCSOutputStream(storage, randomBlobId(), properties, MetricsContext
+        .nullMetrics());
     stream.close();
     stream.close();
   }
 
 
   private void writeAndVerify(Storage client, BlobId uri, byte [] data, boolean arrayWrite) {
-    try (GCSOutputStream stream = new GCSOutputStream(client, uri, properties)) {
+    try (GCSOutputStream stream = new GCSOutputStream(client, uri, properties,
+        MetricsContext.nullMetrics())) {
       if (arrayWrite) {
         stream.write(data);
         assertEquals(data.length, stream.getPos());


### PR DESCRIPTION
This PR adds metrics tracking for `GCSFileIO`. This would help reporting IO metrics via the Hadoop `FileSystem.Statistics`.