### PR TITLE
Core: Optimise BaseFileScanTask memory usage

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFileScanTask.java
@@ -34,7 +34,7 @@ public class BaseFileScanTask implements FileScanTask {
   private final DeleteFile[] deletes;
   private final String schemaString;
   private final String specString;
-  private final ResidualEvaluator residuals;
+  private final Expression expr;
 
   private transient PartitionSpec spec = null;
 
@@ -44,7 +44,7 @@ public class BaseFileScanTask implements FileScanTask {
     this.deletes = deletes != null ? deletes : new DeleteFile[0];
     this.schemaString = schemaString;
     this.specString = specString;
-    this.residuals = residuals;
+    this.expr = (residuals == null) ? null : residuals.residualFor(file.partition());
   }
 
   @Override
@@ -77,7 +77,7 @@ public class BaseFileScanTask implements FileScanTask {
 
   @Override
   public Expression residual() {
-    return residuals.residualFor(file.partition());
+    return expr;
   }
 
   @Override


### PR DESCRIPTION
BaseFileScanTask has a reference to "ResidualEvaluator" and is used only in "residual()" function. However, there can be corner cases where upstream has added large number of literals to residual evaluator (e.g in one of the cases Hive added 79000 LongLiterals in residual evaluator). When these tasks are serialized, they cause memory pressure. Intent is to avoid this, by computing the expression right upfront, and not retaining "ResidualEvalutor" in BaseFileScanTask.