### PR TITLE
Core: Predicate pushdown for all_data_files table

### DIFF
--- a/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
@@ -81,14 +81,13 @@ public class AllDataFilesTable extends BaseFilesTable {
 
     @Override
     public CloseableIterable<FileScanTask> planFiles() {
-      return super.planAllFiles();
+      return super.planFilesAllSnapshots();
     }
 
     @Override
     protected CloseableIterable<ManifestFile> manifests() {
       try (CloseableIterable<ManifestFile> iterable = new ParallelIterable<>(
-          Iterables.transform(table().snapshots(),
-              snapshot -> (Iterable<ManifestFile>) () -> snapshot.dataManifests().iterator()),
+          Iterables.transform(table().snapshots(), snapshot -> () -> snapshot.dataManifests().iterator()),
           context().planExecutor())) {
         return CloseableIterable.withNoopClose(Sets.newHashSet(iterable));
       } catch (IOException e) {

--- a/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
@@ -65,11 +65,6 @@ public class AllDataFilesTable extends BaseFilesTable {
     }
 
     @Override
-    public boolean allScan() {
-      return true;
-    }
-
-    @Override
     protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
       return new AllDataFilesTableScan(ops, table, schema, fileSchema(), context);
     }
@@ -82,6 +77,11 @@ public class AllDataFilesTable extends BaseFilesTable {
     @Override
     public TableScan asOfTime(long timestampMillis) {
       throw new UnsupportedOperationException("Cannot select snapshot: all_data_files is for all snapshots");
+    }
+
+    @Override
+    public CloseableIterable<FileScanTask> planFiles() {
+      return super.planAllFiles();
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
@@ -80,6 +80,11 @@ public class AllDataFilesTable extends BaseFilesTable {
     }
 
     @Override
+    public CloseableIterable<FileScanTask> planFiles() {
+      return super.planAllFiles();
+    }
+
+    @Override
     protected CloseableIterable<ManifestFile> manifests() {
       try (CloseableIterable<ManifestFile> iterable = new ParallelIterable<>(
           Iterables.transform(table().snapshots(),

--- a/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
@@ -20,18 +20,10 @@
 package org.apache.iceberg;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.concurrent.ExecutorService;
-import org.apache.iceberg.BaseFilesTable.ManifestReadTask;
 import org.apache.iceberg.exceptions.RuntimeIOException;
-import org.apache.iceberg.expressions.Expression;
-import org.apache.iceberg.expressions.Expressions;
-import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
-import org.apache.iceberg.types.TypeUtil;
-import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.util.ParallelIterable;
 
 /**
@@ -41,7 +33,7 @@ import org.apache.iceberg.util.ParallelIterable;
  * <p>
  * This table may return duplicate rows.
  */
-public class AllDataFilesTable extends BaseMetadataTable {
+public class AllDataFilesTable extends BaseFilesTable {
 
   AllDataFilesTable(TableOperations ops, Table table) {
     this(ops, table, table.name() + ".all_data_files");
@@ -57,44 +49,24 @@ public class AllDataFilesTable extends BaseMetadataTable {
   }
 
   @Override
-  public Schema schema() {
-    StructType partitionType = Partitioning.partitionType(table());
-    Schema schema = new Schema(DataFile.getType(partitionType).fields());
-    if (partitionType.fields().size() < 1) {
-      // avoid returning an empty struct, which is not always supported. instead, drop the partition field (id 102)
-      return TypeUtil.selectNot(schema, Sets.newHashSet(102));
-    } else {
-      return schema;
-    }
-  }
-
-  @Override
   MetadataTableType metadataTableType() {
     return MetadataTableType.ALL_DATA_FILES;
   }
 
-  public static class AllDataFilesTableScan extends BaseAllMetadataTableScan {
-    private final Schema fileSchema;
+  public static class AllDataFilesTableScan extends BaseFilesTableScan {
 
     AllDataFilesTableScan(TableOperations ops, Table table, Schema fileSchema) {
-      super(ops, table, fileSchema);
-      this.fileSchema = fileSchema;
+      super(ops, table, fileSchema, MetadataTableType.ALL_DATA_FILES);
     }
 
     private AllDataFilesTableScan(TableOperations ops, Table table, Schema schema, Schema fileSchema,
                                   TableScanContext context) {
-      super(ops, table, schema, context);
-      this.fileSchema = fileSchema;
-    }
-
-    @Override
-    protected String tableType() {
-      return MetadataTableType.ALL_DATA_FILES.name();
+      super(ops, table, schema, fileSchema, context, MetadataTableType.ALL_DATA_FILES);
     }
 
     @Override
     protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
-      return new AllDataFilesTableScan(ops, table, schema, fileSchema, context);
+      return new AllDataFilesTableScan(ops, table, schema, fileSchema(), context);
     }
 
     @Override
@@ -108,30 +80,15 @@ public class AllDataFilesTable extends BaseMetadataTable {
     }
 
     @Override
-    protected CloseableIterable<FileScanTask> planFiles(
-        TableOperations ops, Snapshot snapshot, Expression rowFilter,
-        boolean ignoreResiduals, boolean caseSensitive, boolean colStats) {
-      CloseableIterable<ManifestFile> manifests = allDataManifestFiles(
-          ops.current().snapshots(), context().planExecutor());
-      String schemaString = SchemaParser.toJson(schema());
-      String specString = PartitionSpecParser.toJson(PartitionSpec.unpartitioned());
-      Expression filter = ignoreResiduals ? Expressions.alwaysTrue() : rowFilter;
-      ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(filter);
-
-      return CloseableIterable.transform(manifests, manifest ->
-          new ManifestReadTask(ops.io(), ops.current().specsById(), manifest, schema(),
-              schemaString, specString, residuals));
-    }
-  }
-
-  private static CloseableIterable<ManifestFile> allDataManifestFiles(
-      List<Snapshot> snapshots, ExecutorService workerPool) {
-    try (CloseableIterable<ManifestFile> iterable = new ParallelIterable<>(
-        Iterables.transform(snapshots, snapshot -> (Iterable<ManifestFile>) () -> snapshot.dataManifests().iterator()),
-        workerPool)) {
-      return CloseableIterable.withNoopClose(Sets.newHashSet(iterable));
-    } catch (IOException e) {
-      throw new RuntimeIOException(e, "Failed to close parallel iterable");
+    protected CloseableIterable<ManifestFile> manifests() {
+      try (CloseableIterable<ManifestFile> iterable = new ParallelIterable<>(
+          Iterables.transform(table().snapshots(),
+              snapshot -> (Iterable<ManifestFile>) () -> snapshot.dataManifests().iterator()),
+          context().planExecutor())) {
+        return CloseableIterable.withNoopClose(Sets.newHashSet(iterable));
+      } catch (IOException e) {
+        throw new RuntimeIOException(e, "Failed to close parallel iterable");
+      }
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
@@ -87,7 +87,8 @@ public class AllDataFilesTable extends BaseFilesTable {
     @Override
     protected CloseableIterable<ManifestFile> manifests() {
       try (CloseableIterable<ManifestFile> iterable = new ParallelIterable<>(
-          Iterables.transform(table().snapshots(), snapshot -> () -> snapshot.dataManifests().iterator()),
+          Iterables.transform(table().snapshots(),
+              snapshot -> (Iterable<ManifestFile>) () -> snapshot.dataManifests().iterator()),
           context().planExecutor())) {
         return CloseableIterable.withNoopClose(Sets.newHashSet(iterable));
       } catch (IOException e) {

--- a/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllDataFilesTable.java
@@ -65,6 +65,11 @@ public class AllDataFilesTable extends BaseFilesTable {
     }
 
     @Override
+    public boolean allScan() {
+      return true;
+    }
+
+    @Override
     protected TableScan newRefinedScan(TableOperations ops, Table table, Schema schema, TableScanContext context) {
       return new AllDataFilesTableScan(ops, table, schema, fileSchema(), context);
     }
@@ -77,11 +82,6 @@ public class AllDataFilesTable extends BaseFilesTable {
     @Override
     public TableScan asOfTime(long timestampMillis) {
       throw new UnsupportedOperationException("Cannot select snapshot: all_data_files is for all snapshots");
-    }
-
-    @Override
-    public CloseableIterable<FileScanTask> planFiles() {
-      return super.planAllFiles();
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
@@ -19,14 +19,9 @@
 
 package org.apache.iceberg;
 
-import org.apache.iceberg.events.Listeners;
-import org.apache.iceberg.events.ScanEvent;
 import org.apache.iceberg.io.CloseableIterable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 abstract class BaseAllMetadataTableScan extends BaseMetadataTableScan {
-  private static final Logger LOG = LoggerFactory.getLogger(BaseAllMetadataTableScan.class);
 
   BaseAllMetadataTableScan(TableOperations ops, Table table, Schema fileSchema) {
     super(ops, table, fileSchema);
@@ -58,9 +53,6 @@ abstract class BaseAllMetadataTableScan extends BaseMetadataTableScan {
 
   @Override
   public CloseableIterable<FileScanTask> planFiles() {
-    LOG.info("Scanning metadata table {} with filter {}.", table(), filter());
-    Listeners.notifyAll(new ScanEvent(table().name(), 0L, filter(), schema()));
-
-    return planFiles(tableOps(), snapshot(), filter(), shouldIgnoreResiduals(), isCaseSensitive(), colStats());
+    return super.planAllFiles();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
@@ -19,6 +19,8 @@
 
 package org.apache.iceberg;
 
+import org.apache.iceberg.io.CloseableIterable;
+
 abstract class BaseAllMetadataTableScan extends BaseMetadataTableScan {
 
   BaseAllMetadataTableScan(TableOperations ops, Table table, Schema fileSchema) {
@@ -50,7 +52,7 @@ abstract class BaseAllMetadataTableScan extends BaseMetadataTableScan {
   }
 
   @Override
-  protected boolean allScan() {
-    return true;
+  public CloseableIterable<FileScanTask> planFiles() {
+    return super.planAllFiles();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
@@ -53,6 +53,6 @@ abstract class BaseAllMetadataTableScan extends BaseMetadataTableScan {
 
   @Override
   public CloseableIterable<FileScanTask> planFiles() {
-    return super.planAllFiles();
+    return super.planFilesAllSnapshots();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
@@ -19,8 +19,6 @@
 
 package org.apache.iceberg;
 
-import org.apache.iceberg.io.CloseableIterable;
-
 abstract class BaseAllMetadataTableScan extends BaseMetadataTableScan {
 
   BaseAllMetadataTableScan(TableOperations ops, Table table, Schema fileSchema) {
@@ -52,7 +50,7 @@ abstract class BaseAllMetadataTableScan extends BaseMetadataTableScan {
   }
 
   @Override
-  public CloseableIterable<FileScanTask> planFiles() {
-    return super.planAllFiles();
+  protected boolean allScan() {
+    return true;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
@@ -20,8 +20,6 @@
 package org.apache.iceberg;
 
 import java.util.Map;
-import org.apache.iceberg.events.Listeners;
-import org.apache.iceberg.events.ScanEvent;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.ManifestEvaluator;
@@ -34,8 +32,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types.StructType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Base class logic for files metadata tables
@@ -59,7 +55,6 @@ abstract class BaseFilesTable extends BaseMetadataTable {
   }
 
   abstract static class BaseFilesTableScan extends BaseMetadataTableScan {
-    private static final Logger LOG = LoggerFactory.getLogger(BaseFilesTableScan.class);
 
     private final Schema fileSchema;
     private final MetadataTableType type;
@@ -91,18 +86,6 @@ abstract class BaseFilesTable extends BaseMetadataTable {
     public TableScan appendsAfter(long fromSnapshotId) {
       throw new UnsupportedOperationException(
           String.format("Cannot incrementally scan table of type %s", type.name()));
-    }
-
-    @Override
-    public CloseableIterable<FileScanTask> planFiles() {
-      if (type.equals(MetadataTableType.ALL_DATA_FILES)) {
-        LOG.info("Scanning metadata table {} with filter {}.", table(), filter());
-        Listeners.notifyAll(new ScanEvent(table().name(), 0L, filter(), schema()));
-
-        return planFiles(tableOps(), snapshot(), filter(), shouldIgnoreResiduals(), isCaseSensitive(), colStats());
-      } else {
-        return super.planFiles();
-      }
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
@@ -108,7 +108,7 @@ abstract class BaseFilesTable extends BaseMetadataTable {
     }
 
     /**
-     * @return list of manifest files to explore for this files metadata table scan
+     * @return iterable of manifest files to explore for this files metadata table scan
      */
     protected abstract CloseableIterable<ManifestFile> manifests();
 

--- a/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg;
 
-import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
@@ -110,13 +109,11 @@ abstract class BaseFilesTable extends BaseMetadataTable {
     /**
      * @return list of manifest files to explore for this files metadata table scan
      */
-    protected abstract List<ManifestFile> manifests();
+    protected abstract CloseableIterable<ManifestFile> manifests();
 
-    private CloseableIterable<ManifestFile> filterManifests(List<ManifestFile> manifests,
+    private CloseableIterable<ManifestFile> filterManifests(CloseableIterable<ManifestFile> manifests,
                                                             Expression rowFilter,
                                                             boolean caseSensitive) {
-      CloseableIterable<ManifestFile> manifestIterable = CloseableIterable.withNoopClose(manifests);
-
       // use an inclusive projection to remove the partition name prefix and filter out any non-partition expressions
       PartitionSpec spec = transformSpec(fileSchema, table().spec(), PARTITION_FIELD_PREFIX);
       Expression partitionFilter = Projections.inclusive(spec, caseSensitive).project(rowFilter);
@@ -124,7 +121,7 @@ abstract class BaseFilesTable extends BaseMetadataTable {
       ManifestEvaluator manifestEval = ManifestEvaluator.forPartitionFilter(
           partitionFilter, table().spec(), caseSensitive);
 
-      return CloseableIterable.filter(manifestIterable, manifestEval::eval);
+      return CloseableIterable.filter(manifests, manifestEval::eval);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
@@ -20,6 +20,8 @@
 package org.apache.iceberg;
 
 import java.util.Map;
+import org.apache.iceberg.events.Listeners;
+import org.apache.iceberg.events.ScanEvent;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.ManifestEvaluator;
@@ -32,6 +34,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types.StructType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Base class logic for files metadata tables
@@ -55,6 +59,8 @@ abstract class BaseFilesTable extends BaseMetadataTable {
   }
 
   abstract static class BaseFilesTableScan extends BaseMetadataTableScan {
+    private static final Logger LOG = LoggerFactory.getLogger(BaseFilesTableScan.class);
+
     private final Schema fileSchema;
     private final MetadataTableType type;
 
@@ -85,6 +91,18 @@ abstract class BaseFilesTable extends BaseMetadataTable {
     public TableScan appendsAfter(long fromSnapshotId) {
       throw new UnsupportedOperationException(
           String.format("Cannot incrementally scan table of type %s", type.name()));
+    }
+
+    @Override
+    public CloseableIterable<FileScanTask> planFiles() {
+      if (type.equals(MetadataTableType.ALL_DATA_FILES)) {
+        LOG.info("Scanning metadata table {} with filter {}.", table(), filter());
+        Listeners.notifyAll(new ScanEvent(table().name(), 0L, filter(), schema()));
+
+        return planFiles(tableOps(), snapshot(), filter(), shouldIgnoreResiduals(), isCaseSensitive(), colStats());
+      } else {
+        return super.planFiles();
+      }
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
@@ -90,7 +90,7 @@ abstract class BaseFilesTable extends BaseMetadataTable {
 
     @Override
     protected CloseableIterable<FileScanTask> planFiles(TableOperations ops, Snapshot snapshot, Expression rowFilter,
-        boolean ignoreResiduals, boolean caseSensitive, boolean colStats) {
+                                                        boolean ignoreResiduals, boolean caseSensitive, boolean colStats) {
       CloseableIterable<ManifestFile> filtered = filterManifests(manifests(), rowFilter, caseSensitive);
 
       String schemaString = SchemaParser.toJson(schema());
@@ -108,7 +108,7 @@ abstract class BaseFilesTable extends BaseMetadataTable {
     }
 
     /**
-     * @return list of manifest files to explore for this files metadata table scan
+     * Returns an iterable of manifest files to explore for this Files metadata table scan
      */
     protected abstract CloseableIterable<ManifestFile> manifests();
 

--- a/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
@@ -90,7 +90,8 @@ abstract class BaseFilesTable extends BaseMetadataTable {
 
     @Override
     protected CloseableIterable<FileScanTask> planFiles(TableOperations ops, Snapshot snapshot, Expression rowFilter,
-                                                        boolean ignoreResiduals, boolean caseSensitive, boolean colStats) {
+                                                        boolean ignoreResiduals, boolean caseSensitive,
+                                                        boolean colStats) {
       CloseableIterable<ManifestFile> filtered = filterManifests(manifests(), rowFilter, caseSensitive);
 
       String schemaString = SchemaParser.toJson(schema());

--- a/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
@@ -108,7 +108,7 @@ abstract class BaseFilesTable extends BaseMetadataTable {
     }
 
     /**
-     * @return iterable of manifest files to explore for this files metadata table scan
+     * @return list of manifest files to explore for this files metadata table scan
      */
     protected abstract CloseableIterable<ManifestFile> manifests();
 

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTableScan.java
@@ -46,9 +46,9 @@ abstract class BaseMetadataTableScan extends BaseTableScan {
   }
 
   /**
-   * Alternative to {@link #planFiles()}, allows exploring old snapshots even for empty table.
+   * Alternative to {@link #planFiles()}, allows exploring old snapshots even for an empty table.
    */
-  protected CloseableIterable<FileScanTask> planAllFiles() {
+  protected CloseableIterable<FileScanTask> planFilesAllSnapshots() {
     LOG.info("Scanning metadata table {} with filter {}.", table(), filter());
     Listeners.notifyAll(new ScanEvent(table().name(), 0L, filter(), schema()));
 

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTableScan.java
@@ -37,13 +37,6 @@ abstract class BaseMetadataTableScan extends BaseTableScan {
     super(ops, table, schema, context);
   }
 
-  /**
-   * @return if metadata table scan is for all snapshots, ie 'all_x' metadata tables
-   */
-  protected boolean allScan() {
-    return false;
-  }
-
   @Override
   public long targetSplitSize() {
     long tableValue = tableOps().current().propertyAsLong(
@@ -52,15 +45,13 @@ abstract class BaseMetadataTableScan extends BaseTableScan {
     return PropertyUtil.propertyAsLong(options(), TableProperties.SPLIT_SIZE, tableValue);
   }
 
-  @Override
-  public CloseableIterable<FileScanTask> planFiles() {
-    if (allScan()) { // Avoid returning early for empty tables
-      LOG.info("Scanning metadata table {} with filter {}.", table(), filter());
-      Listeners.notifyAll(new ScanEvent(table().name(), 0L, filter(), schema()));
+  /**
+   * Alternative to {@link #planFiles()}, allows exploring old snapshots even for empty table.
+   */
+  protected CloseableIterable<FileScanTask> planAllFiles() {
+    LOG.info("Scanning metadata table {} with filter {}.", table(), filter());
+    Listeners.notifyAll(new ScanEvent(table().name(), 0L, filter(), schema()));
 
-      return planFiles(tableOps(), snapshot(), filter(), shouldIgnoreResiduals(), isCaseSensitive(), colStats());
-    } else {
-      return super.planFiles();
-    }
+    return planFiles(tableOps(), snapshot(), filter(), shouldIgnoreResiduals(), isCaseSensitive(), colStats());
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTableScan.java
@@ -19,9 +19,15 @@
 
 package org.apache.iceberg;
 
+import org.apache.iceberg.events.Listeners;
+import org.apache.iceberg.events.ScanEvent;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.util.PropertyUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 abstract class BaseMetadataTableScan extends BaseTableScan {
+  private static final Logger LOG = LoggerFactory.getLogger(BaseMetadataTableScan.class);
 
   protected BaseMetadataTableScan(TableOperations ops, Table table, Schema schema) {
     super(ops, table, schema);
@@ -37,5 +43,15 @@ abstract class BaseMetadataTableScan extends BaseTableScan {
         TableProperties.METADATA_SPLIT_SIZE,
         TableProperties.METADATA_SPLIT_SIZE_DEFAULT);
     return PropertyUtil.propertyAsLong(options(), TableProperties.SPLIT_SIZE, tableValue);
+  }
+
+  /**
+   * Alternative to {@link #planFiles()}, allows exploring old snapshots even for empty table.
+   */
+  protected CloseableIterable<FileScanTask> planAllFiles() {
+    LOG.info("Scanning metadata table {} with filter {}.", table(), filter());
+    Listeners.notifyAll(new ScanEvent(table().name(), 0L, filter(), schema()));
+
+    return planFiles(tableOps(), snapshot(), filter(), shouldIgnoreResiduals(), isCaseSensitive(), colStats());
   }
 }

--- a/core/src/main/java/org/apache/iceberg/DataFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DataFilesTable.java
@@ -19,7 +19,7 @@
 
 package org.apache.iceberg;
 
-import java.util.List;
+import org.apache.iceberg.io.CloseableIterable;
 
 /**
  * A {@link Table} implementation that exposes a table's data files as rows.
@@ -60,8 +60,8 @@ public class DataFilesTable extends BaseFilesTable {
     }
 
     @Override
-    protected List<ManifestFile> manifests() {
-      return snapshot().dataManifests();
+    protected CloseableIterable<ManifestFile> manifests() {
+      return CloseableIterable.withNoopClose(snapshot().dataManifests());
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/DeleteFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFilesTable.java
@@ -19,7 +19,7 @@
 
 package org.apache.iceberg;
 
-import java.util.List;
+import org.apache.iceberg.io.CloseableIterable;
 
 /**
  * A {@link Table} implementation that exposes a table's delete files as rows.
@@ -60,8 +60,8 @@ public class DeleteFilesTable extends BaseFilesTable {
     }
 
     @Override
-    protected List<ManifestFile> manifests() {
-      return snapshot().deleteManifests();
+    protected CloseableIterable<ManifestFile> manifests() {
+      return CloseableIterable.withNoopClose(snapshot().deleteManifests());
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/FilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/FilesTable.java
@@ -19,7 +19,7 @@
 
 package org.apache.iceberg;
 
-import java.util.List;
+import org.apache.iceberg.io.CloseableIterable;
 
 /**
  * A {@link Table} implementation that exposes a table's files as rows.
@@ -60,8 +60,8 @@ public class FilesTable extends BaseFilesTable {
     }
 
     @Override
-    protected List<ManifestFile> manifests() {
-      return snapshot().allManifests();
+    protected CloseableIterable<ManifestFile> manifests() {
+      return CloseableIterable.withNoopClose(snapshot().allManifests());
     }
   }
 }

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
@@ -200,7 +200,7 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
 
     Table table = Spark3Util.loadIcebergTable(spark, tableName);
     List<ManifestFile> expectedDataManifests = TestHelpers.dataManifests(table);
-    Assert.assertEquals("Should have 2 data files", 1, expectedDataManifests.size());
+    Assert.assertEquals("Should have 1 data manifest", 1, expectedDataManifests.size());
 
     // Clear table to test whether 'all_files' can read past files
     List<Object[]> results = sql("DELETE FROM %s", tableName);
@@ -248,7 +248,7 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
 
     Table table = Spark3Util.loadIcebergTable(spark, tableName);
     List<ManifestFile> expectedDataManifests = TestHelpers.dataManifests(table);
-    Assert.assertEquals("Should have 2 data files", 2, expectedDataManifests.size());
+    Assert.assertEquals("Should have 2 data manifests", 2, expectedDataManifests.size());
 
     // Clear table to test whether 'all_files' can read past files
     List<Object[]> results = sql("DELETE FROM %s", tableName);

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
@@ -130,7 +130,7 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     List<SimpleRecord> recordsB = Lists.newArrayList(
         new SimpleRecord(1, "b"),
         new SimpleRecord(2, "b")
-        );
+    );
     spark.createDataset(recordsB, Encoders.bean(SimpleRecord.class))
         .coalesce(1)
         .writeTo(tableName)
@@ -179,6 +179,94 @@ public class TestMetadataTables extends SparkExtensionsTestBase {
     Assert.assertEquals("Metadata table should return two files", 2, actualFiles.size());
     TestHelpers.assertEqualsSafe(filesTableSchema.asStruct(), expectedFiles.get(0), actualFiles.get(0));
     TestHelpers.assertEqualsSafe(filesTableSchema.asStruct(), expectedFiles.get(1), actualFiles.get(1));
+  }
+
+  @Test
+  public void testAllFiles() throws Exception {
+    sql("CREATE TABLE %s (id bigint, data string) USING iceberg TBLPROPERTIES" +
+        "('format-version'='2', 'write.delete.mode'='merge-on-read')", tableName);
+
+    List<SimpleRecord> records = Lists.newArrayList(
+        new SimpleRecord(1, "a"),
+        new SimpleRecord(2, "b"),
+        new SimpleRecord(3, "c"),
+        new SimpleRecord(4, "d")
+    );
+    spark.createDataset(records, Encoders.bean(SimpleRecord.class))
+        .coalesce(1)
+        .writeTo(tableName)
+        .append();
+
+
+    Table table = Spark3Util.loadIcebergTable(spark, tableName);
+    List<ManifestFile> expectedDataManifests = TestHelpers.dataManifests(table);
+    Assert.assertEquals("Should have 2 data files", 1, expectedDataManifests.size());
+
+    // Clear table to test whether 'all_files' can read past files
+    List<Object[]> results = sql("DELETE FROM %s", tableName);
+    Assert.assertEquals("Table should be cleared", 0, results.size());
+
+    Schema entriesTableSchema = Spark3Util.loadIcebergTable(spark, tableName + ".entries").schema();
+    Schema filesTableSchema = Spark3Util.loadIcebergTable(spark, tableName + ".all_data_files").schema();
+
+    List<Row> actualDataFiles = spark.sql("SELECT * FROM " + tableName + ".all_data_files").collectAsList();
+
+    List<Record> expectedDataFiles = expectedEntries(table, FileContent.DATA,
+        entriesTableSchema, expectedDataManifests, null);
+
+    Assert.assertEquals("Should be one data file manifest entry", 1, expectedDataFiles.size());
+    Assert.assertEquals("Metadata table should return one data file", 1, actualDataFiles.size());
+
+    TestHelpers.assertEqualsSafe(filesTableSchema.asStruct(), expectedDataFiles.get(0), actualDataFiles.get(0));
+  }
+
+  @Test
+  public void testAllFilesPartitioned() throws Exception {
+    sql("CREATE TABLE %s (id bigint, data string) " +
+        "USING iceberg " +
+        "PARTITIONED BY (data) " +
+        "TBLPROPERTIES" +
+        "('format-version'='2', 'write.delete.mode'='merge-on-read')", tableName);
+
+    List<SimpleRecord> recordsA = Lists.newArrayList(
+        new SimpleRecord(1, "a"),
+        new SimpleRecord(2, "a")
+    );
+    spark.createDataset(recordsA, Encoders.bean(SimpleRecord.class))
+        .coalesce(1)
+        .writeTo(tableName)
+        .append();
+
+    List<SimpleRecord> recordsB = Lists.newArrayList(
+        new SimpleRecord(1, "b"),
+        new SimpleRecord(2, "b")
+    );
+    spark.createDataset(recordsB, Encoders.bean(SimpleRecord.class))
+        .coalesce(1)
+        .writeTo(tableName)
+        .append();
+
+    Table table = Spark3Util.loadIcebergTable(spark, tableName);
+    List<ManifestFile> expectedDataManifests = TestHelpers.dataManifests(table);
+    Assert.assertEquals("Should have 2 data files", 2, expectedDataManifests.size());
+
+    // Clear table to test whether 'all_files' can read past files
+    List<Object[]> results = sql("DELETE FROM %s", tableName);
+    Assert.assertEquals("Table should be cleared", 0, results.size());
+
+    List<Row> actualDataFiles = spark.sql("SELECT * FROM " + tableName + ".all_data_files " +
+        "WHERE partition.data='a'").collectAsList();
+
+    Schema entriesTableSchema = Spark3Util.loadIcebergTable(spark, tableName + ".entries").schema();
+    Schema filesTableSchema = Spark3Util.loadIcebergTable(spark, tableName + ".all_data_files").schema();
+
+    List<Record> expectedDataFiles = expectedEntries(table, FileContent.DATA,
+        entriesTableSchema, expectedDataManifests, "a");
+
+    Assert.assertEquals("Should be one data file manifest entry", 1, expectedDataFiles.size());
+    Assert.assertEquals("Metadata table should return one data file", 1, actualDataFiles.size());
+
+    TestHelpers.assertEqualsSafe(filesTableSchema.asStruct(), expectedDataFiles.get(0), actualDataFiles.get(0));
   }
 
   /**


### PR DESCRIPTION
This adopts all_data_files table on new base class added in #4139 , which will allow it predicate-push-down for partition predicates.

Change the base class  manifests() method slightly from List to Iterable, to support the original ParallelIterable of the AllDataFilesTable.

Inherit some WAP (staging snapshot) handling from BaseAllMetadataTableScan.