### PR TITLE
Spark: add procedure to generate symlink manifests

### DIFF
--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestGenerateSymlinkFormatManifestsProcedure.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestGenerateSymlinkFormatManifestsProcedure.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.extensions;
+
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.iceberg.AssertHelpers;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestGenerateSymlinkFormatManifestsProcedure extends SparkExtensionsTestBase {
+
+  public TestGenerateSymlinkFormatManifestsProcedure(
+      String catalogName, String implementation, Map<String, String> config) {
+    super(catalogName, implementation, config);
+  }
+
+  @After
+  public void removeTables() throws Exception {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @Test
+  public void testGenerateSymlinkFormatManifestsEmptyTable() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+    AssertHelpers.assertThrows("Should not support generate symlink manifest for empty table",
+        ValidationException.class,
+        "Cannot generate symlink manifests for an empty table",
+        () -> sql("CALL %s.system.generate_symlink_format_manifest('%s')", catalogName, tableIdent));
+  }
+
+  @Test
+  public void testGenerateSymlinkFormatManifestsUnpartitioned() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+    List<Object[]> result = sql("CALL %s.system.generate_symlink_format_manifest('%s')", catalogName, tableIdent);
+    Table table = validationCatalog.loadTable(tableIdent);
+    List<Object[]> expected = Lists.newArrayList();
+    expected.add(row(table.currentSnapshot().snapshotId(), 2L));
+    assertEquals("Should find 2 files", expected, result);
+    checkDirectoryExists(table.location(), "_symlink_format_manifest");
+    checkDirectoryExists(table.location(), "_symlink_format_manifest",
+        Long.toString(table.currentSnapshot().snapshotId()));
+  }
+
+  @Test
+  public void testGenerateSymlinkFormatManifestsPartitioned() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg PARTITIONED BY (data)", tableName);
+    sql("INSERT INTO TABLE %s VALUES (1, 'a'), (1, 'b'), (1, 'c')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b'), (2, 'c'), (2, 'd')", tableName);
+    List<Object[]> result = sql("CALL %s.system.generate_symlink_format_manifest('%s')", catalogName, tableIdent);
+    Table table = validationCatalog.loadTable(tableIdent);
+    List<Object[]> expected = Lists.newArrayList();
+    expected.add(row(table.currentSnapshot().snapshotId(), 6L));
+    assertEquals("Should find 6 files", expected, result);
+    checkDirectoryExists(table.location(), "_symlink_format_manifest");
+    checkDirectoryExists(table.location(), "_symlink_format_manifest",
+        Long.toString(table.currentSnapshot().snapshotId()));
+    checkDirectoryExists(table.location(), "_symlink_format_manifest",
+        Long.toString(table.currentSnapshot().snapshotId()), "data=a");
+    checkDirectoryExists(table.location(), "_symlink_format_manifest",
+        Long.toString(table.currentSnapshot().snapshotId()), "data=b");
+    checkDirectoryExists(table.location(), "_symlink_format_manifest",
+        Long.toString(table.currentSnapshot().snapshotId()), "data=c");
+    checkDirectoryExists(table.location(), "_symlink_format_manifest",
+        Long.toString(table.currentSnapshot().snapshotId()), "data=d");
+  }
+
+  @Test
+  public void testGenerateSymlinkFormatManifestsHiddenPartitioned() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg " +
+        "PARTITIONED BY (bucket(16, data))", tableName);
+    sql("INSERT INTO TABLE %s VALUES (1, 'a'), (1, 'b'), (1, 'c')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b'), (2, 'c'), (2, 'd')", tableName);
+    List<Object[]> result = sql("CALL %s.system.generate_symlink_format_manifest('%s')", catalogName, tableIdent);
+    Table table = validationCatalog.loadTable(tableIdent);
+    String location = table.location();
+    List<Object[]> expected = Lists.newArrayList();
+    expected.add(row(table.currentSnapshot().snapshotId(), 6L));
+    assertEquals("Should find 6 files", expected, result);
+    checkDirectoryExists(table.location(), "_symlink_format_manifest");
+    checkDirectoryExists(table.location(), "_symlink_format_manifest",
+        Long.toString(table.currentSnapshot().snapshotId()));
+    checkDirectoryExists(table.location(), "_symlink_format_manifest",
+        Long.toString(table.currentSnapshot().snapshotId()), "data_bucket=15");
+    checkDirectoryExists(table.location(), "_symlink_format_manifest",
+        Long.toString(table.currentSnapshot().snapshotId()), "data_bucket=2");
+    checkDirectoryExists(table.location(), "_symlink_format_manifest",
+        Long.toString(table.currentSnapshot().snapshotId()), "data_bucket=3");
+  }
+
+  @Test
+  public void testGenerateSymlinkFormatManifestsCustomLocationPositionArgument() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+    String customLocation = table.location() + "/" + UUID.randomUUID();
+    List<Object[]> result = sql("CALL %s.system.generate_symlink_format_manifest('%s', '%s')",
+        catalogName, tableIdent, customLocation);
+    List<Object[]> expected = Lists.newArrayList();
+    expected.add(row(table.currentSnapshot().snapshotId(), 2L));
+    assertEquals("Should find 2 files", expected, result);
+    checkDirectoryExists(customLocation);
+  }
+
+  @Test
+  public void testGenerateSymlinkFormatManifestsCustomLocationNamedArgument() {
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+    Table table = validationCatalog.loadTable(tableIdent);
+    String customLocation = table.location() + "/" + UUID.randomUUID();
+    List<Object[]> result = sql(
+        "CALL %s.system.generate_symlink_format_manifest(symlink_root_location => '%s', table => '%s')",
+        catalogName, customLocation, tableIdent);
+    List<Object[]> expected = Lists.newArrayList();
+    expected.add(row(table.currentSnapshot().snapshotId(), 2L));
+    assertEquals("Should find 2 files", expected, result);
+    checkDirectoryExists(customLocation);
+  }
+
+  private void checkDirectoryExists(String... paths) {
+    String path = String.join("/", paths);
+    Assert.assertTrue("Directory should exist: " + path, Files.isDirectory(Paths.get(URI.create(path))));
+  }
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/GenerateSymlinkFormatManifestProcedure.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/GenerateSymlinkFormatManifestProcedure.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.spark.procedures;
+
+import java.util.Arrays;
+import org.apache.iceberg.MetadataTableType;
+import org.apache.iceberg.Partitioning;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.spark.Spark3Util;
+import org.apache.iceberg.spark.SparkTableUtil;
+import org.apache.iceberg.spark.source.SparkTable;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.catalog.CatalogPlugin;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.iceberg.catalog.ProcedureParameter;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+
+class GenerateSymlinkFormatManifestProcedure extends BaseProcedure {
+  private static final ProcedureParameter[] PARAMETERS = new ProcedureParameter[]{
+      ProcedureParameter.required("table", DataTypes.StringType),
+      ProcedureParameter.optional("symlink_root_location", DataTypes.StringType)
+  };
+
+  private static final StructType OUTPUT_TYPE = new StructType(new StructField[]{
+      new StructField("snapshot_id", DataTypes.LongType, false, Metadata.empty()),
+      new StructField("data_file_count", DataTypes.LongType, false, Metadata.empty())
+  });
+
+  private static final String PROCEDURE_CONTEXT = "generate symlink format manifest";
+  private static final String SYMLINK_DIRECTORY_DEFAULT = "_symlink_format_manifest";
+
+  private GenerateSymlinkFormatManifestProcedure(TableCatalog tableCatalog) {
+    super(tableCatalog);
+  }
+
+  public static SparkProcedures.ProcedureBuilder builder() {
+    return new Builder<GenerateSymlinkFormatManifestProcedure>() {
+      @Override
+      protected GenerateSymlinkFormatManifestProcedure doBuild() {
+        return new GenerateSymlinkFormatManifestProcedure(tableCatalog());
+      }
+    };
+  }
+
+  @Override
+  public ProcedureParameter[] parameters() {
+    return PARAMETERS;
+  }
+
+  @Override
+  public StructType outputType() {
+    return OUTPUT_TYPE;
+  }
+
+  @Override
+  public InternalRow[] call(InternalRow args) {
+    String tableIdent = args.getString(0);
+    Preconditions.checkArgument(tableIdent != null && !tableIdent.isEmpty(),
+        "Cannot handle an empty identifier for argument table");
+
+    CatalogPlugin defaultCatalog = spark().sessionState().catalogManager().currentCatalog();
+    Spark3Util.CatalogAndIdentifier catalogAndIdent = Spark3Util.catalogAndIdentifier(
+        PROCEDURE_CONTEXT, spark(), tableIdent, defaultCatalog);
+    SparkTable sparkTable = loadSparkTable(catalogAndIdent.identifier());
+    org.apache.iceberg.Table icebergTable = sparkTable.table();
+    ValidationException.check(icebergTable.currentSnapshot() != null,
+        "Cannot generate symlink manifests for an empty table");
+
+    long snapshotId = icebergTable.currentSnapshot().snapshotId();
+    String symlinkRootLocation = args.isNullAt(1) ?
+        defaultSymlinkManifestRootLocation(icebergTable.location(), snapshotId) : args.getString(1);
+
+    Types.StructType partitionType = Partitioning.partitionType(icebergTable);
+    Dataset<Row> entries = SparkTableUtil.loadCatalogMetadataTable(spark(), icebergTable, MetadataTableType.ENTRIES)
+        .filter("status < 2 AND data_file.content = 0");
+
+    long rowCount = entries.count();
+    if (partitionType.fields().isEmpty()) {
+      entries.select("data_file.file_path")
+          .write()
+          .format("parquet")
+          .save(symlinkRootLocation);
+    } else {
+      String[] partitionColumns = partitionType.fields().stream()
+          .map(Types.NestedField::name)
+          .toArray(String[]::new);
+      String[] entryPartitionColumns = Arrays.stream(partitionColumns)
+          .map(name -> "data_file.partition." + name)
+          .toArray(String[]::new);
+      entries.select("data_file.file_path", entryPartitionColumns)
+          .write()
+          .partitionBy(partitionColumns)
+          .format("parquet")
+          .save(symlinkRootLocation);
+    }
+
+    return new InternalRow[] {newInternalRow(snapshotId, rowCount)};
+  }
+
+  @Override
+  public String description() {
+    return "GenerateSymlinkFormatManifestProcedure";
+  }
+
+  private String defaultSymlinkManifestRootLocation(String tableLocation, long snapshotId) {
+    int len = tableLocation.length();
+    StringBuilder sb = new StringBuilder();
+    sb.append(tableLocation);
+    if (sb.charAt(len - 1) != '/') {
+      sb.append('/');
+    }
+
+    sb.append(SYMLINK_DIRECTORY_DEFAULT);
+    sb.append('/');
+    sb.append(snapshotId);
+    return sb.toString();
+  }
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/procedures/SparkProcedures.java
@@ -53,6 +53,7 @@ public class SparkProcedures {
     mapBuilder.put("snapshot", SnapshotTableProcedure::builder);
     mapBuilder.put("add_files", AddFilesProcedure::builder);
     mapBuilder.put("ancestors_of", AncestorsOfProcedure::builder);
+    mapBuilder.put("generate_symlink_format_manifest", GenerateSymlinkFormatManifestProcedure::builder);
     return mapBuilder.build();
   }
 


### PR DESCRIPTION
Add a Spark procedure to generate symlink manifests, so that systems without Iceberg support can read Iceberg table data using an external table:

```sql
CREATE EXTERNAL TABLE mytable ([(col_name1 col_datatype1, ...)])
[PARTITIONED BY (col_name2 col_datatype2, ...)]
ROW FORMAT SERDE 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe'
STORED AS INPUTFORMAT 'org.apache.hadoop.hive.ql.io.SymlinkTextInputFormat'
OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
LOCATION '<symlink-table-root-path>' 
```

I did not add an action for this because this is to just give a gateway for users with any existing query engine that does not natively support Iceberg (in my case it's Redshift Spectrum) to start reading Iceberg, because most engines support Hive with symlink input format to some extent. If we think it deserves an action in core API, I can also add that.

The procedure looks like:

```
CALL catalog.system.generate_symlink_format_manifest(
  table => 'table_name', 
  symlink_root_location => 's3://some/path'
);
```

The `symlink_root_location` is optional. The default is `<table_root>/_symlink_format_manifest/<snapshot_id>`. A snapshot ID suffix is added because if this procedure is executed twice against the same table, we don't want to mix the results if the table is updated. If users want to use a consistent root path for the symlink table, it could be input as an override. 

I thought about adding another option for `snapshot_id` in the input, so we can generate a symlink table for any historical snapshots, but decided to not do that to avoid making the procedure too complicated. We can add it as a follow up if needed.

The procedure currently returns the `snapshot_id` that the procedure is executed against, and `data_file_count` for the number of data files in the symlink manifests.

Regarding partitioning, the generated symlink table exposes all the hidden partitions, and use the union of all historical table partition specs. For example, if the table is partitioned by spec1 `category`, spec 2 `bucket(16, id)`, users are expected to create a symlink table with `PARTITIONED BY (id_bucket int, category string)`.

Regarding merge-on-read, generated symlink table does not consider delete files. This is basically a "snapshot view" of the table. A compaction is needed to generate the most up-to-date view of the table.