### PR TITLE
Python: Refactor to use common decimal and datetime util

### DIFF
--- a/python/src/iceberg/utils/datetime.py
+++ b/python/src/iceberg/utils/datetime.py
@@ -1,0 +1,65 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+"""Helper methods for working with date/time representations
+"""
+import re
+from datetime import date, datetime, time
+
+EPOCH_DATE = date.fromisoformat("1970-01-01")
+EPOCH_TIMESTAMP = datetime.fromisoformat("1970-01-01T00:00:00.000000")
+ISO_TIMESTAMP = re.compile(r"\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d(.\d{1,6})?")
+EPOCH_TIMESTAMPTZ = datetime.fromisoformat("1970-01-01T00:00:00.000000+00:00")
+ISO_TIMESTAMPTZ = re.compile(r"\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d(.\d{1,6})?[-+]\d\d:\d\d")
+
+
+def micros_to_days(timestamp: int) -> int:
+    """Converts a timestamp in microseconds to a date in days"""
+    return (datetime.fromtimestamp(timestamp / 1_000_000) - EPOCH_TIMESTAMP).days
+
+
+def date_to_days(date_str: str) -> int:
+    """Converts an ISO-8601 formatted date to days from 1970-01-01"""
+    return (date.fromisoformat(date_str) - EPOCH_DATE).days
+
+
+def time_to_micros(time_str: str) -> int:
+    """Converts an ISO-8601 formatted time to microseconds from midnight"""
+    t = time.fromisoformat(time_str)
+    return (((t.hour * 60 + t.minute) * 60) + t.second) * 1_000_000 + t.microsecond
+
+
+def datetime_to_micros(dt: datetime) -> int:
+    """Converts a datetime to microseconds from 1970-01-01T00:00:00.000000"""
+    if dt.tzinfo:
+        delta = dt - EPOCH_TIMESTAMPTZ
+    else:
+        delta = dt - EPOCH_TIMESTAMP
+    return (delta.days * 86400 + delta.seconds) * 1_000_000 + delta.microseconds
+
+
+def timestamp_to_micros(timestamp_str: str) -> int:
+    """Converts an ISO-9601 formatted timestamp without zone to microseconds from 1970-01-01T00:00:00.000000"""
+    if ISO_TIMESTAMP.fullmatch(timestamp_str):
+        return datetime_to_micros(datetime.fromisoformat(timestamp_str))
+    raise ValueError(f"Invalid timestamp without zone: {timestamp_str} (must be ISO-8601)")
+
+
+def timestamptz_to_micros(timestamptz_str: str) -> int:
+    """Converts an ISO-8601 formatted timestamp with zone to microseconds from 1970-01-01T00:00:00.000000+00:00"""
+    if ISO_TIMESTAMPTZ.fullmatch(timestamptz_str):
+        return datetime_to_micros(datetime.fromisoformat(timestamptz_str))
+    raise ValueError(f"Invalid timestamp with zone: {timestamptz_str} (must be ISO-8601)")

--- a/python/src/iceberg/utils/decimal.py
+++ b/python/src/iceberg/utils/decimal.py
@@ -48,7 +48,7 @@ def unscaled_to_decimal(unscaled: int, scale: int) -> Decimal:
     return Decimal((sign, digits, -scale))
 
 
-def min_size(value: Union[int, Decimal]) -> int:
+def bytes_required(value: Union[int, Decimal]) -> int:
     """Returns the minimum number of bytes needed to serialize a decimal or unscaled value
 
     Args:
@@ -74,4 +74,4 @@ def decimal_to_bytes(value: Decimal) -> bytes:
         bytes: the unscaled value of the Decimal as bytes
     """
     unscaled_value = decimal_to_unscaled(value)
-    return unscaled_value.to_bytes(min_size(unscaled_value), byteorder="big", signed=True)
+    return unscaled_value.to_bytes(bytes_required(unscaled_value), byteorder="big", signed=True)

--- a/python/src/iceberg/utils/decimal.py
+++ b/python/src/iceberg/utils/decimal.py
@@ -66,5 +66,12 @@ def min_size(value: Union[int, Decimal]) -> int:
 
 
 def decimal_to_bytes(value: Decimal) -> bytes:
+    """Returns a byte representation of a decimal
+
+    Args:
+        value (Decimal): a decimal value
+    Returns:
+        bytes: the unscaled value of the Decimal as bytes
+    """
     unscaled_value = decimal_to_unscaled(value)
     return unscaled_value.to_bytes(min_size(unscaled_value), byteorder="big", signed=True)

--- a/python/src/iceberg/utils/decimal.py
+++ b/python/src/iceberg/utils/decimal.py
@@ -1,0 +1,70 @@
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+"""Helper methods for working with Python Decimals
+"""
+from decimal import Decimal
+from typing import Union
+
+
+def decimal_to_unscaled(value: Decimal) -> int:
+    """Get an unscaled value given a Decimal value
+
+    Args:
+        value (Decimal): A Decimal instance
+
+    Returns:
+        int: The unscaled value
+    """
+    sign, digits, _ = value.as_tuple()
+    return int(Decimal((sign, digits, 0)).to_integral_value())
+
+
+def unscaled_to_decimal(unscaled: int, scale: int) -> Decimal:
+    """Get a scaled Decimal value given an unscaled value and a scale
+
+    Args:
+        unscaled (int): An unscaled value
+        scale (int): A scale to set for the returned Decimal instance
+
+    Returns:
+        Decimal: A scaled Decimal instance
+    """
+    sign, digits, _ = Decimal(unscaled).as_tuple()
+    return Decimal((sign, digits, -scale))
+
+
+def min_size(value: Union[int, Decimal]) -> int:
+    """Returns the minimum number of bytes needed to serialize a decimal or unscaled value
+
+    Args:
+        value (int | Decimal): a Decimal value or unscaled int value
+
+    Returns:
+        int: the minimum number of bytes needed to serialize the value
+    """
+    if isinstance(value, int):
+        return (value.bit_length() + 7) // 8
+    elif isinstance(value, Decimal):
+        return (decimal_to_unscaled(value).bit_length() + 7) // 8
+
+    raise ValueError(f"Unsupported value: {value}")
+
+
+def decimal_to_bytes(value: Decimal) -> bytes:
+    unscaled_value = decimal_to_unscaled(value)
+    return unscaled_value.to_bytes(min_size(unscaled_value), byteorder="big", signed=True)

