### PR TITLE
Flink: fix missing copy in ScanContext

### DIFF
--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/ScanContext.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/ScanContext.java
@@ -200,8 +200,9 @@ class ScanContext implements Serializable {
         .project(schema)
         .filters(filters)
         .limit(limit)
-        .exposeLocality(exposeLocality)
         .includeColumnStats(includeColumnStats)
+        .exposeLocality(exposeLocality)
+        .planParallelism(planParallelism)
         .build();
   }
 
@@ -223,6 +224,7 @@ class ScanContext implements Serializable {
         .limit(limit)
         .includeColumnStats(includeColumnStats)
         .exposeLocality(exposeLocality)
+        .planParallelism(planParallelism)
         .build();
   }
 


### PR DESCRIPTION
Fix missing copy metioned in #4329 by @stevenzwu .