### PR TITLE
Enable parallel_delete in spark action to speed up snapshot expire

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/BaseExpireSnapshotsActionResult.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseExpireSnapshotsActionResult.java
@@ -19,7 +19,9 @@
 
 package org.apache.iceberg.actions;
 
-public class BaseExpireSnapshotsActionResult implements ExpireSnapshots.Result {
+import java.io.Serializable;
+
+public class BaseExpireSnapshotsActionResult implements ExpireSnapshots.Result, Serializable {
 
   private final long deletedDataFilesCount;
   private final long deletedManifestsCount;

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
@@ -285,7 +285,7 @@ public class TestExpireSnapshotsProcedure extends SparkExtensionsTestBase {
   }
 
   @Test
-  public void testExpireSnapshotWithStreamResultsEnabled() {
+  public void testExpireSnapshotWithParallelDeleteEnabled() {
     sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
 
     sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
@@ -304,7 +304,7 @@ public class TestExpireSnapshotsProcedure extends SparkExtensionsTestBase {
             "older_than => TIMESTAMP '%s'," +
             "table => '%s'," +
             "retain_last => 1, " +
-            "stream_results => true)",
+            "parallel_delete => true)",
         catalogName, currentTimestamp, tableIdent);
     assertEquals("Procedure output must match", ImmutableList.of(row(0L, 0L, 1L)), output);
   }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/ExpireSnapshotsProcedure.java
@@ -47,7 +47,7 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
       ProcedureParameter.optional("older_than", DataTypes.TimestampType),
       ProcedureParameter.optional("retain_last", DataTypes.IntegerType),
       ProcedureParameter.optional("max_concurrent_deletes", DataTypes.IntegerType),
-      ProcedureParameter.optional("stream_results", DataTypes.BooleanType)
+      ProcedureParameter.optional("parallel_delete", DataTypes.BooleanType)
   };
 
   private static final StructType OUTPUT_TYPE = new StructType(new StructField[]{
@@ -85,7 +85,7 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
     Long olderThanMillis = args.isNullAt(1) ? null : DateTimeUtil.microsToMillis(args.getLong(1));
     Integer retainLastNum = args.isNullAt(2) ? null : args.getInt(2);
     Integer maxConcurrentDeletes = args.isNullAt(3) ? null : args.getInt(3);
-    Boolean streamResult = args.isNullAt(4) ? null : args.getBoolean(4);
+    Boolean parallelDelete = args.isNullAt(4) ? null : args.getBoolean(4);
 
     Preconditions.checkArgument(maxConcurrentDeletes == null || maxConcurrentDeletes > 0,
         "max_concurrent_deletes should have value > 0,  value: " + maxConcurrentDeletes);
@@ -105,8 +105,8 @@ public class ExpireSnapshotsProcedure extends BaseProcedure {
         action.executeDeleteWith(executorService(maxConcurrentDeletes, "expire-snapshots"));
       }
 
-      if (streamResult != null) {
-        action.option(BaseExpireSnapshotsSparkAction.STREAM_RESULTS, Boolean.toString(streamResult));
+      if (parallelDelete != null) {
+        action.option(BaseExpireSnapshotsSparkAction.PARALLEL_DELETE, Boolean.toString(parallelDelete));
       }
 
       ExpireSnapshots.Result result = action.execute();


### PR DESCRIPTION
If there are huge amount of files(~80K) to delete for the snapshot expire, the spark job will be running hours to delete those files even we have already used `max_concurrent_deletes` in the spark procedure.
We can leverage the spark `mapPartitions` mechanism to distribute the tasks to executors for executing, which can fully utilize the executor CPU/IO for large snapshot expiry. See some testing result as below:

### Test Result
#### Using `max_concurrent_deletes` = 50
Driver spec: 45G/8 CPU Core
Executor spec: 6G/1 Core
Executor num: 50
Deleted data file count: ~70K
Total running hour: 3.5H

#### Using `parallel_delete`(use spark `mapPartitions` to distribute the tasks to Spark executors)
Driver spec: 10G/1 CPU Core
Executor spec: 6G/1 Core
Executor num: 50
Deleted data file count: ~110K
Total running hour: 1.5H

