### PR TITLE
Spark: Simplify validation in BaseRewriteDataFilesSparkAction

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
@@ -385,7 +385,7 @@ abstract class BaseRewriteDataFilesSparkAction
         "Cannot set %s to %s, the value must be positive.",
         MAX_CONCURRENT_FILE_GROUP_REWRITES, maxConcurrentFileGroupRewrites);
 
-    Preconditions.checkArgument(!partialProgressEnabled || partialProgressEnabled && maxCommits > 0,
+    Preconditions.checkArgument(!partialProgressEnabled || maxCommits > 0,
         "Cannot set %s to %s, the value must be positive when %s is true",
         PARTIAL_PROGRESS_MAX_COMMITS, maxCommits, PARTIAL_PROGRESS_ENABLED);
   }


### PR DESCRIPTION
This change simplifies the validation in `BaseRewriteDataFilesSparkAction`. 

The earlier validation was `!partialProgressEnabled || partialProgressEnabled && maxCommits > 0`. The right side of the OR condition is always evaluated when `partialProgressEnabled` is true. Hence, we need not to mention `partialProgressEnabled` explicitly on the right side of the OR condition.