### PR TITLE
Core: InvalidateTable in CachingCatalog should invoke InvalidateTable on the wrapped catalog too.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -164,22 +164,19 @@ public class CachingCatalog implements Catalog {
   @Override
   public boolean dropTable(TableIdentifier ident, boolean purge) {
     boolean dropped = catalog.dropTable(ident, purge);
-    invalidate(ident);
+    invalidateTable(ident);
     return dropped;
   }
 
   @Override
   public void renameTable(TableIdentifier from, TableIdentifier to) {
     catalog.renameTable(from, to);
-    invalidate(from);
+    invalidateTable(from);
   }
 
   @Override
   public void invalidateTable(TableIdentifier ident) {
-    invalidate(ident);
-  }
-
-  private void invalidate(TableIdentifier ident) {
+    catalog.invalidateTable(ident);
     TableIdentifier canonicalized = canonicalizeIdentifier(ident);
     tableCache.invalidate(canonicalized);
     tableCache.invalidateAll(metadataTableIdentifiers(canonicalized));
@@ -270,7 +267,7 @@ public class CachingCatalog implements Catalog {
       // committed. when the transaction commits, invalidate the table in the cache if it is present.
       return CommitCallbackTransaction.addCallback(
           innerBuilder.replaceTransaction(),
-          () -> invalidate(ident));
+          () -> invalidateTable(ident));
     }
 
     @Override
@@ -279,7 +276,7 @@ public class CachingCatalog implements Catalog {
       // committed. when the transaction commits, invalidate the table in the cache if it is present.
       return CommitCallbackTransaction.addCallback(
           innerBuilder.createOrReplaceTransaction(),
-          () -> invalidate(ident));
+          () -> invalidateTable(ident));
     }
   }
 }


### PR DESCRIPTION
When there is a chain of catalogs with one catalog wrapped inside the other, then the missing catalog.invalidateTable
call can prevent a table from being invalidated. In case the wrapped catalog is a CachingCatalog, then this prevents the table to be removed from the cache. We need to call catalog.invalidateTable() so that the call can recurse to invoke invalidateTable on all the chained catalogs. 