### PR TITLE
Core: Add ResourcePaths helper for REST

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
@@ -64,6 +64,7 @@ public class ResourcePaths {
 
   public String table(TableIdentifier ident) {
     return SLASH.join(
-        "v1", prefix, "namespaces", RESTUtil.encodeNamespace(ident.namespace()), "tables", RESTUtil.encodeString(ident.name()));
+        "v1", prefix, "namespaces", RESTUtil.encodeNamespace(ident.namespace()), "tables",
+        RESTUtil.encodeString(ident.name()));
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest;
+
+import java.util.Map;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.base.Joiner;
+
+public class ResourcePaths {
+  private static final Joiner SLASH = Joiner.on("/").skipNulls();
+  private static final String PREFIX = "prefix";
+
+  public static ResourcePaths forCatalogProperties(Map<String, String> properties) {
+    return new ResourcePaths(properties.get(PREFIX));
+  }
+
+  public static String config() {
+    return "v1/config";
+  }
+
+  private final String prefix;
+
+  public ResourcePaths(String prefix) {
+    this.prefix = prefix;
+  }
+
+  public String namespaces() {
+    return SLASH.join("v1", prefix, "namespaces");
+  }
+
+  public String namespace(Namespace ns) {
+    return SLASH.join("v1", prefix, "namespaces", RESTUtil.encodeNamespace(ns));
+  }
+
+  public String namespaceProperties(Namespace ns) {
+    return SLASH.join("v1", prefix, "namespaces", RESTUtil.encodeNamespace(ns), "properties");
+  }
+
+  public String tables(Namespace ns) {
+    return SLASH.join("v1", prefix, "namespaces", RESTUtil.encodeNamespace(ns), "tables");
+  }
+
+  public String stageCreate(Namespace ns) {
+    return SLASH.join("v1", prefix, "namespaces", RESTUtil.encodeNamespace(ns), "stageCreate");
+  }
+
+  public String table(TableIdentifier ident) {
+    return SLASH.join(
+        "v1", prefix, "namespaces", RESTUtil.encodeNamespace(ident.namespace()), "tables", RESTUtil.encodeString(ident.name()));
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -425,6 +425,52 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   }
 
   @Test
+  public void testTableNameWithSlash() {
+    C catalog = catalog();
+
+    TableIdentifier ident = TableIdentifier.of("ns", "tab/le");
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(Namespace.of("ns"));
+    }
+
+    Assert.assertFalse("Table should not exist", catalog.tableExists(ident));
+
+    catalog.buildTable(ident, SCHEMA).create();
+    Assert.assertTrue("Table should exist", catalog.tableExists(ident));
+
+    Table loaded = catalog.loadTable(ident);
+    Assert.assertEquals("Schema should match expected ID assignment",
+        TABLE_SCHEMA.asStruct(), loaded.schema().asStruct());
+
+    catalog.dropTable(ident);
+
+    Assert.assertFalse("Table should not exist", catalog.tableExists(ident));
+  }
+
+  @Test
+  public void testTableNameWithDot() {
+    C catalog = catalog();
+
+    TableIdentifier ident = TableIdentifier.of("ns", "ta.ble");
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(Namespace.of("ns"));
+    }
+
+    Assert.assertFalse("Table should not exist", catalog.tableExists(ident));
+
+    catalog.buildTable(ident, SCHEMA).create();
+    Assert.assertTrue("Table should exist", catalog.tableExists(ident));
+
+    Table loaded = catalog.loadTable(ident);
+    Assert.assertEquals("Schema should match expected ID assignment",
+        TABLE_SCHEMA.asStruct(), loaded.schema().asStruct());
+
+    catalog.dropTable(ident);
+
+    Assert.assertFalse("Table should not exist", catalog.tableExists(ident));
+  }
+
+  @Test
   public void testBasicCreateTableThatAlreadyExists() {
     C catalog = catalog();
 

--- a/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -325,10 +325,10 @@ public class RESTCatalogAdapter implements RESTClient {
   }
 
   private static Namespace namespaceFromPathVars(Map<String, String> pathVars) {
-    return RESTUtil.urlDecode(pathVars.get("namespace"));
+    return RESTUtil.decodeNamespace(pathVars.get("namespace"));
   }
 
   private static TableIdentifier identFromPathVars(Map<String, String> pathVars) {
-    return TableIdentifier.of(namespaceFromPathVars(pathVars), pathVars.get("table"));
+    return TableIdentifier.of(namespaceFromPathVars(pathVars), RESTUtil.decodeString(pathVars.get("table")));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
@@ -71,10 +71,10 @@ public class TestRESTUtil {
         new Object[] {new String[] {"dogs"}, "dogs"},
         new Object[] {new String[] {"dogs.named.hank"}, "dogs.named.hank"},
         new Object[] {new String[] {"dogs/named/hank"}, "dogs%2Fnamed%2Fhank"},
-        new Object[] {new String[] {"dogs", "named", "hank"}, "dogs\u0000named\u0000hank"},
+        new Object[] {new String[] {"dogs", "named", "hank"}, "dogs%00named%00hank"},
         new Object[] {
             new String[] {"dogs.and.cats", "named", "hank.or.james-westfall"},
-            "dogs.and.cats\u0000named\u0000hank.or.james-westfall"
+            "dogs.and.cats%00named%00hank.or.james-westfall"
         }
     };
 

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
@@ -85,11 +85,11 @@ public class TestRESTUtil {
       Namespace namespace = Namespace.of(levels);
 
       // To be placed into a URL path as query parameter or path parameter
-      Assertions.assertThat(RESTUtil.urlEncode(namespace))
+      Assertions.assertThat(RESTUtil.encodeNamespace(namespace))
           .isEqualTo(encodedNs);
 
       // Decoded (after pulling as String) from URL
-      Namespace asNamespace = RESTUtil.urlDecode(encodedNs);
+      Namespace asNamespace = RESTUtil.decodeNamespace(encodedNs);
       Assertions.assertThat(asNamespace).isEqualTo(namespace);
     }
   }
@@ -97,11 +97,11 @@ public class TestRESTUtil {
   @Test
   public void testNamespaceUrlEncodeDecodeDoesNotAllowNull() {
     Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(() -> RESTUtil.urlEncode(null))
+        .isThrownBy(() -> RESTUtil.encodeNamespace(null))
         .withMessage("Invalid namespace: null");
 
     Assertions.assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(() -> RESTUtil.urlDecode(null))
+        .isThrownBy(() -> RESTUtil.decodeNamespace(null))
         .withMessage("Invalid namespace: null");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestResourcePaths.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestResourcePaths.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest;
+
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestResourcePaths {
+  private final String prefix = "ws/catalog";
+  private final ResourcePaths withPrefix = ResourcePaths.forCatalogProperties(ImmutableMap.of("prefix", prefix));
+  private final ResourcePaths withoutPrefix = ResourcePaths.forCatalogProperties(ImmutableMap.of());
+
+  @Test
+  public void testConfigPath() {
+    // prefix does not affect the config route because config is merged into catalog properties
+    Assert.assertEquals(ResourcePaths.config(), "v1/config");
+  }
+
+  @Test
+  public void testNamespaces() {
+    Assert.assertEquals("v1/ws/catalog/namespaces", withPrefix.namespaces());
+    Assert.assertEquals("v1/namespaces", withoutPrefix.namespaces());
+  }
+
+  @Test
+  public void testNamespace() {
+    Namespace ns = Namespace.of("ns");
+    Assert.assertEquals("v1/ws/catalog/namespaces/ns", withPrefix.namespace(ns));
+    Assert.assertEquals("v1/namespaces/ns", withoutPrefix.namespace(ns));
+  }
+
+  @Test
+  public void testNamespaceWithSlash() {
+    Namespace ns = Namespace.of("n/s");
+    Assert.assertEquals("v1/ws/catalog/namespaces/n%2Fs", withPrefix.namespace(ns));
+    Assert.assertEquals("v1/namespaces/n%2Fs", withoutPrefix.namespace(ns));
+  }
+
+  @Test
+  public void testNamespaceWithMultipartNamespace() {
+    Namespace ns = Namespace.of("n", "s");
+    Assert.assertEquals("v1/ws/catalog/namespaces/n%00s", withPrefix.namespace(ns));
+    Assert.assertEquals("v1/namespaces/n%00s", withoutPrefix.namespace(ns));
+  }
+
+  @Test
+  public void testNamespaceProperties() {
+    Namespace ns = Namespace.of("ns");
+    Assert.assertEquals("v1/ws/catalog/namespaces/ns/properties", withPrefix.namespaceProperties(ns));
+    Assert.assertEquals("v1/namespaces/ns/properties", withoutPrefix.namespaceProperties(ns));
+  }
+
+  @Test
+  public void testNamespacePropertiesWithSlash() {
+    Namespace ns = Namespace.of("n/s");
+    Assert.assertEquals("v1/ws/catalog/namespaces/n%2Fs/properties", withPrefix.namespaceProperties(ns));
+    Assert.assertEquals("v1/namespaces/n%2Fs/properties", withoutPrefix.namespaceProperties(ns));
+  }
+
+  @Test
+  public void testNamespacePropertiesWithMultipartNamespace() {
+    Namespace ns = Namespace.of("n", "s");
+    Assert.assertEquals("v1/ws/catalog/namespaces/n%00s/properties", withPrefix.namespaceProperties(ns));
+    Assert.assertEquals("v1/namespaces/n%00s/properties", withoutPrefix.namespaceProperties(ns));
+  }
+
+  @Test
+  public void testTables() {
+    Namespace ns = Namespace.of("ns");
+    Assert.assertEquals("v1/ws/catalog/namespaces/ns/tables", withPrefix.tables(ns));
+    Assert.assertEquals("v1/namespaces/ns/tables", withoutPrefix.tables(ns));
+  }
+
+  @Test
+  public void testTablesWithSlash() {
+    Namespace ns = Namespace.of("n/s");
+    Assert.assertEquals("v1/ws/catalog/namespaces/n%2Fs/tables", withPrefix.tables(ns));
+    Assert.assertEquals("v1/namespaces/n%2Fs/tables", withoutPrefix.tables(ns));
+  }
+
+  @Test
+  public void testTablesWithMultipartNamespace() {
+    Namespace ns = Namespace.of("n", "s");
+    Assert.assertEquals("v1/ws/catalog/namespaces/n%00s/tables", withPrefix.tables(ns));
+    Assert.assertEquals("v1/namespaces/n%00s/tables", withoutPrefix.tables(ns));
+  }
+
+  @Test
+  public void testStageCreate() {
+    Namespace ns = Namespace.of("ns");
+    Assert.assertEquals("v1/ws/catalog/namespaces/ns/stageCreate", withPrefix.stageCreate(ns));
+    Assert.assertEquals("v1/namespaces/ns/stageCreate", withoutPrefix.stageCreate(ns));
+  }
+
+  @Test
+  public void testStageCreateWithSlash() {
+    Namespace ns = Namespace.of("n/s");
+    Assert.assertEquals("v1/ws/catalog/namespaces/n%2Fs/stageCreate", withPrefix.stageCreate(ns));
+    Assert.assertEquals("v1/namespaces/n%2Fs/stageCreate", withoutPrefix.stageCreate(ns));
+  }
+
+  @Test
+  public void testStageCreateWithMultipartNamespace() {
+    Namespace ns = Namespace.of("n", "s");
+    Assert.assertEquals("v1/ws/catalog/namespaces/n%00s/stageCreate", withPrefix.stageCreate(ns));
+    Assert.assertEquals("v1/namespaces/n%00s/stageCreate", withoutPrefix.stageCreate(ns));
+  }
+
+  @Test
+  public void testTable() {
+    TableIdentifier ident = TableIdentifier.of("ns", "table");
+    Assert.assertEquals("v1/ws/catalog/namespaces/ns/tables/table", withPrefix.table(ident));
+    Assert.assertEquals("v1/namespaces/ns/tables/table", withoutPrefix.table(ident));
+  }
+
+  @Test
+  public void testTableWithSlash() {
+    TableIdentifier ident = TableIdentifier.of("n/s", "tab/le");
+    Assert.assertEquals("v1/ws/catalog/namespaces/n%2Fs/tables/tab%2Fle", withPrefix.table(ident));
+    Assert.assertEquals("v1/namespaces/n%2Fs/tables/tab%2Fle", withoutPrefix.table(ident));
+  }
+
+  @Test
+  public void testTableWithMultipartNamespace() {
+    TableIdentifier ident = TableIdentifier.of("n", "s", "table");
+    Assert.assertEquals("v1/ws/catalog/namespaces/n%00s/tables/table", withPrefix.table(ident));
+    Assert.assertEquals("v1/namespaces/n%00s/tables/table", withoutPrefix.table(ident));
+  }
+}


### PR DESCRIPTION
This adds a helper class, `ResourcePaths` to construct resource paths in the REST catalog. This cleans up path construction to be based on REST resource and adds support for the `prefix` parameter in the REST spec.

This also adds tests for each resource and validates the multipart namespace (null byte) handling.