### PR TITLE
Core: Skipping manifest clean-up for all Error or Exception.

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -356,8 +356,8 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
       if (event != null) {
         Listeners.notifyAll(event);
       }
-    } catch (RuntimeException e) {
-      LOG.warn("Failed to notify listeners", e);
+    } catch (Throwable t) {
+      LOG.warn("Failed to notify listeners", t);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -343,8 +343,8 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
         LOG.warn("Failed to load committed snapshot, skipping manifest clean-up");
       }
 
-    } catch (RuntimeException e) {
-      LOG.warn("Failed to load committed table metadata, skipping manifest clean-up", e);
+    } catch (Throwable t) {
+      LOG.warn("Failed to load committed table metadata, skipping manifest clean-up", t);
     }
 
     notifyListeners();


### PR DESCRIPTION
In our production environment, we found operation committed success but Spark Job throw `OutOfMemoryError` exception,  some data files were deleted, we could not read current-snapshot  due to FileNotFoundException.
The manifest clean-up may throw Exception or Error, and we should also catch RuntimeError like `OutOfMemoryError`, otherwise,  it would lead to abort and delete datafile. 
