### PR TITLE
Spark 3.1: Simplify validation in BaseRewriteDataFilesSparkAction

### DIFF
--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
@@ -379,7 +379,7 @@ abstract class BaseRewriteDataFilesSparkAction
         "Cannot set %s to %s, the value must be positive.",
         MAX_CONCURRENT_FILE_GROUP_REWRITES, maxConcurrentFileGroupRewrites);
 
-    Preconditions.checkArgument(!partialProgressEnabled || partialProgressEnabled && maxCommits > 0,
+    Preconditions.checkArgument(!partialProgressEnabled || maxCommits > 0,
         "Cannot set %s to %s, the value must be positive when %s is true",
         PARTIAL_PROGRESS_MAX_COMMITS, maxCommits, PARTIAL_PROGRESS_ENABLED);
   }


### PR DESCRIPTION
This PR backports https://github.com/apache/iceberg/pull/4324 to Iceberg Spark 3.1 runtime.