### PR TITLE
API: Add UnboundSortOrder that has no schema

### DIFF
--- a/api/src/main/java/org/apache/iceberg/SortOrder.java
+++ b/api/src/main/java/org/apache/iceberg/SortOrder.java
@@ -266,7 +266,7 @@ public class SortOrder implements Serializable {
 
     Builder addSortField(String transformAsString, int sourceId, SortDirection direction, NullOrder nullOrder) {
       Types.NestedField column = schema.findField(sourceId);
-      Preconditions.checkNotNull(column, "Cannot find source column: %s", sourceId);
+      ValidationException.check(column != null, "Cannot find source column: %s", sourceId);
       Transform<?, ?> transform = Transforms.fromString(column.type(), transformAsString);
       SortField sortField = new SortField(transform, sourceId, direction, nullOrder);
       fields.add(sortField);

--- a/api/src/main/java/org/apache/iceberg/SortOrder.java
+++ b/api/src/main/java/org/apache/iceberg/SortOrder.java
@@ -135,6 +135,16 @@ public class SortOrder implements Serializable {
     return fieldList;
   }
 
+  UnboundSortOrder toUnbound() {
+    UnboundSortOrder.Builder builder = UnboundSortOrder.builder().withOrderId(orderId);
+
+    for (SortField field : fields) {
+      builder.addSortField(field.transform().toString(), field.sourceId(), field.direction(), field.nullOrder());
+    }
+
+    return builder.build();
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
@@ -244,7 +254,7 @@ public class SortOrder implements Serializable {
       return this;
     }
 
-    Builder addSortField(Term term, SortDirection direction, NullOrder nullOrder) {
+    private Builder addSortField(Term term, SortDirection direction, NullOrder nullOrder) {
       Preconditions.checkArgument(term instanceof UnboundTerm, "Term must be unbound");
       // ValidationException is thrown by bind if binding fails so we assume that boundTerm is correct
       BoundTerm<?> boundTerm = ((UnboundTerm<?>) term).bind(schema.asStruct(), caseSensitive);
@@ -260,11 +270,6 @@ public class SortOrder implements Serializable {
       Transform<?, ?> transform = Transforms.fromString(column.type(), transformAsString);
       SortField sortField = new SortField(transform, sourceId, direction, nullOrder);
       fields.add(sortField);
-      return this;
-    }
-
-    Builder addSortField(Transform<?, ?> transform, int sourceId, SortDirection direction, NullOrder nullOrder) {
-      fields.add(new SortField(transform, sourceId, direction, nullOrder));
       return this;
     }
 

--- a/api/src/main/java/org/apache/iceberg/UnboundSortOrder.java
+++ b/api/src/main/java/org/apache/iceberg/UnboundSortOrder.java
@@ -1,15 +1,20 @@
 /*
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.apache.iceberg;

--- a/api/src/main/java/org/apache/iceberg/UnboundSortOrder.java
+++ b/api/src/main/java/org/apache/iceberg/UnboundSortOrder.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.Collections;
+import java.util.List;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+public class UnboundSortOrder {
+  private static final UnboundSortOrder UNSORTED_ORDER = new UnboundSortOrder(0, Collections.emptyList());
+
+  private final int orderId;
+  private final List<UnboundSortField> fields;
+
+  private UnboundSortOrder(int orderId, List<UnboundSortField> fields) {
+    this.orderId = orderId;
+    this.fields = fields;
+  }
+
+  public SortOrder bind(Schema schema) {
+    SortOrder.Builder builder = SortOrder.builderFor(schema).withOrderId(orderId);
+
+    for (UnboundSortField field : fields) {
+      builder.addSortField(field.transformAsString, field.sourceId, field.direction, field.nullOrder);
+    }
+
+    return builder.build();
+  }
+
+  SortOrder bindUnchecked(Schema schema) {
+    SortOrder.Builder builder = SortOrder.builderFor(schema).withOrderId(orderId);
+
+    for (UnboundSortField field : fields) {
+      builder.addSortField(field.transformAsString, field.sourceId, field.direction, field.nullOrder);
+    }
+
+    return builder.buildUnchecked();
+  }
+
+  int orderId() {
+    return orderId;
+  }
+
+  List<UnboundSortField> fields() {
+    return fields;
+  }
+
+  /**
+   * Creates a new {@link SortOrder.Builder sort order builder} for unbound sort orders.
+   *
+   * @return a sort order builder
+   */
+  static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * A builder used to create {@link UnboundSortOrder unbound sort orders}.
+   * <p>
+   * Call {@link #builder()} to create a new builder.
+   */
+  static class Builder {
+    private final List<UnboundSortField> fields = Lists.newArrayList();
+    private Integer orderId = null;
+
+    private Builder() {
+    }
+
+    Builder withOrderId(int newOrderId) {
+      this.orderId = newOrderId;
+      return this;
+    }
+
+    Builder addSortField(String transformAsString, int sourceId, SortDirection direction, NullOrder nullOrder) {
+      fields.add(new UnboundSortField(transformAsString, sourceId, direction, nullOrder));
+      return this;
+    }
+
+    UnboundSortOrder build() {
+      if (fields.isEmpty()) {
+        if (orderId != null && orderId != 0) {
+          throw new IllegalArgumentException("Unsorted order ID must be 0");
+        }
+        return UNSORTED_ORDER;
+      }
+
+      if (orderId != null && orderId == 0) {
+        throw new IllegalArgumentException("Sort order ID 0 is reserved for unsorted order");
+      }
+
+      // default ID to 1 as 0 is reserved for unsorted order
+      int actualOrderId = orderId != null ? orderId : 1;
+      return new UnboundSortOrder(actualOrderId, fields);
+    }
+  }
+
+  static class UnboundSortField {
+    private final String transformAsString;
+    private final int sourceId;
+    private final SortDirection direction;
+    private final NullOrder nullOrder;
+
+    private UnboundSortField(String transformAsString, int sourceId, SortDirection direction, NullOrder nullOrder) {
+      this.transformAsString = transformAsString;
+      this.sourceId = sourceId;
+      this.direction = direction;
+      this.nullOrder = nullOrder;
+    }
+
+    public String transformAsString() {
+      return transformAsString;
+    }
+
+    public int sourceId() {
+      return sourceId;
+    }
+
+    public SortDirection direction() {
+      return direction;
+    }
+
+    public NullOrder nullOrder() {
+      return nullOrder;
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdate.java
@@ -139,13 +139,17 @@ public interface MetadataUpdate extends Serializable {
   }
 
   class AddSortOrder implements MetadataUpdate {
-    private final SortOrder sortOrder;
+    private final UnboundSortOrder sortOrder;
 
     public AddSortOrder(SortOrder sortOrder) {
+      this(sortOrder.toUnbound());
+    }
+
+    public AddSortOrder(UnboundSortOrder sortOrder) {
       this.sortOrder = sortOrder;
     }
 
-    public SortOrder sortOrder() {
+    public UnboundSortOrder sortOrder() {
       return sortOrder;
     }
 

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
@@ -33,7 +33,6 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
-import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.SortOrderParser;
 import org.apache.iceberg.UnboundSortOrder;
 import org.apache.iceberg.catalog.Namespace;

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.SortOrderParser;
+import org.apache.iceberg.UnboundSortOrder;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.catalog.TableIdentifierParser;
@@ -56,8 +57,8 @@ public class RESTSerializers {
         .addDeserializer(Schema.class, new SchemaDeserializer())
         .addSerializer(PartitionSpec.class, new PartitionSpecSerializer())
         .addDeserializer(PartitionSpec.class, new PartitionSpecDeserializer())
-        .addSerializer(SortOrder.class, new SortOrderSerializer())
-        .addDeserializer(SortOrder.class, new SortOrderDeserializer());
+        .addSerializer(UnboundSortOrder.class, new UnboundSortOrderSerializer())
+        .addDeserializer(UnboundSortOrder.class, new UnboundSortOrderDeserializer());
     mapper.registerModule(module);
   }
 
@@ -133,20 +134,19 @@ public class RESTSerializers {
     }
   }
 
-  public static class SortOrderSerializer extends JsonSerializer<SortOrder> {
+  public static class UnboundSortOrderSerializer extends JsonSerializer<UnboundSortOrder> {
     @Override
-    public void serialize(SortOrder sortOrder, JsonGenerator gen, SerializerProvider serializers)
+    public void serialize(UnboundSortOrder sortOrder, JsonGenerator gen, SerializerProvider serializers)
         throws IOException {
       SortOrderParser.toJson(sortOrder, gen);
     }
   }
 
-  public static class SortOrderDeserializer extends JsonDeserializer<SortOrder> {
+  public static class UnboundSortOrderDeserializer extends JsonDeserializer<UnboundSortOrder> {
     @Override
-    public SortOrder deserialize(JsonParser p, DeserializationContext context) throws IOException {
+    public UnboundSortOrder deserialize(JsonParser p, DeserializationContext context) throws IOException {
       JsonNode jsonNode = p.getCodec().readTree(p);
-      Schema schema = (Schema) context.getAttribute("schema");
-      return SortOrderParser.fromJson(schema, jsonNode);
+      return SortOrderParser.fromJson(jsonNode);
     }
   }
 }


### PR DESCRIPTION
This is to support the REST catalog. Building a sort order currently requires a schema, which is not part of the serialization format. This adds an intermediate class, `UnboundSortOrder` that can be built without a schema and later bound to a schema.