### PR TITLE
Spark 3.2: Use SnapshotSummary to deduce latestOffset in Spark SS

### DIFF
--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -37,6 +37,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.SerializableTable;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
@@ -44,7 +45,6 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.SparkReadOptions;
@@ -111,8 +111,8 @@ public class SparkMicroBatchStream implements MicroBatchStream {
     }
 
     Snapshot latestSnapshot = table.currentSnapshot();
-    return new StreamingOffset(
-        latestSnapshot.snapshotId(), Iterables.size(latestSnapshot.addedFiles(table.io())), false);
+    return new StreamingOffset(latestSnapshot.snapshotId(),
+        Long.parseLong(latestSnapshot.summary().getOrDefault(SnapshotSummary.ADDED_FILES_PROP, "0")), false);
   }
 
   @Override

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -45,6 +45,7 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.SparkReadOptions;
@@ -112,7 +113,9 @@ public class SparkMicroBatchStream implements MicroBatchStream {
 
     Snapshot latestSnapshot = table.currentSnapshot();
     return new StreamingOffset(latestSnapshot.snapshotId(),
-        Long.parseLong(latestSnapshot.summary().getOrDefault(SnapshotSummary.ADDED_FILES_PROP, "0")), false);
+        Long.parseLong(latestSnapshot.summary().getOrDefault(SnapshotSummary.ADDED_FILES_PROP,
+            String.valueOf(Iterables.size(latestSnapshot.addedFiles())))),
+        false);
   }
 
   @Override


### PR DESCRIPTION
- At present we iterate the iterator of addedFiles to find the no of added files in the snapshot, this info is already present in snapshot summary. We should use this rather than iterating the addedFiles iterator to determine files added.

Came across this while working on 
- https://github.com/apache/iceberg/pull/4479

--- 

cc @rdblue, @RussellSpitzer, @jackye1995, @kbendick 