### PR TITLE
AWS: Add table and namespace S3 tags

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -355,4 +355,9 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
       }
     }
   }
+
+  @VisibleForTesting
+  Map<String, String> tableCatalogProperties() {
+    return tableCatalogProperties;
+  }
 }


### PR DESCRIPTION
This change adds table level [S3 Tags](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html) to the objects while writing using `S3FileIO`. Users can pass these opt-in catalog properties to tag the objects in S3:

Spark SQL launch command:
```
sh spark-sql --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCatalog \
    --conf spark.sql.catalog.my_catalog.warehouse=s3://<bucket>/s3-tagging \
    --conf spark.sql.catalog.my_catalog.catalog-impl=org.apache.iceberg.aws.glue.GlueCatalog \
    --conf spark.sql.catalog.my_catalog.io-impl=org.apache.iceberg.aws.s3.S3FileIO \
    --conf spark.sql.catalog.my_catalog.s3.write.table-name-tag-enabled=true \
    --conf spark.sql.catalog.my_catalog.s3.write.namespace-name-tag-enabled=true
```

Tags added in S3:

```
aws s3api get-object-tagging --bucket <bucket> --key s3-tagging/data/00000-0-a81d170b-9d71-4b45-886a-390088b2513b-00001.parquet
{
    "TagSet": [
        {
            "Key": "iceberg.table",
            "Value": "test_table_tag"
        },
        {
            "Key": "iceberg.namespace",
            "Value": "test_db"
        }
    ]
}
```

---
cc: @jackye1995 @arminnajafi @singhpk234 @amogh-jahagirdar @xiaoxuandev @yyanyy