### PR TITLE
There is no 'key_metadata' field in manifest_file, so delete it

### DIFF
--- a/core/src/main/java/org/apache/iceberg/V2Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V2Metadata.java
@@ -132,8 +132,6 @@ class V2Metadata {
           return wrapped.deletedRowsCount();
         case 13:
           return wrapped.partitions();
-        case 14:
-          return wrapped.keyMetadata();
         default:
           throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
       }


### PR DESCRIPTION
The schema in manifest_file:
```
  static final Schema MANIFEST_LIST_SCHEMA = new Schema(
      ManifestFile.PATH,
      ManifestFile.LENGTH,
      ManifestFile.SPEC_ID,
      ManifestFile.MANIFEST_CONTENT.asRequired(),
      ManifestFile.SEQUENCE_NUMBER.asRequired(),
      ManifestFile.MIN_SEQUENCE_NUMBER.asRequired(),
      ManifestFile.SNAPSHOT_ID.asRequired(),
      ManifestFile.ADDED_FILES_COUNT.asRequired(),
      ManifestFile.EXISTING_FILES_COUNT.asRequired(),
      ManifestFile.DELETED_FILES_COUNT.asRequired(),
      ManifestFile.ADDED_ROWS_COUNT.asRequired(),
      ManifestFile.EXISTING_ROWS_COUNT.asRequired(),
      ManifestFile.DELETED_ROWS_COUNT.asRequired(),
      ManifestFile.PARTITION_SUMMARIES,
      ManifestFile.WRITER_ID.asRequired()
  );
```
There is no field about `key_metadata`, so in `get()` method, delete it.