### PR TITLE
Docs: fix format-version doc returns 404 not found 

### DIFF
--- a/docs/tables/configuration.md
+++ b/docs/tables/configuration.md
@@ -104,7 +104,7 @@ The value of these properties are not persisted as a part of the table metadata.
 
 | Property       | Default  | Description                                                   |
 | -------------- | -------- | ------------------------------------------------------------- |
-| format-version | 1        | Table's format version (can be 1 or 2) as defined in the [Spec](./spec.md#format-versioning). |
+| format-version | 1        | Table's format version (can be 1 or 2) as defined in the [Spec](../../format/spec.md#format-versioning). |
 
 ### Compatibility flags
 


### PR DESCRIPTION
This link returns not found

<img width="1064" alt="image" src="https://user-images.githubusercontent.com/29967142/161061457-333da0ab-c63c-490b-b247-253238f5b40b.png">

<img width="637" alt="image" src="https://user-images.githubusercontent.com/29967142/161061203-70e90f55-239e-4153-aa7a-e0a859707def.png">
