### PR TITLE
Core: Fix deleted data files validation in OverwriteFiles

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseOverwriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseOverwriteFiles.java
@@ -35,7 +35,7 @@ public class BaseOverwriteFiles extends MergingSnapshotProducer<OverwriteFiles> 
   private Long startingSnapshotId = null;
   private Expression conflictDetectionFilter = null;
   private boolean validateNewDataFiles = false;
-  private boolean validateNewDeleteFiles = false;
+  private boolean validateNewDeletes = false;
 
   protected BaseOverwriteFiles(String tableName, TableOperations ops) {
     super(tableName, ops);
@@ -98,7 +98,7 @@ public class BaseOverwriteFiles extends MergingSnapshotProducer<OverwriteFiles> 
 
   @Override
   public OverwriteFiles validateNoConflictingDeletes() {
-    this.validateNewDeleteFiles = true;
+    this.validateNewDeletes = true;
     failMissingDeletePaths();
     return this;
   }
@@ -134,10 +134,11 @@ public class BaseOverwriteFiles extends MergingSnapshotProducer<OverwriteFiles> 
       validateAddedDataFiles(base, startingSnapshotId, dataConflictDetectionFilter());
     }
 
-    if (validateNewDeleteFiles) {
+    if (validateNewDeletes) {
       if (rowFilter() != Expressions.alwaysFalse()) {
         Expression filter = conflictDetectionFilter != null ? conflictDetectionFilter : rowFilter();
         validateNoNewDeleteFiles(base, startingSnapshotId, filter);
+        validateDeletedDataFiles(base, startingSnapshotId, filter);
       }
 
       if (deletedDataFiles.size() > 0) {


### PR DESCRIPTION
This PR fixes the deleted data files validation for overwrites by filter in `OverwriteFiles`. Right now, we allow removal of data files in partitions we overwrite, which, I think violates the assumption.

Found by @szehon-ho in #4293.