### PR TITLE
Core: Fix delete file index with non equality column filter lost equlity delete files

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -476,7 +476,6 @@ class DeleteFileIndex {
           matchingManifests,
           manifest ->
               ManifestFiles.readDeleteManifest(manifest, io, specsById)
-                  .filterRows(dataFilter)
                   .filterPartitions(partitionFilter)
                   .filterPartitions(partitionSet)
                   .caseSensitive(caseSensitive)

--- a/core/src/test/java/org/apache/iceberg/TestOverwriteWithValidation.java
+++ b/core/src/test/java/org/apache/iceberg/TestOverwriteWithValidation.java
@@ -128,19 +128,19 @@ public class TestOverwriteWithValidation extends TableTestBase {
       .build();
 
   private static final DataFile FILE_DAY_2_ANOTHER_RANGE = DataFiles
-          .builder(PARTITION_SPEC)
-          .withPath("/path/to/data-3.parquet")
-          .withFileSizeInBytes(0)
-          .withPartitionPath("date=2018-06-09")
-          .withMetrics(new Metrics(5L,
-                  null, // no column sizes
-                  ImmutableMap.of(1, 5L, 2, 3L), // value count
-                  ImmutableMap.of(1, 0L, 2, 2L), // null count
-                  null,
-                  ImmutableMap.of(1, longToBuffer(10L)), // lower bounds
-                  ImmutableMap.of(1, longToBuffer(14L)) // upper bounds
-          ))
-          .build();
+      .builder(PARTITION_SPEC)
+      .withPath("/path/to/data-3.parquet")
+      .withFileSizeInBytes(0)
+      .withPartitionPath("date=2018-06-09")
+      .withMetrics(new Metrics(5L,
+          null, // no column sizes
+          ImmutableMap.of(1, 5L, 2, 3L), // value count
+          ImmutableMap.of(1, 0L, 2, 2L), // null count
+          null,
+          ImmutableMap.of(1, longToBuffer(10L)), // lower bounds
+          ImmutableMap.of(1, longToBuffer(14L)) // upper bounds
+      ))
+      .build();
 
   private static final DeleteFile FILE_DAY_2_ANOTHER_RANGE_EQ_DELETES = FileMetadata.deleteFileBuilder(PARTITION_SPEC)
       .ofEqualityDeletes()

--- a/core/src/test/java/org/apache/iceberg/TestOverwriteWithValidation.java
+++ b/core/src/test/java/org/apache/iceberg/TestOverwriteWithValidation.java
@@ -96,23 +96,6 @@ public class TestOverwriteWithValidation extends TableTestBase {
       ))
       .build();
 
-
-  private static final DataFile FILE_DAY_2_ANOTHER_RANGE = DataFiles
-          .builder(PARTITION_SPEC)
-          .withPath("/path/to/data-3.parquet")
-          .withFileSizeInBytes(0)
-          .withPartitionPath("date=2018-06-09")
-          .withMetrics(new Metrics(5L,
-                  null, // no column sizes
-                  ImmutableMap.of(1, 5L, 2, 3L), // value count
-                  ImmutableMap.of(1, 0L, 2, 2L), // null count
-                  null,
-                  ImmutableMap.of(1, longToBuffer(10L)), // lower bounds
-                  ImmutableMap.of(1, longToBuffer(14L)) // upper bounds
-          ))
-          .build();
-
-
   private static final DeleteFile FILE_DAY_2_EQ_DELETES = FileMetadata.deleteFileBuilder(PARTITION_SPEC)
       .ofEqualityDeletes()
       .withPath("/path/to/data-2-eq-deletes.parquet")
@@ -143,6 +126,21 @@ public class TestOverwriteWithValidation extends TableTestBase {
           ImmutableMap.of(1, longToBuffer(9L)) // upper bounds
       ))
       .build();
