### PR TITLE
Flink - Log warning when in table upsert mode for Flink 1.12 due to correctness issues

### DIFF
--- a/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -385,7 +385,7 @@ public class FlinkSink {
       // See in https://github.com/apache/iceberg/pull/4364 for more information.
       if (upsertMode) {
         String deprecationNotice =
-            "This job is running in upsert mode. Upsert mode should not be used with Flink 1.12 because it will " +
+            "This table sink is running in upsert mode. Upsert mode should not be used with Flink 1.12 because it will " +
             "write incorrect delete file metadata, which could prevent deletes from being correctly applied. " +
             "Upgrading to Flink 1.13+ is recommended. " +
             "To safely use Flink 1.12, set manifest metrics to counts only.";

--- a/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -376,11 +376,13 @@ public class FlinkSink {
           UPSERT_ENABLED, UPSERT_ENABLED_DEFAULT);
 
       // `upsert` mode should not be used in Flink 1.12 due to correctness issues.
-      // As part of a patch release, apachee-iceberg-flink-runtime_1.12:0.13.2,
+      // As part of a patch release, apache-iceberg-flink-runtime_1.12:0.13.2,
       // it has been decided the best course of action would be to log a warning
-      // asking people to upgrade, as Flink 1.12 is deprecated from both upstream
-      // Flink as well as Iceberg as of Iceberg 0.14.0. But we allow the configuration
-      // given that it's a patch release and the change would be otherwise very breaking.
+      // asking people to upgrade, as Flink 1.12 has been deprecated in upstream Apache Flink
+      // for some time as well as will be removed in the next major Iceberg release, Iceberg 0.14.0.
+      //
+      // But we allow the configuration given that it's a patch release and the change would be otherwise
+      // too breaking for a patch release.
       //
       // See in https://github.com/apache/iceberg/pull/4364 for more information.
       if (upsertMode) {

--- a/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -398,8 +398,8 @@ public class FlinkSink {
         if (!table.spec().isUnpartitioned()) {
           for (PartitionField partitionField : table.spec().fields()) {
             Preconditions.checkState(equalityFieldIds.contains(partitionField.sourceId()),
-              "In UPSERT mode, partition field '%s' should be included in equality fields: '%s'",
-              partitionField, equalityFieldColumns);
+                "In UPSERT mode, partition field '%s' should be included in equality fields: '%s'",
+                partitionField, equalityFieldColumns);
           }
         }
       }

--- a/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -385,10 +385,9 @@ public class FlinkSink {
       // See in https://github.com/apache/iceberg/pull/4364 for more information.
       if (upsertMode) {
         String deprecationNotice =
-            "This job is running in upsert mode. Upsert mode should not be used with Flink 1.12 due to correctness " +
-            "issues. Please upgrade to Flink 1.13+ if upsert mode is truly needed. If upsert mode is not needed, " +
-            "set the table property `write.upsert.enabled` to 'false' and don't use `upsert(true)` while " +
-            "using the Flink Sink builder";
+            "Upsert mode should not be used with Flink 1.12 because it will write incorrect delete file metadata, " +
+            "which could prevent deletes from being correctly applied. Upgrading to Flink 1.13+ is recommended. " +
+            "To safely use Flink 1.12, set manifest metrics to counts only.";
         LOG.error(deprecationNotice);
 
         Preconditions.checkState(!overwrite,

--- a/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -379,8 +379,8 @@ public class FlinkSink {
       // See in https://github.com/apache/iceberg/pull/4364 for more information.
       if (upsertMode) {
         throw new UnsupportedOperationException(
-            "upsert mode is not supported in Flink 1.12 due to correctness issues. Please upgrade to Flink 1.13+ if " +
-            "upsert mode is needed. If `upsert` mode is not needed, set the table's `write.upsert.enabled` " +
+            "Upsert mode is not supported in Flink 1.12 due to correctness issues. Please upgrade to Flink 1.13+ if " +
+            "upsert mode is needed. If upsert mode is not needed, set the table property `write.upsert.enabled` " +
             "property to 'false'.");
       }
 

--- a/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -385,8 +385,9 @@ public class FlinkSink {
       // See in https://github.com/apache/iceberg/pull/4364 for more information.
       if (upsertMode) {
         String deprecationNotice =
-            "Upsert mode should not be used with Flink 1.12 because it will write incorrect delete file metadata, " +
-            "which could prevent deletes from being correctly applied. Upgrading to Flink 1.13+ is recommended. " +
+            "This job is running in upsert mode. Upsert mode should not be used with Flink 1.12 because it will " +
+            "write incorrect delete file metadata, which could prevent deletes from being correctly applied. " +
+            "Upgrading to Flink 1.13+ is recommended. " +
             "To safely use Flink 1.12, set manifest metrics to counts only.";
         LOG.error(deprecationNotice);
 

--- a/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -384,12 +384,11 @@ public class FlinkSink {
       //
       // See in https://github.com/apache/iceberg/pull/4364 for more information.
       if (upsertMode) {
-        String deprecationNotice =
-            "This table sink is running in upsert mode. Upsert mode should not be used with Flink 1.12 because it will " +
-            "write incorrect delete file metadata, which could prevent deletes from being correctly applied. " +
-            "Upgrading to Flink 1.13+ is recommended. " +
-            "To safely use Flink 1.12, set manifest metrics to counts only.";
-        LOG.error(deprecationNotice);
+        LOG.error(
+            "This table sink is running in upsert mode. Upsert mode should not be used with Flink 1.12 because " +
+            "it will write incorrect delete file metadata, which could prevent deletes from being correctly" +
+            "applied. Upgrading to Flink 1.13+ is recommended. " +
+            "To safely use Flink 1.12, set manifest metrics to counts only.");
 
         Preconditions.checkState(!overwrite,
             "OVERWRITE mode shouldn't be enable when configuring to use UPSERT data stream.");

--- a/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
+++ b/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
@@ -434,30 +434,30 @@ public class TestFlinkIcebergSinkV2 extends TableTestBase {
   @Test
   public void testUpsertOnDataKey() throws Exception {
     List<List<Row>> elementsPerCheckpoint = ImmutableList.of(
-            ImmutableList.of(
-                    row("+I", 1, "aaa"),
-                    row("+I", 2, "aaa"),
-                    row("+I", 3, "bbb")
-            ),
-            ImmutableList.of(
-                    row("+U", 4, "aaa"),
-                    row("-U", 3, "bbb"),
-                    row("+U", 5, "bbb")
-            ),
-            ImmutableList.of(
-                    row("+I", 6, "aaa"),
-                    row("+U", 7, "bbb")
-            )
+        ImmutableList.of(
+            row("+I", 1, "aaa"),
+            row("+I", 2, "aaa"),
+            row("+I", 3, "bbb")
+        ),
+        ImmutableList.of(
+            row("+U", 4, "aaa"),
+            row("-U", 3, "bbb"),
+            row("+U", 5, "bbb")
+        ),
+        ImmutableList.of(
+            row("+I", 6, "aaa"),
+            row("+U", 7, "bbb")
+        )
     );
 
     List<List<Record>> expectedRecords = ImmutableList.of(
-            ImmutableList.of(record(2, "aaa"), record(3, "bbb")),
-            ImmutableList.of(record(4, "aaa"), record(5, "bbb")),
-            ImmutableList.of(record(6, "aaa"), record(7, "bbb"))
+        ImmutableList.of(record(2, "aaa"), record(3, "bbb")),
+        ImmutableList.of(record(4, "aaa"), record(5, "bbb")),
+        ImmutableList.of(record(6, "aaa"), record(7, "bbb"))
     );
 
     testChangeLogs(ImmutableList.of("data"), row -> row.getField(ROW_DATA_POS), true,
-            elementsPerCheckpoint, expectedRecords);
+        elementsPerCheckpoint, expectedRecords);
   }
 
   @Test

--- a/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
+++ b/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
@@ -377,19 +377,6 @@ public class TestFlinkIcebergSinkV2 extends TableTestBase {
         false, elementsPerCheckpoint, expectedRecords);
   }
 
-  @Test
-  public void testUpsertModeIsDisabled() throws Exception {
-    DataStream<Row> dataStream = env.addSource(new BoundedTestSource<>(ImmutableList.of()), ROW_TYPE_INFO);
-    AssertHelpers.assertThrows("Upsert mode is not supported in Flink 1.12",
-        UnsupportedOperationException.class, "Upsert mode is not supported in Flink 1.12",
-        () -> FlinkSink.forRow(dataStream, SimpleDataUtil.FLINK_SCHEMA)
-            .tableLoader(tableLoader)
-            .tableSchema(SimpleDataUtil.FLINK_SCHEMA)
-            .writeParallelism(parallelism)
-            .upsert(true)
-            .append());
-  }
-
   private StructLikeSet expectedRowSet(Record... records) {
     return SimpleDataUtil.expectedRowSet(table, records);
   }

--- a/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
+++ b/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
@@ -53,7 +53,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.StructLikeSet;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -160,7 +159,7 @@ public class TestFlinkIcebergSinkV2 extends TableTestBase {
                               boolean insertAsUpsert,
                               List<List<Row>> elementsPerCheckpoint,
                               List<List<Record>> expectedRecordsPerCheckpoint) throws Exception {
-    Assume.assumeFalse("Upsert mode is not supported in Flink 1.12",  insertAsUpsert);
+    Assert.assertFalse("Upsert mode is not supported in Flink 1.12",  insertAsUpsert);
 
     DataStream<Row> dataStream = env.addSource(new BoundedTestSource<>(elementsPerCheckpoint), ROW_TYPE_INFO);
 

--- a/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
+++ b/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
@@ -463,31 +463,31 @@ public class TestFlinkIcebergSinkV2 extends TableTestBase {
   @Test
   public void testUpsertOnIdDataKey() throws Exception {
     List<List<Row>> elementsPerCheckpoint = ImmutableList.of(
-            ImmutableList.of(
-                    row("+I", 1, "aaa"),
-                    row("+U", 1, "aaa"),
-                    row("+I", 2, "bbb")
-            ),
-            ImmutableList.of(
-                    row("+I", 1, "aaa"),
-                    row("-D", 2, "bbb"),
-                    row("+I", 2, "ccc")
-            ),
-            ImmutableList.of(
-                    row("+U", 1, "bbb"),
-                    row("-U", 1, "ccc"),
-                    row("-D", 1, "aaa")
-            )
+        ImmutableList.of(
+            row("+I", 1, "aaa"),
+            row("+U", 1, "aaa"),
+            row("+I", 2, "bbb")
+        ),
+        ImmutableList.of(
+            row("+I", 1, "aaa"),
+            row("-D", 2, "bbb"),
+            row("+I", 2, "ccc")
+        ),
+        ImmutableList.of(
+            row("+U", 1, "bbb"),
+            row("-U", 1, "ccc"),
+            row("-D", 1, "aaa")
+        )
     );
 
     List<List<Record>> expectedRecords = ImmutableList.of(
-            ImmutableList.of(record(1, "aaa"), record(2, "bbb")),
-            ImmutableList.of(record(1, "aaa"), record(2, "ccc")),
-            ImmutableList.of(record(1, "bbb"), record(2, "ccc"))
+        ImmutableList.of(record(1, "aaa"), record(2, "bbb")),
+        ImmutableList.of(record(1, "aaa"), record(2, "ccc")),
+        ImmutableList.of(record(1, "bbb"), record(2, "ccc"))
     );
 
     testChangeLogs(ImmutableList.of("id", "data"), row -> Row.of(row.getField(ROW_ID_POS), row.getField(ROW_DATA_POS)),
-            true, elementsPerCheckpoint, expectedRecords);
+        true, elementsPerCheckpoint, expectedRecords);
   }
 
   private StructLikeSet expectedRowSet(Record... records) {

--- a/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
+++ b/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
@@ -375,6 +375,121 @@ public class TestFlinkIcebergSinkV2 extends TableTestBase {
         false, elementsPerCheckpoint, expectedRecords);
   }
 
+  @Test
+  public void testUpsertModeCheck() throws Exception {
+    DataStream<Row> dataStream = env.addSource(new BoundedTestSource<>(ImmutableList.of()), ROW_TYPE_INFO);
+    FlinkSink.Builder builder = FlinkSink.forRow(dataStream, SimpleDataUtil.FLINK_SCHEMA)
+        .tableLoader(tableLoader)
+        .tableSchema(SimpleDataUtil.FLINK_SCHEMA)
+        .writeParallelism(parallelism)
+        .upsert(true);
+
+    AssertHelpers.assertThrows("Should be error because upsert mode and overwrite mode enable at the same time.",
+        IllegalStateException.class, "OVERWRITE mode shouldn't be enable",
+        () -> builder.equalityFieldColumns(ImmutableList.of("id", "data")).overwrite(true).append()
+    );
+
+    AssertHelpers.assertThrows("Should be error because equality field columns are empty.",
+        IllegalStateException.class, "Equality field columns shouldn't be empty",
+        () -> builder.equalityFieldColumns(ImmutableList.of()).overwrite(false).append()
+    );
+  }
+
+  @Test
+  public void testUpsertOnIdKey() throws Exception {
+    List<List<Row>> elementsPerCheckpoint = ImmutableList.of(
+        ImmutableList.of(
+            row("+I", 1, "aaa"),
+            row("+U", 1, "bbb")
+        ),
+        ImmutableList.of(
+            row("+I", 1, "ccc")
+        ),
+        ImmutableList.of(
+            row("+U", 1, "ddd"),
+            row("+I", 1, "eee")
+        )
+    );
+
+    List<List<Record>> expectedRecords = ImmutableList.of(
+        ImmutableList.of(record(1, "bbb")),
+        ImmutableList.of(record(1, "ccc")),
+        ImmutableList.of(record(1, "eee"))
+    );
+
+    if (!partitioned) {
+      testChangeLogs(ImmutableList.of("id"), row -> row.getField(ROW_ID_POS), true,
+          elementsPerCheckpoint, expectedRecords);
+    } else {
+      AssertHelpers.assertThrows("Should be error because equality field columns don't include all partition keys",
+          IllegalStateException.class, "should be included in equality fields",
+          () -> {
+            testChangeLogs(ImmutableList.of("id"), row -> row.getField(ROW_ID_POS), true,
+                elementsPerCheckpoint, expectedRecords);
+            return null;
+          });
+    }
+  }
+
+  @Test
+  public void testUpsertOnDataKey() throws Exception {
+    List<List<Row>> elementsPerCheckpoint = ImmutableList.of(
+            ImmutableList.of(
+                    row("+I", 1, "aaa"),
+                    row("+I", 2, "aaa"),
+                    row("+I", 3, "bbb")
+            ),
+            ImmutableList.of(
+                    row("+U", 4, "aaa"),
+                    row("-U", 3, "bbb"),
+                    row("+U", 5, "bbb")
+            ),
+            ImmutableList.of(
+                    row("+I", 6, "aaa"),
+                    row("+U", 7, "bbb")
+            )
+    );
+
+    List<List<Record>> expectedRecords = ImmutableList.of(
+            ImmutableList.of(record(2, "aaa"), record(3, "bbb")),
+            ImmutableList.of(record(4, "aaa"), record(5, "bbb")),
+            ImmutableList.of(record(6, "aaa"), record(7, "bbb"))
+    );
+
+    testChangeLogs(ImmutableList.of("data"), row -> row.getField(ROW_DATA_POS), true,
+            elementsPerCheckpoint, expectedRecords);
+  }
+
+  @Test
+  public void testUpsertOnIdDataKey() throws Exception {
+    List<List<Row>> elementsPerCheckpoint = ImmutableList.of(
+            ImmutableList.of(
+                    row("+I", 1, "aaa"),
+                    row("+U", 1, "aaa"),
+                    row("+I", 2, "bbb")
+            ),
+            ImmutableList.of(
+                    row("+I", 1, "aaa"),
+                    row("-D", 2, "bbb"),
+                    row("+I", 2, "ccc")
+            ),
+            ImmutableList.of(
+                    row("+U", 1, "bbb"),
+                    row("-U", 1, "ccc"),
+                    row("-D", 1, "aaa")
+            )
+    );
+
+    List<List<Record>> expectedRecords = ImmutableList.of(
+            ImmutableList.of(record(1, "aaa"), record(2, "bbb")),
+            ImmutableList.of(record(1, "aaa"), record(2, "ccc")),
+            ImmutableList.of(record(1, "bbb"), record(2, "ccc"))
+    );
+
+    testChangeLogs(ImmutableList.of("id", "data"), row -> Row.of(row.getField(ROW_ID_POS), row.getField(ROW_DATA_POS)),
+            true, elementsPerCheckpoint, expectedRecords);
+  }
+
   private StructLikeSet expectedRowSet(Record... records) {
     return SimpleDataUtil.expectedRowSet(table, records);
   }

--- a/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
+++ b/flink/v1.12/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkIcebergSinkV2.java
@@ -159,8 +159,6 @@ public class TestFlinkIcebergSinkV2 extends TableTestBase {
                               boolean insertAsUpsert,
                               List<List<Row>> elementsPerCheckpoint,
                               List<List<Record>> expectedRecordsPerCheckpoint) throws Exception {
-    Assert.assertFalse("Upsert mode is not supported in Flink 1.12",  insertAsUpsert);
-
     DataStream<Row> dataStream = env.addSource(new BoundedTestSource<>(elementsPerCheckpoint), ROW_TYPE_INFO);
 
     FlinkSink.forRow(dataStream, SimpleDataUtil.FLINK_SCHEMA)


### PR DESCRIPTION
In https://github.com/apache/iceberg/pull/4364, we fixed an issue that was causing data correctness bugs when using `upsert` mode when writing to v2 table's with Flink.

The fix for the issue did not resolve the issue in Flink 1.12: https://github.com/apache/iceberg/pull/4418

Because Flink 1.12 has been deprecated, it was decided that we should log a warning  if their table is in Flink's 1.12's upsert mode which asks them to upgrade Flink versions to something supported for the upcoming patch release, Iceberg 0.13.2.

