### PR TITLE
Docs: Clarify timestamp in stored procedures

### DIFF
--- a/docs/spark/spark-procedures.md
+++ b/docs/spark/spark-procedures.md
@@ -105,7 +105,7 @@ This procedure invalidates all cached Spark plans that reference the affected ta
 
 #### Example
 
-Roll back `db.sample` to one day
+Roll back `db.sample` to a specific day and time.
 ```sql
 CALL catalog_name.system.rollback_to_timestamp('db.sample', TIMESTAMP '2021-06-30 00:00:00.000')
 ```
@@ -215,16 +215,10 @@ If `older_than` and `retain_last` are omitted, the table's [expiration propertie
 
 #### Examples
 
-Remove snapshots older than one day, but retain the last 100 snapshots:
+Remove snapshots older than specific day and time, but retain the last 100 snapshots:
 
 ```sql
 CALL hive_prod.system.expire_snapshots('db.sample', TIMESTAMP '2021-06-30 00:00:00.000', 100)
-```
-
-Erase all snapshots older than the current timestamp but retain the last 5 snapshots:
-
-```sql
-CALL hive_prod.system.expire_snapshots(table => 'db.sample', older_than => now(), retain_last => 5)
 ```
 
 ### `remove_orphan_files`

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RollbackToTimestampProcedure.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RollbackToTimestampProcedure.java
@@ -76,7 +76,7 @@ class RollbackToTimestampProcedure extends BaseProcedure {
   @Override
   public InternalRow[] call(InternalRow args) {
     Identifier tableIdent = toIdentifier(args.getString(0), PARAMETERS[0].name());
-    // timestamps in Spark have nanosecond precision so this conversion is lossy
+    // timestamps in Spark have microsecond precision so this conversion is lossy
     long timestampMillis = DateTimeUtil.microsToMillis(args.getLong(1));
 
     return modifyIcebergTable(tableIdent, table -> {

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/RollbackToTimestampProcedure.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/procedures/RollbackToTimestampProcedure.java
@@ -76,7 +76,7 @@ class RollbackToTimestampProcedure extends BaseProcedure {
   @Override
   public InternalRow[] call(InternalRow args) {
     Identifier tableIdent = toIdentifier(args.getString(0), PARAMETERS[0].name());
-    // timestamps in Spark have nanosecond precision so this conversion is lossy
+    // timestamps in Spark have microsecond precision so this conversion is lossy
     long timestampMillis = DateTimeUtil.microsToMillis(args.getLong(1));
 
     return modifyIcebergTable(tableIdent, table -> {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/RollbackToTimestampProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/RollbackToTimestampProcedure.java
@@ -76,7 +76,7 @@ class RollbackToTimestampProcedure extends BaseProcedure {
   @Override
   public InternalRow[] call(InternalRow args) {
     Identifier tableIdent = toIdentifier(args.getString(0), PARAMETERS[0].name());
-    // timestamps in Spark have nanosecond precision so this conversion is lossy
+    // timestamps in Spark have microsecond precision so this conversion is lossy
     long timestampMillis = DateTimeUtil.microsToMillis(args.getLong(1));
 
     return modifyIcebergTable(tableIdent, table -> {


### PR DESCRIPTION
- Spark supports [microseconds precision](https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/types/TimestampType.scala#L26)  but in code we cast to milliseconds, so better to warn the users.
- Some code comment was wrong about spark precision. 
- Remove generic spark expressions for timestamp in expire_snapshots example (as it is not supported)