### PR TITLE
Core - REST Catalog call /v1/config route

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClientFactory.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClientFactory.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest;
+
+import java.util.Map;
+import java.util.function.Function;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+/**
+ * Takes in the full configuration for the {@link RESTCatalog}, which should already have
+ * called the server's initial configuration route.
+ * Using the merged configuration, an instance of {@link RESTClient} is obtained that can be used with the
+ * RESTCatalog.
+ */
+public class HTTPClientFactory implements Function<Map<String, String>, RESTClient> {
+
+  @Override
+  public RESTClient apply(Map<String, String> properties) {
+    Preconditions.checkArgument(properties != null, "Invalid configuration: null");
+    Preconditions.checkArgument(properties.containsKey(CatalogProperties.URI), "REST Catalog server URI is required");
+
+    String baseURI = properties.get(CatalogProperties.URI).trim();
+
+    HTTPClient.Builder builder = HTTPClient.builder()
+        .uri(baseURI);
+
+    // Only apply bearer auth token if one is provided.
+    String token = properties.get(RESTCatalogProperties.AUTH_TOKEN);
+    if (token != null && !token.trim().isEmpty()) {
+      builder.withBearerAuth(token.trim());
+    }
+
+    return builder.build();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java
@@ -19,6 +19,8 @@
 
 package org.apache.iceberg.rest;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -57,10 +59,14 @@ import org.apache.iceberg.rest.responses.GetNamespaceResponse;
 import org.apache.iceberg.rest.responses.ListNamespacesResponse;
 import org.apache.iceberg.rest.responses.ListTablesResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.apache.iceberg.rest.responses.RESTCatalogConfigResponse;
 import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
 import org.apache.iceberg.util.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public class RESTCatalog implements Catalog, SupportsNamespaces, Configurable<Configuration> {
+public class RESTCatalog implements Catalog, SupportsNamespaces, Configurable<Configuration>, Closeable {
+  private static final Logger LOG = LoggerFactory.getLogger(RESTCatalog.class);
   private final Function<Map<String, String>, RESTClient> clientBuilder;
   private RESTClient client = null;
   private String catalogName = null;
@@ -69,18 +75,28 @@ public class RESTCatalog implements Catalog, SupportsNamespaces, Configurable<Co
   private Object conf = null;
   private FileIO io = null;
 
+  public RESTCatalog() {
+    this(new HTTPClientFactory());
+  }
+
   RESTCatalog(Function<Map<String, String>, RESTClient> clientBuilder) {
     this.clientBuilder = clientBuilder;
   }
 
   @Override
   public void initialize(String name, Map<String, String> props) {
-    this.client = clientBuilder.apply(props);
+    RESTCatalogConfigResponse config = fetchConfig(props);
+    Map<String, String> mergedProps = config.merge(props);
+    this.client = clientBuilder.apply(mergedProps);
     this.catalogName = name;
-    this.properties = ImmutableMap.copyOf(props);
-    this.paths = ResourcePaths.forCatalogProperties(props);
-    String ioImpl = props.get(CatalogProperties.FILE_IO_IMPL);
-    this.io = CatalogUtil.loadFileIO(ioImpl != null ? ioImpl : ResolvingFileIO.class.getName(), props, conf);
+    this.properties = mergedProps;
+    this.paths = ResourcePaths.forCatalogProperties(properties);
+    String ioImpl = properties.get(CatalogProperties.FILE_IO_IMPL);
+    this.io = CatalogUtil.loadFileIO(ioImpl != null ? ioImpl : ResolvingFileIO.class.getName(), properties, conf);
+  }
+
+  public Map<String, String> properties() {
+    return properties;
   }
 
   @Override
@@ -197,6 +213,13 @@ public class RESTCatalog implements Catalog, SupportsNamespaces, Configurable<Co
   @Override
   public TableBuilder buildTable(TableIdentifier identifier, Schema schema) {
     return new Builder(identifier, schema);
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (client != null) {
+      client.close();
+    }
   }
 
   private class Builder implements TableBuilder {
@@ -404,5 +427,24 @@ public class RESTCatalog implements Catalog, SupportsNamespaces, Configurable<Co
     RESTClient tableClient = clientBuilder.apply(fullConf);
 
     return Pair.of(tableClient, tableIO);
+  }
+
+  private RESTCatalogConfigResponse fetchConfig(Map<String, String> props) {
+    // Create a client for one time use, as we will reconfigure the client using the merged server and application
+    // defined configuration.
+    RESTClient singleUseClient = clientBuilder.apply(props);
+
+    try {
+      RESTCatalogConfigResponse configResponse = singleUseClient
+          .get(ResourcePaths.config(), RESTCatalogConfigResponse.class, ErrorHandlers.defaultErrorHandler());
+      configResponse.validate();
+      return configResponse;
+    } finally {
+      try {
+        singleUseClient.close();
+      } catch (IOException e) {
+        LOG.error("Failed to close HTTP client used for getting catalog configuration. Possible resource leak.", e);
+      }
+    }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTCatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTCatalogProperties.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest;
+
+/**
+ * Catalog properties which are specific to the RESTCatalog, which can be used in conjunction with
+ * {@link org.apache.iceberg.CatalogProperties}
+ */
+public class RESTCatalogProperties {
+
+  private RESTCatalogProperties() {
+  }
+
+  /**
+   * A Bearer authorization token which will be used to authenticate requests with the server.
+   */
+  public static final String AUTH_TOKEN = "token";
+}

--- a/core/src/main/java/org/apache/iceberg/rest/RESTObjectMapper.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTObjectMapper.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.rest;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class RESTObjectMapper {
+  private static final JsonFactory FACTORY = new JsonFactory();
+  private static final ObjectMapper MAPPER = new ObjectMapper(FACTORY);
+  private static volatile boolean isInitialized = false;
+
+  private RESTObjectMapper() {
+  }
+
+  static ObjectMapper mapper() {
+    if (!isInitialized) {
+      synchronized (RESTObjectMapper.class) {
+        if (!isInitialized) {
+          MAPPER.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+          MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+          RESTSerializers.registerAll(MAPPER);
+          isInitialized = true;
+        }
+      }
+    }
+
+    return MAPPER;
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -19,7 +19,6 @@
 
 package org.apache.iceberg.rest;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +46,7 @@ import org.apache.iceberg.rest.requests.CreateTableRequest;
 import org.apache.iceberg.rest.requests.UpdateNamespacePropertiesRequest;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.iceberg.rest.responses.RESTCatalogConfigResponse;
 import org.apache.iceberg.util.Pair;
 
 /**
@@ -154,8 +154,7 @@ public class RESTCatalogAdapter implements RESTClient {
                                                   Object body, Class<T> responseType) {
     switch (route) {
       case CONFIG:
-        // TODO: use the correct response object
-        return castResponse(responseType, ImmutableMap.of());
+        return castResponse(responseType, RESTCatalogConfigResponse.builder().build());
 
       case LIST_NAMESPACES:
         if (asNamespaceCatalog != null) {
@@ -281,9 +280,9 @@ public class RESTCatalogAdapter implements RESTClient {
 
   @Override
   public void close() throws IOException {
-    if (catalog instanceof Closeable) {
-      ((Closeable) catalog).close();
-    }
+    // The calling test is responsible for closing the underlying catalog backing this REST catalog
+    // so that the underlying backend catalog is not closed and reopened during the REST catalog's
+    // initialize method when fetching the server configuration.
   }
 
   private static class BadResponseType extends RuntimeException {

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -19,9 +19,6 @@
 
 package org.apache.iceberg.rest;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.PropertyAccessor;
-import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
@@ -52,20 +49,17 @@ public class TestHTTPClient {
   private static final int PORT = 1080;
   private static final String BEARER_AUTH_TOKEN = "auth_token";
   private static final String URI = String.format("http://127.0.0.1:%d", PORT);
-  private static final JsonFactory FACTORY = new JsonFactory();
-  private static final ObjectMapper MAPPER = new ObjectMapper(FACTORY);
+  private static final ObjectMapper MAPPER = RESTObjectMapper.mapper();
 
   private static ClientAndServer mockServer;
   private static RESTClient restClient;
 
   @BeforeClass
   public static void beforeClass() {
-    MAPPER.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
     mockServer = startClientAndServer(PORT);
     restClient = HTTPClient
         .builder()
         .uri(URI)
-        .mapper(MAPPER)
         .withBearerAuth(BEARER_AUTH_TOKEN)
         .build();
   }

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -20,15 +20,23 @@
 package org.apache.iceberg.rest;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Consumer;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.catalog.CatalogTests;
 import org.apache.iceberg.jdbc.JdbcCatalog;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.rest.responses.ErrorResponse;
+import org.apache.iceberg.rest.responses.RESTCatalogConfigResponse;
+import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
@@ -36,13 +44,14 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
   public Path temp;
 
   private RESTCatalog restCatalog;
+  private JdbcCatalog backendCatalog;
 
   @BeforeEach
   public void createCatalog() {
     File warehouse = temp.toFile();
     Configuration conf = new Configuration();
 
-    JdbcCatalog backendCatalog = new JdbcCatalog();
+    this.backendCatalog = new JdbcCatalog();
     backendCatalog.setConf(conf);
     Map<String, String> backendCatalogProperties = ImmutableMap.of(
         CatalogProperties.WAREHOUSE_LOCATION, warehouse.getAbsolutePath(),
@@ -55,7 +64,19 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
 
     this.restCatalog = new RESTCatalog((config) -> adaptor);
     restCatalog.setConf(conf);
-    restCatalog.initialize("prod", ImmutableMap.of());
+
+    restCatalog.initialize("prod", ImmutableMap.of(CatalogProperties.URI, "ignored"));
+  }
+
+  @AfterEach
+  public void closeCatalog() throws IOException {
+    if (restCatalog != null) {
+      restCatalog.close();
+    }
+
+    if (backendCatalog != null) {
+      backendCatalog.close();
+    }
   }
 
   @Override
@@ -71,5 +92,73 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
   @Override
   protected boolean supportsServerSideRetry() {
     return true;
+  }
+
+  /* RESTCatalog specific tests */
+
+  @Test
+  public void testConfigRoute() throws IOException {
+    RESTClient testClient = new RESTClient() {
+      @Override
+      public void head(String path, Consumer<ErrorResponse> errorHandler) {
+        throw new UnsupportedOperationException("Should not be called for testConfigRoute");
+      }
+
+      @Override
+      public <T extends RESTResponse> T delete(String path, Class<T> responseType,
+                                               Consumer<ErrorResponse> errorHandler) {
+        throw new UnsupportedOperationException("Should not be called for testConfigRoute");
+      }
+
+      @Override
+      public <T extends RESTResponse> T get(String path, Class<T> responseType, Consumer<ErrorResponse> errorHandler) {
+        return (T) RESTCatalogConfigResponse
+            .builder()
+            .withDefaults(ImmutableMap.of(CatalogProperties.CLIENT_POOL_SIZE, "1"))
+            .withOverrides(ImmutableMap.of(CatalogProperties.CACHE_ENABLED, "false"))
+            .build();
+      }
+
+      @Override
+      public <T extends RESTResponse> T post(String path, RESTRequest body, Class<T> responseType,
+                                             Consumer<ErrorResponse> errorHandler) {
+        throw new UnsupportedOperationException("Should not be called for testConfigRoute");
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+
+    RESTCatalog restCat = new RESTCatalog((config) -> testClient);
+    Map<String, String> initialConfig = ImmutableMap.of(
+        CatalogProperties.URI, "http://localhost:8080",
+        CatalogProperties.CACHE_ENABLED, "true");
+
+    restCat.setConf(new Configuration());
+    restCat.initialize("prod", initialConfig);
+
+    Assert.assertEquals("Catalog properties after initialize should use the server's override properties",
+        "false", restCat.properties().get(CatalogProperties.CACHE_ENABLED));
+
+    Assert.assertEquals("Catalog after initialize should use the server's default properties if not specified",
+        "1", restCat.properties().get(CatalogProperties.CLIENT_POOL_SIZE));
+    restCat.close();
+  }
+
+  @Test
+  public void testInitializeWithBadArguments() throws IOException {
+    RESTCatalog restCat = new RESTCatalog();
+    AssertHelpers.assertThrows("Configuration passed to initialize cannot be null",
+        IllegalArgumentException.class,
+        "Invalid configuration: null",
+        () -> restCat.initialize("prod", null));
+
+    AssertHelpers.assertThrows("Configuration passed to initialize must have uri",
+        IllegalArgumentException.class,
+        "REST Catalog server URI is required",
+        () -> restCat.initialize("prod", ImmutableMap.of()));
+
+    restCat.close();
   }
 }


### PR DESCRIPTION
Adds the initial call to `/v1/config` and merges the server-side configuration with the client configuration.

Also adds in an object mapper specific to the RESTCatalog, so that the object mapper in `JsonUtils` doesn't need to be modified.