### PR TITLE
Core: use primitive type in error code in ErrorResponse

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/responses/ErrorResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/ErrorResponse.java
@@ -57,7 +57,7 @@ public class ErrorResponse implements RESTResponse {
     return type;
   }
 
-  public Integer code() {
+  public int code() {
     return code;
   }
 
@@ -93,7 +93,7 @@ public class ErrorResponse implements RESTResponse {
   public static class Builder {
     private String message;
     private String type;
-    private Integer code;
+    private int code;
     private List<String> stack;
 
     private Builder() {
@@ -125,13 +125,13 @@ public class ErrorResponse implements RESTResponse {
       return this;
     }
 
-    public Builder responseCode(Integer responseCode) {
+    public Builder responseCode(int responseCode) {
       this.code = responseCode;
       return this;
     }
 
     public ErrorResponse build() {
-      Preconditions.checkArgument(code != null, "Invalid response, missing field: code");
+      Preconditions.checkArgument(code != 0, "Invalid response, missing field: code");
       return new ErrorResponse(message, type, code, stack);
     }
   }

--- a/core/src/main/java/org/apache/iceberg/rest/responses/ErrorResponseParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/ErrorResponseParser.java
@@ -100,7 +100,7 @@ public class ErrorResponseParser {
     JsonNode error = jsonNode.get(ERROR);
     String message = JsonUtil.getStringOrNull(MESSAGE, error);
     String type = JsonUtil.getStringOrNull(TYPE, error);
-    Integer code = JsonUtil.getIntOrNull(CODE, error);
+    int code = JsonUtil.getInt(CODE, error);
     List<String> stack = JsonUtil.getStringListOrNull(STACK, error);
     return ErrorResponse.builder()
         .withMessage(message)

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestErrorResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestErrorResponseParser.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.rest.responses;
 
 import java.util.Arrays;
 import java.util.List;
+import org.apache.iceberg.AssertHelpers;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -30,7 +31,7 @@ public class TestErrorResponseParser {
   public void testErrorResponseToJson() {
     String message = "The given namespace does not exist";
     String type = "NoSuchNamespaceException";
-    Integer code = 404;
+    int code = 404;
     String errorModelJson = String.format("{\"message\":\"%s\",\"type\":\"%s\",\"code\":%d}", message, type, code);
     String json = "{\"error\":" + errorModelJson + "}";
     ErrorResponse response = ErrorResponse.builder().withMessage(message).withType(type).responseCode(code).build();
@@ -42,7 +43,7 @@ public class TestErrorResponseParser {
   public void testErrorResponseToJsonWithStack() {
     String message = "The given namespace does not exist";
     String type = "NoSuchNamespaceException";
-    Integer code = 404;
+    int code = 404;
     List<String> stack = Arrays.asList("a", "b");
     String errorModelJson = String.format(
         "{\"message\":\"%s\",\"type\":\"%s\",\"code\":%d,\"stack\":[\"a\",\"b\"]}", message, type, code);
@@ -61,7 +62,7 @@ public class TestErrorResponseParser {
   public void testErrorResponseFromJson() {
     String message = "The given namespace does not exist";
     String type = "NoSuchNamespaceException";
-    Integer code = 404;
+    int code = 404;
     String errorModelJson = String.format("{\"message\":\"%s\",\"type\":\"%s\",\"code\":%d}", message, type, code);
     String json = "{\"error\":" + errorModelJson + "}";
 
@@ -73,7 +74,7 @@ public class TestErrorResponseParser {
   public void testErrorResponseFromJsonWithStack() {
     String message = "The given namespace does not exist";
     String type = "NoSuchNamespaceException";
-    Integer code = 404;
+    int code = 404;
     List<String> stack = Arrays.asList("a", "b");
     String errorModelJson = String.format(
         "{\"message\":\"%s\",\"type\":\"%s\",\"code\":%d,\"stack\":[\"a\",\"b\"]}", message, type, code);
@@ -89,10 +90,21 @@ public class TestErrorResponseParser {
   }
 
   @Test
+  public void testErrorResponseFromJsonWithoutCode() {
+    String message = "The given namespace does not exist";
+    String type = "NoSuchNamespaceException";
+    String errorModelJson = String.format("{\"message\":\"%s\",\"type\":\"%s\"}", message, type);
+    String json = "{\"error\":" + errorModelJson + "}";
+
+    AssertHelpers.assertThrows("ErrorResponse should contain code", IllegalArgumentException.class,
+        "Cannot parse missing int code", () -> ErrorResponseParser.fromJson(json));
+  }
+
+  @Test
   public void testErrorResponseFromJsonWithExplicitNullStack() {
     String message = "The given namespace does not exist";
     String type = "NoSuchNamespaceException";
-    Integer code = 404;
+    int code = 404;
     List<String> stack = null;
     String errorModelJson = String.format(
         "{\"message\":\"%s\",\"type\":\"%s\",\"code\":%d,\"stack\":null}", message, type, code);


### PR DESCRIPTION
This change attempts to use primitive type in code property of Error Response, As per my understanding since we use our own parser i.e ErrorResponseParser we should be fine. 

Don't have strong reason to support why this is required, would say something that caught my eye and in general we should use primitive type over boxed if possible.

--- 
cc @kbendick