### PR TITLE
Parquet: Avoid modifying existing conf of HadoopOutputFile rather create new one

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -266,7 +266,7 @@ public class Parquet {
             "Cannot write with both write support and Parquet value writer");
 
         for (Map.Entry<String, String> entry : config.entrySet()) {
-          this.conf.set(entry.getKey(), entry.getValue());
+          conf.set(entry.getKey(), entry.getValue());
         }
 
         ParquetProperties parquetProperties = ParquetProperties.builder()

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -113,6 +113,7 @@ public class Parquet {
 
   public static class WriteBuilder {
     private final OutputFile file;
+    private final Configuration conf;
     private final Map<String, String> metadata = Maps.newLinkedHashMap();
     private final Map<String, String> config = Maps.newLinkedHashMap();
     private Schema schema = null;
@@ -126,6 +127,11 @@ public class Parquet {
 
     private WriteBuilder(OutputFile file) {
       this.file = file;
+      if (file instanceof HadoopOutputFile) {
+        this.conf = new Configuration(((HadoopOutputFile) file).getConf());
+      } else {
+        this.conf = new Configuration();
+      }
     }
 
     public WriteBuilder forTable(Table table) {
@@ -258,15 +264,9 @@ public class Parquet {
       if (createWriterFunc != null) {
         Preconditions.checkArgument(writeSupport == null,
             "Cannot write with both write support and Parquet value writer");
-        Configuration conf;
-        if (file instanceof HadoopOutputFile) {
-          conf = ((HadoopOutputFile) file).getConf();
-        } else {
-          conf = new Configuration();
-        }
 
         for (Map.Entry<String, String> entry : config.entrySet()) {
-          conf.set(entry.getKey(), entry.getValue());
+          this.conf.set(entry.getKey(), entry.getValue());
         }
 
         ParquetProperties parquetProperties = ParquetProperties.builder()

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
@@ -85,6 +85,15 @@ public abstract class SparkRowLevelOperationsTestBase extends SparkExtensionsTes
             true,
             WRITE_DISTRIBUTION_MODE_NONE
         },
+        { "testhive", SparkCatalog.class.getName(),
+          ImmutableMap.of(
+              "type", "hive",
+              "default-namespace", "default"
+          ),
+          "parquet",
+          true,
+          WRITE_DISTRIBUTION_MODE_NONE
+        },
         { "testhadoop", SparkCatalog.class.getName(),
             ImmutableMap.of(
                 "type", "hadoop"

--- a/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
+++ b/spark/v3.2/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
@@ -86,13 +86,13 @@ public abstract class SparkRowLevelOperationsTestBase extends SparkExtensionsTes
             WRITE_DISTRIBUTION_MODE_NONE
         },
         { "testhive", SparkCatalog.class.getName(),
-          ImmutableMap.of(
-              "type", "hive",
-              "default-namespace", "default"
-          ),
-          "parquet",
-          true,
-          WRITE_DISTRIBUTION_MODE_NONE
+            ImmutableMap.of(
+                "type", "hive",
+                "default-namespace", "default"
+            ),
+            "parquet",
+            true,
+            WRITE_DISTRIBUTION_MODE_NONE
         },
         { "testhadoop", SparkCatalog.class.getName(),
             ImmutableMap.of(


### PR DESCRIPTION
we faced concurrent modification issue in ORC when trying to modify existing hadoop conf from HadoopFileIO in ORC write builder.  ref : [Issue#4383](https://github.com/apache/iceberg/issues/4383), [PR#4384](https://github.com/apache/iceberg/pull/4384)

Looks like this code snippet was present in Parquet#write as well, based on discussion https://github.com/apache/iceberg/pull/3810#issuecomment-1061334692

As per my understanding, we should do the same changes as we did in the ORC, here in parquet. The issue we had in ORC (given that we expect our PR fixed it), could also happen in Parquet#write under same circumstances, added a test for the same

----
cc @openinx, @hililiwei , @rdblue 