### PR TITLE
Flink: remove redundant code

### DIFF
--- a/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/source/RowDataFileScanTaskReader.java
+++ b/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/source/RowDataFileScanTaskReader.java
@@ -132,7 +132,6 @@ public class RowDataFileScanTaskReader implements FileScanTaskReader<RowData> {
   private CloseableIterable<RowData> newParquetIterable(
       FileScanTask task, Schema schema, Map<Integer, ?> idToConstant, InputFilesDecryptor inputFilesDecryptor) {
     Parquet.ReadBuilder builder = Parquet.read(inputFilesDecryptor.getInputFile(task))
-        .reuseContainers()
         .split(task.start(), task.length())
         .project(schema)
         .createReaderFunc(fileSchema -> FlinkParquetReaders.buildReader(schema, fileSchema, idToConstant))

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/RowDataFileScanTaskReader.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/RowDataFileScanTaskReader.java
@@ -132,7 +132,6 @@ public class RowDataFileScanTaskReader implements FileScanTaskReader<RowData> {
   private CloseableIterable<RowData> newParquetIterable(
       FileScanTask task, Schema schema, Map<Integer, ?> idToConstant, InputFilesDecryptor inputFilesDecryptor) {
     Parquet.ReadBuilder builder = Parquet.read(inputFilesDecryptor.getInputFile(task))
-        .reuseContainers()
         .split(task.start(), task.length())
         .project(schema)
         .createReaderFunc(fileSchema -> FlinkParquetReaders.buildReader(schema, fileSchema, idToConstant))

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/RowDataFileScanTaskReader.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/RowDataFileScanTaskReader.java
@@ -132,7 +132,6 @@ public class RowDataFileScanTaskReader implements FileScanTaskReader<RowData> {
   private CloseableIterable<RowData> newParquetIterable(
       FileScanTask task, Schema schema, Map<Integer, ?> idToConstant, InputFilesDecryptor inputFilesDecryptor) {
     Parquet.ReadBuilder builder = Parquet.read(inputFilesDecryptor.getInputFile(task))
-        .reuseContainers()
         .split(task.start(), task.length())
         .project(schema)
         .createReaderFunc(fileSchema -> FlinkParquetReaders.buildReader(schema, fileSchema, idToConstant))


### PR DESCRIPTION
```
    Parquet.ReadBuilder builder = Parquet.read(inputFilesDecryptor.getInputFile(task))
        .reuseContainers()
        .split(task.start(), task.length())
        .project(schema)
        .createReaderFunc(fileSchema -> FlinkParquetReaders.buildReader(schema, fileSchema, idToConstant))
        .filter(task.residual())
        .caseSensitive(caseSensitive)
        .reuseContainers()
```
call `reuseContainers` twice...

