### PR TITLE
Spark/Flink: ORC support estimated length for unclosed file.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/io/ClusteredDataWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/ClusteredDataWriter.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.io;
 
 import java.util.List;
 import org.apache.iceberg.DataFile;
-import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -35,16 +34,14 @@ public class ClusteredDataWriter<T> extends ClusteredWriter<T, DataWriteResult> 
   private final FileWriterFactory<T> writerFactory;
   private final OutputFileFactory fileFactory;
   private final FileIO io;
-  private final FileFormat fileFormat;
   private final long targetFileSizeInBytes;
   private final List<DataFile> dataFiles;
 
   public ClusteredDataWriter(FileWriterFactory<T> writerFactory, OutputFileFactory fileFactory,
-                             FileIO io, FileFormat fileFormat, long targetFileSizeInBytes) {
+                             FileIO io, long targetFileSizeInBytes) {
     this.writerFactory = writerFactory;
     this.fileFactory = fileFactory;
     this.io = io;
-    this.fileFormat = fileFormat;
     this.targetFileSizeInBytes = targetFileSizeInBytes;
     this.dataFiles = Lists.newArrayList();
   }

--- a/core/src/main/java/org/apache/iceberg/io/ClusteredEqualityDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/ClusteredEqualityDeleteWriter.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.io;
 
 import java.util.List;
 import org.apache.iceberg.DeleteFile;
-import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -36,16 +35,14 @@ public class ClusteredEqualityDeleteWriter<T> extends ClusteredWriter<T, DeleteW
   private final FileWriterFactory<T> writerFactory;
   private final OutputFileFactory fileFactory;
   private final FileIO io;
-  private final FileFormat fileFormat;
   private final long targetFileSizeInBytes;
   private final List<DeleteFile> deleteFiles;
 
   public ClusteredEqualityDeleteWriter(FileWriterFactory<T> writerFactory, OutputFileFactory fileFactory,
-                                       FileIO io, FileFormat fileFormat, long targetFileSizeInBytes) {
+                                       FileIO io, long targetFileSizeInBytes) {
     this.writerFactory = writerFactory;
     this.fileFactory = fileFactory;
     this.io = io;
-    this.fileFormat = fileFormat;
     this.targetFileSizeInBytes = targetFileSizeInBytes;
     this.deleteFiles = Lists.newArrayList();
   }

--- a/core/src/main/java/org/apache/iceberg/io/ClusteredPositionDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/ClusteredPositionDeleteWriter.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.io;
 
 import java.util.List;
 import org.apache.iceberg.DeleteFile;
-import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.deletes.PositionDelete;
@@ -37,17 +36,15 @@ public class ClusteredPositionDeleteWriter<T> extends ClusteredWriter<PositionDe
   private final FileWriterFactory<T> writerFactory;
   private final OutputFileFactory fileFactory;
   private final FileIO io;
-  private final FileFormat fileFormat;
   private final long targetFileSizeInBytes;
   private final List<DeleteFile> deleteFiles;
   private final CharSequenceSet referencedDataFiles;
 
   public ClusteredPositionDeleteWriter(FileWriterFactory<T> writerFactory, OutputFileFactory fileFactory,
-                                       FileIO io, FileFormat fileFormat, long targetFileSizeInBytes) {
+                                       FileIO io, long targetFileSizeInBytes) {
     this.writerFactory = writerFactory;
     this.fileFactory = fileFactory;
     this.io = io;
-    this.fileFormat = fileFormat;
     this.targetFileSizeInBytes = targetFileSizeInBytes;
     this.deleteFiles = Lists.newArrayList();
     this.referencedDataFiles = CharSequenceSet.empty();

--- a/core/src/main/java/org/apache/iceberg/io/FanoutDataWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/FanoutDataWriter.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.io;
 
 import java.util.List;
 import org.apache.iceberg.DataFile;
-import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -35,16 +34,14 @@ public class FanoutDataWriter<T> extends FanoutWriter<T, DataWriteResult> {
   private final FileWriterFactory<T> writerFactory;
   private final OutputFileFactory fileFactory;
   private final FileIO io;
-  private final FileFormat fileFormat;
   private final long targetFileSizeInBytes;
   private final List<DataFile> dataFiles;
 
   public FanoutDataWriter(FileWriterFactory<T> writerFactory, OutputFileFactory fileFactory,
-                          FileIO io, FileFormat fileFormat, long targetFileSizeInBytes) {
+                          FileIO io, long targetFileSizeInBytes) {
     this.writerFactory = writerFactory;
     this.fileFactory = fileFactory;
     this.io = io;
-    this.fileFormat = fileFormat;
     this.targetFileSizeInBytes = targetFileSizeInBytes;
     this.dataFiles = Lists.newArrayList();
   }

--- a/data/src/test/java/org/apache/iceberg/io/TestPartitioningWriters.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestPartitioningWriters.java
@@ -82,8 +82,7 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
   public void testClusteredDataWriterNoRecords() throws IOException {
     FileWriterFactory<T> writerFactory = newWriterFactory(table.schema());
     ClusteredDataWriter<T> writer = new ClusteredDataWriter<>(
-        writerFactory, fileFactory, table.io(),
-        fileFormat, TARGET_FILE_SIZE);
+        writerFactory, fileFactory, table.io(), TARGET_FILE_SIZE);
 
     writer.close();
     Assert.assertEquals("Must be no data files", 0, writer.result().dataFiles().size());
@@ -100,8 +99,7 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
 
     FileWriterFactory<T> writerFactory = newWriterFactory(table.schema());
     ClusteredDataWriter<T> writer = new ClusteredDataWriter<>(
-        writerFactory, fileFactory, table.io(),
-        fileFormat, TARGET_FILE_SIZE);
+        writerFactory, fileFactory, table.io(), TARGET_FILE_SIZE);
 
     PartitionSpec spec = table.spec();
 
@@ -138,8 +136,7 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
 
     FileWriterFactory<T> writerFactory = newWriterFactory(table.schema());
     ClusteredDataWriter<T> writer = new ClusteredDataWriter<>(
-        writerFactory, fileFactory, table.io(),
-        fileFormat, TARGET_FILE_SIZE);
+        writerFactory, fileFactory, table.io(), TARGET_FILE_SIZE);
 
     PartitionSpec spec = table.spec();
 
