### PR TITLE
AWS : make passing s3WriteTags javaDoc example engine agnostic

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -250,7 +250,7 @@ public class AwsProperties implements Serializable {
    * <p>
    * For more details, see https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html
    * <p>
-   * Example : s3.write.tags.my_key=my_val
+   * Example: s3.write.tags.my_key=my_val
    */
   public static final String S3_WRITE_TAGS_PREFIX = "s3.write.tags.";
 

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -250,7 +250,7 @@ public class AwsProperties implements Serializable {
    * <p>
    * For more details, see https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html
    * <p>
-   * Example in Spark: --conf spark.sql.catalog.my_catalog.s3.write.tags.my_key=my_val
+   * Example : s3.write.tags.my_key=my_val
    */
   public static final String S3_WRITE_TAGS_PREFIX = "s3.write.tags.";
 


### PR DESCRIPTION
make the example in java doc of s3WriteTagPrefix engine agnostic.

earlier suggestion : https://github.com/apache/iceberg/pull/4334#discussion_r828195275