### PR TITLE
Spark - Allow procedures to have leading comments - Backport to Spark 3.1

### DIFF
--- a/spark/v3.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
+++ b/spark/v3.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
@@ -105,7 +105,15 @@ class IcebergSparkSqlExtensionsParser(delegate: ParserInterface) extends ParserI
   }
 
   private def isIcebergCommand(sqlText: String): Boolean = {
-    val normalized = sqlText.toLowerCase(Locale.ROOT).trim().replaceAll("\\s+", " ")
+    val normalized = sqlText.toLowerCase(Locale.ROOT).trim()
+        // Strip simple SQL comments that terminate a line, e.g. comments starting with `--`
+        .replaceAll("--.*?\\n", " ")
+        // Strip newlines.
+        .replaceAll("\\s+", " ")
+        // Strip comments of the form  /* ... */. This must come after stripping newlines so that
+        // comments that span multiple lines are caught.
+        .replaceAll("/\\*.*?\\*/", " ")
+        .trim()
     normalized.startsWith("call") || (
         normalized.startsWith("alter table") && (
             normalized.contains("add partition field") ||

--- a/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
+++ b/spark/v3.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
@@ -249,4 +249,40 @@ public class TestExpireSnapshotsProcedure extends SparkExtensionsTestBase {
         catalogName, currentTimestamp, tableIdent);
     assertEquals("Procedure output must match", ImmutableList.of(row(0L, 0L, 1L)), output);
   }
+
+  @Test
+  public void testExpireSnapshotsProcedureWorksWithSqlComments() {
+    // Ensure that systems such as dbt, that add leading comments into the generated SQL commands, will
+    // work with Iceberg-specific DDL
+    sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'a')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'b')", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Assert.assertEquals("Should be 2 snapshots", 2, Iterables.size(table.snapshots()));
+
+    waitUntilAfter(table.currentSnapshot().timestampMillis());
+
+    Timestamp currentTimestamp = Timestamp.from(Instant.ofEpochMilli(System.currentTimeMillis()));
+
+    String callStatement =
+        "/* CALL statement is used to expire snapshots */\n" +
+        "-- And we have single line comments as well \n" +
+        "/* And comments that span *multiple* \n" +
+        " lines */ CALL /* this is the actual CALL */ %s.system.expire_snapshots(" +
+        "   older_than => TIMESTAMP '%s'," +
+        "   table => '%s'," +
+        "   retain_last => 1)";
+    List<Object[]> output = sql(
+        callStatement, catalogName, currentTimestamp, tableIdent);
+    assertEquals("Procedure output must match",
+        ImmutableList.of(row(0L, 0L, 1L)),
+        output);
+
+    table.refresh();
+
+    Assert.assertEquals("Should be 1 snapshot remaining", 1, Iterables.size(table.snapshots()));
+  }
 }


### PR DESCRIPTION
This backports https://github.com/apache/iceberg/pull/4396 to Spark 3.1

Allow for procedures to have leading comments when checking if the command is Iceberg specific DDL.

This allows for systems that add leading comments to SQL statements for metadata purposes, such as dbt, to work if the command in question is an Iceberg Spark Procedure.