### PR TITLE
Spec: REST catalog drop table that should not return 404

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -510,16 +510,6 @@ paths:
           $ref: '#/components/responses/UnauthorizedResponse'
         403:
           $ref: '#/components/responses/ForbiddenResponse'
-        404:
-          description:
-            Not Found - NoSuchTableException, Table to drop does not exist
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorModel'
-              examples:
-                TableToDeleteDoesNotExist:
-                  $ref: '#/components/examples/NoSuchTableError'
         5XX:
           $ref: '#/components/responses/ServerErrorResponse'
 
@@ -1455,7 +1445,7 @@ components:
             properties:
               dropped:
                 type: boolean
-                description: true if the table was found and removed from the catalog
+                description: true if the table was found and removed from the catalog, false if the table did not exist
               purged:
                 type: boolean
                 description: whether the underlying data was purged or is being purged


### PR DESCRIPTION
This removes the 404 response from the REST catalog when dropping a table. The Catalog API should not throw `NoSuchTableException` and instead returns false if the table did not exist. The equivalent behavior in the REST API is to always return 200 with `false` for the `dropped` field.

Related to this comment: https://github.com/apache/iceberg/pull/4322#discussion_r827506294