### PR TITLE
AWS: Remove get from getter method.

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -452,7 +452,7 @@ public class AwsProperties implements Serializable {
     this.isS3ChecksumEnabled = eTagCheckEnabled;
   }
 
-  public Set<Tag> getS3WriteTags() {
+  public Set<Tag> s3WriteTags() {
     return s3WriteTags;
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -124,7 +124,7 @@ class S3OutputStream extends PositionOutputStream {
     this.s3 = s3;
     this.location = location;
     this.awsProperties = awsProperties;
-    this.writeTags = awsProperties.getS3WriteTags();
+    this.writeTags = awsProperties.s3WriteTags();
 
     this.createStack = Thread.currentThread().getStackTrace();
 

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
@@ -234,7 +234,7 @@ public class TestS3OutputStream {
     if (properties.isS3ChecksumEnabled()) {
       List<PutObjectRequest> putObjectRequests = putObjectRequestArgumentCaptor.getAllValues();
       String tagging = putObjectRequests.get(0).tagging();
-      assertEquals(getTags(properties.getS3WriteTags()), tagging);
+      assertEquals(getTags(properties.s3WriteTags()), tagging);
     }
   }
 


### PR DESCRIPTION
This is a minor follow-up to #4350 that removes an unnecessary `get` from S3 write tag config.