### PR TITLE
Core: Add stack trace to ErrorResponse

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/responses/ErrorResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/ErrorResponse.java
@@ -19,7 +19,10 @@
 
 package org.apache.iceberg.rest.responses;
 
-import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 /**
@@ -30,11 +33,13 @@ public class ErrorResponse {
   private String message;
   private String type;
   private int code;
+  private List<String> stack;
 
-  private ErrorResponse(String message, String type, int code) {
+  private ErrorResponse(String message, String type, int code, List<String> stack) {
     this.message = message;
     this.type = type;
     this.code = code;
+    this.stack = stack;
     validate();
   }
 
@@ -54,13 +59,29 @@ public class ErrorResponse {
     return code;
   }
 
+  public List<String> stack() {
+    return stack;
+  }
+
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("message", message)
-        .add("type", type)
-        .add("code", code)
-        .toString();
+    StringBuilder sb = new StringBuilder();
+    sb.append("ErrorResponse(")
+        .append("code=")
+        .append(code)
+        .append(", type=")
+        .append(type)
+        .append(", message=")
+        .append(message)
+        .append(")");
+
+    if (stack != null && !stack.isEmpty()) {
+      for (String line : stack) {
+        sb.append("\n").append(line);
+      }
+    }
+
+    return sb.toString();
   }
 
   public static Builder builder() {
@@ -71,6 +92,7 @@ public class ErrorResponse {
     private String message;
     private String type;
     private Integer code;
+    private List<String> stack;
 
     private Builder() {
     }
@@ -85,6 +107,22 @@ public class ErrorResponse {
       return this;
     }
 
+    public Builder withStackTrace(Throwable throwable) {
+      StringWriter sw = new StringWriter();
+      try (PrintWriter pw = new PrintWriter(sw)) {
+        throwable.printStackTrace(pw);
+      }
+
+      this.stack = Arrays.asList(sw.toString().split("\n"));
+
+      return this;
+    }
+
+    public Builder withStackTrace(List<String> trace) {
+      this.stack = trace;
+      return this;
+    }
+
     public Builder responseCode(Integer responseCode) {
       this.code = responseCode;
       return this;
@@ -92,7 +130,7 @@ public class ErrorResponse {
 
     public ErrorResponse build() {
       Preconditions.checkArgument(code != null, "Invalid response, missing field: code");
-      return new ErrorResponse(message, type, code);
+      return new ErrorResponse(message, type, code, stack);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/responses/ErrorResponseParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/ErrorResponseParser.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.UncheckedIOException;
+import java.util.List;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.JsonUtil;
 
@@ -36,6 +37,7 @@ public class ErrorResponseParser {
   private static final String MESSAGE = "message";
   private static final String TYPE = "type";
   private static final String CODE = "code";
+  private static final String STACK = "stack";
 
   public static String toJson(ErrorResponse errorResponse) {
     return toJson(errorResponse, false);
@@ -64,6 +66,13 @@ public class ErrorResponseParser {
     generator.writeStringField(MESSAGE, errorResponse.message());
     generator.writeStringField(TYPE, errorResponse.type());
     generator.writeNumberField(CODE, errorResponse.code());
+    if (errorResponse.stack() != null) {
+      generator.writeArrayFieldStart(STACK);
+      for (String line : errorResponse.stack()) {
+        generator.writeString(line);
+      }
+      generator.writeEndArray();
+    }
 
     generator.writeEndObject();
 
@@ -92,10 +101,12 @@ public class ErrorResponseParser {
     String message = JsonUtil.getStringOrNull(MESSAGE, error);
     String type = JsonUtil.getStringOrNull(TYPE, error);
     Integer code = JsonUtil.getIntOrNull(CODE, error);
+    List<String> stack = JsonUtil.getStringListOrNull(STACK, error);
     return ErrorResponse.builder()
         .withMessage(message)
         .withType(type)
         .responseCode(code)
+        .withStackTrace(stack)
         .build();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -327,7 +327,8 @@ public class RESTCatalogAdapter implements RESTClient {
     errorBuilder
         .responseCode(EXCEPTION_ERROR_CODES.getOrDefault(exc.getClass(), 500))
         .withType(exc.getClass().getSimpleName())
-        .withMessage(exc.getMessage());
+        .withMessage(exc.getMessage())
+        .withStackTrace(exc);
   }
 
   private static Namespace namespaceFromPathVars(Map<String, String> pathVars) {

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestErrorResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestErrorResponseParser.java
@@ -19,6 +19,8 @@
 
 package org.apache.iceberg.rest.responses;
 
+import java.util.Arrays;
+import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -37,6 +39,25 @@ public class TestErrorResponseParser {
   }
 
   @Test
+  public void testErrorResponseToJsonWithStack() {
+    String message = "The given namespace does not exist";
+    String type = "NoSuchNamespaceException";
+    Integer code = 404;
+    List<String> stack = Arrays.asList("a", "b");
+    String errorModelJson = String.format(
+        "{\"message\":\"%s\",\"type\":\"%s\",\"code\":%d,\"stack\":[\"a\",\"b\"]}", message, type, code);
+    String json = "{\"error\":" + errorModelJson + "}";
+    ErrorResponse response = ErrorResponse.builder()
+        .withMessage(message)
+        .withType(type)
+        .responseCode(code)
+        .withStackTrace(stack)
+        .build();
+    Assert.assertEquals("Should be able to serialize an error response as json",
+        json, ErrorResponseParser.toJson(response));
+  }
+
+  @Test
   public void testErrorResponseFromJson() {
     String message = "The given namespace does not exist";
     String type = "NoSuchNamespaceException";
@@ -48,9 +69,29 @@ public class TestErrorResponseParser {
     assertEquals(expected, ErrorResponseParser.fromJson(json));
   }
 
+  @Test
+  public void testErrorResponseFromJsonWithStack() {
+    String message = "The given namespace does not exist";
+    String type = "NoSuchNamespaceException";
+    Integer code = 404;
+    List<String> stack = Arrays.asList("a", "b");
+    String errorModelJson = String.format(
+        "{\"message\":\"%s\",\"type\":\"%s\",\"code\":%d,\"stack\":[\"a\",\"b\"]}", message, type, code);
+    String json = "{\"error\":" + errorModelJson + "}";
+
+    ErrorResponse expected = ErrorResponse.builder()
+        .withMessage(message)
+        .withType(type)
+        .responseCode(code)
+        .withStackTrace(stack)
+        .build();
+    assertEquals(expected, ErrorResponseParser.fromJson(json));
+  }
+
   public void assertEquals(ErrorResponse expected, ErrorResponse actual) {
     Assert.assertEquals("Message should be equal", expected.message(), actual.message());
     Assert.assertEquals("Type should be equal", expected.type(), actual.type());
     Assert.assertEquals("Response code should be equal", expected.code(), actual.code());
+    Assert.assertEquals("Stack should be equal", expected.stack(), actual.stack());
   }
 }


### PR DESCRIPTION
#4367 added a way to send stack traces in REST error responses. This updates the `ErrorResponse` implementation and test code to send stack traces.