### PR TITLE
Add a field 'write-id' to track table change. Because when datafiles …

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ManifestFile.java
+++ b/api/src/main/java/org/apache/iceberg/ManifestFile.java
@@ -64,14 +64,16 @@ public interface ManifestFile {
       "Summary for each partition");
   Types.NestedField KEY_METADATA = optional(519, "key_metadata", Types.BinaryType.get(),
       "Encryption key metadata blob");
-  // next ID to assign: 520
+  Types.NestedField WRITE_ID = optional(520, "write_id", Types.LongType.get(),
+          "Write id to track datafiles change");
+  // next ID to assign: 521
 
   Schema SCHEMA = new Schema(
       PATH, LENGTH, SPEC_ID, MANIFEST_CONTENT,
       SEQUENCE_NUMBER, MIN_SEQUENCE_NUMBER, SNAPSHOT_ID,
       ADDED_FILES_COUNT, EXISTING_FILES_COUNT, DELETED_FILES_COUNT,
       ADDED_ROWS_COUNT, EXISTING_ROWS_COUNT, DELETED_ROWS_COUNT,
-      PARTITION_SUMMARIES, KEY_METADATA);
+      PARTITION_SUMMARIES, KEY_METADATA, WRITE_ID);
 
   static Schema schema() {
     return SCHEMA;
@@ -187,6 +189,11 @@ public interface ManifestFile {
   default ByteBuffer keyMetadata() {
     return null;
   }
+
+  /**
+   * Returns write id of the commit that added the manifest file.It is to track datafile change.
+   */
+  long writeId();
 
   /**
    * Copies this {@link ManifestFile manifest file}. Readers can reuse manifest file instances; use

--- a/api/src/main/java/org/apache/iceberg/RewriteFiles.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteFiles.java
@@ -63,6 +63,18 @@ public interface RewriteFiles extends SnapshotUpdate<RewriteFiles> {
   RewriteFiles rewriteFiles(Set<DataFile> filesToDelete, Set<DataFile> filesToAdd, long sequenceNumber);
 
   /**
+   * Add a rewrite that replaces one set of data files with another set that contains the same data.
+   * The sequence number provided will be used for all the data files added.
+   *
+   * @param filesToDelete  files that will be replaced (deleted), cannot be null or empty.
+   * @param filesToAdd     files that will be added, cannot be null or empty.
+   * @param sequenceNumber sequence number to use for all data files added
+   * @param writeId       write id to track all data files change
+   * @return this for method chaining
+   */
+  RewriteFiles rewriteFiles(Set<DataFile> filesToDelete, Set<DataFile> filesToAdd, long sequenceNumber, long writeId);
+
+  /**
    * Add a rewrite that replaces one set of files with another set that contains the same data.
    *
    * @param dataFilesToReplace   data files that will be replaced (deleted).

--- a/api/src/main/java/org/apache/iceberg/Snapshot.java
+++ b/api/src/main/java/org/apache/iceberg/Snapshot.java
@@ -42,6 +42,16 @@ public interface Snapshot extends Serializable {
   long sequenceNumber();
 
   /**
+   * A monotonically increasing long that tracks the order of changes to the table.
+   * However, this sequence number will not be impacted by compaction.
+   * <p>
+   * Write id are assigned when a snapshot is committed.
+   *
+   * @return a long write id
+   */
+  long writeId();
+
+  /**
    * Return this snapshot's ID.
    *
    * @return a long ID
@@ -135,4 +145,5 @@ public interface Snapshot extends Serializable {
   default Integer schemaId() {
     return null;
   }
+
 }

--- a/api/src/test/java/org/apache/iceberg/TestHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/TestHelpers.java
@@ -326,6 +326,11 @@ public class TestHelpers {
     }
 
     @Override
+    public long writeId() {
+      return 0;
+    }
+
+    @Override
     public Long snapshotId() {
       return snapshotId;
     }

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
@@ -71,6 +71,13 @@ class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements 
   }
 
   @Override
+  public RewriteFiles rewriteFiles(Set<DataFile> filesToDelete, Set<DataFile> filesToAdd, long sequenceNumber, long writeId) {
+    setNewFilesSequenceNumber(sequenceNumber);
+    setNewWriteId(writeId + 1);
+    return rewriteFiles(filesToDelete, ImmutableSet.of(), filesToAdd, ImmutableSet.of());
+  }
+
+  @Override
   public RewriteFiles rewriteFiles(Set<DataFile> dataFilesToReplace, Set<DeleteFile> deleteFilesToReplace,
                                    Set<DataFile> dataFilesToAdd, Set<DeleteFile> deleteFilesToAdd) {
     verifyInputAndOutputFiles(dataFilesToReplace, deleteFilesToReplace, dataFilesToAdd, deleteFilesToAdd);

--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -34,11 +34,13 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
 class BaseSnapshot implements Snapshot {
   private static final long INITIAL_SEQUENCE_NUMBER = 0;
+  private static final long INITIAL_WRITE_ID = 0;
 
   private final FileIO io;
   private final long snapshotId;
   private final Long parentId;
   private final long sequenceNumber;
+  private final long writeId;
   private final long timestampMillis;
   private final String manifestListLocation;
   private final String operation;
@@ -73,15 +75,8 @@ class BaseSnapshot implements Snapshot {
                Map<String, String> summary,
                Integer schemaId,
                String manifestList) {
-    this.io = io;
-    this.sequenceNumber = sequenceNumber;
-    this.snapshotId = snapshotId;
-    this.parentId = parentId;
-    this.timestampMillis = timestampMillis;
-    this.operation = operation;
-    this.summary = summary;
-    this.schemaId = schemaId;
-    this.manifestListLocation = manifestList;
+    this(io, sequenceNumber, snapshotId, parentId,
+            timestampMillis, operation, summary, schemaId, manifestList, INITIAL_WRITE_ID);
   }
 
   BaseSnapshot(FileIO io,
@@ -96,9 +91,36 @@ class BaseSnapshot implements Snapshot {
     this.allManifests = dataManifests;
   }
 
+  BaseSnapshot(FileIO io,
+               long sequenceNumber,
+               long snapshotId,
+               Long parentId,
+               long timestampMillis,
+               String operation,
+               Map<String, String> summary,
+               Integer schemaId,
+               String manifestList,
+               long writeId) {
+    this.io = io;
+    this.sequenceNumber = sequenceNumber;
+    this.snapshotId = snapshotId;
+    this.parentId = parentId;
+    this.timestampMillis = timestampMillis;
+    this.operation = operation;
+    this.summary = summary;
+    this.schemaId = schemaId;
+    this.manifestListLocation = manifestList;
+    this.writeId = writeId;
+  }
+
   @Override
   public long sequenceNumber() {
     return sequenceNumber;
+  }
+
+  @Override
+  public long writeId() {
+    return writeId;
   }
 
   @Override
@@ -241,7 +263,8 @@ class BaseSnapshot implements Snapshot {
           Objects.equal(this.parentId, other.parentId()) &&
           this.sequenceNumber == other.sequenceNumber() &&
           this.timestampMillis == other.timestampMillis() &&
-          Objects.equal(this.schemaId, other.schemaId());
+          Objects.equal(this.schemaId, other.schemaId()) &&
+          this.writeId == other.writeId();
     }
 
     return false;
@@ -254,7 +277,8 @@ class BaseSnapshot implements Snapshot {
       this.parentId,
       this.sequenceNumber,
       this.timestampMillis,
-      this.schemaId
+      this.schemaId,
+       this.writeId
     );
   }
 

--- a/core/src/main/java/org/apache/iceberg/FastAppend.java
+++ b/core/src/main/java/org/apache/iceberg/FastAppend.java
@@ -51,6 +51,7 @@ class FastAppend extends SnapshotProducer<AppendFiles> implements AppendFiles {
   private final List<ManifestFile> rewrittenAppendManifests = Lists.newArrayList();
   private ManifestFile newManifest = null;
   private boolean hasNewFiles = false;
+  private long writeId = -1;
 
   FastAppend(String tableName, TableOperations ops) {
     super(ops);

--- a/core/src/main/java/org/apache/iceberg/InheritableMetadataFactory.java
+++ b/core/src/main/java/org/apache/iceberg/InheritableMetadataFactory.java
@@ -35,7 +35,8 @@ class InheritableMetadataFactory {
   static InheritableMetadata fromManifest(ManifestFile manifest) {
     Preconditions.checkArgument(manifest.snapshotId() != null,
         "Cannot read from ManifestFile with null (unassigned) snapshot ID");
-    return new BaseInheritableMetadata(manifest.partitionSpecId(), manifest.snapshotId(), manifest.sequenceNumber());
+    return new BaseInheritableMetadata(manifest.partitionSpecId(), manifest.snapshotId(),
+            manifest.sequenceNumber(), manifest.writeId());
   }
 
   static InheritableMetadata forCopy(long snapshotId) {
@@ -46,11 +47,17 @@ class InheritableMetadataFactory {
     private final int specId;
     private final long snapshotId;
     private final long sequenceNumber;
+    private final long writeId;
 
     private BaseInheritableMetadata(int specId, long snapshotId, long sequenceNumber) {
+      this(specId, snapshotId, sequenceNumber, 0);
+    }
+
+    private BaseInheritableMetadata(int specId, long snapshotId, long sequenceNumber, long writeId) {
       this.specId = specId;
       this.snapshotId = snapshotId;
       this.sequenceNumber = sequenceNumber;
+      this.writeId = writeId;
     }
 
     @Override
@@ -64,6 +71,9 @@ class InheritableMetadataFactory {
       }
       if (manifestEntry.sequenceNumber() == null) {
         manifestEntry.setSequenceNumber(sequenceNumber);
+      }
+      if (manifestEntry.writeId() == null) {
+        manifestEntry.setWriteId(writeId);
       }
       return manifestEntry;
     }

--- a/core/src/main/java/org/apache/iceberg/ManifestEntry.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntry.java
@@ -46,15 +46,17 @@ interface ManifestEntry<F extends ContentFile<F>> {
   Types.NestedField STATUS = required(0, "status", Types.IntegerType.get());
   Types.NestedField SNAPSHOT_ID = optional(1, "snapshot_id", Types.LongType.get());
   Types.NestedField SEQUENCE_NUMBER = optional(3, "sequence_number", Types.LongType.get());
+  Types.NestedField WRITE_ID = optional(4, "write_id", Types.LongType.get());
   int DATA_FILE_ID = 2;
-  // next ID to assign: 4
+  // next ID to assign: 5
 
   static Schema getSchema(StructType partitionType) {
     return wrapFileSchema(DataFile.getType(partitionType));
   }
 
   static Schema wrapFileSchema(StructType fileType) {
-    return new Schema(STATUS, SNAPSHOT_ID, SEQUENCE_NUMBER, required(DATA_FILE_ID, "data_file", fileType));
+    return new Schema(STATUS, SNAPSHOT_ID, SEQUENCE_NUMBER, required(DATA_FILE_ID, "data_file", fileType),
+            WRITE_ID);
   }
 
   /**
@@ -85,6 +87,18 @@ interface ManifestEntry<F extends ContentFile<F>> {
    * @param sequenceNumber a sequence number
    */
   void setSequenceNumber(long sequenceNumber);
+
+  /**
+   * Returns write id of the snapshot in which the file was added to the table.
+   */
+  Long writeId();
+
+  /**
+   * Set write id for this manifest entry.
+   *
+   * @param writeId write id
+   */
+  void setWriteId(long writeId);
 
   /**
    * Returns a file.

--- a/core/src/main/java/org/apache/iceberg/ManifestListWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestListWriter.java
@@ -74,12 +74,17 @@ abstract class ManifestListWriter implements FileAppender<ManifestFile> {
     private final V2Metadata.IndexedManifestFile wrapper;
 
     V2Writer(OutputFile snapshotFile, long snapshotId, Long parentSnapshotId, long sequenceNumber) {
+      this(snapshotFile, snapshotId, parentSnapshotId, sequenceNumber, 0);
+    }
+
+    V2Writer(OutputFile snapshotFile, long snapshotId, Long parentSnapshotId, long sequenceNumber, long writeId) {
       super(snapshotFile, ImmutableMap.of(
           "snapshot-id", String.valueOf(snapshotId),
           "parent-snapshot-id", String.valueOf(parentSnapshotId),
           "sequence-number", String.valueOf(sequenceNumber),
-          "format-version", "2"));
-      this.wrapper = new V2Metadata.IndexedManifestFile(snapshotId, sequenceNumber);
+          "format-version", "2",
+          "writeId", String.valueOf(writeId)));
+      this.wrapper = new V2Metadata.IndexedManifestFile(snapshotId, sequenceNumber, writeId);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/ManifestLists.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestLists.java
@@ -55,10 +55,23 @@ class ManifestLists {
     switch (formatVersion) {
       case 1:
         Preconditions.checkArgument(sequenceNumber == TableMetadata.INITIAL_SEQUENCE_NUMBER,
-            "Invalid sequence number for v1 manifest list: %s", sequenceNumber);
+                "Invalid sequence number for v1 manifest list: %s", sequenceNumber);
         return new ManifestListWriter.V1Writer(manifestListFile, snapshotId, parentSnapshotId);
       case 2:
         return new ManifestListWriter.V2Writer(manifestListFile, snapshotId, parentSnapshotId, sequenceNumber);
+    }
+    throw new UnsupportedOperationException("Cannot write manifest list for table version: " + formatVersion);
+  }
+
+  static ManifestListWriter write(int formatVersion, OutputFile manifestListFile,
+                                  long snapshotId, Long parentSnapshotId, long sequenceNumber, long writeId) {
+    switch (formatVersion) {
+      case 1:
+        Preconditions.checkArgument(sequenceNumber == TableMetadata.INITIAL_SEQUENCE_NUMBER,
+            "Invalid sequence number for v1 manifest list: %s", sequenceNumber);
+        return new ManifestListWriter.V1Writer(manifestListFile, snapshotId, parentSnapshotId);
+      case 2:
+        return new ManifestListWriter.V2Writer(manifestListFile, snapshotId, parentSnapshotId, sequenceNumber, writeId);
     }
     throw new UnsupportedOperationException("Cannot write manifest list for table version: " + formatVersion);
   }

--- a/core/src/main/java/org/apache/iceberg/SnapshotParser.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotParser.java
@@ -115,6 +115,7 @@ public class SnapshotParser {
         "Cannot parse table version from a non-object: %s", node);
 
     long sequenceNumber = TableMetadata.INITIAL_SEQUENCE_NUMBER;
+    long writeId = TableMetadata.INITIAL_WRITE_ID;
     if (node.has(SEQUENCE_NUMBER)) {
       sequenceNumber = JsonUtil.getLong(SEQUENCE_NUMBER, node);
     }
@@ -151,7 +152,7 @@ public class SnapshotParser {
       // the manifest list is stored in a manifest list file
       String manifestList = JsonUtil.getString(MANIFEST_LIST, node);
       return new BaseSnapshot(
-          io, sequenceNumber, snapshotId, parentId, timestamp, operation, summary, schemaId, manifestList);
+          io, sequenceNumber, snapshotId, parentId, timestamp, operation, summary, schemaId, manifestList, writeId);
 
     } else {
       // fall back to an embedded manifest list. pass in the manifest's InputFile so length can be

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -87,6 +87,7 @@ public class TableMetadataParser {
   static final String TABLE_UUID = "table-uuid";
   static final String LOCATION = "location";
   static final String LAST_SEQUENCE_NUMBER = "last-sequence-number";
+  static final String LAST_WRITE_ID = "last-write-id";
   static final String LAST_UPDATED_MILLIS = "last-updated-ms";
   static final String LAST_COLUMN_ID = "last-column-id";
   static final String SCHEMA = "schema";
@@ -163,6 +164,7 @@ public class TableMetadataParser {
     generator.writeStringField(LOCATION, metadata.location());
     if (metadata.formatVersion() > 1) {
       generator.writeNumberField(LAST_SEQUENCE_NUMBER, metadata.lastSequenceNumber());
+      generator.writeNumberField(LAST_WRITE_ID, metadata.lastWriteId());
     }
     generator.writeNumberField(LAST_UPDATED_MILLIS, metadata.lastUpdatedMillis());
     generator.writeNumberField(LAST_COLUMN_ID, metadata.lastColumnId());
@@ -313,10 +315,13 @@ public class TableMetadataParser {
     String uuid = JsonUtil.getStringOrNull(TABLE_UUID, node);
     String location = JsonUtil.getString(LOCATION, node);
     long lastSequenceNumber;
+    long lastWriteId;
     if (formatVersion > 1) {
       lastSequenceNumber = JsonUtil.getLong(LAST_SEQUENCE_NUMBER, node);
+      lastWriteId = JsonUtil.getLong(LAST_WRITE_ID, node);
     } else {
       lastSequenceNumber = TableMetadata.INITIAL_SEQUENCE_NUMBER;
+      lastWriteId = TableMetadata.INITIAL_WRITE_ID;
     }
     int lastAssignedColumnId = JsonUtil.getInt(LAST_COLUMN_ID, node);
 
@@ -454,7 +459,7 @@ public class TableMetadataParser {
         lastSequenceNumber, lastUpdatedMillis, lastAssignedColumnId, currentSchemaId, schemas, defaultSpecId, specs,
         lastAssignedPartitionId, defaultSortOrderId, sortOrders, properties, currentVersionId,
         snapshots, entries.build(), metadataEntries.build(), refs,
-        ImmutableList.of() /* no changes from the file */);
+        ImmutableList.of(), lastWriteId/* no changes from the file */);
   }
 
   private static Map<String, SnapshotRef> refsFromJson(JsonNode refMap) {

--- a/core/src/main/java/org/apache/iceberg/V1Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V1Metadata.java
@@ -126,6 +126,11 @@ class V1Metadata {
     }
 
     @Override
+    public long writeId() {
+      return wrapped.writeId();
+    }
+
+    @Override
     public Long snapshotId() {
       return wrapped.snapshotId();
     }
@@ -288,6 +293,16 @@ class V1Metadata {
     @Override
     public void setSequenceNumber(long sequenceNumber) {
       wrapped.setSequenceNumber(sequenceNumber);
+    }
+
+    @Override
+    public Long writeId() {
+      return wrapped.writeId();
+    }
+
+    @Override
+    public void setWriteId(long writeId) {
+      wrapped.setWriteId(writeId);
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
@@ -81,7 +81,8 @@ public class RewriteDataFilesCommitManager {
     RewriteFiles rewrite = table.newRewrite().validateFromSnapshot(startingSnapshotId);
     if (useStartingSequenceNumber) {
       long sequenceNumber = table.snapshot(startingSnapshotId).sequenceNumber();
-      rewrite.rewriteFiles(rewrittenDataFiles, addedDataFiles, sequenceNumber);
+      long writeId = table.snapshot(startingSnapshotId).writeId();
+      rewrite.rewriteFiles(rewrittenDataFiles, addedDataFiles, sequenceNumber, writeId);
     } else {
       rewrite.rewriteFiles(rewrittenDataFiles, addedDataFiles);
     }

--- a/core/src/main/java/org/apache/iceberg/avro/ValueWriters.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ValueWriters.java
@@ -195,6 +195,9 @@ public class ValueWriters {
 
     @Override
     public void write(Long l, Encoder encoder) throws IOException {
+      if (l == null) {
+        l = null;
+      }
       encoder.writeLong(l);
     }
   }

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -190,7 +190,7 @@ public class TestTableMetadata {
         ImmutableList.of(schema), 6, ImmutableList.of(spec), spec.lastAssignedFieldId(),
         TableMetadata.INITIAL_SORT_ORDER_ID, ImmutableList.of(sortOrder), ImmutableMap.of("property", "value"),
         currentSnapshotId, Arrays.asList(previousSnapshot, currentSnapshot), ImmutableList.of(), ImmutableList.of(),
-        ImmutableMap.of(), ImmutableList.of());
+        ImmutableMap.of(), ImmutableList.of(), 0);
 
     String asJson = toJsonWithoutSpecAndSchemaList(expected);
     TableMetadata metadata = TableMetadataParser.fromJson(ops.io(), asJson);
@@ -393,7 +393,7 @@ public class TestTableMetadata {
         7, ImmutableList.of(TEST_SCHEMA), 5, ImmutableList.of(SPEC_5), SPEC_5.lastAssignedFieldId(),
         3, ImmutableList.of(SORT_ORDER_3), ImmutableMap.of("property", "value"), currentSnapshotId,
         Arrays.asList(previousSnapshot, currentSnapshot), reversedSnapshotLog,
-        ImmutableList.copyOf(previousMetadataLog), ImmutableMap.of(), ImmutableList.of());
+        ImmutableList.copyOf(previousMetadataLog), ImmutableMap.of(), ImmutableList.of(), 0);
 
     String asJson = TableMetadataParser.toJson(base);
     TableMetadata metadataFromJson = TableMetadataParser.fromJson(ops.io(), asJson);
@@ -430,7 +430,7 @@ public class TestTableMetadata {
         7, ImmutableList.of(TEST_SCHEMA), 5, ImmutableList.of(SPEC_5), SPEC_5.lastAssignedFieldId(),
         3, ImmutableList.of(SORT_ORDER_3), ImmutableMap.of("property", "value"), currentSnapshotId,
         Arrays.asList(previousSnapshot, currentSnapshot), reversedSnapshotLog,
-        ImmutableList.copyOf(previousMetadataLog), ImmutableMap.of(), ImmutableList.of());
+        ImmutableList.copyOf(previousMetadataLog), ImmutableMap.of(), ImmutableList.of(), 0);
 
     previousMetadataLog.add(latestPreviousMetadata);
 
@@ -479,7 +479,7 @@ public class TestTableMetadata {
         ImmutableList.of(SPEC_5), SPEC_5.lastAssignedFieldId(), 3, ImmutableList.of(SORT_ORDER_3),
         ImmutableMap.of("property", "value"), currentSnapshotId,
         Arrays.asList(previousSnapshot, currentSnapshot), reversedSnapshotLog,
-        ImmutableList.copyOf(previousMetadataLog), ImmutableMap.of(), ImmutableList.of());
+        ImmutableList.copyOf(previousMetadataLog), ImmutableMap.of(), ImmutableList.of(), 0);
 
     previousMetadataLog.add(latestPreviousMetadata);
 
