### PR TITLE
Spark: Skip corrupt files in Spark Procedures and Actions

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/MigrateTable.java
+++ b/api/src/main/java/org/apache/iceberg/actions/MigrateTable.java
@@ -52,6 +52,15 @@ public interface MigrateTable extends Action<MigrateTable, MigrateTable.Result> 
     throw new UnsupportedOperationException("Dropping a backup is not supported");
   }
 
+  /**
+   * if true, skip files which cannot be migrated into Iceberg
+   *
+   * @return this for method chaining
+   */
+  default MigrateTable skipOnError() {
+    throw new UnsupportedOperationException("Skip on error is not supported");
+  }
+
   /** The action result that contains a summary of the execution. */
   @Value.Immutable
   interface Result {

--- a/docs/spark-procedures.md
+++ b/docs/spark-procedures.md
@@ -479,11 +479,12 @@ By default, the original table is retained with the name `table_BACKUP_`.
 
 #### Usage
 
-| Argument Name | Required? | Type | Description |
-|---------------|-----------|------|-------------|
-| `table`       | ✔️  | string | Name of the table to migrate |
-| `properties`  | ️   | map<string, string> | Properties for the new Iceberg table |
-| `drop_backup` |   | boolean | When true, the original table will not be retained as backup (defaults to false) |
+| Argument Name     | Required? | Type                | Description                                                                        |
+|-------------------|-----------|---------------------|------------------------------------------------------------------------------------|
+| `table`           | ✔️        | string              | Name of the table to migrate                                                       |
+| `properties`      | ️         | map<string, string> | Properties for the new Iceberg table                                               |
+| `drop_backup`     | ️         | boolean             | When true, the original table will not be retained as backup (defaults to false)   |
+| `skip_on_error`   | ️         | boolean             | If true, skip files which cannot be imported into Iceberg (false by default)       |
 
 #### Output
 
@@ -522,6 +523,7 @@ will then treat these files as if they are part of the set of files  owned by Ic
 | `source_table`          | ✔️        | string              | Table where files should come from, paths are also possible in the form of \`file_format\`.\`path\` |
 | `partition_filter`      | ️         | map<string, string> | A map of partitions in the source table to import from                                              |
 | `check_duplicate_files` | ️         | boolean             | Whether to prevent files existing in the table from being added (defaults to true)                  |
+| `skip_on_error`         | ️         | boolean             | If true, skip files which cannot be imported into Iceberg (false by default)                        |
 
 Warning : Schema is not validated, adding files with different schema to the Iceberg table will cause issues.
 

--- a/docs/spark-procedures.md
+++ b/docs/spark-procedures.md
@@ -484,7 +484,7 @@ By default, the original table is retained with the name `table_BACKUP_`.
 | `table`           | ✔️        | string              | Name of the table to migrate                                                       |
 | `properties`      | ️         | map<string, string> | Properties for the new Iceberg table                                               |
 | `drop_backup`     | ️         | boolean             | When true, the original table will not be retained as backup (defaults to false)   |
-| `skip_on_error`   | ️         | boolean             | If true, skip files which cannot be imported into Iceberg (false by default)       |
+| `skip_on_error`   | ️         | boolean             | If true, skip files which cannot be imported into Iceberg (defaults to false)      |
 
 #### Output
 
@@ -523,7 +523,7 @@ will then treat these files as if they are part of the set of files  owned by Ic
 | `source_table`          | ✔️        | string              | Table where files should come from, paths are also possible in the form of \`file_format\`.\`path\` |
 | `partition_filter`      | ️         | map<string, string> | A map of partitions in the source table to import from                                              |
 | `check_duplicate_files` | ️         | boolean             | Whether to prevent files existing in the table from being added (defaults to true)                  |
-| `skip_on_error`         | ️         | boolean             | If true, skip files which cannot be imported into Iceberg (false by default)                        |
+| `skip_on_error`         | ️         | boolean             | If true, skip files which cannot be imported into Iceberg (defaults to false)                        |
 
 Warning : Schema is not validated, adding files with different schema to the Iceberg table will cause issues.
 

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
@@ -1013,7 +1013,6 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
                 + "source_table => '%s',"
                 + "skip_on_error => true)",
             catalogName, tableName, sourceTableName);
-
     assertEquals("Procedure output must match", ImmutableList.of(row(2L, 1L)), result);
 
     assertEquals(

--- a/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
+++ b/spark/v3.3/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
@@ -44,6 +44,7 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.assertj.core.api.Assertions;
 import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Assert;
@@ -986,26 +987,24 @@ public class TestAddFilesProcedure extends SparkExtensionsTestBase {
     // Create an empty(considered corrupted) file.
     Assert.assertTrue(new File(fileTableDir + File.separator + "corrupt.parquet").createNewFile());
 
-    AssertHelpers.assertThrows(
-        "Throws an exception when a corrupted file is encountered",
-        RuntimeException.class,
-        "not a Parquet file (length is too low: 0)",
-        () ->
-            sql(
-                "CALL %s.system.add_files(" + "table => '%s', " + "source_table => '%s')",
-                catalogName, tableName, sourceTableName));
+    Assertions.assertThatThrownBy(
+            () ->
+                sql(
+                    "CALL %s.system.add_files(" + "table => '%s', " + "source_table => '%s')",
+                    catalogName, tableName, sourceTableName))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("not a Parquet file (length is too low: 0)");
 
-    AssertHelpers.assertThrows(
-        "Throws an exception when a corrupted file is encountered",
-        RuntimeException.class,
-        "not a Parquet file (length is too low: 0)",
-        () ->
-            sql(
-                "CALL %s.system.add_files("
-                    + "table => '%s', "
-                    + "source_table => '%s',"
-                    + "skip_on_error => false)",
-                catalogName, tableName, sourceTableName));
+    Assertions.assertThatThrownBy(
+            () ->
+                sql(
+                    "CALL %s.system.add_files("
+                        + "table => '%s', "
+                        + "source_table => '%s',"
+                        + "skip_on_error => false)",
+                    catalogName, tableName, sourceTableName))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("not a Parquet file (length is too low: 0)");
 
     List<Object[]> result =
         sql(

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -515,7 +515,7 @@ public class SparkTableUtil {
         stagingDir,
         Collections.emptyMap(),
         checkDuplicateFiles,
-        false /* skipOnErrorOrNot */);
+        false /* skip on error or not */);
   }
 
   /**
@@ -568,7 +568,7 @@ public class SparkTableUtil {
         stagingDir,
         Collections.emptyMap(),
         false,
-        false /* skipOnErrorOrNot */);
+        false /* skip on error or not */);
   }
 
   private static void importUnpartitionedSparkTable(
@@ -774,7 +774,7 @@ public class SparkTableUtil {
       PartitionSpec spec,
       String stagingDir) {
     importSparkPartitions(
-        spark, partitions, targetTable, spec, stagingDir, false, false /* skipOnErrorOrNot */);
+        spark, partitions, targetTable, spec, stagingDir, false, false /* skip on error or not */);
   }
 
   public static List<SparkPartition> filterPartitions(

--- a/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
+++ b/spark/v3.3/spark/src/main/java/org/apache/iceberg/spark/procedures/AddFilesProcedure.java
@@ -66,7 +66,11 @@ class AddFilesProcedure extends BaseProcedure {
 
   private static final ProcedureParameter[] PARAMETERS =
       new ProcedureParameter[] {
-        TABLE_PARAM, SOURCE_TABLE_PARAM, PARTITION_FILTER_PARAM, CHECK_DUPLICATE_FILES_PARAM, SKIP_ON_ERROR_PARAM
+        TABLE_PARAM,
+        SOURCE_TABLE_PARAM,
+        PARTITION_FILTER_PARAM,
+        CHECK_DUPLICATE_FILES_PARAM,
+        SKIP_ON_ERROR_PARAM
       };
 
   private static final StructType OUTPUT_TYPE =
@@ -113,12 +117,7 @@ class AddFilesProcedure extends BaseProcedure {
 
     boolean checkDuplicateFiles = input.asBoolean(CHECK_DUPLICATE_FILES_PARAM, true);
 
-    boolean skipOnError;
-    if (args.isNullAt(4)) {
-      skipOnError = false;
-    } else {
-      skipOnError = args.getBoolean(4);
-    }
+    boolean skipOnError = input.asBoolean(SKIP_ON_ERROR_PARAM, false);
 
     return importToIceberg(
         tableIdent, sourceIdent, partitionFilter, checkDuplicateFiles, skipOnError);

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -28,7 +28,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.apache.hadoop.fs.Path;
@@ -438,7 +437,7 @@ public class TestCreateActions extends SparkCatalogTestBase {
         .partitionBy(partitionColumns.toSeq())
         .saveAsTable(source);
 
-    List<File> expectedFiles = expectedFiles(source).collect(Collectors.toList());
+    List<File> expectedFiles = expectedFiles(source);
 
     Assertions.assertThat(expectedFiles).hasSize(2);
 
@@ -1044,10 +1043,10 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
   private long expectedFilesCount(String source)
       throws NoSuchDatabaseException, NoSuchTableException, ParseException {
-    return expectedFiles(source).count();
+    return expectedFiles(source).size();
   }
 
-  private Stream<File> expectedFiles(String source)
+  private List<File> expectedFiles(String source)
       throws NoSuchDatabaseException, NoSuchTableException, ParseException {
     CatalogTable sourceTable = loadSessionTable(source);
     List<URI> uris;
@@ -1071,7 +1070,8 @@ public class TestCreateActions extends SparkCatalogTestBase {
                 FileUtils.listFiles(
                     Paths.get(uri).toFile(), TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE)
                     .stream())
-        .filter(file -> !file.toString().endsWith("crc") && !file.toString().contains("_SUCCESS"));
+        .filter(file -> !file.toString().endsWith("crc") && !file.toString().contains("_SUCCESS"))
+        .collect(Collectors.toList());
   }
 
   // Insert records into the destination, makes sure those records exist and source table is

--- a/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.3/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -32,7 +32,6 @@ import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.apache.hadoop.fs.Path;
-import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.MigrateTable;
@@ -450,11 +449,9 @@ public class TestCreateActions extends SparkCatalogTestBase {
 
     MigrateTable migrateAction = SparkActions.get().migrateTable(source);
 
-    AssertHelpers.assertThrows(
-        "Expected an exception",
-        RuntimeException.class,
-        "not a Parquet file (length is too low: 0)",
-        migrateAction::execute);
+    Assertions.assertThatThrownBy(migrateAction::execute)
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("not a Parquet file (length is too low: 0)");
 
     // skip files which cannot be imported into Iceberg
     migrateAction = SparkActions.get().migrateTable(source).skipOnError();


### PR DESCRIPTION
Closes: https://github.com/apache/iceberg/issues/4051
## Brief change log
> In our datalake, it is posible to corrupt files to exists in the same directory of a hive table. We've been using the Iceber add_files procedure to migrate those tables to Iceberg. Unfortunately, Iceberg will fail when it encounters a corrupt (a file that doesn't match the file type Iceberg is looking for) file. Below is a sample exception. So, is it possible to tell Iceberg to ignore those files?

 Skip corrupt files in Spark Procedures and Action

## Brief change log
The `'skip_corrupt_files'`  option is added to Spark `migrate/add_files` Procedures, which can be used to skip corrupted files.
```SQL
CALL catalog.system.migrate(
table => 'table',
skip_on_error => true)
```
```SQL
CALL catalog.system.add_files(
table => 'table',
source_table => 'source_table',
skip_on_error => true)
```
## Verifying this change

1. After generating two available data files, delete the second and create an empty file to verify that it works as expected.
TestAddFilesProcedure.java\TestMigrateTableProcedure.java