### PR TITLE
Remove magic number usage for last assigned partition id

### DIFF
--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -304,7 +304,7 @@ public class PartitionSpec implements Serializable {
   }
 
   private static final PartitionSpec UNPARTITIONED_SPEC =
-      new PartitionSpec(new Schema(), 0, ImmutableList.of(), PARTITION_DATA_ID_START - 1);
+      new PartitionSpec(new Schema(), 0, ImmutableList.of(), unpartitionedLastAssignedId());
 
   /**
    * Returns a spec for unpartitioned tables.
@@ -313,6 +313,10 @@ public class PartitionSpec implements Serializable {
    */
   public static PartitionSpec unpartitioned() {
     return UNPARTITIONED_SPEC;
+  }
+
+  private static int unpartitionedLastAssignedId() {
+    return PARTITION_DATA_ID_START - 1;
   }
 
   /**
@@ -336,7 +340,7 @@ public class PartitionSpec implements Serializable {
     private final Set<String> partitionNames = Sets.newHashSet();
     private Map<Map.Entry<Integer, String>, PartitionField> dedupFields = Maps.newHashMap();
     private int specId = 0;
-    private final AtomicInteger lastAssignedFieldId = new AtomicInteger(PARTITION_DATA_ID_START - 1);
+    private final AtomicInteger lastAssignedFieldId = new AtomicInteger(unpartitionedLastAssignedId());
     // check if there are conflicts between partition and schema field name
     private boolean checkConflicts = true;
 

--- a/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
+++ b/core/src/main/java/org/apache/iceberg/BaseUpdatePartitionSpec.java
@@ -84,7 +84,7 @@ class BaseUpdatePartitionSpec implements UpdatePartitionSpec {
    */
   @VisibleForTesting
   BaseUpdatePartitionSpec(int formatVersion, PartitionSpec spec) {
-    this(formatVersion, spec, spec.fields().stream().mapToInt(PartitionField::fieldId).max().orElse(999));
+    this(formatVersion, spec, spec.lastAssignedFieldId());
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -386,7 +386,8 @@ public class TableMetadataParser {
     if (lastAssignedPartitionId == null) {
       Preconditions.checkArgument(formatVersion == 1,
           "%s must exist in format v%s", LAST_PARTITION_ID, formatVersion);
-      lastAssignedPartitionId = specs.stream().mapToInt(PartitionSpec::lastAssignedFieldId).max().orElse(999);
+      lastAssignedPartitionId = specs.stream().mapToInt(PartitionSpec::lastAssignedFieldId).max()
+          .orElse(PartitionSpec.unpartitioned().lastAssignedFieldId());
     }
 
     // parse the sort orders


### PR DESCRIPTION
While reading code about partition spec, i find some usages of magic number 999 which should be `PARTITION_DATA_ID_START - 1` i think. Fix me if i misunderstand.

@rdblue would you help to review if you have time?