@@ -162,8 +159,7 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
     Schema equalityDeleteRowSchema = table.schema().select("id");
     FileWriterFactory<T> writerFactory = newWriterFactory(table.schema(), equalityFieldIds, equalityDeleteRowSchema);
     ClusteredEqualityDeleteWriter<T> writer = new ClusteredEqualityDeleteWriter<>(
-        writerFactory, fileFactory, table.io(),
-        fileFormat, TARGET_FILE_SIZE);
+        writerFactory, fileFactory, table.io(), TARGET_FILE_SIZE);
 
     writer.close();
     Assert.assertEquals(0, writer.result().deleteFiles().size());
@@ -226,8 +222,7 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
         .commit();
 
     ClusteredEqualityDeleteWriter<T> writer = new ClusteredEqualityDeleteWriter<>(
-        writerFactory, fileFactory, table.io(),
-        fileFormat, TARGET_FILE_SIZE);
+        writerFactory, fileFactory, table.io(), TARGET_FILE_SIZE);
 
     PartitionSpec unpartitionedSpec = table.specs().get(0);
     PartitionSpec bucketSpec = table.specs().get(1);
@@ -274,8 +269,7 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
         .commit();
 
     ClusteredEqualityDeleteWriter<T> writer = new ClusteredEqualityDeleteWriter<>(
-        writerFactory, fileFactory, table.io(),
-        fileFormat, TARGET_FILE_SIZE);
+        writerFactory, fileFactory, table.io(), TARGET_FILE_SIZE);
 
     PartitionSpec unpartitionedSpec = table.specs().get(0);
     PartitionSpec bucketSpec = table.specs().get(1);
@@ -303,8 +297,7 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
   public void testClusteredPositionDeleteWriterNoRecords() throws IOException {
     FileWriterFactory<T> writerFactory = newWriterFactory(table.schema());
     ClusteredPositionDeleteWriter<T> writer = new ClusteredPositionDeleteWriter<>(
-        writerFactory, fileFactory, table.io(),
-        fileFormat, TARGET_FILE_SIZE);
+        writerFactory, fileFactory, table.io(), TARGET_FILE_SIZE);
 
     writer.close();
     Assert.assertEquals(0, writer.result().deleteFiles().size());
@@ -365,8 +358,7 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
         .commit();
 
     ClusteredPositionDeleteWriter<T> writer = new ClusteredPositionDeleteWriter<>(
-        writerFactory, fileFactory, table.io(),
-        fileFormat, TARGET_FILE_SIZE);
+        writerFactory, fileFactory, table.io(), TARGET_FILE_SIZE);
 
     PartitionSpec unpartitionedSpec = table.specs().get(0);
     PartitionSpec bucketSpec = table.specs().get(1);
@@ -411,8 +403,7 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
         .commit();
 
     ClusteredPositionDeleteWriter<T> writer = new ClusteredPositionDeleteWriter<>(
-        writerFactory, fileFactory, table.io(),
-        fileFormat, TARGET_FILE_SIZE);
+        writerFactory, fileFactory, table.io(), TARGET_FILE_SIZE);
 
     PartitionSpec unpartitionedSpec = table.specs().get(0);
     PartitionSpec bucketSpec = table.specs().get(1);
@@ -446,8 +437,7 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
   public void testFanoutDataWriterNoRecords() throws IOException {
     FileWriterFactory<T> writerFactory = newWriterFactory(table.schema());
     FanoutDataWriter<T> writer = new FanoutDataWriter<>(
-        writerFactory, fileFactory, table.io(),
-        fileFormat, TARGET_FILE_SIZE);
+        writerFactory, fileFactory, table.io(), TARGET_FILE_SIZE);
 
     writer.close();
     Assert.assertEquals("Must be no data files", 0, writer.result().dataFiles().size());
@@ -464,8 +454,7 @@ public abstract class TestPartitioningWriters<T> extends WriterTestBase<T> {
 
     FileWriterFactory<T> writerFactory = newWriterFactory(table.schema());
     FanoutDataWriter<T> writer = new FanoutDataWriter<>(
-        writerFactory, fileFactory, table.io(),
-        fileFormat, TARGET_FILE_SIZE);
+        writerFactory, fileFactory, table.io(), TARGET_FILE_SIZE);
 
     PartitionSpec spec = table.spec();
 

--- a/data/src/test/java/org/apache/iceberg/io/TestPositionDeltaWriters.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestPositionDeltaWriters.java
@@ -80,14 +80,11 @@ public abstract class TestPositionDeltaWriters<T> extends WriterTestBase<T> {
     FileWriterFactory<T> writerFactory = newWriterFactory(table.schema());
 
     ClusteredDataWriter<T> insertWriter = new ClusteredDataWriter<>(
-        writerFactory, fileFactory, table.io(),
-        fileFormat, TARGET_FILE_SIZE);
+        writerFactory, fileFactory, table.io(), TARGET_FILE_SIZE);
     ClusteredDataWriter<T> updateWriter = new ClusteredDataWriter<>(
-        writerFactory, fileFactory, table.io(),
-        fileFormat, TARGET_FILE_SIZE);
+        writerFactory, fileFactory, table.io(), TARGET_FILE_SIZE);
     ClusteredPositionDeleteWriter<T> deleteWriter = new ClusteredPositionDeleteWriter<>(
-        writerFactory, fileFactory, table.io(),
-        fileFormat, TARGET_FILE_SIZE);
+        writerFactory, fileFactory, table.io(), TARGET_FILE_SIZE);
     PositionDeltaWriter<T> deltaWriter = new BasePositionDeltaWriter<>(insertWriter, updateWriter, deleteWriter);
 
     deltaWriter.insert(toRow(1, "aaa"), table.spec(), null);
