### PR TITLE
AWS : Address S3FileIOIntegrationTest failures

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -67,7 +67,7 @@ public class S3FileIO implements FileIO, SupportsBulkOperations {
   private transient S3Client client;
   private MetricsContext metrics = MetricsContext.nullMetrics();
   private final AtomicBoolean isResourceClosed = new AtomicBoolean(false);
-  private Set<Tag> writeTags;
+  private Set<Tag> writeTags = Sets.newHashSet();
 
   /**
    * No-arg constructor to load the FileIO dynamically.


### PR DESCRIPTION
presently TestS3FileIOIntegration fails with NPE because of s3FileIo.Initialize not being called.

This happens because writeTags is never intialized if we don't call it's initialize and it always remains null so when we check if it's empty or not while initializing upload / mutlipart upload it faces NPE.

https://github.com/apache/iceberg/blob/c1adf2034280884d05afad4e67f09f2872c47d78/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java#L70

https://github.com/apache/iceberg/blob/c1adf2034280884d05afad4e67f09f2872c47d78/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java#L263


Ideally we should initialize while declaration like we do metrics to avoid this scenario. 

Post this fix test passes

-----


cc: @jackye1995 @rajarshisarkar @arminnajafi @amogh-jahagirdar @xiaoxuandev @yyanyy