### PR TITLE
Flink: fix parquet readers for array data

### DIFF
--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
@@ -24,10 +24,12 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GenericArrayData;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RawValueData;
@@ -482,8 +484,10 @@ public class FlinkParquetReaders {
 
     @Override
     protected ArrayData buildList(ReusableArrayData list) {
-      list.setNumElements(writePos);
-      return list;
+      // Since ReusableArrayData is not accepted by Flink, use GenericArrayData temporarily to walk around it.
+      // Revert this to use ReusableArrayData once it is fixed in Flink.
+      // For your reference, https://issues.apache.org/jira/browse/FLINK-25238.
+      return new GenericArrayData(Arrays.copyOf(list.values, writePos));
     }
   }
 

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkScan.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkScan.java
@@ -311,7 +311,8 @@ public abstract class TestFlinkScan {
   public void testCustomizedFlinkDataTypes() throws Exception {
     Schema schema = new Schema(
         Types.NestedField.required(
-            1, "map", Types.MapType.ofRequired(2, 3, Types.StringType.get(), Types.StringType.get())));
+            1, "map", Types.MapType.ofRequired(2, 3, Types.StringType.get(), Types.StringType.get())),
+        Types.NestedField.required(4, "arr", Types.ListType.ofRequired(5, Types.StringType.get())));
     Table table = catalog.createTable(TestFixtures.TABLE_IDENTIFIER, schema);
     List<Record> records = RandomGenericData.generate(schema, 10, 0L);
     GenericAppenderHelper helper = new GenericAppenderHelper(table, fileFormat, TEMPORARY_FOLDER);


### PR DESCRIPTION
In flink, only three predefined types of `ArrayData` are accepted by
`ArrayDataSerializer#copy`. It's not allowed to return customized type
of `ArrayData`, otherwise a `ClassCastException` will be thrown.