### PR TITLE
Spark: DESCRIBE TABLE EXTENDED shows identifier fields

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -77,7 +77,7 @@ public class SparkTable implements org.apache.spark.sql.connector.catalog.Table,
   private static final Logger LOG = LoggerFactory.getLogger(SparkTable.class);
 
   private static final Set<String> RESERVED_PROPERTIES =
-      ImmutableSet.of("provider", "format", "current-snapshot-id", "location", "sort-order");
+      ImmutableSet.of("provider", "format", "current-snapshot-id", "location", "sort-order", "identifier-fields");
   private static final Set<TableCapability> CAPABILITIES = ImmutableSet.of(
       TableCapability.BATCH_READ,
       TableCapability.BATCH_WRITE,
@@ -162,6 +162,11 @@ public class SparkTable implements org.apache.spark.sql.connector.catalog.Table,
 
     if (!icebergTable.sortOrder().isUnsorted()) {
       propsBuilder.put("sort-order", Spark3Util.describe(icebergTable.sortOrder()));
+    }
+
+    Set<String> identifierFields = icebergTable.schema().identifierFieldNames();
+    if (!identifierFields.isEmpty()) {
+      propsBuilder.put("identifier-fields", "[" + String.join(",", identifierFields) + "]");
     }
 
     icebergTable.properties().entrySet().stream()

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/actions/TestCreateActions.java
@@ -492,6 +492,10 @@ public class TestCreateActions extends SparkCatalogTestBase {
     Assert.assertTrue("Location isn't correct", table.properties().get("location").endsWith(destTableName));
     Assert.assertEquals("Sort-order isn't correct", "id ASC NULLS FIRST, data DESC NULLS LAST",
         table.properties().get("sort-order"));
+    Assert.assertNull("Identifier fields should be null", table.properties().get("identifier-fields"));
+
+    table.table().updateSchema().allowIncompatibleChanges().requireColumn("id").setIdentifierFields("id").commit();
+    Assert.assertEquals("Identifier fields aren't correct", "[id]", table.properties().get("identifier-fields"));
   }
 
   @Test


### PR DESCRIPTION
Unit tests was updated. Also tested manually in Spark SQL. The first table does not have identifier fields while the second table (same schema) has identifier fields.
<img width="1519" alt="Screen Shot 2022-04-02 at 5 19 57 PM" src="https://user-images.githubusercontent.com/159186/161405924-1def9111-4ee1-48e8-9738-d04d209f7759.png">

Was following the pattern in #2330 for `location`. Thanks @flyrain 

Not sure is example `[userName,productId]` a good format? The comma is used to join multiple table properties in the shell.