### PR TITLE
Adding specId for partitions metadata table

### DIFF
--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -45,10 +45,10 @@ public class PartitionsTable extends BaseMetadataTable {
     super(ops, table, name);
 
     this.schema = new Schema(
-        Types.NestedField.required(1, "spec_id", Types.IntegerType.get()),
-        Types.NestedField.required(2, "partition", Partitioning.partitionType(table)),
-        Types.NestedField.required(3, "record_count", Types.LongType.get()),
-        Types.NestedField.required(4, "file_count", Types.IntegerType.get())
+        Types.NestedField.required(1, "partition", Partitioning.partitionType(table)),
+        Types.NestedField.required(2, "record_count", Types.LongType.get()),
+        Types.NestedField.required(3, "file_count", Types.IntegerType.get()),
+        Types.NestedField.required(4, "spec_id", Types.IntegerType.get())
     );
   }
 
@@ -90,7 +90,7 @@ public class PartitionsTable extends BaseMetadataTable {
   }
 
   private static StaticDataTask.Row convertPartition(Partition partition) {
-    return StaticDataTask.Row.of(partition.specId, partition.key, partition.recordCount, partition.fileCount);
+    return StaticDataTask.Row.of(partition.key, partition.recordCount, partition.fileCount, partition.specId);
   }
 
   private static Iterable<Partition> partitions(StaticTableScan scan) {
@@ -165,22 +165,22 @@ public class PartitionsTable extends BaseMetadataTable {
   }
 
   static class Partition {
-    private int specId;
     private final StructLike key;
     private long recordCount;
     private int fileCount;
+    private int specId;
 
     Partition(StructLike key) {
-      this.specId = 0;
       this.key = key;
       this.recordCount = 0;
       this.fileCount = 0;
+      this.specId = 0;
     }
 
     void update(DataFile file) {
-      this.specId = file.specId();
       this.recordCount += file.recordCount();
       this.fileCount += 1;
+      this.specId = file.specId();
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -364,7 +364,7 @@ public class TestMetadataTableScans extends TableTestBase {
 
     Table partitionsTable = new PartitionsTable(table.ops(), table);
     Types.StructType expected = new Schema(
-        required(2, "partition", Types.StructType.of(
+        required(1, "partition", Types.StructType.of(
             optional(1000, "data_bucket", Types.IntegerType.get())))).asStruct();
 
     TableScan scanNoFilter = partitionsTable.newScan().select("partition.data_bucket");

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -364,7 +364,7 @@ public class TestMetadataTableScans extends TableTestBase {
 
     Table partitionsTable = new PartitionsTable(table.ops(), table);
     Types.StructType expected = new Schema(
-        required(1, "partition", Types.StructType.of(
+        required(2, "partition", Types.StructType.of(
             optional(1000, "data_bucket", Types.IntegerType.get())))).asStruct();
 
     TableScan scanNoFilter = partitionsTable.newScan().select("partition.data_bucket");

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1049,8 +1049,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         .save(loadLocation(tableIdentifier));
 
     Types.StructType expectedSchema = Types.StructType.of(
-        required(3, "record_count", Types.LongType.get()),
-        required(4, "file_count", Types.IntegerType.get()));
+        required(2, "record_count", Types.LongType.get()),
+        required(3, "file_count", Types.IntegerType.get()));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 
@@ -1107,16 +1107,16 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         partitionsTable.schema().findType("partition").asStructType(), "partition"));
     List<GenericData.Record> expected = Lists.newArrayList();
     expected.add(builder
-        .set("spec_id", 0)
         .set("partition", partitionBuilder.set("id", 1).build())
         .set("record_count", 1L)
         .set("file_count", 1)
+        .set("spec_id", 0)
         .build());
     expected.add(builder
-        .set("spec_id", 0)
         .set("partition", partitionBuilder.set("id", 2).build())
         .set("record_count", 1L)
         .set("file_count", 1)
+        .set("spec_id", 0)
         .build());
 
     Assert.assertEquals("Partitions table should have two rows", 2, expected.size());

--- a/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v2.4/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1049,8 +1049,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         .save(loadLocation(tableIdentifier));
 
     Types.StructType expectedSchema = Types.StructType.of(
-        required(2, "record_count", Types.LongType.get()),
-        required(3, "file_count", Types.IntegerType.get()));
+        required(3, "record_count", Types.LongType.get()),
+        required(4, "file_count", Types.IntegerType.get()));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 
@@ -1107,11 +1107,13 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         partitionsTable.schema().findType("partition").asStructType(), "partition"));
     List<GenericData.Record> expected = Lists.newArrayList();
     expected.add(builder
+        .set("spec_id", 0)
         .set("partition", partitionBuilder.set("id", 1).build())
         .set("record_count", 1L)
         .set("file_count", 1)
         .build());
     expected.add(builder
+        .set("spec_id", 0)
         .set("partition", partitionBuilder.set("id", 2).build())
         .set("record_count", 1L)
         .set("file_count", 1)

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1050,8 +1050,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         .save(loadLocation(tableIdentifier));
 
     Types.StructType expectedSchema = Types.StructType.of(
-        required(3, "record_count", Types.LongType.get()),
-        required(4, "file_count", Types.IntegerType.get()));
+        required(2, "record_count", Types.LongType.get()),
+        required(3, "file_count", Types.IntegerType.get()));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 
@@ -1108,16 +1108,16 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         partitionsTable.schema().findType("partition").asStructType(), "partition"));
     List<GenericData.Record> expected = Lists.newArrayList();
     expected.add(builder
-        .set("spec_id", 0)
         .set("partition", partitionBuilder.set("id", 1).build())
         .set("record_count", 1L)
         .set("file_count", 1)
+        .set("spec_id", 0)
         .build());
     expected.add(builder
-        .set("spec_id", 0)
         .set("partition", partitionBuilder.set("id", 2).build())
         .set("record_count", 1L)
         .set("file_count", 1)
+        .set("spec_id", 0)
         .build());
 
     Assert.assertEquals("Partitions table should have two rows", 2, expected.size());

--- a/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.0/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1050,8 +1050,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         .save(loadLocation(tableIdentifier));
 
     Types.StructType expectedSchema = Types.StructType.of(
-        required(2, "record_count", Types.LongType.get()),
-        required(3, "file_count", Types.IntegerType.get()));
+        required(3, "record_count", Types.LongType.get()),
+        required(4, "file_count", Types.IntegerType.get()));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 
@@ -1108,11 +1108,13 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         partitionsTable.schema().findType("partition").asStructType(), "partition"));
     List<GenericData.Record> expected = Lists.newArrayList();
     expected.add(builder
+        .set("spec_id", 0)
         .set("partition", partitionBuilder.set("id", 1).build())
         .set("record_count", 1L)
         .set("file_count", 1)
         .build());
     expected.add(builder
+        .set("spec_id", 0)
         .set("partition", partitionBuilder.set("id", 2).build())
         .set("record_count", 1L)
         .set("file_count", 1)

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1050,8 +1050,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         .save(loadLocation(tableIdentifier));
 
     Types.StructType expectedSchema = Types.StructType.of(
-        required(3, "record_count", Types.LongType.get()),
-        required(4, "file_count", Types.IntegerType.get()));
+        required(2, "record_count", Types.LongType.get()),
+        required(3, "file_count", Types.IntegerType.get()));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 
@@ -1108,16 +1108,16 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         partitionsTable.schema().findType("partition").asStructType(), "partition"));
     List<GenericData.Record> expected = Lists.newArrayList();
     expected.add(builder
-        .set("spec_id", 0)
         .set("partition", partitionBuilder.set("id", 1).build())
         .set("record_count", 1L)
         .set("file_count", 1)
+        .set("spec_id", 0)
         .build());
     expected.add(builder
-        .set("spec_id", 0)
         .set("partition", partitionBuilder.set("id", 2).build())
         .set("record_count", 1L)
         .set("file_count", 1)
+        .set("spec_id", 0)
         .build());
 
     Assert.assertEquals("Partitions table should have two rows", 2, expected.size());