--- a/python/tests/test_conversions.py
+++ b/python/tests/test_conversions.py
@@ -77,6 +77,7 @@ from decimal import Decimal
 
 import pytest
 
+import iceberg.utils.decimal as decimal_util
 from iceberg import conversions
 from iceberg.types import (
     BinaryType,
@@ -112,7 +113,7 @@ from iceberg.types import (
 )
 def test_decimal_to_unscaled(value, expected_result):
     """Test converting a decimal to an unscaled value"""
-    assert conversions.decimal_to_unscaled(value=value) == expected_result
+    assert decimal_util.decimal_to_unscaled(value=value) == expected_result
 
 
 @pytest.mark.parametrize(
@@ -130,7 +131,7 @@ def test_decimal_to_unscaled(value, expected_result):
 )
 def test_unscaled_to_decimal(unscaled, scale, expected_result):
     """Test converting an unscaled value to a decimal with a specified scale"""
-    assert conversions.unscaled_to_decimal(unscaled=unscaled, scale=scale) == expected_result
+    assert decimal_util.unscaled_to_decimal(unscaled=unscaled, scale=scale) == expected_result
 
 
 @pytest.mark.parametrize(

--- a/python/tests/test_transforms.py
+++ b/python/tests/test_transforms.py
@@ -18,6 +18,7 @@
 from decimal import Decimal
 from uuid import UUID
 
+import mmh3 as mmh3
 import pytest
 
 from iceberg import transforms
@@ -117,3 +118,10 @@ def test_bucket_method(type_var):
     assert bucket_transform.num_buckets == 8
     assert bucket_transform.apply(None) is None
     assert bucket_transform.to_human_string("test") == "test"
+
+
+def test_string_with_surrogate_pair():
+    string_with_surrogate_pair = "string with a surrogate pair: 💰"
+    as_bytes = bytes(string_with_surrogate_pair, "UTF-8")
+    bucket_transform = transforms.bucket(StringType(), 100)
+    assert bucket_transform.hash(string_with_surrogate_pair) == mmh3.hash(as_bytes)

--- a/python/tests/test_transforms.py
+++ b/python/tests/test_transforms.py
@@ -15,8 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from datetime import datetime
-from decimal import Decimal, getcontext
+from decimal import Decimal
 from uuid import UUID
 
 import pytest
@@ -35,6 +34,12 @@ from iceberg.types import (
     TimeType,
     UUIDType,
 )
+from iceberg.utils.datetime import (
+    date_to_days,
+    time_to_micros,
+    timestamp_to_micros,
+    timestamptz_to_micros,
+)
 
 
 @pytest.mark.parametrize(
@@ -43,15 +48,15 @@ from iceberg.types import (
         (1, IntegerType(), 1392991556),
         (34, IntegerType(), 2017239379),
         (34, LongType(), 2017239379),
-        (17486, DateType(), -653330422),
-        (81068000000, TimeType(), -662762989),
+        (date_to_days("2017-11-16"), DateType(), -653330422),
+        (time_to_micros("22:31:08"), TimeType(), -662762989),
         (
-            int(datetime.fromisoformat("2017-11-16T22:31:08+00:00").timestamp() * 1000000),
+            timestamp_to_micros("2017-11-16T22:31:08"),
             TimestampType(),
             -2047944441,
         ),
         (
-            int(datetime.fromisoformat("2017-11-16T14:31:08-08:00").timestamp() * 1000000),
+            timestamptz_to_micros("2017-11-16T14:31:08-08:00"),
             TimestamptzType(),
             -2047944441,
         ),
@@ -63,25 +68,6 @@ from iceberg.types import (
 )
 def test_bucket_hash_values(test_input, test_type, expected):
     assert transforms.bucket(test_type, 8).hash(test_input) == expected
-
-
-@pytest.mark.parametrize(
-    "test_input,test_type,scale_factor,expected_hash,expected",
-    [
-        (Decimal("14.20"), DecimalType(9, 2), Decimal(10) ** -2, -500754589, 59),
-        (
-            Decimal("137302769811943318102518958871258.37580"),
-            DecimalType(38, 5),
-            Decimal(10) ** -5,
-            -32334285,
-            63,
-        ),
-    ],
-)
-def test_decimal_bucket(test_input, test_type, scale_factor, expected_hash, expected):
-    getcontext().prec = 38
-    assert transforms.bucket(test_type, 100).hash(test_input.quantize(scale_factor)) == expected_hash
-    assert transforms.bucket(test_type, 100).apply(test_input.quantize(scale_factor)) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This fixes a couple of minor comments from #4416 and refactors to use common decimal and datetime util functions.