### PR TITLE
Add a new TableScan#appendInRange method that accepts nullable fromSn…

### DIFF
--- a/api/src/main/java/org/apache/iceberg/TableScan.java
+++ b/api/src/main/java/org/apache/iceberg/TableScan.java
@@ -147,8 +147,25 @@ public interface TableScan {
    * @param toSnapshotId read append data up to this snapshot id
    * @return a table scan which can read append data from {@code fromSnapshotId}
    * exclusive and up to {@code toSnapshotId} inclusive
+   *
+   * @deprecated Please use the appendsBetween with non-primitive fromSnapshotId of Long type
    */
-  TableScan appendsBetween(long fromSnapshotId, long toSnapshotId);
+  @Deprecated
+  default TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
+    return appendsBetween(Long.valueOf(fromSnapshotId), toSnapshotId);
+  }
+
+  /**
+   * Create a new {@link TableScan} to read appended data from {@code fromSnapshotId} exclusive to {@code toSnapshotId}
+   * inclusive.
+   *
+   * @param fromSnapshotId the last snapshot id read by the user, exclusive. If it is null,
+   *                       all the ancestor snapshots of the toSnapshotId should be discovered
+   * @param toSnapshotId read append data up to this snapshot id
+   * @return a table scan which can read append data from {@code fromSnapshotId}
+   * exclusive and up to {@code toSnapshotId} inclusive
+   */
+  TableScan appendsBetween(Long fromSnapshotId, long toSnapshotId);
 
   /**
    * Create a new {@link TableScan} to read appended data from {@code fromSnapshotId} exclusive to the current snapshot

--- a/api/src/main/java/org/apache/iceberg/TableScan.java
+++ b/api/src/main/java/org/apache/iceberg/TableScan.java
@@ -152,7 +152,7 @@ public interface TableScan {
    */
   @Deprecated
   default TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
-    return appendsBetween(Long.valueOf(fromSnapshotId), toSnapshotId);
+    return appendsInRange(Long.valueOf(fromSnapshotId), toSnapshotId);
   }
 
   /**
@@ -165,7 +165,7 @@ public interface TableScan {
    * @return a table scan which can read append data from {@code fromSnapshotId}
    * exclusive and up to {@code toSnapshotId} inclusive
    */
-  TableScan appendsBetween(Long fromSnapshotId, long toSnapshotId);
+  TableScan appendsInRange(Long fromSnapshotId, long toSnapshotId);
 
   /**
    * Create a new {@link TableScan} to read appended data from {@code fromSnapshotId} exclusive to the current snapshot

--- a/api/src/main/java/org/apache/iceberg/events/IncrementalTableScanEvent.java
+++ b/api/src/main/java/org/apache/iceberg/events/IncrementalTableScanEvent.java
@@ -24,19 +24,16 @@ import org.apache.iceberg.expressions.Expression;
 
 /**
  * Event sent to listeners when an incremental table scan is planned.
- *
- * @deprecated by {@link IncrementalTableScanEvent}
  */
