### PR TITLE
Flink 1.13: Fix parquet readers for array data

### DIFF
--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
@@ -24,10 +24,12 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GenericArrayData;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RawValueData;
@@ -482,8 +484,10 @@ public class FlinkParquetReaders {
 
     @Override
     protected ArrayData buildList(ReusableArrayData list) {
-      list.setNumElements(writePos);
-      return list;
+      // Since ReusableArrayData is not accepted by Flink, use GenericArrayData temporarily to walk around it.
+      // Revert this to use ReusableArrayData once it is fixed in Flink.
+      // For your reference, https://issues.apache.org/jira/browse/FLINK-25238.
+      return new GenericArrayData(Arrays.copyOf(list.values, writePos));
     }
   }
 

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestHelpers.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/TestHelpers.java
@@ -27,7 +27,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -135,9 +134,7 @@ public class TestHelpers {
   }
 
   public static void assertRows(List<Row> results, List<Row> expected) {
-    expected.sort(Comparator.comparing(Row::toString));
-    results.sort(Comparator.comparing(Row::toString));
-    Assert.assertEquals(expected, results);
+    Assertions.assertThat(results).containsExactlyInAnyOrderElementsOf(expected);
   }
 
   public static void assertRowData(Schema schema, StructLike expected, RowData actual) {

--- a/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkScan.java
+++ b/flink/v1.13/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkScan.java
@@ -307,6 +307,19 @@ public abstract class TestFlinkScan {
     TestHelpers.assertRecords(run(), records, typesSchema);
   }
 
+  @Test
+  public void testCustomizedFlinkDataTypes() throws Exception {
+    Schema schema = new Schema(
+        Types.NestedField.required(
+            1, "map", Types.MapType.ofRequired(2, 3, Types.StringType.get(), Types.StringType.get())),
+        Types.NestedField.required(4, "arr", Types.ListType.ofRequired(5, Types.StringType.get())));
+    Table table = catalog.createTable(TestFixtures.TABLE_IDENTIFIER, schema);
+    List<Record> records = RandomGenericData.generate(schema, 10, 0L);
+    GenericAppenderHelper helper = new GenericAppenderHelper(table, fileFormat, TEMPORARY_FOLDER);
+    helper.appendToTable(records);
+    TestHelpers.assertRecords(run(), records, schema);
+  }
+
   private static void assertRows(List<Row> results, Row... expected) {
     TestHelpers.assertRows(results, Arrays.asList(expected));
   }


### PR DESCRIPTION
Apply fixing #4432 to Flink version 1.13