--- a/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1050,8 +1050,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         .save(loadLocation(tableIdentifier));
 
     Types.StructType expectedSchema = Types.StructType.of(
-        required(2, "record_count", Types.LongType.get()),
-        required(3, "file_count", Types.IntegerType.get()));
+        required(3, "record_count", Types.LongType.get()),
+        required(4, "file_count", Types.IntegerType.get()));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 
@@ -1108,11 +1108,13 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         partitionsTable.schema().findType("partition").asStructType(), "partition"));
     List<GenericData.Record> expected = Lists.newArrayList();
     expected.add(builder
+        .set("spec_id", 0)
         .set("partition", partitionBuilder.set("id", 1).build())
         .set("record_count", 1L)
         .set("file_count", 1)
         .build());
     expected.add(builder
+        .set("spec_id", 0)
         .set("partition", partitionBuilder.set("id", 2).build())
         .set("record_count", 1L)
         .set("file_count", 1)

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1051,8 +1051,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         .save(loadLocation(tableIdentifier));
 
     Types.StructType expectedSchema = Types.StructType.of(
-        required(2, "record_count", Types.LongType.get()),
-        required(3, "file_count", Types.IntegerType.get()));
+        required(3, "record_count", Types.LongType.get()),
+        required(4, "file_count", Types.IntegerType.get()));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 
@@ -1109,11 +1109,13 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         partitionsTable.schema().findType("partition").asStructType(), "partition"));
     List<GenericData.Record> expected = Lists.newArrayList();
     expected.add(builder
+        .set("spec_id", 0)
         .set("partition", partitionBuilder.set("id", 1).build())
         .set("record_count", 1L)
         .set("file_count", 1)
         .build());
     expected.add(builder
+        .set("spec_id", 0)
         .set("partition", partitionBuilder.set("id", 2).build())
         .set("record_count", 1L)
         .set("file_count", 1)

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -1051,8 +1051,8 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         .save(loadLocation(tableIdentifier));
 
     Types.StructType expectedSchema = Types.StructType.of(
-        required(3, "record_count", Types.LongType.get()),
-        required(4, "file_count", Types.IntegerType.get()));
+        required(2, "record_count", Types.LongType.get()),
+        required(3, "file_count", Types.IntegerType.get()));
 
     Table partitionsTable = loadTable(tableIdentifier, "partitions");
 
