### PR TITLE
Nessie: Fix Use reference with hash command

### DIFF
--- a/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/BaseTestIceberg.java
@@ -121,13 +121,21 @@ public abstract class BaseTestIceberg {
   }
 
   NessieCatalog initCatalog(String ref) {
+    return initCatalog(ref, null);
+  }
+
+  NessieCatalog initCatalog(String ref, String hash) {
     NessieCatalog newCatalog = new NessieCatalog();
     newCatalog.setConf(hadoopConfig);
-    newCatalog.initialize("nessie", ImmutableMap.of("ref", ref,
-        CatalogProperties.URI, uri,
-        "auth-type", "NONE",
-        CatalogProperties.WAREHOUSE_LOCATION, temp.toUri().toString()
-    ));
+    ImmutableMap.Builder<String, String> options = ImmutableMap.<String, String>builder()
+        .put("ref", ref)
+        .put(CatalogProperties.URI, uri)
+        .put("auth-type", "NONE")
+        .put(CatalogProperties.WAREHOUSE_LOCATION, temp.toUri().toString());
+    if (hash != null) {
+      options.put("ref.hash", hash);
+    }
+    newCatalog.initialize("nessie", options.build());
     return newCatalog;
   }
 

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestBranchVisibility.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestBranchVisibility.java
@@ -110,6 +110,19 @@ public class TestBranchVisibility extends BaseTestIceberg {
   }
 
   @Test
+  public void testCatalogInitialHash() {
+    updateSchema(testCatalog, tableIdentifier2);
+    String hash = "f1234d75178d892a133a410355a5a990cf75d2f33eba25d575943d4df632f3a4";
+    NessieCatalog refCatalog = initCatalog("test", hash);
+    Assertions.assertThat(refCatalog.initialHash()).isEqualTo(hash);
+    Assertions.assertThat(refCatalog.currentHash()).isEqualTo(refCatalog.initialHash());
+    // reset initial hash
+    refCatalog = initCatalog("test", null);
+    Assertions.assertThat(refCatalog.initialHash()).isEqualTo(null);
+    Assertions.assertThat(refCatalog.currentHash()).isEqualTo(null);
+  }
+
+  @Test
   public void testCatalogWithTableNames() {
     updateSchema(testCatalog, tableIdentifier2);
 


### PR DESCRIPTION
Use the new configuration `NessieConfigConstants.CONF_NESSIE_REF_HASH` to set/reset the initial hash for the use reference command.

NessieCatalog#loadReference() is called from 
a) NessieCatalog#Initialize()
b) newTableOps()

hash from `newTableOps()` flow should only be used for current operation. When Hash is not specified in `newTableOps()`, it should fallback to Initial Hash (set from Use reference command)

This is part of a fix for https://github.com/projectnessie/nessie/issues/3439