### PR TITLE
Aliyun: Deprecate OSSInputStream public constructor

### DIFF
--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSInputStream.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSInputStream.java
@@ -35,6 +35,10 @@ import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @deprecated moving to package-private in 0.15.0
+ */
+@Deprecated
 public class OSSInputStream extends SeekableInputStream {
   private static final Logger LOG = LoggerFactory.getLogger(OSSInputStream.class);
   private static final int SKIP_SIZE = 1024 * 1024;
@@ -51,6 +55,10 @@ public class OSSInputStream extends SeekableInputStream {
   private final Counter<Long> readBytes;
   private final Counter<Integer> readOperations;
 
+  /**
+   * @deprecated moving to package-private in 0.15.0
+   */
+  @Deprecated
   public OSSInputStream(OSS client, OSSURI uri) {
     this(client, uri, MetricsContext.nullMetrics());
   }


### PR DESCRIPTION
This PR is a follow-up of @rdblue's feedback: https://github.com/apache/iceberg/pull/4393#discussion_r838900710

Deprecating the constructor would maintain parity with the other InputStream classes like `GCSInputStream`, `EcsSeekableInputStream`, and `S3InputStream` which have a package private constructor.

cc: @rdblue 