### PR TITLE
Infra - Disable CI for anything in open-api or format folder

### DIFF
--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -40,6 +40,8 @@ on:
     - 'python/**'
     - 'python_legacy/**'
     - 'docs/**'
+    - 'open-api/**'
+    - 'format/**'
     - '.gitattributes'
     - 'README.md'
     - 'CONTRIBUTING.md'

--- a/.github/workflows/hive-ci.yml
+++ b/.github/workflows/hive-ci.yml
@@ -38,6 +38,8 @@ on:
     - 'python/**'
     - 'python_legacy/**'
     - 'docs/**'
+    - 'open-api/**'
+    - 'format/**'
     - '.gitattributes'
     - 'README.md'
     - 'CONTRIBUTING.md'

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -35,6 +35,8 @@ on:
     - 'python/**'
     - 'python_legacy/**'
     - 'docs/**'
+    - 'open-api/**'
+    - 'format/**'
     - '.gitattributes'
     - 'README.md'
     - 'CONTRIBUTING.md'

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -40,6 +40,8 @@ on:
     - 'python/**'
     - 'python_legacy/**'
     - 'docs/**'
+    - 'open-api/**'
+    - 'format/**'
     - '.gitattributes'
     - 'README.md'
     - 'CONTRIBUTING.md'


### PR DESCRIPTION
Disables running CI workflows for any PR that is opened that only updates the `open-api` folder or the `format` folder.

The `docs` folder is already covered.