### PR TITLE
Flink: Clear the deprecated FlinkSink#build.

### DIFF
--- a/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.12/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -313,18 +313,6 @@ public class FlinkSink {
      * Append the iceberg sink operators to write records to iceberg table.
      *
      * @return {@link DataStreamSink} for sink.
-     * @deprecated this will be removed in 0.14.0; use {@link #append()} because its returned {@link DataStreamSink}
-     * has a more correct data type.
-     */
-    @Deprecated
-    public DataStreamSink<RowData> build() {
-      return chainIcebergOperators();
-    }
-
-    /**
-     * Append the iceberg sink operators to write records to iceberg table.
-     *
-     * @return {@link DataStreamSink} for sink.
      */
     public DataStreamSink<Void> append() {
       return chainIcebergOperators();

--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -313,18 +313,6 @@ public class FlinkSink {
      * Append the iceberg sink operators to write records to iceberg table.
      *
      * @return {@link DataStreamSink} for sink.
-     * @deprecated this will be removed in 0.14.0; use {@link #append()} because its returned {@link DataStreamSink}
-     * has a more correct data type.
-     */
-    @Deprecated
-    public DataStreamSink<RowData> build() {
-      return chainIcebergOperators();
-    }
-
-    /**
-     * Append the iceberg sink operators to write records to iceberg table.
-     *
-     * @return {@link DataStreamSink} for sink.
      */
     public DataStreamSink<Void> append() {
       return chainIcebergOperators();

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -334,18 +334,6 @@ public class FlinkSink {
      * Append the iceberg sink operators to write records to iceberg table.
      *
      * @return {@link DataStreamSink} for sink.
-     * @deprecated this will be removed in 0.14.0; use {@link #append()} because its returned {@link DataStreamSink}
-     * has a more correct data type.
-     */
-    @Deprecated
-    public DataStreamSink<RowData> build() {
-      return chainIcebergOperators();
-    }
-
-    /**
-     * Append the iceberg sink operators to write records to iceberg table.
-     *
-     * @return {@link DataStreamSink} for sink.
      */
     public DataStreamSink<Void> append() {
       return chainIcebergOperators();


### PR DESCRIPTION
Just clear the deprecated `FlinkSink#build` among flink versions.