### PR TITLE
Nessie: Extract Catalog client code to NessieClient for Trino Consumption

### DIFF
--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseMetastoreCatalog;
@@ -34,37 +33,19 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.common.DynMethods;
-import org.apache.iceberg.exceptions.AlreadyExistsException;
-import org.apache.iceberg.exceptions.CommitFailedException;
-import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
-import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.util.Tasks;
 import org.projectnessie.client.NessieClientBuilder;
 import org.projectnessie.client.NessieConfigConstants;
-import org.projectnessie.client.api.CommitMultipleOperationsBuilder;
 import org.projectnessie.client.api.NessieApiV1;
 import org.projectnessie.client.http.HttpClientBuilder;
-import org.projectnessie.client.http.HttpClientException;
-import org.projectnessie.error.BaseNessieClientServerException;
-import org.projectnessie.error.NessieConflictException;
-import org.projectnessie.error.NessieNamespaceAlreadyExistsException;
-import org.projectnessie.error.NessieNamespaceNotEmptyException;
-import org.projectnessie.error.NessieNamespaceNotFoundException;
-import org.projectnessie.error.NessieNotFoundException;
-import org.projectnessie.error.NessieReferenceNotFoundException;
-import org.projectnessie.model.Branch;
 import org.projectnessie.model.ContentKey;
-import org.projectnessie.model.GetNamespacesResponse;
-import org.projectnessie.model.IcebergTable;
-import org.projectnessie.model.Operation;
 import org.projectnessie.model.TableReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -127,7 +108,7 @@ public class NessieCatalog extends BaseMetastoreCatalog implements AutoCloseable
     NessieApiV1 api = createNessieClientBuilder(options.get(NessieConfigConstants.CONF_NESSIE_CLIENT_BUILDER_IMPL))
         .fromConfig(x -> options.get(removePrefix.apply(x)))
         .build(NessieApiV1.class);
-    this.client = new NessieIcebergClient(api, requestedRef, null);
+    this.client = new NessieIcebergClient(api, requestedRef, null, catalogOptions);
   }
 
   private static NessieClientBuilder<?> createNessieClientBuilder(String customBuilder) {
@@ -159,13 +140,9 @@ public class NessieCatalog extends BaseMetastoreCatalog implements AutoCloseable
     TableReference tr = TableReference.parse(tableIdentifier.name());
     Preconditions.checkArgument(!tr.hasTimestamp(), "Invalid table name: # is only allowed for hashes (reference by " +
         "timestamp is not supported)");
-    NessieIcebergClient newClient = client;
-    if (tr.getReference() != null) {
-      newClient = new NessieIcebergClient(client.getApi(), tr.getReference(), tr.getHash());
-    }
     return new NessieTableOperations(
         ContentKey.of(org.projectnessie.model.Namespace.of(tableIdentifier.namespace().levels()), tr.getName()),
-        newClient,
+        client.withReference(tr.getReference(), tr.getHash()),
         fileIO,
         catalogOptions);
   }
@@ -180,140 +157,27 @@ public class NessieCatalog extends BaseMetastoreCatalog implements AutoCloseable
 
   @Override
   public List<TableIdentifier> listTables(Namespace namespace) {
-    return client.tableStream(namespace).collect(Collectors.toList());
+    return client.listTables(namespace);
   }
 
   @Override
   public boolean dropTable(TableIdentifier identifier, boolean purge) {
-    client.getRef().checkMutable();
-
-    IcebergTable existingTable = client.table(identifier);
-    if (existingTable == null) {
-      return false;
-    }
-
-    if (purge) {
-      LOG.info("Purging data for table {} was set to true but is ignored", identifier.toString());
-    }
-
-    CommitMultipleOperationsBuilder commitBuilderBase = client.getApi().commitMultipleOperations()
-        .commitMeta(NessieUtil.buildCommitMetadata(String.format("Iceberg delete table %s", identifier),
-            catalogOptions))
-        .operation(Operation.Delete.of(NessieUtil.toKey(identifier)));
-
-    // We try to drop the table. Simple retry after ref update.
-    boolean threw = true;
-    try {
-      Tasks.foreach(commitBuilderBase)
-          .retry(5)
-          .stopRetryOn(NessieNotFoundException.class)
-          .throwFailureWhenFinished()
-          .onFailure((o, exception) -> client.refresh())
-          .run(commitBuilder -> {
-            Branch branch = commitBuilder
-                .branch(client.getRef().getAsBranch())
-                .commit();
-            client.getRef().updateReference(branch);
-          }, BaseNessieClientServerException.class);
-      threw = false;
-    } catch (NessieConflictException e) {
-      LOG.error("Cannot drop table: failed after retry (update ref '{}' and retry)", client.getRef().getName(), e);
-    } catch (NessieNotFoundException e) {
-      LOG.error("Cannot drop table: ref '{}' is no longer valid.", client.getRef().getName(), e);
-    } catch (BaseNessieClientServerException e) {
-      LOG.error("Cannot drop table: unknown error", e);
-    }
-    return !threw;
+    return client.dropTable(identifier, purge);
   }
 
   @Override
