### PR TITLE
Add support for listing partition recursively during the table migration

### DIFF
--- a/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
+++ b/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
@@ -53,6 +53,8 @@ import org.apache.iceberg.relocated.com.google.common.util.concurrent.ThreadFact
 import org.apache.iceberg.util.Tasks;
 
 public class TableMigrationUtil {
+  public static final String TABLE_MIGRATION_FILE_LISTING_RECURSIVE = "tableMigrationFileListingRecursive";
+
   private static final PathFilter HIDDEN_PATH_FILTER =
       p -> !p.getName().startsWith("_") && !p.getName().startsWith(".");
 
@@ -136,7 +138,8 @@ public class TableMigrationUtil {
     Path partition = new Path(partitionUri);
     FileSystem fs = partition.getFileSystem(conf);
     List<FileStatus> fileStatus = Lists.newArrayList();
-    RemoteIterator<LocatedFileStatus> iterators = fs.listFiles(partition, true);
+    boolean isRecursiveListing = conf.getBoolean(TABLE_MIGRATION_FILE_LISTING_RECURSIVE, false);
+    RemoteIterator<LocatedFileStatus> iterators = fs.listFiles(partition, isRecursiveListing);
     while (iterators.hasNext()) {
       LocatedFileStatus status = iterators.next();
       if (status.isFile() && HIDDEN_PATH_FILTER.accept(status.getPath())) {

--- a/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
+++ b/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.data;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +28,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.stream.Collectors;
+
+import org.apache.commons.compress.utils.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -135,7 +136,7 @@ public class TableMigrationUtil {
   private static List<FileStatus> listStatus(Configuration conf, String partitionUri) throws IOException {
     Path partition = new Path(partitionUri);
     FileSystem fs = partition.getFileSystem(conf);
-    List<FileStatus> fileStatus = new ArrayList<>();
+    List<FileStatus> fileStatus = Lists.newArrayList();
     RemoteIterator<LocatedFileStatus> iterators = fs.listFiles(partition, true);
     while (iterators.hasNext()) {
       LocatedFileStatus status = iterators.next();

--- a/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
+++ b/data/src/main/java/org/apache/iceberg/data/TableMigrationUtil.java
@@ -28,8 +28,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.stream.Collectors;
-
-import org.apache.commons.compress.utils.Lists;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -49,6 +47,7 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.orc.OrcMetrics;
 import org.apache.iceberg.parquet.ParquetUtil;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.iceberg.util.Tasks;


### PR DESCRIPTION
Data files that locate at the subdirectory in a Hive table's partition are invisible to Iceberg table migration. This diff solves that.

I have two questions:
1. I am thinking to make the recursive support turned off by default and make it configurable. What will be a good place to hold such config? Should this be a table property? or should this be an engine specific property?
2. should we add a unit test for this? if so, where I should add to. thanks.