@@ -533,7 +533,7 @@ public class TestTableMetadata {
         SortOrder.unsorted().orderId(), ImmutableList.of(SortOrder.unsorted()),
         ImmutableMap.of("property", "value"), currentSnapshotId,
         Arrays.asList(previousSnapshot, currentSnapshot), reversedSnapshotLog,
-        ImmutableList.copyOf(previousMetadataLog), ImmutableMap.of(), ImmutableList.of());
+        ImmutableList.copyOf(previousMetadataLog), ImmutableMap.of(), ImmutableList.of(), 0);
 
     previousMetadataLog.add(latestPreviousMetadata);
 
@@ -559,7 +559,8 @@ public class TestTableMetadata {
             LAST_ASSIGNED_COLUMN_ID, 7, ImmutableList.of(TEST_SCHEMA),
             SPEC_5.specId(), ImmutableList.of(SPEC_5), SPEC_5.lastAssignedFieldId(),
             3, ImmutableList.of(SORT_ORDER_3), ImmutableMap.of(), -1L,
-            ImmutableList.of(), ImmutableList.of(), ImmutableList.of(), ImmutableMap.of(), ImmutableList.of())
+            ImmutableList.of(), ImmutableList.of(), ImmutableList.of(), ImmutableMap.of(),
+            ImmutableList.of())
     );
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestWriteIdForV2Table.java
+++ b/core/src/test/java/org/apache/iceberg/TestWriteIdForV2Table.java
@@ -1,0 +1,423 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg;
+
+import org.apache.iceberg.ManifestEntry.Status;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.junit.Test;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class TestWriteIdForV2Table extends TableTestBase {
+
+  public TestWriteIdForV2Table() {
+    super(2);
+  }
+
+  @Test
+  public void testRewrite() {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+    long commitId1 = snap1.snapshotId();
+    ManifestFile manifestFile = table.currentSnapshot().allManifests().get(0);
+    validateSnapshot(null, snap1, 1, FILE_A);
+    validateManifest(manifestFile, seqs(1), ids(commitId1), files(FILE_A));
+    V2Assert.assertEquals("Snapshot write id should be 1", 1, snap1.writeId());
+    V2Assert.assertEquals("Last write id should be 1", 1, readMetadata().lastWriteId());
+
+    table.newFastAppend().appendFile(FILE_B).commit();
+    Snapshot snap2 = table.currentSnapshot();
+    long commitId2 = snap2.snapshotId();
+    manifestFile = table.currentSnapshot().allManifests().get(0);
+    validateSnapshot(snap1, snap2, 2, FILE_B);
+    validateManifest(manifestFile, seqs(2), ids(commitId2), files(FILE_B));
+    V2Assert.assertEquals("Snapshot write id should be 2", 2, snap2.writeId());
+    V2Assert.assertEquals("Last write id should be 2", 2, readMetadata().lastWriteId());
+
+    table.newRewrite().rewriteFiles(ImmutableSet.of(FILE_A, FILE_B), ImmutableSet.of(FILE_C)).commit();
+
+   // table.rewriteManifests().clusterBy(file -> "").commit();
+    Snapshot snap3 = table.currentSnapshot();
+    ManifestFile newManifest3 = snap3.allManifests().stream()
+        .filter(manifest -> manifest.snapshotId() == snap3.snapshotId())
+        .collect(Collectors.toList()).get(0);
+
+    V2Assert.assertEquals("Snapshot write id should be 3", 3, snap3.writeId());
+    V2Assert.assertEquals("Last write id should be 3", 3, readMetadata().lastWriteId());
+
+    // FILE_A and FILE_B in manifest may reorder
+    for (ManifestEntry<DataFile> entry : ManifestFiles.read(newManifest3, FILE_IO).entries()) {
+      if (entry.file().path().equals(FILE_A.path())) {
+        V2Assert.assertEquals("FILE_A write id should be 1", 1, entry.writeId().longValue());
+      }
+
+      if (entry.file().path().equals(FILE_B.path())) {
+        V2Assert.assertEquals("FILE_b write id should be 2", 2, entry.writeId().longValue());
+      }
+
+      if (entry.file().path().equals(FILE_C.path())) {
+        V2Assert.assertEquals("FILE_c write id should be 3", 3, entry.writeId().longValue());
+      }
+    }
+
+    table.rewriteManifests().clusterBy(file -> "").commit();
+    Snapshot snap4 = table.currentSnapshot();
+    ManifestFile newManifest4 = snap4.allManifests().stream()
+            .filter(manifest -> manifest.snapshotId() == snap4.snapshotId())
+            .collect(Collectors.toList()).get(0);
+
+    V2Assert.assertEquals("Snapshot write id should be 3", 4, snap4.writeId());
+    V2Assert.assertEquals("Last write id should be 3", 4, readMetadata().lastWriteId());
+
+    // FILE_A and FILE_B in manifest may reorder
+    for (ManifestEntry<DataFile> entry : ManifestFiles.read(newManifest4, FILE_IO).entries()) {
+
+      V2Assert.assertEquals("The length of entries should be 1, and the entry file path should be FILE_C",
+              FILE_C.path(), entry.file().path());
+      V2Assert.assertEquals("FILE_c write id should be 3", 3, entry.writeId().longValue());
+
+    }
+  }
+
+  @Test
+  public void testCommitConflict() {
+    AppendFiles appendA = table.newFastAppend();
+    appendA.appendFile(FILE_A).apply();
+
+    table.updateProperties()
+        .set(TableProperties.COMMIT_NUM_RETRIES, "0")
+        .commit();
+
+    table.ops().failCommits(1);
+
+    AssertHelpers.assertThrows("Should reject commit",
+        CommitFailedException.class, "Injected failure",
+        () -> table.newFastAppend().appendFile(FILE_B).commit());
+
+    table.updateProperties()
+        .set(TableProperties.COMMIT_NUM_RETRIES, "5")
+        .commit();
+
+    appendA.commit();
+    Snapshot snap1 = table.currentSnapshot();
+    long commitId1 = snap1.snapshotId();
+    ManifestFile manifestFile = table.currentSnapshot().allManifests().get(0);
+    validateSnapshot(null, snap1, 1, FILE_A);
+    validateManifest(manifestFile, seqs(1), ids(commitId1), files(FILE_A));
+    V2Assert.assertEquals("Snapshot write id should be 1", 1, snap1.writeId());
+    V2Assert.assertEquals("Last write id should be 1", 1, readMetadata().lastWriteId());
+
+    AppendFiles appendFiles = table.newFastAppend().appendFile(FILE_C);
+    appendFiles.apply();
+    table.newFastAppend().appendFile(FILE_D).commit();
+    Snapshot snap2 = table.currentSnapshot();
+    long commitId2 = snap2.snapshotId();
+    manifestFile = table.currentSnapshot().allManifests().get(0);
+    validateSnapshot(snap1, snap2, 2, FILE_D);
+    validateManifest(manifestFile, seqs(2), ids(commitId2), files(FILE_D));
+    V2Assert.assertEquals("Snapshot write id should be 2", 2, snap2.writeId());
+    V2Assert.assertEquals("Last write id should be 2", 2, readMetadata().lastWriteId());
+
+    appendFiles.commit();
+    Snapshot snap3 = table.currentSnapshot();
+    long commitId3 = snap3.snapshotId();
+    manifestFile = table.currentSnapshot().allManifests().get(0);
+    validateManifest(manifestFile, seqs(3), ids(commitId3), files(FILE_C));
+    validateSnapshot(snap2, snap3, 3, FILE_C);
+    V2Assert.assertEquals("Snapshot write id should be 3", 3, snap3.writeId());
+    V2Assert.assertEquals("Last write id should be 3", 3, readMetadata().lastWriteId());
+  }
+
+  @Test
+  public void testRollBack() {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+    long commitId1 = snap1.snapshotId();
+    ManifestFile manifestFile = table.currentSnapshot().allManifests().get(0);
+    validateSnapshot(null, snap1, 1, FILE_A);
+    validateManifest(manifestFile, seqs(1), ids(commitId1), files(FILE_A));
+    V2Assert.assertEquals("Snapshot write id should be 1", 1, snap1.writeId());
+    V2Assert.assertEquals("Last write id should be 1", 1, readMetadata().lastWriteId());
+
+    table.newFastAppend().appendFile(FILE_B).commit();
+    Snapshot snap2 = table.currentSnapshot();
+    long commitId2 = snap2.snapshotId();
+    manifestFile = table.currentSnapshot().allManifests().get(0);
+    validateSnapshot(snap1, snap2, 2, FILE_B);
+    validateManifest(manifestFile, seqs(2), ids(commitId2), files(FILE_B));
+    V2Assert.assertEquals("Snapshot write id should be 2", 2, snap2.writeId());
+    V2Assert.assertEquals("Last write id should be 2", 2, readMetadata().lastWriteId());
+
+    table.manageSnapshots().rollbackTo(commitId1).commit();
+    Snapshot snap3 = table.currentSnapshot();
+    V2Assert.assertEquals("Snapshot write id should be 1", 1, snap3.writeId());
+    V2Assert.assertEquals("Last write id should be 2", 2, readMetadata().lastWriteId());
+
+    table.newFastAppend().appendFile(FILE_C).commit();
+    Snapshot snap4 = table.currentSnapshot();
+    long commitId4 = snap4.snapshotId();
+    manifestFile = table.currentSnapshot().allManifests().get(0);
+    validateSnapshot(snap3, snap4, 3, FILE_C);
+    validateManifest(manifestFile, seqs(3), ids(commitId4), files(FILE_C));
+    V2Assert.assertEquals("Snapshot write id should be 1", 3, snap4.writeId());
+    V2Assert.assertEquals("Last write id should be 3", 3, readMetadata().lastWriteId());
+  }
+
+  @Test
+  public void testSingleTransaction() {
+    Transaction txn = table.newTransaction();
+    txn.newAppend().appendFile(FILE_A).commit();
+    txn.commitTransaction();
+    Snapshot snap = table.currentSnapshot();
+    long commitId = snap.snapshotId();
+    ManifestFile manifestFile = table.currentSnapshot().allManifests().get(0);
+    validateSnapshot(null, snap, 1, FILE_A);
+    validateManifest(manifestFile, seqs(1), ids(commitId), files(FILE_A));
+    V2Assert.assertEquals("Snapshot write id should be 1", 1, snap.writeId());
+    V2Assert.assertEquals("Last write id should be 1", 1, readMetadata().lastWriteId());
+  }
+
+  @Test
+  public void testConcurrentTransaction() {
+    Transaction txn1 = table.newTransaction();
+    Transaction txn2 = table.newTransaction();
+    Transaction txn3 = table.newTransaction();
+    Transaction txn4 = table.newTransaction();
+
+    txn1.newFastAppend().appendFile(FILE_A).commit();
+    txn3.newOverwrite().addFile(FILE_C).commit();
+    txn4.newDelete().deleteFile(FILE_A).commit();
+    txn2.newAppend().appendFile(FILE_B).commit();
+
+    txn1.commitTransaction();
+    Snapshot snap1 = table.currentSnapshot();
+    long commitId1 = snap1.snapshotId();
+    ManifestFile manifestFile1 = table.currentSnapshot().allManifests().get(0);
+    validateSnapshot(null, snap1, 1, FILE_A);
+    validateManifest(manifestFile1, seqs(1), ids(commitId1), files(FILE_A));
+    V2Assert.assertEquals("Snapshot write id should be 1", 1, snap1.writeId());
+    V2Assert.assertEquals("Last write id should be 1", 1, readMetadata().lastWriteId());
+
+    txn2.commitTransaction();
+    Snapshot snap2 = table.currentSnapshot();
+    long commitId2 = snap2.snapshotId();
+    ManifestFile manifestFile = table.currentSnapshot().allManifests().get(0);
+    validateSnapshot(snap1, snap2, 2, FILE_B);
+    validateManifest(manifestFile, seqs(2), ids(commitId2), files(FILE_B));
+    V2Assert.assertEquals("Snapshot write id should be 2", 2, snap2.writeId());
+    V2Assert.assertEquals("Last write id should be 2", 2, readMetadata().lastWriteId());
+
+    txn3.commitTransaction();
+    Snapshot snap3 = table.currentSnapshot();
+    long commitId3 = snap3.snapshotId();
+    manifestFile = table.currentSnapshot().allManifests().stream()
+        .filter(manifest -> manifest.snapshotId() == commitId3)
+        .collect(Collectors.toList()).get(0);
+    validateManifest(manifestFile, seqs(3), ids(commitId3), files(FILE_C));
+    validateSnapshot(snap2, snap3, 3, FILE_C);
+    V2Assert.assertEquals("Snapshot write id should be 3", 3, snap3.writeId());
+    V2Assert.assertEquals("Last write id should be 3", 3, readMetadata().lastWriteId());
+
+    txn4.commitTransaction();
+    Snapshot snap4 = table.currentSnapshot();
+    long commitId4 = snap4.snapshotId();
+    manifestFile = table.currentSnapshot().allManifests().stream()
+        .filter(manifest -> manifest.snapshotId() == commitId4)
+        .collect(Collectors.toList()).get(0);
+    validateManifest(manifestFile, seqs(4), ids(commitId4), files(FILE_A), statuses(Status.DELETED));
+    V2Assert.assertEquals("Snapshot write id should be 4", 4, snap4.writeId());
+    V2Assert.assertEquals("Last write id should be 4", 4, readMetadata().lastWriteId());
+  }
+
+  @Test
+  public void testMultipleOperationsTransaction() {
+    Transaction txn = table.newTransaction();
+    txn.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = txn.table().currentSnapshot();
+    long commitId1 = snap1.snapshotId();
+    ManifestFile manifestFile = snap1.allManifests().get(0);
+    validateSnapshot(null, snap1, 1, FILE_A);
+    validateManifest(manifestFile, seqs(1), ids(commitId1), files(FILE_A));
+    V2Assert.assertEquals("Snapshot write id should be 1", 1, snap1.writeId());
+    V2Assert.assertEquals("Last write id should be 0", 0, readMetadata().lastWriteId());
+
+    Set<DataFile> toAddFiles = Sets.newHashSet();
+    Set<DataFile> toDeleteFiles = Sets.newHashSet();
+    toAddFiles.add(FILE_B);
+    toDeleteFiles.add(FILE_A);
+    txn.newRewrite().rewriteFiles(toDeleteFiles, toAddFiles).commit();
+    txn.commitTransaction();
+
+    Snapshot snap2 = table.currentSnapshot();
+    long commitId2 = snap2.snapshotId();
+    manifestFile = snap2.allManifests().stream()
+        .filter(manifest -> manifest.snapshotId() == commitId2)
+        .collect(Collectors.toList()).get(0);
+
+    validateManifest(manifestFile, seqs(2), ids(commitId2), files(FILE_B));
+    V2Assert.assertEquals("Snapshot write id should be 2", 2, snap2.writeId());
+    V2Assert.assertEquals("Last write id should be 2", 2, readMetadata().lastWriteId());
+  }
+
+  @Test
+  public void testExpirationInTransaction() {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+    long commitId1 = snap1.snapshotId();
+    ManifestFile manifestFile = table.currentSnapshot().allManifests().get(0);
+    validateSnapshot(null, snap1, 1, FILE_A);
+    validateManifest(manifestFile, seqs(1), ids(commitId1), files(FILE_A));
+    V2Assert.assertEquals("Snapshot write id should be 1", 1, snap1.writeId());
+    V2Assert.assertEquals("Last write id should be 1", 1, readMetadata().lastWriteId());
+
+    table.newAppend().appendFile(FILE_B).commit();
+    Snapshot snap2 = table.currentSnapshot();
+    long commitId2 = snap2.snapshotId();
+    manifestFile = table.currentSnapshot().allManifests().get(0);
+    validateSnapshot(snap1, snap2, 2, FILE_B);
+    validateManifest(manifestFile, seqs(2), ids(commitId2), files(FILE_B));
+    V2Assert.assertEquals("Snapshot write id should be 2", 2, snap2.writeId());
+    V2Assert.assertEquals("Last write id should be 2", 2, readMetadata().lastWriteId());
+
+    Transaction txn = table.newTransaction();
+    txn.expireSnapshots().expireSnapshotId(commitId1).commit();
+    txn.commitTransaction();
+    V2Assert.assertEquals("Last write id should be 2", 2, readMetadata().lastWriteId());
+  }
+
+  @Test
+  public void testTransactionFailure() {
+    table.newAppend()
+        .appendFile(FILE_A)
+        .appendFile(FILE_B)
+        .commit();
+    Snapshot snap1 = table.currentSnapshot();
+    long commitId1 = snap1.snapshotId();
+    ManifestFile manifestFile = table.currentSnapshot().allManifests().get(0);
+    validateSnapshot(null, snap1, 1, FILE_A, FILE_B);
+    validateManifest(manifestFile, seqs(1, 1), ids(commitId1, commitId1), files(FILE_A, FILE_B));
+    V2Assert.assertEquals("Snapshot write id should be 1", 1, snap1.writeId());
+    V2Assert.assertEquals("Last write id should be 1", 1, readMetadata().lastWriteId());
+
+    table.updateProperties()
+        .set(TableProperties.COMMIT_NUM_RETRIES, "0")
+        .commit();
+
+    table.ops().failCommits(1);
+
+    Transaction txn = table.newTransaction();
+    txn.newAppend().appendFile(FILE_C).commit();
+
+    AssertHelpers.assertThrows("Transaction commit should fail",
+        CommitFailedException.class, "Injected failure", txn::commitTransaction);
+
+    V2Assert.assertEquals("Last write id should be 1", 1, readMetadata().lastWriteId());
+  }
+
+  @Test
+  public void testCherryPicking() {
+    table.newAppend()
+        .appendFile(FILE_A)
+        .commit();
+    Snapshot snap1 = table.currentSnapshot();
+    long commitId1 = snap1.snapshotId();
+    ManifestFile manifestFile = snap1.allManifests().get(0);
+    validateSnapshot(null, snap1, 1, FILE_A);
+    validateManifest(manifestFile, seqs(1), ids(commitId1), files(FILE_A));
+    V2Assert.assertEquals("Snapshot write id should be 1", 1, snap1.writeId());
+    V2Assert.assertEquals("Last write id should be 1", 1, readMetadata().lastWriteId());
+
+    table.newAppend()
+        .appendFile(FILE_B)
+        .stageOnly()
+        .commit();
+
+    Snapshot snap2 = table.currentSnapshot();
+    V2Assert.assertEquals("Snapshot write id should be 1", 1, snap2.writeId());
+    V2Assert.assertEquals("Last write id should be 2", 2, readMetadata().lastWriteId());
+
+    // pick the snapshot that's staged but not committed
+    Snapshot stagedSnapshot = readMetadata().snapshots().get(1);
+    V2Assert.assertEquals("Snapshot write id should be 2", 2, stagedSnapshot.writeId());
+
+    // table has new commit
+    table.newAppend()
+        .appendFile(FILE_C)
+        .commit();
+
+    Snapshot snap3 = table.currentSnapshot();
+    long commitId3 = snap3.snapshotId();
+    manifestFile = snap3.allManifests().get(0);
+    validateManifest(manifestFile, seqs(3), ids(commitId3), files(FILE_C));
+    validateSnapshot(snap2, snap3, 3, FILE_C);
+    V2Assert.assertEquals("Snapshot write id should be 3", 3, snap3.writeId());
+    V2Assert.assertEquals("Last write id should be 3", 3, readMetadata().lastWriteId());
+
+    // cherry-pick snapshot
+    table.manageSnapshots().cherrypick(stagedSnapshot.snapshotId()).commit();
+    Snapshot snap4 = table.currentSnapshot();
+    long commitId4 = snap4.snapshotId();
+    manifestFile = table.currentSnapshot().allManifests().get(0);
+    validateManifest(manifestFile, seqs(4), ids(commitId4), files(FILE_B));
+    validateSnapshot(snap3, snap4, 4, FILE_B);
+    V2Assert.assertEquals("Snapshot write id should be 4", 4, snap4.writeId());
+    V2Assert.assertEquals("Last write id should be 4", 4, readMetadata().lastWriteId());
+  }
+
+  @Test
+  public void testCherryPickFastForward() {
+    table.newAppend()
+        .appendFile(FILE_A)
+        .commit();
+    Snapshot snap1 = table.currentSnapshot();
+    long commitId1 = snap1.snapshotId();
+    ManifestFile manifestFile = snap1.allManifests().get(0);
+    validateSnapshot(null, snap1, 1, FILE_A);
+    validateManifest(manifestFile, seqs(1), ids(commitId1), files(FILE_A));
+    V2Assert.assertEquals("Snapshot write id should be 1", 1, snap1.writeId());
+    V2Assert.assertEquals("Last write id should be 1", 1, readMetadata().lastWriteId());
+
+    table.newAppend()
+        .appendFile(FILE_B)
+        .stageOnly()
+        .commit();
+    Snapshot snap2 = table.currentSnapshot();
+    V2Assert.assertEquals("Snapshot write id should be 1", 1, snap2.writeId());
+    V2Assert.assertEquals("Last write id should be 2", 2, readMetadata().lastWriteId());
+
+    // pick the snapshot that's staged but not committed
+    Snapshot stagedSnapshot = readMetadata().snapshots().get(1);
+    V2Assert.assertEquals("Snapshot write id should be 2", 2, stagedSnapshot.writeId());
+
+    // cherry-pick snapshot, this will fast forward
+    table.manageSnapshots().cherrypick(stagedSnapshot.snapshotId()).commit();
+    Snapshot snap3 = table.currentSnapshot();
+    long commitId3 = snap3.snapshotId();
+    manifestFile = snap3.allManifests().get(0);
+    validateManifest(manifestFile, seqs(2), ids(commitId3), files(FILE_B));
+    validateSnapshot(snap2, snap3, 2, FILE_B);
+    V2Assert.assertEquals("Snapshot write id should be 2", 2, snap3.writeId());
+    V2Assert.assertEquals("Last write id should be 2", 2, readMetadata().lastWriteId());
+  }
+
+}

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/ManifestFileBean.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/actions/ManifestFileBean.java
@@ -138,6 +138,11 @@ public class ManifestFileBean implements ManifestFile {
   }
 
   @Override
+  public long writeId() {
+    return 0;
+  }
+
+  @Override
   public ManifestFile copy() {
     throw new UnsupportedOperationException("Cannot copy");
   }


### PR DESCRIPTION
…compact, we don't know which data files don't have update-to-date using the sequence number.


See: https://docs.google.com/document/d/17q0pukixKR2a2BESJWykz4ENhCKSf8yQr751P2i7PF8/edit#