### PR TITLE
Spark 3.2: Cleanup DataFrame overwritePartitions isolation level handling

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -277,17 +277,15 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
       IsolationLevel isolationLevel = writeConf.isolationLevel();
       Long validateFromSnapshotId = writeConf.validateFromSnapshotId();
 
+      if (isolationLevel != null && validateFromSnapshotId != null) {
+        dynamicOverwrite.validateFromSnapshot(validateFromSnapshotId);
+      }
+
       if (isolationLevel == SERIALIZABLE) {
-        if (validateFromSnapshotId != null) {
-          dynamicOverwrite.validateFromSnapshot(validateFromSnapshotId);
-        }
         dynamicOverwrite.validateNoConflictingData();
         dynamicOverwrite.validateNoConflictingDeletes();
 
       } else if (isolationLevel == SNAPSHOT) {
-        if (validateFromSnapshotId != null) {
-          dynamicOverwrite.validateFromSnapshot(validateFromSnapshotId);
-        }
         dynamicOverwrite.validateNoConflictingDeletes();
       }
 


### PR DESCRIPTION
This makes some minor cleanup and add one more test for #2925 

This is from comment https://github.com/apache/iceberg/pull/4293#discussion_r823035860 of splitting these changes from that pr into a separate one.
