### PR TITLE
Core: Make CatalogTests run with JUnit5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -203,6 +203,9 @@ project(':iceberg-common') {
 }
 
 project(':iceberg-core') {
+  test {
+    useJUnitPlatform()
+  }
   dependencies {
     api project(':iceberg-api')
     implementation project(':iceberg-common')

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -58,7 +58,7 @@ import org.apache.iceberg.util.CharSequenceSet;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
 

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -20,7 +20,7 @@
 package org.apache.iceberg.rest;
 
 import java.io.File;
-import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.hadoop.conf.Configuration;
@@ -28,19 +28,18 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.catalog.CatalogTests;
 import org.apache.iceberg.jdbc.JdbcCatalog;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
-  @Rule
-  public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir
+  public Path temp;
 
   private RESTCatalog restCatalog;
 
-  @Before
-  public void createCatalog() throws IOException {
-    File warehouse = temp.newFolder();
+  @BeforeEach
+  public void createCatalog() {
+    File warehouse = temp.toFile();
     Configuration conf = new Configuration();
 
     JdbcCatalog backendCatalog = new JdbcCatalog();


### PR DESCRIPTION
We are planning to add a `TestNessieCatalog` test that extends the
existing `CatalogTests` class. However, Nessie tests require
JUnit5 functionality to set up the Nessie server, therefore we need to
convert these catalog tests to JUnit5.