### PR TITLE
Core: Add Serializer for TableMetadata to REST Catalogs Serializers

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -155,7 +155,7 @@ public class TableMetadataParser {
     }
   }
 
-  private static void toJson(TableMetadata metadata, JsonGenerator generator) throws IOException {
+  public static void toJson(TableMetadata metadata, JsonGenerator generator) throws IOException {
     generator.writeStartObject();
 
     generator.writeNumberField(FORMAT_VERSION, metadata.formatVersion());

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
@@ -33,6 +33,8 @@ import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.SortOrderParser;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.UnboundPartitionSpec;
 import org.apache.iceberg.UnboundSortOrder;
 import org.apache.iceberg.catalog.Namespace;
@@ -61,8 +63,17 @@ public class RESTSerializers {
         .addSerializer(UnboundPartitionSpec.class, new UnboundPartitionSpecSerializer())
         .addDeserializer(UnboundPartitionSpec.class, new UnboundPartitionSpecDeserializer())
         .addSerializer(UnboundSortOrder.class, new UnboundSortOrderSerializer())
-        .addDeserializer(UnboundSortOrder.class, new UnboundSortOrderDeserializer());
+        .addDeserializer(UnboundSortOrder.class, new UnboundSortOrderDeserializer())
+        .addSerializer(TableMetadata.class, new TableMetadataSerializer());
     mapper.registerModule(module);
+  }
+
+  public static class TableMetadataSerializer extends JsonSerializer<TableMetadata> {
+    @Override
+    public void serialize(TableMetadata metadata, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
+      TableMetadataParser.toJson(metadata, gen);
+    }
   }
 
   public static class ErrorResponseDeserializer extends JsonDeserializer<ErrorResponse> {


### PR DESCRIPTION
There's presently no serializer for `TableMetadata` in the set of serializers registered for the REST catalogs object mapper.

Given that we already have a `toJson` method that handles this without the need for any FileIO objects etc, this can be added in now.

Work on a deserializer that the REST catalog can use is on going.