### PR TITLE
Core - Mark the object mapper in HTTPClient#Builder as visible for testing

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -41,6 +41,7 @@ import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.iceberg.exceptions.RESTException;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -249,13 +250,8 @@ public class HTTPClient implements RESTClient {
       return this;
     }
 
-    // Visible for testing
-    public Builder httpClient(CloseableHttpClient client) {
-      this.httpClient = client;
-      return this;
-    }
-
-    public Builder mapper(ObjectMapper objectMapper) {
+    @VisibleForTesting
+    Builder mapper(ObjectMapper objectMapper) {
       this.mapper = objectMapper;
       return this;
     }


### PR DESCRIPTION
As a follow up to some comments on this PR here https://github.com/apache/iceberg/pull/4245#discussion_r835964263, the RESTCatalog's HTTPClient's builder should only expose the object mapper for testing.

Otherwise, the correct object mapper that knows how to handle all of the necessary request / response types should be used.

Also removing a method that is not used, `Builder#httpClient`.

cc @rdblue 