-  public void renameTable(TableIdentifier from, TableIdentifier toOriginal) {
-    client.getRef().checkMutable();
-
-    TableIdentifier to = NessieUtil.removeCatalogName(toOriginal, name());
-
-    IcebergTable existingFromTable = client.table(from);
-    if (existingFromTable == null) {
-      throw new NoSuchTableException("table '%s' doesn't exists", from.name());
-    }
-    IcebergTable existingToTable = client.table(to);
-    if (existingToTable != null) {
-      throw new AlreadyExistsException("table '%s' already exists", to.name());
-    }
-
-    CommitMultipleOperationsBuilder operations = client.getApi().commitMultipleOperations()
-        .commitMeta(NessieUtil.buildCommitMetadata(String.format("Iceberg rename table from '%s' to '%s'",
-            from, to), catalogOptions))
-        .operation(Operation.Put.of(NessieUtil.toKey(to), existingFromTable, existingFromTable))
-        .operation(Operation.Delete.of(NessieUtil.toKey(from)));
-
-    try {
-      Tasks.foreach(operations)
-          .retry(5)
-          .stopRetryOn(NessieNotFoundException.class)
-          .throwFailureWhenFinished()
-          .onFailure((o, exception) -> client.refresh())
-          .run(ops -> {
-            Branch branch = ops
-                .branch(client.getRef().getAsBranch())
-                .commit();
-            client.getRef().updateReference(branch);
-          }, BaseNessieClientServerException.class);
-    } catch (NessieNotFoundException e) {
-      // important note: the NotFoundException refers to the ref only. If a table was not found it would imply that the
-      // another commit has deleted the table from underneath us. This would arise as a Conflict exception as opposed to
-      // a not found exception. This is analogous to a merge conflict in git when a table has been changed by one user
-      // and removed by another.
-      throw new RuntimeException(String.format("Cannot rename table '%s' to '%s': " +
-          "ref '%s' no longer exists.", from.name(), to.name(), client.getRef().getName()), e);
-    } catch (BaseNessieClientServerException e) {
-      throw new CommitFailedException(e, "Cannot rename table '%s' to '%s': " +
-          "the current reference is not up to date.", from.name(), to.name());
-    } catch (HttpClientException ex) {
-      // Intentionally catch all nessie-client-exceptions here and not just the "timeout" variant
-      // to catch all kinds of network errors (e.g. connection reset). Network code implementation
-      // details and all kinds of network devices can induce unexpected behavior. So better be
-      // safe than sorry.
-      throw new CommitStateUnknownException(ex);
-    }
-    // Intentionally just "throw through" Nessie's HttpClientException here and do not "special case"
-    // just the "timeout" variant to propagate all kinds of network errors (e.g. connection reset).
-    // Network code implementation details and all kinds of network devices can induce unexpected
-    // behavior. So better be safe than sorry.
+  public void renameTable(TableIdentifier from, TableIdentifier to) {
+    client.renameTable(from, NessieUtil.removeCatalogName(to, name()));
   }
 
   @Override
   public void createNamespace(Namespace namespace, Map<String, String> metadata) {
-    try {
-      client.getRef().checkMutable();
-      client.getApi().createNamespace()
-          .reference(client.getRef().getReference())
-          .namespace(org.projectnessie.model.Namespace.of(namespace.levels()))
-          .create();
-      client.refresh();
-    } catch (NessieNamespaceAlreadyExistsException e) {
-      throw new AlreadyExistsException(e, "Namespace '%s' already exists.", namespace);
-    } catch (NessieNotFoundException e) {
-      throw new RuntimeException(String.format("Cannot create Namespace '%s': " +
-          "ref '%s' is no longer valid.", namespace, client.getRef().getName()), e);
-    }
+    client.createNamespace(namespace, metadata);
   }
 
   @Override
   public List<Namespace> listNamespaces(Namespace namespace) throws NoSuchNamespaceException {
-    try {
-      GetNamespacesResponse response = client.getApi().getMultipleNamespaces()
-          .reference(client.getRef().getReference())
-          .namespace(org.projectnessie.model.Namespace.of(namespace.levels()))
-          .get();
-      return response.getNamespaces().stream()
-          .map(ns -> Namespace.of(ns.getElements().toArray(new String[0])))
-          .collect(Collectors.toList());
-    } catch (NessieReferenceNotFoundException e) {
-      throw new RuntimeException(
-          String.format("Cannot list Namespaces starting from '%s': " +
-              "ref '%s' is no longer valid.", namespace, client.getRef().getName()), e);
-    }
+    return client.listNamespaces(namespace);
   }
 
   /**
@@ -325,38 +189,12 @@ public class NessieCatalog extends BaseMetastoreCatalog implements AutoCloseable
    */
   @Override
   public Map<String, String> loadNamespaceMetadata(Namespace namespace) throws NoSuchNamespaceException {
-    try {
-      client.getApi().getNamespace()
-          .reference(client.getRef().getReference())
-          .namespace(org.projectnessie.model.Namespace.of(namespace.levels()))
-          .get();
-    } catch (NessieNamespaceNotFoundException e) {
-      throw new NoSuchNamespaceException(e, "Namespace '%s' does not exist.", namespace);
-    } catch (NessieReferenceNotFoundException e) {
-      throw new RuntimeException(String.format("Cannot load Namespace '%s': " +
-          "ref '%s' is no longer valid.", namespace, client.getRef().getName()), e);
-    }
-    return ImmutableMap.of();
+    return client.loadNamespaceMetadata(namespace);
   }
 
   @Override
   public boolean dropNamespace(Namespace namespace) throws NamespaceNotEmptyException {
-    try {
-      client.getRef().checkMutable();
-      client.getApi().deleteNamespace()
-          .reference(client.getRef().getReference())
-          .namespace(org.projectnessie.model.Namespace.of(namespace.levels()))
-          .delete();
-      client.refresh();
-      return true;
-    } catch (NessieNamespaceNotFoundException e) {
-      return false;
-    } catch (NessieNotFoundException e) {
-      LOG.error("Cannot drop Namespace '{}': ref '{}' is no longer valid.", namespace, client.getRef().getName(), e);
-      return false;
-    } catch (NessieNamespaceNotEmptyException e) {
-      throw new NamespaceNotEmptyException(e, "Namespace '%s' is not empty. One or more tables exist.", namespace);
-    }
+    return client.dropNamespace(namespace);
   }
 
   @Override

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
@@ -106,8 +106,7 @@ public class NessieIcebergClient implements AutoCloseable {
       return new UpdateableReference(ref, hash != null);
     } catch (NessieNotFoundException ex) {
       if (requestedRef != null) {
-        throw new IllegalArgumentException(String.format("Nessie ref '%s' does not exist. This ref must exist " +
-            "before creating a NessieCatalog.", requestedRef), ex);
+        throw new IllegalArgumentException(String.format("Nessie ref '%s' does not exist", requestedRef), ex);
       }
 
       throw new IllegalArgumentException(String.format("Nessie does not have an existing default branch. " +

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
@@ -19,28 +19,57 @@
 
 package org.apache.iceberg.nessie;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
+import java.util.stream.Collectors;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
+import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
+import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.util.Tasks;
 import org.projectnessie.client.NessieConfigConstants;
+import org.projectnessie.client.api.CommitMultipleOperationsBuilder;
 import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.client.http.HttpClientException;
+import org.projectnessie.error.BaseNessieClientServerException;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.error.NessieNamespaceAlreadyExistsException;
+import org.projectnessie.error.NessieNamespaceNotEmptyException;
+import org.projectnessie.error.NessieNamespaceNotFoundException;
 import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.error.NessieReferenceNotFoundException;
 import org.projectnessie.model.Branch;
 import org.projectnessie.model.Content;
 import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.EntriesResponse;
+import org.projectnessie.model.GetNamespacesResponse;
 import org.projectnessie.model.IcebergTable;
+import org.projectnessie.model.Operation;
 import org.projectnessie.model.Reference;
 import org.projectnessie.model.Tag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class NessieIcebergClient implements AutoCloseable {
 
+  private static final Logger LOG = LoggerFactory.getLogger(NessieIcebergClient.class);
+
   private final NessieApiV1 api;
   private final Supplier<UpdateableReference> reference;
+  private final Map<String, String> catalogOptions;
 
-  public NessieIcebergClient(NessieApiV1 api, String requestedRef, String requestedHash) {
+  public NessieIcebergClient(
+      NessieApiV1 api, String requestedRef, String requestedHash, Map<String, String> catalogOptions) {
     this.api = api;
+    this.catalogOptions = catalogOptions;
     this.reference = () -> loadReference(requestedRef, requestedHash);
   }
 
@@ -54,6 +83,13 @@ public class NessieIcebergClient implements AutoCloseable {
 
   public void refresh() throws NessieNotFoundException {
     getRef().refresh(api);
+  }
+
+  public NessieIcebergClient withReference(String requestedRef, String hash) {
+    if (null == requestedRef) {
+      return this;
+    }
+    return new NessieIcebergClient(getApi(), requestedRef, hash, catalogOptions);
   }
 
   private UpdateableReference loadReference(String requestedRef, String hash) {
@@ -80,14 +116,42 @@ public class NessieIcebergClient implements AutoCloseable {
     }
   }
 
-  public Stream<TableIdentifier> tableStream(Namespace namespace) {
+  public List<TableIdentifier> listTables(Namespace namespace) {
     try {
-      return api.getEntries().reference(getRef().getReference()).get().getEntries().stream()
-          .filter(NessieUtil.namespacePredicate(namespace))
-          .map(NessieUtil::toIdentifier);
+      return api.getEntries()
+          .reference(getRef().getReference())
+          .get()
+          .getEntries()
+          .stream()
+          .filter(namespacePredicate(namespace))
+          .filter(e -> Content.Type.ICEBERG_TABLE == e.getType())
+          .map(this::toIdentifier)
+          .collect(Collectors.toList());
     } catch (NessieNotFoundException ex) {
       throw new NoSuchNamespaceException(ex, "Unable to list tables due to missing ref '%s'", getRef().getName());
     }
+  }
+
+  private Predicate<EntriesResponse.Entry> namespacePredicate(Namespace ns) {
+    if (ns == null) {
+      return e -> true;
+    }
+
+    final List<String> namespace = Arrays.asList(ns.levels());
+    return e -> {
+      List<String> names = e.getName().getElements();
+
+      if (names.size() <= namespace.size()) {
+        return false;
+      }
+
+      return namespace.equals(names.subList(0, namespace.size()));
+    };
+  }
+
+  private TableIdentifier toIdentifier(EntriesResponse.Entry entry) {
+    List<String> elements = entry.getName().getElements();
+    return TableIdentifier.of(elements.toArray(new String[elements.size()]));
   }
 
   public IcebergTable table(TableIdentifier tableIdentifier) {
@@ -98,6 +162,167 @@ public class NessieIcebergClient implements AutoCloseable {
     } catch (NessieNotFoundException e) {
       return null;
     }
+  }
+
+  public void createNamespace(Namespace namespace, Map<String, String> metadata) {
+    try {
+      getRef().checkMutable();
+      getApi().createNamespace()
+          .reference(getRef().getReference())
+          .namespace(org.projectnessie.model.Namespace.of(namespace.levels()))
+          .create();
+      refresh();
+    } catch (NessieNamespaceAlreadyExistsException e) {
+      throw new AlreadyExistsException(e, "Namespace already exists: %s", namespace);
+    } catch (NessieNotFoundException e) {
+      throw new RuntimeException(String.format("Cannot create Namespace '%s': " +
+          "ref '%s' is no longer valid.", namespace, getRef().getName()), e);
+    }
+  }
+
+  public List<Namespace> listNamespaces(Namespace namespace) throws NoSuchNamespaceException {
+    try {
+      GetNamespacesResponse response = getApi().getMultipleNamespaces()
+          .reference(getRef().getReference())
+          .namespace(org.projectnessie.model.Namespace.of(namespace.levels()))
+          .get();
+      return response.getNamespaces().stream()
+          .map(ns -> Namespace.of(ns.getElements().toArray(new String[0])))
+          .collect(Collectors.toList());
+    } catch (NessieReferenceNotFoundException e) {
+      throw new RuntimeException(
+          String.format("Cannot list Namespaces starting from '%s': " +
+              "ref '%s' is no longer valid.", namespace, getRef().getName()), e);
+    }
+  }
+
+  public boolean dropNamespace(Namespace namespace) throws NamespaceNotEmptyException {
+    try {
+      getRef().checkMutable();
+      getApi().deleteNamespace()
+          .reference(getRef().getReference())
+          .namespace(org.projectnessie.model.Namespace.of(namespace.levels()))
+          .delete();
+      refresh();
+      return true;
+    } catch (NessieNamespaceNotFoundException e) {
+      return false;
+    } catch (NessieNotFoundException e) {
+      LOG.error("Cannot drop Namespace '{}': ref '{}' is no longer valid.", namespace, getRef().getName(), e);
+      return false;
+    } catch (NessieNamespaceNotEmptyException e) {
+      throw new NamespaceNotEmptyException(e, "Namespace '%s' is not empty. One or more tables exist.", namespace);
+    }
+  }
+
+  public Map<String, String> loadNamespaceMetadata(Namespace namespace) throws NoSuchNamespaceException {
+    try {
+      getApi().getNamespace()
+          .reference(getRef().getReference())
+          .namespace(org.projectnessie.model.Namespace.of(namespace.levels()))
+          .get();
+    } catch (NessieNamespaceNotFoundException e) {
+      throw new NoSuchNamespaceException(e, "Namespace does not exist: %s", namespace);
+    } catch (NessieReferenceNotFoundException e) {
+      throw new RuntimeException(String.format("Cannot load Namespace '%s': " +
+          "ref '%s' is no longer valid.", namespace, getRef().getName()), e);
+    }
+    return ImmutableMap.of();
+  }
+
+  public void renameTable(TableIdentifier from, TableIdentifier to) {
+    getRef().checkMutable();
+
+    IcebergTable existingFromTable = table(from);
+    if (existingFromTable == null) {
+      throw new NoSuchTableException("Table does not exist: %s", from.name());
+    }
+    IcebergTable existingToTable = table(to);
+    if (existingToTable != null) {
+      throw new AlreadyExistsException("Table already exists: %s", to.name());
+    }
+
+    CommitMultipleOperationsBuilder operations = getApi().commitMultipleOperations()
+        .commitMeta(NessieUtil.buildCommitMetadata(String.format("Iceberg rename table from '%s' to '%s'",
+            from, to), catalogOptions))
+        .operation(Operation.Put.of(NessieUtil.toKey(to), existingFromTable, existingFromTable))
+        .operation(Operation.Delete.of(NessieUtil.toKey(from)));
+
+    try {
+      Tasks.foreach(operations)
+          .retry(5)
+          .stopRetryOn(NessieNotFoundException.class)
+          .throwFailureWhenFinished()
+          .onFailure((o, exception) -> refresh())
+          .run(ops -> {
+            Branch branch = ops
+                .branch(getRef().getAsBranch())
+                .commit();
+            getRef().updateReference(branch);
+          }, BaseNessieClientServerException.class);
+    } catch (NessieNotFoundException e) {
+      // important note: the NotFoundException refers to the ref only. If a table was not found it would imply that the
+      // another commit has deleted the table from underneath us. This would arise as a Conflict exception as opposed to
+      // a not found exception. This is analogous to a merge conflict in git when a table has been changed by one user
+      // and removed by another.
+      throw new RuntimeException(String.format("Cannot rename table '%s' to '%s': " +
+          "ref '%s' no longer exists.", from.name(), to.name(), getRef().getName()), e);
+    } catch (BaseNessieClientServerException e) {
+      throw new CommitFailedException(e, "Cannot rename table '%s' to '%s': " +
+          "the current reference is not up to date.", from.name(), to.name());
+    } catch (HttpClientException ex) {
+      // Intentionally catch all nessie-client-exceptions here and not just the "timeout" variant
+      // to catch all kinds of network errors (e.g. connection reset). Network code implementation
+      // details and all kinds of network devices can induce unexpected behavior. So better be
+      // safe than sorry.
+      throw new CommitStateUnknownException(ex);
+    }
+    // Intentionally just "throw through" Nessie's HttpClientException here and do not "special case"
+    // just the "timeout" variant to propagate all kinds of network errors (e.g. connection reset).
+    // Network code implementation details and all kinds of network devices can induce unexpected
+    // behavior. So better be safe than sorry.
+  }
+
+  public boolean dropTable(TableIdentifier identifier, boolean purge) {
+    getRef().checkMutable();
+
+    IcebergTable existingTable = table(identifier);
+    if (existingTable == null) {
+      return false;
+    }
+
+    if (purge) {
+      LOG.info("Purging data for table {} was set to true but is ignored", identifier.toString());
+    }
+
+    CommitMultipleOperationsBuilder commitBuilderBase = getApi().commitMultipleOperations()
+        .commitMeta(NessieUtil.buildCommitMetadata(String.format("Iceberg delete table %s", identifier),
+            catalogOptions))
+        .operation(Operation.Delete.of(NessieUtil.toKey(identifier)));
+
+    // We try to drop the table. Simple retry after ref update.
+    boolean threw = true;
+    try {
+      Tasks.foreach(commitBuilderBase)
+          .retry(5)
+          .stopRetryOn(NessieNotFoundException.class)
+          .throwFailureWhenFinished()
+          .onFailure((o, exception) -> refresh())
+          .run(commitBuilder -> {
+            Branch branch = commitBuilder
+                .branch(getRef().getAsBranch())
+                .commit();
+            getRef().updateReference(branch);
+          }, BaseNessieClientServerException.class);
+      threw = false;
+    } catch (NessieConflictException e) {
+      LOG.error("Cannot drop table: failed after retry (update ref '{}' and retry)", getRef().getName(), e);
+    } catch (NessieNotFoundException e) {
+      LOG.error("Cannot drop table: ref '{}' is no longer valid.", getRef().getName(), e);
+    } catch (BaseNessieClientServerException e) {
+      LOG.error("Cannot drop table: unknown error", e);
+    }
+    return !threw;
   }
 
   @Override

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.nessie;
+
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.NoSuchNamespaceException;
+import org.projectnessie.client.NessieConfigConstants;
+import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.Content;
+import org.projectnessie.model.ContentKey;
+import org.projectnessie.model.IcebergTable;
+import org.projectnessie.model.Reference;
+import org.projectnessie.model.Tag;
+
+public class NessieIcebergClient implements AutoCloseable {
+
+  private final NessieApiV1 api;
+  private final Supplier<UpdateableReference> reference;
+
+  public NessieIcebergClient(NessieApiV1 api, String requestedRef, String requestedHash) {
+    this.api = api;
+    this.reference = () -> loadReference(requestedRef, requestedHash);
+  }
+
+  public NessieApiV1 getApi() {
+    return api;
+  }
+
+  public UpdateableReference getRef() {
+    return reference.get();
+  }
+
+  public void refresh() throws NessieNotFoundException {
+    getRef().refresh(api);
+  }
+
+  private UpdateableReference loadReference(String requestedRef, String hash) {
+    try {
+      Reference ref =
+          requestedRef == null ? api.getDefaultBranch() : api.getReference().refName(requestedRef).get();
+      if (hash != null) {
+        if (ref instanceof Branch) {
+          ref = Branch.of(ref.getName(), hash);
+        } else {
+          ref = Tag.of(ref.getName(), hash);
+        }
+      }
+      return new UpdateableReference(ref, hash != null);
+    } catch (NessieNotFoundException ex) {
+      if (requestedRef != null) {
+        throw new IllegalArgumentException(String.format("Nessie ref '%s' does not exist. This ref must exist " +
+            "before creating a NessieCatalog.", requestedRef), ex);
+      }
+
+      throw new IllegalArgumentException(String.format("Nessie does not have an existing default branch. " +
+              "Either configure an alternative ref via '%s' or create the default branch on the server.",
+              NessieConfigConstants.CONF_NESSIE_REF), ex);
+    }
+  }
+
+  public Stream<TableIdentifier> tableStream(Namespace namespace) {
+    try {
+      return api.getEntries().reference(getRef().getReference()).get().getEntries().stream()
+          .filter(NessieUtil.namespacePredicate(namespace))
+          .map(NessieUtil::toIdentifier);
+    } catch (NessieNotFoundException ex) {
+      throw new NoSuchNamespaceException(ex, "Unable to list tables due to missing ref '%s'", getRef().getName());
+    }
+  }
+
+  public IcebergTable table(TableIdentifier tableIdentifier) {
+    try {
+      ContentKey key = NessieUtil.toKey(tableIdentifier);
+      Content table = api.getContent().key(key).reference(getRef().getReference()).get().get(key);
+      return table != null ? table.unwrap(IcebergTable.class).orElse(null) : null;
+    } catch (NessieNotFoundException e) {
+      return null;
+    }
+  }
+
+  @Override
+  public void close() {
+    if (null != api) {
+      api.close();
+    }
+  }
+}

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieUtil.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.catalog.Namespace;
@@ -32,7 +31,6 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.projectnessie.model.CommitMeta;
 import org.projectnessie.model.ContentKey;
-import org.projectnessie.model.EntriesResponse;
 import org.projectnessie.model.ImmutableCommitMeta;
 
 public final class NessieUtil {
@@ -41,30 +39,6 @@ public final class NessieUtil {
   static final String APPLICATION_TYPE = "application-type";
 
   private NessieUtil() {
-  }
-
-  static Predicate<EntriesResponse.Entry> namespacePredicate(Namespace ns) {
-    // TODO: filter to just iceberg tables.
-    if (ns == null) {
-      return e -> true;
-    }
-
-    final List<String> namespace = Arrays.asList(ns.levels());
-    Predicate<EntriesResponse.Entry> predicate = e -> {
-      List<String> names = e.getName().getElements();
-
-      if (names.size() <= namespace.size()) {
-        return false;
-      }
-
-      return namespace.equals(names.subList(0, namespace.size()));
-    };
-    return predicate;
-  }
-
-  static TableIdentifier toIdentifier(EntriesResponse.Entry entry) {
-    List<String> elements = entry.getName().getElements();
-    return TableIdentifier.of(elements.toArray(new String[elements.size()]));
   }
 
   static TableIdentifier removeCatalogName(TableIdentifier to, String name) {

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestBranchVisibility.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestBranchVisibility.java
@@ -63,7 +63,6 @@ public class TestBranchVisibility extends BaseTestIceberg {
   public void before() throws NessieNotFoundException, NessieConflictException {
     createTable(tableIdentifier1, 1); // table 1
     createTable(tableIdentifier2, 1); // table 2
-    catalog.refresh();
     createBranch("test", catalog.currentHash());
     testCatalog = initCatalog("test");
   }
@@ -72,7 +71,6 @@ public class TestBranchVisibility extends BaseTestIceberg {
   public void after() throws NessieNotFoundException, NessieConflictException {
     catalog.dropTable(tableIdentifier1);
     catalog.dropTable(tableIdentifier2);
-    catalog.refresh();
     for (Reference reference : api.getAllReferences().get().getReferences()) {
       if (!reference.getName().equals("main")) {
         api.deleteBranch().branch((Branch) reference).delete();
@@ -147,7 +145,6 @@ public class TestBranchVisibility extends BaseTestIceberg {
     String metadataOnTest = addRow(catalog, tableIdentifier1, "initial-data",
         ImmutableMap.of("id0", 4L));
     long snapshotIdOnTest = snapshotIdFromMetadata(catalog, metadataOnTest);
-    catalog.refresh();
 
     String hashOnTest = catalog.currentHash();
     createBranch(branch1, hashOnTest, branchTest);

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieTable.java
@@ -340,10 +340,6 @@ public class TestNessieTable extends BaseTestIceberg {
         .hasSize(2)
         .containsExactly(commit.getHash(), branch.getHash());
 
-    // previously this would fail with "Cannot commit: Reference hash is out of date. Update the reference ..."
-    // because the UpdateableReference between NessieCatalog and NessieTableOperations was updated independently of each
-    // other. However, given that both classes now share the same UpdateableReference via NessieIcebergClient,
-    // the error doesn't happen anymore, so we just make sure that all 3 commits exist.
     icebergTable.updateSchema().addColumn("data", Types.LongType.get()).commit();
     Branch latest = (Branch) api.getReference().refName(BRANCH).get();
     Assertions.assertThat(api.getCommitLog().refName(BRANCH).get().getLogEntries())


### PR DESCRIPTION
This adds a new `NessieIcebergClient` class that encapsulates some of
the features that have been used across the `NessieCatalog`.
It also slightly improves the error messages to include the reference or
the table name when something fails.

Note that the `testFailure()` method was updated, because we're now
always using the same `UpdateableReference` between `NessieCatalog` and
`NessieTableOperations`, so that it's higly unlikely that those two get
out-of-sync.