### PR TITLE
Docs: update Spark Write doc for partitioned tables

### DIFF
--- a/docs/spark/spark-writes.md
+++ b/docs/spark/spark-writes.md
@@ -313,7 +313,7 @@ distribution & sort order to Spark.
 {{< hint info >}}
 Both global sort (sorting all the data in the write) and local sort (sorting the data within a Spark task) can be used to write against a partitioned table.
 
-In SQL, the [`ORDER BY`](https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-orderby.html) will achieve global sorting and [`SORT BY`](https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-sortby.html) will achieve local sorting.
+In SQL, [`ORDER BY`](https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-orderby.html) will achieve global sorting and [`SORT BY`](https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-sortby.html) will achieve local sorting.
 
 In the Dataframe API, the `orderBy`/`sort` functions will achieve global sorting and `sortWithinPartitions` will achieve local sorting.
 {{< /hint >}}

--- a/docs/spark/spark-writes.md
+++ b/docs/spark/spark-writes.md
@@ -311,7 +311,7 @@ distribution & sort order to Spark.
 {{< /hint >}}
 
 {{< hint info >}}
-Both global sort and local sort (data sorted within each partition) can be used to write against partitioned table.
+Both global sort (sorting all the data in the write) and local sort (sorting the data within a Spark task) can be used to write against partitioned table.
 
 In SQL, the [`ORDER BY`](https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-orderby.html) will achieve global sorting and [`SORT BY`](https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-sortby.html) will achieve local sorting.
 

--- a/docs/spark/spark-writes.md
+++ b/docs/spark/spark-writes.md
@@ -413,7 +413,7 @@ Explicit registration of the function is necessary because Spark doesn't allow I
 which can be used in query.
 {{< /hint >}}
 
-Here the bucket function is registered as `iceberg_bucket16`, which can be used in sort clause.
+Here the bucket function is registered as `iceberg_bucket16`, which can be used in a sort clause.
 
 In Spark SQL, the function can be used as follows:
 

--- a/docs/spark/spark-writes.md
+++ b/docs/spark/spark-writes.md
@@ -311,7 +311,7 @@ distribution & sort order to Spark.
 {{< /hint >}}
 
 {{< hint info >}}
-Both global sort (sorting all the data in the write) and local sort (sorting the data within a Spark task) can be used to write against partitioned table.
+Both global sort (sorting all the data in the write) and local sort (sorting the data within a Spark task) can be used to write against a partitioned table.
 
 In SQL, the [`ORDER BY`](https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-orderby.html) will achieve global sorting and [`SORT BY`](https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-sortby.html) will achieve local sorting.
 

--- a/docs/spark/spark-writes.md
+++ b/docs/spark/spark-writes.md
@@ -356,7 +356,7 @@ SELECT id, data, category, ts FROM another_table
 SORT BY day(ts), category
 ```
 
-#### In the Dataframe API
+#### Sort Order Using the Dataframe API
 
 To globally sort data based on `ts` and `category`:
 

--- a/docs/spark/spark-writes.md
+++ b/docs/spark/spark-writes.md
@@ -330,7 +330,7 @@ USING iceberg
 PARTITIONED BY (days(ts), category)
 ```
 
-#### In Spark SQL
+#### Sort Order Using Spark SQL
 
 To globally sort data based on `ts` and `category`:
 

--- a/docs/spark/spark-writes.md
+++ b/docs/spark/spark-writes.md
@@ -348,7 +348,7 @@ SELECT id, data, category, ts FROM another_table
 SORT BY ts, category
 ```
 
-`SORT BY` clauses can also be used with partition transforms. The [date-and-timestamp-functions](https://spark.apache.org/docs/latest/sql-ref-functions-builtin.html#date-and-timestamp-functions) will be used when partition transforms is time related; truncate related functions such as `substr` will be used when partition transform is `truncate[W]`; [define and register UDFs](https://spark.apache.org/docs/latest/sql-ref-functions-udf-scalar.html) can also take effect.
+`SORT BY` clauses can also be used with partition transforms. The [date-and-timestamp-functions](https://spark.apache.org/docs/latest/sql-ref-functions-builtin.html#date-and-timestamp-functions) should be used when partition transforms are time related. Truncate related functions such as `substr` should be used when the partition transform is `truncate[W]`. It is required to [define and register UDFs](https://spark.apache.org/docs/latest/sql-ref-functions-udf-scalar.html) when the partition transform is [bucket transform](##Bucket Transform).
 
 ```sql
 INSERT INTO prod.db.sample
@@ -382,7 +382,7 @@ data.sortWithinPartitions("ts", "category")
 
 #### Bucket Transform
 
-It's easy to add the original column to the sort condition for the most partition transformations, except `bucket`.
+`Bucket` transforms require additional steps which are not necessary with other partition transforms.
 
 For `bucket` partition transformation, it is required to register the Iceberg transform function in Spark to specify it during sort.
 


### PR DESCRIPTION
I am using spark sql to write data, the amount of data is very large, so I don't want to sort the data globally, but I didn't find an example of partial sorting in the documentation, I want to add it here, thanks!

Sort by definition in spark sql documentation:
https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-sortby.html
<img width="812" alt="image" src="https://user-images.githubusercontent.com/29967142/161223329-0a593296-049f-4d21-ba02-d7711259d83b.png">

The test:
The first step is to create a table:
<img width="762" alt="wecom-temp-0f83c792cf74f323d1f2dc9431255605" src="https://user-images.githubusercontent.com/29967142/161223676-d070a45a-6180-4641-a52f-651f41db90c9.png">

Then query the data by sort by:
<img width="863" alt="wecom-temp-7a6e180f1068256a1eb80b87156a8bf6" src="https://user-images.githubusercontent.com/29967142/161223812-7d89515f-6538-4f7d-91c8-1a8c32c105d6.png">