@@ -148,14 +145,11 @@ public abstract class TestPositionDeltaWriters<T> extends WriterTestBase<T> {
     PartitionSpec partitionedSpec = table.specs().get(1);
 
     ClusteredDataWriter<T> insertWriter = new ClusteredDataWriter<>(
-        writerFactory, fileFactory, table.io(),
-        fileFormat, TARGET_FILE_SIZE);
+        writerFactory, fileFactory, table.io(), TARGET_FILE_SIZE);
     ClusteredDataWriter<T> updateWriter = new ClusteredDataWriter<>(
-        writerFactory, fileFactory, table.io(),
-        fileFormat, TARGET_FILE_SIZE);
+        writerFactory, fileFactory, table.io(), TARGET_FILE_SIZE);
     ClusteredPositionDeleteWriter<T> deleteWriter = new ClusteredPositionDeleteWriter<>(
-        writerFactory, fileFactory, table.io(),
-        fileFormat, TARGET_FILE_SIZE);
+        writerFactory, fileFactory, table.io(), TARGET_FILE_SIZE);
     PositionDeltaWriter<T> deltaWriter = new BasePositionDeltaWriter<>(insertWriter, updateWriter, deleteWriter);
 
     deltaWriter.delete(dataFile1.path(), 2L, unpartitionedSpec, null);
@@ -220,14 +214,11 @@ public abstract class TestPositionDeltaWriters<T> extends WriterTestBase<T> {
     PartitionSpec partitionedSpec = table.specs().get(1);
 
     ClusteredDataWriter<T> insertWriter = new ClusteredDataWriter<>(
-        writerFactory, fileFactory, table.io(),
-        fileFormat, TARGET_FILE_SIZE);
+        writerFactory, fileFactory, table.io(), TARGET_FILE_SIZE);
     ClusteredDataWriter<T> updateWriter = new ClusteredDataWriter<>(
-        writerFactory, fileFactory, table.io(),
-        fileFormat, TARGET_FILE_SIZE);
+        writerFactory, fileFactory, table.io(), TARGET_FILE_SIZE);
     ClusteredPositionDeleteWriter<T> deleteWriter = new ClusteredPositionDeleteWriter<>(
-        writerFactory, fileFactory, table.io(),
-        fileFormat, TARGET_FILE_SIZE);
+        writerFactory, fileFactory, table.io(), TARGET_FILE_SIZE);
     PositionDeltaWriter<T> deltaWriter = new BasePositionDeltaWriter<>(insertWriter, updateWriter, deleteWriter);
 
     deltaWriter.delete(dataFile1.path(), 2L, unpartitionedSpec, null);

