### PR TITLE
Spark - Ignore SQL comments when testing if SQL command is an Iceberg specific command

### DIFF
--- a/spark/v3.2/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
+++ b/spark/v3.2/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
@@ -177,7 +177,8 @@ class IcebergSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserI
 
   private def isIcebergCommand(sqlText: String): Boolean = {
     val normalized = sqlText.toLowerCase(Locale.ROOT).trim()
-      // Catch all SQL comments, including simple comments (that start with --), as well as multiline comments
+      // Catch all SQL comments, including simple comments (that start with --), as well as comments
+      // of the form /* ... */, including those that span multiple lines.
       .replaceAll("(?ms)/\\*.*?\\*/|--.*?\\n", " ")
       // Replace any remaining newlines
       .replaceAll("\\s+", " ")

--- a/spark/v3.2/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
+++ b/spark/v3.2/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
@@ -177,15 +177,10 @@ class IcebergSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserI
 
   private def isIcebergCommand(sqlText: String): Boolean = {
     val normalized = sqlText.toLowerCase(Locale.ROOT).trim()
-//      .replaceAll("\\s+", " ")
-//      .replaceAll("(?m)^--.*$", "") // replace all simple single line SQL comments
-//      .replaceAll("/\\*.*?\\*/", "") // replace bracketed SQL comments
       // Catch all SQL comments, including simple comments (that start with --), as well as multiline comments
       .replaceAll("(?ms)/\\*.*?\\*/|--.*?\\n", " ")
-      // replace new lines - needed for getting multiline comments that have SQL text after them
-      .replaceAll("\\s+", " ") // replace new lines - needed for getting multiline comments
-//      .replaceAll("/\\*.*?\\*/", "") // replace bracketed SQL comments
-      .replaceAll("\\s+", " ") // replace newlines
+      // Replace any remaining newlines
+      .replaceAll("\\s+", " ")
       .trim()
     normalized.startsWith("call") || (
         normalized.startsWith("alter table") && (

--- a/spark/v3.2/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
+++ b/spark/v3.2/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
@@ -177,11 +177,13 @@ class IcebergSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserI
 
   private def isIcebergCommand(sqlText: String): Boolean = {
     val normalized = sqlText.toLowerCase(Locale.ROOT).trim()
-      // Catch all SQL comments, including simple comments (that start with --), as well as comments
-      // of the form /* ... */, including those that span multiple lines.
-      .replaceAll("(?ms)/\\*.*?\\*/|--.*?\\n", " ")
-      // Replace any remaining newlines
+      // Strip simple SQL comments that terminate a line, e.g. comments starting with `--` .
+      .replaceAll("--.*?\\n", " ")
+      // Strip newlines.
       .replaceAll("\\s+", " ")
+      // Strip comments of the form  /* ... */. This must come after stripping newlines so that
+      // comments that span multiple lines are caught.
+      .replaceAll("/\\*.*?\\*/", " ")
       .trim()
     normalized.startsWith("call") || (
         normalized.startsWith("alter table") && (

--- a/spark/v3.2/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
+++ b/spark/v3.2/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
@@ -176,7 +176,17 @@ class IcebergSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserI
   }
 
   private def isIcebergCommand(sqlText: String): Boolean = {
-    val normalized = sqlText.toLowerCase(Locale.ROOT).trim().replaceAll("\\s+", " ")
+    val normalized = sqlText.toLowerCase(Locale.ROOT).trim()
+//      .replaceAll("\\s+", " ")
+//      .replaceAll("(?m)^--.*$", "") // replace all simple single line SQL comments
+//      .replaceAll("/\\*.*?\\*/", "") // replace bracketed SQL comments
+      // Catch all SQL comments, including simple comments (that start with --), as well as multiline comments
+      .replaceAll("(?ms)/\\*.*?\\*/|--.*?\\n", " ")
+      // replace new lines - needed for getting multiline comments that have SQL text after them
+      .replaceAll("\\s+", " ") // replace new lines - needed for getting multiline comments
+//      .replaceAll("/\\*.*?\\*/", "") // replace bracketed SQL comments
+      .replaceAll("\\s+", " ") // replace newlines
+      .trim()
     normalized.startsWith("call") || (
         normalized.startsWith("alter table") && (
             normalized.contains("add partition field") ||

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
@@ -22,8 +22,10 @@ package org.apache.iceberg.spark.extensions;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.List;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.expressions.Expression;
 import org.apache.spark.sql.catalyst.expressions.Literal;
@@ -135,6 +137,28 @@ public class TestCallStatementParser {
     AssertHelpers.assertThrows("Should fail with a sensible parse error", IcebergParseException.class,
         "missing '(' at 'radish'",
         () -> parser.parsePlan("CALL cat.system radish kebab"));
+  }
+
+  @Test
+  public void testCallStripsLeadingBracketedComments() throws ParseException {
+    // These comments are meant to look like those that dbt would add to statements.
+    List<String> callStatementsWithComments = Lists.newArrayList(
+        "/* bracketed comment */  CALL cat.system.func('${spark.extra.prop}')",
+        "/**/  CALL cat.system.func('${spark.extra.prop}')",
+        "-- single line comment \n CALL cat.system.func('${spark.extra.prop}')",
+        "-- multiple \n-- single line \n-- comments \n CALL cat.system.func('${spark.extra.prop}')",
+        "/* select * from multiline_comment \n where x like '%sql%'; */ CALL cat.system.func('${spark.extra.prop}')",
+        "/* {\"app\": \"dbt\", \"dbt_version\": \"1.0.1\", \"profile_name\": \"profile1\", \"target_name\": \"dev\", " +
+            "\"node_id\": \"model.profile1.stg_users\"} \n*/ CALL cat.system.func('${spark.extra.prop}')"
+    );
+    for (String sqlText : callStatementsWithComments) {
+      CallStatement call = (CallStatement) parser.parsePlan(sqlText);
+      Assert.assertEquals(ImmutableList.of("cat", "system", "func"), JavaConverters.seqAsJavaList(call.name()));
+
+      Assert.assertEquals(1, call.args().size());
+
+      checkArg(call, 0, "value", DataTypes.StringType);
+    }
   }
 
   private void checkArg(CallStatement call, int index, Object expectedValue, DataType expectedType) {

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
@@ -150,7 +150,9 @@ public class TestCallStatementParser {
         "/* {\"app\": \"dbt\", \"dbt_version\": \"1.0.1\", \"profile_name\": \"profile1\", \"target_name\": \"dev\", " +
             "\"node_id\": \"model.profile1.stg_users\"} \n*/ CALL cat.system.func('${spark.extra.prop}')",
         "/* Some multi-line comment \n" +
-            "*/ CALL /* inline comment */ cat.system.func('${spark.extra.prop}') -- ending comment"
+            "*/ CALL /* inline comment */ cat.system.func('${spark.extra.prop}') -- ending comment",
+        "CALL -- a line ending comment\n" +
+            "cat.system.func('${spark.extra.prop}')"
     );
     for (String sqlText : callStatementsWithComments) {
       CallStatement call = (CallStatement) parser.parsePlan(sqlText);

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
@@ -140,8 +140,7 @@ public class TestCallStatementParser {
   }
 
   @Test
-  public void testCallStripsLeadingComments() throws ParseException {
-    // These comments are meant to look like those that systems like DBT would add to statements.
+  public void testCallStripsComments() throws ParseException {
     List<String> callStatementsWithComments = Lists.newArrayList(
         "/* bracketed comment */  CALL cat.system.func('${spark.extra.prop}')",
         "/**/  CALL cat.system.func('${spark.extra.prop}')",
@@ -149,7 +148,9 @@ public class TestCallStatementParser {
         "-- multiple \n-- single line \n-- comments \n CALL cat.system.func('${spark.extra.prop}')",
         "/* select * from multiline_comment \n where x like '%sql%'; */ CALL cat.system.func('${spark.extra.prop}')",
         "/* {\"app\": \"dbt\", \"dbt_version\": \"1.0.1\", \"profile_name\": \"profile1\", \"target_name\": \"dev\", " +
-            "\"node_id\": \"model.profile1.stg_users\"} \n*/ CALL cat.system.func('${spark.extra.prop}')"
+            "\"node_id\": \"model.profile1.stg_users\"} \n*/ CALL cat.system.func('${spark.extra.prop}')",
+        "/* Some multi-line comment \n" +
+            "*/ CALL /* inline comment */ cat.system.func('${spark.extra.prop}') -- ending comment"
     );
     for (String sqlText : callStatementsWithComments) {
       CallStatement call = (CallStatement) parser.parsePlan(sqlText);

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCallStatementParser.java
@@ -140,8 +140,8 @@ public class TestCallStatementParser {
   }
 
   @Test
-  public void testCallStripsLeadingBracketedComments() throws ParseException {
-    // These comments are meant to look like those that dbt would add to statements.
+  public void testCallStripsLeadingComments() throws ParseException {
+    // These comments are meant to look like those that systems like DBT would add to statements.
     List<String> callStatementsWithComments = Lists.newArrayList(
         "/* bracketed comment */  CALL cat.system.func('${spark.extra.prop}')",
         "/**/  CALL cat.system.func('${spark.extra.prop}')",

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
@@ -308,4 +308,39 @@ public class TestExpireSnapshotsProcedure extends SparkExtensionsTestBase {
         catalogName, currentTimestamp, tableIdent);
     assertEquals("Procedure output must match", ImmutableList.of(row(0L, 0L, 1L)), output);
   }
+
+  @Test
+  public void testExpireSnapshotsProcedureWorksWithSqlComments() {
+    // Ensure that systems such as dbt, that inject comments into the generated SQL files, will
+    // work with Iceberg-specific DDL
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Assert.assertEquals("Should be 2 snapshots", 2, Iterables.size(table.snapshots()));
+
+    waitUntilAfter(table.currentSnapshot().timestampMillis());
+
+    Timestamp currentTimestamp = Timestamp.from(Instant.ofEpochMilli(System.currentTimeMillis()));
+
+    String callStatement =
+        "/* CALL statement is used to expire snapshots */\n" +
+        "-- And we have single line comments as well \n" +
+        "CALL /* this is the actual CALL */ %s.system.expire_snapshots(" +
+        "   older_than => TIMESTAMP '%s'," +
+        "   table => '%s'," +
+        "   retain_last => 1)";
+    List<Object[]> output = sql(
+        callStatement, catalogName, currentTimestamp, tableIdent);
+    assertEquals("Procedure output must match",
+        ImmutableList.of(row(0L, 0L, 1L)),
+        output);
+
+    table.refresh();
+
+    Assert.assertEquals("Should be 1 snapshot remaining", 1, Iterables.size(table.snapshots()));
+  }
 }

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
@@ -329,7 +329,8 @@ public class TestExpireSnapshotsProcedure extends SparkExtensionsTestBase {
     String callStatement =
         "/* CALL statement is used to expire snapshots */\n" +
         "-- And we have single line comments as well \n" +
-        "CALL /* this is the actual CALL */ %s.system.expire_snapshots(" +
+        "/* And comments that span *multiple* \n" +
+        " lines */ CALL /* this is the actual CALL */ %s.system.expire_snapshots(" +
         "   older_than => TIMESTAMP '%s'," +
         "   table => '%s'," +
         "   retain_last => 1)";


### PR DESCRIPTION
This closes issue https://github.com/apache/iceberg/issues/4289

Currently, We ignore simple comments (those that start with `--`), as well as bracketed comments in our IcebergSqlExtensions ANTLR grammar.

However, we have a function `isIcebergCommand`, that checks if a command is an Iceberg command by checking if the string starts with specific phrases that match known Iceberg commands.

The sqlText has not yet been passed through the full ANTLR process, so we need to ignore comments manually, akin to ignoring new-lines in https://github.com/apache/iceberg/pull/2729

-------------------------------------------------

There might be a better way to handle this, but this does work for recognizing the Iceberg commands, while still allowing the antlr parser to remove comments, as it has special handling to ensure that SQL hints are _not_ stripped out.

So nothing about how the query is processed is changing, just how we determine whether or not this is Iceberg specific DDL.