### PR TITLE
Dell: Add metrics tracking for EcsFileIO

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -612,12 +612,6 @@ project(':iceberg-dell') {
     testImplementation "javax.xml.bind:jaxb-api"
     testImplementation "javax.activation:activation"
     testImplementation "org.glassfish.jaxb:jaxb-runtime"
-    testImplementation("org.apache.hadoop:hadoop-common") {
-      exclude group: 'org.apache.avro', module: 'avro'
-      exclude group: 'org.slf4j', module: 'slf4j-log4j12'
-      exclude group: 'javax.servlet', module: 'servlet-api'
-      exclude group: 'com.google.code.gson', module: 'gson'
-    }
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -612,6 +612,12 @@ project(':iceberg-dell') {
     testImplementation "javax.xml.bind:jaxb-api"
     testImplementation "javax.activation:activation"
     testImplementation "org.glassfish.jaxb:jaxb-runtime"
+    testImplementation("org.apache.hadoop:hadoop-common") {
+      exclude group: 'org.apache.avro', module: 'avro'
+      exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+      exclude group: 'javax.servlet', module: 'servlet-api'
+      exclude group: 'com.google.code.gson', module: 'gson'
+    }
   }
 }
 

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/BaseEcsFile.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/BaseEcsFile.java
@@ -23,6 +23,7 @@ import com.emc.object.s3.S3Client;
 import com.emc.object.s3.S3Exception;
 import com.emc.object.s3.S3ObjectMetadata;
 import org.apache.iceberg.dell.DellProperties;
