### PR TITLE
AWS: Make S3 client initialization thread safe in S3FileIO.

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -72,7 +72,7 @@ public class S3FileIO implements FileIO, SupportsBulkOperations {
 
   private SerializableSupplier<S3Client> s3;
   private AwsProperties awsProperties;
-  private transient S3Client client;
+  private transient volatile S3Client client;
   private MetricsContext metrics = MetricsContext.nullMetrics();
   private final AtomicBoolean isResourceClosed = new AtomicBoolean(false);
 
@@ -240,7 +240,11 @@ public class S3FileIO implements FileIO, SupportsBulkOperations {
 
   private S3Client client() {
     if (client == null) {
-      client = s3.get();
+      synchronized (this) {
+        if (client == null) {
+          client = s3.get();
+        }
+      }
     }
     return client;
   }


### PR DESCRIPTION
FileIO can be shared by threads in the pool (ManifestGroup.planFiles - ParallelIterable), and those threads likely start at about the same time, race condition could happen.