### PR TITLE
AWS: Add support for s3 access points

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
@@ -45,6 +45,7 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
   private int timeout;
   private String region;
   private String s3Endpoint;
+  private boolean s3UseArnRegionEnabled;
   private String httpClientType;
 
   @Override
@@ -52,6 +53,7 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
     return S3Client.builder()
         .applyMutation(this::configure)
         .applyMutation(builder -> AwsClientFactories.configureEndpoint(builder, s3Endpoint))
+        .serviceConfiguration(s -> s.useArnRegionEnabled(s3UseArnRegionEnabled).build())
         .build();
   }
 
@@ -84,6 +86,8 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
 
     this.s3Endpoint = properties.get(AwsProperties.S3FILEIO_ENDPOINT);
     this.tags = toTags(properties);
+    this.s3UseArnRegionEnabled = PropertyUtil.propertyAsBoolean(properties, AwsProperties.S3_ACCESS_POINTS_PREFIX,
+        AwsProperties.S3_USE_ARN_REGION_ENABLED_DEFAULT);
     this.httpClientType = PropertyUtil.propertyAsString(properties,
         AwsProperties.HTTP_CLIENT_TYPE, AwsProperties.HTTP_CLIENT_TYPE_DEFAULT);
   }
@@ -123,6 +127,10 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
 
   protected String httpClientType() {
     return httpClientType;
+  }
+
+  protected boolean s3UseArnRegionEnabled() {
+    return s3UseArnRegionEnabled;
   }
 
   private StsClient sts() {

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
@@ -83,6 +83,7 @@ public class AwsClientFactories {
     private String s3AccessKeyId;
     private String s3SecretAccessKey;
     private String s3SessionToken;
+    private Boolean s3UseArnRegionEnabled;
     private String httpClientType;
 
     DefaultAwsClientFactory() {
@@ -93,6 +94,7 @@ public class AwsClientFactories {
       return S3Client.builder()
           .httpClientBuilder(configureHttpClientBuilder(httpClientType))
           .applyMutation(builder -> configureEndpoint(builder, s3Endpoint))
+          .serviceConfiguration(s -> s.useArnRegionEnabled(s3UseArnRegionEnabled).build())
           .credentialsProvider(credentialsProvider(s3AccessKeyId, s3SecretAccessKey, s3SessionToken))
           .build();
     }
@@ -118,6 +120,8 @@ public class AwsClientFactories {
       this.s3AccessKeyId = properties.get(AwsProperties.S3FILEIO_ACCESS_KEY_ID);
       this.s3SecretAccessKey = properties.get(AwsProperties.S3FILEIO_SECRET_ACCESS_KEY);
       this.s3SessionToken = properties.get(AwsProperties.S3FILEIO_SESSION_TOKEN);
+      this.s3UseArnRegionEnabled = PropertyUtil.propertyAsBoolean(properties, AwsProperties.S3_USE_ARN_REGION_ENABLED,
+          AwsProperties.S3_USE_ARN_REGION_ENABLED_DEFAULT);
 
       ValidationException.check((s3AccessKeyId == null && s3SecretAccessKey == null) ||
           (s3AccessKeyId != null && s3SecretAccessKey != null),

--- a/aws/src/main/java/org/apache/iceberg/aws/lakeformation/LakeFormationAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/lakeformation/LakeFormationAwsClientFactory.java
@@ -81,6 +81,7 @@ public class LakeFormationAwsClientFactory extends AssumeRoleAwsClientFactory {
           .httpClientBuilder(AwsClientFactories.configureHttpClientBuilder(httpClientType()))
           .applyMutation(builder -> AwsClientFactories.configureEndpoint(builder, s3Endpoint()))
           .credentialsProvider(new LakeFormationCredentialsProvider(lakeFormation(), buildTableArn()))
+          .serviceConfiguration(s -> s.useArnRegionEnabled(s3UseArnRegionEnabled()).build())
           .region(Region.of(region()))
           .build();
     } else {

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -108,7 +108,7 @@ public class S3FileIO implements FileIO, SupportsBulkOperations {
 
   @Override
   public void deleteFile(String path) {
-    S3URI location = new S3URI(path);
+    S3URI location = new S3URI(path, awsProperties.s3BucketToAccessPointMapping());
     DeleteObjectRequest deleteRequest =
         DeleteObjectRequest.builder().bucket(location.bucket()).key(location.key()).build();
 
@@ -128,7 +128,7 @@ public class S3FileIO implements FileIO, SupportsBulkOperations {
     SetMultimap<String, String> bucketToObjects = Multimaps.newSetMultimap(Maps.newHashMap(), Sets::newHashSet);
     int numberOfFailedDeletions = 0;
     for (String path : paths) {
-      S3URI location = new S3URI(path);
+      S3URI location = new S3URI(path, awsProperties.s3BucketToAccessPointMapping());
       String bucket = location.bucket();
       String objectKey = location.key();
       Set<String> objectsInBucket = bucketToObjects.get(bucket);

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputFile.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3InputFile.java
@@ -28,7 +28,8 @@ import software.amazon.awssdk.services.s3.S3Client;
 public class S3InputFile extends BaseS3File implements InputFile {
   public static S3InputFile fromLocation(String location, S3Client client, AwsProperties awsProperties,
       MetricsContext metrics) {
-    return new S3InputFile(client, new S3URI(location), awsProperties, metrics);
+    return new S3InputFile(client, new S3URI(location, awsProperties.s3BucketToAccessPointMapping()),
+        awsProperties, metrics);
   }
 
   S3InputFile(S3Client client, S3URI uri, AwsProperties awsProperties, MetricsContext metrics) {

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
@@ -32,7 +32,8 @@ import software.amazon.awssdk.services.s3.S3Client;
 public class S3OutputFile extends BaseS3File implements OutputFile {
   public static S3OutputFile fromLocation(String location, S3Client client, AwsProperties awsProperties,
       MetricsContext metrics) {
-    return new S3OutputFile(client, new S3URI(location), awsProperties, metrics);
+    return new S3OutputFile(client, new S3URI(location, awsProperties.s3BucketToAccessPointMapping()),
+        awsProperties, metrics);
   }
 
   S3OutputFile(S3Client client, S3URI uri, AwsProperties awsProperties, MetricsContext metrics) {

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3URI.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3URI.java
@@ -19,8 +19,10 @@
 
 package org.apache.iceberg.aws.s3;
 
+import java.util.Map;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.Test;
 
@@ -89,5 +91,18 @@ public class TestS3URI {
       assertEquals("bucket", uri.bucket());
       assertEquals("path/to/file", uri.key());
     }
+  }
+
+  @Test
+  public void testS3URIWithBucketToAccessPointMapping() {
+    String p1 = "s3://bucket/path/to/file?query=foo#bar";
+    Map<String, String> bucketToAccessPointMapping = ImmutableMap.of(
+        "bucket", "access-point"
+    );
+    S3URI uri1 = new S3URI(p1, bucketToAccessPointMapping);
+
+    assertEquals("access-point", uri1.bucket());
+    assertEquals("path/to/file", uri1.key());
+    assertEquals(p1, uri1.toString());
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -328,6 +328,7 @@ project(':iceberg-aws') {
     }
 
     testImplementation 'software.amazon.awssdk:iam'
+    testImplementation 'software.amazon.awssdk:s3control'
     testImplementation project(path: ':iceberg-api', configuration: 'testArtifacts')
     testImplementation("com.adobe.testing:s3mock-junit4") {
       exclude module: "spring-boot-starter-logging"


### PR DESCRIPTION
This tries to add support of s3 access points 
ref : https://aws.amazon.com/s3/features/access-points/

```shell
    spark-shell \
        --conf spark.sql.catalog.test=org.apache.iceberg.spark.SparkCatalog \
        --conf spark.sql.catalog.test.warehouse=s3://my-bucket \
        --conf spark.sql.catalog.test.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog \
        --conf spark.sql.catalog.test.io-impl=org.apache.iceberg.aws.s3.S3FileIO \
        --conf spark.sql.catalog.test.s3.access-points.my-bucket=arn:aws:s3::123456789012:accesspoint:mfzwi23gnjvgw.mrap
```

The s3.access-points config provides a map of bucket to endpoint mapping for paths stored in Iceberg, so that the S3FileIO can use the access point to get the bucket instead when the mapping is configured.

---

cc: @jackye1995 @rajarshisarkar @arminnajafi @amogh-jahagirdar @xiaoxuandev @yyanyy
