### PR TITLE
[Spec] Clarify whether floating point lower and upper bounds can contain NaNs

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -423,7 +423,7 @@ Notes:
 
 1. Single-value serialization for lower and upper bounds is detailed in Appendix D.
 2. For `float` and `double`, the value `-0.0` must precede `+0.0`, as in the IEEE 754 `totalOrder` predicate. NaNs
-   are not permitted as mix/max upper bounds.
+   are not permitted as lower or upper bounds.
 3. If sort order ID is missing or unknown, then the order is assumed to be unsorted. Only data files and equality delete files should be written with a non-null order id. [Position deletes](#position-delete-files) are required to be sorted by file and position, not a table order, and should set sort order id to null. Readers must ignore sort order id for position delete files.
 
 The `partition` struct stores the tuple of partition values for each file. Its type is derived from the partition fields of the partition spec used to write the manifest file. In v2, the partition struct's field ids must match the ids from the partition spec.

--- a/format/spec.md
+++ b/format/spec.md
@@ -422,8 +422,7 @@ The schema of a manifest file is a struct called `manifest_entry` with the follo
 Notes:
 
 1. Single-value serialization for lower and upper bounds is detailed in Appendix D.
-2. For `float` and `double`, the value `-0.0` must precede `+0.0`, as in the IEEE 754 `totalOrder` predicate. NaNs
-   are not permitted as lower or upper bounds.
+2. For `float` and `double`, the value `-0.0` must precede `+0.0`, as in the IEEE 754 `totalOrder` predicate. NaNs are not permitted as lower or upper bounds.
 3. If sort order ID is missing or unknown, then the order is assumed to be unsorted. Only data files and equality delete files should be written with a non-null order id. [Position deletes](#position-delete-files) are required to be sorted by file and position, not a table order, and should set sort order id to null. Readers must ignore sort order id for position delete files.
 
 The `partition` struct stores the tuple of partition values for each file. Its type is derived from the partition fields of the partition spec used to write the manifest file. In v2, the partition struct's field ids must match the ids from the partition spec.

--- a/format/spec.md
+++ b/format/spec.md
@@ -422,7 +422,8 @@ The schema of a manifest file is a struct called `manifest_entry` with the follo
 Notes:
 
 1. Single-value serialization for lower and upper bounds is detailed in Appendix D.
-2. For `float` and `double`, the value `-0.0` must precede `+0.0`, as in the IEEE 754 `totalOrder` predicate.
+2. For `float` and `double`, the value `-0.0` must precede `+0.0`, as in the IEEE 754 `totalOrder` predicate. NaNs
+   are not permitted as mix/max upper bounds.
 3. If sort order ID is missing or unknown, then the order is assumed to be unsorted. Only data files and equality delete files should be written with a non-null order id. [Position deletes](#position-delete-files) are required to be sorted by file and position, not a table order, and should set sort order id to null. Readers must ignore sort order id for position delete files.
 
 The `partition` struct stores the tuple of partition values for each file. Its type is derived from the partition fields of the partition spec used to write the manifest file. In v2, the partition struct's field ids must match the ids from the partition spec.


### PR DESCRIPTION
This is somewhat pedantic.  Based on current wording:
`Each value must be less than or equal to all non-null, non-NaN values in the column for the file [2]`

Based on defined sorting statistics
`Sorting floating-point numbers should produce the following behavior: -NaN < -Infinity < -value < -0 < 0 < value < Infinity < NaN` -NaN could be a lower bound and NaN could be an upper bound.

This PR tries to clarify whether statistics can or can't used for lower and upper bounds (I think the first sentence quoted might have been intended to rule out NaN but it isn't clear, so I'm happy to reverse this language to state that +/- NaN are valid values for bounds if that is the case).