+
+  private static final DataFile FILE_DAY_2_ANOTHER_RANGE = DataFiles
+          .builder(PARTITION_SPEC)
+          .withPath("/path/to/data-3.parquet")
+          .withFileSizeInBytes(0)
+          .withPartitionPath("date=2018-06-09")
+          .withMetrics(new Metrics(5L,
+                  null, // no column sizes
+                  ImmutableMap.of(1, 5L, 2, 3L), // value count
+                  ImmutableMap.of(1, 0L, 2, 2L), // null count
+                  null,
+                  ImmutableMap.of(1, longToBuffer(10L)), // lower bounds
+                  ImmutableMap.of(1, longToBuffer(14L)) // upper bounds
+          ))
+          .build();
 
   private static final DeleteFile FILE_DAY_2_ANOTHER_RANGE_EQ_DELETES = FileMetadata.deleteFileBuilder(PARTITION_SPEC)
       .ofEqualityDeletes()

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
@@ -259,20 +259,20 @@ public class TestFlinkTableSink extends FlinkCatalogTestBase {
     String tableName = "test_insert";
 
     Map<String, String> tableProps = ImmutableMap.of(
-            "write.format.default", format.name(),
-            TableProperties.FORMAT_VERSION, "2",
-            TableProperties.UPSERT_ENABLED, "true"
+      "write.format.default", format.name(),
+      TableProperties.FORMAT_VERSION, "2",
+      TableProperties.UPSERT_ENABLED, "true"
     );
 
     sql("CREATE TABLE %s(id INT NOT NULL, dt DATE, PRIMARY KEY (id) NOT ENFORCED) PARTITIONED BY (id) WITH %s",
-            tableName, toWithClause(tableProps));
+      tableName, toWithClause(tableProps));
 
     // insert data set
-    sql("INSERT INTO %s VALUES " +
-                    "(1, to_date('2021-01-01','yyyy-MM-dd'))", tableName);
+    sql("INSERT INTO %s VALUES "
+      + "(1, to_date('2021-01-01','yyyy-MM-dd'))", tableName);
 
-    sql("INSERT INTO %s VALUES " +
-                    "(1, to_date('2022-01-01','yyyy-MM-dd'))", tableName);
+    sql("INSERT INTO %s VALUES "
+      + "(1, to_date('2022-01-01','yyyy-MM-dd'))", tableName);
 
     List<Row> rows = sql("SELECT * FROM %s WHERE dt < '2022-01-01'", tableName);
 

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
@@ -259,20 +259,20 @@ public class TestFlinkTableSink extends FlinkCatalogTestBase {
     String tableName = "test_insert";
 
     Map<String, String> tableProps = ImmutableMap.of(
-      "write.format.default", format.name(),
-      TableProperties.FORMAT_VERSION, "2",
-      TableProperties.UPSERT_ENABLED, "true"
+        "write.format.default", format.name(),
+        TableProperties.FORMAT_VERSION, "2",
+        TableProperties.UPSERT_ENABLED, "true"
     );
 
     sql("CREATE TABLE %s(id INT NOT NULL, dt DATE, PRIMARY KEY (id) NOT ENFORCED) PARTITIONED BY (id) WITH %s",
-      tableName, toWithClause(tableProps));
+        tableName, toWithClause(tableProps));
 
     // insert data set
-    sql("INSERT INTO %s VALUES "
-      + "(1, to_date('2021-01-01','yyyy-MM-dd'))", tableName);
+    sql("INSERT INTO %s VALUES " +
+        "(1, to_date('2021-01-01','yyyy-MM-dd'))", tableName);
 
-    sql("INSERT INTO %s VALUES "
-      + "(1, to_date('2022-01-01','yyyy-MM-dd'))", tableName);
+    sql("INSERT INTO %s VALUES " +
+        "(1, to_date('2022-01-01','yyyy-MM-dd'))", tableName);
 
     List<Row> rows = sql("SELECT * FROM %s WHERE dt < '2022-01-01'", tableName);
 

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
@@ -253,9 +253,8 @@ public class TestFlinkTableSink extends FlinkCatalogTestBase {
     }
   }
 
-
   @Test
-  public void testInsertWithUpsertAndQueryNonEqualityField() {
+  public void testInsertWithUpsertAndScanFilterWithNonEqualityField() {
     Assume.assumeTrue(format == FileFormat.PARQUET);
     String tableName = "test_insert";
 


### PR DESCRIPTION
When we through Flink to write enabled the `upsert` option, and then we specify non equality columns conditions in the query, some of the equality delete files will be lost due to the wrong usage of the filter.  