### PR TITLE
Flink - Remove deprecated calls to blink planner that has been removed

### DIFF
--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/FlinkTestBase.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/FlinkTestBase.java
@@ -74,7 +74,6 @@ public abstract class FlinkTestBase extends TestBaseUtils {
         if (tEnv == null) {
           EnvironmentSettings settings = EnvironmentSettings
               .newInstance()
-              .useBlinkPlanner()
               .inBatchMode()
               .build();
 

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestFlinkTableSink.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.Expressions;
@@ -96,14 +95,11 @@ public class TestFlinkTableSink extends FlinkCatalogTestBase {
   protected TableEnvironment getTableEnv() {
     if (tEnv == null) {
       synchronized (this) {
-        EnvironmentSettings.Builder settingsBuilder = EnvironmentSettings
-            .newInstance()
-            .useBlinkPlanner();
+        EnvironmentSettings.Builder settingsBuilder = EnvironmentSettings.newInstance();
         if (isStreamingJob) {
           settingsBuilder.inStreamingMode();
           StreamExecutionEnvironment env = StreamExecutionEnvironment
               .getExecutionEnvironment(MiniClusterResource.DISABLE_CLASSLOADER_CHECK_CONFIG);
-          env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
           env.enableCheckpointing(400);
           env.setMaxParallelism(2);
           env.setParallelism(2);

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
@@ -189,9 +189,7 @@ public class TestIcebergConnector extends FlinkTestBase {
     if (tEnv == null) {
       synchronized (this) {
         if (tEnv == null) {
-          EnvironmentSettings.Builder settingsBuilder = EnvironmentSettings
-              .newInstance()
-              .useBlinkPlanner();
+          EnvironmentSettings.Builder settingsBuilder = EnvironmentSettings.newInstance();
           if (isStreaming) {
             settingsBuilder.inStreamingMode();
             StreamExecutionEnvironment env = StreamExecutionEnvironment

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/ChangeLogTableTestBase.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/ChangeLogTableTestBase.java
@@ -52,7 +52,6 @@ public class ChangeLogTableTestBase extends FlinkTestBase {
         if (tEnv == null) {
           EnvironmentSettings settings = EnvironmentSettings
               .newInstance()
-              .useBlinkPlanner()
               .inStreamingMode()
               .build();
 

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkScanSql.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkScanSql.java
@@ -72,7 +72,6 @@ public class TestFlinkScanSql extends TestFlinkSource {
         if (tEnv == null) {
           this.tEnv = TableEnvironment.create(EnvironmentSettings
               .newInstance()
-              .useBlinkPlanner()
               .inBatchMode().build());
         }
       }

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamScanSql.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamScanSql.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.flink.core.execution.JobClient;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
@@ -66,12 +65,10 @@ public class TestStreamScanSql extends FlinkCatalogTestBase {
         if (tEnv == null) {
           EnvironmentSettings.Builder settingsBuilder = EnvironmentSettings
               .newInstance()
-              .useBlinkPlanner()
               .inStreamingMode();
 
           StreamExecutionEnvironment env = StreamExecutionEnvironment
               .getExecutionEnvironment(MiniClusterResource.DISABLE_CLASSLOADER_CHECK_CONFIG);
-          env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
           env.enableCheckpointing(400);
 
           StreamTableEnvironment streamTableEnv = StreamTableEnvironment.create(env, settingsBuilder.build());


### PR DESCRIPTION
The `blink` planner has been the default as of 1.14.

These calls to `useBlinkPlanner` are currently no-ops, but will become invalid as of Flink 1.15.

Removing them now from the Flink 1.14 code base to remove deprecation warnings, as well as to make migrating code to the upcoming Flink 1.15 release easier.

Additionally, I've removed calls to setting stream time characteristic as `EventTime`. `EventTime` is the default time characteristic, and functions should handle event time and processing time as needed. Given these are tests, it's essentially a no-op but we might want to ensure we adhere to this when we copy over for Flink 1.15.