### PR TITLE
Spark - Update commands for running Spark 3.1 JMH Benchmarks

### DIFF
--- a/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetReadersFlatDataBenchmark.java
+++ b/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetReadersFlatDataBenchmark.java
@@ -59,9 +59,9 @@ import static org.apache.iceberg.types.Types.NestedField.required;
  * A benchmark that evaluates the performance of reading Parquet data with a flat schema using
  * Iceberg and Spark Parquet readers.
  *
- * To run this benchmark for either spark-2 or spark-3:
+ * To run this benchmark for spark-3.1:
  * <code>
- *   ./gradlew :iceberg-spark:iceberg-spark[2|3]:jmh
+ *   ./gradlew -DsparkVersions=3.1 :iceberg-spark:iceberg-spark-3.1_2.12:jmh
  *       -PjmhIncludeRegex=SparkParquetReadersFlatDataBenchmark
  *       -PjmhOutputPath=benchmark/spark-parquet-readers-flat-data-benchmark-result.txt
  * </code>

--- a/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetReadersNestedDataBenchmark.java
+++ b/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetReadersNestedDataBenchmark.java
@@ -59,9 +59,9 @@ import static org.apache.iceberg.types.Types.NestedField.required;
  * A benchmark that evaluates the performance of reading nested Parquet data using
  * Iceberg and Spark Parquet readers.
  *
- * To run this benchmark for either spark-2 or spark-3:
+ * To run this benchmark for spark-3.1:
  * <code>
- *   ./gradlew :iceberg-spark:iceberg-spark[2|3]:jmh
+ *   ./gradlew -DsparkVersions=3.1 :iceberg-spark:iceberg-spark-3.1_2.12:jmh
  *       -PjmhIncludeRegex=SparkParquetReadersNestedDataBenchmark
  *       -PjmhOutputPath=benchmark/spark-parquet-readers-nested-data-benchmark-result.txt
  * </code>

--- a/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersFlatDataBenchmark.java
+++ b/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersFlatDataBenchmark.java
@@ -52,9 +52,9 @@ import static org.apache.iceberg.types.Types.NestedField.required;
  * A benchmark that evaluates the performance of writing Parquet data with a flat schema using
  * Iceberg and Spark Parquet writers.
  *
- * To run this benchmark for either spark-2 or spark-3:
+ * To run this benchmark for spark-3.1:
  * <code>
- *   ./gradlew :iceberg-spark:iceberg-spark[2|3]:jmh
+ *   ./gradlew -DsparkVersions=3.1 :iceberg-spark:iceberg-spark-3.1_2.12:jmh
  *       -PjmhIncludeRegex=SparkParquetWritersFlatDataBenchmark
  *       -PjmhOutputPath=benchmark/spark-parquet-writers-flat-data-benchmark-result.txt
  * </code>

--- a/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersNestedDataBenchmark.java
+++ b/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/data/parquet/SparkParquetWritersNestedDataBenchmark.java
@@ -52,9 +52,9 @@ import static org.apache.iceberg.types.Types.NestedField.required;
  * A benchmark that evaluates the performance of writing nested Parquet data using
  * Iceberg and Spark Parquet writers.
  *
- * To run this benchmark for either spark-2 or spark-3:
+ * To run this benchmark for spark-3.1:
  * <code>
- *   ./gradlew :iceberg-spark:iceberg-spark[2|3]:jmh
+ *   ./gradlew -DsparkVersions=3.1 :iceberg-spark:iceberg-spark-3.1_2.12:jmh
  *       -PjmhIncludeRegex=SparkParquetWritersNestedDataBenchmark
  *       -PjmhOutputPath=benchmark/spark-parquet-writers-nested-data-benchmark-result.txt
  * </code>