-@Deprecated
-public final class IncrementalScanEvent {
+public final class IncrementalTableScanEvent {
   private final String tableName;
-  private final long fromSnapshotId;
+  private final Long fromSnapshotId;
   private final long toSnapshotId;
   private final Expression filter;
   private final Schema projection;
 
-  public IncrementalScanEvent(String tableName, long fromSnapshotId, long toSnapshotId, Expression filter,
-                              Schema projection) {
+  public IncrementalTableScanEvent(String tableName, Long fromSnapshotId, long toSnapshotId, Expression filter,
+                                   Schema projection) {
     this.tableName = tableName;
     this.fromSnapshotId = fromSnapshotId;
     this.toSnapshotId = toSnapshotId;
@@ -48,7 +45,7 @@ public final class IncrementalScanEvent {
     return tableName;
   }
 
-  public long fromSnapshotId() {
+  public Long fromSnapshotId() {
     return fromSnapshotId;
   }
 

--- a/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
@@ -40,7 +40,7 @@ abstract class BaseAllMetadataTableScan extends BaseMetadataTableScan {
   protected abstract String tableType();
 
   @Override
-  public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
+  public TableScan appendsBetween(Long fromSnapshotId, long toSnapshotId) {
     throw new UnsupportedOperationException(
         String.format("Cannot incrementally scan table of type %s", tableType()));
   }

--- a/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseAllMetadataTableScan.java
@@ -40,7 +40,7 @@ abstract class BaseAllMetadataTableScan extends BaseMetadataTableScan {
   protected abstract String tableType();
 
   @Override
-  public TableScan appendsBetween(Long fromSnapshotId, long toSnapshotId) {
+  public TableScan appendsInRange(Long fromSnapshotId, long toSnapshotId) {
     throw new UnsupportedOperationException(
         String.format("Cannot incrementally scan table of type %s", tableType()));
   }

--- a/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
@@ -77,7 +77,7 @@ abstract class BaseFilesTable extends BaseMetadataTable {
     }
 
     @Override
-    public TableScan appendsBetween(Long fromSnapshotId, long toSnapshotId) {
+    public TableScan appendsInRange(Long fromSnapshotId, long toSnapshotId) {
       throw new UnsupportedOperationException(
           String.format("Cannot incrementally scan table of type %s", type.name()));
     }

--- a/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFilesTable.java
@@ -77,7 +77,7 @@ abstract class BaseFilesTable extends BaseMetadataTable {
     }
 
     @Override
-    public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
+    public TableScan appendsBetween(Long fromSnapshotId, long toSnapshotId) {
       throw new UnsupportedOperationException(
           String.format("Cannot incrementally scan table of type %s", type.name()));
     }

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -106,7 +106,7 @@ abstract class BaseTableScan implements TableScan {
   }
 
   @Override
-  public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
+  public TableScan appendsBetween(Long fromSnapshotId, long toSnapshotId) {
     throw new UnsupportedOperationException("Incremental scan is not supported");
   }
 

--- a/core/src/main/java/org/apache/iceberg/BaseTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTableScan.java
@@ -106,7 +106,7 @@ abstract class BaseTableScan implements TableScan {
   }
 
   @Override
-  public TableScan appendsBetween(Long fromSnapshotId, long toSnapshotId) {
+  public TableScan appendsInRange(Long fromSnapshotId, long toSnapshotId) {
     throw new UnsupportedOperationException("Incremental scan is not supported");
   }
 

--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -47,7 +47,7 @@ public class DataTableScan extends BaseTableScan {
   }
 
   @Override
-  public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
+  public TableScan appendsBetween(Long fromSnapshotId, long toSnapshotId) {
     Long scanSnapshotId = snapshotId();
     Preconditions.checkState(scanSnapshotId == null,
         "Cannot enable incremental scan, scan-snapshot set to id=%s", scanSnapshotId);
@@ -60,7 +60,7 @@ public class DataTableScan extends BaseTableScan {
     Snapshot currentSnapshot = table().currentSnapshot();
     Preconditions.checkState(currentSnapshot != null, "Cannot scan appends after %s, there is no current snapshot",
         fromSnapshotId);
-    return appendsBetween(fromSnapshotId, currentSnapshot.snapshotId());
+    return appendsBetween(Long.valueOf(fromSnapshotId), currentSnapshot.snapshotId());
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -47,7 +47,7 @@ public class DataTableScan extends BaseTableScan {
   }
 
   @Override
-  public TableScan appendsBetween(Long fromSnapshotId, long toSnapshotId) {
+  public TableScan appendsInRange(Long fromSnapshotId, long toSnapshotId) {
     Long scanSnapshotId = snapshotId();
     Preconditions.checkState(scanSnapshotId == null,
         "Cannot enable incremental scan, scan-snapshot set to id=%s", scanSnapshotId);
@@ -60,7 +60,7 @@ public class DataTableScan extends BaseTableScan {
     Snapshot currentSnapshot = table().currentSnapshot();
     Preconditions.checkState(currentSnapshot != null, "Cannot scan appends after %s, there is no current snapshot",
         fromSnapshotId);
-    return appendsBetween(Long.valueOf(fromSnapshotId), currentSnapshot.snapshotId());
+    return this.appendsInRange(Long.valueOf(fromSnapshotId), currentSnapshot.snapshotId());
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/DataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/DataTableScan.java
@@ -60,7 +60,7 @@ public class DataTableScan extends BaseTableScan {
     Snapshot currentSnapshot = table().currentSnapshot();
     Preconditions.checkState(currentSnapshot != null, "Cannot scan appends after %s, there is no current snapshot",
         fromSnapshotId);
-    return this.appendsInRange(Long.valueOf(fromSnapshotId), currentSnapshot.snapshotId());
+    return this.appendsInRange(fromSnapshotId, currentSnapshot.snapshotId());
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/IncrementalDataTableScan.java
@@ -65,7 +65,7 @@ class IncrementalDataTableScan extends DataTableScan {
     final Snapshot currentSnapshot = table().currentSnapshot();
     Preconditions.checkState(currentSnapshot != null,
         "Cannot scan appends after %s, there is no current snapshot", newFromSnapshotId);
-    return this.appendsInRange(Long.valueOf(newFromSnapshotId), currentSnapshot.snapshotId());
+    return this.appendsInRange(newFromSnapshotId, currentSnapshot.snapshotId());
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
@@ -81,7 +81,7 @@ public class ManifestEntriesTable extends BaseMetadataTable {
     }
 
     @Override
-    public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
+    public TableScan appendsBetween(Long fromSnapshotId, long toSnapshotId) {
       throw new UnsupportedOperationException(
           String.format("Cannot incrementally scan table of type %s", MetadataTableType.ENTRIES.name()));
     }

--- a/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestEntriesTable.java
@@ -81,7 +81,7 @@ public class ManifestEntriesTable extends BaseMetadataTable {
     }
 
     @Override
-    public TableScan appendsBetween(Long fromSnapshotId, long toSnapshotId) {
+    public TableScan appendsInRange(Long fromSnapshotId, long toSnapshotId) {
       throw new UnsupportedOperationException(
           String.format("Cannot incrementally scan table of type %s", MetadataTableType.ENTRIES.name()));
     }

--- a/core/src/main/java/org/apache/iceberg/StaticTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/StaticTableScan.java
@@ -42,7 +42,7 @@ class StaticTableScan extends BaseMetadataTableScan {
   }
 
   @Override
-  public TableScan appendsBetween(Long fromSnapshotId, long toSnapshotId) {
+  public TableScan appendsInRange(Long fromSnapshotId, long toSnapshotId) {
     throw new UnsupportedOperationException(
         String.format("Cannot incrementally scan table of type %s", tableType));
   }

--- a/core/src/main/java/org/apache/iceberg/StaticTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/StaticTableScan.java
@@ -42,7 +42,7 @@ class StaticTableScan extends BaseMetadataTableScan {
   }
 
   @Override
-  public TableScan appendsBetween(long fromSnapshotId, long toSnapshotId) {
+  public TableScan appendsBetween(Long fromSnapshotId, long toSnapshotId) {
     throw new UnsupportedOperationException(
         String.format("Cannot incrementally scan table of type %s", tableType));
   }

--- a/core/src/main/java/org/apache/iceberg/TableScanContext.java
+++ b/core/src/main/java/org/apache/iceberg/TableScanContext.java
@@ -165,7 +165,7 @@ final class TableScanContext {
     return fromSnapshotId;
   }
 
-  TableScanContext fromSnapshotId(long id) {
+  TableScanContext fromSnapshotId(Long id) {
     return new TableScanContext(snapshotId, rowFilter, ignoreResiduals,
         caseSensitive, colStats, projectedSchema, selectedColumns, options, id, toSnapshotId,
         planExecutor);

--- a/core/src/test/java/org/apache/iceberg/TestIncrementalDataTableScan.java
+++ b/core/src/test/java/org/apache/iceberg/TestIncrementalDataTableScan.java
@@ -69,11 +69,11 @@ public class TestIncrementalDataTableScan extends TableTestBase {
     AssertHelpers.assertThrows(
         "Check refinement api",
         IllegalArgumentException.class, "from snapshot id 1 not in existing snapshot ids range (2, 4]",
-        () -> table.newScan().appendsInRange(Long.valueOf(2L), 5L).appendsInRange(Long.valueOf(1L), 4L));
+        () -> table.newScan().appendsInRange(2L, 5L).appendsInRange(1L, 4L));
     AssertHelpers.assertThrows(
         "Check refinement api",
         IllegalArgumentException.class, "to snapshot id 3 not in existing snapshot ids range (1, 2]",
-        () -> table.newScan().appendsInRange(Long.valueOf(1L), 2L).appendsInRange(Long.valueOf(1L), 3L));
+        () -> table.newScan().appendsInRange(1L, 2L).appendsInRange(1L, 3L));
   }
 
   @Test
@@ -214,7 +214,7 @@ public class TestIncrementalDataTableScan extends TableTestBase {
 
     TableScan scan1 = table.newScan()
         .filter(Expressions.equal("id", 5))
-        .appendsInRange(Long.valueOf(1L), 3L);
+        .appendsInRange(1L, 3L);
 
     try (CloseableIterable<CombinedScanTask> tasks = scan1.planTasks()) {
       Assert.assertTrue("Tasks should not be empty", com.google.common.collect.Iterables.size(tasks) > 0);
@@ -227,7 +227,7 @@ public class TestIncrementalDataTableScan extends TableTestBase {
 
     TableScan scan2 = table.newScan()
         .filter(Expressions.equal("id", 5))
-        .appendsInRange(Long.valueOf(1L), 3L)
+        .appendsInRange(1L, 3L)
         .ignoreResiduals();
 
     try (CloseableIterable<CombinedScanTask> tasks = scan2.planTasks()) {

--- a/core/src/test/java/org/apache/iceberg/TestIncrementalDataTableScan.java
+++ b/core/src/test/java/org/apache/iceberg/TestIncrementalDataTableScan.java
@@ -100,6 +100,9 @@ public class TestIncrementalDataTableScan extends TableTestBase {
 
     MyListener listener1 = new MyListener();
     Listeners.register(listener1, IncrementalTableScanEvent.class);
+    filesMatch(Lists.newArrayList("A", "B", "C", "D", "E"), appendsInRangeScan(null, 5));
+    Assert.assertNull(listener1.event().fromSnapshotId());
+    Assert.assertTrue(listener1.event().toSnapshotId() == 5);
     filesMatch(Lists.newArrayList("B", "C", "D", "E"), appendsBetweenScan(1, 5));
     Assert.assertTrue(listener1.event().fromSnapshotId() == 1);
     Assert.assertTrue(listener1.event().toSnapshotId() == 5);
@@ -307,6 +310,14 @@ public class TestIncrementalDataTableScan extends TableTestBase {
     Snapshot s1 = table.snapshot(fromSnapshotId);
     Snapshot s2 = table.snapshot(toSnapshotId);
     TableScan appendsBetween = table.newScan().appendsInRange(s1.snapshotId(), s2.snapshotId());
+    return filesToScan(appendsBetween);
+  }
+
+  /**
+   * Main difference with appendsBetweenScan above is that fromSnapshotId can be null
+   */
+  private List<String> appendsInRangeScan(Long fromSnapshotId, long toSnapshotId) {
+    TableScan appendsBetween = table.newScan().appendsInRange(fromSnapshotId, toSnapshotId);
     return filesToScan(appendsBetween);
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestIncrementalDataTableScan.java
+++ b/core/src/test/java/org/apache/iceberg/TestIncrementalDataTableScan.java
@@ -24,7 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.apache.iceberg.events.IncrementalScanEvent;
+import org.apache.iceberg.events.IncrementalTableScanEvent;
 import org.apache.iceberg.events.Listener;
 import org.apache.iceberg.events.Listeners;
 import org.apache.iceberg.expressions.Expressions;
@@ -60,7 +60,7 @@ public class TestIncrementalDataTableScan extends TableTestBase {
     AssertHelpers.assertThrows(
         "from and to snapshots cannot be the same, since from snapshot is exclusive and not part of the scan",
         IllegalArgumentException.class, "from and to snapshot ids cannot be the same",
-        () -> appendsBetweenScan(1, 1));
+        () -> appendsBetweenScan(1L, 1L));
 
     add(table.newAppend(), files("B"));
     add(table.newAppend(), files("C"));
@@ -69,11 +69,11 @@ public class TestIncrementalDataTableScan extends TableTestBase {
     AssertHelpers.assertThrows(
         "Check refinement api",
         IllegalArgumentException.class, "from snapshot id 1 not in existing snapshot ids range (2, 4]",
-        () -> table.newScan().appendsBetween(2, 5).appendsBetween(1, 4));
+        () -> table.newScan().appendsBetween(Long.valueOf(2L), 5L).appendsBetween(Long.valueOf(1L), 4L));
     AssertHelpers.assertThrows(
         "Check refinement api",
         IllegalArgumentException.class, "to snapshot id 3 not in existing snapshot ids range (1, 2]",
-        () -> table.newScan().appendsBetween(1, 2).appendsBetween(1, 3));
+        () -> table.newScan().appendsBetween(Long.valueOf(1L), 2L).appendsBetween(Long.valueOf(1L), 3L));
   }
 
   @Test
@@ -84,26 +84,29 @@ public class TestIncrementalDataTableScan extends TableTestBase {
     add(table.newAppend(), files("D"));
     add(table.newAppend(), files("E")); // 5
 
-    class MyListener implements Listener<IncrementalScanEvent> {
+    class MyListener implements Listener<IncrementalTableScanEvent> {
 
-      IncrementalScanEvent lastEvent = null;
+      IncrementalTableScanEvent lastEvent = null;
 
       @Override
-      public void notify(IncrementalScanEvent event) {
+      public void notify(IncrementalTableScanEvent event) {
         this.lastEvent = event;
       }
 
-      public IncrementalScanEvent event() {
+      public IncrementalTableScanEvent event() {
         return lastEvent;
       }
     }
 
     MyListener listener1 = new MyListener();
-    Listeners.register(listener1, IncrementalScanEvent.class);
-    filesMatch(Lists.newArrayList("B", "C", "D", "E"), appendsBetweenScan(1, 5));
+    Listeners.register(listener1, IncrementalTableScanEvent.class);
+    filesMatch(Lists.newArrayList("A", "B", "C", "D", "E"), appendsBetweenScan(null, 5L));
+    Assert.assertTrue(listener1.event().fromSnapshotId() == null);
+    Assert.assertTrue(listener1.event().toSnapshotId() == 5);
+    filesMatch(Lists.newArrayList("B", "C", "D", "E"), appendsBetweenScan(1L, 5L));
     Assert.assertTrue(listener1.event().fromSnapshotId() == 1);
     Assert.assertTrue(listener1.event().toSnapshotId() == 5);
-    filesMatch(Lists.newArrayList("C", "D", "E"), appendsBetweenScan(2, 5));
+    filesMatch(Lists.newArrayList("C", "D", "E"), appendsBetweenScan(2L, 5L));
     Assert.assertTrue(listener1.event().fromSnapshotId() == 2);
     Assert.assertTrue(listener1.event().toSnapshotId() == 5);
     Assert.assertEquals(table.schema(), listener1.event().projection());
@@ -118,29 +121,29 @@ public class TestIncrementalDataTableScan extends TableTestBase {
     add(table.newAppend(), files("C"));
     add(table.newAppend(), files("D"));
     add(table.newAppend(), files("E")); // 5
-    filesMatch(Lists.newArrayList("B", "C", "D", "E"), appendsBetweenScan(1, 5));
+    filesMatch(Lists.newArrayList("B", "C", "D", "E"), appendsBetweenScan(1L, 5L));
 
     replace(table.newRewrite(), files("A", "B", "C"), files("F", "G")); // 6
     // Replace commits are ignored
-    filesMatch(Lists.newArrayList("B", "C", "D", "E"), appendsBetweenScan(1, 6));
-    filesMatch(Lists.newArrayList("E"), appendsBetweenScan(4, 6));
+    filesMatch(Lists.newArrayList("B", "C", "D", "E"), appendsBetweenScan(1L, 6L));
+    filesMatch(Lists.newArrayList("E"), appendsBetweenScan(4L, 6L));
     // 6th snapshot is a replace. No new content is added
-    Assert.assertTrue("Replace commits are ignored", appendsBetweenScan(5, 6).isEmpty());
+    Assert.assertTrue("Replace commits are ignored", appendsBetweenScan(5L, 6L).isEmpty());
     delete(table.newDelete(), files("D")); // 7
     // 7th snapshot is a delete.
-    Assert.assertTrue("Replace and delete commits are ignored", appendsBetweenScan(5, 7).isEmpty());
-    Assert.assertTrue("Delete commits are ignored", appendsBetweenScan(6, 7).isEmpty());
+    Assert.assertTrue("Replace and delete commits are ignored", appendsBetweenScan(5L, 7L).isEmpty());
+    Assert.assertTrue("Delete commits are ignored", appendsBetweenScan(6L, 7L).isEmpty());
     add(table.newAppend(), files("I")); // 8
     // snapshots 6 and 7 are ignored
-    filesMatch(Lists.newArrayList("B", "C", "D", "E", "I"), appendsBetweenScan(1, 8));
-    filesMatch(Lists.newArrayList("I"), appendsBetweenScan(6, 8));
-    filesMatch(Lists.newArrayList("I"), appendsBetweenScan(7, 8));
+    filesMatch(Lists.newArrayList("B", "C", "D", "E", "I"), appendsBetweenScan(1L, 8L));
+    filesMatch(Lists.newArrayList("I"), appendsBetweenScan(6L, 8L));
+    filesMatch(Lists.newArrayList("I"), appendsBetweenScan(7L, 8L));
 
     overwrite(table.newOverwrite(), files("H"), files("E")); // 9
     AssertHelpers.assertThrows(
         "Overwrites are not supported for Incremental scan", UnsupportedOperationException.class,
         "Found overwrite operation, cannot support incremental data in snapshots (8, 9]",
-        () -> appendsBetweenScan(8, 9));
+        () -> appendsBetweenScan(8L, 9L));
   }
 
   @Test
@@ -153,31 +156,31 @@ public class TestIncrementalDataTableScan extends TableTestBase {
     add(transaction.newAppend(), files("D"));
     add(transaction.newAppend(), files("E")); // 5
     transaction.commitTransaction();
-    filesMatch(Lists.newArrayList("B", "C", "D", "E"), appendsBetweenScan(1, 5));
+    filesMatch(Lists.newArrayList("B", "C", "D", "E"), appendsBetweenScan(1L, 5L));
 
     transaction = table.newTransaction();
     replace(transaction.newRewrite(), files("A", "B", "C"), files("F", "G")); // 6
     transaction.commitTransaction();
     // Replace commits are ignored
-    filesMatch(Lists.newArrayList("B", "C", "D", "E"), appendsBetweenScan(1, 6));
-    filesMatch(Lists.newArrayList("E"), appendsBetweenScan(4, 6));
+    filesMatch(Lists.newArrayList("B", "C", "D", "E"), appendsBetweenScan(1L, 6L));
+    filesMatch(Lists.newArrayList("E"), appendsBetweenScan(4L, 6L));
     // 6th snapshot is a replace. No new content is added
-    Assert.assertTrue("Replace commits are ignored", appendsBetweenScan(5, 6).isEmpty());
+    Assert.assertTrue("Replace commits are ignored", appendsBetweenScan(5L, 6L).isEmpty());
 
     transaction = table.newTransaction();
     delete(transaction.newDelete(), files("D")); // 7
     transaction.commitTransaction();
     // 7th snapshot is a delete.
-    Assert.assertTrue("Replace and delete commits are ignored", appendsBetweenScan(5, 7).isEmpty());
-    Assert.assertTrue("Delete commits are ignored", appendsBetweenScan(6, 7).isEmpty());
+    Assert.assertTrue("Replace and delete commits are ignored", appendsBetweenScan(5L, 7L).isEmpty());
+    Assert.assertTrue("Delete commits are ignored", appendsBetweenScan(6L, 7L).isEmpty());
 
     transaction = table.newTransaction();
     add(transaction.newAppend(), files("I")); // 8
     transaction.commitTransaction();
     // snapshots 6, 7 and 8 are ignored
-    filesMatch(Lists.newArrayList("B", "C", "D", "E", "I"), appendsBetweenScan(1, 8));
-    filesMatch(Lists.newArrayList("I"), appendsBetweenScan(6, 8));
-    filesMatch(Lists.newArrayList("I"), appendsBetweenScan(7, 8));
+    filesMatch(Lists.newArrayList("B", "C", "D", "E", "I"), appendsBetweenScan(1L, 8L));
+    filesMatch(Lists.newArrayList("I"), appendsBetweenScan(6L, 8L));
+    filesMatch(Lists.newArrayList("I"), appendsBetweenScan(7L, 8L));
   }
 
   @Test
@@ -188,7 +191,7 @@ public class TestIncrementalDataTableScan extends TableTestBase {
     // Go back to snapshot "B"
     table.rollback().toSnapshotId(2).commit(); // 2
     Assert.assertEquals(2, table.currentSnapshot().snapshotId());
-    filesMatch(Lists.newArrayList("B"), appendsBetweenScan(1, 2));
+    filesMatch(Lists.newArrayList("B"), appendsBetweenScan(1L, 2L));
     filesMatch(Lists.newArrayList("B"), appendsAfterScan(1));
 
     Transaction transaction = table.newTransaction();
@@ -199,7 +202,7 @@ public class TestIncrementalDataTableScan extends TableTestBase {
     // Go back to snapshot "E"
     table.rollback().toSnapshotId(5).commit();
     Assert.assertEquals(5, table.currentSnapshot().snapshotId());
-    filesMatch(Lists.newArrayList("B", "D", "E"), appendsBetweenScan(1, 5));
+    filesMatch(Lists.newArrayList("B", "D", "E"), appendsBetweenScan(1L, 5));
     filesMatch(Lists.newArrayList("B", "D", "E"), appendsAfterScan(1));
   }
 
@@ -211,7 +214,7 @@ public class TestIncrementalDataTableScan extends TableTestBase {
 
     TableScan scan1 = table.newScan()
         .filter(Expressions.equal("id", 5))
-        .appendsBetween(1, 3);
+        .appendsBetween(Long.valueOf(1L), 3L);
 
     try (CloseableIterable<CombinedScanTask> tasks = scan1.planTasks()) {
       Assert.assertTrue("Tasks should not be empty", com.google.common.collect.Iterables.size(tasks) > 0);
@@ -224,7 +227,7 @@ public class TestIncrementalDataTableScan extends TableTestBase {
 
     TableScan scan2 = table.newScan()
         .filter(Expressions.equal("id", 5))
-        .appendsBetween(1, 3)
+        .appendsBetween(Long.valueOf(1L), 3L)
         .ignoreResiduals();
 
     try (CloseableIterable<CombinedScanTask> tasks = scan2.planTasks()) {
@@ -303,10 +306,8 @@ public class TestIncrementalDataTableScan extends TableTestBase {
     return filesToScan(appendsAfter);
   }
 
-  private List<String> appendsBetweenScan(long fromSnapshotId, long toSnapshotId) {
-    Snapshot s1 = table.snapshot(fromSnapshotId);
-    Snapshot s2 = table.snapshot(toSnapshotId);
-    TableScan appendsBetween = table.newScan().appendsBetween(s1.snapshotId(), s2.snapshotId());
+  private List<String> appendsBetweenScan(Long fromSnapshotId, long toSnapshotId) {
+    TableScan appendsBetween = table.newScan().appendsBetween(fromSnapshotId, toSnapshotId);
     return filesToScan(appendsBetween);
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestIncrementalDataTableScan.java
+++ b/core/src/test/java/org/apache/iceberg/TestIncrementalDataTableScan.java
@@ -69,11 +69,11 @@ public class TestIncrementalDataTableScan extends TableTestBase {
     AssertHelpers.assertThrows(
         "Check refinement api",
         IllegalArgumentException.class, "from snapshot id 1 not in existing snapshot ids range (2, 4]",
-        () -> table.newScan().appendsBetween(Long.valueOf(2L), 5L).appendsBetween(Long.valueOf(1L), 4L));
+        () -> table.newScan().appendsInRange(Long.valueOf(2L), 5L).appendsInRange(Long.valueOf(1L), 4L));
     AssertHelpers.assertThrows(
         "Check refinement api",
         IllegalArgumentException.class, "to snapshot id 3 not in existing snapshot ids range (1, 2]",
-        () -> table.newScan().appendsBetween(Long.valueOf(1L), 2L).appendsBetween(Long.valueOf(1L), 3L));
+        () -> table.newScan().appendsInRange(Long.valueOf(1L), 2L).appendsInRange(Long.valueOf(1L), 3L));
   }
 
   @Test
@@ -214,7 +214,7 @@ public class TestIncrementalDataTableScan extends TableTestBase {
 
     TableScan scan1 = table.newScan()
         .filter(Expressions.equal("id", 5))
-        .appendsBetween(Long.valueOf(1L), 3L);
+        .appendsInRange(Long.valueOf(1L), 3L);
 
     try (CloseableIterable<CombinedScanTask> tasks = scan1.planTasks()) {
       Assert.assertTrue("Tasks should not be empty", com.google.common.collect.Iterables.size(tasks) > 0);
@@ -227,7 +227,7 @@ public class TestIncrementalDataTableScan extends TableTestBase {
 
     TableScan scan2 = table.newScan()
         .filter(Expressions.equal("id", 5))
-        .appendsBetween(Long.valueOf(1L), 3L)
+        .appendsInRange(Long.valueOf(1L), 3L)
         .ignoreResiduals();
 
     try (CloseableIterable<CombinedScanTask> tasks = scan2.planTasks()) {
@@ -307,7 +307,7 @@ public class TestIncrementalDataTableScan extends TableTestBase {
   }
 
   private List<String> appendsBetweenScan(Long fromSnapshotId, long toSnapshotId) {
-    TableScan appendsBetween = table.newScan().appendsBetween(fromSnapshotId, toSnapshotId);
+    TableScan appendsBetween = table.newScan().appendsInRange(fromSnapshotId, toSnapshotId);
     return filesToScan(appendsBetween);
   }
 

--- a/data/src/main/java/org/apache/iceberg/data/IcebergGenerics.java
+++ b/data/src/main/java/org/apache/iceberg/data/IcebergGenerics.java
@@ -78,7 +78,7 @@ public class IcebergGenerics {
     }
 
     public ScanBuilder appendsBetween(long fromSnapshotId, long toSnapshotId) {
-      this.tableScan = tableScan.appendsBetween(Long.valueOf(fromSnapshotId), toSnapshotId);
+      this.tableScan = tableScan.appendsInRange(Long.valueOf(fromSnapshotId), toSnapshotId);
       return this;
     }
 

--- a/data/src/main/java/org/apache/iceberg/data/IcebergGenerics.java
+++ b/data/src/main/java/org/apache/iceberg/data/IcebergGenerics.java
@@ -78,7 +78,7 @@ public class IcebergGenerics {
     }
 
     public ScanBuilder appendsBetween(long fromSnapshotId, long toSnapshotId) {
-      this.tableScan = tableScan.appendsBetween(fromSnapshotId, toSnapshotId);
+      this.tableScan = tableScan.appendsBetween(Long.valueOf(fromSnapshotId), toSnapshotId);
       return this;
     }
 

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitPlanner.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitPlanner.java
@@ -96,10 +96,12 @@ public class FlinkSplitPlanner {
 
     if (context.startSnapshotId() != null) {
       if (context.endSnapshotId() != null) {
-        scan = scan.appendsBetween(context.startSnapshotId(), context.endSnapshotId());
+        scan = scan.appendsInRange(context.startSnapshotId(), context.endSnapshotId());
       } else {
         scan = scan.appendsAfter(context.startSnapshotId());
       }
+    } else {
+      scan = scan.appendsInRange(context.startSnapshotId(), context.endSnapshotId());
     }
 
     if (context.splitSize() != null) {

--- a/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitPlanner.java
+++ b/flink/v1.14/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitPlanner.java
@@ -94,14 +94,13 @@ public class FlinkSplitPlanner {
       scan = scan.asOfTime(context.asOfTimestamp());
     }
 
-    if (context.startSnapshotId() != null) {
-      if (context.endSnapshotId() != null) {
-        scan = scan.appendsInRange(context.startSnapshotId(), context.endSnapshotId());
-      } else {
+    if (context.endSnapshotId() != null) {
+      // null startSnapshotId is ok
+      scan = scan.appendsInRange(context.startSnapshotId(), context.endSnapshotId());
+    } else {
+      if (context.startSnapshotId() != null) {
         scan = scan.appendsAfter(context.startSnapshotId());
       }
-    } else {
-      scan = scan.appendsInRange(context.startSnapshotId(), context.endSnapshotId());
     }
 
     if (context.splitSize() != null) {

--- a/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
+++ b/flink/v1.14/flink/src/test/java/org/apache/iceberg/flink/SimpleDataUtil.java
@@ -275,7 +275,7 @@ public class SimpleDataUtil {
       TableScan tableScan = table.newScan();
       if (current.parentId() != null) {
         // Collect the data files that was added only in current snapshot.
-        tableScan = tableScan.appendsBetween(current.parentId(), current.snapshotId());
+        tableScan = tableScan.appendsInRange(current.parentId(), current.snapshotId());
       } else {
         // Collect the data files that was added in the oldest snapshot.
         tableScan = tableScan.useSnapshot(current.snapshotId());

--- a/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.2/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -189,7 +189,7 @@ public class SparkScanBuilder implements ScanBuilder, SupportsPushDownFilters, S
 
     if (startSnapshotId != null) {
       if (endSnapshotId != null) {
-        scan = scan.appendsBetween(startSnapshotId, endSnapshotId);
+        scan = scan.appendsInRange(startSnapshotId, endSnapshotId);
       } else {
         scan = scan.appendsAfter(startSnapshotId);
       }


### PR DESCRIPTION
…apshotId as Long type (instead of current primitive long).

There are two reasons to support null fromSnapshotId
- Support inclusive streaming starting strategy. We can simply pass in the parentId of the starting snapshot, which can be null
- Support incremental streaming scan for a empty table, where the fromSnapshotId could be null

This change is binary compatible. Old interfaces are marked as deprecated.