### PR TITLE
Core : Fix NPE post HadoopMetricContext Deserialization

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
@@ -33,7 +33,7 @@ public class HadoopMetricsContext implements FileIOMetricsContext {
   public static final String SCHEME = "io.metrics-scheme";
 
   private String scheme;
-  private transient FileSystem.Statistics statistics;
+  private transient volatile FileSystem.Statistics statistics;
 
   public HadoopMetricsContext(String scheme) {
     ValidationException.check(scheme != null,

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
@@ -112,17 +112,14 @@ public class HadoopMetricsContext implements FileIOMetricsContext {
   }
 
   private FileSystem.Statistics statistics() {
-    FileSystem.Statistics localStatisticsRef = statistics;
-    if (localStatisticsRef == null) {
+    if (statistics == null) {
       synchronized (this) {
-        localStatisticsRef = statistics;
-        if (localStatisticsRef == null) {
-          localStatisticsRef = FileSystem.getStatistics(scheme, null);
-          statistics = localStatisticsRef;
+        if (statistics == null) {
+          this.statistics = FileSystem.getStatistics(scheme, null);
         }
       }
     }
 
-    return localStatisticsRef;
+    return statistics;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
@@ -128,10 +128,17 @@ public class HadoopMetricsContext implements FileIOMetricsContext {
   }
 
   private FileSystem.Statistics statistics() {
-    if (statistics == null) {
-      statistics = statisticsSupplier.get();
+    FileSystem.Statistics localStatisticsRef = statistics;
+    if (localStatisticsRef == null) {
+      synchronized (this) {
+        localStatisticsRef = statistics;
+        if (localStatisticsRef == null) {
+          localStatisticsRef = statisticsSupplier.get();
+          statistics = localStatisticsRef;
+        }
+      }
     }
 
-    return statistics;
+    return localStatisticsRef;
   }
 }

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/TestHadoopMetricsContextSerialization.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/TestHadoopMetricsContextSerialization.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg;
+
+import com.google.common.collect.Maps;
+import java.io.IOException;
+import org.apache.iceberg.hadoop.HadoopMetricsContext;
+import org.apache.iceberg.io.FileIOMetricsContext;
+import org.apache.iceberg.metrics.MetricsContext;
+import org.junit.Test;
+
+public class TestHadoopMetricsContextSerialization {
+
+  @Test(expected = Test.None.class)
+  public void testHadoopMetricsContextKryoSerialization() throws IOException {
+    MetricsContext metricsContext = new HadoopMetricsContext("s3");
+
+    metricsContext.initialize(Maps.newHashMap());
+
+    MetricsContext deserializedMetricContext = KryoHelpers.roundTripSerialize(metricsContext);
+    // statistics are properly re-initialized post de-serialization
+    deserializedMetricContext
+        .counter(FileIOMetricsContext.WRITE_BYTES, Long.class, MetricsContext.Unit.BYTES)
+        .increment();
+  }
+
+  @Test(expected = Test.None.class)
+  public void testHadoopMetricsContextJavaSerialization() throws IOException, ClassNotFoundException {
+    MetricsContext metricsContext = new HadoopMetricsContext("s3");
+
+    metricsContext.initialize(Maps.newHashMap());
+
+    MetricsContext deserializedMetricContext = TestHelpers.roundTripSerialize(metricsContext);
+    // statistics are properly re-initialized post de-serialization
+    deserializedMetricContext
+        .counter(FileIOMetricsContext.WRITE_BYTES, Long.class, MetricsContext.Unit.BYTES)
+        .increment();
+  }
+}

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/TestHadoopMetricsContextSerialization.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/TestHadoopMetricsContextSerialization.java
@@ -1,38 +1,29 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.iceberg;
 
-import com.google.common.collect.Maps;
 import java.io.IOException;
 import org.apache.iceberg.hadoop.HadoopMetricsContext;
 import org.apache.iceberg.io.FileIOMetricsContext;
 import org.apache.iceberg.metrics.MetricsContext;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.Test;
 
 public class TestHadoopMetricsContextSerialization {


### PR DESCRIPTION
- Currently when we use any serializer other than JavaSerializer (for ex : KryoSerializer), we face an NPE due to statistics being null and not be re-initialized on de-serialization (since we broadcast FileIO and hence part of this we serialize it at driver & de serialize it in executor for spark) .


This PR attempts to address the issue reported below : 

Closes #4288 