+import org.apache.iceberg.metrics.MetricsContext;
 
 abstract class BaseEcsFile {
 
@@ -30,11 +31,13 @@ abstract class BaseEcsFile {
   private final EcsURI uri;
   private final DellProperties dellProperties;
   private S3ObjectMetadata metadata;
+  private final MetricsContext metrics;
 
-  BaseEcsFile(S3Client client, EcsURI uri, DellProperties dellProperties) {
+  BaseEcsFile(S3Client client, EcsURI uri, DellProperties dellProperties, MetricsContext metrics) {
     this.client = client;
     this.uri = uri;
     this.dellProperties = dellProperties;
+    this.metrics = metrics;
   }
 
   public String location() {
@@ -51,6 +54,10 @@ abstract class BaseEcsFile {
 
   public DellProperties dellProperties() {
     return dellProperties;
+  }
+
+  protected MetricsContext metrics() {
+    return metrics;
   }
 
   /**

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsFileIO.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsFileIO.java
@@ -90,7 +90,8 @@ public class EcsFileIO implements FileIO {
       this.metrics = ctor.newInstance("ecs");
 
       metrics.initialize(properties);
-    } catch (NoSuchMethodException | ClassCastException e) {
+    } catch (NoClassDefFoundError | NoSuchMethodException | ClassCastException e) {
+      this.metrics = MetricsContext.nullMetrics();
       LOG.warn("Unable to load metrics class: '{}', falling back to null metrics", DEFAULT_METRICS_IMPL, e);
     }
   }

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsFileIO.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsFileIO.java
@@ -91,7 +91,6 @@ public class EcsFileIO implements FileIO {
 
       metrics.initialize(properties);
     } catch (NoClassDefFoundError | NoSuchMethodException | ClassCastException e) {
-      this.metrics = MetricsContext.nullMetrics();
       LOG.warn("Unable to load metrics class: '{}', falling back to null metrics", DEFAULT_METRICS_IMPL, e);
     }
   }

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsFileIO.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsFileIO.java
@@ -22,13 +22,17 @@ package org.apache.iceberg.dell.ecs;
 import com.emc.object.s3.S3Client;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.dell.DellClientFactories;
 import org.apache.iceberg.dell.DellClientFactory;
 import org.apache.iceberg.dell.DellProperties;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.util.SerializableSupplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * FileIO implementation backed by Dell EMC ECS.
@@ -39,20 +43,24 @@ import org.apache.iceberg.util.SerializableSupplier;
  */
 public class EcsFileIO implements FileIO {
 
+  private static final Logger LOG = LoggerFactory.getLogger(EcsFileIO.class);
+  private static final String DEFAULT_METRICS_IMPL = "org.apache.iceberg.hadoop.HadoopMetricsContext";
+
   private SerializableSupplier<S3Client> s3;
   private DellProperties dellProperties;
   private DellClientFactory dellClientFactory;
   private transient S3Client client;
   private final AtomicBoolean isResourceClosed = new AtomicBoolean(false);
+  private MetricsContext metrics = MetricsContext.nullMetrics();
 
   @Override
   public InputFile newInputFile(String path) {
-    return EcsInputFile.fromLocation(path, client(), dellProperties);
+    return EcsInputFile.fromLocation(path, client(), dellProperties, metrics);
   }
 
   @Override
   public OutputFile newOutputFile(String path) {
-    return EcsOutputFile.fromLocation(path, client(), dellProperties);
+    return EcsOutputFile.fromLocation(path, client(), dellProperties, metrics);
   }
 
   @Override
@@ -74,6 +82,17 @@ public class EcsFileIO implements FileIO {
     this.dellProperties = new DellProperties(properties);
     this.dellClientFactory = DellClientFactories.from(properties);
     this.s3 = dellClientFactory::ecsS3;
+
+    // Report Hadoop metrics if Hadoop is available
+    try {
+      DynConstructors.Ctor<MetricsContext> ctor =
+          DynConstructors.builder(MetricsContext.class).hiddenImpl(DEFAULT_METRICS_IMPL, String.class).buildChecked();
+      this.metrics = ctor.newInstance("ecs");
+
+      metrics.initialize(properties);
+    } catch (NoSuchMethodException | ClassCastException e) {
+      LOG.warn("Unable to load metrics class: '{}', falling back to null metrics", DEFAULT_METRICS_IMPL, e);
+    }
   }
 
   @Override

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsFileIO.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsFileIO.java
@@ -91,6 +91,7 @@ public class EcsFileIO implements FileIO {
 
       metrics.initialize(properties);
     } catch (NoClassDefFoundError | NoSuchMethodException | ClassCastException e) {
+      this.metrics = MetricsContext.nullMetrics();
       LOG.warn("Unable to load metrics class: '{}', falling back to null metrics", DEFAULT_METRICS_IMPL, e);
     }
   }

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsInputFile.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsInputFile.java
@@ -23,19 +23,25 @@ import com.emc.object.s3.S3Client;
 import org.apache.iceberg.dell.DellProperties;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.SeekableInputStream;
+import org.apache.iceberg.metrics.MetricsContext;
 
 class EcsInputFile extends BaseEcsFile implements InputFile {
 
   public static EcsInputFile fromLocation(String location, S3Client client) {
-    return new EcsInputFile(client, new EcsURI(location), new DellProperties());
+    return new EcsInputFile(client, new EcsURI(location), new DellProperties(), MetricsContext.nullMetrics());
   }
 
   public static EcsInputFile fromLocation(String location, S3Client client, DellProperties dellProperties) {
-    return new EcsInputFile(client, new EcsURI(location), dellProperties);
+    return new EcsInputFile(client, new EcsURI(location), dellProperties, MetricsContext.nullMetrics());
   }
 
-  EcsInputFile(S3Client client, EcsURI uri, DellProperties dellProperties) {
-    super(client, uri, dellProperties);
+  static EcsInputFile fromLocation(String location, S3Client client, DellProperties dellProperties,
+      MetricsContext metrics) {
+    return new EcsInputFile(client, new EcsURI(location), dellProperties, metrics);
+  }
+
+  EcsInputFile(S3Client client, EcsURI uri, DellProperties dellProperties, MetricsContext metrics) {
+    super(client, uri, dellProperties, metrics);
   }
 
   /**
@@ -50,6 +56,6 @@ class EcsInputFile extends BaseEcsFile implements InputFile {
 
   @Override
   public SeekableInputStream newStream() {
-    return new EcsSeekableInputStream(client(), uri());
+    return new EcsSeekableInputStream(client(), uri(), metrics());
   }
 }

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsOutputFile.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsOutputFile.java
@@ -28,10 +28,19 @@ import org.apache.iceberg.io.PositionOutputStream;
 import org.apache.iceberg.metrics.MetricsContext;
 
 class EcsOutputFile extends BaseEcsFile implements OutputFile {
+
+  /**
+   * @deprecated moving to package-private in 0.15.0
+   */
+  @Deprecated
   public static EcsOutputFile fromLocation(String location, S3Client client) {
     return new EcsOutputFile(client, new EcsURI(location), new DellProperties(), MetricsContext.nullMetrics());
   }
 
+  /**
+   * @deprecated moving to package-private in 0.15.0
+   */
+  @Deprecated
   public static EcsOutputFile fromLocation(String location, S3Client client, DellProperties dellProperties) {
     return new EcsOutputFile(client, new EcsURI(location), dellProperties, MetricsContext.nullMetrics());
   }

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsOutputFile.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsOutputFile.java
@@ -29,18 +29,10 @@ import org.apache.iceberg.metrics.MetricsContext;
 
 class EcsOutputFile extends BaseEcsFile implements OutputFile {
 
-  /**
-   * @deprecated moving to package-private in 0.15.0
-   */
-  @Deprecated
   public static EcsOutputFile fromLocation(String location, S3Client client) {
     return new EcsOutputFile(client, new EcsURI(location), new DellProperties(), MetricsContext.nullMetrics());
   }
 
-  /**
-   * @deprecated moving to package-private in 0.15.0
-   */
-  @Deprecated
   public static EcsOutputFile fromLocation(String location, S3Client client, DellProperties dellProperties) {
     return new EcsOutputFile(client, new EcsURI(location), dellProperties, MetricsContext.nullMetrics());
   }

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsOutputFile.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsOutputFile.java
@@ -25,18 +25,24 @@ import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.PositionOutputStream;
+import org.apache.iceberg.metrics.MetricsContext;
 
 class EcsOutputFile extends BaseEcsFile implements OutputFile {
   public static EcsOutputFile fromLocation(String location, S3Client client) {
-    return new EcsOutputFile(client, new EcsURI(location), new DellProperties());
+    return new EcsOutputFile(client, new EcsURI(location), new DellProperties(), MetricsContext.nullMetrics());
   }
 
   public static EcsOutputFile fromLocation(String location, S3Client client, DellProperties dellProperties) {
-    return new EcsOutputFile(client, new EcsURI(location), dellProperties);
+    return new EcsOutputFile(client, new EcsURI(location), dellProperties, MetricsContext.nullMetrics());
   }
 
-  EcsOutputFile(S3Client client, EcsURI uri, DellProperties dellProperties) {
-    super(client, uri, dellProperties);
+  static EcsOutputFile fromLocation(String location, S3Client client, DellProperties dellProperties,
+      MetricsContext metrics) {
+    return new EcsOutputFile(client, new EcsURI(location), dellProperties, metrics);
+  }
+
+  EcsOutputFile(S3Client client, EcsURI uri, DellProperties dellProperties, MetricsContext metrics) {
+    super(client, uri, dellProperties, metrics);
   }
 
   /**
@@ -56,11 +62,11 @@ class EcsOutputFile extends BaseEcsFile implements OutputFile {
 
   @Override
   public PositionOutputStream createOrOverwrite() {
-    return EcsAppendOutputStream.create(client(), uri());
+    return EcsAppendOutputStream.create(client(), uri(), metrics());
   }
 
   @Override
   public InputFile toInputFile() {
-    return new EcsInputFile(client(), uri(), dellProperties());
+    return new EcsInputFile(client(), uri(), dellProperties(), metrics());
   }
 }

--- a/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsAppendOutputStream.java
+++ b/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsAppendOutputStream.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import org.apache.iceberg.dell.mock.ecs.EcsS3MockRule;
+import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -40,7 +41,8 @@ public class TestEcsAppendOutputStream {
     try (EcsAppendOutputStream output = EcsAppendOutputStream.createWithBufferSize(
         rule.client(),
         new EcsURI(rule.bucket(), objectName),
-        10)) {
+        10,
+        MetricsContext.nullMetrics())) {
       // write 1 byte
       output.write('1');
       // write 3 bytes
@@ -64,7 +66,8 @@ public class TestEcsAppendOutputStream {
     try (EcsAppendOutputStream output = EcsAppendOutputStream.createWithBufferSize(
         rule.client(),
         new EcsURI(rule.bucket(), objectName),
-        10)) {
+        10,
+        MetricsContext.nullMetrics())) {
       // write 7 bytes
       output.write("7654321".getBytes());
     }
@@ -72,7 +75,8 @@ public class TestEcsAppendOutputStream {
     try (EcsAppendOutputStream output = EcsAppendOutputStream.createWithBufferSize(
         rule.client(),
         new EcsURI(rule.bucket(), objectName),
-        10)) {
+        10,
+        MetricsContext.nullMetrics())) {
       // write 14 bytes
       output.write("1234567".getBytes());
       output.write("1234567".getBytes());

--- a/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsSeekableInputStream.java
+++ b/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsSeekableInputStream.java
@@ -23,6 +23,7 @@ import com.emc.object.s3.request.PutObjectRequest;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.apache.iceberg.dell.mock.ecs.EcsS3MockRule;
+import org.apache.iceberg.metrics.MetricsContext;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -39,7 +40,8 @@ public class TestEcsSeekableInputStream {
 
     try (EcsSeekableInputStream input = new EcsSeekableInputStream(
         rule.client(),
-        new EcsURI(rule.bucket(), objectName))) {
+        new EcsURI(rule.bucket(), objectName),
+        MetricsContext.nullMetrics())) {
       input.seek(2);
       Assert.assertEquals("Expect 2 when seek to 2", '2', input.read());
     }
@@ -52,7 +54,8 @@ public class TestEcsSeekableInputStream {
 
     try (EcsSeekableInputStream input = new EcsSeekableInputStream(
         rule.client(),
-        new EcsURI(rule.bucket(), objectName))) {
+        new EcsURI(rule.bucket(), objectName),
+        MetricsContext.nullMetrics())) {
       input.seek(999);
       input.seek(3);
       Assert.assertEquals("Expect 3 when seek to 3 finally", '3', input.read());
@@ -66,7 +69,8 @@ public class TestEcsSeekableInputStream {
 
     try (EcsSeekableInputStream input = new EcsSeekableInputStream(
         rule.client(),
-        new EcsURI(rule.bucket(), objectName))) {
+        new EcsURI(rule.bucket(), objectName),
+        MetricsContext.nullMetrics())) {
       Assert.assertEquals("The first byte should be 0 ", '0', input.read());
     }
   }
@@ -78,7 +82,8 @@ public class TestEcsSeekableInputStream {
 
     try (EcsSeekableInputStream input = new EcsSeekableInputStream(
         rule.client(),
-        new EcsURI(rule.bucket(), objectName))) {
+        new EcsURI(rule.bucket(), objectName),
+        MetricsContext.nullMetrics())) {
       byte[] buffer = new byte[3];
       Assert.assertEquals("The first read should be 3 bytes", 3, input.read(buffer));
       Assert.assertEquals("The first 3 bytes should be 012", "012",


### PR DESCRIPTION
This PR adds metrics tracking for `EcsFileIO`. This would help reporting IO metrics via the Hadoop `FileSystem.Statistics`.

---
cc: @danielcweeks @rdblue @kbendick 