### PR TITLE
AWS: Move S3 writeTags to AwsProperties

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.aws.dynamodb.DynamoDbCatalog;
 import org.apache.iceberg.aws.s3.S3FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.PropertyUtil;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.Tag;
@@ -270,7 +271,7 @@ public class AwsProperties implements Serializable {
 
   private boolean isS3ChecksumEnabled;
 
-  private Set<Tag> s3WriteTags;
+  private final Set<Tag> s3WriteTags;
 
   public AwsProperties() {
     this.s3FileIoSseType = S3FILEIO_SSE_TYPE_NONE;
@@ -289,6 +290,8 @@ public class AwsProperties implements Serializable {
     this.glueCatalogSkipArchive = GLUE_CATALOG_SKIP_ARCHIVE_DEFAULT;
 
     this.dynamoDbTableName = DYNAMODB_TABLE_NAME_DEFAULT;
+
+    this.s3WriteTags = Sets.newHashSet();
   }
 
   public AwsProperties(Map<String, String> properties) {
@@ -456,7 +459,7 @@ public class AwsProperties implements Serializable {
     return s3WriteTags;
   }
 
-  public Set<Tag> toTags(Map<String, String> properties, String prefix) {
+  private Set<Tag> toTags(Map<String, String> properties, String prefix) {
     return PropertyUtil.propertiesWithPrefix(properties, prefix)
         .entrySet().stream()
         .map(e -> Tag.builder().key(e.getKey()).value(e.getValue()).build())

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -263,15 +263,13 @@ public class AwsProperties implements Serializable {
   private double s3FileIoMultipartThresholdFactor;
   private String s3fileIoStagingDirectory;
   private ObjectCannedACL s3FileIoAcl;
+  private boolean isS3ChecksumEnabled;
+  private final Set<Tag> s3WriteTags;
 
   private String glueCatalogId;
   private boolean glueCatalogSkipArchive;
 
   private String dynamoDbTableName;
-
-  private boolean isS3ChecksumEnabled;
-
-  private final Set<Tag> s3WriteTags;
 
   public AwsProperties() {
     this.s3FileIoSseType = S3FILEIO_SSE_TYPE_NONE;
@@ -285,13 +283,12 @@ public class AwsProperties implements Serializable {
     this.s3FileIoDeleteBatchSize = S3FILEIO_DELETE_BATCH_SIZE_DEFAULT;
     this.s3fileIoStagingDirectory = System.getProperty("java.io.tmpdir");
     this.isS3ChecksumEnabled = S3_CHECKSUM_ENABLED_DEFAULT;
+    this.s3WriteTags = Sets.newHashSet();
 
     this.glueCatalogId = null;
     this.glueCatalogSkipArchive = GLUE_CATALOG_SKIP_ARCHIVE_DEFAULT;
 
     this.dynamoDbTableName = DYNAMODB_TABLE_NAME_DEFAULT;
-
-    this.s3WriteTags = Sets.newHashSet();
   }
 
   public AwsProperties(Map<String, String> properties) {
@@ -345,10 +342,10 @@ public class AwsProperties implements Serializable {
         s3FileIoDeleteBatchSize <= S3FILEIO_DELETE_BATCH_SIZE_MAX,
         String.format("Deletion batch size must be between 1 and %s", S3FILEIO_DELETE_BATCH_SIZE_MAX));
 
+    this.s3WriteTags = toTags(properties, S3_WRITE_TAGS_PREFIX);
+
     this.dynamoDbTableName = PropertyUtil.propertyAsString(properties, DYNAMODB_TABLE_NAME,
         DYNAMODB_TABLE_NAME_DEFAULT);
-
-    this.s3WriteTags = toTags(properties, S3_WRITE_TAGS_PREFIX);
   }
 
   public String s3FileIoSseType() {

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -270,7 +270,7 @@ public class AwsProperties implements Serializable {
 
   private boolean isS3ChecksumEnabled;
 
-  private Set<Tag> writeTags;
+  private Set<Tag> s3WriteTags;
 
   public AwsProperties() {
     this.s3FileIoSseType = S3FILEIO_SSE_TYPE_NONE;
@@ -345,7 +345,7 @@ public class AwsProperties implements Serializable {
     this.dynamoDbTableName = PropertyUtil.propertyAsString(properties, DYNAMODB_TABLE_NAME,
         DYNAMODB_TABLE_NAME_DEFAULT);
 
-    this.writeTags = toTags(properties, S3_WRITE_TAGS_PREFIX);
+    this.s3WriteTags = toTags(properties, S3_WRITE_TAGS_PREFIX);
   }
 
   public String s3FileIoSseType() {
@@ -452,8 +452,8 @@ public class AwsProperties implements Serializable {
     this.isS3ChecksumEnabled = eTagCheckEnabled;
   }
 
-  public Set<Tag> getWriteTags() {
-    return writeTags;
+  public Set<Tag> getS3WriteTags() {
+    return s3WriteTags;
   }
 
   public Set<Tag> toTags(Map<String, String> properties, String prefix) {

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/BaseS3File.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/BaseS3File.java
@@ -19,16 +19,13 @@
 
 package org.apache.iceberg.aws.s3;
 
-import java.util.Set;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.metrics.MetricsContext;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import software.amazon.awssdk.http.HttpStatusCode;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
-import software.amazon.awssdk.services.s3.model.Tag;
 
 abstract class BaseS3File {
   private final S3Client client;
@@ -36,23 +33,12 @@ abstract class BaseS3File {
   private final AwsProperties awsProperties;
   private HeadObjectResponse metadata;
   private final MetricsContext metrics;
-  private final Set<Tag> writeTags;
 
   BaseS3File(S3Client client, S3URI uri, AwsProperties awsProperties, MetricsContext metrics) {
     this.client = client;
     this.uri = uri;
     this.awsProperties = awsProperties;
     this.metrics = metrics;
-    this.writeTags = Sets.newHashSet();
-  }
-
-  BaseS3File(S3Client client, S3URI uri, AwsProperties awsProperties, MetricsContext metrics,
-      Set<Tag> writeTags) {
-    this.client = client;
-    this.uri = uri;
-    this.awsProperties = awsProperties;
-    this.metrics = metrics;
-    this.writeTags = writeTags;
   }
 
   public String location() {
@@ -73,10 +59,6 @@ abstract class BaseS3File {
 
   protected MetricsContext metrics() {
     return metrics;
-  }
-
-  public Set<Tag> writeTags() {
-    return writeTags;
   }
 
   /**

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputFile.java
@@ -21,30 +21,22 @@ package org.apache.iceberg.aws.s3;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.Set;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.PositionOutputStream;
 import org.apache.iceberg.metrics.MetricsContext;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.Tag;
 
 public class S3OutputFile extends BaseS3File implements OutputFile {
   public static S3OutputFile fromLocation(String location, S3Client client, AwsProperties awsProperties,
       MetricsContext metrics) {
-    return new S3OutputFile(client, new S3URI(location), awsProperties, metrics, Sets.newHashSet());
+    return new S3OutputFile(client, new S3URI(location), awsProperties, metrics);
   }
 
-  public static S3OutputFile fromLocation(String location, S3Client client, AwsProperties awsProperties,
-      MetricsContext metrics, Set<Tag> writeTags) {
-    return new S3OutputFile(client, new S3URI(location), awsProperties, metrics, writeTags);
-  }
-
-  S3OutputFile(S3Client client, S3URI uri, AwsProperties awsProperties, MetricsContext metrics, Set<Tag> writeTags) {
-    super(client, uri, awsProperties, metrics, writeTags);
+  S3OutputFile(S3Client client, S3URI uri, AwsProperties awsProperties, MetricsContext metrics) {
+    super(client, uri, awsProperties, metrics);
   }
 
   /**
@@ -65,7 +57,7 @@ public class S3OutputFile extends BaseS3File implements OutputFile {
   @Override
   public PositionOutputStream createOrOverwrite() {
     try {
-      return new S3OutputStream(client(), uri(), awsProperties(), metrics(), writeTags());
+      return new S3OutputStream(client(), uri(), awsProperties(), metrics());
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to create output stream for location: " + uri(), e);
     }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -260,7 +260,7 @@ class S3OutputStream extends PositionOutputStream {
     CreateMultipartUploadRequest.Builder requestBuilder = CreateMultipartUploadRequest.builder()
         .bucket(location.bucket())
         .key(location.key());
-    if (!writeTags.isEmpty()) {
+    if (writeTags != null && !writeTags.isEmpty()) {
       requestBuilder.tagging(Tagging.builder().tagSet(writeTags).build());
     }
 
@@ -378,7 +378,7 @@ class S3OutputStream extends PositionOutputStream {
           .bucket(location.bucket())
           .key(location.key());
 
-      if (!writeTags.isEmpty()) {
+      if (writeTags != null && !writeTags.isEmpty()) {
         requestBuilder.tagging(Tagging.builder().tagSet(writeTags).build());
       }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -105,7 +105,7 @@ class S3OutputStream extends PositionOutputStream {
   private boolean closed = false;
 
   @SuppressWarnings("StaticAssignmentInConstructor")
-  S3OutputStream(S3Client s3, S3URI location, AwsProperties awsProperties, MetricsContext metrics, Set<Tag> writeTags)
+  S3OutputStream(S3Client s3, S3URI location, AwsProperties awsProperties, MetricsContext metrics)
       throws IOException {
     if (executorService == null) {
       synchronized (S3OutputStream.class) {
@@ -124,7 +124,7 @@ class S3OutputStream extends PositionOutputStream {
     this.s3 = s3;
     this.location = location;
     this.awsProperties = awsProperties;
-    this.writeTags = writeTags;
+    this.writeTags = awsProperties.getWriteTags();
 
     this.createStack = Thread.currentThread().getStackTrace();
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -260,7 +260,7 @@ class S3OutputStream extends PositionOutputStream {
     CreateMultipartUploadRequest.Builder requestBuilder = CreateMultipartUploadRequest.builder()
         .bucket(location.bucket())
         .key(location.key());
-    if (writeTags != null && !writeTags.isEmpty()) {
+    if (!writeTags.isEmpty()) {
       requestBuilder.tagging(Tagging.builder().tagSet(writeTags).build());
     }
 
@@ -378,7 +378,7 @@ class S3OutputStream extends PositionOutputStream {
           .bucket(location.bucket())
           .key(location.key());
 
-      if (writeTags != null && !writeTags.isEmpty()) {
+      if (!writeTags.isEmpty()) {
         requestBuilder.tagging(Tagging.builder().tagSet(writeTags).build());
       }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -124,7 +124,7 @@ class S3OutputStream extends PositionOutputStream {
     this.s3 = s3;
     this.location = location;
     this.awsProperties = awsProperties;
-    this.writeTags = awsProperties.getWriteTags();
+    this.writeTags = awsProperties.getS3WriteTags();
 
     this.createStack = Thread.currentThread().getStackTrace();
 

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
@@ -34,7 +34,6 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.SerializableSupplier;
 import org.junit.Assert;
@@ -50,7 +49,6 @@ import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
 import software.amazon.awssdk.services.s3.model.S3Error;
-import software.amazon.awssdk.services.s3.model.Tag;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -191,31 +189,5 @@ public class TestS3FileIO {
     SerializableSupplier<S3Client> post = SerializationUtils.deserialize(data);
 
     assertEquals("s3", post.get().serviceName());
-  }
-
-  @Test
-  public void testWriteTags() throws IOException {
-    String location = "s3://bucket/path/to/file.txt";
-    byte[] expected = new byte[1024 * 1024];
-    random.nextBytes(expected);
-
-    InputFile in = s3FileIO.newInputFile(location);
-    assertFalse(in.exists());
-
-    OutputFile out = s3FileIO.newOutputFile(location);
-    try (OutputStream os = out.createOrOverwrite()) {
-      IOUtils.write(expected, os);
-    }
-
-    assertTrue(in.exists());
-
-    // Assert for writeTags
-    assertTrue(((S3InputFile) in).writeTags().isEmpty());
-    assertEquals(((S3OutputFile) out).writeTags().size(), 1);
-    assertEquals(((S3OutputFile) out).writeTags(), ImmutableSet.of(
-        Tag.builder().key("tagKey1").value("TagValue1").build()));
-
-    s3FileIO.deleteFile(in);
-    assertFalse(s3FileIO.newInputFile(location).exists());
   }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
@@ -234,7 +234,7 @@ public class TestS3OutputStream {
     if (properties.isS3ChecksumEnabled()) {
       List<PutObjectRequest> putObjectRequests = putObjectRequestArgumentCaptor.getAllValues();
       String tagging = putObjectRequests.get(0).tagging();
-      assertEquals(getTags(properties.getWriteTags()), tagging);
+      assertEquals(getTags(properties.getS3WriteTags()), tagging);
     }
   }
 

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
@@ -36,7 +36,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -88,13 +87,12 @@ public class TestS3OutputStream {
   private final Random random = new Random(1);
   private final Path tmpDir = Files.createTempDirectory("s3fileio-test-");
   private final String newTmpDirectory = "/tmp/newStagingDirectory";
-  private final Set<Tag> tags = ImmutableSet.of(
-      Tag.builder().key("abc").value("123").build(),
-      Tag.builder().key("def").value("789").build());
 
   private final AwsProperties properties = new AwsProperties(ImmutableMap.of(
       AwsProperties.S3FILEIO_MULTIPART_SIZE, Integer.toString(5 * 1024 * 1024),
-      AwsProperties.S3FILEIO_STAGING_DIRECTORY, tmpDir.toString()));
+      AwsProperties.S3FILEIO_STAGING_DIRECTORY, tmpDir.toString(),
+      "s3.write.tags.abc", "123",
+      "s3.write.tags.def", "789"));
 
   public TestS3OutputStream() throws IOException {
   }
@@ -122,8 +120,7 @@ public class TestS3OutputStream {
   public void testAbortAfterFailedPartUpload() {
     doThrow(new RuntimeException()).when(s3mock).uploadPart((UploadPartRequest) any(), (RequestBody) any());
 
-    try (S3OutputStream stream = new S3OutputStream(
-        s3mock, randomURI(), properties, nullMetrics(), tags)) {
+    try (S3OutputStream stream = new S3OutputStream(s3mock, randomURI(), properties, nullMetrics())) {
       stream.write(randomData(10 * 1024 * 1024));
     } catch (Exception e) {
       verify(s3mock, atLeastOnce()).abortMultipartUpload((AbortMultipartUploadRequest) any());
@@ -134,8 +131,7 @@ public class TestS3OutputStream {
   public void testAbortMultipart() {
     doThrow(new RuntimeException()).when(s3mock).completeMultipartUpload((CompleteMultipartUploadRequest) any());
 
-    try (S3OutputStream stream = new S3OutputStream(
-        s3mock, randomURI(), properties, nullMetrics(), tags)) {
+    try (S3OutputStream stream = new S3OutputStream(s3mock, randomURI(), properties, nullMetrics())) {
       stream.write(randomData(10 * 1024 * 1024));
     } catch (Exception e) {
       verify(s3mock).abortMultipartUpload((AbortMultipartUploadRequest) any());
@@ -144,7 +140,7 @@ public class TestS3OutputStream {
 
   @Test
   public void testMultipleClose() throws IOException {
-    S3OutputStream stream = new S3OutputStream(s3, randomURI(), properties, nullMetrics(), tags);
+    S3OutputStream stream = new S3OutputStream(s3, randomURI(), properties, nullMetrics());
     stream.close();
     stream.close();
   }
@@ -153,8 +149,7 @@ public class TestS3OutputStream {
   public void testStagingDirectoryCreation() throws IOException {
     AwsProperties newStagingDirectoryAwsProperties = new AwsProperties(ImmutableMap.of(
         AwsProperties.S3FILEIO_STAGING_DIRECTORY, newTmpDirectory));
-    S3OutputStream stream = new S3OutputStream(
-        s3, randomURI(), newStagingDirectoryAwsProperties, nullMetrics(), tags);
+    S3OutputStream stream = new S3OutputStream(s3, randomURI(), newStagingDirectoryAwsProperties, nullMetrics());
     stream.close();
   }
 
@@ -239,7 +234,7 @@ public class TestS3OutputStream {
     if (properties.isS3ChecksumEnabled()) {
       List<PutObjectRequest> putObjectRequests = putObjectRequestArgumentCaptor.getAllValues();
       String tagging = putObjectRequests.get(0).tagging();
-      assertEquals(getTags(tags), tagging);
+      assertEquals(getTags(properties.getWriteTags()), tagging);
     }
   }
 
@@ -261,7 +256,7 @@ public class TestS3OutputStream {
   }
 
   private void writeAndVerify(S3Client client, S3URI uri, byte [] data, boolean arrayWrite) {
-    try (S3OutputStream stream = new S3OutputStream(client, uri, properties, nullMetrics(), tags)) {
+    try (S3OutputStream stream = new S3OutputStream(client, uri, properties, nullMetrics())) {
       if (arrayWrite) {
         stream.write(data);
         assertEquals(data.length, stream.getPos());


### PR DESCRIPTION
This change moves S3 `writeTags` to `AwsProperties`. This provides a cleaner solution as `AwsProperties` was designed to be the extension point for new configs without changing constructors.

Users can pass their custom tags as part of the catalog properties.

Spark SQL launch command:
```
sh spark-sql --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCatalog \
    --conf spark.sql.catalog.my_catalog.warehouse=s3://iceberg-warehouse/s3-tagging \
    --conf spark.sql.catalog.my_catalog.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog \
    --conf spark.sql.catalog.my_catalog.io-impl=org.apache.iceberg.aws.s3.S3FileIO \
    --conf spark.sql.catalog.my_catalog.s3.write.tags.my_key=my_val \
    --conf spark.sql.catalog.my_catalog.s3.write.tags.my_key2=my_val2
```

Tags added in S3:

```
aws s3api get-object-tagging --bucket iceberg-warehouse --key s3-tagging/data/00000-0-7eb83d01-ad82-41ca-814b-c7686d9d9211-00001.parquet
{
    "TagSet": [
        {
            "Key": "my_key2",
            "Value": "my_val2"
        },
        {
            "Key": "my_key",
            "Value": "my_val"
        }
    ]
}
```
---
cc: @jackye1995 @arminnajafi @singhpk234 @amogh-jahagirdar @xiaoxuandev @yyanyy