### PR TITLE
Core: Files table predicate filtering wrong for tables with evolved partition specs

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
@@ -118,13 +118,15 @@ abstract class BaseFilesTable extends BaseMetadataTable {
 
 
     private boolean filter(ManifestFile manifestFile, Expression rowFilter, boolean caseSensitive) {
-      PartitionSpec originalSpec = table().specs().get(manifestFile.partitionSpecId());
+      if (!table().spec().equals(table().specs().get(manifestFile.partitionSpecId()))) {
+        return true;
+      }
 
       // use an inclusive projection to remove the partition name prefix and filter out any non-partition expressions
-      PartitionSpec spec = transformSpec(fileSchema, originalSpec, PARTITION_FIELD_PREFIX);
+      PartitionSpec spec = transformSpec(fileSchema, table().spec(), PARTITION_FIELD_PREFIX);
       Expression partitionFilter = Projections.inclusive(spec, caseSensitive).project(rowFilter);
       ManifestEvaluator manifestEval = ManifestEvaluator.forPartitionFilter(
-          partitionFilter, originalSpec, caseSensitive);
+          partitionFilter, spec, caseSensitive);
 
       return manifestEval.eval(manifestFile);
     }

--- a/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
@@ -98,7 +98,7 @@ abstract class BaseFilesTable extends BaseMetadataTable {
 
       LoadingCache<Integer, ManifestEvaluator> evalCache = Caffeine.newBuilder().build(specId -> {
         PartitionSpec spec = specsById.get(specId);
-        PartitionSpec transformedSpec = transformSpec(fileSchema, spec, PARTITION_FIELD_PREFIX);
+        PartitionSpec transformedSpec = transformSpec(fileSchema, spec);
         return ManifestEvaluator.forRowFilter(rowFilter, transformedSpec, caseSensitive);
       });
 

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -35,7 +35,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
  * deserialization.
  */
 abstract class BaseMetadataTable implements Table, HasTableOperations, Serializable {
-  protected static final String PARTITION_FIELD_PREFIX = "partition.";
   private final PartitionSpec spec = PartitionSpec.unpartitioned();
   private final SortOrder sortOrder = SortOrder.unsorted();
   private final TableOperations ops;
@@ -52,18 +51,17 @@ abstract class BaseMetadataTable implements Table, HasTableOperations, Serializa
    * This method transforms the table's partition spec to a spec that is used to rewrite the user-provided filter
    * expression against the given metadata table.
    * <p>
-   * The resulting partition spec maps $partitionPrefix.X fields to partition X using an identity partition transform.
+   * The resulting partition spec maps partition.X fields to partition X using an identity partition transform.
    * When this spec is used to project an expression for the given metadata table, the projection will remove
-   * predicates for non-partition fields (not in the spec) and will remove the "$partitionPrefix." prefix from fields.
+   * predicates for non-partition fields (not in the spec) and will remove the "partition." prefix from fields.
    *
    * @param metadataTableSchema schema of the metadata table
    * @param spec spec on which the metadata table schema is based
-   * @param partitionPrefix prefix to remove from each field in the partition spec
    * @return a spec used to rewrite the metadata table filters to partition filters using an inclusive projection
    */
-  static PartitionSpec transformSpec(Schema metadataTableSchema, PartitionSpec spec, String partitionPrefix) {
+  static PartitionSpec transformSpec(Schema metadataTableSchema, PartitionSpec spec) {
     PartitionSpec.Builder identitySpecBuilder = PartitionSpec.builderFor(metadataTableSchema).checkConflicts(false);
-    spec.fields().forEach(pf -> identitySpecBuilder.add(pf.fieldId(), partitionPrefix + pf.name(), "identity"));
+    spec.fields().forEach(pf -> identitySpecBuilder.add(pf.fieldId(), pf.name(), "identity"));
     return identitySpecBuilder.build();
   }
 

--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -63,7 +63,7 @@ abstract class BaseMetadataTable implements Table, HasTableOperations, Serializa
    */
   static PartitionSpec transformSpec(Schema metadataTableSchema, PartitionSpec spec, String partitionPrefix) {
     PartitionSpec.Builder identitySpecBuilder = PartitionSpec.builderFor(metadataTableSchema).checkConflicts(false);
-    spec.fields().forEach(pf -> identitySpecBuilder.identity(partitionPrefix + pf.name(), pf.name()));
+    spec.fields().forEach(pf -> identitySpecBuilder.add(pf.fieldId(), partitionPrefix + pf.name(), "identity"));
     return identitySpecBuilder.build();
   }
 

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -110,7 +110,7 @@ public class PartitionsTable extends BaseMetadataTable {
 
     // use an inclusive projection to remove the partition name prefix and filter out any non-partition expressions
     Expression partitionFilter = Projections
-        .inclusive(transformSpec(scan.schema(), table.spec(), PARTITION_FIELD_PREFIX), caseSensitive)
+        .inclusive(transformSpec(scan.schema(), table.spec()), caseSensitive)
         .project(scan.filter());
 
     ManifestGroup manifestGroup = new ManifestGroup(table.io(), snapshot.dataManifests(), snapshot.deleteManifests())

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableFilters.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableFilters.java
@@ -319,9 +319,8 @@ public class TestMetadataTableFilters extends TableTestBase {
     TableScan scan = metadataTable.newScan().filter(filter);
     CloseableIterable<FileScanTask> tasks = scan.planFiles();
 
-    // In V1 we cannot filter once fields are removed from partition spec
-    // All 4 original data/delete files written by old spec, plus both data file/delete file written by new spec
-    Assert.assertEquals(expectedScanTaskCount(6), Iterables.size(tasks));
+    // All 4 original data/delete files written by old spec, plus one data file/delete file written by new spec
+    Assert.assertEquals(expectedScanTaskCount(5), Iterables.size(tasks));
 
     filter = Expressions.and(
         Expressions.equal("partition.data_bucket", 0),
@@ -329,8 +328,8 @@ public class TestMetadataTableFilters extends TableTestBase {
     scan = metadataTable.newScan().filter(filter);
     tasks = scan.planFiles();
 
-    // 1 original data/delete files written by old spec, plus both of new data file/delete file written by new spec
-    Assert.assertEquals(expectedScanTaskCount(3), Iterables.size(tasks));
+    // 1 original data/delete files written by old spec (V1 filters out new specs which don't have this value)
+    Assert.assertEquals(expectedScanTaskCount(1), Iterables.size(tasks));
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableFilters.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableFilters.java
@@ -261,23 +261,14 @@ public class TestMetadataTableFilters extends TableTestBase {
     populateTableNewSpec();
 
     Table metadataTable = createMetadataTable();
-    Expression newSpecFilter = Expressions.and(
+    Expression filter = Expressions.and(
         Expressions.equal("partition.id", 10),
         Expressions.greaterThan("record_count", 0));
-    TableScan scanNewSpec = metadataTable.newScan().filter(newSpecFilter);
-    CloseableIterable<FileScanTask> tasksNewSpecScan = scanNewSpec.planFiles();
+    TableScan scan = metadataTable.newScan().filter(filter);
+    CloseableIterable<FileScanTask> tasks = scan.planFiles();
 
     // All 4 original data/delete files written by old spec, plus one new data file/delete file written by new spec
-    Assert.assertEquals(expectedScanTaskCount(5), Iterables.size(tasksNewSpecScan));
-
-    Expression oldSpecFilter = Expressions.and(
-        Expressions.equal("partition.data_bucket", 0),
-        Expressions.greaterThan("record_count", 0));
-    TableScan scanOldSpec = metadataTable.newScan().filter(oldSpecFilter);
-    CloseableIterable<FileScanTask> tasksOldSpecScan = scanOldSpec.planFiles();
-
-    // 1 of original/data files written by old spec, plus both of new data file/delete file written by new spec
-    Assert.assertEquals(expectedScanTaskCount(3), Iterables.size(tasksOldSpecScan));
+    Assert.assertEquals(expectedScanTaskCount(5), Iterables.size(tasks));
   }
 
   private void populateTableNewSpec() {

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTablesWithPartitionEvolution.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTablesWithPartitionEvolution.java
@@ -22,8 +22,6 @@ package org.apache.iceberg.spark.source;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
-import java.util.concurrent.ThreadLocalRandom;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.HasTableOperations;
@@ -74,14 +72,29 @@ public class TestMetadataTablesWithPartitionEvolution extends SparkCatalogTestBa
                 "default-namespace", "default"
             ),
             ORC,
-            formatVersion()
+            1
+        },
+        { "testhive", SparkCatalog.class.getName(),
+            ImmutableMap.of(
+                "type", "hive",
+                "default-namespace", "default"
+            ),
+            ORC,
+            2
         },
         { "testhadoop", SparkCatalog.class.getName(),
             ImmutableMap.of(
                 "type", "hadoop"
             ),
             PARQUET,
-            formatVersion()
+            1
+        },
+        { "testhadoop", SparkCatalog.class.getName(),
+            ImmutableMap.of(
+                "type", "hadoop"
+            ),
+            PARQUET,
+            2
         },
         { "spark_catalog", SparkSessionCatalog.class.getName(),
             ImmutableMap.of(
@@ -92,16 +105,10 @@ public class TestMetadataTablesWithPartitionEvolution extends SparkCatalogTestBa
                 "cache-enabled", "false" // Spark will delete tables using v1, leaving the cache out of sync
             ),
             AVRO,
-            formatVersion()
+            1
         }
     };
   }
-
-  private static int formatVersion() {
-    return RANDOM.nextInt(2) + 1;
-  }
-
-  private static final Random RANDOM = ThreadLocalRandom.current();
 
   private final FileFormat fileFormat;
   private final int formatVersion;
@@ -186,6 +193,109 @@ public class TestMetadataTablesWithPartitionEvolution extends SparkCatalogTestBa
           ImmutableList.of(row(null, null), row(null, 2), row("b1", null), row("b1", 2)),
           "STRUCT<data:STRING,category_bucket_8_another_name:INT>",
           tableType);
+    }
+  }
+
+  @Test
+  public void testFilesMetadataTableFilter() throws ParseException {
+    sql("CREATE TABLE %s (id bigint NOT NULL, category string, data string) USING iceberg " +
+        "TBLPROPERTIES ('commit.manifest-merge.enabled' 'false')", tableName);
+    initTable();
+
+    sql("INSERT INTO TABLE %s VALUES (1, 'c1', 'd1')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'c2', 'd2')", tableName);
+
+    // verify the metadata tables while the current spec is still unpartitioned
+    for (MetadataTableType tableType : Arrays.asList(FILES, ALL_DATA_FILES)) {
+      Dataset<Row> df = loadMetadataTable(tableType);
+      Assert.assertTrue("Partition must be skipped", df.schema().getFieldIndex("partition").isEmpty());
+    }
+
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    table.updateSpec()
+        .addField("data")
+        .commit();
+    sql("REFRESH TABLE %s", tableName);
+    sql("INSERT INTO TABLE %s VALUES (1, 'c1', 'd1')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'c2', 'd2')", tableName);
+
+    // verify the metadata tables after adding the first partition column
+    for (MetadataTableType tableType : Arrays.asList(FILES, ALL_DATA_FILES)) {
+      assertPartitions(
+          ImmutableList.of(row("d2")),
+          "STRUCT<data:STRING>",
+          tableType,
+          "partition.data = 'd2'");
+    }
+
+    table.updateSpec()
+        .addField("category")
+        .commit();
+    sql("REFRESH TABLE %s", tableName);
+    sql("INSERT INTO TABLE %s VALUES (1, 'c1', 'd1')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (2, 'c2', 'd2')", tableName);
+
+    Dataset<Row> result = loadMetadataTable(ALL_ENTRIES);
+    result.collectAsList().forEach(f -> System.out.println(f));
+
+    // verify the metadata tables after adding the second partition column
+    for (MetadataTableType tableType : Arrays.asList(FILES, ALL_DATA_FILES)) {
+      assertPartitions(ImmutableList.of(row("d2", null), row("d2", "c2")),
+          "STRUCT<data:STRING,category:STRING>",
+          tableType,
+          "partition.data = 'd2'");
+    }
+    for (MetadataTableType tableType : Arrays.asList(FILES, ALL_DATA_FILES)) {
+      assertPartitions(
+          ImmutableList.of(row("d2", "c2")),
+          "STRUCT<data:STRING,category:STRING>",
+          tableType,
+          "partition.category = 'c2'");
+    }
+
+    table.updateSpec()
+        .removeField("data")
+        .commit();
+    sql("REFRESH TABLE %s", tableName);
+
+    // Verify new partitions do not show up for removed 'partition.data=d2' query
+    sql("INSERT INTO TABLE %s VALUES (3, 'c3', 'd2')", tableName);
+    sql("INSERT INTO TABLE %s VALUES (4, 'c4', 'd2')", tableName);
+
+    // Verify new partitions do show up for 'partition.category=c2' query
+    sql("INSERT INTO TABLE %s VALUES (5, 'c2', 'd5')", tableName);
+
+    // no new partition should show up for 'data' partition query as partition field has been removed
+    for (MetadataTableType tableType : Arrays.asList(FILES, ALL_DATA_FILES)) {
+      assertPartitions(
+          ImmutableList.of(row("d2", null), row("d2", "c2")),
+          "STRUCT<data:STRING,category:STRING>",
+          tableType,
+          "partition.data = 'd2'");
+    }
+    // new partition shows up from 'category' partition field query
+    for (MetadataTableType tableType : Arrays.asList(FILES, ALL_DATA_FILES)) {
+      assertPartitions(
+          ImmutableList.of(row(null, "c2"), row("d2", "c2")),
+          "STRUCT<data:STRING,category:STRING>",
+          tableType,
+          "partition.category = 'c2'");
+    }
+
+    table.updateSpec()
+        .renameField("category", "category_another_name")
+        .commit();
+    sql("REFRESH TABLE %s", tableName);
+
+    // Verify new partitions do show up for 'category=c2' query
+    sql("INSERT INTO TABLE %s VALUES (6, 'c2', 'd6')", tableName);
+    for (MetadataTableType tableType : Arrays.asList(FILES, ALL_DATA_FILES)) {
+      assertPartitions(
+          ImmutableList.of(row(null, "c2"), row(null, "c2"), row("d2", "c2")),
+          "STRUCT<data:STRING,category_another_name:STRING>",
+          tableType,
+          "partition.category_another_name = 'c2'");
     }
   }
 
@@ -299,7 +409,15 @@ public class TestMetadataTablesWithPartitionEvolution extends SparkCatalogTestBa
 
   private void assertPartitions(List<Object[]> expectedPartitions, String expectedTypeAsString,
                                 MetadataTableType tableType) throws ParseException {
+    assertPartitions(expectedPartitions, expectedTypeAsString, tableType, null);
+  }
+
+  private void assertPartitions(List<Object[]> expectedPartitions, String expectedTypeAsString,
+                                MetadataTableType tableType, String filter) throws ParseException {
     Dataset<Row> df = loadMetadataTable(tableType);
+    if (filter != null) {
+      df = df.filter(filter);
+    }
 
     DataType expectedType = spark.sessionState().sqlParser().parseDataType(expectedTypeAsString);
     switch (tableType) {

--- a/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTablesWithPartitionEvolution.java
+++ b/spark/v3.2/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTablesWithPartitionEvolution.java
@@ -106,6 +106,17 @@ public class TestMetadataTablesWithPartitionEvolution extends SparkCatalogTestBa
             ),
             AVRO,
             1
+        },
+        { "spark_catalog", SparkSessionCatalog.class.getName(),
+            ImmutableMap.of(
+                "type", "hive",
+                "default-namespace", "default",
+                "clients", "1",
+                "parquet-enabled", "false",
+                "cache-enabled", "false" // Spark will delete tables using v1, leaving the cache out of sync
+            ),
+            AVRO,
+            2
         }
     };
   }
