### PR TITLE
Docs : add s3 access-point documentation

### DIFF
--- a/docs/integrations/aws.md
+++ b/docs/integrations/aws.md
@@ -438,7 +438,7 @@ For more details on tag restrictions, please refer [User-Defined Tag Restriction
 ### S3 Access Points
 
 [Access Points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html) can be used for operating
-s3 objects from the specified bucket, against which access-point was mapped. This is useful for multi-region access,
+s3 objects from the specified bucket, against which access-point was mapped. This is useful for multi-region access, cross-region access,
 disaster recovery, etc.
 
 For example, to use S3 access-point with Spark 3.0, you can start the Spark SQL shell with:
@@ -447,9 +447,10 @@ spark-sql --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCata
     --conf spark.sql.catalog.my_catalog.warehouse=s3://my-bucket/my/key/prefix \
     --conf spark.sql.catalog.my_catalog.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog \
     --conf spark.sql.catalog.my_catalog.io-impl=org.apache.iceberg.aws.s3.S3FileIO \
-    --conf spark.sql.catalog.test.s3.access-points.my-bucket=arn:aws:s3::123456789012:accesspoint:mfzwi23gnjvgw.mrap
+    --conf spark.sql.catalog.test.s3.access-points.my-bucket1=arn:aws:s3::123456789012:accesspoint:mfzwi23gnjvgw.mrap \
+    --conf spark.sql.catalog.test.s3.access-points.my-bucket2=arn:aws:s3::123456789012:accesspoint:mfzwi23gnjvgw.mrap
 ```
-For the above example, the objects in S3 on `my-bucket` bucket will use `arn:aws:s3::123456789012:accesspoint:mfzwi23gnjvgw.mrap`
+For the above example, the objects in S3 on `my-bucket1` and `my-bucket2` buckets will use `arn:aws:s3::123456789012:accesspoint:mfzwi23gnjvgw.mrap`
 access-point for all S3 operations.
 
 For more details on using access-points, please refer [Using access points with compatible Amazon S3 operations](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-points-usage-examples.html).

--- a/docs/integrations/aws.md
+++ b/docs/integrations/aws.md
@@ -437,9 +437,12 @@ For more details on tag restrictions, please refer [User-Defined Tag Restriction
 
 ### S3 Access Points
 
-[Access Points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html) can be used for operating
-S3 objects from the specified bucket, against which access-point was mapped. This is useful for multi-region access, cross-region access,
+[Access Points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html) can be used to perform 
+S3 operations by specifying a mapping of bucket to access points. This is useful for multi-region access, cross-region access,
 disaster recovery, etc.
+
+For using cross-region access points, we need to additionally set `use-arn-region-enabled` catalog property to
+`true` to enable `S3FileIO` to make cross-region calls, it's not required for same / multi-region access points.
 
 For example, to use S3 access-point with Spark 3.0, you can start the Spark SQL shell with:
 ```
@@ -447,6 +450,7 @@ spark-sql --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCata
     --conf spark.sql.catalog.my_catalog.warehouse=s3://my-bucket2/my/key/prefix \
     --conf spark.sql.catalog.my_catalog.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog \
     --conf spark.sql.catalog.my_catalog.io-impl=org.apache.iceberg.aws.s3.S3FileIO \
+    --conf spark.sql.catalog.my_catalog.s3.use-arn-region-enabled=false \
     --conf spark.sql.catalog.test.s3.access-points.my-bucket1=arn:aws:s3::123456789012:accesspoint:mfzwi23gnjvgw.mrap \
     --conf spark.sql.catalog.test.s3.access-points.my-bucket2=arn:aws:s3::123456789012:accesspoint:mfzwi23gnjvgw.mrap
 ```

--- a/docs/integrations/aws.md
+++ b/docs/integrations/aws.md
@@ -438,13 +438,13 @@ For more details on tag restrictions, please refer [User-Defined Tag Restriction
 ### S3 Access Points
 
 [Access Points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html) can be used for operating
-s3 objects from the specified bucket, against which access-point was mapped. This is useful for multi-region access, cross-region access,
+S3 objects from the specified bucket, against which access-point was mapped. This is useful for multi-region access, cross-region access,
 disaster recovery, etc.
 
 For example, to use S3 access-point with Spark 3.0, you can start the Spark SQL shell with:
 ```
 spark-sql --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCatalog \
-    --conf spark.sql.catalog.my_catalog.warehouse=s3://my-bucket/my/key/prefix \
+    --conf spark.sql.catalog.my_catalog.warehouse=s3://my-bucket2/my/key/prefix \
     --conf spark.sql.catalog.my_catalog.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog \
     --conf spark.sql.catalog.my_catalog.io-impl=org.apache.iceberg.aws.s3.S3FileIO \
     --conf spark.sql.catalog.test.s3.access-points.my-bucket1=arn:aws:s3::123456789012:accesspoint:mfzwi23gnjvgw.mrap \

--- a/docs/integrations/aws.md
+++ b/docs/integrations/aws.md
@@ -435,6 +435,23 @@ For the above example, the objects in S3 will be saved with tags: `my_key1=my_va
 
 For more details on tag restrictions, please refer [User-Defined Tag Restrictions](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/allocation-tag-restrictions.html).
 
+### S3 AccessPoints
+
+[AccessPoints](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html) can be used for operating
+s3 objects from the specified bucket, against which access-point was mapped.
+For example, to use S3 access-point with Spark 3.0, you can start the Spark SQL shell with:
+```
+spark-sql --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCatalog \
+    --conf spark.sql.catalog.my_catalog.warehouse=s3://my-bucket/my/key/prefix \
+    --conf spark.sql.catalog.my_catalog.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog \
+    --conf spark.sql.catalog.my_catalog.io-impl=org.apache.iceberg.aws.s3.S3FileIO \
+    --conf spark.sql.catalog.test.s3.access-points.my-bucket=arn:aws:s3::123456789012:accesspoint:mfzwi23gnjvgw.mrap
+```
+For the above example, the objects in S3 on `my-bucket` bucket will use `arn:aws:s3::123456789012:accesspoint:mfzwi23gnjvgw.mrap`
+access-point for all S3 operations.
+
+For more details on using access-points, please refer [Using access points with compatible Amazon S3 operations](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-points-usage-examples.html).
+
 ## AWS Client Customization
 
 Many organizations have customized their way of configuring AWS clients with their own credential provider, access proxy, retry strategy, etc.

--- a/docs/integrations/aws.md
+++ b/docs/integrations/aws.md
@@ -435,10 +435,12 @@ For the above example, the objects in S3 will be saved with tags: `my_key1=my_va
 
 For more details on tag restrictions, please refer [User-Defined Tag Restrictions](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/allocation-tag-restrictions.html).
 
-### S3 AccessPoints
+### S3 Access Points
 
-[AccessPoints](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html) can be used for operating
-s3 objects from the specified bucket, against which access-point was mapped.
+[Access Points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-access-points.html) can be used for operating
+s3 objects from the specified bucket, against which access-point was mapped. This is useful for multi-region access,
+disaster recovery, etc.
+
 For example, to use S3 access-point with Spark 3.0, you can start the Spark SQL shell with:
 ```
 spark-sql --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCatalog \


### PR DESCRIPTION
Adds documentation for using s3 access-points : 
 - Introduced in https://github.com/apache/iceberg/pull/4334

slack thread : https://apache-iceberg.slack.com/archives/C025PH0G1D4/p1645066803099319


----
cc @rdblue, @jackye1995, @rajarshisarkar, @anuragmantri