### PR TITLE
Parquet: parquet_writer.java should close the writeStore when flushRowGroup's finished is false

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -53,7 +53,7 @@ In addition to row-level deletes, version 2 makes some requirements stricter for
 * **Evolution** -- Tables will support full schema and partition spec evolution. Schema evolution supports safe column add, drop, reorder and rename, including in nested structures.
 * **Dependable types** -- Tables will provide well-defined and dependable support for a core set of types.
 * **Storage separation** -- Partitioning will be table configuration. Reads will be planned using predicates on data values, not partition values. Tables will support evolving partition schemes.
-* **Formats** -- Underlying data file formats will support identical schema evolution rules and types. Both read-optimized and write-optimized formats will be available.
+* **Formats** -- Underlying data file formats will support identical schema evolution rules and types. Both read- and write-optimized formats will be available.
 
 ## Overview
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -53,7 +53,7 @@ In addition to row-level deletes, version 2 makes some requirements stricter for
 * **Evolution** -- Tables will support full schema and partition spec evolution. Schema evolution supports safe column add, drop, reorder and rename, including in nested structures.
 * **Dependable types** -- Tables will provide well-defined and dependable support for a core set of types.
 * **Storage separation** -- Partitioning will be table configuration. Reads will be planned using predicates on data values, not partition values. Tables will support evolving partition schemes.
-* **Formats** -- Underlying data file formats will support identical schema evolution rules and types. Both read- and write-optimized formats will be available.
+* **Formats** -- Underlying data file formats will support identical schema evolution rules and types. Both read-optimized and write-optimized formats will be available.
 
 ## Overview
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
@@ -204,6 +204,7 @@ class ParquetWriter<T> implements FileAppender<T>, Closeable {
         flushPageStoreToWriter.invoke(writer);
         writer.endBlock();
         if (!finished) {
+          writeStore.close();
           startRowGroup();
         }
       }


### PR DESCRIPTION
When parquetWriter.java call close， it called the writeStore.close 

public void close() throws IOException {
    if (!closed) {
      this.closed = true;
      flushRowGroup(true);
      writeStore.close();                       ------ here close the writeStore
      if (writer != null) {
        writer.end(metadata);
      }
    }
  }

But in checksize function when called the  flushRowGroup(false); 

private void flushRowGroup(boolean finished) {
    try {
      if (recordCount > 0) {
        ensureWriterInitialized();
        writer.startBlock(recordCount);
        writeStore.flush();
        flushPageStoreToWriter.invoke(writer);
        writer.endBlock();
        if (!finished) {
          startRowGroup();                ---- here new another one, but the old not closed
        }
      }
    } catch (IOException e) {
      throw new UncheckedIOException("Failed to flush row group", e);
    }
  }


It doesn't close the writeStore and then new another one.

So i think when the finish is false we should close the writeStore.