@@ -235,9 +246,6 @@ public class TestMetadataTablesWithPartitionEvolution extends SparkCatalogTestBa
     sql("REFRESH TABLE %s", tableName);
     sql("INSERT INTO TABLE %s VALUES (1, 'c1', 'd1')", tableName);
     sql("INSERT INTO TABLE %s VALUES (2, 'c2', 'd2')", tableName);
-
-    Dataset<Row> result = loadMetadataTable(ALL_ENTRIES);
-    result.collectAsList().forEach(f -> System.out.println(f));
 
     // verify the metadata tables after adding the second partition column
     for (MetadataTableType tableType : Arrays.asList(FILES, ALL_DATA_FILES)) {


### PR DESCRIPTION
The change https://github.com/apache/iceberg/pull/2926 introduced partition predicate push down for the "files" metadata table.  However, it is incorrect in the case that the partition spec evolves and data written in both specs.  The projectionFilter is constructed by projecting the expression on the current table's partition spec, and evaluating the values against the manifest file.

Say for example, we have a table that had a former partition spec that is "data", and a new partition spec that is "id", with manifests written with both specs.

A query like "select * from my_table.files where files.partition.id=1" projects successfully against the current partition spec "id" to have a ManifestEvaluator looking for value 1.  It looks for this against all manifest-files, even those written with the old partition-spec "data".  This erroneously filters those old manifests where data is 1, and correctly filters new manifests where id is 1, giving wrong results.