### PR TITLE
Core - Fix JsonUtils collection or null functions when an explicit null value is used

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
@@ -149,7 +149,7 @@ public class JsonUtil {
   }
 
   public static List<String> getStringListOrNull(String property, JsonNode node) {
-    if (!node.has(property)) {
+    if (!node.has(property) || node.get(property).isNull()) {
       return null;
     }
 
@@ -159,7 +159,7 @@ public class JsonUtil {
   }
 
   public static Set<Integer> getIntegerSetOrNull(String property, JsonNode node) {
-    if (!node.has(property)) {
+    if (!node.has(property) || node.get(property).isNull()) {
       return null;
     }
 

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestErrorResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestErrorResponseParser.java
@@ -88,6 +88,25 @@ public class TestErrorResponseParser {
     assertEquals(expected, ErrorResponseParser.fromJson(json));
   }
 
+  @Test
+  public void testErrorResponseFromJsonWithExplicitNullStack() {
+    String message = "The given namespace does not exist";
+    String type = "NoSuchNamespaceException";
+    Integer code = 404;
+    List<String> stack = null;
+    String errorModelJson = String.format(
+        "{\"message\":\"%s\",\"type\":\"%s\",\"code\":%d,\"stack\":null}", message, type, code);
+    String json = "{\"error\":" + errorModelJson + "}";
+
+    ErrorResponse expected = ErrorResponse.builder()
+        .withMessage(message)
+        .withType(type)
+        .responseCode(code)
+        .withStackTrace(stack)
+        .build();
+    assertEquals(expected, ErrorResponseParser.fromJson(json));
+  }
+
   public void assertEquals(ErrorResponse expected, ErrorResponse actual) {
     Assert.assertEquals("Message should be equal", expected.message(), actual.message());
     Assert.assertEquals("Type should be equal", expected.type(), actual.type());


### PR DESCRIPTION
When testing the `ErrorResponse`, it came up that `JsonUtils#getStringListOrNull` fails when the node in question (element by name) is explicitly null.

Fixes the issue for both `getXCollectionOrNull` functions in `JsonUtils`.