### PR TITLE
Core: do not allow setting fields nested in optional struct as identi…

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -1261,17 +1261,24 @@ public class TestSchemaUpdate {
   @Test
   public void testAddNestedIdentifierFieldColumns() {
     Schema newSchema = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
-        .setIdentifierFields("preferences.feature1")
+        .allowIncompatibleChanges()
+        .addRequiredColumn("required_struct", Types.StructType.of(
+            Types.NestedField.required(SCHEMA_LAST_COLUMN_ID + 2, "field", Types.StringType.get())
+        ))
+        .apply();
+
+    newSchema = new SchemaUpdate(newSchema, SCHEMA_LAST_COLUMN_ID + 2)
+        .setIdentifierFields("required_struct.field")
         .apply();
 
     Assert.assertEquals("set existing nested field as identifier should succeed",
-        Sets.newHashSet(newSchema.findField("preferences.feature1").fieldId()),
+        Sets.newHashSet(newSchema.findField("required_struct.field").fieldId()),
         newSchema.identifierFieldIds());
 
     newSchema = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
         .allowIncompatibleChanges()
         .addRequiredColumn("new", Types.StructType.of(
-            Types.NestedField.required(SCHEMA_LAST_COLUMN_ID + 1, "field", Types.StringType.get())
+            Types.NestedField.required(SCHEMA_LAST_COLUMN_ID + 2, "field", Types.StringType.get())
         ))
         .setIdentifierFields("new.field")
         .apply();
@@ -1283,8 +1290,8 @@ public class TestSchemaUpdate {
     newSchema = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
         .allowIncompatibleChanges()
         .addRequiredColumn("new", Types.StructType.of(
-            Types.NestedField.required(SCHEMA_LAST_COLUMN_ID + 1, "field", Types.StructType.of(
-                Types.NestedField.required(SCHEMA_LAST_COLUMN_ID + 2, "nested", Types.StringType.get())))))
+            Types.NestedField.required(SCHEMA_LAST_COLUMN_ID + 2, "field", Types.StructType.of(
+                Types.NestedField.required(SCHEMA_LAST_COLUMN_ID + 3, "nested", Types.StringType.get())))))
         .setIdentifierFields("new.field.nested")
         .apply();
 
@@ -1400,22 +1407,34 @@ public class TestSchemaUpdate {
         .addRequiredColumn("col_float", Types.FloatType.get())
         .addRequiredColumn("col_double", Types.DoubleType.get())
         .addRequiredColumn("new", Types.StructType.of(
-            Types.NestedField.required(SCHEMA_LAST_COLUMN_ID + 3, "fields", Types.ListType.ofOptional(
-                SCHEMA_LAST_COLUMN_ID + 4, Types.StructType.of(
-                    Types.NestedField.required(SCHEMA_LAST_COLUMN_ID + 5, "nested", Types.StringType.get())
+            Types.NestedField.required(SCHEMA_LAST_COLUMN_ID + 4, "fields", Types.ListType.ofRequired(
+                SCHEMA_LAST_COLUMN_ID + 5, Types.StructType.of(
+                    Types.NestedField.required(SCHEMA_LAST_COLUMN_ID + 6, "nested", Types.StringType.get())
                 ))
             )
         ))
-        .addRequiredColumn("new_map", Types.MapType.ofRequired(SCHEMA_LAST_COLUMN_ID + 6, 11,
+        .addRequiredColumn("new_map", Types.MapType.ofRequired(SCHEMA_LAST_COLUMN_ID + 8, SCHEMA_LAST_COLUMN_ID + 9,
             Types.StructType.of(
-                required(SCHEMA_LAST_COLUMN_ID + 7, "key_col", Types.StringType.get())
+                required(SCHEMA_LAST_COLUMN_ID + 10, "key_col", Types.StringType.get())
             ),
             Types.StructType.of(
-                required(SCHEMA_LAST_COLUMN_ID + 8, "val_col", Types.StringType.get())
+                required(SCHEMA_LAST_COLUMN_ID + 11, "val_col", Types.StringType.get())
             )), "map of address to coordinate")
+        .addRequiredColumn("required_list", Types.ListType.ofRequired(SCHEMA_LAST_COLUMN_ID + 13,
+            Types.StructType.of(
+                required(SCHEMA_LAST_COLUMN_ID + 14, "x", Types.LongType.get()),
+                required(SCHEMA_LAST_COLUMN_ID + 15, "y", Types.LongType.get())
+            )))
         .apply();
 
-    int lastColId = SCHEMA_LAST_COLUMN_ID + 8;
+    int lastColId = SCHEMA_LAST_COLUMN_ID + 15;
+
+    AssertHelpers.assertThrows("add a nested field in list should fail",
+        IllegalArgumentException.class,
+        "must not be nested in " + newSchema.findField("required_list"),
+        () -> new SchemaUpdate(newSchema, lastColId)
+            .setIdentifierFields("required_list.element.x")
+            .apply());
 
     AssertHelpers.assertThrows("add a double field should fail",
         IllegalArgumentException.class,
@@ -1438,11 +1457,18 @@ public class TestSchemaUpdate {
             .setIdentifierFields("new_map.value.val_col")
             .apply());
 
-    AssertHelpers.assertThrows("add a nested field in struct of a map should fail",
+    AssertHelpers.assertThrows("add a nested field in struct of a list should fail",
         IllegalArgumentException.class,
         "must not be nested in " + newSchema.findField("new.fields"),
         () -> new SchemaUpdate(newSchema, lastColId)
             .setIdentifierFields("new.fields.element.nested")
+            .apply());
+
+    AssertHelpers.assertThrows("add a nested field in an optional struct should fail",
+        IllegalArgumentException.class,
+        "must not be nested in an optional field " + newSchema.findField("preferences"),
+        () -> new SchemaUpdate(newSchema, lastColId)
+            .setIdentifierFields("preferences.feature1")
             .apply());
   }
 
@@ -1476,6 +1502,24 @@ public class TestSchemaUpdate {
         "Cannot delete identifier field 1: id: required int. To force deletion, " +
             "also call setIdentifierFields to update identifier fields.",
         () -> new SchemaUpdate(schemaWithIdentifierFields, SCHEMA_LAST_COLUMN_ID).deleteColumn("id").apply());
+  }
+
+  @Test
+  public void testDeleteContainingNestedIdentifierFieldColumnsFails() {
+    Schema newSchema = new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
+        .allowIncompatibleChanges()
+        .addRequiredColumn("out", Types.StructType.of(
+            Types.NestedField.required(SCHEMA_LAST_COLUMN_ID + 2, "nested", Types.StringType.get())
+        ))
+        .setIdentifierFields("out.nested")
+        .apply();
+
+    AssertHelpers.assertThrows(
+        "delete a struct with a nested identifier column without setting identifier fields should fail",
+        IllegalArgumentException.class,
+        "Cannot delete field 24: out: required struct<25: nested: required string> " +
+            "as it will delete nested identifier field 25: nested: required string",
+        () -> new SchemaUpdate(newSchema, SCHEMA_LAST_COLUMN_ID + 2).deleteColumn("out").apply());
   }
 
   @Test


### PR DESCRIPTION
…fier fields and do not allow deleting columns with nested identifier fields

This PR does 2 things:
1.  Disable setting required fields nested in optional struct as identifier fields. Currently we only check if the identifier fields is required to prevent nullable identifier fields, but a required field nested in an optional struct is also nullable;
2. Disable deletion of struct type columns with nested identifier fields.

@jackye1995 Could you help review this? Thanks!