### PR TITLE
Core: Make removal of delete files optional in manifest filtering

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
@@ -369,11 +369,11 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
 
         hasDeletedFiles = allRowsMatch;
 
-        if (failAnyDelete) {
-          throw new DeleteException(reader.spec().partitionToPath(file.partition()));
-        }
-
         if (hasDeletedFiles) {
+          if (failAnyDelete) {
+            throw new DeleteException(reader.spec().partitionToPath(file.partition()));
+          }
+
           // as soon as a deleted file is detected, stop scanning
           break;
         }

--- a/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
@@ -350,10 +350,10 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
     return canContainExpressionDeletes || canContainDroppedPartitions || canContainDroppedFiles || canContainDropBySeq;
   }
 
-  @SuppressWarnings({"CollectionUndefinedEquality", "checkstyle:CyclomaticComplexity"})
+  @SuppressWarnings("CollectionUndefinedEquality")
   private boolean manifestHasDeletedFiles(PartitionAndMetricsEvaluator evaluator, ManifestReader<F> reader) {
     boolean isDelete = reader.isDeleteManifestReader();
-    boolean hasDeletedFiles = false;
+
     for (ManifestEntry<F> entry : reader.liveEntries()) {
       F file = entry.file();
       boolean markedForDelete = deletePaths.contains(file.path()) ||
@@ -367,19 +367,18 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
             "Cannot delete file where some, but not all, rows match filter %s: %s",
             this.deleteExpression, file.path());
 
-        hasDeletedFiles = allRowsMatch;
-
-        if (hasDeletedFiles) {
+        if (allRowsMatch) {
           if (failAnyDelete) {
             throw new DeleteException(reader.spec().partitionToPath(file.partition()));
           }
 
           // as soon as a deleted file is detected, stop scanning
-          break;
+          return true;
         }
       }
     }
-    return hasDeletedFiles;
+
+    return false;
   }
 
   @SuppressWarnings({"CollectionUndefinedEquality", "checkstyle:CyclomaticComplexity"})

--- a/core/src/test/java/org/apache/iceberg/TestOverwriteWithValidation.java
+++ b/core/src/test/java/org/apache/iceberg/TestOverwriteWithValidation.java
@@ -1014,15 +1014,9 @@ public class TestOverwriteWithValidation extends TableTestBase {
         .addDeletes(FILE_DAY_2_ANOTHER_RANGE_EQ_DELETES)
         .commit();
 
-    Snapshot baseSnapshot = table.currentSnapshot();
-
     table.newOverwrite()
         .overwriteByRowFilter(EXPRESSION_DAY_2_ANOTHER_ID_RANGE)
         .addFile(FILE_DAY_2_MODIFIED)
-        .validateFromSnapshot(baseSnapshot.snapshotId())
-        .conflictDetectionFilter(EXPRESSION_DAY_2_ANOTHER_ID_RANGE)
-        .validateNoConflictingData()
-        .validateNoConflictingDeletes()
         .commit();
 
     validateTableFiles(table, FILE_DAY_2, FILE_DAY_2_MODIFIED);


### PR DESCRIPTION
This PR is a follow-up to #4304. In that PR, we updated the method that checks whether a manifest has an entry to be deleted. However, we did not update the method that actually does the manifest filtering. As a consequence, the test added in this PR would fail with a runtime exception as one delete file should be removed and one kept. In addition, we should not introduce any extra calls to `evaluator` as they are expensive.

Overall, the problem is that whenever we overwrite data by filter, we should not fail operations when it is not possible to remove delete files. Removal of delete files is optional and is an optimization we should perform if possible.