--- a/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/avro/AvroWritersBenchmark.java
+++ b/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/avro/AvroWritersBenchmark.java
@@ -25,9 +25,9 @@ import org.apache.iceberg.spark.source.WritersBenchmark;
 /**
  * A benchmark that evaluates the performance of various Iceberg writers for Avro data.
  *
- * To run this benchmark for either spark-2 or spark-3:
+ * To run this benchmark for spark-3.1:
  * <code>
- *   ./gradlew :iceberg-spark:iceberg-spark[2|3]:jmh
+ *   ./gradlew -DsparkVersions=3.1 :iceberg-spark:iceberg-spark-3.1_2.12:jmh
  *       -PjmhIncludeRegex=AvroWritersBenchmark
  *       -PjmhOutputPath=benchmark/avro-writers-benchmark-result.txt
  * </code>

--- a/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/avro/IcebergSourceFlatAvroDataReadBenchmark.java
+++ b/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/avro/IcebergSourceFlatAvroDataReadBenchmark.java
@@ -41,9 +41,9 @@ import static org.apache.spark.sql.functions.expr;
  * A benchmark that evaluates the performance of reading Avro data with a flat schema
  * using Iceberg and the built-in file source in Spark.
  *
- * To run this benchmark for either spark-2 or spark-3:
+ * To run this benchmark for spark-3.1:
  * <code>
- *   ./gradlew :iceberg-spark:iceberg-spark[2|3]:jmh
+ *   ./gradlew -DsparkVersions=3.1 :iceberg-spark:iceberg-spark-3.1_2.12:jmh
  *       -PjmhIncludeRegex=IcebergSourceFlatAvroDataReadBenchmark
  *       -PjmhOutputPath=benchmark/iceberg-source-flat-avro-data-read-benchmark-result.txt
  * </code>

--- a/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/avro/IcebergSourceNestedAvroDataReadBenchmark.java
+++ b/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/avro/IcebergSourceNestedAvroDataReadBenchmark.java
@@ -42,9 +42,9 @@ import static org.apache.spark.sql.functions.struct;
  * A benchmark that evaluates the performance of reading Avro data with a flat schema
  * using Iceberg and the built-in file source in Spark.
  *
- * To run this benchmark for either spark-2 or spark-3:
+ * To run this benchmark for spark-3.1:
  * <code>
- *   ./gradlew :iceberg-spark:iceberg-spark[2|3]:jmh
+ *   ./gradlew -DsparkVersions=3.1 :iceberg-spark:iceberg-spark-3.1_2.12:jmh
  *       -PjmhIncludeRegex=IcebergSourceNestedAvroDataReadBenchmark
  *       -PjmhOutputPath=benchmark/iceberg-source-nested-avro-data-read-benchmark-result.txt
  * </code>

--- a/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/orc/IcebergSourceFlatORCDataReadBenchmark.java
+++ b/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/orc/IcebergSourceFlatORCDataReadBenchmark.java
@@ -41,9 +41,9 @@ import static org.apache.spark.sql.functions.expr;
  * A benchmark that evaluates the performance of reading ORC data with a flat schema
  * using Iceberg and the built-in file source in Spark.
  *
- * To run this benchmark for either spark-2 or spark-3:
+ * To run this benchmark for spark-3.1:
  * <code>
- *   ./gradlew :iceberg-spark:iceberg-spark[2|3]:jmh
+ *   ./gradlew -DsparkVersions=3.1 :iceberg-spark:iceberg-spark-3.1_2.12:jmh
  *       -PjmhIncludeRegex=IcebergSourceFlatORCDataReadBenchmark
  *       -PjmhOutputPath=benchmark/iceberg-source-flat-orc-data-read-benchmark-result.txt
  * </code>

--- a/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/orc/IcebergSourceNestedListORCDataWriteBenchmark.java
+++ b/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/orc/IcebergSourceNestedListORCDataWriteBenchmark.java
@@ -40,9 +40,9 @@ import static org.apache.spark.sql.functions.struct;
  * A benchmark that evaluates the performance of writing nested Parquet data using Iceberg
  * and the built-in file source in Spark.
  *
- * To run this benchmark for either spark-2 or spark-3:
+ * To run this benchmark for spark-3.1:
  * <code>
- *   ./gradlew :iceberg-spark:iceberg-spark[2|3]:jmh
+ *   ./gradlew -DsparkVersions=3.1 :iceberg-spark:iceberg-spark-3.1_2.12:jmh
  *       -PjmhIncludeRegex=IcebergSourceNestedListORCDataWriteBenchmark
  *       -PjmhOutputPath=benchmark/iceberg-source-nested-list-orc-data-write-benchmark-result.txt
  * </code>

--- a/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/orc/IcebergSourceNestedORCDataReadBenchmark.java
+++ b/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/orc/IcebergSourceNestedORCDataReadBenchmark.java
@@ -43,9 +43,9 @@ import static org.apache.spark.sql.functions.struct;
  * A benchmark that evaluates the performance of reading ORC data with a flat schema
  * using Iceberg and the built-in file source in Spark.
  *
- * To run this benchmark for either spark-2 or spark-3:
+ * To run this benchmark for spark-3.1:
  * <code>
- *   ./gradlew :iceberg-spark:iceberg-spark[2|3]:jmh
+ *   ./gradlew -DsparkVersions=3.1 :iceberg-spark:iceberg-spark-3.1_2.12:jmh
  *       -PjmhIncludeRegex=IcebergSourceNestedORCDataReadBenchmark
  *       -PjmhOutputPath=benchmark/iceberg-source-nested-orc-data-read-benchmark-result.txt
  * </code>

--- a/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceFlatParquetDataFilterBenchmark.java
+++ b/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceFlatParquetDataFilterBenchmark.java
@@ -44,9 +44,9 @@ import static org.apache.spark.sql.functions.expr;
  *
  * The performance is compared to the built-in file source in Spark.
  *
- * To run this benchmark for either spark-2 or spark-3:
+ * To run this benchmark for spark-3.1:
  * <code>
- *   ./gradlew :iceberg-spark:iceberg-spark[2|3]:jmh
+ *   ./gradlew -DsparkVersions=3.1 :iceberg-spark:iceberg-spark-3.1_2.12:jmh
  *       -PjmhIncludeRegex=IcebergSourceFlatParquetDataFilterBenchmark
  *       -PjmhOutputPath=benchmark/iceberg-source-flat-parquet-data-filter-benchmark-result.txt
  * </code>

--- a/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceFlatParquetDataReadBenchmark.java
+++ b/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceFlatParquetDataReadBenchmark.java
@@ -40,9 +40,9 @@ import static org.apache.spark.sql.functions.expr;
  * A benchmark that evaluates the performance of reading Parquet data with a flat schema
  * using Iceberg and the built-in file source in Spark.
  *
- * To run this benchmark for either spark-2 or spark-3:
+ * To run this benchmark for spark-3.1:
  * <code>
- *   ./gradlew :iceberg-spark:iceberg-spark[2|3]:jmh
+ *   ./gradlew -DsparkVersions=3.1 :iceberg-spark:iceberg-spark-3.1_2.12:jmh
  *       -PjmhIncludeRegex=IcebergSourceFlatParquetDataReadBenchmark
  *       -PjmhOutputPath=benchmark/iceberg-source-flat-parquet-data-read-benchmark-result.txt
  * </code>

--- a/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceFlatParquetDataWriteBenchmark.java
+++ b/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceFlatParquetDataWriteBenchmark.java
@@ -38,9 +38,9 @@ import static org.apache.spark.sql.functions.expr;
  * A benchmark that evaluates the performance of writing Parquet data with a flat schema
  * using Iceberg and the built-in file source in Spark.
  *
- * To run this benchmark for either spark-2 or spark-3:
+ * To run this benchmark for spark-3.1:
  * <code>
- *   ./gradlew :iceberg-spark:iceberg-spark[2|3]:jmh
+ *   ./gradlew -DsparkVersions=3.1 :iceberg-spark:iceberg-spark-3.1_2.12:jmh
  *       -PjmhIncludeRegex=IcebergSourceFlatParquetDataWriteBenchmark
  *       -PjmhOutputPath=benchmark/iceberg-source-flat-parquet-data-write-benchmark-result.txt
  * </code>

--- a/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceNestedListParquetDataWriteBenchmark.java
+++ b/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceNestedListParquetDataWriteBenchmark.java
@@ -41,9 +41,9 @@ import static org.apache.spark.sql.functions.struct;
  * A benchmark that evaluates the performance of writing nested Parquet data using Iceberg
  * and the built-in file source in Spark.
  *
- * To run this benchmark for either spark-2 or spark-3:
+ * To run this benchmark for spark-3.1:
  * <code>
- *   ./gradlew :iceberg-spark:iceberg-spark[2|3]:jmh
+ *   ./gradlew -DsparkVersions=3.1 :iceberg-spark:iceberg-spark-3.1_2.12:jmh
  *       -PjmhIncludeRegex=IcebergSourceNestedListParquetDataWriteBenchmark
  *       -PjmhOutputPath=benchmark/iceberg-source-nested-list-parquet-data-write-benchmark-result.txt
  * </code>

--- a/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceNestedParquetDataFilterBenchmark.java
+++ b/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceNestedParquetDataFilterBenchmark.java
@@ -44,9 +44,9 @@ import static org.apache.spark.sql.functions.struct;
  *
  * The performance is compared to the built-in file source in Spark.
  *
- * To run this benchmark for either spark-2 or spark-3:
+ * To run this benchmark for spark-3.1:
  * <code>
- *   ./gradlew :iceberg-spark:iceberg-spark[2|3]:jmh
+ *   ./gradlew -DsparkVersions=3.1 :iceberg-spark:iceberg-spark-3.1_2.12:jmh
  *       -PjmhIncludeRegex=IcebergSourceNestedParquetDataFilterBenchmark
  *       -PjmhOutputPath=benchmark/iceberg-source-nested-parquet-data-filter-benchmark-result.txt
  * </code>

--- a/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceNestedParquetDataReadBenchmark.java
+++ b/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceNestedParquetDataReadBenchmark.java
@@ -40,9 +40,9 @@ import static org.apache.spark.sql.functions.struct;
  * A benchmark that evaluates the performance of reading nested Parquet data using Iceberg
  * and the built-in file source in Spark.
  *
- * To run this benchmark for either spark-2 or spark-3:
+ * To run this benchmark for spark-3.1:
  * <code>
- *   ./gradlew :iceberg-spark:iceberg-spark[2|3]:jmh
+ *   ./gradlew -DsparkVersions=3.1 :iceberg-spark:iceberg-spark-3.1_2.12:jmh
  *       -PjmhIncludeRegex=IcebergSourceNestedParquetDataReadBenchmark
  *       -PjmhOutputPath=benchmark/iceberg-source-nested-parquet-data-read-benchmark-result.txt
  * </code>

--- a/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceNestedParquetDataWriteBenchmark.java
+++ b/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/IcebergSourceNestedParquetDataWriteBenchmark.java
@@ -39,9 +39,9 @@ import static org.apache.spark.sql.functions.struct;
  * A benchmark that evaluates the performance of writing nested Parquet data using Iceberg
  * and the built-in file source in Spark.
  *
- * To run this benchmark for either spark-2 or spark-3:
+ * To run this benchmark for spark-3.1:
  * <code>
- *   ./gradlew :iceberg-spark:iceberg-spark[2|3]:jmh
+ *   ./gradlew -DsparkVersions=3.1 :iceberg-spark:iceberg-spark-3.1_2.12:jmh
  *       -PjmhIncludeRegex=IcebergSourceNestedParquetDataWriteBenchmark
  *       -PjmhOutputPath=benchmark/iceberg-source-nested-parquet-data-write-benchmark-result.txt
  * </code>

--- a/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/ParquetWritersBenchmark.java
+++ b/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/ParquetWritersBenchmark.java
@@ -25,9 +25,9 @@ import org.apache.iceberg.spark.source.WritersBenchmark;
 /**
  * A benchmark that evaluates the performance of various Iceberg writers for Parquet data.
  *
- * To run this benchmark for either spark-2 or spark-3:
+ * To run this benchmark for spark-3.1:
  * <code>
- *   ./gradlew :iceberg-spark:iceberg-spark[2|3]:jmh
+ *   ./gradlew -DsparkVersions=3.1 :iceberg-spark:iceberg-spark-3.1_2.12:jmh
  *       -PjmhIncludeRegex=ParquetWritersBenchmark
  *       -PjmhOutputPath=benchmark/parquet-writers-benchmark-result.txt
  * </code>

--- a/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/vectorized/VectorizedReadDictionaryEncodedFlatParquetDataBenchmark.java
+++ b/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/vectorized/VectorizedReadDictionaryEncodedFlatParquetDataBenchmark.java
@@ -43,9 +43,9 @@ import static org.apache.spark.sql.functions.to_timestamp;
  * Benchmark to compare performance of reading Parquet dictionary encoded data with a flat schema using vectorized
  * Iceberg read path and the built-in file source in Spark.
  * <p>
- * To run this benchmark for either spark-2 or spark-3:
+ * To run this benchmark for spark-3.1:
  * <code>
- *   ./gradlew :iceberg-spark:iceberg-spark[2|3]:jmh
+ *   ./gradlew -DsparkVersions=3.1 :iceberg-spark:iceberg-spark-3.1_2.12:jmh
  *       -PjmhIncludeRegex=VectorizedReadDictionaryEncodedFlatParquetDataBenchmark
  *       -PjmhOutputPath=benchmark/results.txt
  * </code>

--- a/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/vectorized/VectorizedReadFlatParquetDataBenchmark.java
+++ b/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/parquet/vectorized/VectorizedReadFlatParquetDataBenchmark.java
@@ -51,9 +51,9 @@ import static org.apache.spark.sql.functions.when;
  * Benchmark to compare performance of reading Parquet data with a flat schema using vectorized Iceberg read path and
  * the built-in file source in Spark.
  * <p>
- * To run this benchmark for either spark-2 or spark-3:
+ * To run this benchmark for spark-3.1:
  * <code>
- *   ./gradlew :iceberg-spark:iceberg-spark[2|3]:jmh
+ *   ./gradlew -DsparkVersions=3.1 :iceberg-spark:iceberg-spark-3.1_2.12:jmh
  *       -PjmhIncludeRegex=VectorizedReadFlatParquetDataBenchmark
  *       -PjmhOutputPath=benchmark/results.txt
  * </code>


### PR DESCRIPTION
Similar to https://github.com/apache/iceberg/pull/4328, the Spark JMH benchmarks have invalid commands in their JavaDoc comment ever since we migrated to version specific Spark builds.

This updates all of the Spark 3.1 tests to use the correct project `iceberg-spark-3.1_2.12:jmh` as well as pass the system property `sparkVersions=3.1`, as it's not included in the default Spark versions in our gradle configuration.

cc @rdblue who reviewed the last one.