### PR TITLE
Core: Skip context for object storage in table prefixes

### DIFF
--- a/core/src/main/java/org/apache/iceberg/LocationProviders.java
+++ b/core/src/main/java/org/apache/iceberg/LocationProviders.java
@@ -104,7 +104,12 @@ public class LocationProviders {
 
     ObjectStoreLocationProvider(String tableLocation, Map<String, String> properties) {
       this.storageLocation = stripTrailingSlash(dataLocation(properties, tableLocation));
-      this.context = pathContext(tableLocation);
+      // if the storage location is within the table prefix, don't add table and database name context
+      if (storageLocation.startsWith(tableLocation)) {
+        this.context = null;
+      } else {
+        this.context = pathContext(tableLocation);
+      }
     }
 
     private static String dataLocation(Map<String, String> properties, String tableLocation) {
@@ -129,7 +134,11 @@ public class LocationProviders {
     @Override
     public String newDataLocation(String filename) {
       int hash = HASH_FUNC.apply(filename);
-      return String.format("%s/%08x/%s/%s", storageLocation, hash, context, filename);
+      if (context != null) {
+        return String.format("%s/%08x/%s/%s", storageLocation, hash, context, filename);
+      } else {
+        return String.format("%s/%08x/%s", storageLocation, hash, filename);
+      }
     }
 
     private static String pathContext(String tableLocation) {

--- a/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
+++ b/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
@@ -19,6 +19,8 @@
 
 package org.apache.iceberg;
 
+import com.google.common.base.Splitter;
+import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.io.LocationProvider;
 import org.junit.Assert;
@@ -271,5 +273,22 @@ public class TestLocationProvider extends TableTestBase {
 
     Assert.assertTrue("write data path should be used when set",
         table.locationProvider().newDataLocation("file").contains(dataPath));
+  }
+
+  @Test
+  public void testObjectStorageWithinTableLocation() {
+    table.updateProperties()
+        .set(TableProperties.OBJECT_STORE_ENABLED, "true")
+        .commit();
+
+    String fileLocation = table.locationProvider().newDataLocation("test.parquet");
+    String relativeLocation = fileLocation.replaceFirst(table.location(), "");
+    List<String> parts = Splitter.on("/").splitToList(relativeLocation);
+
+    Assert.assertEquals("Should contain 4 parts", 4, parts.size());
+    Assert.assertTrue("First part should be empty", parts.get(0).isEmpty());
+    Assert.assertEquals("Second part should be data", "data", parts.get(1));
+    Assert.assertFalse("Third part should be a hash value", parts.get(2).isEmpty());
+    Assert.assertEquals("Fourth part should be the file name passed in", "test.parquet", parts.get(3));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
+++ b/core/src/test/java/org/apache/iceberg/TestLocationProvider.java
@@ -19,10 +19,10 @@
 
 package org.apache.iceberg;
 
-import com.google.common.base.Splitter;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.io.LocationProvider;
+import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
This detects when an object storage location is within a table's prefix and avoids adding the table and database names to file paths as context.