### PR TITLE
Spark: Add option to introduce ordering of RewriteFileGroup

### DIFF
--- a/api/src/main/java/org/apache/iceberg/RewriteJobOrder.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteJobOrder.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import java.util.Locale;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+/**
+ * Enum of supported rewrite job order, it defines the order in which the file groups should be
+ * written.
+ * <p><ul>
+ * <li> bytes-asc: rewrite the smallest job groups first.
+ * <li> bytes-desc: rewrite the largest job groups first.
+ * <li> files-asc: rewrite the job groups with the least files first.
+ * <li> files-desc: rewrite the job groups with the most files first.
+ * <li> none: rewrite job groups in the order they were planned (no specific ordering).
+ * </ul><p>
+ */
+public enum RewriteJobOrder {
+  BYTES_ASC("bytes-asc"), BYTES_DESC("bytes-desc"),
+  FILES_ASC("files-asc"), FILES_DESC("files-desc"), NONE("none");
+
+  private final String orderName;
+
+  RewriteJobOrder(String orderName) {
+    this.orderName = orderName;
+  }
+
+  public String orderName() {
+    return orderName;
+  }
+
+  public static RewriteJobOrder fromName(String orderName) {
+    Preconditions.checkArgument(orderName != null, "Rewrite job order name should not be null");
+    // Replace the hyphen in order name with underscore to map to the enum value. For example: bytes-asc to BYTES_ASC
+    return RewriteJobOrder.valueOf(orderName.replaceFirst("-", "_").toUpperCase(Locale.ENGLISH));
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
@@ -20,6 +20,7 @@
 package org.apache.iceberg.actions;
 
 import java.util.List;
+import org.apache.iceberg.RewriteJobOrder;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.expressions.Expression;
@@ -87,6 +88,21 @@ public interface RewriteDataFiles extends SnapshotUpdate<RewriteDataFiles, Rewri
    */
   String USE_STARTING_SEQUENCE_NUMBER = "use-starting-sequence-number";
   boolean USE_STARTING_SEQUENCE_NUMBER_DEFAULT = true;
+
+  /**
+   * Forces the rewrite job order based on the value.
+   * <p><ul>
+   * <li> If rewrite.job-order=bytes-asc, then rewrite the smallest job groups first.
+   * <li> If rewrite.job-order=bytes-desc, then rewrite the largest job groups first.
+   * <li> If rewrite.job-order=files-asc, then rewrite the job groups with the least files first.
+   * <li> If rewrite.job-order=files-desc, then rewrite the job groups with the most files first.
+   * <li> If rewrite.job-order=none, then rewrite job groups in the order they were planned (no
+   * specific ordering).
+   * </ul><p>
+   * Defaults to none.
+   */
+  String REWRITE_JOB_ORDER = "rewrite.job-order";
+  String REWRITE_JOB_ORDER_DEFAULT = RewriteJobOrder.NONE.orderName();
 
   /**
    * Choose BINPACK as a strategy for this rewrite operation

--- a/core/src/main/java/org/apache/iceberg/actions/RewriteFileGroup.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteFileGroup.java
@@ -77,4 +77,12 @@ public class RewriteFileGroup {
         .add("numAddedFiles", addedFiles == null ? "Rewrite Incomplete" : Integer.toString(addedFiles.size()))
         .toString();
   }
+
+  public long sizeInBytes() {
+    return fileScanTasks.stream().mapToLong(FileScanTask::length).sum();
+  }
+
+  public int numFiles() {
+    return fileScanTasks.size();
+  }
 }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/BaseRewriteDataFilesSparkAction.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.spark.actions;
 import java.io.IOException;
 import java.math.RoundingMode;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -34,6 +35,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.RewriteJobOrder;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
@@ -80,7 +82,8 @@ public class BaseRewriteDataFilesSparkAction
       PARTIAL_PROGRESS_ENABLED,
       PARTIAL_PROGRESS_MAX_COMMITS,
       TARGET_FILE_SIZE_BYTES,
-      USE_STARTING_SEQUENCE_NUMBER
+      USE_STARTING_SEQUENCE_NUMBER,
+      REWRITE_JOB_ORDER
   );
 
   private final Table table;
@@ -90,6 +93,7 @@ public class BaseRewriteDataFilesSparkAction
   private int maxCommits;
   private boolean partialProgressEnabled;
   private boolean useStartingSequenceNumber;
+  private RewriteJobOrder rewriteJobOrder;
   private RewriteStrategy strategy = null;
 
   protected BaseRewriteDataFilesSparkAction(SparkSession spark, Table table) {
@@ -146,7 +150,6 @@ public class BaseRewriteDataFilesSparkAction
     }
 
     validateAndInitOptions();
-    strategy = strategy.options(options());
 
     Map<StructLike, List<List<FileScanTask>>> fileGroupsByPartition = planFileGroups(startingSnapshotId);
     RewriteExecutionContext ctx = new RewriteExecutionContext(fileGroupsByPartition);
@@ -166,7 +169,7 @@ public class BaseRewriteDataFilesSparkAction
     }
   }
 
-  private Map<StructLike, List<List<FileScanTask>>> planFileGroups(long startingSnapshotId) {
+  Map<StructLike, List<List<FileScanTask>>> planFileGroups(long startingSnapshotId) {
     CloseableIterable<FileScanTask> fileScanTasks = table.newScan()
         .useSnapshot(startingSnapshotId)
         .filter(filter)
@@ -328,11 +331,9 @@ public class BaseRewriteDataFilesSparkAction
     return new BaseRewriteDataFilesResult(rewriteResults);
   }
 
-  private Stream<RewriteFileGroup> toGroupStream(RewriteExecutionContext ctx,
-                                                 Map<StructLike, List<List<FileScanTask>>> fileGroupsByPartition) {
-
-    // Todo Add intelligence to the order in which we do rewrites instead of just using partition order
-    return fileGroupsByPartition.entrySet().stream()
+  Stream<RewriteFileGroup> toGroupStream(RewriteExecutionContext ctx,
+      Map<StructLike, List<List<FileScanTask>>> fileGroupsByPartition) {
+    Stream<RewriteFileGroup> rewriteFileGroupStream = fileGroupsByPartition.entrySet().stream()
         .flatMap(e -> {
           StructLike partition = e.getKey();
           List<List<FileScanTask>> fileGroups = e.getValue();
@@ -343,9 +344,26 @@ public class BaseRewriteDataFilesSparkAction
             return new RewriteFileGroup(info, tasks);
           });
         });
+
+    return rewriteFileGroupStream.sorted(rewriteGroupComparator());
   }
 
-  private void validateAndInitOptions() {
+  private Comparator<RewriteFileGroup> rewriteGroupComparator() {
+    switch (rewriteJobOrder) {
+      case BYTES_ASC:
+        return Comparator.comparing(RewriteFileGroup::sizeInBytes);
+      case BYTES_DESC:
+        return Comparator.comparing(RewriteFileGroup::sizeInBytes, Comparator.reverseOrder());
+      case FILES_ASC:
+        return Comparator.comparing(RewriteFileGroup::numFiles);
+      case FILES_DESC:
+        return Comparator.comparing(RewriteFileGroup::numFiles, Comparator.reverseOrder());
+      default:
+        return (fileGroupOne, fileGroupTwo) -> 0;
+    }
+  }
+
+  void validateAndInitOptions() {
     Set<String> validOptions = Sets.newHashSet(strategy.validOptions());
     validOptions.addAll(VALID_OPTIONS);
 
@@ -355,6 +373,8 @@ public class BaseRewriteDataFilesSparkAction
     Preconditions.checkArgument(invalidKeys.isEmpty(),
         "Cannot use options %s, they are not supported by the action or the strategy %s",
         invalidKeys, strategy.name());
+
+    strategy = strategy.options(options());
 
     maxConcurrentFileGroupRewrites = PropertyUtil.propertyAsInt(options(),
         MAX_CONCURRENT_FILE_GROUP_REWRITES,
@@ -371,6 +391,10 @@ public class BaseRewriteDataFilesSparkAction
     useStartingSequenceNumber = PropertyUtil.propertyAsBoolean(options(),
         USE_STARTING_SEQUENCE_NUMBER,
         USE_STARTING_SEQUENCE_NUMBER_DEFAULT);
+
+    rewriteJobOrder = RewriteJobOrder.fromName(PropertyUtil.propertyAsString(options(),
+        REWRITE_JOB_ORDER,
+        REWRITE_JOB_ORDER_DEFAULT));
 
     Preconditions.checkArgument(maxConcurrentFileGroupRewrites >= 1,
         "Cannot set %s to %s, the value must be positive.",


### PR DESCRIPTION
This PR introduces ordering of `RewriteFileGroup`. This should be helpful in cases where we want to force the compaction order according to the size (in bytes) or number of files.

Introduce a new Spark option `rewrite.job-order = {"bytes-asc", "bytes-desc", "files-asc", "files-desc", "none"}`.

- `rewrite.job-order=bytes-asc`: rewrite the smallest job groups first.
- `rewrite.job-order=bytes-desc`: rewrite the largest job groups first.
- `rewrite.job-order=files-asc`: rewrite the job groups with the least files first.
- `rewrite.job-order=files-desc`: rewrite the job groups with the most files first.
- `rewrite.job-order=none`: rewrite job groups in the order they were planned (no specific ordering).

---

cc: @RussellSpitzer

