### PR TITLE
core: Provide mechanism to cache manifest file content

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg;
 
 import java.util.concurrent.TimeUnit;
+import org.apache.iceberg.io.ContentCache;
 
 public class CatalogProperties {
 
@@ -56,6 +57,64 @@ public class CatalogProperties {
 
   public static final long CACHE_EXPIRATION_INTERVAL_MS_DEFAULT = TimeUnit.SECONDS.toMillis(30);
   public static final long CACHE_EXPIRATION_INTERVAL_MS_OFF = -1;
+
+  /**
+   * Controls whether to use {@link ContentCache} during manifest file reads or not.
+   *
+   * <p>This value will be ignored and the file cache will be disabled if any of the following is
+   * true:
+   *
+   * <ul>
+   *   <li>{@link #IO_CACHE_EXPIRATION_INTERVAL_MS} is set to negative number.
+   *   <li>{@link #IO_CACHE_MAX_TOTAL_BYTES} is set to non-positive value.
+   *   <li>{@link #IO_CACHE_MAX_CONTENT_LENGTH} is set to non-positive value.
+   * </ul>
+   */
+  public static final String IO_CACHE_ENABLED = "io.cache-enabled";
+
+  public static final boolean IO_CACHE_ENABLED_DEFAULT = false;
+
+  /**
+   * Controls the duration for which entries in the {@link ContentCache} are cached.
+   *
+   * <p>Behavior of specific values of cache.expiration-interval-ms:
+   *
+   * <ul>
+   *   <li>Negative Values - Caching disabled
+   *   <li>Zero - Cache entries expires only if it gets evicted due to memory pressure from {@link
+   *       #IO_CACHE_MAX_TOTAL_BYTES} setting.
+   *   <li>Positive Values - Cache entries expire if not accessed via the cache after this many
+   *       milliseconds
+   * </ul>
+   */
+  public static final String IO_CACHE_EXPIRATION_INTERVAL_MS = "io.cache.expiration-interval-ms";
+
+  public static final long IO_CACHE_EXPIRATION_INTERVAL_MS_DEFAULT = TimeUnit.SECONDS.toMillis(60);
+
+  /**
+   * Controls the maximum total amount of bytes to cache in {@link ContentCache}.
+   *
+   * <p>Behavior of specific values of cache.content.max-total-bytes:
+   *
+   * <ul>
+   *   <li>Non-Positive Values - Caching disabled
+   *   <li>Positive Values - Maximum total amount of bytes allowed in cache before cache start doing
+   *       eviction
+   * </ul>
+   */
+  public static final String IO_CACHE_MAX_TOTAL_BYTES = "io.cache.max-total-bytes";
+
+  public static final long IO_CACHE_MAX_TOTAL_BYTES_DEFAULT = 100 * 1024 * 1024;
+
+  /**
+   * Controls the maximum length of file to be considered for caching.
+   *
+   * <p>An {@link org.apache.iceberg.io.InputFile} will not be cached if the length is longer than
+   * this limit.
+   */
+  public static final String IO_CACHE_MAX_CONTENT_LENGTH = "io.cache.max-content-length";
+
+  public static final long IO_CACHE_MAX_CONTENT_LENGTH_DEFAULT = 8 * 1024 * 1024;
 
   public static final String URI = "uri";
   public static final String CLIENT_POOL_SIZE = "clients";

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -65,14 +65,14 @@ public class CatalogProperties {
    * true:
    *
    * <ul>
-   *   <li>{@link #IO_CACHE_EXPIRATION_INTERVAL_MS} is set to negative number.
-   *   <li>{@link #IO_CACHE_MAX_TOTAL_BYTES} is set to non-positive value.
-   *   <li>{@link #IO_CACHE_MAX_CONTENT_LENGTH} is set to non-positive value.
+   *   <li>{@link #IO_MANIFEST_CACHE_EXPIRATION_INTERVAL_MS} is set to negative number.
+   *   <li>{@link #IO_MANIFEST_CACHE_MAX_TOTAL_BYTES} is set to non-positive value.
+   *   <li>{@link #IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH} is set to non-positive value.
    * </ul>
    */
-  public static final String IO_CACHE_ENABLED = "io.cache-enabled";
+  public static final String IO_MANIFEST_CACHE_ENABLED = "io.manifest.cache-enabled";
 
-  public static final boolean IO_CACHE_ENABLED_DEFAULT = false;
+  public static final boolean IO_MANIFEST_CACHE_ENABLED_DEFAULT = false;
 
   /**
    * Controls the duration for which entries in the {@link ContentCache} are cached.
@@ -82,14 +82,16 @@ public class CatalogProperties {
    * <ul>
    *   <li>Negative Values - Caching disabled
    *   <li>Zero - Cache entries expires only if it gets evicted due to memory pressure from {@link
-   *       #IO_CACHE_MAX_TOTAL_BYTES} setting.
+   *       #IO_MANIFEST_CACHE_MAX_TOTAL_BYTES} setting.
    *   <li>Positive Values - Cache entries expire if not accessed via the cache after this many
    *       milliseconds
    * </ul>
    */
-  public static final String IO_CACHE_EXPIRATION_INTERVAL_MS = "io.cache.expiration-interval-ms";
+  public static final String IO_MANIFEST_CACHE_EXPIRATION_INTERVAL_MS =
+      "io.manifest.cache.expiration-interval-ms";
 
-  public static final long IO_CACHE_EXPIRATION_INTERVAL_MS_DEFAULT = TimeUnit.SECONDS.toMillis(60);
+  public static final long IO_MANIFEST_CACHE_EXPIRATION_INTERVAL_MS_DEFAULT =
+      TimeUnit.SECONDS.toMillis(60);
 
   /**
    * Controls the maximum total amount of bytes to cache in {@link ContentCache}.
@@ -102,9 +104,10 @@ public class CatalogProperties {
    *       eviction
    * </ul>
    */
-  public static final String IO_CACHE_MAX_TOTAL_BYTES = "io.cache.max-total-bytes";
+  public static final String IO_MANIFEST_CACHE_MAX_TOTAL_BYTES =
+      "io.manifest.cache.max-total-bytes";
 
-  public static final long IO_CACHE_MAX_TOTAL_BYTES_DEFAULT = 100 * 1024 * 1024;
+  public static final long IO_MANIFEST_CACHE_MAX_TOTAL_BYTES_DEFAULT = 100 * 1024 * 1024;
 
   /**
    * Controls the maximum length of file to be considered for caching.
@@ -112,9 +115,10 @@ public class CatalogProperties {
    * <p>An {@link org.apache.iceberg.io.InputFile} will not be cached if the length is longer than
    * this limit.
    */
-  public static final String IO_CACHE_MAX_CONTENT_LENGTH = "io.cache.max-content-length";
+  public static final String IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH =
+      "io.manifest.cache.max-content-length";
 
-  public static final long IO_CACHE_MAX_CONTENT_LENGTH_DEFAULT = 8 * 1024 * 1024;
+  public static final long IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH_DEFAULT = 8 * 1024 * 1024;
 
   public static final String URI = "uri";
   public static final String CLIENT_POOL_SIZE = "clients";

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg;
 
 import java.util.concurrent.TimeUnit;
-import org.apache.iceberg.io.ContentCache;
 
 public class CatalogProperties {
 
@@ -59,15 +58,14 @@ public class CatalogProperties {
   public static final long CACHE_EXPIRATION_INTERVAL_MS_OFF = -1;
 
   /**
-   * Controls whether to use {@link ContentCache} during manifest file reads or not.
+   * Controls whether to use caching during manifest reads or not.
    *
-   * <p>This value will be ignored and the file cache will be disabled if any of the following is
-   * true:
+   * <p>Enabling manifest file caching require the following configuration constraints to be true:
    *
    * <ul>
-   *   <li>{@link #IO_MANIFEST_CACHE_EXPIRATION_INTERVAL_MS} is set to negative number.
-   *   <li>{@link #IO_MANIFEST_CACHE_MAX_TOTAL_BYTES} is set to non-positive value.
-   *   <li>{@link #IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH} is set to non-positive value.
+   *   <li>{@link #IO_MANIFEST_CACHE_EXPIRATION_INTERVAL_MS} must be a non-negative value.
+   *   <li>{@link #IO_MANIFEST_CACHE_MAX_TOTAL_BYTES} must be a positive value.
+   *   <li>{@link #IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH} must be a positive value.
    * </ul>
    */
   public static final String IO_MANIFEST_CACHE_ENABLED = "io.manifest.cache-enabled";
@@ -75,12 +73,11 @@ public class CatalogProperties {
   public static final boolean IO_MANIFEST_CACHE_ENABLED_DEFAULT = false;
 
   /**
-   * Controls the duration for which entries in the {@link ContentCache} are cached.
+   * Controls the maximum duration for which an entry stays in the manifest cache.
    *
-   * <p>Behavior of specific values of cache.expiration-interval-ms:
+   * <p>Must be a non-negative value. Following are specific behaviors of this config:
    *
    * <ul>
-   *   <li>Negative Values - Caching disabled
    *   <li>Zero - Cache entries expires only if it gets evicted due to memory pressure from {@link
    *       #IO_MANIFEST_CACHE_MAX_TOTAL_BYTES} setting.
    *   <li>Positive Values - Cache entries expire if not accessed via the cache after this many
@@ -94,15 +91,9 @@ public class CatalogProperties {
       TimeUnit.SECONDS.toMillis(60);
 
   /**
-   * Controls the maximum total amount of bytes to cache in {@link ContentCache}.
+   * Controls the maximum total amount of bytes to cache in manifest cache.
    *
-   * <p>Behavior of specific values of cache.content.max-total-bytes:
-   *
-   * <ul>
-   *   <li>Non-Positive Values - Caching disabled
-   *   <li>Positive Values - Maximum total amount of bytes allowed in cache before cache start doing
-   *       eviction
-   * </ul>
+   * <p>Must be a positive value.
    */
   public static final String IO_MANIFEST_CACHE_MAX_TOTAL_BYTES =
       "io.manifest.cache.max-total-bytes";
@@ -113,7 +104,7 @@ public class CatalogProperties {
    * Controls the maximum length of file to be considered for caching.
    *
    * <p>An {@link org.apache.iceberg.io.InputFile} will not be cached if the length is longer than
-   * this limit.
+   * this limit. Must be a positive value.
    */
   public static final String IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH =
       "io.manifest.cache.max-content-length";

--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -341,11 +341,20 @@ public class ManifestFiles {
   }
 
   private static InputFile newInputFile(FileIO io, String path, long length) {
-    boolean enabled = cachingEnabled(io);
+    boolean enabled = false;
+
+    try {
+      enabled = cachingEnabled(io);
+    } catch (UnsupportedOperationException e) {
+      // There is an issue reading io.properties(). Disable caching.
+      enabled = false;
+    }
 
     if (enabled) {
       ContentCache cache = contentCache(io);
-      Preconditions.checkNotNull(cache);
+      Preconditions.checkNotNull(
+          cache,
+          "ContentCache creation failed. Check that all manifest caching configurations has valid value.");
       LOG.debug("FileIO-level cache stats: {}", CONTENT_CACHES.stats());
       return cache.tryCache(io, path, length);
     }

--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -366,28 +366,28 @@ public class ManifestFiles {
     return SystemProperties.IO_MANIFEST_CACHE_MAX_FILEIO_DEFAULT;
   }
 
-  public static boolean cachingEnabled(FileIO io) {
+  static boolean cachingEnabled(FileIO io) {
     return PropertyUtil.propertyAsBoolean(
         io.properties(),
         CatalogProperties.IO_MANIFEST_CACHE_ENABLED,
         CatalogProperties.IO_MANIFEST_CACHE_ENABLED_DEFAULT);
   }
 
-  public static long cacheDurationMs(FileIO io) {
+  static long cacheDurationMs(FileIO io) {
     return PropertyUtil.propertyAsLong(
         io.properties(),
         CatalogProperties.IO_MANIFEST_CACHE_EXPIRATION_INTERVAL_MS,
         CatalogProperties.IO_MANIFEST_CACHE_EXPIRATION_INTERVAL_MS_DEFAULT);
   }
 
-  public static long cacheTotalBytes(FileIO io) {
+  static long cacheTotalBytes(FileIO io) {
     return PropertyUtil.propertyAsLong(
         io.properties(),
         CatalogProperties.IO_MANIFEST_CACHE_MAX_TOTAL_BYTES,
         CatalogProperties.IO_MANIFEST_CACHE_MAX_TOTAL_BYTES_DEFAULT);
   }
 
-  public static long cacheMaxContentLength(FileIO io) {
+  static long cacheMaxContentLength(FileIO io) {
     return PropertyUtil.propertyAsLong(
         io.properties(),
         CatalogProperties.IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH,

--- a/core/src/main/java/org/apache/iceberg/SystemProperties.java
+++ b/core/src/main/java/org/apache/iceberg/SystemProperties.java
@@ -33,6 +33,14 @@ public class SystemProperties {
   /** Whether to use the shared worker pool when planning table scans. */
   public static final String SCAN_THREAD_POOL_ENABLED = "iceberg.scan.plan-in-worker-pool";
 
+  /**
+   * Maximum number of distinct {@link org.apache.iceberg.io.FileIO} that is allowed to have
+   * associated {@link org.apache.iceberg.io.ContentCache} in memory at a time.
+   */
+  public static final String IO_CACHE_MAX_FILEIO = "iceberg.io.cache.max-fileio";
+
+  public static final int IO_CACHE_MAX_FILEIO_DEFAULT = 8;
+
   static boolean getBoolean(String systemProperty, boolean defaultValue) {
     String value = System.getProperty(systemProperty);
     if (value != null) {

--- a/core/src/main/java/org/apache/iceberg/SystemProperties.java
+++ b/core/src/main/java/org/apache/iceberg/SystemProperties.java
@@ -37,9 +37,9 @@ public class SystemProperties {
    * Maximum number of distinct {@link org.apache.iceberg.io.FileIO} that is allowed to have
    * associated {@link org.apache.iceberg.io.ContentCache} in memory at a time.
    */
-  public static final String IO_CACHE_MAX_FILEIO = "iceberg.io.cache.max-fileio";
+  public static final String IO_MANIFEST_CACHE_MAX_FILEIO = "iceberg.io.manifest.cache.fileio-max";
 
-  public static final int IO_CACHE_MAX_FILEIO_DEFAULT = 8;
+  public static final int IO_MANIFEST_CACHE_MAX_FILEIO_DEFAULT = 8;
 
   static boolean getBoolean(String systemProperty, boolean defaultValue) {
     String value = System.getProperty(systemProperty);

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
@@ -40,6 +40,7 @@ import org.apache.iceberg.util.SerializableSupplier;
 public class HadoopFileIO implements FileIO, HadoopConfigurable, SupportsPrefixOperations {
 
   private SerializableSupplier<Configuration> hadoopConf;
+  private Map<String, String> properties = ImmutableMap.of();
 
   /**
    * Constructor used for dynamic FileIO loading.
@@ -59,6 +60,11 @@ public class HadoopFileIO implements FileIO, HadoopConfigurable, SupportsPrefixO
 
   public Configuration conf() {
     return hadoopConf.get();
+  }
+
+  @Override
+  public void initialize(Map<String, String> props) {
+    this.properties = props;
   }
 
   @Override
@@ -89,7 +95,7 @@ public class HadoopFileIO implements FileIO, HadoopConfigurable, SupportsPrefixO
 
   @Override
   public Map<String, String> properties() {
-    return ImmutableMap.of();
+    return properties;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
@@ -35,12 +35,13 @@ import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.SupportsPrefixOperations;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
+import org.apache.iceberg.util.SerializableMap;
 import org.apache.iceberg.util.SerializableSupplier;
 
 public class HadoopFileIO implements FileIO, HadoopConfigurable, SupportsPrefixOperations {
 
   private SerializableSupplier<Configuration> hadoopConf;
-  private Map<String, String> properties = ImmutableMap.of();
+  private SerializableMap<String, String> properties = SerializableMap.copyOf(ImmutableMap.of());
 
   /**
    * Constructor used for dynamic FileIO loading.
@@ -64,7 +65,7 @@ public class HadoopFileIO implements FileIO, HadoopConfigurable, SupportsPrefixO
 
   @Override
   public void initialize(Map<String, String> props) {
-    this.properties = props;
+    this.properties = SerializableMap.copyOf(props);
   }
 
   @Override
@@ -95,7 +96,7 @@ public class HadoopFileIO implements FileIO, HadoopConfigurable, SupportsPrefixO
 
   @Override
   public Map<String, String> properties() {
-    return properties;
+    return properties.immutableMap();
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/io/ContentCache.java
+++ b/core/src/main/java/org/apache/iceberg/io/ContentCache.java
@@ -1,0 +1,300 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.io;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Weigher;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.exceptions.NotFoundException;
+import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.PropertyUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ContentCache {
+  private static final Logger LOG = LoggerFactory.getLogger(ContentCache.class);
+  private static final int BUFFER_CHUNK_SIZE = 4 * 1024 * 1024; // 4MB
+
+  public static ContentCache createCache(Map<String, String> properties) {
+    boolean enabled =
+        PropertyUtil.propertyAsBoolean(
+            properties,
+            CatalogProperties.IO_CACHE_ENABLED,
+            CatalogProperties.IO_CACHE_ENABLED_DEFAULT);
+    long durationMs =
+        PropertyUtil.propertyAsLong(
+            properties,
+            CatalogProperties.IO_CACHE_EXPIRATION_INTERVAL_MS,
+            CatalogProperties.IO_CACHE_EXPIRATION_INTERVAL_MS_DEFAULT);
+    long totalBytes =
+        PropertyUtil.propertyAsLong(
+            properties,
+            CatalogProperties.IO_CACHE_MAX_TOTAL_BYTES,
+            CatalogProperties.IO_CACHE_MAX_TOTAL_BYTES_DEFAULT);
+    long contentLength =
+        PropertyUtil.propertyAsLong(
+            properties,
+            CatalogProperties.IO_CACHE_MAX_CONTENT_LENGTH,
+            CatalogProperties.IO_CACHE_MAX_CONTENT_LENGTH_DEFAULT);
+
+    if (enabled && durationMs >= 0 && totalBytes > 0 && contentLength > 0) {
+      return new ContentCache(durationMs, totalBytes, contentLength);
+    } else {
+      return null;
+    }
+  }
+
+  private final long expireAfterAccessMs;
+  private final long maxTotalBytes;
+  private final long maxContentLength;
+  private final Cache<String, CacheEntry> cache;
+
+  public ContentCache(long expireAfterAccessMs, long maxTotalBytes, long maxContentLength) {
+    this.expireAfterAccessMs = expireAfterAccessMs;
+    this.maxTotalBytes = maxTotalBytes;
+    this.maxContentLength = maxContentLength;
+
+    Caffeine<Object, Object> builder = Caffeine.newBuilder();
+    if (expireAfterAccessMs > 0) {
+      builder = builder.expireAfterAccess(Duration.ofMillis(expireAfterAccessMs));
+    }
+
+    this.cache =
+        builder
+            .maximumWeight(maxTotalBytes)
+            .weigher(
+                (Weigher<String, CacheEntry>)
+                    (key, value) -> (int) Math.min(value.length, Integer.MAX_VALUE))
+            .recordStats()
+            .build();
+  }
+
+  public long expireAfterAccess() {
+    return expireAfterAccessMs;
+  }
+
+  public long maxContentLength() {
+    return maxContentLength;
+  }
+
+  public long maxTotalBytes() {
+    return maxTotalBytes;
+  }
+
+  public CacheStats stats() {
+    return cache.stats();
+  }
+
+  public CacheEntry get(String key, Function<String, CacheEntry> mappingFunction) {
+    return cache.get(key, mappingFunction);
+  }
+
+  public CacheEntry getIfPresent(String location) {
+    return cache.getIfPresent(location);
+  }
+
+  public InputFile tryCache(FileIO io, String location, long length) {
+    if (length <= maxContentLength) {
+      return new CachingInputFile(this, io, location, length);
+    }
+    return io.newInputFile(location, length);
+  }
+
+  public void invalidate(String key) {
+    cache.invalidate(key);
+  }
+
+  public void invalidateAll() {
+    cache.invalidateAll();
+  }
+
+  public void cleanUp() {
+    cache.cleanUp();
+  }
+
+  public long estimatedCacheSize() {
+    return cache.estimatedSize();
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName()
+        + '{'
+        + "expireAfterAccessMs="
+        + expireAfterAccessMs
+        + ", "
+        + "maxContentLength="
+        + maxContentLength
+        + ", "
+        + "maxTotalBytes="
+        + maxTotalBytes
+        + ", "
+        + "cacheStats="
+        + cache.stats()
+        + '}';
+  }
+
+  private static class CacheEntry {
+    private final long length;
+    private final List<ByteBuffer> buffers;
+
+    private CacheEntry(long length, List<ByteBuffer> buffers) {
+      this.length = length;
+      this.buffers = buffers;
+    }
+  }
+
+  private static class CachingInputFile implements InputFile {
+    private final ContentCache contentCache;
+    private final FileIO io;
+    private final String location;
+    private final long length;
+    private InputFile fallbackInputFile = null;
+
+    private CachingInputFile(ContentCache cache, FileIO io, String location, long length) {
+      this.contentCache = cache;
+      this.io = io;
+      this.location = location;
+      this.length = length;
+    }
+
+    private InputFile wrappedInputFile() {
+      if (fallbackInputFile == null) {
+        fallbackInputFile = io.newInputFile(location, length);
+      }
+      return fallbackInputFile;
+    }
+
+    @Override
+    public long getLength() {
+      CacheEntry buf = contentCache.getIfPresent(location);
+      if (buf != null) {
+        return buf.length;
+      } else if (fallbackInputFile != null) {
+        return fallbackInputFile.getLength();
+      } else {
+        return length;
+      }
+    }
+
+    /**
+     * Opens a new {@link SeekableInputStream} for the underlying data file, either through cache or
+     * through the inner FileIO.
+     *
+     * <p>If data file is not cached yet, and it can fit in the cache, the file content will be
+     * cached first before returning a {@link ByteBufferInputStream}. Otherwise, return a new
+     * SeekableInputStream from the inner FIleIO.
+     *
+     * @return a {@link ByteBufferInputStream} if file exist in the cache or can fit in the cache.
+     *     Otherwise, return a new SeekableInputStream from the inner FIleIO.
+     */
+    @Override
+    public SeekableInputStream newStream() {
+      try {
+        // read-through cache if file length is less than or equal to maximum length allowed to
+        // cache.
+        if (getLength() <= contentCache.maxContentLength()) {
+          return cachedStream();
+        }
+
+        // fallback to non-caching input stream.
+        return wrappedInputFile().newStream();
+      } catch (FileNotFoundException e) {
+        throw new NotFoundException(
+            e, "Failed to open input stream for file %s: %s", location, e.toString());
+      } catch (IOException e) {
+        throw new RuntimeIOException(
+            e, "Failed to open input stream for file %s: %s", location, e.toString());
+      }
+    }
+
+    @Override
+    public String location() {
+      return location;
+    }
+
+    @Override
+    public boolean exists() {
+      CacheEntry buf = contentCache.getIfPresent(location);
+      return buf != null || wrappedInputFile().exists();
+    }
+
+    private CacheEntry cacheEntry() {
+      long start = System.currentTimeMillis();
+      try (SeekableInputStream stream = wrappedInputFile().newStream()) {
+        long fileLength = getLength();
+        long totalBytesToRead = fileLength;
+        List<ByteBuffer> buffers = Lists.newArrayList();
+
+        while (totalBytesToRead > 0) {
+          // read the stream in 4MB chunk
+          int bytesToRead = (int) Math.min(BUFFER_CHUNK_SIZE, totalBytesToRead);
+          byte[] buf = new byte[bytesToRead];
+          int bytesRead = IOUtil.readRemaining(stream, buf, 0, bytesToRead);
+          totalBytesToRead -= bytesRead;
+
+          if (bytesRead < bytesToRead) {
+            // Read less than it should be, possibly hitting EOF. Abandon caching by throwing
+            // IOException and let the caller fallback to non-caching input file.
+            throw new IOException(
+                "Expected to read "
+                    + fileLength
+                    + " bytes, but only "
+                    + (fileLength - totalBytesToRead)
+                    + " bytes "
+                    + "read.");
+          } else {
+            buffers.add(ByteBuffer.wrap(buf));
+          }
+        }
+
+        CacheEntry newEntry = new CacheEntry(fileLength - totalBytesToRead, buffers);
+        LOG.debug("cacheEntry took {} ms for {}", (System.currentTimeMillis() - start), location);
+        return newEntry;
+      } catch (IOException ex) {
+        throw new RuntimeIOException(ex);
+      }
+    }
+
+    private SeekableInputStream cachedStream() throws IOException {
+      try {
+        CacheEntry entry = contentCache.get(location, k -> cacheEntry());
+        Preconditions.checkNotNull(
+            entry, "CacheEntry should not be null when there is no RuntimeException occurs");
+        LOG.debug("Cache stats: {}", contentCache.stats());
+        return ByteBufferInputStream.wrap(entry.buffers);
+      } catch (RuntimeIOException ex) {
+        throw ex.getCause();
+      } catch (RuntimeException ex) {
+        throw new IOException("Caught an error while reading through cache", ex);
+      }
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestManifestCaching.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestCaching.java
@@ -182,7 +182,7 @@ public class TestManifestCaching extends HadoopTableTestBase {
     Assert.assertEquals(maxIO, manifestCache.estimatedSize());
     Assert.assertEquals(maxIO, manifestCache.stats().loadCount());
     Assert.assertEquals(
-        "No entries should be evicted before IO_CACHE_MAX_FILEIO_DEFAULT exceeded.",
+        "No entries should be evicted before IO_MANIFEST_CACHE_MAX_FILEIO_DEFAULT exceeded.",
         0,
         manifestCache.stats().evictionCount());
 

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestManifestCaching.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestManifestCaching.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.hadoop;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.io.ContentCache;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestManifestCaching extends HadoopTableTestBase {
+
+  @Test
+  public void testPlanWithCache() throws Exception {
+    Map<String, String> properties =
+        ImmutableMap.of(
+            CatalogProperties.FILE_IO_IMPL,
+            HadoopFileIO.class.getName(),
+            CatalogProperties.IO_CACHE_ENABLED,
+            "true");
+    Table table = createTable(properties);
+    ContentCache cache = ManifestFiles.getOrCreateCache(table.io());
+    Assert.assertEquals(0, cache.estimatedCacheSize());
+
+    int numFiles = 4;
+    List<DataFile> files16Mb = newFiles(numFiles, 16 * 1024 * 1024);
+    appendFiles(files16Mb, table);
+
+    // planTask with SPLIT_SIZE half of the file size
+    TableScan scan1 =
+        table.newScan().option(TableProperties.SPLIT_SIZE, String.valueOf(8 * 1024 * 1024));
+    Assert.assertEquals(
+        "Should get 2 tasks per file", numFiles * 2, Iterables.size(scan1.planTasks()));
+    Assert.assertEquals(
+        "All manifest files should be cached", numFiles, cache.estimatedCacheSize());
+    Assert.assertEquals(
+        "All manifest files should be recently loaded", numFiles, cache.stats().loadCount());
+    long missCount = cache.stats().missCount();
+
+    // planFiles and verify that cache size still the same
+    TableScan scan2 = table.newScan();
+    Assert.assertEquals("Should get 1 tasks per file", numFiles, Iterables.size(scan2.planFiles()));
+    Assert.assertEquals("Cache size should remain the same", numFiles, cache.estimatedCacheSize());
+    Assert.assertEquals(
+        "All manifest file reads should hit cache", missCount, cache.stats().missCount());
+
+    ManifestFiles.dropCache(table.io());
+  }
+
+  @Test
+  public void testPlanWithSmallCache() throws Exception {
+    Map<String, String> properties =
+        ImmutableMap.of(
+            CatalogProperties.FILE_IO_IMPL, HadoopFileIO.class.getName(),
+            CatalogProperties.IO_CACHE_ENABLED, "true",
+            CatalogProperties.IO_CACHE_MAX_TOTAL_BYTES, "1",
+            CatalogProperties.IO_CACHE_MAX_CONTENT_LENGTH, "1");
+    Table table = createTable(properties);
+
+    int numFiles = 4;
+    List<DataFile> files16Mb = newFiles(numFiles, 16 * 1024 * 1024);
+    appendFiles(files16Mb, table);
+
+    // We should never hit cache.
+    TableScan scan = table.newScan();
+    ContentCache cache = ManifestFiles.getOrCreateCache(scan.table().io());
+    Assert.assertEquals(1, cache.maxContentLength());
+    Assert.assertEquals(1, cache.maxTotalBytes());
+    Assert.assertEquals("Should get 1 tasks per file", numFiles, Iterables.size(scan.planFiles()));
+    Assert.assertEquals("Cache should be empty", 0, cache.estimatedCacheSize());
+    Assert.assertEquals("File should not be loaded through cache", 0, cache.stats().loadCount());
+    Assert.assertEquals("Cache should not serve file", 0, cache.stats().requestCount());
+    ManifestFiles.dropCache(scan.table().io());
+  }
+
+  @Test
+  public void testUniqueCache() throws Exception {
+    Map<String, String> properties1 =
+        ImmutableMap.of(
+            CatalogProperties.FILE_IO_IMPL,
+            HadoopFileIO.class.getName(),
+            CatalogProperties.IO_CACHE_ENABLED,
+            "true");
+    Table table1 = createTable(properties1);
+
+    Map<String, String> properties2 =
+        ImmutableMap.of(
+            CatalogProperties.FILE_IO_IMPL, HadoopFileIO.class.getName(),
+            CatalogProperties.IO_CACHE_ENABLED, "true",
+            CatalogProperties.IO_CACHE_MAX_TOTAL_BYTES, "1",
+            CatalogProperties.IO_CACHE_MAX_CONTENT_LENGTH, "1");
+    Table table2 = createTable(properties2);
+
+    ContentCache cache1 = ManifestFiles.getOrCreateCache(table1.io());
+    ContentCache cache2 = ManifestFiles.getOrCreateCache(table2.io());
+    ContentCache cache3 = ManifestFiles.getOrCreateCache(table2.io());
+    Assert.assertNotSame(cache1, cache2);
+    Assert.assertSame(cache2, cache3);
+
+    ManifestFiles.dropCache(table1.io());
+    ManifestFiles.dropCache(table2.io());
+  }
+
+  @Test
+  public void testRecreateCache() throws Exception {
+    Map<String, String> properties =
+        ImmutableMap.of(
+            CatalogProperties.FILE_IO_IMPL,
+            HadoopFileIO.class.getName(),
+            CatalogProperties.IO_CACHE_ENABLED,
+            "true");
+    Table table = createTable(properties);
+
+    ContentCache cache1 = ManifestFiles.getOrCreateCache(table.io());
+    ManifestFiles.dropCache(table.io());
+
+    ContentCache cache2 = ManifestFiles.getOrCreateCache(table.io());
+    Assert.assertNotSame(cache1, cache2);
+    ManifestFiles.dropCache(table.io());
+  }
+
+  private Table createTable(Map<String, String> properties) throws Exception {
+    TableIdentifier tableIdent = TableIdentifier.of("db", "ns1", "ns2", "tbl");
+    return hadoopCatalog(properties)
+        .buildTable(tableIdent, SCHEMA)
+        .withPartitionSpec(SPEC)
+        .create();
+  }
+
+  private void appendFiles(Iterable<DataFile> files, Table table) {
+    for (DataFile file : files) {
+      AppendFiles appendFile = table.newAppend();
+      appendFile.appendFile(file);
+      appendFile.commit();
+    }
+  }
+
+  private List<DataFile> newFiles(int numFiles, long sizeInBytes) {
+    return newFiles(numFiles, sizeInBytes, FileFormat.PARQUET, 1);
+  }
+
+  private List<DataFile> newFiles(
+      int numFiles, long sizeInBytes, FileFormat fileFormat, int numOffset) {
+    List<DataFile> files = Lists.newArrayList();
+    for (int fileNum = 0; fileNum < numFiles; fileNum++) {
+      files.add(newFile(sizeInBytes, fileFormat, numOffset));
+    }
+    return files;
+  }
+
+  private DataFile newFile(long sizeInBytes, FileFormat fileFormat, int numOffsets) {
+    String fileName = UUID.randomUUID().toString();
+    DataFiles.Builder builder =
+        DataFiles.builder(PartitionSpec.unpartitioned())
+            .withPath(fileFormat.addExtension(fileName))
+            .withFileSizeInBytes(sizeInBytes)
+            .withRecordCount(2);
+
+    if (numOffsets > 1) {
+      long stepSize = sizeInBytes / numOffsets;
+      List<Long> offsets =
+          LongStream.range(0, numOffsets)
+              .map(i -> i * stepSize)
+              .boxed()
+              .collect(Collectors.toList());
+      builder.withSplitOffsets(offsets);
+    }
+
+    return builder.build();
+  }
+}


### PR DESCRIPTION
This is a draft PR for ManifestCache implementation.

The `ManifestCache` interface closely follow `com.github.benmanes.caffeine.cache.Cache` interface, with addition of specifying `maxContentLength()`. If stream length is longer than `maxContentLength()`, AvroIO will skip caching it to avoid memory pressure. An example of implementation, `CaffeineManifestCache`, can be seen in TestAvroFileSplit.java.

I will tidy this up and add documentations as we go. Looking forward for any feedback.

Closes #4508 