### PR TITLE
Docs: Add Drill to Documentation

### DIFF
--- a/docs/drill/_index.md
+++ b/docs/drill/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Drill"
+bookIconImage: ../img/drill-logo.png
+bookFlatSection: true
+weight: 430
+bookExternalUrlNewWindow: https://drill.apache.org/docs/iceberg-format-plugin/
+---
+<!--
+ - Licensed to the Apache Software Foundation (ASF) under one or more
+ - contributor license agreements.  See the NOTICE file distributed with
+ - this work for additional information regarding copyright ownership.
+ - The ASF licenses this file to You under the Apache License, Version 2.0
+ - (the "License"); you may not use this file except in compliance with
+ - the License.  You may obtain a copy of the License at
+ -
+ -   http://www.apache.org/licenses/LICENSE-2.0
+ -
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -->


### PR DESCRIPTION
This PR adds a link to the documentation for Apache Drill's connector for Iceberg tables. 