### PR TITLE
Infra - Trigger CI when pushing to a release branch or tag

### DIFF
--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -22,8 +22,9 @@ on:
   push:
     branches:
     - 'master'
+    - '0.**'
     tags:
-    - '**'
+    - 'apache-iceberg-**'
   pull_request:
     paths-ignore:
     - '.github/workflows/python-ci.yml'

--- a/.github/workflows/hive-ci.yml
+++ b/.github/workflows/hive-ci.yml
@@ -22,8 +22,9 @@ on:
   push:
     branches:
     - 'master'
+    - '0.**'
     tags:
-    - '**'
+    - 'apache-iceberg-**'
   pull_request:
     paths-ignore:
     - '.github/workflows/python-ci.yml'

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -22,8 +22,9 @@ on:
   push:
     branches:
     - 'master'
+    - '0.**'
     tags:
-    - '**'
+    - 'apache-iceberg-**'
   pull_request:
     paths-ignore:
     - '.github/workflows/python-ci.yml'

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -22,8 +22,9 @@ on:
   push:
     branches:
     - 'master'
+    - '0.**'
     tags:
-    - '**'
+    - 'apache-iceberg-**'
   pull_request:
     paths:
     - '.github/workflows/python-ci.yml'

--- a/.github/workflows/python-legacy-ci.yml
+++ b/.github/workflows/python-legacy-ci.yml
@@ -22,8 +22,9 @@ on:
   push:
     branches:
     - 'master'
+    - '0.**'
     tags:
-    - '**'
+    - 'apache-iceberg-**'
   pull_request:
     paths:
     - '.github/workflows/python-legacy-ci.yml'

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -22,8 +22,9 @@ on:
   push:
     branches:
     - 'master'
+    - '0.**'
     tags:
-    - '**'
+    - 'apache-iceberg-**'
   pull_request:
     paths-ignore:
     - '.github/workflows/python-ci.yml'


### PR DESCRIPTION
We'd like to run CI to completion when we push to a release branch.

Release branches are of the form `0.x.y` right now, so matching on `0.**`

For release tags, they are normally `apache-iceberg-**`, so I've updated the CI suites to run on push to a tag of that format.

cc @rdblue @snazy @nastra 