### PR TITLE
Docs: Fix broken javadoc link for RewriteManifests

### DIFF
--- a/docs/spark/spark-procedures.md
+++ b/docs/spark/spark-procedures.md
@@ -312,7 +312,7 @@ Rewrite manifests for a table to optimize scan planning.
 
 Data files in manifests are sorted by fields in the partition spec. This procedure runs in parallel using a Spark job.
 
-See the [`RewriteManifestsAction` Javadoc](../../../javadoc/{{% icebergVersion %}}/org/apache/iceberg/actions/RewriteManifestsAction.html)
+See the [`RewriteManifests` Javadoc](../../../javadoc/{{% icebergVersion %}}/org/apache/iceberg/actions/RewriteManifests.html)
 to see more configuration options.
 
 {{< hint info >}}


### PR DESCRIPTION
Fix broken javadoc link for RewriteManifests in the docs. 

previous link: https://iceberg.apache.org/javadoc/0.13.1/org/apache/iceberg/actions/RewriteManifestsAction.html
new link: https://iceberg.apache.org/javadoc/0.13.1/org/apache/iceberg/actions/RewriteManifests.html