--- a/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
+++ b/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
@@ -23,6 +23,7 @@ package org.apache.iceberg.flink.actions;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.configuration.CoreOptions;
@@ -50,7 +51,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -320,7 +320,6 @@ public class TestRewriteDataFilesAction extends FlinkCatalogTestBase {
    */
   @Test
   public void testRewriteAvoidRepeateCompress() throws IOException {
-    Assume.assumeFalse("ORC does not support getting length when file is opening", format.equals(FileFormat.ORC));
     List<Record> expected = Lists.newArrayList();
     Schema schema = icebergTableUnPartitioned.schema();
     GenericAppenderFactory genericAppenderFactory = new GenericAppenderFactory(schema);
@@ -329,7 +328,7 @@ public class TestRewriteDataFilesAction extends FlinkCatalogTestBase {
     try (FileAppender<Record> fileAppender = genericAppenderFactory.newAppender(Files.localOutput(file), format)) {
       long filesize = 20000;
       for (; fileAppender.length() < filesize; count++) {
-        Record record = SimpleDataUtil.createRecord(count, "iceberg");
+        Record record = SimpleDataUtil.createRecord(count, UUID.randomUUID().toString());
         fileAppender.add(record);
         expected.add(record);
       }

--- a/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergStreamWriter.java
+++ b/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergStreamWriter.java
@@ -233,10 +233,6 @@ public class TestIcebergStreamWriter {
 
   @Test
   public void testTableWithTargetFileSize() throws Exception {
-    // TODO: ORC file does not support target file size before closed.
-    if (format == FileFormat.ORC) {
-      return;
-    }
     // Adjust the target-file-size in table properties.
     table.updateProperties()
         .set(TableProperties.WRITE_TARGET_FILE_SIZE_BYTES, "4") // ~4 bytes; low enough to trigger

--- a/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestTaskWriters.java
+++ b/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestTaskWriters.java
@@ -183,10 +183,6 @@ public class TestTaskWriters {
 
   @Test
   public void testRollingWithTargetFileSize() throws IOException {
-    // TODO ORC don't support target file size before closed.
-    if (format == FileFormat.ORC) {
-      return;
-    }
     try (TaskWriter<RowData> taskWriter = createTaskWriter(4)) {
       List<RowData> rows = Lists.newArrayListWithCapacity(8000);
       List<Record> records = Lists.newArrayListWithCapacity(8000);

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/actions/TestRewriteDataFilesAction.java
@@ -23,6 +23,7 @@ package org.apache.iceberg.flink.actions;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.configuration.CoreOptions;
@@ -50,7 +51,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -322,7 +322,6 @@ public class TestRewriteDataFilesAction extends FlinkCatalogTestBase {
    */
   @Test
   public void testRewriteAvoidRepeateCompress() throws IOException {
-    Assume.assumeFalse("ORC does not support getting length when file is opening", format.equals(FileFormat.ORC));
     List<Record> expected = Lists.newArrayList();
     Schema schema = icebergTableUnPartitioned.schema();
     GenericAppenderFactory genericAppenderFactory = new GenericAppenderFactory(schema);
@@ -331,7 +330,7 @@ public class TestRewriteDataFilesAction extends FlinkCatalogTestBase {
     try (FileAppender<Record> fileAppender = genericAppenderFactory.newAppender(Files.localOutput(file), format)) {
       long filesize = 20000;
       for (; fileAppender.length() < filesize; count++) {
-        Record record = SimpleDataUtil.createRecord(count, "iceberg");
+        Record record = SimpleDataUtil.createRecord(count, UUID.randomUUID().toString());
         fileAppender.add(record);
         expected.add(record);
       }

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergStreamWriter.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergStreamWriter.java
@@ -233,10 +233,6 @@ public class TestIcebergStreamWriter {
 
   @Test
   public void testTableWithTargetFileSize() throws Exception {
-    // TODO: ORC file does not support target file size before closed.
-    if (format == FileFormat.ORC) {
-      return;
-    }
     // Adjust the target-file-size in table properties.
     table.updateProperties()
         .set(TableProperties.WRITE_TARGET_FILE_SIZE_BYTES, "4") // ~4 bytes; low enough to trigger

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/sink/TestTaskWriters.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/sink/TestTaskWriters.java
@@ -183,10 +183,6 @@ public class TestTaskWriters {
 
   @Test
   public void testRollingWithTargetFileSize() throws IOException {
-    // TODO ORC don't support target file size before closed.
-    if (format == FileFormat.ORC) {
-      return;
-    }
     try (TaskWriter<RowData> taskWriter = createTaskWriter(4)) {
       List<RowData> rows = Lists.newArrayListWithCapacity(8000);
       List<Record> records = Lists.newArrayListWithCapacity(8000);

--- a/spark/v2.4/spark/src/jmh/java/org/apache/iceberg/spark/source/WritersBenchmark.java
+++ b/spark/v2.4/spark/src/jmh/java/org/apache/iceberg/spark/source/WritersBenchmark.java
@@ -136,8 +136,7 @@ public abstract class WritersBenchmark extends IcebergSourceBenchmark {
         .build();
 
     ClusteredDataWriter<InternalRow> writer = new ClusteredDataWriter<>(
-        writerFactory, fileFactory, io,
-        fileFormat(), TARGET_FILE_SIZE_IN_BYTES);
+        writerFactory, fileFactory, io, TARGET_FILE_SIZE_IN_BYTES);
 
     try (ClusteredDataWriter<InternalRow> closeableWriter = writer) {
       for (InternalRow row : rows) {
@@ -186,8 +185,7 @@ public abstract class WritersBenchmark extends IcebergSourceBenchmark {
         .build();
 
     ClusteredDataWriter<InternalRow> writer = new ClusteredDataWriter<>(
-        writerFactory, fileFactory, io,
-        fileFormat(), TARGET_FILE_SIZE_IN_BYTES);
+        writerFactory, fileFactory, io, TARGET_FILE_SIZE_IN_BYTES);
 
     PartitionKey partitionKey = new PartitionKey(partitionedSpec, table().schema());
     StructType dataSparkType = SparkSchemaUtil.convert(table().schema());
@@ -242,8 +240,7 @@ public abstract class WritersBenchmark extends IcebergSourceBenchmark {
         .build();
 
     FanoutDataWriter<InternalRow> writer = new FanoutDataWriter<>(
-        writerFactory, fileFactory, io,
-        fileFormat(), TARGET_FILE_SIZE_IN_BYTES);
+        writerFactory, fileFactory, io, TARGET_FILE_SIZE_IN_BYTES);
 
     PartitionKey partitionKey = new PartitionKey(partitionedSpec, table().schema());
     StructType dataSparkType = SparkSchemaUtil.convert(table().schema());
@@ -301,8 +298,7 @@ public abstract class WritersBenchmark extends IcebergSourceBenchmark {
         .build();
 
     ClusteredEqualityDeleteWriter<InternalRow> writer = new ClusteredEqualityDeleteWriter<>(
-        writerFactory, fileFactory, io,
-        fileFormat(), TARGET_FILE_SIZE_IN_BYTES);
+        writerFactory, fileFactory, io, TARGET_FILE_SIZE_IN_BYTES);
 
     PartitionKey partitionKey = new PartitionKey(partitionedSpec, table().schema());
     StructType deleteSparkType = SparkSchemaUtil.convert(table().schema());
@@ -329,8 +325,7 @@ public abstract class WritersBenchmark extends IcebergSourceBenchmark {
         .build();
 
     ClusteredPositionDeleteWriter<InternalRow> writer = new ClusteredPositionDeleteWriter<>(
-        writerFactory, fileFactory, io,
-        fileFormat(), TARGET_FILE_SIZE_IN_BYTES);
+        writerFactory, fileFactory, io, TARGET_FILE_SIZE_IN_BYTES);
 
     PositionDelete<InternalRow> positionDelete = PositionDelete.create();
     try (ClusteredPositionDeleteWriter<InternalRow> closeableWriter = writer) {

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
@@ -365,11 +365,9 @@ public class TestSparkDataWrite {
         files.add(file);
       }
     }
-    // TODO: ORC file now not support target file size
-    if (!format.equals(FileFormat.ORC)) {
-      Assert.assertEquals("Should have 4 DataFiles", 4, files.size());
-      Assert.assertTrue("All DataFiles contain 1000 rows", files.stream().allMatch(d -> d.recordCount() == 1000));
-    }
+
+    Assert.assertEquals("Should have 4 DataFiles", 4, files.size());
+    Assert.assertTrue("All DataFiles contain 1000 rows", files.stream().allMatch(d -> d.recordCount() == 1000));
   }
 
   @Test
@@ -585,11 +583,9 @@ public class TestSparkDataWrite {
         files.add(file);
       }
     }
-    // TODO: ORC file now not support target file size
-    if (!format.equals(FileFormat.ORC)) {
-      Assert.assertEquals("Should have 8 DataFiles", 8, files.size());
-      Assert.assertTrue("All DataFiles contain 1000 rows", files.stream().allMatch(d -> d.recordCount() == 1000));
-    }
+
+    Assert.assertEquals("Should have 8 DataFiles", 8, files.size());
+    Assert.assertTrue("All DataFiles contain 1000 rows", files.stream().allMatch(d -> d.recordCount() == 1000));
   }
 
   public enum IcebergOptionsType {

--- a/spark/v3.0/spark/src/jmh/java/org/apache/iceberg/spark/source/WritersBenchmark.java
+++ b/spark/v3.0/spark/src/jmh/java/org/apache/iceberg/spark/source/WritersBenchmark.java
@@ -136,8 +136,7 @@ public abstract class WritersBenchmark extends IcebergSourceBenchmark {
         .build();
 
     ClusteredDataWriter<InternalRow> writer = new ClusteredDataWriter<>(
-        writerFactory, fileFactory, io,
-        fileFormat(), TARGET_FILE_SIZE_IN_BYTES);
+        writerFactory, fileFactory, io, TARGET_FILE_SIZE_IN_BYTES);
 
     try (ClusteredDataWriter<InternalRow> closeableWriter = writer) {
       for (InternalRow row : rows) {
@@ -186,8 +185,7 @@ public abstract class WritersBenchmark extends IcebergSourceBenchmark {
         .build();
 
     ClusteredDataWriter<InternalRow> writer = new ClusteredDataWriter<>(
-        writerFactory, fileFactory, io,
-        fileFormat(), TARGET_FILE_SIZE_IN_BYTES);
+        writerFactory, fileFactory, io, TARGET_FILE_SIZE_IN_BYTES);
 
     PartitionKey partitionKey = new PartitionKey(partitionedSpec, table().schema());
     StructType dataSparkType = SparkSchemaUtil.convert(table().schema());
@@ -242,8 +240,7 @@ public abstract class WritersBenchmark extends IcebergSourceBenchmark {
         .build();
 
     FanoutDataWriter<InternalRow> writer = new FanoutDataWriter<>(
-        writerFactory, fileFactory, io,
-        fileFormat(), TARGET_FILE_SIZE_IN_BYTES);
+        writerFactory, fileFactory, io, TARGET_FILE_SIZE_IN_BYTES);
 
     PartitionKey partitionKey = new PartitionKey(partitionedSpec, table().schema());
     StructType dataSparkType = SparkSchemaUtil.convert(table().schema());
@@ -301,8 +298,7 @@ public abstract class WritersBenchmark extends IcebergSourceBenchmark {
         .build();
 
     ClusteredEqualityDeleteWriter<InternalRow> writer = new ClusteredEqualityDeleteWriter<>(
-        writerFactory, fileFactory, io,
-        fileFormat(), TARGET_FILE_SIZE_IN_BYTES);
+        writerFactory, fileFactory, io, TARGET_FILE_SIZE_IN_BYTES);
 
     PartitionKey partitionKey = new PartitionKey(partitionedSpec, table().schema());
     StructType deleteSparkType = SparkSchemaUtil.convert(table().schema());
@@ -329,8 +325,7 @@ public abstract class WritersBenchmark extends IcebergSourceBenchmark {
         .build();
 
     ClusteredPositionDeleteWriter<InternalRow> writer = new ClusteredPositionDeleteWriter<>(
-        writerFactory, fileFactory, io,
-        fileFormat(), TARGET_FILE_SIZE_IN_BYTES);
+        writerFactory, fileFactory, io, TARGET_FILE_SIZE_IN_BYTES);
 
     PositionDelete<InternalRow> positionDelete = PositionDelete.create();
     try (ClusteredPositionDeleteWriter<InternalRow> closeableWriter = writer) {

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -561,12 +561,11 @@ class SparkWrite {
           .build();
 
       if (spec.isUnpartitioned()) {
-        return new UnpartitionedDataWriter(writerFactory, fileFactory, io, spec, format, targetFileSize);
+        return new UnpartitionedDataWriter(writerFactory, fileFactory, io, spec, targetFileSize);
 
       } else {
         return new PartitionedDataWriter(
-            writerFactory, fileFactory, io, spec, writeSchema, dsSchema,
-            format, targetFileSize, partitionedFanoutEnabled);
+            writerFactory, fileFactory, io, spec, writeSchema, dsSchema, targetFileSize, partitionedFanoutEnabled);
       }
     }
   }
@@ -583,7 +582,7 @@ class SparkWrite {
     private final FileIO io;
 
     private UnpartitionedDataWriter(SparkFileWriterFactory writerFactory, OutputFileFactory fileFactory,
-                                    FileIO io, PartitionSpec spec, FileFormat format, long targetFileSize) {
+                                    FileIO io, PartitionSpec spec, long targetFileSize) {
       this.delegate = new RollingDataWriter<>(writerFactory, fileFactory, io, targetFileSize, spec, null);
       this.io = io;
     }
@@ -626,12 +625,11 @@ class SparkWrite {
 
     private PartitionedDataWriter(SparkFileWriterFactory writerFactory, OutputFileFactory fileFactory,
                                   FileIO io, PartitionSpec spec, Schema dataSchema,
-                                  StructType dataSparkType, FileFormat format,
-                                  long targetFileSize, boolean fanoutEnabled) {
+                                  StructType dataSparkType, long targetFileSize, boolean fanoutEnabled) {
       if (fanoutEnabled) {
-        this.delegate = new FanoutDataWriter<>(writerFactory, fileFactory, io, format, targetFileSize);
+        this.delegate = new FanoutDataWriter<>(writerFactory, fileFactory, io, targetFileSize);
       } else {
-        this.delegate = new ClusteredDataWriter<>(writerFactory, fileFactory, io, format, targetFileSize);
+        this.delegate = new ClusteredDataWriter<>(writerFactory, fileFactory, io, targetFileSize);
       }
       this.io = io;
       this.spec = spec;

--- a/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -43,7 +43,6 @@ import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.SnapshotUpdate;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
-import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.ClusteredDataWriter;
@@ -585,13 +584,7 @@ class SparkWrite {
 
     private UnpartitionedDataWriter(SparkFileWriterFactory writerFactory, OutputFileFactory fileFactory,
                                     FileIO io, PartitionSpec spec, FileFormat format, long targetFileSize) {
-      // TODO: support ORC rolling writers
-      if (format == FileFormat.ORC) {
-        EncryptedOutputFile outputFile = fileFactory.newOutputFile();
-        delegate = writerFactory.newDataWriter(outputFile, spec, null);
-      } else {
-        delegate = new RollingDataWriter<>(writerFactory, fileFactory, io, targetFileSize, spec, null);
-      }
+      this.delegate = new RollingDataWriter<>(writerFactory, fileFactory, io, targetFileSize, spec, null);
       this.io = io;
     }
 

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
@@ -365,11 +365,9 @@ public class TestSparkDataWrite {
         files.add(file);
       }
     }
-    // TODO: ORC file now not support target file size
-    if (!format.equals(FileFormat.ORC)) {
-      Assert.assertEquals("Should have 4 DataFiles", 4, files.size());
-      Assert.assertTrue("All DataFiles contain 1000 rows", files.stream().allMatch(d -> d.recordCount() == 1000));
-    }
+
+    Assert.assertEquals("Should have 4 DataFiles", 4, files.size());
+    Assert.assertTrue("All DataFiles contain 1000 rows", files.stream().allMatch(d -> d.recordCount() == 1000));
   }
 
   @Test
@@ -585,11 +583,9 @@ public class TestSparkDataWrite {
         files.add(file);
       }
     }
-    // TODO: ORC file now not support target file size
-    if (!format.equals(FileFormat.ORC)) {
-      Assert.assertEquals("Should have 8 DataFiles", 8, files.size());
-      Assert.assertTrue("All DataFiles contain 1000 rows", files.stream().allMatch(d -> d.recordCount() == 1000));
-    }
+
+    Assert.assertEquals("Should have 8 DataFiles", 8, files.size());
+    Assert.assertTrue("All DataFiles contain 1000 rows", files.stream().allMatch(d -> d.recordCount() == 1000));
   }
 
   public enum IcebergOptionsType {

--- a/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/WritersBenchmark.java
+++ b/spark/v3.1/spark/src/jmh/java/org/apache/iceberg/spark/source/WritersBenchmark.java
@@ -136,8 +136,7 @@ public abstract class WritersBenchmark extends IcebergSourceBenchmark {
         .build();
 
     ClusteredDataWriter<InternalRow> writer = new ClusteredDataWriter<>(
-        writerFactory, fileFactory, io,
-        fileFormat(), TARGET_FILE_SIZE_IN_BYTES);
+        writerFactory, fileFactory, io, TARGET_FILE_SIZE_IN_BYTES);
 
     try (ClusteredDataWriter<InternalRow> closeableWriter = writer) {
       for (InternalRow row : rows) {
@@ -186,8 +185,7 @@ public abstract class WritersBenchmark extends IcebergSourceBenchmark {
         .build();
 
     ClusteredDataWriter<InternalRow> writer = new ClusteredDataWriter<>(
-        writerFactory, fileFactory, io,
-        fileFormat(), TARGET_FILE_SIZE_IN_BYTES);
+        writerFactory, fileFactory, io, TARGET_FILE_SIZE_IN_BYTES);
 
     PartitionKey partitionKey = new PartitionKey(partitionedSpec, table().schema());
     StructType dataSparkType = SparkSchemaUtil.convert(table().schema());
@@ -242,8 +240,7 @@ public abstract class WritersBenchmark extends IcebergSourceBenchmark {
         .build();
 
     FanoutDataWriter<InternalRow> writer = new FanoutDataWriter<>(
-        writerFactory, fileFactory, io,
-        fileFormat(), TARGET_FILE_SIZE_IN_BYTES);
+        writerFactory, fileFactory, io, TARGET_FILE_SIZE_IN_BYTES);
 
     PartitionKey partitionKey = new PartitionKey(partitionedSpec, table().schema());
     StructType dataSparkType = SparkSchemaUtil.convert(table().schema());
@@ -301,8 +298,7 @@ public abstract class WritersBenchmark extends IcebergSourceBenchmark {
         .build();
 
     ClusteredEqualityDeleteWriter<InternalRow> writer = new ClusteredEqualityDeleteWriter<>(
-        writerFactory, fileFactory, io,
-        fileFormat(), TARGET_FILE_SIZE_IN_BYTES);
+        writerFactory, fileFactory, io, TARGET_FILE_SIZE_IN_BYTES);
 
     PartitionKey partitionKey = new PartitionKey(partitionedSpec, table().schema());
     StructType deleteSparkType = SparkSchemaUtil.convert(table().schema());
@@ -329,8 +325,7 @@ public abstract class WritersBenchmark extends IcebergSourceBenchmark {
         .build();
 
     ClusteredPositionDeleteWriter<InternalRow> writer = new ClusteredPositionDeleteWriter<>(
-        writerFactory, fileFactory, io,
-        fileFormat(), TARGET_FILE_SIZE_IN_BYTES);
+        writerFactory, fileFactory, io, TARGET_FILE_SIZE_IN_BYTES);
 
     PositionDelete<InternalRow> positionDelete = PositionDelete.create();
     try (ClusteredPositionDeleteWriter<InternalRow> closeableWriter = writer) {

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -561,12 +561,11 @@ class SparkWrite {
           .build();
 
       if (spec.isUnpartitioned()) {
-        return new UnpartitionedDataWriter(writerFactory, fileFactory, io, spec, format, targetFileSize);
+        return new UnpartitionedDataWriter(writerFactory, fileFactory, io, spec, targetFileSize);
 
       } else {
         return new PartitionedDataWriter(
-            writerFactory, fileFactory, io, spec, writeSchema, dsSchema,
-            format, targetFileSize, partitionedFanoutEnabled);
+            writerFactory, fileFactory, io, spec, writeSchema, dsSchema, targetFileSize, partitionedFanoutEnabled);
       }
     }
   }
@@ -583,7 +582,7 @@ class SparkWrite {
     private final FileIO io;
 
     private UnpartitionedDataWriter(SparkFileWriterFactory writerFactory, OutputFileFactory fileFactory,
-                                    FileIO io, PartitionSpec spec, FileFormat format, long targetFileSize) {
+                                    FileIO io, PartitionSpec spec, long targetFileSize) {
       this.delegate = new RollingDataWriter<>(writerFactory, fileFactory, io, targetFileSize, spec, null);
       this.io = io;
     }
@@ -626,12 +625,11 @@ class SparkWrite {
 
     private PartitionedDataWriter(SparkFileWriterFactory writerFactory, OutputFileFactory fileFactory,
                                   FileIO io, PartitionSpec spec, Schema dataSchema,
-                                  StructType dataSparkType, FileFormat format,
-                                  long targetFileSize, boolean fanoutEnabled) {
+                                  StructType dataSparkType, long targetFileSize, boolean fanoutEnabled) {
       if (fanoutEnabled) {
-        this.delegate = new FanoutDataWriter<>(writerFactory, fileFactory, io, format, targetFileSize);
+        this.delegate = new FanoutDataWriter<>(writerFactory, fileFactory, io, targetFileSize);
       } else {
-        this.delegate = new ClusteredDataWriter<>(writerFactory, fileFactory, io, format, targetFileSize);
+        this.delegate = new ClusteredDataWriter<>(writerFactory, fileFactory, io, targetFileSize);
       }
       this.io = io;
       this.spec = spec;

--- a/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -43,7 +43,6 @@ import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.SnapshotUpdate;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
-import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.ClusteredDataWriter;
@@ -585,13 +584,7 @@ class SparkWrite {
 
     private UnpartitionedDataWriter(SparkFileWriterFactory writerFactory, OutputFileFactory fileFactory,
                                     FileIO io, PartitionSpec spec, FileFormat format, long targetFileSize) {
-      // TODO: support ORC rolling writers
-      if (format == FileFormat.ORC) {
-        EncryptedOutputFile outputFile = fileFactory.newOutputFile();
-        delegate = writerFactory.newDataWriter(outputFile, spec, null);
-      } else {
-        delegate = new RollingDataWriter<>(writerFactory, fileFactory, io, targetFileSize, spec, null);
-      }
+      this.delegate = new RollingDataWriter<>(writerFactory, fileFactory, io, targetFileSize, spec, null);
       this.io = io;
     }
 

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkDataWrite.java
@@ -365,11 +365,9 @@ public class TestSparkDataWrite {
         files.add(file);
       }
     }
-    // TODO: ORC file now not support target file size
-    if (!format.equals(FileFormat.ORC)) {
-      Assert.assertEquals("Should have 4 DataFiles", 4, files.size());
-      Assert.assertTrue("All DataFiles contain 1000 rows", files.stream().allMatch(d -> d.recordCount() == 1000));
-    }
+
+    Assert.assertEquals("Should have 4 DataFiles", 4, files.size());
+    Assert.assertTrue("All DataFiles contain 1000 rows", files.stream().allMatch(d -> d.recordCount() == 1000));
   }
 
   @Test
@@ -585,11 +583,9 @@ public class TestSparkDataWrite {
         files.add(file);
       }
     }
-    // TODO: ORC file now not support target file size
-    if (!format.equals(FileFormat.ORC)) {
-      Assert.assertEquals("Should have 8 DataFiles", 8, files.size());
-      Assert.assertTrue("All DataFiles contain 1000 rows", files.stream().allMatch(d -> d.recordCount() == 1000));
-    }
+
+    Assert.assertEquals("Should have 8 DataFiles", 8, files.size());
+    Assert.assertTrue("All DataFiles contain 1000 rows", files.stream().allMatch(d -> d.recordCount() == 1000));
   }
 
   public enum IcebergOptionsType {

--- a/spark/v3.2/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceDeleteBenchmark.java
+++ b/spark/v3.2/spark/src/jmh/java/org/apache/iceberg/spark/source/IcebergSourceDeleteBenchmark.java
@@ -171,8 +171,7 @@ public abstract class IcebergSourceDeleteBenchmark extends IcebergSourceBenchmar
         .build();
 
     ClusteredPositionDeleteWriter<InternalRow> writer = new ClusteredPositionDeleteWriter<>(
-        writerFactory, fileFactory, table().io(),
-        fileFormat(), TARGET_FILE_SIZE_IN_BYTES);
+        writerFactory, fileFactory, table().io(), TARGET_FILE_SIZE_IN_BYTES);
 
     PartitionSpec unpartitionedSpec = table().specs().get(0);
 
@@ -228,7 +227,7 @@ public abstract class IcebergSourceDeleteBenchmark extends IcebergSourceBenchmar
         .build();
 
     ClusteredEqualityDeleteWriter<InternalRow> writer = new ClusteredEqualityDeleteWriter<>(
-        writerFactory, fileFactory, table().io(), fileFormat(), TARGET_FILE_SIZE_IN_BYTES);
+        writerFactory, fileFactory, table().io(), TARGET_FILE_SIZE_IN_BYTES);
 
     PartitionSpec unpartitionedSpec = table().specs().get(0);
     try (ClusteredEqualityDeleteWriter<InternalRow> closeableWriter = writer) {

--- a/spark/v3.2/spark/src/jmh/java/org/apache/iceberg/spark/source/WritersBenchmark.java
+++ b/spark/v3.2/spark/src/jmh/java/org/apache/iceberg/spark/source/WritersBenchmark.java
@@ -137,8 +137,7 @@ public abstract class WritersBenchmark extends IcebergSourceBenchmark {
         .build();
 
     ClusteredDataWriter<InternalRow> writer = new ClusteredDataWriter<>(
-        writerFactory, fileFactory, io,
-        fileFormat(), TARGET_FILE_SIZE_IN_BYTES);
+        writerFactory, fileFactory, io, TARGET_FILE_SIZE_IN_BYTES);
 
     try (ClusteredDataWriter<InternalRow> closeableWriter = writer) {
       for (InternalRow row : rows) {
@@ -187,8 +186,7 @@ public abstract class WritersBenchmark extends IcebergSourceBenchmark {
         .build();
 
     ClusteredDataWriter<InternalRow> writer = new ClusteredDataWriter<>(
-        writerFactory, fileFactory, io,
-        fileFormat(), TARGET_FILE_SIZE_IN_BYTES);
+        writerFactory, fileFactory, io, TARGET_FILE_SIZE_IN_BYTES);
 
     PartitionKey partitionKey = new PartitionKey(partitionedSpec, table().schema());
     StructType dataSparkType = SparkSchemaUtil.convert(table().schema());
@@ -243,8 +241,7 @@ public abstract class WritersBenchmark extends IcebergSourceBenchmark {
         .build();
 
     FanoutDataWriter<InternalRow> writer = new FanoutDataWriter<>(
-        writerFactory, fileFactory, io,
-        fileFormat(), TARGET_FILE_SIZE_IN_BYTES);
+        writerFactory, fileFactory, io, TARGET_FILE_SIZE_IN_BYTES);
 
     PartitionKey partitionKey = new PartitionKey(partitionedSpec, table().schema());
     StructType dataSparkType = SparkSchemaUtil.convert(table().schema());
@@ -302,8 +299,7 @@ public abstract class WritersBenchmark extends IcebergSourceBenchmark {
         .build();
 
     ClusteredEqualityDeleteWriter<InternalRow> writer = new ClusteredEqualityDeleteWriter<>(
-        writerFactory, fileFactory, io,
-        fileFormat(), TARGET_FILE_SIZE_IN_BYTES);
+        writerFactory, fileFactory, io, TARGET_FILE_SIZE_IN_BYTES);
 
     PartitionKey partitionKey = new PartitionKey(partitionedSpec, table().schema());
     StructType deleteSparkType = SparkSchemaUtil.convert(table().schema());
@@ -330,8 +326,7 @@ public abstract class WritersBenchmark extends IcebergSourceBenchmark {
         .build();
 
     ClusteredPositionDeleteWriter<InternalRow> writer = new ClusteredPositionDeleteWriter<>(
-        writerFactory, fileFactory, io,
-        fileFormat(), TARGET_FILE_SIZE_IN_BYTES);
+        writerFactory, fileFactory, io, TARGET_FILE_SIZE_IN_BYTES);
 
     PositionDelete<InternalRow> positionDelete = PositionDelete.create();
     try (ClusteredPositionDeleteWriter<InternalRow> closeableWriter = writer) {

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkPositionDeltaWrite.java
@@ -361,8 +361,7 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
                           OutputFileFactory deleteFileFactory, Context context) {
 
       this.delegate = new ClusteredPositionDeleteWriter<>(
-          writerFactory, deleteFileFactory, table.io(),
-          context.deleteFileFormat(), context.targetDeleteFileSize());
+          writerFactory, deleteFileFactory, table.io(), context.targetDeleteFileSize());
       this.positionDelete = PositionDelete.create();
       this.io = table.io();
       this.specs = table.specs();
@@ -504,13 +503,12 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
                                                                              SparkFileWriterFactory writerFactory,
                                                                              OutputFileFactory fileFactory,
                                                                              Context context) {
-      FileFormat fileFormat = context.dataFileFormat();
       long targetFileSize = context.targetDataFileSize();
 
       if (table.spec().isPartitioned() && context.fanoutWriterEnabled()) {
-        return new FanoutDataWriter<>(writerFactory, fileFactory, table.io(), fileFormat, targetFileSize);
+        return new FanoutDataWriter<>(writerFactory, fileFactory, table.io(), targetFileSize);
       } else {
-        return new ClusteredDataWriter<>(writerFactory, fileFactory, table.io(), fileFormat, targetFileSize);
+        return new ClusteredDataWriter<>(writerFactory, fileFactory, table.io(), targetFileSize);
       }
     }
 
@@ -518,14 +516,13 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
                                                                              SparkFileWriterFactory writerFactory,
                                                                              OutputFileFactory fileFactory,
                                                                              Context context) {
-      FileFormat fileFormat = context.dataFileFormat();
       long targetFileSize = context.targetDataFileSize();
 
       if (table.spec().isPartitioned()) {
         // use a fanout writer for partitioned tables to write updates as they may be out of order
-        return new FanoutDataWriter<>(writerFactory, fileFactory, table.io(), fileFormat, targetFileSize);
+        return new FanoutDataWriter<>(writerFactory, fileFactory, table.io(), targetFileSize);
       } else {
-        return new ClusteredDataWriter<>(writerFactory, fileFactory, table.io(), fileFormat, targetFileSize);
+        return new ClusteredDataWriter<>(writerFactory, fileFactory, table.io(), targetFileSize);
       }
     }
 
@@ -533,9 +530,8 @@ class SparkPositionDeltaWrite implements DeltaWrite, RequiresDistributionAndOrde
                                                                        SparkFileWriterFactory writerFactory,
                                                                        OutputFileFactory fileFactory,
                                                                        Context context) {
-      FileFormat fileFormat = context.deleteFileFormat();
       long targetFileSize = context.targetDeleteFileSize();
-      return new ClusteredPositionDeleteWriter<>(writerFactory, fileFactory, table.io(), fileFormat, targetFileSize);
+      return new ClusteredPositionDeleteWriter<>(writerFactory, fileFactory, table.io(), targetFileSize);
     }
   }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -612,12 +612,11 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
           .build();
 
       if (spec.isUnpartitioned()) {
-        return new UnpartitionedDataWriter(writerFactory, fileFactory, io, spec, format, targetFileSize);
+        return new UnpartitionedDataWriter(writerFactory, fileFactory, io, spec, targetFileSize);
 
       } else {
         return new PartitionedDataWriter(
-            writerFactory, fileFactory, io, spec, writeSchema, dsSchema,
-            format, targetFileSize, partitionedFanoutEnabled);
+            writerFactory, fileFactory, io, spec, writeSchema, dsSchema, targetFileSize, partitionedFanoutEnabled);
       }
     }
   }
@@ -634,8 +633,8 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
     private final FileIO io;
 
     private UnpartitionedDataWriter(SparkFileWriterFactory writerFactory, OutputFileFactory fileFactory,
-                                    FileIO io, PartitionSpec spec, FileFormat format, long targetFileSize) {
-      delegate = new RollingDataWriter<>(writerFactory, fileFactory, io, targetFileSize, spec, null);
+                                    FileIO io, PartitionSpec spec, long targetFileSize) {
+      this.delegate = new RollingDataWriter<>(writerFactory, fileFactory, io, targetFileSize, spec, null);
       this.io = io;
     }
 
@@ -677,12 +676,11 @@ abstract class SparkWrite implements Write, RequiresDistributionAndOrdering {
 
     private PartitionedDataWriter(SparkFileWriterFactory writerFactory, OutputFileFactory fileFactory,
                                   FileIO io, PartitionSpec spec, Schema dataSchema,
-                                  StructType dataSparkType, FileFormat format,
-                                  long targetFileSize, boolean fanoutEnabled) {
+                                  StructType dataSparkType, long targetFileSize, boolean fanoutEnabled) {
       if (fanoutEnabled) {
-        this.delegate = new FanoutDataWriter<>(writerFactory, fileFactory, io, format, targetFileSize);
+        this.delegate = new FanoutDataWriter<>(writerFactory, fileFactory, io, targetFileSize);
       } else {
-        this.delegate = new ClusteredDataWriter<>(writerFactory, fileFactory, io, format, targetFileSize);
+        this.delegate = new ClusteredDataWriter<>(writerFactory, fileFactory, io, targetFileSize);
       }
       this.io = io;
       this.spec = spec;


### PR DESCRIPTION
This PR consists of the following parts:

- Port ORC rolling writer  and unit test to `Spark 3.1 3.0 2.4` and `Flink 1.13 1.12`, refer: [#3784](https://github.com/apache/iceberg/pull/3784)
- Clear the `Formart`  that are no longer needed.