@@ -1109,16 +1109,16 @@ public abstract class TestIcebergSourceTablesBase extends SparkTestBase {
         partitionsTable.schema().findType("partition").asStructType(), "partition"));
     List<GenericData.Record> expected = Lists.newArrayList();
     expected.add(builder
-        .set("spec_id", 0)
         .set("partition", partitionBuilder.set("id", 1).build())
         .set("record_count", 1L)
         .set("file_count", 1)
+        .set("spec_id", 0)
         .build());
     expected.add(builder
-        .set("spec_id", 0)
         .set("partition", partitionBuilder.set("id", 2).build())
         .set("record_count", 1L)
         .set("file_count", 1)
+        .set("spec_id", 0)
         .build());
 
     Assert.assertEquals("Partitions table should have two rows", 2, expected.size());


### PR DESCRIPTION
As per #4292, PartitionsTable should call Partitioning.partitionType() to gather the partition struct in its schema. Also the result should show specId too, as the partition key might not be considered a unique key on its own without specId in V2 format. (E.g a partition column removed then re-added along with another column..)

This is just the initial change so that I can see what tests would need fixing and to check with community if the new schema is okay like this:

1. spec_id
2. partition
3. record_count
4. file_count

I think in other meta tables the spec_id precedes the partition key in the output, so I prepended the existing schema here with it. I'm not sure if this counts as a backward-incompatible change though. What do you think @aokolnychyi ?
