### PR TITLE
[BUILD] : Add DELL in PR labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -81,3 +81,5 @@ ALIYUN:
   - aliyun/**/*
 GCP:
   - gcp/**/*
+DELL:
+  - dell/**/*


### PR DESCRIPTION
- on raising a PR effecting DELL changes, the PR was not tagged with DELL label (looks like DELL folder was added recently), where as Aliyun / GCP tag got added.
 - https://github.com/apache/iceberg/pull/4461

This change attempts to give PR labeler a way to tag DELL related changes with DELL tag.

---- 

cc @kbendick 