### PR TITLE
Spark [3.2] : Improve stats estimation for spark scan

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -145,10 +145,12 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
     }
 
     long numRows = 0L;
+    long defaultRowSizeInBytes = readSchema().defaultSize();
 
     for (CombinedScanTask task : tasks()) {
       for (FileScanTask file : task.files()) {
-        numRows += file.file().recordCount();
+        // TODO: if possible, take deletes also into consideration.
+        numRows += Math.min(file.length() / defaultRowSizeInBytes, file.file().recordCount());
       }
     }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -145,12 +145,12 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
     }
 
     long numRows = 0L;
-    long defaultRowSizeInBytes = readSchema().defaultSize();
 
     for (CombinedScanTask task : tasks()) {
       for (FileScanTask file : task.files()) {
         // TODO: if possible, take deletes also into consideration.
-        numRows += Math.min(file.length() / defaultRowSizeInBytes, file.file().recordCount());
+        double fractionOfFileScanned = ((double) file.length() / file.file().fileSizeInBytes());
+        numRows += (fractionOfFileScanned * file.file().recordCount());
       }
     }
 

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -149,7 +149,7 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
     for (CombinedScanTask task : tasks()) {
       for (FileScanTask file : task.files()) {
         // TODO: if possible, take deletes also into consideration.
-        double fractionOfFileScanned = ((double) file.length() / file.file().fileSizeInBytes());
+        double fractionOfFileScanned = ((double) file.length()) / file.file().fileSizeInBytes();
         numRows += (fractionOfFileScanned * file.file().recordCount());
       }
     }


### PR DESCRIPTION
As per my understanding, presently we don't take `SplitScanTask`(which also implements FileScanTask),into consideration where we would _**not**_ be reading the complete file rather a subpart of the file. 

So in this case it's better to find number of records actually scanned by the task, rather than going to datafile this splitscanTask is based on and get's its complete record count. 

At present it seems like we are over-estimating the size by taking complete record count of the file associated with the SplitScanTask, where as we are just scanning the subset of data from this file.

---

cc @rdblue @aokolnychyi @RussellSpitzer @jackye1995  @wypoon 