### PR TITLE
Flink 1.13: Inferred parallelism should respect global settings

### DIFF
--- a/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSource.java
+++ b/flink/v1.13/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSource.java
@@ -225,6 +225,9 @@ public class FlinkSource {
 
       if (!context.isStreaming()) {
         int parallelism = inferParallelism(format, context);
+        if (env.getMaxParallelism() > 0) {
+          parallelism = Math.min(parallelism, env.getMaxParallelism());
+        }
         return env.createInput(format, typeInfo).setParallelism(parallelism);
       } else {
         StreamingMonitorFunction function = new StreamingMonitorFunction(tableLoader, context);


### PR DESCRIPTION
apply #4531 to Flink 1.13