### PR TITLE
Spark: Support identifier fields when creating table with SQL

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Schema.java
+++ b/api/src/main/java/org/apache/iceberg/Schema.java
@@ -129,6 +129,22 @@ public class Schema implements Serializable {
     }
   }
 
+  public static Set<Integer> identifierFieldNamesToIds(StructType struct, Set<String> identifierFiledNames) {
+    Map<String, Integer> nameToId = TypeUtil.indexByName(struct);
+    Set<Integer> identifierFieldIds = Sets.newHashSet();
+    // Validate identifier field by name exists
+    for (String identifierName : identifierFiledNames) {
+      Preconditions.checkArgument(nameToId.containsKey(identifierName),
+          "Identifier field named %s does not exist", identifierName);
+      identifierFieldIds.add(nameToId.get(identifierName));
+    }
+    // Validate field by id can be an identifier field
+    Map<Integer, Types.NestedField> idToField = TypeUtil.indexById(struct);
+    Map<Integer, Integer> idToParent = TypeUtil.indexParents(struct);
+    identifierFieldIds.forEach(id -> validateIdentifierField(id, idToField, idToParent));
+    return identifierFieldIds;
+  }
+
   public Schema(NestedField... columns) {
     this(DEFAULT_SCHEMA_ID, Arrays.asList(columns));
   }

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
@@ -130,6 +130,10 @@ public class SparkSchemaUtil {
     return convert(sparkType, false);
   }
 
+  public static Schema convert(StructType sparkType, boolean useTimestampWithoutZone) {
+    return convert(sparkType, useTimestampWithoutZone, ImmutableSet.of());
+  }
+
   /**
    * Convert a Spark {@link StructType struct} to a {@link Schema} with new field ids.
    * <p>
@@ -145,9 +149,12 @@ public class SparkSchemaUtil {
    * @return the equivalent Schema
    * @throws IllegalArgumentException if the type cannot be converted
    */
-  public static Schema convert(StructType sparkType, boolean useTimestampWithoutZone) {
+  public static Schema convert(StructType sparkType, boolean useTimestampWithoutZone,
+                               Set<String> identifierFieldNames) {
     Type converted = SparkTypeVisitor.visit(sparkType, new SparkTypeToType(sparkType));
-    Schema schema = new Schema(converted.asNestedType().asStructType().fields());
+    Set<Integer> identifierIds = Schema.identifierFieldNamesToIds(converted.asNestedType().asStructType(),
+        identifierFieldNames);
+    Schema schema = new Schema(converted.asNestedType().asStructType().fields(), identifierIds);
     if (useTimestampWithoutZone) {
       schema = SparkFixupTimestampType.fixup(schema);
     }


### PR DESCRIPTION
Currently Spark SQL does not allow user to specify 'identifier-fields' when creating table. This is a PoC effort.

```sql
CREATE TABLE t1(
        id BIGINT NOT NULL,
        name STRING NOT NULL,
        data STRING)
USING iceberg
TBLPROPERTIES ('identifier-fields'='id,name')
```

After this, we can add support for other engines like Hive easily.