### PR TITLE
Core - Add marker interfaces for both RESTRequests and RESTResponses

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -201,17 +201,20 @@ public class HTTPClient implements RESTClient {
   }
 
   @Override
-  public <T> T get(String path, Class<T> responseType, Consumer<ErrorResponse> errorHandler) {
+  public <T extends RESTResponse> T get(String path, Class<T> responseType,
+                                        Consumer<ErrorResponse> errorHandler) {
     return execute(Method.GET, path, null, responseType, errorHandler);
   }
 
   @Override
-  public <T> T post(String path, Object body, Class<T> responseType, Consumer<ErrorResponse> errorHandler) {
+  public <T extends RESTResponse> T post(String path, RESTRequest body, Class<T> responseType,
+                                         Consumer<ErrorResponse> errorHandler) {
     return execute(Method.POST, path, body, responseType, errorHandler);
   }
 
   @Override
-  public <T> T delete(String path, Class<T> responseType, Consumer<ErrorResponse> errorHandler) {
+  public <T extends RESTResponse> T delete(String path, Class<T> responseType,
+                                           Consumer<ErrorResponse> errorHandler) {
     return execute(Method.DELETE, path, null, responseType, errorHandler);
   }
 

--- a/core/src/main/java/org/apache/iceberg/rest/RESTMessage.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTMessage.java
@@ -19,22 +19,16 @@
 
 package org.apache.iceberg.rest;
 
-import java.io.Closeable;
-import java.util.function.Consumer;
-import org.apache.iceberg.rest.responses.ErrorResponse;
-
 /**
- * Interface for a basic HTTP Client for interfacing with the REST catalog.
+ * Interface to mark both REST requests and responses.
  */
-public interface RESTClient extends Closeable {
+public interface RESTMessage {
 
-  void head(String path, Consumer<ErrorResponse> errorHandler);
-
-  <T extends RESTResponse> T delete(String path, Class<T> responseType, Consumer<ErrorResponse> errorHandler);
-
-  <T extends RESTResponse> T get(String path, Class<T> responseType, Consumer<ErrorResponse> errorHandler);
-
-  <T extends RESTResponse> T post(String path, RESTRequest body, Class<T> responseType,
-                                  Consumer<ErrorResponse> errorHandler);
+  /**
+   * Ensures that a constructed instance of a REST message is valid according to the REST spec.
+   * <p>
+   * This is needed when parsing data that comes from external sources and the object might have
+   * been constructed without all the required fields present.
+   */
+  void validate();
 }
-

--- a/core/src/main/java/org/apache/iceberg/rest/RESTRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTRequest.java
@@ -19,22 +19,8 @@
 
 package org.apache.iceberg.rest;
 
-import java.io.Closeable;
-import java.util.function.Consumer;
-import org.apache.iceberg.rest.responses.ErrorResponse;
-
 /**
- * Interface for a basic HTTP Client for interfacing with the REST catalog.
+ * Interface to mark a REST request.
  */
-public interface RESTClient extends Closeable {
-
-  void head(String path, Consumer<ErrorResponse> errorHandler);
-
-  <T extends RESTResponse> T delete(String path, Class<T> responseType, Consumer<ErrorResponse> errorHandler);
-
-  <T extends RESTResponse> T get(String path, Class<T> responseType, Consumer<ErrorResponse> errorHandler);
-
-  <T extends RESTResponse> T post(String path, RESTRequest body, Class<T> responseType,
-                                  Consumer<ErrorResponse> errorHandler);
+public interface RESTRequest extends RESTMessage {
 }
-

--- a/core/src/main/java/org/apache/iceberg/rest/RESTResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTResponse.java
@@ -19,22 +19,8 @@
 
 package org.apache.iceberg.rest;
 
-import java.io.Closeable;
-import java.util.function.Consumer;
-import org.apache.iceberg.rest.responses.ErrorResponse;
-
 /**
- * Interface for a basic HTTP Client for interfacing with the REST catalog.
+ * Interface to mark a REST response
  */
-public interface RESTClient extends Closeable {
-
-  void head(String path, Consumer<ErrorResponse> errorHandler);
-
-  <T extends RESTResponse> T delete(String path, Class<T> responseType, Consumer<ErrorResponse> errorHandler);
-
-  <T extends RESTResponse> T get(String path, Class<T> responseType, Consumer<ErrorResponse> errorHandler);
-
-  <T extends RESTResponse> T post(String path, RESTRequest body, Class<T> responseType,
-                                  Consumer<ErrorResponse> errorHandler);
+public interface RESTResponse extends RESTMessage {
 }
-

--- a/core/src/main/java/org/apache/iceberg/rest/requests/CreateNamespaceRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/CreateNamespaceRequest.java
@@ -26,11 +26,12 @@ import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.rest.RESTRequest;
 
 /**
  * A REST request to create a namespace, with an optional set of properties.
  */
-public class CreateNamespaceRequest {
+public class CreateNamespaceRequest implements RESTRequest {
 
   private Namespace namespace;
   private Map<String, String> properties;
@@ -45,9 +46,9 @@ public class CreateNamespaceRequest {
     validate();
   }
 
-  CreateNamespaceRequest validate() {
+  @Override
+  public void validate() {
     Preconditions.checkArgument(namespace != null, "Invalid namespace: null");
-    return this;
   }
 
   public Namespace namespace() {

--- a/core/src/main/java/org/apache/iceberg/rest/requests/CreateTableRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/CreateTableRequest.java
@@ -28,11 +28,12 @@ import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.rest.RESTRequest;
 
 /**
  * A REST request to create a namespace, with an optional set of properties.
  */
-public class CreateTableRequest {
+public class CreateTableRequest implements RESTRequest {
 
   private String name;
   private String location;
@@ -56,10 +57,10 @@ public class CreateTableRequest {
     validate();
   }
 
-  public CreateTableRequest validate() {
+  @Override
+  public void validate() {
     Preconditions.checkArgument(name != null, "Invalid table name: null");
     Preconditions.checkArgument(schema != null, "Invalid schema: null");
-    return this;
   }
 
   public String name() {

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateNamespacePropertiesRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateNamespacePropertiesRequest.java
@@ -32,11 +32,12 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.rest.RESTRequest;
 
 /**
  * A REST request to set and/or remove properties on a namespace.
  */
-public class UpdateNamespacePropertiesRequest {
+public class UpdateNamespacePropertiesRequest implements RESTRequest {
 
   private List<String> removals;
   private Map<String, String> updates;
@@ -51,14 +52,13 @@ public class UpdateNamespacePropertiesRequest {
     validate();
   }
 
-  public UpdateNamespacePropertiesRequest validate() {
+  @Override
+  public void validate() {
     Set<String> commonKeys = Sets.intersection(updates().keySet(), Sets.newHashSet(removals()));
     if (!commonKeys.isEmpty()) {
       throw new UnprocessableEntityException(
           "Invalid namespace update, cannot simultaneously set and remove keys: %s", commonKeys);
     }
-
-    return this;
   }
 
   public List<String> removals() {

--- a/core/src/main/java/org/apache/iceberg/rest/requests/UpdateTableRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/UpdateTableRequest.java
@@ -30,8 +30,9 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.rest.RESTRequest;
 
-public class UpdateTableRequest {
+public class UpdateTableRequest implements RESTRequest {
 
   private List<UpdateRequirement> requirements;
   private List<MetadataUpdate> updates;
@@ -43,6 +44,10 @@ public class UpdateTableRequest {
   public UpdateTableRequest(List<UpdateRequirement> requirements, List<MetadataUpdate> updates) {
     this.requirements = requirements;
     this.updates = updates;
+  }
+
+  @Override
+  public void validate() {
   }
 
   public List<UpdateRequirement> requirements() {

--- a/core/src/main/java/org/apache/iceberg/rest/responses/CreateNamespaceResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/CreateNamespaceResponse.java
@@ -26,11 +26,12 @@ import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.rest.RESTResponse;
 
 /**
  * Represents a REST response for a request to create a namespace / database.
  */
-public class CreateNamespaceResponse {
+public class CreateNamespaceResponse implements RESTResponse {
 
   private Namespace namespace;
   private Map<String, String> properties;
@@ -45,9 +46,9 @@ public class CreateNamespaceResponse {
     validate();
   }
 
-  CreateNamespaceResponse validate() {
+  @Override
+  public void validate() {
     Preconditions.checkArgument(namespace != null, "Invalid namespace: null");
-    return this;
   }
 
   public Namespace namespace() {

--- a/core/src/main/java/org/apache/iceberg/rest/responses/ErrorResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/ErrorResponse.java
@@ -24,11 +24,12 @@ import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.rest.RESTResponse;
 
 /**
  * Standard response body for all API errors
  */
-public class ErrorResponse {
+public class ErrorResponse implements RESTResponse {
 
   private String message;
   private String type;
@@ -43,8 +44,9 @@ public class ErrorResponse {
     validate();
   }
 
-  ErrorResponse validate() {
-    return this;
+  @Override
+  public void validate() {
+    // Because we use the `ErrorResponseParser`, validation is done there.
   }
 
   public String message() {

--- a/core/src/main/java/org/apache/iceberg/rest/responses/GetNamespaceResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/GetNamespaceResponse.java
@@ -26,11 +26,12 @@ import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.rest.RESTResponse;
 
 /**
  * Represents a REST response to fetch a namespace and its metadata properties
  */
-public class GetNamespaceResponse {
+public class GetNamespaceResponse implements RESTResponse {
 
   private Namespace namespace;
   private Map<String, String> properties;
@@ -45,9 +46,9 @@ public class GetNamespaceResponse {
     validate();
   }
 
-  GetNamespaceResponse validate() {
+  @Override
+  public void validate() {
     Preconditions.checkArgument(namespace != null, "Invalid namespace: null");
-    return this;
   }
 
   public Namespace namespace() {

--- a/core/src/main/java/org/apache/iceberg/rest/responses/ListNamespacesResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/ListNamespacesResponse.java
@@ -26,8 +26,9 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.rest.RESTResponse;
 
-public class ListNamespacesResponse {
+public class ListNamespacesResponse implements RESTResponse {
 
   private List<Namespace> namespaces;
 
@@ -40,9 +41,9 @@ public class ListNamespacesResponse {
     validate();
   }
 
-  ListNamespacesResponse validate() {
+  @Override
+  public void validate() {
     Preconditions.checkArgument(namespaces != null, "Invalid namespace: null");
-    return this;
   }
 
 

--- a/core/src/main/java/org/apache/iceberg/rest/responses/ListTablesResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/ListTablesResponse.java
@@ -26,11 +26,12 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.rest.RESTResponse;
 
 /**
  * A list of table identifiers in a given namespace.
  */
-public class ListTablesResponse {
+public class ListTablesResponse implements RESTResponse {
 
   private List<TableIdentifier> identifiers;
 
@@ -43,9 +44,9 @@ public class ListTablesResponse {
     validate();
   }
 
-  ListTablesResponse validate() {
+  @Override
+  public void validate() {
     Preconditions.checkArgument(identifiers != null, "Invalid identifier list: null");
-    return this;
   }
 
   public List<TableIdentifier> identifiers() {

--- a/core/src/main/java/org/apache/iceberg/rest/responses/LoadTableResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/LoadTableResponse.java
@@ -25,11 +25,12 @@ import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.rest.RESTResponse;
 
 /**
  *
  */
-public class LoadTableResponse {
+public class LoadTableResponse implements RESTResponse {
 
   private String metadataLocation;
   private TableMetadata meta;
@@ -43,6 +44,10 @@ public class LoadTableResponse {
     this.metadataLocation = metadataLocation;
     this.meta = meta;
     this.config = config;
+  }
+
+  @Override
+  public void validate() {
   }
 
   public String metadataLocation() {

--- a/core/src/main/java/org/apache/iceberg/rest/responses/RESTCatalogConfigResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/RESTCatalogConfigResponse.java
@@ -25,6 +25,7 @@ import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.rest.RESTResponse;
 
 /**
  * Represents a response to requesting server-side provided configuration for the REST catalog.
@@ -39,7 +40,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
  *   <li> overrides - properties that should be used to override client configuration </li>
  * </ul>
  */
-public class RESTCatalogConfigResponse {
+public class RESTCatalogConfigResponse implements RESTResponse {
 
   private Map<String, String> defaults;
   private Map<String, String> overrides;
@@ -54,8 +55,8 @@ public class RESTCatalogConfigResponse {
     validate();
   }
 
-  RESTCatalogConfigResponse validate() {
-    return this;
+  @Override
+  public void validate() {
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/rest/responses/UpdateNamespacePropertiesResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/UpdateNamespacePropertiesResponse.java
@@ -25,11 +25,12 @@ import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.rest.RESTResponse;
 
 /**
  * A REST response to a request to set and/or remove properties on a namespace.
  */
-public class UpdateNamespacePropertiesResponse {
+public class UpdateNamespacePropertiesResponse implements RESTResponse {
 
   // List of namespace property keys that were removed
   private List<String> removed;
@@ -49,8 +50,8 @@ public class UpdateNamespacePropertiesResponse {
     validate();
   }
 
-  UpdateNamespacePropertiesResponse validate() {
-    return this;
+  @Override
+  public void validate() {
   }
 
   public List<String> removed() {

--- a/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -151,7 +151,8 @@ public class RESTCatalogAdapter implements RESTClient {
     }
   }
 
-  public <T> T handleRequest(Route route, Map<String, String> vars, Object body, Class<T> responseType) {
+  public <T extends RESTResponse> T handleRequest(Route route, Map<String, String> vars,
+                                                  Object body, Class<T> responseType) {
     switch (route) {
       case CONFIG:
         // TODO: use the correct response object
@@ -233,8 +234,8 @@ public class RESTCatalogAdapter implements RESTClient {
     return null;
   }
 
-  public <T> T execute(HTTPMethod method, String path, Object body, Class<T> responseType,
-                       Consumer<ErrorResponse> errorHandler) {
+  public <T extends RESTResponse> T execute(HTTPMethod method, String path, Object body, Class<T> responseType,
+                                            Consumer<ErrorResponse> errorHandler) {
     ErrorResponse.Builder errorBuilder = ErrorResponse.builder();
     Pair<Route, Map<String, String>> routeAndVars = Route.from(method, path);
     if (routeAndVars != null) {
@@ -260,17 +261,18 @@ public class RESTCatalogAdapter implements RESTClient {
   }
 
   @Override
-  public <T> T delete(String path, Class<T> responseType, Consumer<ErrorResponse> errorHandler) {
+  public <T extends RESTResponse> T delete(String path, Class<T> responseType, Consumer<ErrorResponse> errorHandler) {
     return execute(HTTPMethod.DELETE, path, null, responseType, errorHandler);
   }
 
   @Override
-  public <T> T post(String path, Object body, Class<T> responseType, Consumer<ErrorResponse> errorHandler) {
+  public <T extends RESTResponse> T post(String path, RESTRequest body, Class<T> responseType,
+                                         Consumer<ErrorResponse> errorHandler) {
     return execute(HTTPMethod.POST, path, body, responseType, errorHandler);
   }
 
   @Override
-  public <T> T get(String path, Class<T> responseType, Consumer<ErrorResponse> errorHandler) {
+  public <T extends RESTResponse> T get(String path, Class<T> responseType, Consumer<ErrorResponse> errorHandler) {
     return execute(HTTPMethod.GET, path, null, responseType, errorHandler);
   }
 
@@ -306,7 +308,7 @@ public class RESTCatalogAdapter implements RESTClient {
     throw new BadRequestType(requestType, request);
   }
 
-  public static <T> T castResponse(Class<T> responseType, Object response) {
+  public static <T extends RESTResponse> T castResponse(Class<T> responseType, Object response) {
     if (responseType.isInstance(response)) {
       return responseType.cast(response);
     }

--- a/core/src/test/java/org/apache/iceberg/rest/RequestResponseTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RequestResponseTestBase.java
@@ -28,7 +28,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public abstract class RequestResponseTestBase<T> {
+public abstract class RequestResponseTestBase<T extends RESTMessage> {
 
   private static final JsonFactory FACTORY = new JsonFactory();
   private static final ObjectMapper MAPPER = new ObjectMapper(FACTORY);

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -217,17 +217,22 @@ public class TestHTTPClient {
     }
   }
 
-  public static class Item {
+  public static class Item implements RESTRequest, RESTResponse {
     private Long id;
     private String data;
 
     // Required for Jackson deserialization
+    @SuppressWarnings("unused")
     public Item() {
     }
 
     public Item(Long id, String data) {
       this.id = id;
       this.data = data;
+    }
+
+    @Override
+    public void validate() {
     }
 
     @Override

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestCreateNamespaceRequest.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestCreateNamespaceRequest.java
@@ -166,6 +166,8 @@ public class TestCreateNamespaceRequest extends RequestResponseTestBase<CreateNa
 
   @Override
   public CreateNamespaceRequest deserialize(String json) throws JsonProcessingException {
-    return mapper().readValue(json, CreateNamespaceRequest.class).validate();
+    CreateNamespaceRequest request = mapper().readValue(json, CreateNamespaceRequest.class);
+    request.validate();
+    return request;
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateNamespacePropertiesRequest.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateNamespacePropertiesRequest.java
@@ -226,6 +226,8 @@ public class TestUpdateNamespacePropertiesRequest extends RequestResponseTestBas
 
   @Override
   public UpdateNamespacePropertiesRequest deserialize(String json) throws JsonProcessingException {
-    return mapper().readValue(json, UpdateNamespacePropertiesRequest.class).validate();
+    UpdateNamespacePropertiesRequest request = mapper().readValue(json, UpdateNamespacePropertiesRequest.class);
+    request.validate();
+    return request;
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestCreateNamespaceResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestCreateNamespaceResponse.java
@@ -169,7 +169,9 @@ public class TestCreateNamespaceResponse extends RequestResponseTestBase<CreateN
 
   @Override
   public CreateNamespaceResponse deserialize(String json) throws JsonProcessingException {
-    return mapper().readValue(json, CreateNamespaceResponse.class).validate();
+    CreateNamespaceResponse response = mapper().readValue(json, CreateNamespaceResponse.class);
+    response.validate();
+    return response;
   }
 }
 

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestGetNamespaceResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestGetNamespaceResponse.java
@@ -157,6 +157,8 @@ public class TestGetNamespaceResponse extends RequestResponseTestBase<GetNamespa
 
   @Override
   public GetNamespaceResponse deserialize(String json) throws JsonProcessingException {
-    return mapper().readValue(json, GetNamespaceResponse.class).validate();
+    GetNamespaceResponse resp = mapper().readValue(json, GetNamespaceResponse.class);
+    resp.validate();
+    return resp;
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestListNamespacesResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestListNamespacesResponse.java
@@ -126,7 +126,9 @@ public class TestListNamespacesResponse extends RequestResponseTestBase<ListName
 
   @Override
   public ListNamespacesResponse deserialize(String json) throws JsonProcessingException {
-    return mapper().readValue(json, ListNamespacesResponse.class).validate();
+    ListNamespacesResponse resp = mapper().readValue(json, ListNamespacesResponse.class);
+    resp.validate();
+    return resp;
   }
 }
 

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestListTablesResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestListTablesResponse.java
@@ -146,6 +146,8 @@ public class TestListTablesResponse extends RequestResponseTestBase<ListTablesRe
 
   @Override
   public ListTablesResponse deserialize(String json) throws JsonProcessingException {
-    return mapper().readValue(json, ListTablesResponse.class).validate();
+    ListTablesResponse resp = mapper().readValue(json, ListTablesResponse.class);
+    resp.validate();
+    return resp;
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestRESTCatalogConfigResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestRESTCatalogConfigResponse.java
@@ -268,6 +268,8 @@ public class TestRESTCatalogConfigResponse extends RequestResponseTestBase<RESTC
 
   @Override
   public RESTCatalogConfigResponse deserialize(String json) throws JsonProcessingException {
-    return mapper().readValue(json, RESTCatalogConfigResponse.class).validate();
+    RESTCatalogConfigResponse resp = mapper().readValue(json, RESTCatalogConfigResponse.class);
+    resp.validate();
+    return resp;
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestUpdateNamespacePropertiesResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestUpdateNamespacePropertiesResponse.java
@@ -260,6 +260,8 @@ public class TestUpdateNamespacePropertiesResponse extends RequestResponseTestBa
 
   @Override
   public UpdateNamespacePropertiesResponse deserialize(String json) throws JsonProcessingException {
-    return mapper().readValue(json, UpdateNamespacePropertiesResponse.class).validate();
+    UpdateNamespacePropertiesResponse resp = mapper().readValue(json, UpdateNamespacePropertiesResponse.class);
+    resp.validate();
+    return resp;
   }
 }


### PR DESCRIPTION
Adds three empty interfaces, that are used for marking classes that correspond to REST requests / responses.
1) `RESTMessage` - This marks either a RESTRequest or a RESTResponse. The name is chosen to match many libraries, like Netty, where the `HTTPRequest` extends `HTTPMessage`.
2) `RESTRequest` - Specific empty subinterface for classes that correlate to REST catalog requests.
3) `RESTResponse` - Specific empty subinterface for classes that correlate to REST catalog resposnes.

Right now, these are empty but in the future we could add things like the `validate` method, or anything else that is needed. Eventually we could possibly even move these into the api module.

For now, this is in response to [a comment here](https://github.com/apache/iceberg/pull/4245#discussion_r832570043) so that we can specify that the generic type going into a method is in fact a REST catalog request and that what's returned is a REST catalog response.

cc @rdblue 