### PR TITLE
iceberg v2 table changelog streaming read feature support

### DIFF
--- a/api/src/main/java/org/apache/iceberg/TableScan.java
+++ b/api/src/main/java/org/apache/iceberg/TableScan.java
@@ -87,6 +87,14 @@ public interface TableScan {
   TableScan caseSensitive(boolean caseSensitive);
 
   /**
+   * Create a new {@link TableScan} from this, used in incremental changLog scan
+   *
+   * @param streaming whether it is a streaming scan
+   * @return a new streaming scan
+   */
+  TableScan streaming(boolean streaming);
+
+  /**
    * Create a new {@link TableScan} from this that loads the column stats with each data file.
    * <p>
    * Column stats include: value count, null value count, lower bounds, and upper bounds.
@@ -218,6 +226,12 @@ public interface TableScan {
    * @return true if case sensitive, false otherwise.
    */
   boolean isCaseSensitive();
+
+  /**
+   * Returns whether this is a streaming scan  {@link #isStreaming()} (boolean)}.
+   * @return true if it is a streaming scan, false otherwise.
+   */
+  boolean isStreaming();
 
   /**
    * Returns the target split size for this scan.

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -157,6 +157,12 @@ abstract class BaseTableScan implements TableScan {
   }
 
   @Override
+  public TableScan streaming(boolean streaming) {
+    return newRefinedScan(
+            ops, table, schema, context.setStreaming(streaming));
+  }
+
+  @Override
   public TableScan includeColumnStats() {
     return newRefinedScan(
         ops, table, schema, context.shouldReturnColumnStats(true));
@@ -209,6 +215,7 @@ abstract class BaseTableScan implements TableScan {
   public CloseableIterable<CombinedScanTask> planTasks() {
     CloseableIterable<FileScanTask> fileScanTasks = planFiles();
     CloseableIterable<FileScanTask> splitFiles = TableScanUtil.splitFiles(fileScanTasks, targetSplitSize());
+
     return TableScanUtil.planTasks(splitFiles, targetSplitSize(), splitLookback(), splitOpenFileCost());
   }
 
@@ -243,6 +250,11 @@ abstract class BaseTableScan implements TableScan {
   @Override
   public boolean isCaseSensitive() {
     return context.caseSensitive();
+  }
+
+  @Override
+  public boolean isStreaming() {
+    return context.streaming();
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
@@ -74,9 +74,10 @@ class IncrementalDataTableScan extends DataTableScan {
     Set<Long> snapshotIds = Sets.newHashSet(Iterables.transform(snapshots, Snapshot::snapshotId));
     Set<ManifestFile> manifests = FluentIterable
         .from(snapshots)
-        .transformAndConcat(Snapshot::dataManifests)
+        .transformAndConcat(Snapshot::allManifests)
         .filter(manifestFile -> snapshotIds.contains(manifestFile.snapshotId()))
         .toSet();
+
 
     ManifestGroup manifestGroup = new ManifestGroup(tableOps().io(), manifests)
         .caseSensitive(isCaseSensitive())
@@ -87,7 +88,9 @@ class IncrementalDataTableScan extends DataTableScan {
                 snapshotIds.contains(manifestEntry.snapshotId()) &&
                 manifestEntry.status() == ManifestEntry.Status.ADDED)
         .specsById(tableOps().current().specsById())
-        .ignoreDeleted();
+        .ignoreDeleted()
+        .streaming(isStreaming())
+        .table(table());
 
     if (shouldIgnoreResiduals()) {
       manifestGroup = manifestGroup.ignoreResiduals();
@@ -114,12 +117,8 @@ class IncrementalDataTableScan extends DataTableScan {
     List<Snapshot> snapshots = Lists.newArrayList();
     for (Snapshot snapshot : SnapshotUtil.ancestorsBetween(toSnapshotId, fromSnapshotId, table::snapshot)) {
       // for now, incremental scan supports only appends
-      if (snapshot.operation().equals(DataOperations.APPEND)) {
+      if (snapshot.operation().equals(DataOperations.APPEND) || snapshot.operation().equals(DataOperations.OVERWRITE)) {
         snapshots.add(snapshot);
-      } else if (snapshot.operation().equals(DataOperations.OVERWRITE)) {
-        throw new UnsupportedOperationException(
-            String.format("Found %s operation, cannot support incremental data in snapshots (%s, %s]",
-                DataOperations.OVERWRITE, fromSnapshotId, toSnapshotId));
       }
     }
     return snapshots;

--- a/core/src/main/java/org/apache/iceberg/ManifestGroup.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestGroup.java
@@ -23,7 +23,6 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
@@ -37,15 +36,17 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ParallelIterable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class ManifestGroup {
   private static final Types.StructType EMPTY_STRUCT = Types.StructType.of();
+  private static final Logger LOG = LoggerFactory.getLogger(ManifestGroup.class);
 
   private final FileIO io;
-  private final Set<ManifestFile> dataManifests;
+  private final List<ManifestFile> dataManifests;
   private final DeleteFileIndex.Builder deleteIndexBuilder;
   private Predicate<ManifestFile> manifestPredicate;
   private Predicate<ManifestEntry<DataFile>> manifestEntryPredicate;
@@ -58,6 +59,8 @@ class ManifestGroup {
   private boolean ignoreResiduals;
   private List<String> columns;
   private boolean caseSensitive;
+  private boolean streaming;
+  private Table table;
   private ExecutorService executorService;
 
   ManifestGroup(FileIO io, Iterable<ManifestFile> manifests) {
@@ -68,7 +71,7 @@ class ManifestGroup {
 
   ManifestGroup(FileIO io, Iterable<ManifestFile> dataManifests, Iterable<ManifestFile> deleteManifests) {
     this.io = io;
-    this.dataManifests = Sets.newHashSet(dataManifests);
+    this.dataManifests = Lists.newArrayList(dataManifests);
     this.deleteIndexBuilder = DeleteFileIndex.builderFor(io, deleteManifests);
     this.dataFilter = Expressions.alwaysTrue();
     this.fileFilter = Expressions.alwaysTrue();
@@ -78,6 +81,7 @@ class ManifestGroup {
     this.ignoreResiduals = false;
     this.columns = ManifestReader.ALL_COLUMNS;
     this.caseSensitive = true;
+    this.streaming = false;
     this.manifestPredicate = m -> true;
     this.manifestEntryPredicate = e -> true;
   }
@@ -141,6 +145,35 @@ class ManifestGroup {
     return this;
   }
 
+  ManifestGroup streaming(boolean newStreaming) {
+    this.streaming = newStreaming;
+    return this;
+  }
+
+  ManifestGroup table(Table tab) {
+    this.table = tab;
+    return this;
+  }
+
+  private ManifestFile tmpManifestFile() {
+    PartitionSpec spec = table.spec();
+    Snapshot currentSnapshot = table.currentSnapshot();
+    return new GenericManifestFile("tmpManifest.avro", 1, spec.specId(), ManifestContent.DATA,
+            currentSnapshot.sequenceNumber(), -1, currentSnapshot.snapshotId(),
+            1, 0, 0, 0, 0,
+            0, null, null);
+  }
+
+  private DataFile tmpDataFile() {
+    PartitionSpec spec = table.spec();
+    DataFile tmpFile = DataFiles.builder(spec)
+            .withPath("tmpData.parquet")
+            .withFileSizeInBytes(1)
+            .withRecordCount(0)
+            .build();
+    return tmpFile;
+  }
+
   ManifestGroup planWith(ExecutorService newExecutorService) {
     this.executorService = newExecutorService;
     deleteIndexBuilder.planWith(newExecutorService);
@@ -161,6 +194,11 @@ class ManifestGroup {
     });
 
     DeleteFileIndex deleteFiles = deleteIndexBuilder.build();
+    if (streaming && deleteFiles.forEmptyDataFile().length == 0) {
+      // no equality delete files in the current snapshot
+      LOG.info("no deleteFiles.");
+      streaming = false;
+    }
 
     boolean dropStats = ManifestReader.dropStats(dataFilter, columns);
     if (!deleteFiles.isEmpty()) {
@@ -189,6 +227,16 @@ class ManifestGroup {
     }
   }
 
+  private Evaluator getFileEvaluator() {
+    Evaluator evaluator;
+    if (fileFilter != null && fileFilter != Expressions.alwaysTrue()) {
+      evaluator = new Evaluator(DataFile.getType(EMPTY_STRUCT), fileFilter, caseSensitive);
+    } else {
+      evaluator = null;
+    }
+    return evaluator;
+  }
+
  /**
    * Returns an iterable for manifest entries in the set of manifests.
    * <p>
@@ -211,11 +259,13 @@ class ManifestGroup {
               spec, caseSensitive);
         });
 
-    Evaluator evaluator;
-    if (fileFilter != null && fileFilter != Expressions.alwaysTrue()) {
-      evaluator = new Evaluator(DataFile.getType(EMPTY_STRUCT), fileFilter, caseSensitive);
-    } else {
-      evaluator = null;
+    Evaluator evaluator = getFileEvaluator();
+
+    if (streaming) {
+      // use a tmpManifest to construct fileScanTask which contains equality delete files only
+      ManifestFile tmpManifest = tmpManifestFile();
+      // place the constructed manifest at first to ensure this task always emit first
+      dataManifests.add(0, tmpManifest);
     }
 
     Iterable<ManifestFile> matchingManifests = evalCache == null ? dataManifests :
@@ -242,28 +292,37 @@ class ManifestGroup {
     return Iterables.transform(
         matchingManifests,
         manifest -> {
-          ManifestReader<DataFile> reader = ManifestFiles.read(manifest, io, specsById)
-              .filterRows(dataFilter)
-              .filterPartitions(partitionFilter)
-              .caseSensitive(caseSensitive)
-              .select(columns);
+          CloseableIterable<ManifestEntry<DataFile>> entries;
+          if (manifest.addedRowsCount() == 0) {
+            GenericManifestEntry<DataFile> tmpManifestEntry = new GenericManifestEntry<>(table.spec().partitionType());
+            tmpManifestEntry.wrapAppend(table.currentSnapshot().snapshotId(), table.currentSnapshot().sequenceNumber(),
+                    tmpDataFile());
+            entries = CloseableIterable.withNoopClose(tmpManifestEntry);
+          } else {
+            ManifestReader<DataFile> reader = ManifestFiles.read(manifest, io, specsById)
+                    .filterRows(dataFilter)
+                    .filterPartitions(partitionFilter)
+                    .caseSensitive(caseSensitive)
+                    .select(columns);
 
-          CloseableIterable<ManifestEntry<DataFile>> entries = reader.entries();
-          if (ignoreDeleted) {
-            entries = reader.liveEntries();
+            entries = reader.entries();
+            if (ignoreDeleted) {
+              entries = reader.liveEntries();
+            }
+
+            if (ignoreExisting) {
+              entries = CloseableIterable.filter(entries,
+                      entry -> entry.status() != ManifestEntry.Status.EXISTING);
+            }
+
+            if (evaluator != null) {
+              entries = CloseableIterable.filter(entries,
+                      entry -> evaluator.eval((GenericDataFile) entry.file()));
+            }
+
+            entries = CloseableIterable.filter(entries, manifestEntryPredicate);
           }
 
-          if (ignoreExisting) {
-            entries = CloseableIterable.filter(entries,
-                entry -> entry.status() != ManifestEntry.Status.EXISTING);
-          }
-
-          if (evaluator != null) {
-            entries = CloseableIterable.filter(entries,
-                entry -> evaluator.eval((GenericDataFile) entry.file()));
-          }
-
-          entries = CloseableIterable.filter(entries, manifestEntryPredicate);
           return entryFn.apply(manifest, entries);
         });
   }

--- a/core/src/main/java/org/apache/iceberg/TableScanContext.java
+++ b/core/src/main/java/org/apache/iceberg/TableScanContext.java
@@ -44,6 +44,7 @@ final class TableScanContext {
   private final Long fromSnapshotId;
   private final Long toSnapshotId;
   private final ExecutorService planExecutor;
+  private final boolean streaming;
 
   TableScanContext() {
     this.snapshotId = null;
@@ -57,12 +58,14 @@ final class TableScanContext {
     this.fromSnapshotId = null;
     this.toSnapshotId = null;
     this.planExecutor = null;
+    this.streaming = false;
   }
 
   private TableScanContext(Long snapshotId, Expression rowFilter, boolean ignoreResiduals,
                            boolean caseSensitive, boolean colStats, Schema projectedSchema,
                            Collection<String> selectedColumns, ImmutableMap<String, String> options,
-                           Long fromSnapshotId, Long toSnapshotId, ExecutorService planExecutor) {
+                           Long fromSnapshotId, Long toSnapshotId, ExecutorService planExecutor,
+                           boolean isStreaming) {
     this.snapshotId = snapshotId;
     this.rowFilter = rowFilter;
     this.ignoreResiduals = ignoreResiduals;
@@ -74,6 +77,7 @@ final class TableScanContext {
     this.fromSnapshotId = fromSnapshotId;
     this.toSnapshotId = toSnapshotId;
     this.planExecutor = planExecutor;
+    this.streaming = isStreaming;
   }
 
   Long snapshotId() {
@@ -83,7 +87,7 @@ final class TableScanContext {
   TableScanContext useSnapshotId(Long scanSnapshotId) {
     return new TableScanContext(scanSnapshotId, rowFilter, ignoreResiduals,
         caseSensitive, colStats, projectedSchema, selectedColumns, options, fromSnapshotId, toSnapshotId,
-        planExecutor);
+        planExecutor, streaming);
   }
 
   Expression rowFilter() {
@@ -93,7 +97,7 @@ final class TableScanContext {
   TableScanContext filterRows(Expression filter) {
     return new TableScanContext(snapshotId, filter, ignoreResiduals,
         caseSensitive, colStats, projectedSchema, selectedColumns, options, fromSnapshotId, toSnapshotId,
-        planExecutor);
+        planExecutor, streaming);
   }
 
   boolean ignoreResiduals() {
@@ -103,7 +107,7 @@ final class TableScanContext {
   TableScanContext ignoreResiduals(boolean shouldIgnoreResiduals) {
     return new TableScanContext(snapshotId, rowFilter, shouldIgnoreResiduals,
         caseSensitive, colStats, projectedSchema, selectedColumns, options, fromSnapshotId, toSnapshotId,
-        planExecutor);
+        planExecutor, streaming);
   }
 
   boolean caseSensitive() {
@@ -113,7 +117,17 @@ final class TableScanContext {
   TableScanContext setCaseSensitive(boolean isCaseSensitive) {
     return new TableScanContext(snapshotId, rowFilter, ignoreResiduals,
         isCaseSensitive, colStats, projectedSchema, selectedColumns, options, fromSnapshotId, toSnapshotId,
-        planExecutor);
+        planExecutor, streaming);
+  }
+
+  boolean streaming() {
+    return streaming;
+  }
+
+  TableScanContext setStreaming(boolean isStreaming) {
+    return new TableScanContext(snapshotId, rowFilter, ignoreResiduals,
+            caseSensitive, colStats, projectedSchema, selectedColumns, options, fromSnapshotId, toSnapshotId,
+            planExecutor, isStreaming);
   }
 
   boolean returnColumnStats() {
@@ -123,7 +137,7 @@ final class TableScanContext {
   TableScanContext shouldReturnColumnStats(boolean returnColumnStats) {
     return new TableScanContext(snapshotId, rowFilter, ignoreResiduals,
         caseSensitive, returnColumnStats, projectedSchema, selectedColumns, options, fromSnapshotId, toSnapshotId,
-        planExecutor);
+        planExecutor, streaming);
   }
 
   Collection<String> selectedColumns() {
@@ -134,7 +148,7 @@ final class TableScanContext {
     Preconditions.checkState(projectedSchema == null, "Cannot select columns when projection schema is set");
     return new TableScanContext(snapshotId, rowFilter, ignoreResiduals,
         caseSensitive, colStats, null, columns, options, fromSnapshotId, toSnapshotId,
-        planExecutor);
+        planExecutor, streaming);
   }
 
   Schema projectedSchema() {
@@ -145,7 +159,7 @@ final class TableScanContext {
     Preconditions.checkState(selectedColumns == null, "Cannot set projection schema when columns are selected");
     return new TableScanContext(snapshotId, rowFilter, ignoreResiduals,
         caseSensitive, colStats, schema, null, options, fromSnapshotId, toSnapshotId,
-        planExecutor);
+        planExecutor, streaming);
   }
 
   Map<String, String> options() {
@@ -158,7 +172,7 @@ final class TableScanContext {
     builder.put(property, value);
     return new TableScanContext(snapshotId, rowFilter, ignoreResiduals,
         caseSensitive, colStats, projectedSchema, selectedColumns, builder.build(), fromSnapshotId, toSnapshotId,
-        planExecutor);
+        planExecutor, streaming);
   }
 
   Long fromSnapshotId() {
@@ -168,7 +182,7 @@ final class TableScanContext {
   TableScanContext fromSnapshotId(long id) {
     return new TableScanContext(snapshotId, rowFilter, ignoreResiduals,
         caseSensitive, colStats, projectedSchema, selectedColumns, options, id, toSnapshotId,
-        planExecutor);
+        planExecutor, streaming);
   }
 
   Long toSnapshotId() {
@@ -178,7 +192,7 @@ final class TableScanContext {
   TableScanContext toSnapshotId(long id) {
     return new TableScanContext(snapshotId, rowFilter, ignoreResiduals,
         caseSensitive, colStats, projectedSchema, selectedColumns, options, fromSnapshotId, id,
-        planExecutor);
+        planExecutor, streaming);
   }
 
   ExecutorService planExecutor() {
@@ -192,6 +206,6 @@ final class TableScanContext {
   TableScanContext planWith(ExecutorService executor) {
     return new TableScanContext(snapshotId, rowFilter, ignoreResiduals,
         caseSensitive, colStats, projectedSchema, selectedColumns, options, fromSnapshotId, toSnapshotId,
-        executor);
+        executor, streaming);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/encryption/InputFilesDecryptor.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/InputFilesDecryptor.java
@@ -21,9 +21,12 @@ package org.apache.iceberg.encryption;
 
 import java.nio.ByteBuffer;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
@@ -53,6 +56,15 @@ public class InputFilesDecryptor {
   public InputFile getInputFile(FileScanTask task) {
     Preconditions.checkArgument(!task.isDataTask(), "Invalid task type");
     return decryptedInputFiles.get(task.file().path().toString());
+  }
+
+  public List<InputFile> getEqDeleteInputFile(FileScanTask task) {
+    Preconditions.checkArgument(!task.isDataTask(), "Invalid task type");
+    return task.deletes()
+            .stream()
+            .filter(file -> file.content().equals(FileContent.EQUALITY_DELETES))
+            .map(e -> decryptedInputFiles.get(e.path().toString()))
+            .collect(Collectors.toList());
   }
 
   public InputFile getInputFile(String location) {

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/data/RowDataProjection.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/data/RowDataProjection.java
@@ -137,6 +137,12 @@ public class RowDataProjection implements RowData {
     return this;
   }
 
+  public RowData wrapDelete(RowData row) {
+    row.setRowKind(RowKind.DELETE);
+    this.rowData = row;
+    return this;
+  }
+
   private Object getValue(int pos) {
     return getters[pos].getFieldOrNull(rowData);
   }

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/FileScanTaskReader.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/FileScanTaskReader.java
@@ -33,4 +33,5 @@ import org.apache.iceberg.io.CloseableIterator;
 @Internal
 public interface FileScanTaskReader<T> extends Serializable {
   CloseableIterator<T> open(FileScanTask fileScanTask, InputFilesDecryptor inputFilesDecryptor);
+  CloseableIterator<T> openDelete(FileScanTask fileScanTask, InputFilesDecryptor inputFilesDecryptor);
 }

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitPlanner.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitPlanner.java
@@ -94,6 +94,10 @@ public class FlinkSplitPlanner {
       scan = scan.asOfTime(context.asOfTimestamp());
     }
 
+    if (context.isStreaming()) {
+      scan = scan.streaming(true);
+    }
+
     if (context.startSnapshotId() != null) {
       if (context.endSnapshotId() != null) {
         scan = scan.appendsBetween(context.startSnapshotId(), context.endSnapshotId());

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/StreamingReaderOperator.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/StreamingReaderOperator.java
@@ -142,6 +142,7 @@ public class StreamingReaderOperator extends AbstractStreamOperator<RowData>
 
   private void processSplits() throws IOException {
     FlinkInputSplit split = splits.poll();
+    LOG.info("A new FlinkInputSplit: {}.", split);
     if (split == null) {
       currentSplitState = SplitState.IDLE;
       return;
@@ -152,6 +153,7 @@ public class StreamingReaderOperator extends AbstractStreamOperator<RowData>
       RowData nextElement = null;
       while (!format.reachedEnd()) {
         nextElement = format.nextRecord(nextElement);
+        LOG.info("A new element: {}.", nextElement);
         sourceContext.collect(nextElement);
       }
     } finally {


### PR DESCRIPTION
This pr support streaming read iceberg changelog by flink and is inherited from PR 3095, it is tested in flink 1.14 and works fine